### PR TITLE
address repeated identical tool-call blocking

### DIFF
--- a/docs/issue-7-notes.md
+++ b/docs/issue-7-notes.md
@@ -1,0 +1,7 @@
+# Issue #7 branch notes
+
+Tracking issue: #7
+
+Purpose: isolate investigation and follow-up work for the runtime behavior that still blocks repeated identical tool calls after two attempts.
+
+This branch exists so the issue can have its own PR/workstream separate from the OAuth web-search changes.

--- a/docs/issue-7-notes.md
+++ b/docs/issue-7-notes.md
@@ -1,7 +1,0 @@
-# Issue #7 branch notes
-
-Tracking issue: #7
-
-Purpose: isolate investigation and follow-up work for the runtime behavior that still blocks repeated identical tool calls after two attempts.
-
-This branch exists so the issue can have its own PR/workstream separate from the OAuth web-search changes.

--- a/src/__tests__/agent/run-agent.test.ts
+++ b/src/__tests__/agent/run-agent.test.ts
@@ -299,11 +299,13 @@ describe('runAgent', () => {
       },
     };
 
+    let executions = 0;
     const listFilesTool: ToolDefinition = {
       name: 'list_files',
       description: 'Lists files in a directory',
       parameters: { type: 'object', properties: {} },
       async execute() {
+        executions += 1;
         return { ok: true, output: 'README.md\nsrc/' };
       },
     };
@@ -318,12 +320,12 @@ describe('runAgent', () => {
 
     expect(result.outcome).toBe('done');
     expect(result.summary).toBe('I should stop repeating the same directory listing.');
+    expect(executions).toBe(3);
     expect(seenMessages[3]).toContainEqual({
       role: 'tool',
       content: JSON.stringify({
-        ok: false,
-        error:
-          'Repeated tool call blocked: list_files was already called 2 times with the same input earlier in this run. Try a different tool or different input.',
+        ok: true,
+        output: 'README.md\nsrc/',
       }),
       toolCallId: 'call-3',
     });
@@ -331,15 +333,15 @@ describe('runAgent', () => {
       type: 'tool.result',
       tool: 'list_files',
       result: {
-        ok: false,
-        error:
-          'Repeated tool call blocked: list_files was already called 2 times with the same input earlier in this run. Try a different tool or different input.',
+        ok: true,
+        output: 'README.md\nsrc/',
       },
     });
   });
 
-  it('normalizes equivalent path spellings and only blocks them after repeated retries', async () => {
+  it('normalizes equivalent path spellings but still allows repeated equivalent tool calls', async () => {
     const seenMessages: ChatMessage[][] = [];
+    let executions = 0;
     const fakeLlm: LlmAdapter = {
       async chat(messages): Promise<LlmResponse> {
         seenMessages.push(structuredClone(messages));
@@ -373,6 +375,7 @@ describe('runAgent', () => {
       description: 'Lists files in a directory',
       parameters: { type: 'object', properties: {} },
       async execute() {
+        executions += 1;
         return { ok: true, output: 'README.md\nsrc/' };
       },
     };
@@ -386,12 +389,12 @@ describe('runAgent', () => {
     });
 
     expect(result.outcome).toBe('done');
+    expect(executions).toBe(3);
     expect(seenMessages[3]).toContainEqual({
       role: 'tool',
       content: JSON.stringify({
-        ok: false,
-        error:
-          'Repeated tool call blocked: list_files was already called 2 times with the same input earlier in this run. Try a different tool or different input.',
+        ok: true,
+        output: 'README.md\nsrc/',
       }),
       toolCallId: 'call-3',
     });

--- a/src/__tests__/agent/run-agent.test.ts
+++ b/src/__tests__/agent/run-agent.test.ts
@@ -453,6 +453,50 @@ describe('runAgent', () => {
     });
   });
 
+  it('warns after 3 consecutive tool errors but still lets the agent continue', async () => {
+    const seenMessages: ChatMessage[][] = [];
+    const fakeLlm: LlmAdapter = {
+      async chat(messages): Promise<LlmResponse> {
+        seenMessages.push(structuredClone(messages));
+
+        if (seenMessages.length <= 3) {
+          return {
+            toolCalls: [{ id: `call-${seenMessages.length}`, tool: 'list_files', input: { path: '.' } }],
+          };
+        }
+
+        return {
+          content: 'I saw the warning and changed approach instead of being stopped.',
+        };
+      },
+    };
+
+    const listFilesTool: ToolDefinition = {
+      name: 'list_files',
+      description: 'Lists files in a directory',
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        return { ok: false, error: 'Transient tool failure while listing files.' };
+      },
+    };
+
+    const result = await runAgent({
+      goal: 'Inspect this repo.',
+      llm: fakeLlm,
+      tools: [listFilesTool],
+      maxSteps: 5,
+      logger: silentLogger,
+    });
+
+    expect(result.outcome).toBe('done');
+    expect(result.summary).toBe('I saw the warning and changed approach instead of being stopped.');
+    expect(seenMessages[3]).toContainEqual({
+      role: 'system',
+      content:
+        'Host warning: there have been 3 consecutive tool errors; latest error: Transient tool failure while listing files.. Try a different approach, different tool, narrower scope, or use report_state if you are genuinely blocked. Do not stop solely because of this warning.',
+    });
+  });
+
   it('adds a follow-through reminder after report_state so the next turn acts on the named blocker', async () => {
     const seenMessages: ChatMessage[][] = [];
     const fakeLlm: LlmAdapter = {

--- a/src/core/agent/run-agent.ts
+++ b/src/core/agent/run-agent.ts
@@ -339,13 +339,7 @@ function handleDeniedToolResult(
   result: ToolResult,
 ): RunResult | undefined {
   context.state.consecutiveErrors++;
-  const maybeFailure = maybeFinishAfterConsecutiveErrors(
-    context,
-    `Stopped after ${MAX_CONSECUTIVE_ERRORS} consecutive tool errors. Last error: ${result.error}`,
-  );
-  if (maybeFailure) {
-    return maybeFailure;
-  }
+  pushConsecutiveErrorWarning(context, result.error);
 
   context.messages.push({
     role: 'tool',
@@ -461,12 +455,10 @@ function handleFailedToolExecution(context: RunContext, result: ToolResult): Run
     });
   } else {
     context.state.consecutiveErrors++;
+    pushConsecutiveErrorWarning(context, result.error);
   }
 
-  return maybeFinishAfterConsecutiveErrors(
-    context,
-    `Stopped after ${MAX_CONSECUTIVE_ERRORS} consecutive tool errors. Last error: ${result.error}`,
-  );
+  return undefined;
 }
 
 function pushProgressReminders(context: RunContext, effectiveCall: ToolCall, result: ToolResult) {
@@ -603,12 +595,16 @@ function finishInterrupted(context: RunContext, logMessage: string): RunResult {
   });
 }
 
-function maybeFinishAfterConsecutiveErrors(context: RunContext, summary: string): RunResult | undefined {
+function pushConsecutiveErrorWarning(context: RunContext, error: string | undefined) {
   if (context.state.consecutiveErrors < MAX_CONSECUTIVE_ERRORS) {
-    return undefined;
+    return;
   }
 
-  return finishRun(context, 'error', summary);
+  context.messages.push({
+    role: 'system',
+    content:
+      `Host warning: there have been ${context.state.consecutiveErrors} consecutive tool errors${error ? `; latest error: ${error}` : ''}. Try a different approach, different tool, narrower scope, or use report_state if you are genuinely blocked. Do not stop solely because of this warning.`,
+  });
 }
 
 function detectActionlessCompletion(

--- a/src/core/agent/tool-dispatch.ts
+++ b/src/core/agent/tool-dispatch.ts
@@ -8,10 +8,8 @@ import type { ToolDefinition, ToolCall, TraceEvent } from '../types.js';
 import type { RunAgentOptions } from './run-agent.js';
 import { createToolRegistry } from '../tools/registry.js';
 import { executeTool } from '../tools/execute-tool.js';
-import { stableSerialize, normalizeToolInput, buildRepeatedToolCallResult } from './util.js';
+import { stableSerialize, normalizeToolInput } from './util.js';
 import type { Logger } from 'pino';
-
-const MAX_IDENTICAL_TOOL_CALLS = 2;
 
 export async function maybeDenyToolCall(args: {
   call: ToolCall;
@@ -121,9 +119,14 @@ async function executeRecordedToolCall(
 
   const signature = `${call.tool}:${stableSerialize(normalizeToolInput(call.tool, call.input))}`;
   const seenCount = seenToolCalls.get(signature) ?? 0;
-  const result = seenCount >= MAX_IDENTICAL_TOOL_CALLS
-    ? buildRepeatedToolCallResult(call.tool)
-    : await executeTool(registry, call);
+  if (seenCount >= 2) {
+    log.warn(
+      { step, tool: call.tool, repeatCount: seenCount + 1 },
+      'Executing repeated identical tool call; warning only',
+    );
+  }
+
+  const result = await executeTool(registry, call);
   seenToolCalls.set(signature, seenCount + 1);
   log.debug({ step, tool: call.tool, ok: result.ok }, 'Tool result');
   record({ type: 'tool.result', tool: call.tool, result, step, timestamp: now() });

--- a/src/core/agent/util.ts
+++ b/src/core/agent/util.ts
@@ -60,7 +60,7 @@ export function isRecoverableToolError(error: string | undefined): boolean {
     return false;
   }
 
-  return error.startsWith('Invalid input for ') || error.startsWith('Repeated tool call blocked:');
+  return error.startsWith('Invalid input for ');
 }
 
 export function isAbortError(err: unknown): boolean {
@@ -75,9 +75,3 @@ export function isAbortError(err: unknown): boolean {
   );
 }
 
-export function buildRepeatedToolCallResult(tool: string): { ok: false; error: string } {
-  return {
-    ok: false,
-    error: `Repeated tool call blocked: ${tool} was already called ${2} times with the same input earlier in this run. Try a different tool or different input.`,
-  };
-}


### PR DESCRIPTION
Closes #7

## Summary
- stop hard-blocking repeated identical tool calls after two attempts
- stop hard-terminating the run after 3 consecutive tool errors
- convert both behaviors into warning-only guidance so the agent can continue and try a different approach

## Behavior changes
### Repeated identical tool calls
Before:
- the runtime returned `Repeated tool call blocked: ...` after the same normalized tool/input pair was seen twice

Now:
- repeated identical tool calls still execute
- the runtime only logs a warning internally when the repeat count is high
- the agent is no longer prevented from re-running the same bounded tool call when it is actually needed

### Consecutive tool errors
Before:
- the runtime stopped the run after `MAX_CONSECUTIVE_ERRORS = 3`

Now:
- the run continues
- after 3 consecutive non-recoverable tool errors, the agent receives a system warning in-context telling it to try a different approach, tool, narrower scope, or `report_state` if genuinely blocked
- the warning does not terminate the run on its own

## Files changed
- `src/core/agent/tool-dispatch.ts`
- `src/core/agent/run-agent.ts`
- `src/core/agent/util.ts`
- `src/__tests__/agent/run-agent.test.ts`

## Verification
- `yarn vitest run src/__tests__/agent/run-agent.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit`

## Rationale
This keeps host guidance visible to the agent without turning reminder/loop-protection heuristics into hard blockers that prevent legitimate debugging, retries, or operator-directed persistence.
