### PR TITLE
tighten record_knowledge sourceRef validation

### DIFF
--- a/src/__tests__/tools/tools.test.ts
+++ b/src/__tests__/tools/tools.test.ts
@@ -886,6 +886,17 @@ describe('memory note tools', () => {
       ok: false,
       error: expect.stringContaining('unsafe sourceRef'),
     });
+    await expect(tool.execute({ summary: 'ok', sourceRefs: ['/tmp/outside.md'] })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('unsafe sourceRef'),
+    });
+    await expect(tool.execute({ summary: 'ok', sourceRefs: ['https://example.com/file.md'] })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('unsafe sourceRef'),
+    });
+    await expect(tool.execute({ summary: 'ok', sourceRefs: ['trace-123', 'session-456', 'command:git status'] })).resolves.toMatchObject({
+      ok: true,
+    });
   });
 
   it('refuses secret-like record_knowledge content', async () => {

--- a/src/core/tools/record-knowledge.ts
+++ b/src/core/tools/record-knowledge.ts
@@ -200,20 +200,20 @@ function isSafeSourceRef(value: string, memoryRoot: string): boolean {
     return false;
   }
 
-  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
+  if (value.startsWith('trace-') || value.startsWith('session-') || value.startsWith('command:')) {
     return true;
   }
 
-  if (value.startsWith('trace-') || value.startsWith('session-') || value.startsWith('command:')) {
-    return true;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
+    return false;
   }
 
   if (isAbsolute(value)) {
     return false;
   }
 
-  const resolved = resolve(memoryRoot, '..', '..', value);
   const workspaceRoot = resolve(memoryRoot, '..', '..');
+  const resolved = resolve(workspaceRoot, value);
   const rel = relative(workspaceRoot, resolved);
   return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
 }

--- a/src/core/tools/record-knowledge.ts
+++ b/src/core/tools/record-knowledge.ts
@@ -212,6 +212,11 @@ function isSafeSourceRef(value: string, memoryRoot: string): boolean {
     return false;
   }
 
+  const normalizedSegments = value.replace(/\\/g, '/').split('/');
+  if (normalizedSegments.includes('..')) {
+    return false;
+  }
+
   const workspaceRoot = resolve(memoryRoot, '..', '..');
   const resolved = resolve(workspaceRoot, value);
   const rel = relative(workspaceRoot, resolved);


### PR DESCRIPTION
## Summary
- tighten `record_knowledge` sourceRef validation so only workspace-relative paths and explicit non-path references are allowed
- add coverage for additional unsafe sourceRef shapes

## Details
This change keeps `record_knowledge` focused on safe, local provenance references.

Behavior tightened:
- reject absolute paths
- reject path traversal outside the workspace
- reject URI-style refs like `https://...`

Still allowed:
- workspace-relative paths
- explicit non-path references already used by the runtime such as `trace-*`, `session-*`, and `command:*`

## Files changed
- `src/core/tools/record-knowledge.ts`
- `src/__tests__/tools/tools.test.ts`

## Verification
- `yarn vitest run src/__tests__/tools/tools.test.ts -t "rejects invalid record_knowledge input and unsafe source refs"`
- `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit`
