### PR TITLE
[codex] Fix Windows OpenAI OAuth browser launch

### DIFF
--- a/src/__tests__/core/openai-oauth.test.ts
+++ b/src/__tests__/core/openai-oauth.test.ts
@@ -6,6 +6,7 @@ import {
   OPENAI_AUTH_ISSUER,
   OPENAI_CODEX_RESPONSES_ENDPOINT,
   OPENAI_CODEX_CLIENT_ID,
+  buildOpenUrlCommand,
   buildOpenAiAuthorizeUrl,
   createOpenAiOAuthCredential,
   exchangeOpenAiOAuthCode,
@@ -40,6 +41,18 @@ describe('OpenAI OAuth helpers', () => {
     expect(url.searchParams.get('code_challenge_method')).toBe('S256');
     expect(url.searchParams.get('codex_cli_simplified_flow')).toBe('true');
     expect(url.searchParams.get('originator')).toBe('heddle');
+  });
+
+  it('opens OAuth URLs on Windows without routing query separators through cmd.exe', () => {
+    const authorizeUrl = 'https://auth.openai.com/oauth/authorize?response_type=code&client_id=client&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback';
+    const command = buildOpenUrlCommand(authorizeUrl, 'win32');
+    const encodedCommand = command.args.at(-1);
+
+    expect(command.command).toBe('powershell.exe');
+    expect(command.args).toContain('-EncodedCommand');
+    expect(encodedCommand).toBeDefined();
+    expect(Buffer.from(encodedCommand!, 'base64').toString('utf16le')).toBe(`Start-Process -FilePath '${authorizeUrl}'`);
+    expect(command.args.join(' ')).not.toContain('cmd /c start');
   });
 
   it('extracts account id from id token claims', () => {

--- a/src/core/auth/openai-oauth.ts
+++ b/src/core/auth/openai-oauth.ts
@@ -354,16 +354,32 @@ function getServerPort(server: Server): number | undefined {
 }
 
 async function openUrlInBrowser(url: string): Promise<void> {
-  const command =
-    process.platform === 'darwin' ? 'open'
-    : process.platform === 'win32' ? 'cmd'
-    : 'xdg-open';
-  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  const { command, args } = buildOpenUrlCommand(url, process.platform);
   const child = spawn(command, args, {
     detached: true,
     stdio: 'ignore',
   });
   child.unref();
+}
+
+export function buildOpenUrlCommand(url: string, platform: NodeJS.Platform = process.platform): { command: string; args: string[] } {
+  if (platform === 'darwin') {
+    return { command: 'open', args: [url] };
+  }
+
+  if (platform === 'win32') {
+    const script = `Start-Process -FilePath '${escapePowerShellSingleQuotedString(url)}'`;
+    return {
+      command: 'powershell.exe',
+      args: ['-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')],
+    };
+  }
+
+  return { command: 'xdg-open', args: [url] };
+}
+
+function escapePowerShellSingleQuotedString(value: string): string {
+  return value.replaceAll("'", "''");
 }
 
 function renderCallbackHtml(title: string, message: string): string {


### PR DESCRIPTION
## Summary

Fixes #4.

Fixes OpenAI OAuth login on Windows by avoiding `cmd.exe` when opening the authorization URL. The previous `cmd /c start` launcher could parse OAuth query separators such as `&` before the browser received the URL, which can produce OpenAI `missing_required_parameter` errors and leave Heddle waiting until the local callback times out.

## Changes

- Route Windows browser launches through `powershell.exe Start-Process` with the OAuth URL passed as an argument.
- Keep macOS and Linux launch behavior unchanged.
- Add regression coverage for Windows OAuth URL launching.

## Validation

- `yarn test src/__tests__/core/openai-oauth.test.ts`
- `yarn build`