### PR TITLE
Add mocked control-plane Playwright session flows

### DIFF
--- a/e2e/control-plane.spec.ts
+++ b/e2e/control-plane.spec.ts
@@ -49,6 +49,38 @@ test('registers and switches to another workspace from the browser', async ({ pa
   await expect(page.getByTestId('overview-active-workspace')).toContainText('secondary');
 });
 
+test('creates a session and sends a mocked prompt through the browser flow', async ({ page }) => {
+  await page.goto('/sessions');
+
+  await page.getByTestId('new-session-button').click();
+  await expect(page.locator('textarea')).toBeVisible();
+
+  await page.locator('textarea').fill('Explain this mocked E2E run');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText('Explain this mocked E2E run')).toBeVisible();
+  await expect(page.getByText('Mocked E2E agent response: Explain this mocked E2E run')).toBeVisible();
+});
+
+test('continues a mocked browser session after an initial prompt', async ({ page }) => {
+  await page.goto('/sessions');
+
+  await page.getByTestId('new-session-button').click();
+  await expect(page.locator('textarea')).toBeVisible();
+
+  await page.locator('textarea').fill('Start a mocked continuation flow');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText('Mocked E2E agent response: Start a mocked continuation flow')).toBeVisible();
+
+  const continueButton = page.getByRole('button', { name: 'Continue' });
+  await expect(continueButton).toBeEnabled();
+  await continueButton.click();
+
+  await expect(page.getByText('Continue from where you left off.', { exact: true })).toBeVisible();
+  await expect(page.getByText('Mocked E2E agent response: Continue from where you left off.', { exact: true })).toBeVisible();
+});
+
 test('mobile navigation exposes the primary sections', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/overview');
@@ -61,5 +93,6 @@ test('mobile navigation exposes the primary sections', async ({ page }) => {
 
   await page.getByTestId('mobile-nav-sessions').click();
   await expect(page).toHaveURL(/\/sessions$/);
-  await expect(page.getByTestId('new-session-button')).toBeVisible();
+  await expect(page.locator('textarea')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Send' })).toBeVisible();
 });

--- a/scripts/e2e-daemon.mjs
+++ b/scripts/e2e-daemon.mjs
@@ -42,6 +42,7 @@ const child = spawn(
       HOME: homeRoot,
       HEDDLE_E2E_PRIMARY_WORKSPACE: primaryWorkspace,
       HEDDLE_E2E_SECONDARY_WORKSPACE: secondaryWorkspace,
+      HEDDLE_E2E_FAKE_AGENT: '1',
     },
     stdio: 'inherit',
   },

--- a/src/server/features/control-plane/services/chat-sessions.ts
+++ b/src/server/features/control-plane/services/chat-sessions.ts
@@ -6,7 +6,8 @@ import { DEFAULT_OPENAI_MODEL } from '../../../../core/config.js';
 import { parseUnifiedDiffFiles } from '../../../../core/review/diff-domain.js';
 import { hasProviderCredentialForModel } from '../../../../core/runtime/api-keys.js';
 import type { ChatSessionLeaseOwner } from '../../../../core/chat/session-lease.js';
-import type { ChatSession } from '../../../../core/chat/types.js';
+import type { ChatSession, TurnSummary } from '../../../../core/chat/types.js';
+import { buildConversationMessages } from '../../../../core/chat/conversation-lines.js';
 import { submitChatSessionPrompt } from '../../../../core/chat/session-submit.js';
 import type {
   ApprovalEventView,
@@ -102,6 +103,10 @@ export async function submitChatPrompt(args: SubmitChatPromptArgs) {
     throw new Error('A run is already in progress for this session.');
   }
 
+  if (process.env.HEDDLE_E2E_FAKE_AGENT === '1') {
+    return runFakeE2eSessionPrompt(args);
+  }
+
   const controller = new AbortController();
   inFlightRuns.set(args.sessionId, controller);
 
@@ -180,6 +185,70 @@ export async function continueChatPrompt(args: Omit<SubmitChatPromptArgs, 'promp
     ...args,
     prompt: DEFAULT_CONTINUE_PROMPT,
   });
+}
+
+async function runFakeE2eSessionPrompt(args: SubmitChatPromptArgs) {
+  const session = readChatSession(args.sessionStoragePath, args.sessionId, true);
+  if (!session) {
+    throw new Error(`Chat session not found: ${args.sessionId}`);
+  }
+
+  const timestamp = new Date().toISOString();
+  const assistantText = `Mocked E2E agent response: ${args.prompt}`;
+  const nextHistory = [
+    ...session.history,
+    { role: 'user' as const, content: args.prompt },
+    { role: 'assistant' as const, content: assistantText },
+  ];
+  const nextTurn: TurnSummary = {
+    id: `e2e-turn-${Date.now()}`,
+    prompt: args.prompt,
+    outcome: 'done',
+    summary: assistantText,
+    steps: 1,
+    traceFile: 'e2e-fake-trace.jsonl',
+    events: ['Mocked E2E session run completed.'],
+  };
+  const updatedSession: ChatSession = {
+    ...session,
+    history: nextHistory,
+    messages: buildConversationMessages(nextHistory),
+    turns: [...session.turns, nextTurn].slice(-8),
+    updatedAt: timestamp,
+    lastContinuePrompt: args.prompt,
+    lease: undefined,
+  };
+
+  saveChatSessions(
+    args.sessionStoragePath,
+    readChatSessionCatalog(args.sessionStoragePath)
+      .map((entry) => readChatSession(args.sessionStoragePath, entry.id, true))
+      .filter((candidate): candidate is ChatSession => Boolean(candidate))
+      .map((candidate) => candidate.id === session.id ? updatedSession : candidate),
+  );
+
+  sessionEventBus.emit(args.sessionId, {
+    sessionId: args.sessionId,
+    timestamp,
+    event: {
+      type: 'trace',
+      runId: `e2e-${args.sessionId}`,
+      timestamp,
+      event: {
+        type: 'run.finished',
+        outcome: 'done',
+        summary: assistantText,
+        step: 1,
+        timestamp,
+      },
+    },
+  } satisfies ControlPlaneSessionLiveEvent);
+
+  return {
+    outcome: 'done',
+    summary: assistantText,
+    session: projectChatSessionDetail(updatedSession)[0] ?? null,
+  };
 }
 
 export function subscribeToControlPlaneSessionEvents(


### PR DESCRIPTION
## Summary
- add an E2E-only fake control-plane session path for browser Playwright runs
- cover browser session send and continue flows without live LLM usage
- update the mobile sessions assertion to match the current mobile entry state

## Verification
- yarn build
- yarn e2e