### PR TITLE
[codex] Fix chat compaction and centralize model policy

### DIFF
--- a/src/__tests__/chat/chat-compaction.test.ts
+++ b/src/__tests__/chat/chat-compaction.test.ts
@@ -4,10 +4,59 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { ChatMessage } from '../../core/llm/types.js';
 import type { LlmAdapter } from '../../core/llm/types.js';
+import { estimateBuiltInContextWindow } from '../../core/llm/openai-models.js';
+import { credentialModeFromSource, resolveSystemSelectedModel } from '../../core/llm/model-policy.js';
+import { setStoredProviderCredential } from '../../core/auth/provider-credentials.js';
+import { resolveProviderCredentialSourceForModel } from '../../core/runtime/api-keys.js';
 import { compactChatHistory, compactChatHistoryWithArchive, isCompactedHistorySummary } from '../../cli/chat/state/compaction.js';
 import { buildConversationMessages } from '../../cli/chat/utils/format.js';
 
 describe('chat history compaction', () => {
+  it('uses the documented context window for the default OpenAI compaction model', () => {
+    expect(estimateBuiltInContextWindow('gpt-5.1-codex-mini')).toBe(400_000);
+  });
+
+  it('uses a conservative context window for GPT-5.4 chat sessions', () => {
+    expect(estimateBuiltInContextWindow('gpt-5.4')).toBe(400_000);
+    expect(estimateBuiltInContextWindow('gpt-5.4-pro')).toBe(400_000);
+  });
+
+  it('uses the active account-sign-in model for OpenAI OAuth compaction', () => {
+    const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-chat-compaction-oauth-model-')), 'auth.json');
+    setStoredProviderCredential({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      expiresAt: Date.now() + 60_000,
+      createdAt: '2026-04-29T00:00:00.000Z',
+      updatedAt: '2026-04-29T00:00:00.000Z',
+    }, storePath);
+
+    expect(resolveSystemSelectedModel({
+      purpose: 'chat-compaction',
+      provider: 'openai',
+      activeModel: 'gpt-5.4',
+      credentialMode: credentialModeFromSource(resolveProviderCredentialSourceForModel('gpt-5.4', { credentialStorePath: storePath })),
+    })).toBe('gpt-5.4');
+    expect(resolveSystemSelectedModel({
+      purpose: 'chat-compaction',
+      provider: 'openai',
+      activeModel: 'o3',
+      credentialMode: credentialModeFromSource(resolveProviderCredentialSourceForModel('o3', { credentialStorePath: storePath })),
+    })).toBe('gpt-5.4');
+    expect(resolveSystemSelectedModel({
+      purpose: 'chat-compaction',
+      provider: 'openai',
+      activeModel: 'gpt-5.4',
+      credentialMode: credentialModeFromSource(resolveProviderCredentialSourceForModel('gpt-5.4', {
+        apiKey: 'sk-test',
+        apiKeyProvider: 'explicit',
+        credentialStorePath: storePath,
+      })),
+    })).toBe('gpt-5.1-codex-mini');
+  });
+
   it('compacts older transcript messages into a summary and keeps recent messages', () => {
     const history: ChatMessage[] = Array.from({ length: 50 }).flatMap((_, index) => [
       { role: 'user' as const, content: `User prompt ${index}: ${'u'.repeat(4000)}` },
@@ -50,6 +99,31 @@ describe('chat history compaction', () => {
     expect(isCompactedHistorySummary(manuallyCompacted.history[0]!)).toBe(true);
     expect(manuallyCompacted.history.length).toBeLessThan(history.length);
     expect(manuallyCompacted.context.compactedMessages).toBeGreaterThan(0);
+  });
+
+  it('keeps recent history by token budget rather than a fixed message count', () => {
+    const history: ChatMessage[] = [
+      ...Array.from({ length: 10 }).flatMap((_, index) => [
+        { role: 'user' as const, content: `Older user ${index}: ${'u'.repeat(2_000)}` },
+        { role: 'assistant' as const, content: `Older assistant ${index}: ${'a'.repeat(2_000)}` },
+      ]),
+      { role: 'user' as const, content: `recent small request` },
+      { role: 'assistant' as const, content: `recent giant tool analysis: ${'a'.repeat(80_000)}` },
+      { role: 'tool' as const, toolCallId: 'huge-tool-1', content: `{"ok":true,"output":"${'t'.repeat(80_000)}"}` },
+      { role: 'assistant' as const, content: `recent giant follow-up: ${'b'.repeat(80_000)}` },
+      { role: 'user' as const, content: 'what was our task?' },
+    ];
+
+    const compacted = compactChatHistory({
+      history,
+      model: 'gpt-4.1',
+      force: true,
+    });
+
+    expect(isCompactedHistorySummary(compacted.history[0]!)).toBe(true);
+    expect(compacted.history.length).toBeLessThan(16);
+    expect(compacted.history.at(-1)).toEqual(history.at(-1));
+    expect(compacted.context.estimatedHistoryTokens).toBeLessThan(90_000);
   });
 
   it('can re-compact an already compacted short session when forced manually', () => {
@@ -185,5 +259,51 @@ describe('chat history compaction', () => {
     expect(llmCalls).toHaveLength(2);
     expect(llmCalls[1]).toContain('Summary call 1.');
     expect(compactedAgain.history[0]?.content).toContain('Archive index:');
+  });
+
+  it('condenses large raw archive content before sending it to the summarizer', async () => {
+    const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-chat-compaction-large-summary-'));
+    const history: ChatMessage[] = Array.from({ length: 40 }).flatMap((_, index) => [
+      { role: 'user' as const, content: `User ${index}: ${'u'.repeat(20_000)}` },
+      { role: 'assistant' as const, content: `Assistant ${index}: ${'a'.repeat(20_000)}` },
+      { role: 'tool' as const, toolCallId: `call-${index}`, content: `Tool ${index}: ${'t'.repeat(20_000)}` },
+    ]);
+    let summarizerInput = '';
+    const llm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-5.1-codex-mini',
+        capabilities: {
+          toolCalls: false,
+          systemMessages: true,
+          reasoningSummaries: false,
+          parallelToolCalls: false,
+        },
+      },
+      async chat(messages) {
+        summarizerInput = messages[1]?.content ?? '';
+        return {
+          content: [
+            '# Compacted Conversation Rolling Summary',
+            '## Work Completed',
+            '- Large archive summarized.',
+          ].join('\n'),
+        };
+      },
+    };
+
+    const compacted = await compactChatHistoryWithArchive({
+      history,
+      model: 'gpt-5.1',
+      sessionId: 'session-large-summary',
+      stateRoot,
+      force: true,
+      summarizer: { llm },
+    });
+
+    expect(compacted.archives).toHaveLength(1);
+    expect(summarizerInput.length).toBeLessThan(300_000);
+    expect(summarizerInput).toContain('Summarizer transcript note');
+    expect(summarizerInput).toContain('full content is in the raw archive');
   });
 });

--- a/src/__tests__/core/openai-oauth.test.ts
+++ b/src/__tests__/core/openai-oauth.test.ts
@@ -158,6 +158,29 @@ describe('OpenAI OAuth helpers', () => {
     );
   });
 
+  it('fails clearly before routing gpt-5.1-codex-mini through account sign-in', async () => {
+    const adapter = createOpenAiAdapter({
+      model: 'gpt-5.1-codex-mini',
+      credential: {
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 120_000,
+        accountId: 'account-123',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      },
+      fetchImpl: (async () => {
+        throw new Error('fetch should not be called');
+      }) as typeof fetch,
+    });
+
+    await expect(adapter.chat([{ role: 'user', content: 'hello' }], [])).rejects.toThrow(
+      'OpenAI account sign-in is not enabled for model gpt-5.1-codex-mini.',
+    );
+  });
+
   it('uses the Codex-compatible Responses payload shape for account sign-in models', async () => {
     const requests: Array<{ url: string; body: string }> = [];
     const adapter = createOpenAiAdapter({

--- a/src/__tests__/core/prompts.test.ts
+++ b/src/__tests__/core/prompts.test.ts
@@ -3,10 +3,12 @@ import { buildSystemPrompt } from '../../core/prompts/system-prompt.js';
 
 describe('buildSystemPrompt', () => {
   it('frames Heddle as a coding and workspace agent rather than a generic chatbot', () => {
-    const prompt = buildSystemPrompt('Explain this project.', ['list_files', 'read_file', 'run_shell_inspect']);
+    const prompt = buildSystemPrompt(['list_files', 'read_file', 'run_shell_inspect']);
 
     expect(prompt).toContain('You are Heddle, a conversational coding and workspace agent.');
     expect(prompt).toContain('You are not a generic chatbot.');
+    expect(prompt).toContain('help the user complete their requested task');
+    expect(prompt).not.toContain('Explain this project.');
     expect(prompt).toContain('## Default Workflow');
     expect(prompt).toContain('1. Clarify the real task.');
     expect(prompt).toContain('2. Gather the minimum relevant evidence first.');
@@ -40,7 +42,7 @@ describe('buildSystemPrompt', () => {
   });
 
   it('includes project-specific context when provided', () => {
-    const prompt = buildSystemPrompt('Help in this repo.', ['list_files'], 'Source: AGENTS.md\nUse yarn and keep answers concise.');
+    const prompt = buildSystemPrompt(['list_files'], 'Source: AGENTS.md\nUse yarn and keep answers concise.');
 
     expect(prompt).toContain('## Project Context');
     expect(prompt).toContain('Source: AGENTS.md');

--- a/src/__tests__/tools/tools.test.ts
+++ b/src/__tests__/tools/tools.test.ts
@@ -504,8 +504,10 @@ describe('viewImageTool', () => {
 
     expect(result).toEqual({
       ok: false,
-      error: 'OpenAI account sign-in is not enabled for model o3. Set OPENAI_API_KEY to use Platform API-key mode for image inspection.',
+      error: expect.stringContaining('OpenAI account sign-in is not enabled for model o3.'),
     });
+    expect(result.error).toContain('set OPENAI_API_KEY');
+    expect(result.error).toContain('image inspection');
   });
 
   it('uses the OAuth-backed OpenAI transport for image inspection when a stored credential is available', async () => {

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -14,6 +14,7 @@ import {
 } from './components/index.js';
 import { buildTuiDebugSnapshot } from './debug/tui-debug-snapshot.js';
 import { estimateBuiltInContextWindow } from '../../core/llm/openai-models.js';
+import { credentialModeFromSource, resolveSystemSelectedModel } from '../../core/llm/model-policy.js';
 import { useApprovalFlow } from './hooks/useApprovalFlow.js';
 import { useAgentRun } from './hooks/useAgentRun.js';
 import { useChatDrift } from './hooks/useChatDrift.js';
@@ -26,8 +27,6 @@ import { autocompleteLocalCommand } from './state/local-commands.js';
 import { currentActivityText } from './utils/format.js';
 import { listMentionableFiles } from './utils/file-mentions.js';
 import { resolveProviderCredentialSourceForModel, type ChatRuntimeConfig, type ProviderCredentialSource } from './utils/runtime.js';
-
-const SESSION_TITLE_MODEL = 'gpt-5.1-codex-mini';
 
 export function App({ runtime }: { runtime: ChatRuntimeConfig }) {
   return <EmbeddedChatApp runtime={runtime} />;
@@ -115,6 +114,12 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     activeSession?.context?.lastRunInputTokens ?? activeSession?.context?.estimatedRequestTokens,
   );
   const authStatus = formatAuthStatus(resolveProviderCredentialSourceForModel(activeModel, runtime));
+  const sessionTitleModel = resolveSystemSelectedModel({
+    purpose: 'session-title',
+    provider: 'openai',
+    activeModel,
+    credentialMode: credentialModeFromSource(runtime.providerCredentialSource),
+  });
   const sessionFooter = `session=${activeSession?.id ?? activeSessionId}${activeSession?.name ? ` (${activeSession.name})` : ''}`;
   const renderedStatus =
     pendingApproval ? 'awaiting approval'
@@ -278,7 +283,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
   const { executeTurn, executeDirectShellCommand } = useAgentRun({
     runtime,
     activeModel,
-    sessionTitleModel: SESSION_TITLE_MODEL,
+    sessionTitleModel,
     activeSessionId,
     sessions,
     state: actionState,

--- a/src/cli/chat/hooks/useAgentRun.ts
+++ b/src/cli/chat/hooks/useAgentRun.ts
@@ -127,6 +127,10 @@ export function useAgentRun(args: UseAgentRunArgs) {
   const projectApprovals = useProjectApprovals(runtime.approvalsFile);
   const activeApiKey = resolveApiKeyForModel(activeModel, runtime);
   const titleApiKey = resolveApiKeyForModel(sessionTitleModel, runtime);
+  const titleCredentialSource = useMemo(
+    () => resolveProviderCredentialSourceForModel(sessionTitleModel, runtime),
+    [runtime, sessionTitleModel],
+  );
   const activeCredentialSource = useMemo(
     () => resolveProviderCredentialSourceForModel(activeModel, runtime),
     [activeModel, runtime],
@@ -168,7 +172,7 @@ export function useAgentRun(args: UseAgentRunArgs) {
 
   const maybeAutoNameSession = (sessionId: string, prompt: string, responseText: string) => {
     const session = sessions.find((candidate) => candidate.id === sessionId);
-    if (!session || !isGenericSessionName(session.name) || !titleApiKey) {
+    if (!session || !isGenericSessionName(session.name) || titleCredentialSource.type === 'missing') {
       return;
     }
 
@@ -357,6 +361,7 @@ export async function executeAgentTurn(args: ExecuteTurnArgs): Promise<RunResult
     systemContext: runtime.systemContext,
     toolNames,
     goal: prompt,
+    summarizer: { credentialSource: runtime.providerCredentialSource },
     onStatusChange: (event) => emitCompactionStatus(event, historyForRun),
   });
   historyForRun = preflightCompacted.history;
@@ -512,6 +517,7 @@ export async function executeAgentTurn(args: ExecuteTurnArgs): Promise<RunResult
       systemContext: runtime.systemContext,
       toolNames,
       goal: prompt,
+      summarizer: { credentialSource: runtime.providerCredentialSource },
       onStatusChange: (event) => emitCompactionStatus(event, result.transcript),
     });
     updateSessionById(sessionId, (sessionToUpdate) => ({
@@ -852,6 +858,7 @@ async function runDirectShellAction(args: ExecuteDirectShellArgs): Promise<void>
       systemContext: runtime.systemContext,
       toolNames: tools.map((tool) => tool.name),
       goal: shellDisplay,
+      summarizer: { credentialSource: runtime.providerCredentialSource },
       onStatusChange: (event) => {
         if (event.status === 'running') {
           state.setStatus('Compacting');

--- a/src/cli/chat/hooks/usePromptSubmission.ts
+++ b/src/cli/chat/hooks/usePromptSubmission.ts
@@ -168,6 +168,7 @@ export function usePromptSubmission({
       workspaceRoot: runtime.workspaceRoot,
       stateRoot: runtime.stateRoot,
       credentialStorePath: runtime.credentialStorePath,
+      providerCredentialSource: runtime.providerCredentialSource,
       preparePrompt: preparePromptWithMentions,
       executeTurn,
       executeDirectShellCommand,

--- a/src/cli/chat/submit.ts
+++ b/src/cli/chat/submit.ts
@@ -3,6 +3,7 @@ import { buildCompactionRunningContext, compactChatHistoryWithArchive } from './
 import { createInitialMessages } from './state/storage.js';
 import type { ChatSession, ConversationLine } from './state/types.js';
 import { buildConversationMessages, normalizeInlineText } from './utils/format.js';
+import type { ProviderCredentialSource } from './utils/runtime.js';
 
 type SessionUpdater = (sessionId: string, updater: (session: ChatSession) => ChatSession) => void;
 
@@ -35,6 +36,7 @@ type SubmitChatPromptArgs = {
   workspaceRoot: string;
   stateRoot: string;
   credentialStorePath?: string;
+  providerCredentialSource?: ProviderCredentialSource;
   preparePrompt?: (prompt: string) => { prompt: string; displayText?: string };
   executeTurn: (prompt: string, displayText?: string, sessionIdOverride?: string) => Promise<void>;
   executeDirectShellCommand: (rawCommand: string) => Promise<void>;
@@ -95,6 +97,7 @@ export async function submitChatPrompt(args: SubmitChatPromptArgs): Promise<void
         sessionId: session.id,
         stateRoot: args.stateRoot,
         force: true,
+        summarizer: { credentialSource: args.providerCredentialSource },
       }).then((compacted) => {
         const changed =
           compacted.history.length !== session.history.length

--- a/src/core/agent/run-agent.ts
+++ b/src/core/agent/run-agent.ts
@@ -201,7 +201,7 @@ function buildInitialMessages(
   history: ChatMessage[] | undefined,
 ): ChatMessage[] {
   return [
-    { role: 'system', content: buildSystemPrompt(goal, toolNames, systemContext) },
+    { role: 'system', content: buildSystemPrompt(toolNames, systemContext) },
     ...sanitizeHistory(history ?? []),
     { role: 'user', content: goal },
   ];

--- a/src/core/chat/compaction.ts
+++ b/src/core/chat/compaction.ts
@@ -1,7 +1,12 @@
 import type { ChatMessage, LlmAdapter, LlmUsage } from '../../index.js';
 import { createLlmAdapter, inferProviderFromModel } from '../../index.js';
-import { hasProviderCredentialForModel, resolveApiKeyForModel } from '../runtime/api-keys.js';
+import { hasProviderCredentialForModel, resolveApiKeyForModel, resolveProviderCredentialSourceForModel, type ProviderCredentialSource } from '../runtime/api-keys.js';
 import { estimateBuiltInContextWindow } from '../llm/openai-models.js';
+import {
+  credentialModeFromSource,
+  resolveSystemSelectedModel,
+  type ModelCredentialMode,
+} from '../llm/model-policy.js';
 import type { ChatArchiveManifest, ChatArchiveRecord, ChatContextStats } from './types.js';
 import {
   createArchiveId,
@@ -16,18 +21,25 @@ import {
 
 const DEFAULT_CONTEXT_WINDOW_ESTIMATE = 200_000;
 const MAX_HISTORY_RATIO = 0.6;
-const MIN_RECENT_MESSAGES = 16;
-const MIN_FORCED_RECENT_MESSAGES = 3;
+const MAX_RECENT_HISTORY_RATIO = 0.18;
+const MIN_RECENT_HISTORY_TOKEN_BUDGET = 8_000;
+const MAX_RECENT_HISTORY_TOKEN_BUDGET = 120_000;
+const PREFERRED_RECENT_MESSAGES = 12;
+const PREFERRED_FORCED_RECENT_MESSAGES = 3;
 const MAX_ROLLING_SUMMARY_CHARS = 12_000;
+const MAX_SUMMARIZER_CONTEXT_RATIO = 0.12;
+const MAX_SUMMARIZER_TRANSCRIPT_TOKENS = 32_000;
+const MAX_SUMMARIZER_TRANSCRIPT_CHARS = 96_000;
+const MAX_SUMMARIZER_MESSAGE_CHARS = 2_000;
+const MIN_SUMMARIZER_MESSAGE_CHARS = 80;
 const COMPACTED_HISTORY_MARKER = 'Heddle compacted earlier conversation history.';
-const DEFAULT_OPENAI_COMPACTION_MODEL = 'gpt-5.1-codex-mini';
-const DEFAULT_ANTHROPIC_COMPACTION_MODEL = 'claude-haiku-4-5';
 
 export type CompactionSummarizerOptions = {
   provider?: 'openai' | 'anthropic' | 'active';
   model?: string;
   apiKey?: string;
   llm?: LlmAdapter;
+  credentialSource?: ProviderCredentialSource;
 };
 
 export type CompactChatHistoryWithArchiveOptions = {
@@ -55,7 +67,8 @@ export async function compactChatHistoryWithArchive(
 ): Promise<CompactChatHistoryResult> {
   const estimatedWindow = estimateBuiltInContextWindow(options.model) ?? DEFAULT_CONTEXT_WINDOW_ESTIMATE;
   const maxHistoryTokens = Math.floor(estimatedWindow * MAX_HISTORY_RATIO);
-  const minRecentMessages = options.force ? MIN_FORCED_RECENT_MESSAGES : MIN_RECENT_MESSAGES;
+  const recentTokenBudget = resolveRecentHistoryTokenBudget(estimatedWindow);
+  const preferredRecentMessages = options.force ? PREFERRED_FORCED_RECENT_MESSAGES : PREFERRED_RECENT_MESSAGES;
   const needsCompaction =
     estimateChatHistoryTokens(options.history) > maxHistoryTokens
     || (Boolean(options.force) && countNonCompactedMessages(options.history) > 0);
@@ -80,7 +93,11 @@ export async function compactChatHistoryWithArchive(
     };
   }
 
-  const splitIndex = findCompactionSplit(options.history, minRecentMessages);
+  const splitIndex = findCompactionSplit(options.history, {
+    recentTokenBudget,
+    preferredRecentMessages,
+    stopAtPreferredMessages: Boolean(options.force),
+  });
   if (splitIndex <= 0 || splitIndex >= options.history.length) {
     const manifest = loadChatArchiveManifest(options.stateRoot, options.sessionId);
     return {
@@ -210,15 +227,20 @@ export function compactChatHistory(options: {
 }): { history: ChatMessage[]; context: ChatContextStats } {
   const estimatedWindow = estimateBuiltInContextWindow(options.model) ?? DEFAULT_CONTEXT_WINDOW_ESTIMATE;
   const maxHistoryTokens = Math.floor(estimatedWindow * MAX_HISTORY_RATIO);
-  const minRecentMessages = options.force ? MIN_FORCED_RECENT_MESSAGES : MIN_RECENT_MESSAGES;
+  const recentTokenBudget = resolveRecentHistoryTokenBudget(estimatedWindow);
+  const preferredRecentMessages = options.force ? PREFERRED_FORCED_RECENT_MESSAGES : PREFERRED_RECENT_MESSAGES;
   let nextHistory = options.history;
   let compactedMessages = 0;
 
   while (
     (estimateChatHistoryTokens(nextHistory) > maxHistoryTokens || (options.force && compactedMessages === 0)) &&
-    countNonCompactedMessages(nextHistory) > minRecentMessages
+    countNonCompactedMessages(nextHistory) > 1
   ) {
-    const splitIndex = findCompactionSplit(nextHistory, minRecentMessages);
+    const splitIndex = findCompactionSplit(nextHistory, {
+      recentTokenBudget,
+      preferredRecentMessages,
+      stopAtPreferredMessages: Boolean(options.force),
+    });
     if (splitIndex <= 0 || splitIndex >= nextHistory.length) {
       break;
     }
@@ -370,9 +392,7 @@ async function summarizeChatArchive(options: {
     createdAt: archive.createdAt,
   }));
 
-  const transcript = options.archivedMessages
-    .map((message, index) => `## Message ${index + 1}\n${renderArchivedMessage(message)}`)
-    .join('\n\n');
+  const transcript = buildSummarizerTranscript(options.archivedMessages, options.summaryModel);
 
   const response = await options.llm.chat([
     {
@@ -437,9 +457,16 @@ function resolveSummarizer(options: CompactChatHistoryWithArchiveOptions): { llm
     : options.summarizer.provider;
   const model =
     options.summarizer?.model
-    ?? (provider === 'anthropic' ?
-      DEFAULT_ANTHROPIC_COMPACTION_MODEL
-    : DEFAULT_OPENAI_COMPACTION_MODEL);
+    ?? resolveSystemSelectedModel({
+      purpose: 'chat-compaction',
+      provider,
+      activeModel: options.model,
+      credentialMode: resolveCompactionCredentialMode({
+        activeModel: options.model,
+        explicitApiKey: options.summarizer?.apiKey,
+        credentialSource: options.summarizer?.credentialSource,
+      }),
+    });
   const apiKey = options.summarizer?.apiKey ?? resolveApiKeyForModel(model);
   if (!hasProviderCredentialForModel(model, {
     apiKey,
@@ -452,6 +479,19 @@ function resolveSummarizer(options: CompactChatHistoryWithArchiveOptions): { llm
     model,
     llm: createLlmAdapter({ model, apiKey }),
   };
+}
+
+function resolveCompactionCredentialMode(args: {
+  activeModel: string;
+  explicitApiKey?: string;
+  credentialSource?: ProviderCredentialSource;
+  credentialStorePath?: string;
+}): ModelCredentialMode {
+  return credentialModeFromSource(args.credentialSource ?? resolveProviderCredentialSourceForModel(args.activeModel, {
+    apiKey: args.explicitApiKey,
+    apiKeyProvider: args.explicitApiKey ? 'explicit' : undefined,
+    credentialStorePath: args.credentialStorePath,
+  }));
 }
 
 function extractPriorSummary(history: ChatMessage[]): string | undefined {
@@ -507,6 +547,71 @@ function renderArchivedMessage(message: ChatMessage): string {
   ].join('\n\n');
 }
 
+function buildSummarizerTranscript(messages: ChatMessage[], summaryModel: string): string {
+  if (messages.length === 0) {
+    return '(no archived messages)';
+  }
+
+  const transcriptCharBudget = resolveSummarizerTranscriptCharBudget(summaryModel);
+  const perMessageBudget = Math.max(
+    MIN_SUMMARIZER_MESSAGE_CHARS,
+    Math.min(MAX_SUMMARIZER_MESSAGE_CHARS, Math.floor(transcriptCharBudget / messages.length) - 80),
+  );
+  const lines: string[] = [
+    `Summarizer transcript note: raw archive contains ${messages.length} complete messages.`,
+    `Each message below is condensed to fit the summarizer request. Read the archive file when exact wording or full tool output matters.`,
+    `Summarizer input budget: about ${Math.floor(transcriptCharBudget / 4).toLocaleString()} estimated text tokens.`,
+  ];
+  let totalChars = lines.join('\n').length;
+
+  for (const [index, message] of messages.entries()) {
+    const rendered = `## Message ${index + 1}\n${renderArchivedMessageForSummary(message, perMessageBudget)}`;
+    const separator = lines.length > 0 ? '\n\n' : '';
+    if (totalChars + separator.length + rendered.length > transcriptCharBudget) {
+      lines.push(`\n\nOmitted ${messages.length - index} additional archived messages from summarizer input to stay within request budget. Inspect the raw archive for full detail.`);
+      break;
+    }
+
+    lines.push(rendered);
+    totalChars += separator.length + rendered.length;
+  }
+
+  return lines.join('\n\n');
+}
+
+function resolveSummarizerTranscriptCharBudget(summaryModel: string): number {
+  const contextWindow = estimateBuiltInContextWindow(summaryModel) ?? DEFAULT_CONTEXT_WINDOW_ESTIMATE;
+  const budgetByContext = Math.floor(contextWindow * MAX_SUMMARIZER_CONTEXT_RATIO);
+  const tokenBudget = Math.min(MAX_SUMMARIZER_TRANSCRIPT_TOKENS, budgetByContext);
+  return Math.min(MAX_SUMMARIZER_TRANSCRIPT_CHARS, tokenBudget * 4);
+}
+
+function renderArchivedMessageForSummary(message: ChatMessage, maxChars: number): string {
+  if (message.role === 'assistant') {
+    const parts = [
+      'Role: assistant',
+      message.content ? `Content excerpt:\n${truncateForSummary(message.content, maxChars)}` : 'Content: (empty)',
+      message.toolCalls?.length ?
+        `Tool calls:\n${truncateForSummary(JSON.stringify(message.toolCalls, null, 2), maxChars)}`
+      : undefined,
+    ].filter((part): part is string => Boolean(part));
+    return parts.join('\n\n');
+  }
+
+  if (message.role === 'tool') {
+    return [
+      'Role: tool',
+      `Tool call id: ${message.toolCallId}`,
+      `Content excerpt:\n${truncateForSummary(message.content, maxChars)}`,
+    ].join('\n\n');
+  }
+
+  return [
+    `Role: ${message.role}`,
+    `Content excerpt:\n${truncateForSummary(message.content, maxChars)}`,
+  ].join('\n\n');
+}
+
 function deriveShortDescription(summary: string): string | undefined {
   const lines = summary
     .split('\n')
@@ -524,6 +629,14 @@ function truncateSummary(value: string): string {
   return `${value.slice(0, MAX_ROLLING_SUMMARY_CHARS - 1).trimEnd()}…`;
 }
 
+function truncateForSummary(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+
+  return `${value.slice(0, Math.max(0, maxChars - 80)).trimEnd()}\n\n[truncated ${value.length - maxChars} chars; full content is in the raw archive]`;
+}
+
 function truncateLine(value: string, maxChars: number): string {
   const compact = value.replace(/\s+/g, ' ').trim();
   if (compact.length <= maxChars) {
@@ -537,22 +650,59 @@ function countNonCompactedMessages(history: ChatMessage[]): number {
   return history.filter((message) => !isCompactedHistorySummary(message)).length;
 }
 
-function findCompactionSplit(history: ChatMessage[], minRecentMessages: number): number {
-  let splitIndex = Math.max(0, history.length - minRecentMessages);
+function resolveRecentHistoryTokenBudget(contextWindow: number): number {
+  return Math.max(
+    MIN_RECENT_HISTORY_TOKEN_BUDGET,
+    Math.min(MAX_RECENT_HISTORY_TOKEN_BUDGET, Math.floor(contextWindow * MAX_RECENT_HISTORY_RATIO)),
+  );
+}
 
-  while (splitIndex < history.length && history[splitIndex]?.role === 'tool') {
-    splitIndex++;
+function findCompactionSplit(history: ChatMessage[], options: {
+  recentTokenBudget: number;
+  preferredRecentMessages: number;
+  stopAtPreferredMessages?: boolean;
+}): number {
+  let splitIndex = history.length;
+  let recentTokens = 0;
+  let recentMessages = 0;
+
+  while (splitIndex > 0) {
+    if (options.stopAtPreferredMessages && recentMessages >= options.preferredRecentMessages) {
+      break;
+    }
+
+    const nextMessage = history[splitIndex - 1];
+    if (!nextMessage) {
+      break;
+    }
+
+    const nextTokens = estimateMessageTokens(nextMessage);
+    const exceedsBudget = recentTokens + nextTokens > options.recentTokenBudget;
+    const reachedPreferredCount = recentMessages >= options.preferredRecentMessages;
+    if (recentMessages > 0 && exceedsBudget && reachedPreferredCount) {
+      break;
+    }
+    if (recentMessages > 0 && exceedsBudget && nextTokens > options.recentTokenBudget) {
+      break;
+    }
+
+    splitIndex--;
+    recentTokens += nextTokens;
+    if (!isCompactedHistorySummary(nextMessage)) {
+      recentMessages++;
+    }
+
+    if (recentMessages >= options.preferredRecentMessages && recentTokens >= options.recentTokenBudget) {
+      break;
+    }
   }
 
-  while (
-    splitIndex < history.length &&
-    splitIndex > 0 &&
-    isAssistantToolCallMessage(history[splitIndex - 1])
-  ) {
-    splitIndex++;
-    while (splitIndex < history.length && history[splitIndex]?.role === 'tool') {
-      splitIndex++;
-    }
+  while (splitIndex > 0 && history[splitIndex]?.role === 'tool') {
+    splitIndex--;
+  }
+
+  if (splitIndex > 0 && isAssistantToolCallMessage(history[splitIndex - 1])) {
+    splitIndex--;
   }
 
   return splitIndex;

--- a/src/core/chat/session-submit.ts
+++ b/src/core/chat/session-submit.ts
@@ -107,6 +107,7 @@ export async function submitChatSessionPrompt(args: SubmitChatSessionPromptArgs)
       toolNames: tools.map((tool) => tool.name),
       goal: args.prompt,
       systemContext,
+      summarizer: { credentialSource: providerCredentialSource },
       onStatusChange: (event) => {
         args.onCompactionStatus?.(event);
         if (event.status === 'running') {
@@ -194,6 +195,7 @@ export async function submitChatSessionPrompt(args: SubmitChatSessionPromptArgs)
       toolNames: tools.map((tool) => tool.name),
       goal: args.prompt,
       systemContext,
+      summarizer: { credentialSource: providerCredentialSource },
       onStatusChange: (event) => {
         args.onCompactionStatus?.(event);
         if (event.status === 'running') {

--- a/src/core/llm/model-policy.ts
+++ b/src/core/llm/model-policy.ts
@@ -1,0 +1,86 @@
+import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from '../config.js';
+import type { ProviderCredentialSource } from '../runtime/api-keys.js';
+import { isOpenAiAccountSignInModel, OPENAI_ACCOUNT_SIGN_IN_MODELS } from './openai-models.js';
+import type { LlmProvider } from './types.js';
+
+export type SystemModelPurpose = 'chat-compaction' | 'session-title';
+export type ModelCredentialMode = 'api-key' | 'oauth' | 'missing';
+
+export const OPENAI_API_KEY_COMPACTION_MODEL = 'gpt-5.1-codex-mini';
+export const OPENAI_OAUTH_SYSTEM_MODEL = 'gpt-5.4';
+export const ANTHROPIC_COMPACTION_MODEL = 'claude-haiku-4-5';
+
+const OPENAI_OAUTH_IMAGE_MODEL_PREFERENCES = ['gpt-5.4', 'gpt-5.4-mini'];
+
+export function credentialModeFromSource(source: ProviderCredentialSource | undefined): ModelCredentialMode {
+  if (source?.type === 'oauth') {
+    return 'oauth';
+  }
+
+  if (source?.type === 'missing') {
+    return 'missing';
+  }
+
+  return 'api-key';
+}
+
+export function resolveSystemSelectedModel(args: {
+  purpose: SystemModelPurpose;
+  provider: LlmProvider;
+  activeModel?: string;
+  credentialMode?: ModelCredentialMode;
+}): string {
+  if (args.provider === 'anthropic') {
+    return args.purpose === 'chat-compaction' ? ANTHROPIC_COMPACTION_MODEL : DEFAULT_ANTHROPIC_MODEL;
+  }
+
+  if (args.provider === 'openai') {
+    if (args.credentialMode === 'oauth') {
+      return args.activeModel && isOpenAiAccountSignInModel(args.activeModel) ? args.activeModel : OPENAI_OAUTH_SYSTEM_MODEL;
+    }
+
+    return args.purpose === 'chat-compaction' ? OPENAI_API_KEY_COMPACTION_MODEL : DEFAULT_OPENAI_MODEL;
+  }
+
+  return DEFAULT_OPENAI_MODEL;
+}
+
+export function validateModelCredentialCompatibility(args: {
+  model: string;
+  provider: LlmProvider;
+  credentialMode?: ModelCredentialMode;
+  usageLabel?: string;
+}): { ok: true } | { ok: false; error: string } {
+  if (args.provider === 'openai' && args.credentialMode === 'oauth' && !isOpenAiAccountSignInModel(args.model)) {
+    return {
+      ok: false,
+      error: `OpenAI account sign-in is not enabled for model ${args.model}. Use one of ${formatOpenAiAccountSignInModels()}, or set OPENAI_API_KEY to use Platform API-key mode${args.usageLabel ? ` for ${args.usageLabel}` : ''}.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export function assertModelCredentialCompatibility(args: {
+  model: string;
+  provider: LlmProvider;
+  credentialMode?: ModelCredentialMode;
+  usageLabel?: string;
+}) {
+  const result = validateModelCredentialCompatibility(args);
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+}
+
+export function resolveOpenAiOAuthImageCandidateModels(activeModel: string): string[] {
+  return uniqueModels([activeModel, ...OPENAI_OAUTH_IMAGE_MODEL_PREFERENCES, ...OPENAI_ACCOUNT_SIGN_IN_MODELS]);
+}
+
+export function formatOpenAiAccountSignInModels(): string {
+  return OPENAI_ACCOUNT_SIGN_IN_MODELS.join(', ');
+}
+
+function uniqueModels(models: string[]): string[] {
+  return [...new Set(models)];
+}

--- a/src/core/llm/openai-models.ts
+++ b/src/core/llm/openai-models.ts
@@ -67,7 +67,6 @@ export const OPENAI_ACCOUNT_SIGN_IN_MODELS = [
   'gpt-5.4-mini',
   'gpt-5.1-codex',
   'gpt-5.1-codex-max',
-  'gpt-5.1-codex-mini',
   'gpt-5.2',
   'gpt-5.2-codex',
   'gpt-5.3-codex',
@@ -133,14 +132,18 @@ export function estimateBuiltInContextWindow(model: string): number | undefined 
 
 function inferContextWindowEstimate(model: string): number {
   if (model.startsWith('gpt-5.5')) {
-    return 1_050_000;
+    return 400_000;
   }
 
   if (model === 'gpt-5.4' || model === 'gpt-5.4-pro') {
-    return 1_050_000;
+    return 400_000;
   }
 
   if (model === 'gpt-5.4-mini') {
+    return 400_000;
+  }
+
+  if (model.startsWith('gpt-5.1') || model.startsWith('gpt-5.2') || model.startsWith('gpt-5.3') || model.startsWith('gpt-5-') || model === 'gpt-5') {
     return 400_000;
   }
 

--- a/src/core/llm/openai.ts
+++ b/src/core/llm/openai.ts
@@ -23,7 +23,7 @@ import {
   setStoredProviderCredential,
   type StoredProviderCredential,
 } from '../auth/provider-credentials.js';
-import { isOpenAiAccountSignInModel, OPENAI_ACCOUNT_SIGN_IN_MODELS } from './openai-models.js';
+import { assertModelCredentialCompatibility } from './model-policy.js';
 
 export type OpenAiAdapterOptions = {
   apiKey?: string;
@@ -69,8 +69,12 @@ export function createOpenAiAdapter(options: OpenAiAdapterOptions = {}): LlmAdap
       signal?: AbortSignal,
       onStreamEvent?: (event: LlmStreamEvent) => void,
     ): Promise<LlmResponse> {
-      if (oauthCredential && !isOpenAiAccountSignInModel(model)) {
-        throw new Error(`OpenAI account sign-in is not enabled for model ${model}. Use one of ${formatOpenAiAccountSignInModels()}, or set OPENAI_API_KEY to use Platform API-key mode.`);
+      if (oauthCredential) {
+        assertModelCredentialCompatibility({
+          model,
+          provider: 'openai',
+          credentialMode: 'oauth',
+        });
       }
 
       const request = buildOpenAiResponsesRequest(messages, {
@@ -187,10 +191,6 @@ function parseStreamedToolCalls(
   }
 
   return toolCalls;
-}
-
-function formatOpenAiAccountSignInModels(): string {
-  return OPENAI_ACCOUNT_SIGN_IN_MODELS.join(', ');
 }
 
 function firstDefinedNonEmpty(...values: Array<string | undefined>): string | undefined {

--- a/src/core/prompts/system-prompt.ts
+++ b/src/core/prompts/system-prompt.ts
@@ -7,20 +7,19 @@
  * Build the system prompt for the agent.
  * Encourages purposeful tool use and a clear execution workflow.
  */
-export function buildSystemPrompt(goal: string, toolNames: string[], projectContext?: string): string {
+export function buildSystemPrompt(toolNames: string[], projectContext?: string): string {
   return `You are Heddle, a conversational coding and workspace agent.
 
 You help a user understand, inspect, change, verify, and explain work in the current project using the tools the host gives you.
 
 You are not a generic chatbot. You are an operator-facing agent working in a real workspace with traces, approvals, and tool execution.
 
-Your job is to help user completes their requested task. When the given task and the intention is clear, you should continue the work to help user complete their goal.
-
-Only stop and ask user if there's something genuinely unclear and you need clarification from the user.
 
 ## Your Goal
 
-${goal}
+Your job is to help the user complete their requested task. When the given task and intention are clear, continue the work to help the user complete their goal.
+
+Only stop and ask the user if something is genuinely unclear and you need clarification from the user.
 
 ## What Heddle Is
 
@@ -30,11 +29,7 @@ ${goal}
 - When describing capabilities to the user, start with user-facing outcomes such as inspect, explain, change, verify, or run commands. Do not lead with internal tool names or implementation details unless the user explicitly asks for technical detail.
 - If the user asks what Heddle itself is, explain it as a coding/workspace agent runtime that is still evolving, not a finished general intelligence system.
 
-## Available Tools
-
-You have access to these tools: ${toolNames.join(', ')}
-
-${projectContext ? `## Project Context\n\n${projectContext}\n\n` : ''}## Operating Principles
+## Operating Principles
 
 - Be direct, calm, and practical.
 - Prefer short progress-oriented explanations over long preambles.
@@ -121,5 +116,14 @@ If the task involved changes or verification, prefer a short summary followed by
 
 ## When to Stop
 
-When you have gathered enough information to fully answer the goal, provide your final answer as a normal message without calling any more tools. Your final message should directly answer the goal and should be useful to an operator, not just technically correct.`;
+When you have gathered enough information to fully answer the goal, provide your final answer as a normal message without calling any more tools. Your final message should directly answer the goal and should be useful to an operator, not just technically correct.
+
+## Available Tools
+
+You have access to these tools: ${toolNames.join(', ')}
+
+## Project Context
+
+${projectContext ?? 'N/A'}
+`;
 }

--- a/src/core/tools/view-image.ts
+++ b/src/core/tools/view-image.ts
@@ -13,7 +13,10 @@ import type { ToolDefinition, ToolResult } from '../types.js';
 import { OPENAI_CODEX_RESPONSES_ENDPOINT } from '../auth/openai-oauth.js';
 import { inferProviderFromModel } from '../llm/factory.js';
 import { createOpenAiOAuthFetch } from '../llm/openai.js';
-import { isOpenAiAccountSignInModel, OPENAI_ACCOUNT_SIGN_IN_MODELS } from '../llm/openai-models.js';
+import {
+  resolveOpenAiOAuthImageCandidateModels,
+  validateModelCredentialCompatibility,
+} from '../llm/model-policy.js';
 import type { LlmProvider } from '../llm/types.js';
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from '../config.js';
 import { resolveOAuthCredentialForModel, type ProviderCredentialSource } from '../runtime/api-keys.js';
@@ -34,7 +37,6 @@ export type ViewImageToolOptions = {
 
 const DEFAULT_IMAGE_PROMPT =
   'Describe the image for a coding assistant. Focus on UI text, error messages, filenames, commands, code, diagrams, and any details relevant to software work.';
-const OPENAI_OAUTH_IMAGE_MODEL_CANDIDATES = ['gpt-5.4', 'gpt-5.4-mini', ...OPENAI_ACCOUNT_SIGN_IN_MODELS];
 
 export const viewImageTool: ToolDefinition = createViewImageTool();
 
@@ -124,10 +126,16 @@ async function executeOpenAiImageView(args: {
     };
   }
 
-  if (oauthCredential && !isOpenAiAccountSignInModel(model)) {
+  const compatibility = validateModelCredentialCompatibility({
+    model,
+    provider: 'openai',
+    credentialMode: oauthCredential ? 'oauth' : undefined,
+    usageLabel: 'image inspection',
+  });
+  if (!compatibility.ok) {
     return {
       ok: false,
-      error: `OpenAI account sign-in is not enabled for model ${model}. Set OPENAI_API_KEY to use Platform API-key mode for image inspection.`,
+      error: compatibility.error,
     };
   }
 
@@ -147,7 +155,7 @@ async function executeOpenAiImageView(args: {
     fetch: oauthFetch,
   });
   const imageBase64 = args.data.toString('base64');
-  const candidateModels = oauthCredential ? uniqueModels([model, ...OPENAI_OAUTH_IMAGE_MODEL_CANDIDATES]) : [model];
+  const candidateModels = oauthCredential ? resolveOpenAiOAuthImageCandidateModels(model) : [model];
   let lastError: unknown;
 
   for (const candidateModel of candidateModels) {


### PR DESCRIPTION
## Summary

Fixes chat history compaction for large sessions and OpenAI OAuth, then centralizes system-selected model decisions so the same policy is used by compaction, title generation, OAuth validation, and image inspection.

## Actual Changes

- Reworked chat compaction in `src/core/chat/compaction.ts` to keep recent history by token budget instead of fixed message count.
- Caps and condenses archived transcript content before sending it to the summarizer, while still writing the full raw archive to disk.
- Adds repeated-compaction safeguards so rolling summaries are reused instead of repeatedly feeding all prior raw archives back into the summarizer.
- Adds conservative context-window estimates for GPT-5.4/GPT-5.4 Pro and keeps the default OpenAI API-key compaction model at `gpt-5.1-codex-mini`.
- Fixes OpenAI OAuth compaction by using a Codex-account-supported model, usually the active `gpt-5.4`, instead of `gpt-5.1-codex-mini`.
- Adds `src/core/llm/model-policy.ts` to centralize system-selected model defaults and credential compatibility checks.
- Routes session-title model selection, compaction summarizer selection, OpenAI OAuth adapter validation, and OAuth image model fallback through the centralized policy.
- Removes `gpt-5.1-codex-mini` from the OpenAI account-sign-in allowlist so unsupported OAuth usage fails locally with a clear error.
- Updates prompt/system-message tests for the moved goal handling and cached-token system prompt changes.
- Adds regression coverage for large archive summarizer input, token-budget compaction, OAuth compaction model selection, unsupported OAuth mini routing, and updated image-inspection OAuth errors.

## Root Cause

There were two separate failures behind the same UI message.

First, large sessions could write a raw archive and then fail before writing a summary or manifest because the summarizer received too much archived text. In the reported session, live history was about 3.6 MB, with roughly 3.1 MB in `history[].content` and one tool result near 890 KB.

Second, OpenAI OAuth compaction was selecting `gpt-5.1-codex-mini`. A live minimal request to the Codex OAuth backend showed that model is rejected for ChatGPT account auth, while the SDK surfaced it as the vague `400 status code (no body)`.

## Validation

- `yarn build`
- Live OAuth probe: `gpt-5.1-codex-mini` reproduced backend 400 unsupported-model response.
- Live OAuth probe: `gpt-5.4` returned 200 and `OK`.
- `npx vitest run src/__tests__/core/openai-oauth.test.ts --reporter dot --pool=forks --testTimeout=10000`
- `npx vitest run src/__tests__/chat/chat-compaction.test.ts --reporter verbose --pool=forks --testNamePattern "uses the active account-sign-in model" --testTimeout=10000`
- `npx vitest run src/__tests__/tools/tools.test.ts --reporter dot --pool=forks --testTimeout=10000`

Note: running the entire `chat-compaction.test.ts` file still hangs in this environment before final reporting; the targeted new regression passes.