### PR TITLE
[codex] Refactor sessions screen state

### DIFF
--- a/src/web/features/control-plane/hooks/sessions-screen/sessionStateTypes.ts
+++ b/src/web/features/control-plane/hooks/sessions-screen/sessionStateTypes.ts
@@ -1,0 +1,32 @@
+import type { ChatSessionDetail, ChatTurnReview, ControlPlaneState, PendingSessionApproval } from '../../../../lib/api';
+
+export type SessionDetailValue = Exclude<ChatSessionDetail, null>;
+export type SessionTurn = SessionDetailValue['turns'][number];
+
+export type SessionsScreenState = {
+  activeSession?: ControlPlaneState['sessions'][number];
+  selectedSessionId?: string;
+  setSelectedSessionId: (sessionId: string) => void;
+  sessionDetail: ChatSessionDetail | null;
+  sessionDetailLoading: boolean;
+  sessionDetailError?: string;
+  sendingPrompt: boolean;
+  runInFlight: boolean;
+  memoryUpdating: boolean;
+  sendPromptError?: string;
+  sendPrompt: (prompt: string) => Promise<void>;
+  creatingSession: boolean;
+  sessionNotice?: string;
+  createSession: () => Promise<void>;
+  continueSession: () => Promise<void>;
+  cancelSessionRun: () => Promise<void>;
+  updateSessionSettings: (settings: { model?: string; driftEnabled?: boolean }) => Promise<void>;
+  pendingApproval: PendingSessionApproval;
+  resolveApproval: (approved: boolean) => Promise<void>;
+  selectedTurnId?: string;
+  setSelectedTurnId: (turnId: string) => void;
+  selectedTurn?: SessionTurn;
+  turnReview: ChatTurnReview | null;
+  turnReviewLoading: boolean;
+  turnReviewError?: string;
+};

--- a/src/web/features/control-plane/hooks/sessions-screen/useLiveSessionMessages.ts
+++ b/src/web/features/control-plane/hooks/sessions-screen/useLiveSessionMessages.ts
@@ -1,0 +1,137 @@
+import { useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
+import type { ChatSessionDetail } from '../../../../lib/api';
+
+export function useLiveSessionMessages(setSessionDetail: Dispatch<SetStateAction<ChatSessionDetail | null>>) {
+  const appendPendingUserTurn = useCallback((prompt: string) => {
+    setSessionDetail((current) => {
+      if (!current) {
+        return current;
+      }
+
+      const nextMessages = current.messages.filter((message) => (
+        message.id !== 'live-user'
+        && message.id !== 'live-assistant'
+        && message.id !== 'live-run-status'
+      ));
+      return {
+        ...current,
+        messages: [
+          ...nextMessages,
+          {
+            id: 'live-user',
+            role: 'user',
+            text: prompt,
+          },
+          {
+            id: 'live-run-status',
+            role: 'assistant',
+            text: 'Heddle is working…',
+            isStreaming: true,
+            isPending: true,
+          },
+        ],
+      };
+    });
+  }, [setSessionDetail]);
+
+  const upsertLiveStatusMessage = useCallback((id: string, text: string, options?: { pending?: boolean; streaming?: boolean }) => {
+    setSessionDetail((current) => {
+      if (!current) {
+        return current;
+      }
+
+      const nextMessages = [...current.messages];
+      const existingIndex = nextMessages.findIndex((message) => message.id === id);
+      const nextMessage = {
+        id,
+        role: 'assistant' as const,
+        text,
+        isPending: options?.pending,
+        isStreaming: options?.streaming,
+      };
+
+      if (existingIndex >= 0) {
+        nextMessages[existingIndex] = nextMessage;
+      } else {
+        nextMessages.push(nextMessage);
+      }
+
+      return {
+        ...current,
+        messages: nextMessages,
+      };
+    });
+  }, [setSessionDetail]);
+
+  const removeLiveStatusMessage = useCallback((id: string) => {
+    setSessionDetail((current) => {
+      if (!current) {
+        return current;
+      }
+
+      return {
+        ...current,
+        messages: current.messages.filter((message) => message.id !== id),
+      };
+    });
+  }, [setSessionDetail]);
+
+  const upsertLiveAssistantMessage = useCallback((text: string, isDone: boolean) => {
+    setSessionDetail((current) => {
+      if (!current) {
+        return current;
+      }
+
+      const nextMessages = current.messages.filter((message) => message.id !== 'live-run-status');
+      const lastMessage = nextMessages.at(-1);
+      if (lastMessage?.id === 'live-assistant' && lastMessage.role === 'assistant') {
+        nextMessages[nextMessages.length - 1] = {
+          ...lastMessage,
+          text,
+          isStreaming: !isDone,
+          isPending: !isDone,
+        };
+      } else {
+        nextMessages.push({
+          id: 'live-assistant',
+          role: 'assistant',
+          text,
+          isStreaming: !isDone,
+          isPending: !isDone,
+        });
+      }
+
+      return {
+        ...current,
+        messages: nextMessages,
+      };
+    });
+  }, [setSessionDetail]);
+
+  return useMemo(() => ({
+    appendPendingUserTurn,
+    upsertLiveStatusMessage,
+    removeLiveStatusMessage,
+    upsertLiveAssistantMessage,
+  }), [appendPendingUserTurn, removeLiveStatusMessage, upsertLiveAssistantMessage, upsertLiveStatusMessage]);
+}
+
+export function mergeTransientMessages(current: ChatSessionDetail | null, next: ChatSessionDetail | null): ChatSessionDetail | null {
+  if (!current || !next || current.id !== next.id) {
+    return next;
+  }
+
+  const transientMessages = current.messages.filter((message) => message.id.startsWith('live-'));
+  if (!transientMessages.length) {
+    return next;
+  }
+
+  const nextMessageIds = new Set(next.messages.map((message) => message.id));
+  return {
+    ...next,
+    messages: [
+      ...next.messages,
+      ...transientMessages.filter((message) => !nextMessageIds.has(message.id)),
+    ],
+  };
+}

--- a/src/web/features/control-plane/hooks/sessions-screen/useSessionDetailSubscription.ts
+++ b/src/web/features/control-plane/hooks/sessions-screen/useSessionDetailSubscription.ts
@@ -1,0 +1,332 @@
+import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
+import type { TraceEvent } from '../../../../../core/types';
+import {
+  fetchChatSessionDetail,
+  fetchPendingSessionApproval,
+  fetchSessionRunningState,
+  subscribeToChatSessionEvents,
+  type ChatSessionDetail,
+  type PendingSessionApproval,
+} from '../../../../lib/api';
+import { mergeTransientMessages } from './useLiveSessionMessages';
+
+type LiveSessionMessageActions = {
+  upsertLiveStatusMessage: (id: string, text: string, options?: { pending?: boolean; streaming?: boolean }) => void;
+  removeLiveStatusMessage: (id: string) => void;
+  upsertLiveAssistantMessage: (text: string, isDone: boolean) => void;
+};
+
+type LiveSessionEvent = {
+  type?: string;
+  text?: string;
+  done?: boolean;
+  tool?: string;
+  step?: number;
+  durationMs?: number;
+  event?: TraceEvent;
+  status?: 'running' | 'finished' | 'failed';
+  archivePath?: string;
+  summaryPath?: string;
+  error?: string;
+};
+
+type SessionEventContext = {
+  sessionId: string;
+  setRunInFlight: Dispatch<SetStateAction<boolean>>;
+  setMemoryUpdating: Dispatch<SetStateAction<boolean>>;
+  setPendingApproval: Dispatch<SetStateAction<PendingSessionApproval>>;
+  refresh: (options?: { silent?: boolean }) => Promise<void>;
+  liveMessages: LiveSessionMessageActions;
+};
+
+type SessionEventHandler = {
+  matches: (event: LiveSessionEvent) => boolean;
+  handle: (event: LiveSessionEvent, context: SessionEventContext) => void;
+};
+
+type TraceEventContext = Pick<SessionEventContext, 'sessionId' | 'setMemoryUpdating' | 'setPendingApproval' | 'refresh' | 'liveMessages'>;
+
+export function useSessionDetailSubscription({
+  selectedSessionId,
+  setSessionDetail,
+  setSessionDetailLoading,
+  setSessionDetailError,
+  setRunInFlight,
+  setMemoryUpdating,
+  setPendingApproval,
+  onSessionsChanged,
+  liveMessages,
+}: {
+  selectedSessionId?: string;
+  setSessionDetail: Dispatch<SetStateAction<ChatSessionDetail | null>>;
+  setSessionDetailLoading: Dispatch<SetStateAction<boolean>>;
+  setSessionDetailError: Dispatch<SetStateAction<string | undefined>>;
+  setRunInFlight: Dispatch<SetStateAction<boolean>>;
+  setMemoryUpdating: Dispatch<SetStateAction<boolean>>;
+  setPendingApproval: Dispatch<SetStateAction<PendingSessionApproval>>;
+  onSessionsChanged?: () => void;
+  liveMessages: LiveSessionMessageActions;
+}) {
+  const onSessionsChangedRef = useRef(onSessionsChanged);
+
+  useEffect(() => {
+    onSessionsChangedRef.current = onSessionsChanged;
+  }, [onSessionsChanged]);
+
+  useEffect(() => {
+    if (!selectedSessionId) {
+      setSessionDetail(null);
+      setSessionDetailError(undefined);
+      return;
+    }
+
+    const sessionId = selectedSessionId;
+    let cancelled = false;
+    let sessionUpdateTimeout: number | undefined;
+
+    async function refresh(options: { silent?: boolean } = {}) {
+      if (!options.silent) {
+        setSessionDetailLoading(true);
+      }
+      try {
+        const next = await fetchChatSessionDetail(sessionId);
+        if (!cancelled) {
+          setSessionDetail((current) => options.silent ? mergeTransientMessages(current, next) : next);
+          setSessionDetailError(undefined);
+        }
+      } catch (refreshError) {
+        if (!cancelled) {
+          setSessionDetailError(refreshError instanceof Error ? refreshError.message : String(refreshError));
+        }
+      } finally {
+        if (!cancelled && !options.silent) {
+          setSessionDetailLoading(false);
+        }
+      }
+    }
+
+    void refresh();
+    void fetchSessionRunningState(sessionId).then((state) => setRunInFlight(state.running));
+    const unsubscribe = subscribeToChatSessionEvents(sessionId, (event) => {
+      if (event.type === 'session.updated') {
+        if (sessionUpdateTimeout !== undefined) {
+          window.clearTimeout(sessionUpdateTimeout);
+        }
+        sessionUpdateTimeout = window.setTimeout(() => {
+          void fetchSessionRunningState(sessionId).then((state) => {
+            if (!cancelled) {
+              setRunInFlight(state.running);
+            }
+          });
+          void refresh({ silent: true });
+          onSessionsChangedRef.current?.();
+        }, 300);
+        return;
+      }
+
+      if (event.type !== 'session.event' || !event.event || typeof event.event !== 'object') {
+        return;
+      }
+
+      handleSessionEvent({
+        sessionId,
+        liveEvent: event.event,
+        setRunInFlight,
+        setMemoryUpdating,
+        setPendingApproval,
+        refresh,
+        liveMessages,
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      if (sessionUpdateTimeout !== undefined) {
+        window.clearTimeout(sessionUpdateTimeout);
+      }
+      unsubscribe();
+    };
+  }, [
+    liveMessages,
+    selectedSessionId,
+    setMemoryUpdating,
+    setPendingApproval,
+    setRunInFlight,
+    setSessionDetail,
+    setSessionDetailError,
+    setSessionDetailLoading,
+  ]);
+}
+
+function handleSessionEvent({
+  sessionId,
+  liveEvent,
+  setRunInFlight,
+  setMemoryUpdating,
+  setPendingApproval,
+  refresh,
+  liveMessages,
+}: {
+  sessionId: string;
+  liveEvent: unknown;
+  setRunInFlight: Dispatch<SetStateAction<boolean>>;
+  setMemoryUpdating: Dispatch<SetStateAction<boolean>>;
+  setPendingApproval: Dispatch<SetStateAction<PendingSessionApproval>>;
+  refresh: (options?: { silent?: boolean }) => Promise<void>;
+  liveMessages: LiveSessionMessageActions;
+}) {
+  const event = liveEvent as LiveSessionEvent;
+  const context: SessionEventContext = {
+    sessionId,
+    setRunInFlight,
+    setMemoryUpdating,
+    setPendingApproval,
+    refresh,
+    liveMessages,
+  };
+  sessionEventHandlers.find((handler) => handler.matches(event))?.handle(event, context);
+}
+
+const compactionStatusHandlers: Record<NonNullable<LiveSessionEvent['status']>, (event: LiveSessionEvent, context: SessionEventContext) => void> = {
+  running: (event, { liveMessages }) => {
+    liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      event.archivePath ? `Compacting earlier history… ${event.archivePath}` : 'Compacting earlier history…',
+      { pending: true, streaming: false },
+    );
+  },
+  failed: (event, { liveMessages }) => {
+    liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      event.error ? `Compaction failed: ${event.error}` : 'Compaction failed.',
+      { pending: false, streaming: false },
+    );
+  },
+  finished: (event, { liveMessages }) => {
+    liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      event.summaryPath ? `Compaction finished. Summary: ${event.summaryPath}` : 'Compaction finished.',
+      { pending: false, streaming: false },
+    );
+  },
+};
+
+const eventTypeHandlers: Record<string, SessionEventHandler['handle']> = {
+  'loop.started': (_event, { setRunInFlight, liveMessages }) => {
+    setRunInFlight(true);
+    liveMessages.upsertLiveStatusMessage('live-run-status', 'Run started…', { pending: true, streaming: true });
+  },
+  'tool.calling': (event, { liveMessages }) => {
+    withStringValue(event.tool, (tool) => liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      `Working… running ${tool}${typeof event.step === 'number' ? ` (step ${event.step})` : ''}`,
+      { pending: true, streaming: true },
+    ));
+  },
+  'tool.completed': (event, { liveMessages }) => {
+    withStringValue(event.tool, (tool) => liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      `${tool} finished${typeof event.durationMs === 'number' ? ` in ${Math.round(event.durationMs)}ms` : ''}`,
+      { pending: false, streaming: false },
+    ));
+  },
+  trace: (event, context) => {
+    withValue(event.event, (traceEvent) => handleTraceEvent(traceEvent, context));
+  },
+  'assistant.stream': (event, { liveMessages }) => {
+    withStringValue(event.text, (text) => liveMessages.upsertLiveAssistantMessage(text, Boolean(event.done)));
+    when(Boolean(event.done), () => liveMessages.removeLiveStatusMessage('live-run-status'));
+  },
+  'loop.finished': (_event, { setRunInFlight, liveMessages, refresh }) => {
+    setRunInFlight(false);
+    liveMessages.removeLiveStatusMessage('live-run-status');
+    void refresh();
+  },
+};
+
+const sessionEventHandlers: SessionEventHandler[] = [
+  {
+    matches: (event) => Boolean(event.status && compactionStatusHandlers[event.status]),
+    handle: (event, context) => event.status && compactionStatusHandlers[event.status](event, context),
+  },
+  {
+    matches: (event) => Boolean(event.type && eventTypeHandlers[event.type]),
+    handle: (event, context) => event.type && eventTypeHandlers[event.type](event, context),
+  },
+];
+
+const traceEventHandlers: Partial<{
+  [EventType in TraceEvent['type']]: (event: Extract<TraceEvent, { type: EventType }>, context: TraceEventContext) => void;
+}> = {
+  'memory.maintenance_started': (event, { setMemoryUpdating, liveMessages }) => {
+    setMemoryUpdating(true);
+    liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      `Memory updating… ${event.candidateIds.length} candidate${event.candidateIds.length === 1 ? '' : 's'}`,
+      { pending: true, streaming: false },
+    );
+  },
+  'memory.maintenance_finished': (event, { setMemoryUpdating, liveMessages, refresh }) => {
+    setMemoryUpdating(false);
+    liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      event.summary ? `Memory updated. ${event.summary}` : 'Memory updated.',
+      { pending: false, streaming: false },
+    );
+    void refresh({ silent: true });
+  },
+  'memory.maintenance_failed': (event, { setMemoryUpdating, liveMessages }) => {
+    setMemoryUpdating(false);
+    liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      event.error ? `Memory update failed: ${event.error}` : 'Memory update failed.',
+      { pending: false, streaming: false },
+    );
+  },
+  'tool.approval_requested': (event, { sessionId, setPendingApproval, liveMessages }) => {
+    void fetchPendingSessionApproval(sessionId).then((approval) => setPendingApproval(approval));
+    liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      `Approval requested for ${event.call.tool}${typeof event.step === 'number' ? ` (step ${event.step})` : ''}`,
+      { pending: true, streaming: false },
+    );
+  },
+  'tool.approval_resolved': (event, { setPendingApproval, liveMessages }) => {
+    setPendingApproval(null);
+    liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      `Approval ${event.approved ? 'granted' : 'denied'} for ${event.call.tool}${event.reason ? ` — ${event.reason}` : ''}`,
+      { pending: false, streaming: false },
+    );
+  },
+  'tool.fallback': (event, { liveMessages }) => {
+    liveMessages.upsertLiveStatusMessage(
+      'live-run-status',
+      `Fallback: ${event.fromCall.tool} → ${event.toCall.tool}`,
+      { pending: true, streaming: false },
+    );
+  },
+};
+
+function handleTraceEvent(traceEvent: TraceEvent, context: TraceEventContext) {
+  const handler = traceEventHandlers[traceEvent.type] as ((event: TraceEvent, context: TraceEventContext) => void) | undefined;
+  handler?.(traceEvent, context);
+}
+
+function withValue<T>(value: T | undefined, callback: (value: T) => void) {
+  if (value !== undefined) {
+    callback(value);
+  }
+}
+
+function withStringValue(value: unknown, callback: (value: string) => void) {
+  if (typeof value === 'string') {
+    callback(value);
+  }
+}
+
+function when(condition: boolean, callback: () => void) {
+  if (condition) {
+    callback();
+  }
+}

--- a/src/web/features/control-plane/hooks/sessions-screen/useSessionMutations.ts
+++ b/src/web/features/control-plane/hooks/sessions-screen/useSessionMutations.ts
@@ -1,0 +1,302 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import {
+  cancelChatSession,
+  continueChatSession,
+  createChatSession,
+  fetchPendingSessionApproval,
+  resolvePendingSessionApproval,
+  sendChatSessionPrompt,
+  updateChatSessionSettings,
+  type ChatSessionDetail,
+  type ChatTurnReview,
+  type PendingSessionApproval,
+} from '../../../../lib/api';
+import type { ToastInput } from '../../../../components/ui/use-toast';
+
+type LiveSessionMessageActions = {
+  appendPendingUserTurn: (prompt: string) => void;
+  upsertLiveStatusMessage: (id: string, text: string, options?: { pending?: boolean; streaming?: boolean }) => void;
+  removeLiveStatusMessage: (id: string) => void;
+};
+
+export function useSessionMutations({
+  selectedSessionId,
+  pendingApproval,
+  sendingPrompt,
+  runInFlight,
+  notify,
+  setSelectedSessionId,
+  setSelectedTurnId,
+  setSessionDetail,
+  setSessionDetailError,
+  setSendingPrompt,
+  setSendPromptError,
+  setTurnReview,
+  setPendingApproval,
+  setRunInFlight,
+  setCreatingSession,
+  setSessionNotice,
+  liveMessages,
+}: {
+  selectedSessionId?: string;
+  pendingApproval: PendingSessionApproval;
+  sendingPrompt: boolean;
+  runInFlight: boolean;
+  notify?: (toast: ToastInput) => void;
+  setSelectedSessionId: (sessionId?: string) => void;
+  setSelectedTurnId: Dispatch<SetStateAction<string | undefined>>;
+  setSessionDetail: Dispatch<SetStateAction<ChatSessionDetail | null>>;
+  setSessionDetailError: Dispatch<SetStateAction<string | undefined>>;
+  setSendingPrompt: Dispatch<SetStateAction<boolean>>;
+  setSendPromptError: Dispatch<SetStateAction<string | undefined>>;
+  setTurnReview: Dispatch<SetStateAction<ChatTurnReview | null>>;
+  setPendingApproval: Dispatch<SetStateAction<PendingSessionApproval>>;
+  setRunInFlight: Dispatch<SetStateAction<boolean>>;
+  setCreatingSession: Dispatch<SetStateAction<boolean>>;
+  setSessionNotice: Dispatch<SetStateAction<string | undefined>>;
+  liveMessages: LiveSessionMessageActions;
+}) {
+  const resolveApproval = useCallback(async (approved: boolean) => {
+    if (!selectedSessionId || !pendingApproval) {
+      return;
+    }
+
+    try {
+      await resolvePendingSessionApproval(
+        selectedSessionId,
+        approved,
+        approved ? 'Approved in web control plane' : 'Denied in web control plane',
+      );
+      setPendingApproval(null);
+      notify?.({
+        title: approved ? 'Approval granted' : 'Approval denied',
+        body: pendingApproval.tool,
+        tone: approved ? 'success' : 'info',
+      });
+    } catch (error) {
+      notify?.({
+        title: 'Approval failed',
+        body: error instanceof Error ? error.message : String(error),
+        tone: 'error',
+      });
+    }
+  }, [notify, pendingApproval, selectedSessionId, setPendingApproval]);
+
+  const createSession = useCallback(async () => {
+    setCreatingSession(true);
+    setSessionNotice('Creating a new session…');
+    try {
+      const created = await createChatSession();
+      setSelectedSessionId(created.id);
+      setSessionDetail(created);
+      setSelectedTurnId(undefined);
+      setTurnReview(null);
+      setPendingApproval(null);
+      setRunInFlight(false);
+      setSendPromptError(undefined);
+      setSessionDetailError(undefined);
+      setSessionNotice(`Created ${created.name}. Ready for a fresh prompt.`);
+      notify?.({
+        title: 'Session created',
+        body: `${created.name} is ready for a fresh prompt.`,
+        tone: 'success',
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setSessionNotice(message);
+      notify?.({
+        title: 'Session creation failed',
+        body: message,
+        tone: 'error',
+      });
+    } finally {
+      setCreatingSession(false);
+    }
+  }, [
+    notify,
+    setCreatingSession,
+    setPendingApproval,
+    setRunInFlight,
+    setSelectedSessionId,
+    setSelectedTurnId,
+    setSendPromptError,
+    setSessionDetail,
+    setSessionDetailError,
+    setSessionNotice,
+    setTurnReview,
+  ]);
+
+  const sendPrompt = useCallback(async (prompt: string) => {
+    const trimmed = prompt.trim();
+    if (!selectedSessionId || !trimmed || sendingPrompt) {
+      return;
+    }
+
+    setSendingPrompt(true);
+    setRunInFlight(true);
+    setSendPromptError(undefined);
+    liveMessages.appendPendingUserTurn(trimmed);
+    try {
+      const result = await sendChatSessionPrompt(selectedSessionId, trimmed);
+      setSessionDetail(result.session);
+      const latestTurnId = result.session?.turns.at(-1)?.id;
+      if (latestTurnId) {
+        setSelectedTurnId(latestTurnId);
+      }
+      setRunInFlight(false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setSendPromptError(message);
+      setRunInFlight(false);
+      notify?.({
+        title: 'Send failed',
+        body: message,
+        tone: 'error',
+      });
+    } finally {
+      setSendingPrompt(false);
+    }
+  }, [
+    liveMessages,
+    notify,
+    selectedSessionId,
+    sendingPrompt,
+    setRunInFlight,
+    setSelectedTurnId,
+    setSendingPrompt,
+    setSendPromptError,
+    setSessionDetail,
+  ]);
+
+  const continueSession = useCallback(async () => {
+    if (!selectedSessionId || sendingPrompt || runInFlight) {
+      return;
+    }
+
+    setSendingPrompt(true);
+    setRunInFlight(true);
+    setSendPromptError(undefined);
+    liveMessages.upsertLiveStatusMessage('live-run-status', 'Continuing from the current transcript…', { pending: true, streaming: true });
+
+    try {
+      const result = await continueChatSession(selectedSessionId);
+      setSessionDetail(result.session);
+      const latestTurnId = result.session?.turns.at(-1)?.id;
+      if (latestTurnId) {
+        setSelectedTurnId(latestTurnId);
+      }
+      setPendingApproval(await fetchPendingSessionApproval(selectedSessionId));
+      setRunInFlight(false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setSendPromptError(message);
+      setRunInFlight(false);
+      notify?.({
+        title: 'Continue failed',
+        body: message,
+        tone: 'error',
+      });
+      liveMessages.removeLiveStatusMessage('live-run-status');
+      setSessionDetail((current) => {
+        if (!current) {
+          return current;
+        }
+        return {
+          ...current,
+          messages: current.messages.filter((message) => message.id !== 'live-assistant'),
+        };
+      });
+    } finally {
+      setSendingPrompt(false);
+    }
+  }, [
+    liveMessages,
+    notify,
+    runInFlight,
+    selectedSessionId,
+    sendingPrompt,
+    setPendingApproval,
+    setRunInFlight,
+    setSelectedTurnId,
+    setSendingPrompt,
+    setSendPromptError,
+    setSessionDetail,
+  ]);
+
+  const cancelSessionRun = useCallback(async () => {
+    if (!selectedSessionId || !runInFlight) {
+      return;
+    }
+
+    try {
+      const result = await cancelChatSession(selectedSessionId);
+      setRunInFlight(false);
+      setPendingApproval(null);
+      liveMessages.removeLiveStatusMessage('live-run-status');
+      setSendPromptError(undefined);
+      setSessionDetail((current) => {
+        if (!current) {
+          return current;
+        }
+        return {
+          ...current,
+          messages: current.messages.filter((message) => message.id !== 'live-user' && message.id !== 'live-assistant'),
+        };
+      });
+      notify?.({
+        title: result.cancelled ? 'Run cancelled' : 'No active run to cancel',
+        body: result.cancelled ? 'The active session run was interrupted.' : undefined,
+        tone: result.cancelled ? 'success' : 'info',
+      });
+    } catch (error) {
+      notify?.({
+        title: 'Cancel failed',
+        body: error instanceof Error ? error.message : String(error),
+        tone: 'error',
+      });
+    }
+  }, [
+    liveMessages,
+    notify,
+    runInFlight,
+    selectedSessionId,
+    setPendingApproval,
+    setRunInFlight,
+    setSendPromptError,
+    setSessionDetail,
+  ]);
+
+  const updateSessionSettings = useCallback(async (settings: { model?: string; driftEnabled?: boolean }) => {
+    if (!selectedSessionId || runInFlight || sendingPrompt) {
+      return;
+    }
+
+    try {
+      const updated = await updateChatSessionSettings(selectedSessionId, settings);
+      setSessionDetail(updated);
+      notify?.({
+        title: 'Session settings updated',
+        body: [
+          settings.model ? `model ${settings.model}` : undefined,
+          typeof settings.driftEnabled === 'boolean' ? `drift ${settings.driftEnabled ? 'on' : 'off'}` : undefined,
+        ].filter(Boolean).join(', '),
+        tone: 'success',
+      });
+    } catch (error) {
+      notify?.({
+        title: 'Settings update failed',
+        body: error instanceof Error ? error.message : String(error),
+        tone: 'error',
+      });
+    }
+  }, [notify, runInFlight, selectedSessionId, sendingPrompt, setSessionDetail]);
+
+  return {
+    resolveApproval,
+    createSession,
+    sendPrompt,
+    continueSession,
+    cancelSessionRun,
+    updateSessionSettings,
+  };
+}

--- a/src/web/features/control-plane/hooks/sessions-screen/useSessionTurnReview.ts
+++ b/src/web/features/control-plane/hooks/sessions-screen/useSessionTurnReview.ts
@@ -1,0 +1,92 @@
+import { useEffect, useMemo, type Dispatch, type SetStateAction } from 'react';
+import {
+  fetchChatTurnReview,
+  type ChatSessionDetail,
+  type ChatTurnReview,
+} from '../../../../lib/api';
+
+export function useSessionTurnReview({
+  sessionDetail,
+  selectedTurnId,
+  setSelectedTurnId,
+  turnReview,
+  setTurnReview,
+  turnReviewLoading,
+  setTurnReviewLoading,
+  turnReviewError,
+  setTurnReviewError,
+}: {
+  sessionDetail: ChatSessionDetail | null;
+  selectedTurnId?: string;
+  setSelectedTurnId: Dispatch<SetStateAction<string | undefined>>;
+  turnReview: ChatTurnReview | null;
+  setTurnReview: Dispatch<SetStateAction<ChatTurnReview | null>>;
+  turnReviewLoading: boolean;
+  setTurnReviewLoading: Dispatch<SetStateAction<boolean>>;
+  turnReviewError?: string;
+  setTurnReviewError: Dispatch<SetStateAction<string | undefined>>;
+}) {
+  useEffect(() => {
+    const latestTurnId = sessionDetail?.turns.at(-1)?.id;
+    if (!sessionDetail) {
+      setSelectedTurnId(undefined);
+      return;
+    }
+    if (!latestTurnId) {
+      setSelectedTurnId(undefined);
+      return;
+    }
+    if (!selectedTurnId || !sessionDetail.turns.some((turn) => turn.id === selectedTurnId)) {
+      setSelectedTurnId(latestTurnId);
+    }
+  }, [selectedTurnId, sessionDetail, setSelectedTurnId]);
+
+  const selectedTurn = useMemo(
+    () => sessionDetail?.turns.find((turn) => turn.id === selectedTurnId) ?? sessionDetail?.turns.at(-1),
+    [selectedTurnId, sessionDetail],
+  );
+
+  useEffect(() => {
+    if (!sessionDetail?.id || !selectedTurnId) {
+      setTurnReview(null);
+      setTurnReviewError(undefined);
+      return;
+    }
+
+    const sessionId = sessionDetail.id;
+    const turnId = selectedTurnId;
+    let cancelled = false;
+    setTurnReviewLoading(true);
+
+    async function refresh() {
+      try {
+        const next = await fetchChatTurnReview(sessionId, turnId);
+        if (!cancelled) {
+          setTurnReview(next);
+          setTurnReviewError(undefined);
+        }
+      } catch (refreshError) {
+        if (!cancelled) {
+          setTurnReviewError(refreshError instanceof Error ? refreshError.message : String(refreshError));
+        }
+      } finally {
+        if (!cancelled) {
+          setTurnReviewLoading(false);
+        }
+      }
+    }
+
+    void refresh();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedTurnId, sessionDetail?.id, selectedTurn?.traceFile, setTurnReview, setTurnReviewError, setTurnReviewLoading]);
+
+  return {
+    selectedTurn,
+    turnReview,
+    turnReviewLoading,
+    turnReviewError,
+  };
+}

--- a/src/web/features/control-plane/hooks/useSessionsScreenState.ts
+++ b/src/web/features/control-plane/hooks/useSessionsScreenState.ts
@@ -1,54 +1,18 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { TraceEvent } from '../../../../core/types';
-import {
-  continueChatSession,
-  createChatSession,
-  fetchChatSessionDetail,
-  fetchChatTurnReview,
-  fetchPendingSessionApproval,
-  fetchSessionRunningState,
-  resolvePendingSessionApproval,
-  sendChatSessionPrompt,
-  subscribeToChatSessionEvents,
-  cancelChatSession,
-  updateChatSessionSettings,
-  type ChatSessionDetail,
-  type ChatTurnReview,
-  type ControlPlaneState,
-  type PendingSessionApproval,
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
+  ChatSessionDetail,
+  ChatTurnReview,
+  ControlPlaneState,
+  PendingSessionApproval,
 } from '../../../lib/api';
 import type { ToastInput } from '../../../components/ui/use-toast';
+import type { SessionsScreenState } from './sessions-screen/sessionStateTypes';
+import { useLiveSessionMessages } from './sessions-screen/useLiveSessionMessages';
+import { useSessionDetailSubscription } from './sessions-screen/useSessionDetailSubscription';
+import { useSessionMutations } from './sessions-screen/useSessionMutations';
+import { useSessionTurnReview } from './sessions-screen/useSessionTurnReview';
 
-export type SessionDetailValue = Exclude<ChatSessionDetail, null>;
-export type SessionTurn = SessionDetailValue['turns'][number];
-
-export type SessionsScreenState = {
-  activeSession?: ControlPlaneState['sessions'][number];
-  selectedSessionId?: string;
-  setSelectedSessionId: (sessionId: string) => void;
-  sessionDetail: ChatSessionDetail | null;
-  sessionDetailLoading: boolean;
-  sessionDetailError?: string;
-  sendingPrompt: boolean;
-  runInFlight: boolean;
-  memoryUpdating: boolean;
-  sendPromptError?: string;
-  sendPrompt: (prompt: string) => Promise<void>;
-  creatingSession: boolean;
-  sessionNotice?: string;
-  createSession: () => Promise<void>;
-  continueSession: () => Promise<void>;
-  cancelSessionRun: () => Promise<void>;
-  updateSessionSettings: (settings: { model?: string; driftEnabled?: boolean }) => Promise<void>;
-  pendingApproval: PendingSessionApproval;
-  resolveApproval: (approved: boolean) => Promise<void>;
-  selectedTurnId?: string;
-  setSelectedTurnId: (turnId: string) => void;
-  selectedTurn?: SessionTurn;
-  turnReview: ChatTurnReview | null;
-  turnReviewLoading: boolean;
-  turnReviewError?: string;
-};
+export type { SessionDetailValue, SessionsScreenState, SessionTurn } from './sessions-screen/sessionStateTypes';
 
 export function useSessionsScreenState(
   sessions: ControlPlaneState['sessions'] | undefined,
@@ -76,119 +40,9 @@ export function useSessionsScreenState(
   const [creatingSession, setCreatingSession] = useState(false);
   const [sessionNotice, setSessionNotice] = useState<string | undefined>();
   const selectedSessionId = options?.selectedSessionId ?? internalSelectedSessionId;
-  const setSelectedSessionId = options?.onSelectedSessionIdChange ?? setInternalSelectedSessionId;
+  const setRawSelectedSessionId = options?.onSelectedSessionIdChange ?? setInternalSelectedSessionId;
   const autoSelectSession = options?.autoSelectSession ?? true;
-  const onSessionsChangedRef = useRef(onSessionsChanged);
-
-  useEffect(() => {
-    onSessionsChangedRef.current = onSessionsChanged;
-  }, [onSessionsChanged]);
-
-  const appendPendingUserTurn = useCallback((prompt: string) => {
-    setSessionDetail((current) => {
-      if (!current) {
-        return current;
-      }
-
-      const nextMessages = current.messages.filter((message) => (
-        message.id !== 'live-user'
-        && message.id !== 'live-assistant'
-        && message.id !== 'live-run-status'
-      ));
-      return {
-        ...current,
-        messages: [
-          ...nextMessages,
-          {
-            id: 'live-user',
-            role: 'user',
-            text: prompt,
-          },
-          {
-            id: 'live-run-status',
-            role: 'assistant',
-            text: 'Heddle is working…',
-            isStreaming: true,
-            isPending: true,
-          },
-        ],
-      };
-    });
-  }, []);
-
-  const upsertLiveStatusMessage = useCallback((id: string, text: string, options?: { pending?: boolean; streaming?: boolean }) => {
-    setSessionDetail((current) => {
-      if (!current) {
-        return current;
-      }
-
-      const nextMessages = [...current.messages];
-      const existingIndex = nextMessages.findIndex((message) => message.id === id);
-      const nextMessage = {
-        id,
-        role: 'assistant' as const,
-        text,
-        isPending: options?.pending,
-        isStreaming: options?.streaming,
-      };
-
-      if (existingIndex >= 0) {
-        nextMessages[existingIndex] = nextMessage;
-      } else {
-        nextMessages.push(nextMessage);
-      }
-
-      return {
-        ...current,
-        messages: nextMessages,
-      };
-    });
-  }, []);
-
-  const removeLiveStatusMessage = useCallback((id: string) => {
-    setSessionDetail((current) => {
-      if (!current) {
-        return current;
-      }
-
-      return {
-        ...current,
-        messages: current.messages.filter((message) => message.id !== id),
-      };
-    });
-  }, []);
-
-  const upsertLiveAssistantMessage = useCallback((text: string, isDone: boolean) => {
-    setSessionDetail((current) => {
-      if (!current) {
-        return current;
-      }
-
-      const nextMessages = current.messages.filter((message) => message.id !== 'live-run-status');
-      const lastMessage = nextMessages.at(-1);
-      if (lastMessage?.id === 'live-assistant' && lastMessage.role === 'assistant') {
-        nextMessages[nextMessages.length - 1] = {
-          ...lastMessage,
-          text,
-          isStreaming: !isDone,
-          isPending: !isDone,
-        };
-      } else {
-        nextMessages.push({
-          id: 'live-assistant',
-          role: 'assistant',
-          text,
-          isStreaming: !isDone,
-          isPending: !isDone,
-        });
-      }
-
-      return {
-        ...current,
-        messages: nextMessages,
-      };
-    });
-  }, []);
+  const liveMessages = useLiveSessionMessages(setSessionDetail);
 
   useEffect(() => {
     if (!autoSelectSession) {
@@ -199,7 +53,7 @@ export function useSessionsScreenState(
       if (selectedSessionId && sessionDetail?.id === selectedSessionId) {
         return;
       }
-      setSelectedSessionId(undefined);
+      setRawSelectedSessionId(undefined);
       return;
     }
 
@@ -208,483 +62,77 @@ export function useSessionsScreenState(
     }
 
     if (!selectedSessionId || !sessions.some((session) => session.id === selectedSessionId)) {
-      setSelectedSessionId(sessions[0].id);
+      setRawSelectedSessionId(sessions[0].id);
     }
-  }, [autoSelectSession, selectedSessionId, sessionDetail?.id, sessions, setSelectedSessionId]);
+  }, [autoSelectSession, selectedSessionId, sessionDetail?.id, sessions, setRawSelectedSessionId]);
 
   const selectSession = useCallback((sessionId: string) => {
-    setSelectedSessionId(sessionId);
+    setRawSelectedSessionId(sessionId);
     setSelectedTurnId(undefined);
     setSessionNotice(undefined);
     setSendPromptError(undefined);
-  }, [setSelectedSessionId]);
+  }, [setRawSelectedSessionId]);
 
-  useEffect(() => {
-    if (!selectedSessionId) {
-      setSessionDetail(null);
-      setSessionDetailError(undefined);
-      return;
-    }
-
-    const sessionId = selectedSessionId;
-    let cancelled = false;
-    let sessionUpdateTimeout: number | undefined;
-
-    async function refresh(options: { silent?: boolean } = {}) {
-      if (!options.silent) {
-        setSessionDetailLoading(true);
-      }
-      try {
-        const next = await fetchChatSessionDetail(sessionId);
-        if (!cancelled) {
-          setSessionDetail((current) => options.silent ? mergeTransientMessages(current, next) : next);
-          setSessionDetailError(undefined);
-        }
-      } catch (refreshError) {
-        if (!cancelled) {
-          setSessionDetailError(refreshError instanceof Error ? refreshError.message : String(refreshError));
-        }
-      } finally {
-        if (!cancelled && !options.silent) {
-          setSessionDetailLoading(false);
-        }
-      }
-    }
-
-    void refresh();
-    void fetchSessionRunningState(sessionId).then((state) => setRunInFlight(state.running));
-    const unsubscribe = subscribeToChatSessionEvents(sessionId, (event) => {
-      if (event.type === 'session.updated') {
-        if (sessionUpdateTimeout !== undefined) {
-          window.clearTimeout(sessionUpdateTimeout);
-        }
-        sessionUpdateTimeout = window.setTimeout(() => {
-          void fetchSessionRunningState(sessionId).then((state) => {
-            if (!cancelled) {
-              setRunInFlight(state.running);
-            }
-          });
-          void refresh({ silent: true });
-          onSessionsChangedRef.current?.();
-        }, 300);
-        return;
-      }
-
-      if (event.type !== 'session.event' || !event.event || typeof event.event !== 'object') {
-        return;
-      }
-
-      const liveEvent = event.event as {
-        type?: string;
-        text?: string;
-        done?: boolean;
-        tool?: string;
-        step?: number;
-        durationMs?: number;
-        outcome?: string;
-        summary?: string;
-        event?: TraceEvent;
-        status?: 'running' | 'finished' | 'failed';
-        archivePath?: string;
-        summaryPath?: string;
-        error?: string;
-      };
-
-      if (liveEvent.status === 'running') {
-        upsertLiveStatusMessage(
-          'live-run-status',
-          liveEvent.archivePath ? `Compacting earlier history… ${liveEvent.archivePath}` : 'Compacting earlier history…',
-          { pending: true, streaming: false },
-        );
-        return;
-      }
-
-      if (liveEvent.status === 'failed') {
-        upsertLiveStatusMessage(
-          'live-run-status',
-          liveEvent.error ? `Compaction failed: ${liveEvent.error}` : 'Compaction failed.',
-          { pending: false, streaming: false },
-        );
-        return;
-      }
-
-      if (liveEvent.status === 'finished') {
-        upsertLiveStatusMessage(
-          'live-run-status',
-          liveEvent.summaryPath ? `Compaction finished. Summary: ${liveEvent.summaryPath}` : 'Compaction finished.',
-          { pending: false, streaming: false },
-        );
-        return;
-      }
-
-      if (liveEvent.type === 'loop.started') {
-        setRunInFlight(true);
-        upsertLiveStatusMessage('live-run-status', 'Run started…', { pending: true, streaming: true });
-        return;
-      }
-
-      if (liveEvent.type === 'tool.calling' && typeof liveEvent.tool === 'string') {
-        upsertLiveStatusMessage(
-          'live-run-status',
-          `Working… running ${liveEvent.tool}${typeof liveEvent.step === 'number' ? ` (step ${liveEvent.step})` : ''}`,
-          { pending: true, streaming: true },
-        );
-        return;
-      }
-
-      if (liveEvent.type === 'tool.completed' && typeof liveEvent.tool === 'string') {
-        upsertLiveStatusMessage(
-          'live-run-status',
-          `${liveEvent.tool} finished${typeof liveEvent.durationMs === 'number' ? ` in ${Math.round(liveEvent.durationMs)}ms` : ''}`,
-          { pending: false, streaming: false },
-        );
-        return;
-      }
-
-      if (liveEvent.type === 'trace' && liveEvent.event) {
-        const traceEvent = liveEvent.event;
-        if (traceEvent.type === 'memory.maintenance_started') {
-          setMemoryUpdating(true);
-          upsertLiveStatusMessage(
-            'live-run-status',
-            `Memory updating… ${traceEvent.candidateIds.length} candidate${traceEvent.candidateIds.length === 1 ? '' : 's'}`,
-            { pending: true, streaming: false },
-          );
-          return;
-        }
-
-        if (traceEvent.type === 'memory.maintenance_finished') {
-          setMemoryUpdating(false);
-          upsertLiveStatusMessage(
-            'live-run-status',
-            traceEvent.summary ? `Memory updated. ${traceEvent.summary}` : 'Memory updated.',
-            { pending: false, streaming: false },
-          );
-          void refresh({ silent: true });
-          return;
-        }
-
-        if (traceEvent.type === 'memory.maintenance_failed') {
-          setMemoryUpdating(false);
-          upsertLiveStatusMessage(
-            'live-run-status',
-            traceEvent.error ? `Memory update failed: ${traceEvent.error}` : 'Memory update failed.',
-            { pending: false, streaming: false },
-          );
-          return;
-        }
-
-        if (traceEvent.type === 'tool.approval_requested') {
-          void fetchPendingSessionApproval(sessionId).then((approval) => setPendingApproval(approval));
-          upsertLiveStatusMessage(
-            'live-run-status',
-            `Approval requested for ${traceEvent.call.tool}${typeof traceEvent.step === 'number' ? ` (step ${traceEvent.step})` : ''}`,
-            { pending: true, streaming: false },
-          );
-          return;
-        }
-
-        if (traceEvent.type === 'tool.approval_resolved') {
-          setPendingApproval(null);
-          upsertLiveStatusMessage(
-            'live-run-status',
-            `Approval ${traceEvent.approved ? 'granted' : 'denied'} for ${traceEvent.call.tool}${traceEvent.reason ? ` — ${traceEvent.reason}` : ''}`,
-            { pending: false, streaming: false },
-          );
-          return;
-        }
-
-        if (traceEvent.type === 'tool.fallback') {
-          upsertLiveStatusMessage(
-            'live-run-status',
-            `Fallback: ${traceEvent.fromCall.tool} → ${traceEvent.toCall.tool}`,
-            { pending: true, streaming: false },
-          );
-          return;
-        }
-      }
-
-      if (liveEvent.type === 'assistant.stream' && typeof liveEvent.text === 'string') {
-        upsertLiveAssistantMessage(liveEvent.text, Boolean(liveEvent.done));
-        if (liveEvent.done) {
-          removeLiveStatusMessage('live-run-status');
-        }
-        return;
-      }
-
-      if (liveEvent.type === 'loop.finished') {
-        setRunInFlight(false);
-        removeLiveStatusMessage('live-run-status');
-        void refresh();
-      }
-    });
-
-    return () => {
-      cancelled = true;
-      if (sessionUpdateTimeout !== undefined) {
-        window.clearTimeout(sessionUpdateTimeout);
-      }
-      unsubscribe();
-    };
-  }, [
-    removeLiveStatusMessage,
+  useSessionDetailSubscription({
     selectedSessionId,
-    upsertLiveAssistantMessage,
-    upsertLiveStatusMessage,
-  ]);
-
-  useEffect(() => {
-    const latestTurnId = sessionDetail?.turns.at(-1)?.id;
-    if (!sessionDetail) {
-      setSelectedTurnId(undefined);
-      return;
-    }
-    if (!latestTurnId) {
-      setSelectedTurnId(undefined);
-      return;
-    }
-    if (!selectedTurnId || !sessionDetail.turns.some((turn) => turn.id === selectedTurnId)) {
-      setSelectedTurnId(latestTurnId);
-    }
-  }, [selectedTurnId, sessionDetail]);
+    setSessionDetail,
+    setSessionDetailLoading,
+    setSessionDetailError,
+    setRunInFlight,
+    setMemoryUpdating,
+    setPendingApproval,
+    onSessionsChanged,
+    liveMessages,
+  });
 
   const activeSession = useMemo(
     () => sessions?.find((session) => session.id === selectedSessionId),
     [selectedSessionId, sessions],
   );
-  const selectedTurn = useMemo(
-    () => sessionDetail?.turns.find((turn) => turn.id === selectedTurnId) ?? sessionDetail?.turns.at(-1),
-    [selectedTurnId, sessionDetail],
-  );
 
-  useEffect(() => {
-    if (!sessionDetail?.id || !selectedTurnId) {
-      setTurnReview(null);
-      setTurnReviewError(undefined);
-      return;
-    }
+  const {
+    selectedTurn,
+    turnReview: loadedTurnReview,
+    turnReviewLoading: loadedTurnReviewLoading,
+    turnReviewError: loadedTurnReviewError,
+  } = useSessionTurnReview({
+    sessionDetail,
+    selectedTurnId,
+    setSelectedTurnId,
+    turnReview,
+    setTurnReview,
+    turnReviewLoading,
+    setTurnReviewLoading,
+    turnReviewError,
+    setTurnReviewError,
+  });
 
-    const sessionId = sessionDetail.id;
-    const turnId = selectedTurnId;
-    let cancelled = false;
-    setTurnReviewLoading(true);
-
-    async function refresh() {
-      try {
-        const next = await fetchChatTurnReview(sessionId, turnId);
-        if (!cancelled) {
-          setTurnReview(next);
-          setTurnReviewError(undefined);
-        }
-      } catch (refreshError) {
-        if (!cancelled) {
-          setTurnReviewError(refreshError instanceof Error ? refreshError.message : String(refreshError));
-        }
-      } finally {
-        if (!cancelled) {
-          setTurnReviewLoading(false);
-        }
-      }
-    }
-
-    void refresh();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedTurnId, sessionDetail?.id, selectedTurn?.traceFile]);
-
-  const resolveApproval = useCallback(async (approved: boolean) => {
-    if (!selectedSessionId || !pendingApproval) {
-      return;
-    }
-
-    try {
-      await resolvePendingSessionApproval(
-        selectedSessionId,
-        approved,
-        approved ? 'Approved in web control plane' : 'Denied in web control plane',
-      );
-      setPendingApproval(null);
-      notify?.({
-        title: approved ? 'Approval granted' : 'Approval denied',
-        body: pendingApproval.tool,
-        tone: approved ? 'success' : 'info',
-      });
-    } catch (error) {
-      notify?.({
-        title: 'Approval failed',
-        body: error instanceof Error ? error.message : String(error),
-        tone: 'error',
-      });
-    }
-  }, [notify, pendingApproval, selectedSessionId]);
-
-  const createSession = useCallback(async () => {
-    setCreatingSession(true);
-    setSessionNotice('Creating a new session…');
-    try {
-      const created = await createChatSession();
-      setSelectedSessionId(created.id);
-      setSessionDetail(created);
-      setSelectedTurnId(undefined);
-      setTurnReview(null);
-      setPendingApproval(null);
-      setRunInFlight(false);
-      setSendPromptError(undefined);
-      setSessionDetailError(undefined);
-      setSessionNotice(`Created ${created.name}. Ready for a fresh prompt.`);
-      notify?.({
-        title: 'Session created',
-        body: `${created.name} is ready for a fresh prompt.`,
-        tone: 'success',
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setSessionNotice(message);
-      notify?.({
-        title: 'Session creation failed',
-        body: message,
-        tone: 'error',
-      });
-    } finally {
-      setCreatingSession(false);
-    }
-  }, [notify, setSelectedSessionId]);
-
-  const sendPrompt = useCallback(async (prompt: string) => {
-    const trimmed = prompt.trim();
-    if (!selectedSessionId || !trimmed || sendingPrompt) {
-      return;
-    }
-
-    setSendingPrompt(true);
-    setRunInFlight(true);
-    setSendPromptError(undefined);
-    appendPendingUserTurn(trimmed);
-    try {
-      const result = await sendChatSessionPrompt(selectedSessionId, trimmed);
-      setSessionDetail(result.session);
-      const latestTurnId = result.session?.turns.at(-1)?.id;
-      if (latestTurnId) {
-        setSelectedTurnId(latestTurnId);
-      }
-      setRunInFlight(false);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setSendPromptError(message);
-      setRunInFlight(false);
-      notify?.({
-        title: 'Send failed',
-        body: message,
-        tone: 'error',
-      });
-    } finally {
-      setSendingPrompt(false);
-    }
-  }, [appendPendingUserTurn, notify, selectedSessionId, sendingPrompt]);
-
-  const continueSession = useCallback(async () => {
-    if (!selectedSessionId || sendingPrompt || runInFlight) {
-      return;
-    }
-
-    setSendingPrompt(true);
-    setRunInFlight(true);
-    setSendPromptError(undefined);
-    upsertLiveStatusMessage('live-run-status', 'Continuing from the current transcript…', { pending: true, streaming: true });
-
-    try {
-      const result = await continueChatSession(selectedSessionId);
-      setSessionDetail(result.session);
-      const latestTurnId = result.session?.turns.at(-1)?.id;
-      if (latestTurnId) {
-        setSelectedTurnId(latestTurnId);
-      }
-      setPendingApproval(await fetchPendingSessionApproval(selectedSessionId));
-      setRunInFlight(false);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setSendPromptError(message);
-      setRunInFlight(false);
-      notify?.({
-        title: 'Continue failed',
-        body: message,
-        tone: 'error',
-      });
-      removeLiveStatusMessage('live-run-status');
-      setSessionDetail((current) => {
-        if (!current) {
-          return current;
-        }
-        return {
-          ...current,
-          messages: current.messages.filter((message) => message.id !== 'live-assistant'),
-        };
-      });
-    } finally {
-      setSendingPrompt(false);
-    }
-  }, [notify, removeLiveStatusMessage, runInFlight, selectedSessionId, sendingPrompt, upsertLiveStatusMessage]);
-
-  const cancelSessionRun = useCallback(async () => {
-    if (!selectedSessionId || !runInFlight) {
-      return;
-    }
-
-    try {
-      const result = await cancelChatSession(selectedSessionId);
-      setRunInFlight(false);
-      setPendingApproval(null);
-      removeLiveStatusMessage('live-run-status');
-      setSendPromptError(undefined);
-      setSessionDetail((current) => {
-        if (!current) {
-          return current;
-        }
-        return {
-          ...current,
-          messages: current.messages.filter((message) => message.id !== 'live-user' && message.id !== 'live-assistant'),
-        };
-      });
-      notify?.({
-        title: result.cancelled ? 'Run cancelled' : 'No active run to cancel',
-        body: result.cancelled ? 'The active session run was interrupted.' : undefined,
-        tone: result.cancelled ? 'success' : 'info',
-      });
-    } catch (error) {
-      notify?.({
-        title: 'Cancel failed',
-        body: error instanceof Error ? error.message : String(error),
-        tone: 'error',
-      });
-    }
-  }, [notify, removeLiveStatusMessage, runInFlight, selectedSessionId]);
-
-  const updateSessionSettings = useCallback(async (settings: { model?: string; driftEnabled?: boolean }) => {
-    if (!selectedSessionId || runInFlight || sendingPrompt) {
-      return;
-    }
-
-    try {
-      const updated = await updateChatSessionSettings(selectedSessionId, settings);
-      setSessionDetail(updated);
-      notify?.({
-        title: 'Session settings updated',
-        body: [
-          settings.model ? `model ${settings.model}` : undefined,
-          typeof settings.driftEnabled === 'boolean' ? `drift ${settings.driftEnabled ? 'on' : 'off'}` : undefined,
-        ].filter(Boolean).join(', '),
-        tone: 'success',
-      });
-    } catch (error) {
-      notify?.({
-        title: 'Settings update failed',
-        body: error instanceof Error ? error.message : String(error),
-        tone: 'error',
-      });
-    }
-  }, [notify, runInFlight, selectedSessionId, sendingPrompt]);
+  const {
+    resolveApproval,
+    createSession,
+    sendPrompt,
+    continueSession,
+    cancelSessionRun,
+    updateSessionSettings,
+  } = useSessionMutations({
+    selectedSessionId,
+    pendingApproval,
+    sendingPrompt,
+    runInFlight,
+    notify,
+    setSelectedSessionId: setRawSelectedSessionId,
+    setSelectedTurnId,
+    setSessionDetail,
+    setSessionDetailError,
+    setSendingPrompt,
+    setSendPromptError,
+    setTurnReview,
+    setPendingApproval,
+    setRunInFlight,
+    setCreatingSession,
+    setSessionNotice,
+    liveMessages,
+  });
 
   return {
     activeSession,
@@ -709,28 +157,8 @@ export function useSessionsScreenState(
     selectedTurnId,
     setSelectedTurnId,
     selectedTurn,
-    turnReview,
-    turnReviewLoading,
-    turnReviewError,
-  };
-}
-
-function mergeTransientMessages(current: ChatSessionDetail | null, next: ChatSessionDetail | null): ChatSessionDetail | null {
-  if (!current || !next || current.id !== next.id) {
-    return next;
-  }
-
-  const transientMessages = current.messages.filter((message) => message.id.startsWith('live-'));
-  if (!transientMessages.length) {
-    return next;
-  }
-
-  const nextMessageIds = new Set(next.messages.map((message) => message.id));
-  return {
-    ...next,
-    messages: [
-      ...next.messages,
-      ...transientMessages.filter((message) => !nextMessageIds.has(message.id)),
-    ],
+    turnReview: loadedTurnReview,
+    turnReviewLoading: loadedTurnReviewLoading,
+    turnReviewError: loadedTurnReviewError,
   };
 }


### PR DESCRIPTION
## Summary

Refactors `useSessionsScreenState` into focused session-screen hooks while preserving its public API.

- Moves shared state types into `sessions-screen/sessionStateTypes`.
- Extracts optimistic/live message helpers into `useLiveSessionMessages`.
- Extracts session detail loading, subscription, and live event handling into `useSessionDetailSubscription`.
- Extracts session creation/send/continue/cancel/settings/approval mutations into `useSessionMutations`.
- Extracts turn selection and trace-backed review loading into `useSessionTurnReview`.
- Replaces long live-event and trace-event `if` chains with extensible handler maps.

## Impact

The existing app-facing hook shape remains unchanged, but the implementation is split by responsibility and is easier to extend without growing the facade or event dispatch logic.

## Validation

- `yarn vitest run src/__tests__/integration/web/control-plane-sessions-state.test.tsx src/__tests__/integration/web/control-plane-sessions-screen.test.tsx`
- `yarn typecheck`
- `yarn test`
- `yarn eslint`
- `yarn build`