### PR TITLE
Fix OAuth credential store path for ask flows

### DIFF
--- a/src/__tests__/agent/agent-loop.test.ts
+++ b/src/__tests__/agent/agent-loop.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { runAgentLoop } from '../../core/runtime/agent-loop.js';
 import { createAgentLoopCheckpoint, getHistoryFromAgentLoopCheckpoint, getHistoryFromAgentLoopState } from '../../core/runtime/events.js';
@@ -12,6 +15,7 @@ const silentLogger = createLogger({ level: 'silent', console: false });
 
 describe('runAgentLoop', () => {
   it('runs through the public execution loop and emits loop events around trace events', async () => {
+    const workspaceRoot = resolve('/tmp/heddle-loop-test');
     const seenMessages: ChatMessage[][] = [];
     const events: AgentLoopEvent[] = [];
     const fakeLlm: LlmAdapter = {
@@ -62,7 +66,7 @@ describe('runAgentLoop', () => {
       includeDefaultTools: false,
       maxSteps: 3,
       logger: silentLogger,
-      workspaceRoot: '/tmp/heddle-loop-test',
+      workspaceRoot,
       onEvent: (event) => events.push(event),
     });
 
@@ -75,7 +79,7 @@ describe('runAgentLoop', () => {
       goal: 'Use the echo tool.',
       model: 'gpt-test',
       provider: 'openai',
-      workspaceRoot: '/tmp/heddle-loop-test',
+      workspaceRoot,
       outcome: 'done',
       summary: 'Done.',
     });
@@ -86,7 +90,7 @@ describe('runAgentLoop', () => {
       goal: 'Use the echo tool.',
       model: 'gpt-test',
       provider: 'openai',
-      workspaceRoot: '/tmp/heddle-loop-test',
+      workspaceRoot,
     });
     expect(events.some((event) => event.type === 'trace' && event.event.type === 'tool.call')).toBe(true);
     expect(events.at(-1)).toMatchObject({
@@ -144,6 +148,42 @@ describe('runAgentLoop', () => {
       text: 'Hello',
       done: true,
     }));
+  });
+
+  it('does not treat the workspace state directory as the OAuth credential store', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'heddle-loop-state-dir-'));
+    await mkdir(join(workspaceRoot, '.heddle'));
+
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-5.5',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: false,
+          parallelToolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        return { content: 'Done.' };
+      },
+    };
+
+    await expect(runAgentLoop({
+      goal: 'Use the fake LLM.',
+      model: 'gpt-5.5',
+      llm: fakeLlm,
+      tools: [],
+      includeDefaultTools: false,
+      maxSteps: 1,
+      logger: silentLogger,
+      workspaceRoot,
+      stateDir: '.heddle',
+    })).resolves.toMatchObject({
+      outcome: 'done',
+      summary: 'Done.',
+    });
   });
 
   it('can resume a later run from a prior serializable checkpoint', async () => {

--- a/src/core/agent/tool-dispatch.ts
+++ b/src/core/agent/tool-dispatch.ts
@@ -3,7 +3,7 @@
 // for the agent loop.
 // ---------------------------------------------------------------------------
 
-import { resolve } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 import type { ToolDefinition, ToolCall, TraceEvent } from '../types.js';
 import type { RunAgentOptions } from './run-agent.js';
 import { createToolRegistry } from '../tools/registry.js';
@@ -189,7 +189,8 @@ function isOutsideWorkspaceInspectionCall(call: ToolCall, workspaceRoot = proces
 
   const resolvedWorkspaceRoot = resolve(workspaceRoot);
   const resolvedTarget = resolve(resolvedWorkspaceRoot, rawPath);
-  return resolvedTarget !== resolvedWorkspaceRoot && !resolvedTarget.startsWith(`${resolvedWorkspaceRoot}/`);
+  const relativeTarget = relative(resolvedWorkspaceRoot, resolvedTarget);
+  return relativeTarget.startsWith('..') || isAbsolute(relativeTarget);
 }
 
 function getInspectFallbackReason(

--- a/src/core/chat/session-submit.ts
+++ b/src/core/chat/session-submit.ts
@@ -81,7 +81,7 @@ export async function submitChatSessionPrompt(args: SubmitChatSessionPromptArgs)
     sessions.map((candidate) => candidate.id === session.id ? leasedSession : candidate),
   );
 
-  const llm = createLlmAdapter({ model, apiKey, credentialStorePath: args.stateRoot });
+  const llm = createLlmAdapter({ model, apiKey });
   const memoryDir = join(args.stateRoot, 'memory');
   const systemContext = appendMemoryCatalogSystemContext({
     systemContext: args.systemContext,
@@ -91,7 +91,6 @@ export async function submitChatSessionPrompt(args: SubmitChatSessionPromptArgs)
     model,
     apiKey,
     providerCredentialSource,
-    credentialStorePath: args.stateRoot,
     workspaceRoot: args.workspaceRoot,
     memoryDir,
     searchIgnoreDirs: [],

--- a/src/core/runtime/agent-loop.ts
+++ b/src/core/runtime/agent-loop.ts
@@ -59,12 +59,10 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<AgentL
   const providerCredentialSource = resolveProviderCredentialSourceForModel(model, {
     apiKey,
     apiKeyProvider: options.apiKey ? 'explicit' : apiKey ? provider : undefined,
-    credentialStorePath: options.stateDir ? resolve(workspaceRoot, options.stateDir) : undefined,
   });
   const llm = options.llm ?? await createLoopLlmAdapter({
     model,
     apiKey,
-    credentialStorePath: options.stateDir ? resolve(workspaceRoot, options.stateDir) : undefined,
   });
   const logger = options.logger ?? createLogger({ pretty: false, level: 'info', console: false });
   const tools = await resolveTools({
@@ -250,7 +248,6 @@ async function resolveTools(
       model: options.model,
       apiKey: options.apiKey,
       providerCredentialSource: options.providerCredentialSource,
-      credentialStorePath: options.stateDir ? resolve(options.workspaceRoot, options.stateDir) : undefined,
       workspaceRoot: options.workspaceRoot,
       stateDir: options.stateDir,
       memoryDir: options.memoryDir,


### PR DESCRIPTION
## Summary

Fixes a Windows `heddle ask` crash when using OpenAI OAuth credentials.

`heddle auth status` correctly reads credentials from the user-level auth store:

```text
C:\Users\Wells\.heddle\auth.json
```

But `heddle ask` was passing the workspace state directory as `credentialStorePath`, causing the OAuth credential loader to try reading the workspace `.heddle` directory as a file. On Windows this exits with:

```text
Fatal error: EISDIR: illegal operation on a directory, read
```

This PR keeps workspace state paths separate from the provider credential store path in ask/runtime flows, so OAuth lookup falls back to the default user-level auth store unless an explicit credential-store file path is provided.

It also updates the outside-workspace inspection check to use `path.relative()`/`path.isAbsolute()` instead of a hard-coded `/` prefix check, so workspace-local reads are not misclassified on Windows paths.

## Reproduction

```powershell
cd C:\Users\Wells\Projects\Heddle
heddle auth status
heddle --model gpt-5.5 --max-steps 1 ask "請先讀 README.md，回覆這個專案是做什麼的。"
```

Observed before this patch:

```text
model: "gpt-5.5"
provider: "openai"
cwd: "C:\Users\Wells\Projects\Heddle"
Fatal error: EISDIR: illegal operation on a directory, read
```

## Stack trace from direct `runAskCli` invocation

```text
Error: EISDIR: illegal operation on a directory, read
    at readFileSync (node:fs:442:20)
    at readProviderCredentialStore (.../dist/src/core/auth/provider-credentials.js:19:31)
    at getStoredProviderCredential (.../dist/src/core/auth/provider-credentials.js:28:12)
    at resolveOAuthCredentialForModel (.../dist/src/core/runtime/api-keys.js:27:24)
    at resolveProviderCredentialSourceForModel (.../dist/src/core/runtime/api-keys.js:47:29)
    at runAgentLoop (.../dist/src/core/runtime/agent-loop.js:14:38)
    at runAskCli (.../dist/src/cli/ask.js:97:26)
```

## Validation

```text
yarn vitest run src/__tests__/agent/agent-loop.test.ts
yarn typecheck
yarn build
yarn eslint
```

`yarn eslint` reports 0 errors and 2 existing React hook dependency warnings in unrelated files.

Manual patched CLI verification:

```powershell
node dist\src\cli\main.js --model gpt-5.5 --max-steps 1 ask "請先讀 README.md，回覆這個專案是做什麼的。"
```

Result: `credentialSource: "oauth"`, `read_file README.md` succeeds, and no `EISDIR` occurs.