### PR TITLE
support OpenAI OAuth for web search

### DIFF
--- a/src/__tests__/tools/tools.test.ts
+++ b/src/__tests__/tools/tools.test.ts
@@ -423,25 +423,15 @@ describe('webSearchTool', () => {
         headers: new Headers(init?.headers),
         body: String(init?.body ?? ''),
       });
-      return Response.json({
-        id: 'resp_1',
-        object: 'response',
-        model: 'gpt-5.4',
-        output_text: 'Hosted search summary',
-        output: [{
-          type: 'message',
-          id: 'msg_1',
-          role: 'assistant',
-          content: [{
-            type: 'output_text',
-            text: 'Hosted search summary',
-            annotations: [{
-              type: 'url_citation',
-              title: 'OpenAI Docs',
-              url: 'https://platform.openai.com/docs',
-            }],
-          }],
-        }],
+      return new Response([
+        'event: response.output_item.done',
+        'data: {"type":"response.output_item.done","item":{"id":"ws_1","type":"web_search_call","status":"completed","action":{"type":"search","sources":[{"type":"url","url":"https://platform.openai.com/docs"}]}}}',
+        '',
+        'event: response.output_text.done',
+        'data: {"type":"response.output_text.done","text":"Hosted search summary"}',
+        '',
+      ].join('\n'), {
+        headers: { 'content-type': 'text/event-stream' },
       });
     });
     vi.stubGlobal('fetch', fetchImpl);
@@ -463,7 +453,7 @@ describe('webSearchTool', () => {
         provider: 'openai',
         model: 'gpt-5.4',
         summary: 'Hosted search summary',
-        citations: [{ title: 'OpenAI Docs', url: 'https://platform.openai.com/docs' }],
+        citations: [{ title: 'https://platform.openai.com/docs', url: 'https://platform.openai.com/docs' }],
       },
     });
     expect(requests).toHaveLength(1);
@@ -471,12 +461,20 @@ describe('webSearchTool', () => {
     expect(requests[0]?.headers.get('ChatGPT-Account-Id')).toBe('account-123');
     const body = JSON.parse(requests[0]?.body ?? '{}') as {
       model?: string;
-      input?: string;
+      store?: boolean;
+      stream?: boolean;
+      instructions?: string;
+      include?: string[];
+      input?: Array<{ type?: string; role?: string; content?: string }>;
       tools?: Array<{ type?: string; search_context_size?: string }>;
     };
     expect(body.model).toBe('gpt-5.4');
-    expect(body.input).toBe('OpenAI Responses API web search tool');
-    expect(body.tools).toEqual([{ type: 'web_search_preview', search_context_size: 'high' }]);
+    expect(body.store).toBe(false);
+    expect(body.stream).toBe(true);
+    expect(body.instructions).toContain('Search the web and answer concisely');
+    expect(body.include).toEqual(['web_search_call.action.sources']);
+    expect(body.input).toEqual([{ type: 'message', role: 'user', content: 'OpenAI Responses API web search tool' }]);
+    expect(body.tools).toEqual([{ type: 'web_search', search_context_size: 'high' }]);
   });
 });
 

--- a/src/__tests__/tools/tools.test.ts
+++ b/src/__tests__/tools/tools.test.ts
@@ -379,27 +379,104 @@ describe('webSearchTool', () => {
     }
   });
 
-  it('does not silently fall back to an OpenAI env key when OAuth is the active credential', async () => {
+  it('fails clearly when OAuth is active but no stored OpenAI credential can be loaded', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-web-search-oauth-missing-'));
+    const credentialStorePath = join(root, 'auth.json');
     vi.stubEnv('OPENAI_API_KEY', 'openai-key');
 
-    try {
-      const result = await createWebSearchTool({
-        model: 'gpt-5.1-codex',
-        providerCredentialSource: {
-          type: 'oauth',
-          provider: 'openai',
-          accountId: 'account-123',
-          expiresAt: Date.now() + 60_000,
-        },
-      }).execute({ query: 'OpenAI Responses API web search tool' });
+    const result = await createWebSearchTool({
+      model: 'gpt-5.4',
+      providerCredentialSource: {
+        type: 'oauth',
+        provider: 'openai',
+        accountId: 'account-123',
+        expiresAt: Date.now() + 60_000,
+      },
+      credentialStorePath,
+    }).execute({ query: 'OpenAI Responses API web search tool' });
 
-      expect(result).toEqual({
-        ok: false,
-        error: 'web_search currently requires OpenAI Platform API-key mode. The active OpenAI credential is account sign-in; set OPENAI_API_KEY or pass an explicit API key to use hosted web search.',
+    expect(result).toEqual({
+      ok: false,
+      error: 'web_search could not load the stored OpenAI account sign-in credential for this workspace. Sign in again with `heddle auth login openai`, or set OPENAI_API_KEY to use Platform API-key mode.',
+    });
+  });
+
+  it('uses the OAuth-backed OpenAI transport for web search when a stored credential is available', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-web-search-oauth-success-'));
+    const credentialStorePath = join(root, 'auth.json');
+    writeFileSync(credentialStorePath, '{}\n');
+    setStoredProviderCredential({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.now() + 120_000,
+      accountId: 'account-123',
+      createdAt: '2026-04-27T00:00:00.000Z',
+      updatedAt: '2026-04-27T00:00:00.000Z',
+    }, credentialStorePath);
+
+    const requests: Array<{ url: string; headers: Headers; body: string }> = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({
+        url: String(url),
+        headers: new Headers(init?.headers),
+        body: String(init?.body ?? ''),
       });
-    } finally {
-      vi.unstubAllEnvs();
-    }
+      return Response.json({
+        id: 'resp_1',
+        object: 'response',
+        model: 'gpt-5.4',
+        output_text: 'Hosted search summary',
+        output: [{
+          type: 'message',
+          id: 'msg_1',
+          role: 'assistant',
+          content: [{
+            type: 'output_text',
+            text: 'Hosted search summary',
+            annotations: [{
+              type: 'url_citation',
+              title: 'OpenAI Docs',
+              url: 'https://platform.openai.com/docs',
+            }],
+          }],
+        }],
+      });
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+
+    const result = await createWebSearchTool({
+      model: 'gpt-5.4',
+      providerCredentialSource: {
+        type: 'oauth',
+        provider: 'openai',
+        accountId: 'account-123',
+        expiresAt: Date.now() + 60_000,
+      },
+      credentialStorePath,
+    }).execute({ query: 'OpenAI Responses API web search tool', contextSize: 'high' });
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        provider: 'openai',
+        model: 'gpt-5.4',
+        summary: 'Hosted search summary',
+        citations: [{ title: 'OpenAI Docs', url: 'https://platform.openai.com/docs' }],
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.headers.get('authorization')).toBe('Bearer access-token');
+    expect(requests[0]?.headers.get('ChatGPT-Account-Id')).toBe('account-123');
+    const body = JSON.parse(requests[0]?.body ?? '{}') as {
+      model?: string;
+      input?: string;
+      tools?: Array<{ type?: string; search_context_size?: string }>;
+    };
+    expect(body.model).toBe('gpt-5.4');
+    expect(body.input).toBe('OpenAI Responses API web search tool');
+    expect(body.tools).toEqual([{ type: 'web_search_preview', search_context_size: 'high' }]);
   });
 });
 

--- a/src/core/llm/openai.ts
+++ b/src/core/llm/openai.ts
@@ -251,6 +251,78 @@ function shouldRouteToCodexResponses(url: URL): boolean {
   return url.pathname.endsWith('/responses') || url.pathname.endsWith('/chat/completions');
 }
 
+export async function executeOpenAiOAuthCodexSse(args: {
+  oauthFetch: ReturnType<typeof createOpenAiOAuthFetch> | undefined;
+  body: unknown;
+  endpoint?: string;
+}): Promise<string> {
+  if (!args.oauthFetch) {
+    throw new Error('Missing OAuth fetch implementation for OpenAI Codex request.');
+  }
+
+  const response = await args.oauthFetch(args.endpoint ?? OPENAI_CODEX_RESPONSES_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(args.body),
+  });
+
+  if (!response.ok) {
+    const failureBody = await response.text();
+    const failure = new Error(failureBody || `${response.status} status code (no body)`);
+    (failure as Error & { status?: number }).status = response.status;
+    throw failure;
+  }
+
+  return await response.text();
+}
+
+export function extractOpenAiCodexOutputTextFromSse(text: string): string {
+  const matches = [...text.matchAll(/^data: (\{.*"type":"response\.output_text\.done".*\})$/gm)];
+  for (let index = matches.length - 1; index >= 0; index -= 1) {
+    const raw = matches[index]?.[1];
+    if (!raw) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as { text?: unknown };
+      if (typeof parsed.text === 'string' && parsed.text.trim()) {
+        return parsed.text;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return '';
+}
+
+export function extractOpenAiCodexSseItems<T>(
+  text: string,
+  predicate: (item: unknown) => item is T,
+): T[] {
+  const items: T[] = [];
+  const matches = [...text.matchAll(/^data: (\{.*"type":"response\.output_item\.done".*\})$/gm)];
+
+  for (const match of matches) {
+    const raw = match[1];
+    if (!raw) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as { item?: unknown };
+      if (predicate(parsed.item)) {
+        items.push(parsed.item);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return items;
+}
+
 // ---------------------------------------------------------------------------
 // Internal converters
 // ---------------------------------------------------------------------------

--- a/src/core/tools/view-image.ts
+++ b/src/core/tools/view-image.ts
@@ -10,9 +10,12 @@ import type { ImageBlockParam } from '@anthropic-ai/sdk/resources/messages/messa
 import OpenAI from 'openai';
 import type { ResponseInputImage, ResponseInputText, ResponseStreamEvent } from 'openai/resources/responses/responses.js';
 import type { ToolDefinition, ToolResult } from '../types.js';
-import { OPENAI_CODEX_RESPONSES_ENDPOINT } from '../auth/openai-oauth.js';
 import { inferProviderFromModel } from '../llm/factory.js';
-import { createOpenAiOAuthFetch } from '../llm/openai.js';
+import {
+  createOpenAiOAuthFetch,
+  executeOpenAiOAuthCodexSse,
+  extractOpenAiCodexOutputTextFromSse,
+} from '../llm/openai.js';
 import {
   resolveOpenAiOAuthImageCandidateModels,
   validateModelCredentialCompatibility,
@@ -220,42 +223,30 @@ async function executeOpenAiOAuthImageStream(args: {
     throw new Error('Missing OAuth fetch implementation for OpenAI image inspection.');
   }
 
-  const headers = { 'content-type': 'application/json' };
-  const body = JSON.stringify({
-    model: args.model,
-    store: false,
-    stream: true,
-    reasoning: { summary: 'auto' },
-    instructions: 'You are a helpful vision assistant. Describe the provided screenshot briefly and focus on visible UI text, structure, and notable details.',
-    input: [{
-      type: 'message',
-      role: 'user',
-      content: [
-        { type: 'input_text', text: args.prompt } satisfies ResponseInputText,
-        {
-          type: 'input_image',
-          detail: 'auto',
-          image_url: args.imageUrl,
-        } satisfies ResponseInputImage,
-      ],
-    }],
+  const text = await executeOpenAiOAuthCodexSse({
+    oauthFetch: args.oauthFetch,
+    body: {
+      model: args.model,
+      store: false,
+      stream: true,
+      reasoning: { summary: 'auto' },
+      instructions: 'You are a helpful vision assistant. Describe the provided screenshot briefly and focus on visible UI text, structure, and notable details.',
+      input: [{
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: args.prompt } satisfies ResponseInputText,
+          {
+            type: 'input_image',
+            detail: 'auto',
+            image_url: args.imageUrl,
+          } satisfies ResponseInputImage,
+        ],
+      }],
+    },
   });
 
-  const response = await args.oauthFetch(OPENAI_CODEX_RESPONSES_ENDPOINT, {
-    method: 'POST',
-    headers,
-    body,
-  });
-
-  if (!response.ok) {
-    const failureBody = await response.text();
-    const failure = new Error(failureBody || `${response.status} status code (no body)`);
-    (failure as Error & { status?: number }).status = response.status;
-    throw failure;
-  }
-
-  const text = await response.text();
-  const outputText = extractOutputTextFromSse(text);
+  const outputText = extractOpenAiCodexOutputTextFromSse(text);
   return {
     model: args.model,
     output_text: outputText || undefined,
@@ -413,33 +404,6 @@ function readOpenAiErrorStatus(error: unknown): number | undefined {
 function formatImageViewFailure(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return `Image view failed: ${message}`;
-}
-
-function extractOutputTextFromSse(text: string): string {
-  const chunks = text.split('\n\n');
-  let output = '';
-
-  for (const chunk of chunks) {
-    const lines = chunk.split('\n');
-    const dataLine = lines.find((line) => line.startsWith('data: '));
-    if (!dataLine) {
-      continue;
-    }
-
-    try {
-      const payload = JSON.parse(dataLine.slice(6)) as ResponseStreamEvent;
-      if (payload.type === 'response.output_text.delta' && payload.delta) {
-        output += payload.delta;
-      }
-      if (payload.type === 'response.output_text.done' && payload.text) {
-        output = payload.text;
-      }
-    } catch {
-      continue;
-    }
-  }
-
-  return output.trim();
 }
 
 function readOpenAiErrorDetails(error: unknown): string | undefined {

--- a/src/core/tools/web-search.ts
+++ b/src/core/tools/web-search.ts
@@ -14,9 +14,14 @@ import OpenAI from 'openai';
 import type { Response, ResponseOutputText, WebSearchTool } from 'openai/resources/responses/responses.js';
 import type { ToolDefinition, ToolResult } from '../types.js';
 import { inferProviderFromModel } from '../llm/factory.js';
+import { createOpenAiOAuthFetch } from '../llm/openai.js';
+import { validateModelCredentialCompatibility } from '../llm/model-policy.js';
 import type { LlmProvider } from '../llm/types.js';
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from '../config.js';
-import type { ProviderCredentialSource } from '../runtime/api-keys.js';
+import {
+  resolveOAuthCredentialForModel,
+  type ProviderCredentialSource,
+} from '../runtime/api-keys.js';
 
 type WebSearchInput = {
   query: string;
@@ -28,6 +33,7 @@ export type WebSearchToolOptions = {
   provider?: LlmProvider;
   apiKey?: string;
   providerCredentialSource?: ProviderCredentialSource;
+  credentialStorePath?: string;
 };
 
 export const webSearchTool: ToolDefinition = createWebSearchTool();
@@ -87,23 +93,44 @@ export function createWebSearchTool(options: WebSearchToolOptions = {}): ToolDef
 }
 
 async function executeOpenAiWebSearch(input: WebSearchInput, options: WebSearchToolOptions): Promise<ToolResult> {
-  if (options.providerCredentialSource?.type === 'oauth') {
+  const model = options.model ?? process.env.OPENAI_WEB_SEARCH_MODEL ?? DEFAULT_OPENAI_MODEL;
+  const oauthCredential =
+    options.providerCredentialSource?.type === 'oauth' ?
+      resolveOAuthCredentialForModel(model, { storePath: options.credentialStorePath })
+    : undefined;
+
+  if (options.providerCredentialSource?.type === 'oauth' && !oauthCredential) {
     return {
       ok: false,
-      error: 'web_search currently requires OpenAI Platform API-key mode. The active OpenAI credential is account sign-in; set OPENAI_API_KEY or pass an explicit API key to use hosted web search.',
+      error: 'web_search could not load the stored OpenAI account sign-in credential for this workspace. Sign in again with `heddle auth login openai`, or set OPENAI_API_KEY to use Platform API-key mode.',
+    };
+  }
+
+  const compatibility = validateModelCredentialCompatibility({
+    model,
+    provider: 'openai',
+    credentialMode: oauthCredential ? 'oauth' : undefined,
+    usageLabel: 'web search',
+  });
+  if (!compatibility.ok) {
+    return {
+      ok: false,
+      error: compatibility.error,
     };
   }
 
   const apiKey = firstDefinedNonEmpty(options.apiKey, process.env.OPENAI_API_KEY, process.env.PERSONAL_OPENAI_API_KEY);
-  if (!apiKey) {
+  if (!oauthCredential && !apiKey) {
     return {
       ok: false,
       error: 'web_search requires OPENAI_API_KEY (or PERSONAL_OPENAI_API_KEY) when the active model provider is OpenAI.',
     };
   }
 
-  const client = new OpenAI({ apiKey });
-  const model = options.model ?? process.env.OPENAI_WEB_SEARCH_MODEL ?? DEFAULT_OPENAI_MODEL;
+  const client = new OpenAI({
+    apiKey: oauthCredential ? 'heddle-oauth-placeholder' : apiKey,
+    fetch: oauthCredential ? createOpenAiOAuthFetch(oauthCredential, { storePath: options.credentialStorePath }) : undefined,
+  });
   const response = await client.responses.create({
     model,
     input: input.query,

--- a/src/core/tools/web-search.ts
+++ b/src/core/tools/web-search.ts
@@ -12,6 +12,7 @@ import type {
 } from '@anthropic-ai/sdk/resources/messages/messages';
 import OpenAI from 'openai';
 import type { Response, ResponseOutputText, WebSearchTool } from 'openai/resources/responses/responses.js';
+import { OPENAI_CODEX_RESPONSES_ENDPOINT } from '../auth/openai-oauth.js';
 import type { ToolDefinition, ToolResult } from '../types.js';
 import { inferProviderFromModel } from '../llm/factory.js';
 import { createOpenAiOAuthFetch } from '../llm/openai.js';
@@ -119,18 +120,19 @@ async function executeOpenAiWebSearch(input: WebSearchInput, options: WebSearchT
     };
   }
 
+  if (oauthCredential) {
+    return await executeOpenAiOAuthWebSearch(input, { ...options, model }, oauthCredential);
+  }
+
   const apiKey = firstDefinedNonEmpty(options.apiKey, process.env.OPENAI_API_KEY, process.env.PERSONAL_OPENAI_API_KEY);
-  if (!oauthCredential && !apiKey) {
+  if (!apiKey) {
     return {
       ok: false,
       error: 'web_search requires OPENAI_API_KEY (or PERSONAL_OPENAI_API_KEY) when the active model provider is OpenAI.',
     };
   }
 
-  const client = new OpenAI({
-    apiKey: oauthCredential ? 'heddle-oauth-placeholder' : apiKey,
-    fetch: oauthCredential ? createOpenAiOAuthFetch(oauthCredential, { storePath: options.credentialStorePath }) : undefined,
-  });
+  const client = new OpenAI({ apiKey });
   const response = await client.responses.create({
     model,
     input: input.query,
@@ -143,6 +145,44 @@ async function executeOpenAiWebSearch(input: WebSearchInput, options: WebSearchT
   return {
     ok: true,
     output: formatOpenAiWebSearchResult(response),
+  };
+}
+
+async function executeOpenAiOAuthWebSearch(
+  input: WebSearchInput,
+  options: WebSearchToolOptions & { model: string },
+  oauthCredential: NonNullable<ReturnType<typeof resolveOAuthCredentialForModel>>,
+): Promise<ToolResult> {
+  const oauthFetch = createOpenAiOAuthFetch(oauthCredential, { storePath: options.credentialStorePath });
+  const response = await oauthFetch(OPENAI_CODEX_RESPONSES_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: options.model,
+      store: false,
+      stream: true,
+      reasoning: { summary: 'auto' },
+      instructions: 'Search the web and answer concisely with citations when available.',
+      include: ['web_search_call.action.sources'],
+      input: [{ type: 'message', role: 'user', content: input.query }],
+      tools: [{
+        type: 'web_search',
+        search_context_size: input.contextSize ?? 'medium',
+      }],
+    }),
+  });
+
+  if (!response.ok) {
+    const failureBody = await response.text();
+    const failure = new Error(failureBody || `${response.status} status code (no body)`);
+    (failure as Error & { status?: number }).status = response.status;
+    throw failure;
+  }
+
+  const sseText = await response.text();
+  return {
+    ok: true,
+    output: formatOpenAiOAuthWebSearchSseResult(sseText, options.model),
   };
 }
 
@@ -248,6 +288,86 @@ function extractOpenAiUrlCitations(response: Response): Array<{ title: string; u
           url: annotation.url,
         });
       }
+    }
+  }
+
+  return citations;
+}
+
+function formatOpenAiOAuthWebSearchSseResult(sseText: string, model: string): {
+  provider: 'openai';
+  model: string;
+  summary: string;
+  citations: Array<{ title: string; url: string }>;
+} {
+  return {
+    provider: 'openai',
+    model,
+    summary: extractSseOutputText(sseText)?.trim() || 'No summary returned.',
+    citations: extractSseWebSearchSources(sseText),
+  };
+}
+
+function extractSseOutputText(sseText: string): string | undefined {
+  const matches = [...sseText.matchAll(/^data: (\{.*"type":"response\.output_text\.done".*\})$/gm)];
+  for (let index = matches.length - 1; index >= 0; index -= 1) {
+    const raw = matches[index]?.[1];
+    if (!raw) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as { text?: unknown };
+      if (typeof parsed.text === 'string' && parsed.text.trim()) {
+        return parsed.text;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
+}
+
+function extractSseWebSearchSources(sseText: string): Array<{ title: string; url: string }> {
+  const citations: Array<{ title: string; url: string }> = [];
+  const seen = new Set<string>();
+  const matches = [...sseText.matchAll(/^data: (\{.*"type":"response\.output_item\.done".*\})$/gm)];
+
+  for (const match of matches) {
+    const raw = match[1];
+    if (!raw) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as {
+        item?: {
+          type?: string;
+          action?: {
+            sources?: Array<{ type?: string; url?: string }>;
+          };
+        };
+      };
+      if (parsed.item?.type !== 'web_search_call') {
+        continue;
+      }
+
+      for (const source of parsed.item.action?.sources ?? []) {
+        if (source.type !== 'url' || !source.url) {
+          continue;
+        }
+        if (seen.has(source.url)) {
+          continue;
+        }
+        seen.add(source.url);
+        citations.push({
+          title: source.url,
+          url: source.url,
+        });
+      }
+    } catch {
+      continue;
     }
   }
 

--- a/src/core/tools/web-search.ts
+++ b/src/core/tools/web-search.ts
@@ -12,10 +12,14 @@ import type {
 } from '@anthropic-ai/sdk/resources/messages/messages';
 import OpenAI from 'openai';
 import type { Response, ResponseOutputText, WebSearchTool } from 'openai/resources/responses/responses.js';
-import { OPENAI_CODEX_RESPONSES_ENDPOINT } from '../auth/openai-oauth.js';
 import type { ToolDefinition, ToolResult } from '../types.js';
 import { inferProviderFromModel } from '../llm/factory.js';
-import { createOpenAiOAuthFetch } from '../llm/openai.js';
+import {
+  createOpenAiOAuthFetch,
+  executeOpenAiOAuthCodexSse,
+  extractOpenAiCodexOutputTextFromSse,
+  extractOpenAiCodexSseItems,
+} from '../llm/openai.js';
 import { validateModelCredentialCompatibility } from '../llm/model-policy.js';
 import type { LlmProvider } from '../llm/types.js';
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from '../config.js';
@@ -154,10 +158,9 @@ async function executeOpenAiOAuthWebSearch(
   oauthCredential: NonNullable<ReturnType<typeof resolveOAuthCredentialForModel>>,
 ): Promise<ToolResult> {
   const oauthFetch = createOpenAiOAuthFetch(oauthCredential, { storePath: options.credentialStorePath });
-  const response = await oauthFetch(OPENAI_CODEX_RESPONSES_ENDPOINT, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
+  const sseText = await executeOpenAiOAuthCodexSse({
+    oauthFetch,
+    body: {
       model: options.model,
       store: false,
       stream: true,
@@ -169,17 +172,8 @@ async function executeOpenAiOAuthWebSearch(
         type: 'web_search',
         search_context_size: input.contextSize ?? 'medium',
       }],
-    }),
+    },
   });
-
-  if (!response.ok) {
-    const failureBody = await response.text();
-    const failure = new Error(failureBody || `${response.status} status code (no body)`);
-    (failure as Error & { status?: number }).status = response.status;
-    throw failure;
-  }
-
-  const sseText = await response.text();
   return {
     ok: true,
     output: formatOpenAiOAuthWebSearchSseResult(sseText, options.model),
@@ -303,71 +297,37 @@ function formatOpenAiOAuthWebSearchSseResult(sseText: string, model: string): {
   return {
     provider: 'openai',
     model,
-    summary: extractSseOutputText(sseText)?.trim() || 'No summary returned.',
+    summary: extractOpenAiCodexOutputTextFromSse(sseText).trim() || 'No summary returned.',
     citations: extractSseWebSearchSources(sseText),
   };
-}
-
-function extractSseOutputText(sseText: string): string | undefined {
-  const matches = [...sseText.matchAll(/^data: (\{.*"type":"response\.output_text\.done".*\})$/gm)];
-  for (let index = matches.length - 1; index >= 0; index -= 1) {
-    const raw = matches[index]?.[1];
-    if (!raw) {
-      continue;
-    }
-
-    try {
-      const parsed = JSON.parse(raw) as { text?: unknown };
-      if (typeof parsed.text === 'string' && parsed.text.trim()) {
-        return parsed.text;
-      }
-    } catch {
-      continue;
-    }
-  }
-
-  return undefined;
 }
 
 function extractSseWebSearchSources(sseText: string): Array<{ title: string; url: string }> {
   const citations: Array<{ title: string; url: string }> = [];
   const seen = new Set<string>();
-  const matches = [...sseText.matchAll(/^data: (\{.*"type":"response\.output_item\.done".*\})$/gm)];
 
-  for (const match of matches) {
-    const raw = match[1];
-    if (!raw) {
-      continue;
-    }
+  const items = extractOpenAiCodexSseItems<{
+    type: 'web_search_call';
+    action?: { sources?: Array<{ type?: string; url?: string }> };
+  }>(
+    sseText,
+    (item): item is { type: 'web_search_call'; action?: { sources?: Array<{ type?: string; url?: string }> } } =>
+      Boolean(item && typeof item === 'object' && (item as { type?: unknown }).type === 'web_search_call'),
+  );
 
-    try {
-      const parsed = JSON.parse(raw) as {
-        item?: {
-          type?: string;
-          action?: {
-            sources?: Array<{ type?: string; url?: string }>;
-          };
-        };
-      };
-      if (parsed.item?.type !== 'web_search_call') {
+  for (const item of items) {
+    for (const source of item.action?.sources ?? []) {
+      if (source.type !== 'url' || !source.url) {
         continue;
       }
-
-      for (const source of parsed.item.action?.sources ?? []) {
-        if (source.type !== 'url' || !source.url) {
-          continue;
-        }
-        if (seen.has(source.url)) {
-          continue;
-        }
-        seen.add(source.url);
-        citations.push({
-          title: source.url,
-          url: source.url,
-        });
+      if (seen.has(source.url)) {
+        continue;
       }
-    } catch {
-      continue;
+      seen.add(source.url);
+      citations.push({
+        title: source.url,
+        url: source.url,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- add OpenAI OAuth/account-sign-in support to `web_search`
- use the Codex-compatible OAuth request shape for hosted web search (`tools: [{ type: "web_search" }]`, `stream: true`, `instructions`, and `include: ["web_search_call.action.sources"]`)
- parse OAuth/Codex SSE output for final summary text and consulted source URLs
- refactor shared Codex/OpenAI OAuth SSE execution + parsing into reusable helpers used by both `web_search` and `view_image`

## Details
This PR ended up covering three slices of the same OAuth web-search work:
1. initial OpenAI OAuth wiring for `web_search`
2. fixing OAuth response parsing so live web search returns real summary/citations instead of an empty result
3. centralizing shared Codex/OAuth SSE handling so future OAuth-backed tools can reuse the same path

Shared helper additions live in:
- `src/core/llm/openai.ts`

Updated tool consumers:
- `src/core/tools/web-search.ts`
- `src/core/tools/view-image.ts`

## Verification
### Automated
- `yarn vitest run src/__tests__/tools/tools.test.ts src/__tests__/core/openai-oauth.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit`

### Live
After restarting chat against the updated branch:
- `web_search` succeeded under OpenAI OAuth and returned a real summary plus citations
- `view_image` also succeeded under OpenAI OAuth on a local GitHub PR screenshot, confirming the shared helper refactor did not break image inspection
