### PR TITLE
Centralize OAuth model compatibility

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['dist/**', 'coverage/**', 'node_modules/**', 'local/**', 'test-results/**'],
+    ignores: ['dist/**', 'coverage/**', 'node_modules/**', 'local/**', 'test-results/**', 'evals/results/**'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/src/__tests__/integration/web/control-plane-sessions-screen.test.tsx
+++ b/src/__tests__/integration/web/control-plane-sessions-screen.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatSessionDetail, ChatTurnReview, ControlPlaneState } from '../../../web/lib/api.js';
 import { SessionsScreen } from '../../../web/features/control-plane/screens/SessionsScreen.js';
@@ -65,7 +65,7 @@ const turnReview: ChatTurnReview = {
 describe('SessionsScreen review UI', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(fetchModelOptions).mockResolvedValue({ groups: [{ label: 'OpenAI', models: ['gpt-5.4'], options: [{ id: 'gpt-5.4', disabled: false }] }] });
+    vi.mocked(fetchModelOptions).mockResolvedValue({ groups: [{ label: 'OpenAI', models: ['gpt-5.4', 'gpt-5.5-pro'], options: [{ id: 'gpt-5.4', disabled: false }, { id: 'gpt-5.5-pro', disabled: false }] }] });
     vi.mocked(fetchWorkspaceChanges).mockResolvedValue({
       vcs: 'git',
       clean: false,
@@ -103,6 +103,11 @@ describe('SessionsScreen review UI', () => {
         sendingPrompt={false}
         runInFlight={false}
         memoryUpdating={false}
+        auth={{
+          preferApiKey: false,
+          openai: { type: 'oauth', provider: 'openai', accountId: 'acct-12345678', expiresAt: Date.now() + 60_000 },
+          anthropic: { type: 'missing', provider: 'anthropic' },
+        }}
         onSendPrompt={async () => undefined}
         creatingSession={false}
         onCreateSession={async () => undefined}
@@ -134,6 +139,11 @@ describe('SessionsScreen review UI', () => {
     await waitFor(() => {
       expect(fetchWorkspaceChanges).toHaveBeenCalledTimes(2);
     });
+
+    fireEvent.click(screen.getByRole('button', { name: 'model' }));
+    const modelListbox = screen.getByRole('listbox', { name: 'Model options' });
+    const unsupportedOption = within(modelListbox).getByRole('option', { name: /gpt-5.5-pro/i });
+    expect(unsupportedOption.getAttribute('disabled')).not.toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Turn history' }));
     await waitFor(() => {

--- a/src/__tests__/integration/web/control-plane-sessions-screen.test.tsx
+++ b/src/__tests__/integration/web/control-plane-sessions-screen.test.tsx
@@ -65,7 +65,7 @@ const turnReview: ChatTurnReview = {
 describe('SessionsScreen review UI', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(fetchModelOptions).mockResolvedValue({ groups: [] });
+    vi.mocked(fetchModelOptions).mockResolvedValue({ groups: [{ label: 'OpenAI', models: ['gpt-5.4'], options: [{ id: 'gpt-5.4', disabled: false }] }] });
     vi.mocked(fetchWorkspaceChanges).mockResolvedValue({
       vcs: 'git',
       clean: false,

--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -60,7 +60,7 @@ describe('llm adapter factory', () => {
     expect(option).toEqual({
       id: 'gpt-5.4-pro',
       disabled: true,
-      disabledReason: 'Not supported in OAuth mode',
+      disabledReason: 'Not supported',
       label: undefined,
     });
   });

--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createAnthropicAdapter } from '../../../core/llm/anthropic.js';
 import { createLlmAdapter, inferProviderFromModel, resolveLlmProvider } from '../../../core/llm/factory.js';
+import { buildCredentialAwareModelOption, resolveCompatibleActiveModel } from '../../../core/llm/model-policy.js';
 
 describe('llm adapter factory', () => {
   it('infers provider from known model prefixes', () => {
@@ -47,5 +48,31 @@ describe('llm adapter factory', () => {
     const adapter = createAnthropicAdapter({ model: 'claude-sonnet-4-6', apiKey: 'test-key' });
     expect(adapter.info?.provider).toBe('anthropic');
     expect(adapter.info?.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('marks unsupported OAuth models as disabled in credential-aware options', () => {
+    const option = buildCredentialAwareModelOption({
+      model: 'gpt-5.4-pro',
+      provider: 'openai',
+      credentialMode: 'oauth',
+    });
+
+    expect(option).toEqual({
+      id: 'gpt-5.4-pro',
+      disabled: true,
+      disabledReason: 'Not supported in OAuth mode',
+      label: undefined,
+    });
+  });
+
+  it('switches unsupported OAuth active models to the safe default with a warning', () => {
+    expect(resolveCompatibleActiveModel({
+      activeModel: 'gpt-5.4-pro',
+      provider: 'openai',
+      credentialMode: 'oauth',
+    })).toEqual({
+      model: 'gpt-5.4',
+      warning: 'Model gpt-5.4-pro is not supported with OpenAI account sign-in. Switched to gpt-5.4 for this session.',
+    });
   });
 });

--- a/src/__tests__/unit/tui/local-commands.test.ts
+++ b/src/__tests__/unit/tui/local-commands.test.ts
@@ -106,6 +106,25 @@ describe('runLocalCommand', () => {
     });
   });
 
+  it('rejects unsupported OAuth model switching before updating the active model', async () => {
+    const setActiveModel = vi.fn();
+    const result = await runLocalCommand(createCommandArgs({
+      prompt: '/model gpt-5.4-pro',
+      setActiveModel,
+      providerCredentialSource: { type: 'oauth', provider: 'openai', accountId: 'acct', expiresAt: Date.now() + 60_000 },
+    }));
+
+    expect(setActiveModel).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      handled: true,
+      kind: 'message',
+    });
+    if (!result.handled || result.kind !== 'message') {
+      throw new Error('expected an OAuth incompatibility message');
+    }
+    expect(result.message).toContain('OpenAI account sign-in is not enabled for model gpt-5.4-pro');
+  });
+
   it('allows switching sessions by recent-session index', async () => {
     const switchSession = vi.fn();
     const sessions = [

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -16,7 +16,7 @@ import { buildTuiDebugSnapshot } from './debug/tui-debug-snapshot.js';
 import { buildConversationMessages } from './utils/format.js';
 import { buildCompactionRunningContext, compactChatHistoryWithArchive } from './state/compaction.js';
 import { estimateBuiltInContextWindow } from '../../core/llm/openai-models.js';
-import { credentialModeFromSource, resolveSystemSelectedModel } from '../../core/llm/model-policy.js';
+import { credentialModeFromSource, resolveCompatibleActiveModel, resolveSystemSelectedModel } from '../../core/llm/model-policy.js';
 import { useApprovalFlow } from './hooks/useApprovalFlow.js';
 import { useAgentRun } from './hooks/useAgentRun.js';
 import { useChatDrift } from './hooks/useChatDrift.js';
@@ -36,7 +36,12 @@ export function App({ runtime }: { runtime: ChatRuntimeConfig }) {
 
 function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
   const nextLocalId = useLocalIds();
-  const [activeModel, setActiveModel] = useState(runtime.model);
+  const initialModelCompatibility = useMemo(() => resolveCompatibleActiveModel({
+    activeModel: runtime.model,
+    provider: runtime.model.startsWith('claude') ? 'anthropic' : 'openai',
+    credentialMode: credentialModeFromSource(runtime.providerCredentialSource),
+  }), [runtime.model, runtime.providerCredentialSource]);
+  const [activeModel, setActiveModel] = useState(initialModelCompatibility.model);
   const {
     draft,
     setDraft,
@@ -77,6 +82,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     mentionableFiles,
     clearDraft,
     replaceDraft,
+    providerCredentialSource: resolveProviderCredentialSourceForModel(activeModel, runtime),
   });
   const drift = useChatDrift({
     activeSession,
@@ -86,6 +92,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
   const previousActiveModelRef = useRef(activeModel);
   const previousModelWriteSessionIdRef = useRef<string | undefined>(activeSession?.id);
 
+  const [modelCompatibilityNotice, setModelCompatibilityNotice] = useState<string | undefined>(initialModelCompatibility.warning);
   const {
     status,
     setStatus,
@@ -182,6 +189,21 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
       setStatus('Idle');
     });
   }, [activeModel, activeSession, runtime.providerCredentialSource, runtime.stateRoot, runtime.systemContext, setStatus, setSessionModel, updateSessionById]);
+
+  useEffect(() => {
+    const nextCompatibility = resolveCompatibleActiveModel({
+      activeModel,
+      provider: activeModel.startsWith('claude') ? 'anthropic' : 'openai',
+      credentialMode: credentialModeFromSource(resolveProviderCredentialSourceForModel(activeModel, runtime)),
+    });
+    if (nextCompatibility.model !== activeModel) {
+      setActiveModel(nextCompatibility.model);
+      if (activeSession) {
+        setSessionModel(activeSession.id, nextCompatibility.model);
+      }
+    }
+    setModelCompatibilityNotice(nextCompatibility.warning);
+  }, [activeModel, activeSession, runtime, setSessionModel]);
 
   const messages = useMemo(() => activeSession?.messages ?? [], [activeSession?.messages]);
   const sessionTitleModel = resolveSystemSelectedModel({
@@ -386,6 +408,11 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
         {runtimeHostWarning ?
           <Text color="yellow">
             {runtimeHostWarning}
+          </Text>
+        : null}
+        {modelCompatibilityNotice ?
+          <Text color="yellow">
+            {modelCompatibilityNotice}
           </Text>
         : null}
       </Box>

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -427,7 +427,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
         paddingY={0}
       >
         <Text bold color={pendingApproval ? 'yellow' : undefined}>
-          {pendingApproval ? 'Approval Required' : compacting ? 'Compacting…' : isRunning ? `Working${workingFrames[workingFrame]}` : 'Prompt'}
+          {pendingApproval ? 'Approval Required' : compacting ? `Compacting${workingFrames[workingFrame] ?? '...'}` : isRunning ? `Working${workingFrames[workingFrame]}` : 'Prompt'}
         </Text>
         {pendingApproval ?
           <ApprovalComposer pendingApproval={pendingApproval} approvalChoice={approvalChoice} />

--- a/src/cli/chat/components/ModelPickerPanel.tsx
+++ b/src/cli/chat/components/ModelPickerPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Text } from 'ink';
+import type { CredentialAwareModelOption } from '../../../core/llm/model-policy.js';
 
 const MAX_VISIBLE_MODELS = 8;
 
@@ -10,7 +11,7 @@ export function ModelPickerPanel({
   highlightedIndex,
 }: {
   query: string;
-  models: string[];
+  models: CredentialAwareModelOption[];
   activeModel: string;
   highlightedIndex: number;
 }) {
@@ -26,12 +27,19 @@ export function ModelPickerPanel({
         visibleModels.map((model, index) => {
           const absoluteIndex = startIndex + index;
           const isHighlighted = absoluteIndex === highlightedIndex;
-          const isActive = model === activeModel;
+          const isActive = model.id === activeModel;
           const marker = isHighlighted ? '◉' : '○';
-          const suffix = isActive ? ' (current)' : '';
+          const suffix = [
+            isActive ? '(current)' : undefined,
+            model.disabled ? `(${model.disabledReason ?? 'unavailable'})` : undefined,
+          ].filter(Boolean).join(' ');
           return (
-            <Text key={model} color={isHighlighted ? 'cyan' : undefined} dimColor={!isHighlighted}>
-              {`${marker} ${model}${suffix}`}
+            <Text
+              key={model.id}
+              color={isHighlighted ? 'cyan' : model.disabled ? 'yellow' : undefined}
+              dimColor={!isHighlighted && !model.disabled}
+            >
+              {`${marker} ${model.id}${suffix ? ` ${suffix}` : ''}`}
             </Text>
           );
         })
@@ -40,7 +48,10 @@ export function ModelPickerPanel({
   );
 }
 
-function getVisibleModels(models: string[], highlightedIndex: number): { visibleModels: string[]; startIndex: number } {
+function getVisibleModels(models: CredentialAwareModelOption[], highlightedIndex: number): {
+  visibleModels: CredentialAwareModelOption[];
+  startIndex: number;
+} {
   if (models.length <= MAX_VISIBLE_MODELS) {
     return { visibleModels: models, startIndex: 0 };
   }

--- a/src/cli/chat/components/ModelPickerPanel.tsx
+++ b/src/cli/chat/components/ModelPickerPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import type { CredentialAwareModelOption } from '../../../core/llm/model-policy.js';
+import { OPENAI_OAUTH_MODE_DESCRIPTION, type CredentialAwareModelOption } from '../../../core/llm/model-policy.js';
 
 const MAX_VISIBLE_MODELS = 8;
 
@@ -23,6 +23,7 @@ export function ModelPickerPanel({
       <Text dimColor>
         {query ? `Search: ${query}` : 'Type after /model set to filter. Use ↑/↓ or Tab to choose.'}
       </Text>
+      {visibleModels.some((model) => model.disabled) ? <Text dimColor>{OPENAI_OAUTH_MODE_DESCRIPTION}</Text> : null}
       {visibleModels.length > 0 ?
         visibleModels.map((model, index) => {
           const absoluteIndex = startIndex + index;

--- a/src/cli/chat/components/ModelPickerPanel.tsx
+++ b/src/cli/chat/components/ModelPickerPanel.tsx
@@ -41,6 +41,7 @@ export function ModelPickerPanel({
               dimColor={!isHighlighted && !model.disabled}
             >
               {`${marker} ${model.id}${suffix ? ` ${suffix}` : ''}`}
+              {isHighlighted && model.disabled ? ` — ${OPENAI_OAUTH_MODE_DESCRIPTION}` : ''}
             </Text>
           );
         })

--- a/src/cli/chat/debug/tui-debug-snapshot.ts
+++ b/src/cli/chat/debug/tui-debug-snapshot.ts
@@ -1,4 +1,5 @@
 import { buildPromptRenderLines } from '../components/PromptInput.js';
+import { OPENAI_OAUTH_MODE_DESCRIPTION, type CredentialAwareModelOption } from '../../../core/llm/model-policy.js';
 import { getLocalCommandHints } from '../state/local-commands.js';
 import type { ChatSession, ConversationLine, PendingApproval } from '../state/types.js';
 import { formatApprovalHint, summarizePendingApproval, truncate } from '../utils/format.js';
@@ -31,7 +32,7 @@ export function buildTuiDebugSnapshot(args: {
   modelPicker?: {
     visible: boolean;
     query?: string;
-    items: string[];
+    items: CredentialAwareModelOption[];
     highlightedIndex: number;
   };
   sessionPicker?: {
@@ -115,7 +116,10 @@ export function buildTuiDebugSnapshot(args: {
   if (args.modelPicker?.visible) {
     lines.push('Model picker');
     lines.push(args.modelPicker.query ? `Search: ${args.modelPicker.query}` : 'Type after /model set to filter. Use ↑/↓ or Tab to choose.');
-    lines.push(...renderPickerLines(args.modelPicker.items, args.modelPicker.highlightedIndex));
+    if (args.modelPicker.items.some((item) => item.disabled)) {
+      lines.push(OPENAI_OAUTH_MODE_DESCRIPTION);
+    }
+    lines.push(...renderCredentialAwareModelPickerLines(args.modelPicker.items, args.modelPicker.highlightedIndex));
     lines.push('');
   }
 
@@ -162,6 +166,17 @@ function renderPickerLines(items: string[], highlightedIndex: number): string[] 
   }
 
   return items.slice(0, 8).map((item, index) => `${index === highlightedIndex ? '◉' : '○'} ${item}`);
+}
+
+function renderCredentialAwareModelPickerLines(items: CredentialAwareModelOption[], highlightedIndex: number): string[] {
+  if (items.length === 0) {
+    return ['No matching entries.'];
+  }
+
+  return items.slice(0, 8).map((item, index) => {
+    const suffix = item.disabled ? ` (${item.disabledReason ?? 'Not supported'})` : '';
+    return `${index === highlightedIndex ? '◉' : '○'} ${item.id}${suffix}`;
+  });
 }
 
 function indentLines(lines: string[]): string[] {

--- a/src/cli/chat/hooks/useChatPickers.ts
+++ b/src/cli/chat/hooks/useChatPickers.ts
@@ -1,5 +1,11 @@
-import { useState } from 'react';
-import { filterBuiltInModels } from '../../../core/llm/openai-models.js';
+import { useMemo, useState } from 'react';
+import { BUILT_IN_MODEL_GROUPS, filterBuiltInModels } from '../../../core/llm/openai-models.js';
+import {
+  buildCredentialAwareModelOption,
+  credentialModeFromSource,
+  type CredentialAwareModelOption,
+} from '../../../core/llm/model-policy.js';
+import type { ProviderCredentialSource } from '../utils/runtime.js';
 import type { PromptKeyInput } from '../components/PromptInput.js';
 import type { ChatSession } from '../state/types.js';
 import { filterMentionableFiles, getMentionQuery, insertMentionSelection } from '../utils/file-mentions.js';
@@ -10,12 +16,14 @@ export function useChatPickers({
   mentionableFiles,
   clearDraft,
   replaceDraft,
+  providerCredentialSource,
 }: {
   draft: string;
   recentSessions: ChatSession[];
   mentionableFiles: string[];
   clearDraft: () => void;
   replaceDraft: (value: string) => void;
+  providerCredentialSource: ProviderCredentialSource;
 }) {
   const [modelPickerIndex, setModelPickerIndex] = useState(0);
   const [sessionPickerIndex, setSessionPickerIndex] = useState(0);
@@ -27,9 +35,20 @@ export function useChatPickers({
   const safeFileMentionPickerIndex = clampPickerIndex(fileMentionPickerIndex, filteredMentionFiles.length);
   const highlightedMentionFile = filteredMentionFiles[safeFileMentionPickerIndex];
 
+  const credentialAwareModels = useMemo(() => {
+    const credentialMode = credentialModeFromSource(providerCredentialSource);
+    return BUILT_IN_MODEL_GROUPS.flatMap((group) => group.models).map((model) =>
+      buildCredentialAwareModelOption({
+        model,
+        provider: model.startsWith('claude') ? 'anthropic' : 'openai',
+        credentialMode,
+      }),
+    );
+  }, [providerCredentialSource]);
+
   const modelPickerQuery = getModelPickerQuery(draft);
   const modelPickerVisible = modelPickerQuery !== undefined;
-  const filteredModels = modelPickerVisible ? filterBuiltInModels(modelPickerQuery) : [];
+  const filteredModels = modelPickerVisible ? filterCredentialAwareModels(credentialAwareModels, modelPickerQuery) : [];
   const safeModelPickerIndex = clampPickerIndex(modelPickerIndex, filteredModels.length);
   const highlightedModel = filteredModels[safeModelPickerIndex];
 
@@ -141,6 +160,11 @@ function getSessionPickerQuery(draft: string): string | undefined {
 
   const remainder = trimmedStart.slice('/session choose'.length);
   return remainder.trim();
+}
+
+function filterCredentialAwareModels(models: CredentialAwareModelOption[], query: string): CredentialAwareModelOption[] {
+  const matchingIds = new Set(filterBuiltInModels(query));
+  return models.filter((model) => matchingIds.has(model.id));
 }
 
 function filterSessionsForPicker(

--- a/src/cli/chat/hooks/usePromptSubmission.ts
+++ b/src/cli/chat/hooks/usePromptSubmission.ts
@@ -179,7 +179,7 @@ export function usePromptSubmission({
       modelPicker.resetIndex();
       await submitChatPrompt({
         ...submitArgs,
-        value: `/model ${modelPicker.highlighted}`,
+        value: `/model ${modelPicker.highlighted.id}`,
       });
       return;
     }

--- a/src/cli/chat/hooks/usePromptSubmission.ts
+++ b/src/cli/chat/hooks/usePromptSubmission.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import type { CredentialAwareModelOption } from '../../../core/llm/model-policy.js';
 import type { ConversationLine, ChatSession } from '../state/types.js';
 import { submitChatPrompt } from '../submit.js';
 import { buildPromptWithFileMentions } from '../utils/file-mentions.js';
@@ -67,7 +68,7 @@ export function usePromptSubmission({
   mentionableFiles: string[];
   modelPicker: {
     visible: boolean;
-    highlighted?: string;
+    highlighted?: CredentialAwareModelOption;
     resetIndex: () => void;
   };
   sessionPicker: {
@@ -177,6 +178,9 @@ export function usePromptSubmission({
 
     if (modelPicker.visible && modelPicker.highlighted) {
       modelPicker.resetIndex();
+      if (modelPicker.highlighted.disabled) {
+        return;
+      }
       await submitChatPrompt({
         ...submitArgs,
         value: `/model ${modelPicker.highlighted.id}`,

--- a/src/cli/chat/state/local-commands.ts
+++ b/src/cli/chat/state/local-commands.ts
@@ -3,7 +3,9 @@ import { summarizeSession } from './storage.js';
 import { formatAuthStatusMessage, loginProviderWithOAuth, logoutProvider } from '../../auth.js';
 import type { OpenAiOAuthCredential } from '../../../core/auth/openai-oauth.js';
 import { COMMON_BUILT_IN_MODELS, formatBuiltInModelGroups } from '../../../core/llm/openai-models.js';
+import { credentialModeFromSource, validateModelCredentialCompatibility } from '../../../core/llm/model-policy.js';
 import type { LlmProvider } from '../../../core/llm/types.js';
+import type { ProviderCredentialSource } from '../utils/runtime.js';
 import { createFileHeartbeatTaskStore } from '../../../core/runtime/heartbeat-task-store.js';
 import { join } from 'node:path';
 
@@ -33,6 +35,7 @@ export type LocalCommandArgs = {
   workspaceRoot: string;
   stateRoot: string;
   credentialStorePath?: string;
+  providerCredentialSource?: ProviderCredentialSource;
   openAiLogin?: () => Promise<OpenAiOAuthCredential>;
 };
 
@@ -251,12 +254,26 @@ function handleModelCommand(args: LocalCommandArgs, value: string): LocalCommand
     return aliased;
   }
 
+  const provider = inferProviderForModel(value);
+  const compatibility = validateModelCredentialCompatibility({
+    model: value,
+    provider,
+    credentialMode: credentialModeFromSource(args.providerCredentialSource),
+  });
+  if (!compatibility.ok) {
+    return messageResult(compatibility.error);
+  }
+
   args.setActiveModel(value);
   return messageResult(
     COMMON_BUILT_IN_MODELS.includes(value) ?
       `Switched model to ${value}`
     : `Switched model to ${value}. This name is not in Heddle's common shortlist, so the next API call will fail if the provider does not recognize it.`,
   );
+}
+
+function inferProviderForModel(model: string): LlmProvider {
+  return model.startsWith('claude') ? 'anthropic' : 'openai';
 }
 
 async function handleAuthLogin(args: LocalCommandArgs, value: string): Promise<LocalCommandResult> {

--- a/src/cli/chat/submit.ts
+++ b/src/cli/chat/submit.ts
@@ -136,6 +136,7 @@ export async function submitChatPrompt(args: SubmitChatPromptArgs): Promise<void
     workspaceRoot: args.workspaceRoot,
     stateRoot: args.stateRoot,
     credentialStorePath: args.credentialStorePath,
+    providerCredentialSource: args.providerCredentialSource,
   } satisfies LocalCommandDeps);
 
   if (!commandResult.handled) {

--- a/src/core/llm/model-policy.ts
+++ b/src/core/llm/model-policy.ts
@@ -17,7 +17,7 @@ export const OPENAI_API_KEY_COMPACTION_MODEL = 'gpt-5.1-codex-mini';
 export const OPENAI_OAUTH_SYSTEM_MODEL = 'gpt-5.4';
 export const ANTHROPIC_COMPACTION_MODEL = 'claude-haiku-4-5';
 const OPENAI_OAUTH_DISABLED_REASON = 'Not supported';
-export const OPENAI_OAUTH_MODE_DESCRIPTION = 'Some OpenAI models are unavailable with account sign-in because OAuth uses the Codex backend allowlist. Use API-key mode for the broader OpenAI catalog.';
+export const OPENAI_OAUTH_MODE_DESCRIPTION = 'OAuth mode supports a smaller OpenAI allowlist.';
 
 const OPENAI_OAUTH_IMAGE_MODEL_PREFERENCES = ['gpt-5.4', 'gpt-5.4-mini'];
 

--- a/src/core/llm/model-policy.ts
+++ b/src/core/llm/model-policy.ts
@@ -6,9 +6,17 @@ import type { LlmProvider } from './types.js';
 export type SystemModelPurpose = 'chat-compaction' | 'session-title';
 export type ModelCredentialMode = 'api-key' | 'oauth' | 'missing';
 
+export type CredentialAwareModelOption = {
+  id: string;
+  label?: string;
+  disabled: boolean;
+  disabledReason?: string;
+};
+
 export const OPENAI_API_KEY_COMPACTION_MODEL = 'gpt-5.1-codex-mini';
 export const OPENAI_OAUTH_SYSTEM_MODEL = 'gpt-5.4';
 export const ANTHROPIC_COMPACTION_MODEL = 'claude-haiku-4-5';
+const OPENAI_OAUTH_DISABLED_REASON = 'Not supported in OAuth mode';
 
 const OPENAI_OAUTH_IMAGE_MODEL_PREFERENCES = ['gpt-5.4', 'gpt-5.4-mini'];
 
@@ -75,6 +83,72 @@ export function assertModelCredentialCompatibility(args: {
 
 export function resolveOpenAiOAuthImageCandidateModels(activeModel: string): string[] {
   return uniqueModels([activeModel, ...OPENAI_OAUTH_IMAGE_MODEL_PREFERENCES, ...OPENAI_ACCOUNT_SIGN_IN_MODELS]);
+}
+
+export function buildCredentialAwareModelOption(args: {
+  model: string;
+  provider: LlmProvider;
+  credentialMode?: ModelCredentialMode;
+  label?: string;
+}): CredentialAwareModelOption {
+  const compatibility = validateModelCredentialCompatibility({
+    model: args.model,
+    provider: args.provider,
+    credentialMode: args.credentialMode,
+  });
+
+  return {
+    id: args.model,
+    label: args.label,
+    disabled: !compatibility.ok,
+    disabledReason: compatibility.ok ? undefined : summarizeCredentialCompatibilityError(args),
+  };
+}
+
+export function summarizeCredentialCompatibilityError(args: {
+  model: string;
+  provider: LlmProvider;
+  credentialMode?: ModelCredentialMode;
+}): string | undefined {
+  if (args.provider === 'openai' && args.credentialMode === 'oauth' && !isOpenAiAccountSignInModel(args.model)) {
+    return OPENAI_OAUTH_DISABLED_REASON;
+  }
+
+  return undefined;
+}
+
+export function resolveCompatibleActiveModel(args: {
+  activeModel: string;
+  provider: LlmProvider;
+  credentialMode?: ModelCredentialMode;
+}): { model: string; warning?: string } {
+  const compatibility = validateModelCredentialCompatibility({
+    model: args.activeModel,
+    provider: args.provider,
+    credentialMode: args.credentialMode,
+  });
+  if (compatibility.ok) {
+    return { model: args.activeModel };
+  }
+
+  const fallback = resolveSystemSelectedModel({
+    purpose: 'session-title',
+    provider: args.provider,
+    activeModel: args.activeModel,
+    credentialMode: args.credentialMode,
+  });
+
+  if (fallback === args.activeModel) {
+    return {
+      model: args.activeModel,
+      warning: `Model ${args.activeModel} is not supported with OpenAI account sign-in. Pick a supported OAuth model with /model set or use API-key mode.`,
+    };
+  }
+
+  return {
+    model: fallback,
+    warning: `Model ${args.activeModel} is not supported with OpenAI account sign-in. Switched to ${fallback} for this session.`,
+  };
 }
 
 export function formatOpenAiAccountSignInModels(): string {

--- a/src/core/llm/model-policy.ts
+++ b/src/core/llm/model-policy.ts
@@ -16,7 +16,8 @@ export type CredentialAwareModelOption = {
 export const OPENAI_API_KEY_COMPACTION_MODEL = 'gpt-5.1-codex-mini';
 export const OPENAI_OAUTH_SYSTEM_MODEL = 'gpt-5.4';
 export const ANTHROPIC_COMPACTION_MODEL = 'claude-haiku-4-5';
-const OPENAI_OAUTH_DISABLED_REASON = 'Not supported in OAuth mode';
+const OPENAI_OAUTH_DISABLED_REASON = 'Not supported';
+export const OPENAI_OAUTH_MODE_DESCRIPTION = 'Some OpenAI models are unavailable with account sign-in because OAuth uses the Codex backend allowlist. Use API-key mode for the broader OpenAI catalog.';
 
 const OPENAI_OAUTH_IMAGE_MODEL_PREFERENCES = ['gpt-5.4', 'gpt-5.4-mini'];
 

--- a/src/server/features/control-plane/router.ts
+++ b/src/server/features/control-plane/router.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { BUILT_IN_MODEL_GROUPS } from '../../../core/llm/openai-models.js';
 import { buildCredentialAwareModelOption, credentialModeFromSource } from '../../../core/llm/model-policy.js';
 import { inferProviderFromModel } from '../../../core/llm/factory.js';
+import { resolveProviderCredentialSourceForModel } from '../../../core/runtime/api-keys.js';
 import { procedure, router } from '../../trpc.js';
 import type { HeddleServerContext } from '../../types.js';
 import {
@@ -168,7 +169,9 @@ export const controlPlaneRouter = router({
     return readChatSessionDetail(resolve(ctx.activeWorkspace.stateRoot, 'chat-sessions.catalog.json'), input.id) ?? null;
   }),
   modelOptions: procedure.query(({ ctx }) => {
-    const credentialMode = credentialModeFromSource(ctx.auth.openai);
+    const credentialMode = credentialModeFromSource(resolveProviderCredentialSourceForModel('gpt-5.4', {
+      preferApiKey: ctx.preferApiKey,
+    }));
     return {
       groups: BUILT_IN_MODEL_GROUPS.map((group) => ({
         label: group.label,

--- a/src/server/features/control-plane/router.ts
+++ b/src/server/features/control-plane/router.ts
@@ -1,6 +1,8 @@
 import { resolve } from 'node:path';
 import { z } from 'zod';
 import { BUILT_IN_MODEL_GROUPS } from '../../../core/llm/openai-models.js';
+import { buildCredentialAwareModelOption, credentialModeFromSource } from '../../../core/llm/model-policy.js';
+import { inferProviderFromModel } from '../../../core/llm/factory.js';
 import { procedure, router } from '../../trpc.js';
 import type { HeddleServerContext } from '../../types.js';
 import {
@@ -165,9 +167,18 @@ export const controlPlaneRouter = router({
   session: procedure.input(sessionInputSchema).query(({ ctx, input }) => {
     return readChatSessionDetail(resolve(ctx.activeWorkspace.stateRoot, 'chat-sessions.catalog.json'), input.id) ?? null;
   }),
-  modelOptions: procedure.query(() => {
+  modelOptions: procedure.query(({ ctx }) => {
+    const credentialMode = credentialModeFromSource(ctx.auth.openai);
     return {
-      groups: BUILT_IN_MODEL_GROUPS,
+      groups: BUILT_IN_MODEL_GROUPS.map((group) => ({
+        label: group.label,
+        models: group.models,
+        options: group.models.map((model) => buildCredentialAwareModelOption({
+          model,
+          provider: inferProviderFromModel(model),
+          credentialMode,
+        })),
+      })),
     };
   }),
   sessionSettingsUpdate: procedure.input(sessionSettingsInputSchema).mutation(({ ctx, input }) => {

--- a/src/web/features/control-plane/components/ModelSelectorPopover.tsx
+++ b/src/web/features/control-plane/components/ModelSelectorPopover.tsx
@@ -1,0 +1,86 @@
+import { Button } from '../../../components/ui/button.js';
+import { Popover, PopoverContent, PopoverTrigger } from '../../../components/ui/popover.js';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../../components/ui/tooltip.js';
+import { OPENAI_OAUTH_MODE_DESCRIPTION } from '../../../../core/llm/model-policy.js';
+import type { CredentialAwareModelGroup } from '../hooks/useCredentialAwareModelOptions.js';
+import { className } from '../utils.js';
+
+type ModelSelectorPopoverProps = {
+  selectedModel: string;
+  selectedModelUnsupported: boolean;
+  disabled: boolean;
+  groups: CredentialAwareModelGroup[];
+  runActive: boolean;
+  modelOptionsError?: string;
+  onSelectModel: (model: string) => void;
+};
+
+export function ModelSelectorPopover({
+  selectedModel,
+  selectedModelUnsupported,
+  disabled,
+  groups,
+  runActive,
+  modelOptionsError,
+  onSelectModel,
+}: ModelSelectorPopoverProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={className('model-select-trigger', selectedModelUnsupported && 'unsupported')}
+          disabled={disabled}
+          title={modelOptionsError ? 'Model options unavailable. Restart the Heddle daemon if this route was just added.' : undefined}
+        >
+          <span>{selectedModel || 'loading models'}</span>
+          {selectedModelUnsupported ? <span className="model-select-trigger-reason">Not supported</span> : null}
+        </Button>
+      </PopoverTrigger>
+      {groups.length > 0 ?
+        <PopoverContent className="model-select-menu p-2" align="end">
+          <div role="listbox" aria-label="Model options">
+            {groups.map((group) => (
+              <div className="model-select-group" key={group.label}>
+                <div className="model-select-group-label">{group.label}</div>
+                {group.resolvedOptions.map((option) => {
+                  const optionButton = (
+                    <button
+                      key={option.id}
+                      className={className('model-select-option', option.id === selectedModel && 'selected', option.disabled && 'disabled')}
+                      type="button"
+                      role="option"
+                      aria-selected={option.id === selectedModel}
+                      aria-disabled={option.disabled}
+                      disabled={option.disabled || runActive}
+                      onClick={() => {
+                        if (!option.disabled) {
+                          onSelectModel(option.id);
+                        }
+                      }}
+                    >
+                      <span>{option.id === selectedModel ? '✓ ' : ''}{option.id}</span>
+                      {option.disabled ? <span className="model-select-option-reason">Not supported</span> : null}
+                    </button>
+                  );
+
+                  return option.disabled ? (
+                    <TooltipProvider key={option.id}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="model-select-option-wrapper">{optionButton}</span>
+                        </TooltipTrigger>
+                        <TooltipContent>{OPENAI_OAUTH_MODE_DESCRIPTION}</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : optionButton;
+                })}
+              </div>
+            ))}
+          </div>
+        </PopoverContent>
+      : null}
+    </Popover>
+  );
+}

--- a/src/web/features/control-plane/control-plane.css
+++ b/src/web/features/control-plane/control-plane.css
@@ -549,6 +549,94 @@ h3 {
   cursor: not-allowed;
 }
 
+.model-select-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.model-select-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 220px;
+}
+
+.model-select-trigger.unsupported,
+.model-select-trigger-reason,
+.model-select-option-reason {
+  color: var(--warn);
+}
+
+.model-select-menu {
+  width: 360px;
+  max-height: 420px;
+  overflow: auto;
+  padding: 6px;
+}
+
+.model-select-group + .model-select-group {
+  margin-top: 6px;
+}
+
+.model-select-group-label {
+  padding: 4px 6px;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.model-select-option-wrapper {
+  display: block;
+}
+
+.model-select-option {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  padding: 6px 8px;
+  text-align: left;
+  font: inherit;
+  font-size: 12px;
+}
+
+.model-select-option:hover,
+.model-select-option:focus {
+  background: rgba(56, 189, 248, 0.14);
+  outline: none;
+}
+
+.model-select-option.selected {
+  color: var(--accent);
+}
+
+.model-select-option.disabled {
+  color: var(--muted);
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.model-select-option.disabled:hover,
+.model-select-option.disabled:focus {
+  background: rgba(251, 191, 36, 0.08);
+}
+
+.model-select-description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
 .sidebar-scroll,
 .conversation-scroll,
 .side-scroll,

--- a/src/web/features/control-plane/hooks/useCredentialAwareModelOptions.ts
+++ b/src/web/features/control-plane/hooks/useCredentialAwareModelOptions.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import type { ModelOptions } from '../../../lib/api.js';
+import { isOpenAiAccountSignInModel } from '../../../../core/llm/openai-models.js';
+import type { ControlPlaneState } from '../../../lib/api.js';
+
+export type CredentialAwareModelGroup = {
+  label: string;
+  models: string[];
+  resolvedOptions: Array<{
+    id: string;
+    disabled: boolean;
+    disabledReason?: string;
+  }>;
+};
+
+export function useCredentialAwareModelOptions(args: {
+  modelOptions: ModelOptions | null;
+  auth?: ControlPlaneState['auth'];
+  selectedModel?: string;
+  runActive: boolean;
+}) {
+  const openAiOauthActive = args.auth?.openai?.type === 'oauth';
+
+  const groups = useMemo<CredentialAwareModelGroup[]>(() => {
+    if (!args.modelOptions) {
+      return [];
+    }
+
+    return args.modelOptions.groups.map((group) => ({
+      ...group,
+      resolvedOptions: (group.options ?? group.models.map((model) => ({ id: model, disabled: false }))).map((option) => {
+        const disabled = openAiOauthActive && option.id.startsWith('gpt-')
+          ? !isOpenAiAccountSignInModel(option.id)
+          : false;
+        return {
+          id: option.id,
+          disabled,
+          disabledReason: disabled ? 'Not supported' : option.disabledReason,
+        };
+      }),
+    }));
+  }, [args.modelOptions, openAiOauthActive]);
+
+  const selectedModelOption = useMemo(() => (
+    groups.flatMap((group) => group.resolvedOptions).find((option) => option.id === args.selectedModel)
+  ), [groups, args.selectedModel]);
+
+  return {
+    groups,
+    selectedModelOption,
+    selectorDisabled: args.runActive || !args.modelOptions,
+  };
+}

--- a/src/web/features/control-plane/screens/SessionsScreen.tsx
+++ b/src/web/features/control-plane/screens/SessionsScreen.tsx
@@ -591,7 +591,16 @@ export function SessionsScreen({
                 >
                   {modelOptions?.groups.map((group) => (
                     <optgroup key={group.label} label={group.label}>
-                      {group.models.map((model) => <option key={model} value={model}>{model}</option>)}
+                      {(group.options ?? group.models.map((model) => ({ id: model, disabled: false }))).map((option) => (
+                        <option
+                          key={option.id}
+                          value={option.id}
+                          disabled={option.disabled}
+                          title={option.disabledReason}
+                        >
+                          {option.disabledReason ? `${option.id} — ${option.disabledReason}` : option.id}
+                        </option>
+                      ))}
                     </optgroup>
                   ))}
                   {!modelOptions ? <option value={sessionDetail?.model ?? activeSession.model ?? ''}>{modelOptionsError ? 'models unavailable' : sessionDetail?.model ?? activeSession.model ?? 'loading models'}</option> : null}

--- a/src/web/features/control-plane/screens/SessionsScreen.tsx
+++ b/src/web/features/control-plane/screens/SessionsScreen.tsx
@@ -14,6 +14,7 @@ import {
   type WorkspaceFileSuggestion,
 } from '../../../lib/api';
 import { formatControlPlaneAuthStatus } from '../auth-status';
+import { OPENAI_OAUTH_MODE_DESCRIPTION } from '../../../../core/llm/model-policy.js';
 import { formatDate, className } from '../utils';
 import { CodeBlock, EmptyState, Pill, WorkspaceSectionHeader } from '../components/common';
 import { SessionListButton } from '../components/lists';
@@ -605,6 +606,9 @@ export function SessionsScreen({
                   ))}
                   {!modelOptions ? <option value={sessionDetail?.model ?? activeSession.model ?? ''}>{modelOptionsError ? 'models unavailable' : sessionDetail?.model ?? activeSession.model ?? 'loading models'}</option> : null}
                 </select>
+                {modelOptions?.groups.some((group) => group.options?.some((option) => option.disabled)) ?
+                  <span>{OPENAI_OAUTH_MODE_DESCRIPTION}</span>
+                : null}
               </label>
               <Pill>turns {activeSession.turnCount}</Pill>
               {compactionStatus === 'running' ? <Pill tone="warn">compacting</Pill> : null}

--- a/src/web/features/control-plane/screens/SessionsScreen.tsx
+++ b/src/web/features/control-plane/screens/SessionsScreen.tsx
@@ -14,11 +14,12 @@ import {
   type WorkspaceFileSuggestion,
 } from '../../../lib/api';
 import { formatControlPlaneAuthStatus } from '../auth-status';
-import { OPENAI_OAUTH_MODE_DESCRIPTION } from '../../../../core/llm/model-policy.js';
 import { formatDate, className } from '../utils';
 import { CodeBlock, EmptyState, Pill, WorkspaceSectionHeader } from '../components/common';
 import { SessionListButton } from '../components/lists';
 import { ConversationMessage } from '../components/ConversationMessage';
+import { ModelSelectorPopover } from '../components/ModelSelectorPopover.js';
+import { useCredentialAwareModelOptions } from '../hooks/useCredentialAwareModelOptions.js';
 import { MobileChatScreen } from '../mobile/MobileChatScreen';
 import { MobileReviewScreen } from '../mobile/MobileReviewScreen';
 import { FullDiffDialog, SessionReviewPanel, type ExpandedDiff, type ReviewMode } from './SessionReviewPanel';
@@ -119,6 +120,17 @@ export function SessionsScreen({
   const runActive = sendingPrompt || runInFlight;
   const authStatus = formatControlPlaneAuthStatus(sessionDetail?.model ?? activeSession?.model, auth);
   const compactionStatus = sessionDetail?.context?.compactionStatus ?? activeSession?.context?.compactionStatus;
+  const selectedModel = sessionDetail?.model ?? activeSession?.model ?? '';
+  const {
+    groups: modelOptionGroups,
+    selectedModelOption,
+    selectorDisabled: modelSelectorDisabled,
+  } = useCredentialAwareModelOptions({
+    modelOptions,
+    auth,
+    selectedModel,
+    runActive,
+  });
   const selectedReviewFile =
     turnReview?.files.find((file) => file.path === selectedReviewFilePath) ?? turnReview?.files[0];
   const selectedWorkspaceFile =
@@ -582,34 +594,21 @@ export function SessionsScreen({
             <div className="session-controls">
               <button className="mobile-nav-button" type="button" onClick={showSessionList}>← Sessions</button>
               <button className="mobile-nav-button mobile-inspector-button" type="button" onClick={openReviewInspector}>Review</button>
-              <label className="select-control">
-                <span>model</span>
-                <select
-                  value={sessionDetail?.model ?? activeSession.model ?? ''}
-                  disabled={runActive || !modelOptions}
-                  onChange={(event) => void onUpdateSessionSettings({ model: event.target.value })}
-                  title={modelOptionsError ? 'Model options unavailable. Restart the Heddle daemon if this route was just added.' : undefined}
-                >
-                  {modelOptions?.groups.map((group) => (
-                    <optgroup key={group.label} label={group.label}>
-                      {(group.options ?? group.models.map((model) => ({ id: model, disabled: false }))).map((option) => (
-                        <option
-                          key={option.id}
-                          value={option.id}
-                          disabled={option.disabled}
-                          title={option.disabledReason}
-                        >
-                          {option.disabledReason ? `${option.id} — ${option.disabledReason}` : option.id}
-                        </option>
-                      ))}
-                    </optgroup>
-                  ))}
-                  {!modelOptions ? <option value={sessionDetail?.model ?? activeSession.model ?? ''}>{modelOptionsError ? 'models unavailable' : sessionDetail?.model ?? activeSession.model ?? 'loading models'}</option> : null}
-                </select>
-                {modelOptions?.groups.some((group) => group.options?.some((option) => option.disabled)) ?
-                  <span>{OPENAI_OAUTH_MODE_DESCRIPTION}</span>
-                : null}
-              </label>
+              <div className="model-select-control">
+                <label className="select-control">
+                  <span>model</span>
+                  <ModelSelectorPopover
+                    selectedModel={selectedModel}
+                    selectedModelUnsupported={Boolean(selectedModelOption?.disabled)}
+                    disabled={modelSelectorDisabled}
+                    groups={modelOptionGroups}
+                    runActive={runActive}
+                    modelOptionsError={modelOptionsError}
+                    onSelectModel={(model) => void onUpdateSessionSettings({ model })}
+                  />
+                </label>
+                {!modelOptions ? <p className="model-select-description">{modelOptionsError ? 'models unavailable' : 'loading models'}</p> : null}
+              </div>
               <Pill>turns {activeSession.turnCount}</Pill>
               {compactionStatus === 'running' ? <Pill tone="warn">compacting</Pill> : null}
               <button


### PR DESCRIPTION
## Summary
- centralize OpenAI OAuth compatibility behavior on top of the core allowlist/model-policy rules
- disable unsupported OAuth models before selection in both TUI and the web control plane
- refine the web selector into a compact shadcn-style popover with hover-only explanation for unsupported models
- extract web selector behavior into a dedicated hook and component so SessionsScreen stays semantically focused

## Implementation notes
- core compatibility rules remain centralized in  and 
- the web client now consumes those rules through 
- the web selector UI now lives in 
- TUI keeps disabled labels and hover-context for unsupported OAuth models while rejecting direct  switches for unsupported choices

## Verification
- yarn build
- yarn test:unit
- vitest run src/__tests__/integration/web src/__tests__/integration/chat src/__tests__/integration/control-plane

Closes #20