### PR TITLE
[codex] Unify control-plane session model selection

### DIFF
--- a/src/__tests__/integration/chat/chat-runtime.test.ts
+++ b/src/__tests__/integration/chat/chat-runtime.test.ts
@@ -366,6 +366,77 @@ describe('executeAgentTurn final message persistence', () => {
 describe('control-plane shared chat runtime integration', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  function createControlPlaneSessionStoragePath() {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-control-plane-runtime-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    return resolve(stateRoot, 'chat-sessions.catalog.json');
+  }
+
+  it('defaults new control-plane sessions to the shared OpenAI default model', () => {
+    vi.stubEnv('OPENAI_MODEL', '');
+    vi.stubEnv('ANTHROPIC_MODEL', '');
+
+    const session = createControlPlaneChatSession({
+      sessionStoragePath: createControlPlaneSessionStoragePath(),
+      suggestedName: 'Default model test',
+    });
+
+    expect(session.model).toBe('gpt-5.4');
+  });
+
+  it('falls back to an OAuth-compatible model when a configured OpenAI model is unsupported', () => {
+    vi.stubEnv('OPENAI_MODEL', 'gpt-4.1');
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');
+    const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-control-plane-oauth-')), 'auth.json');
+    const now = '2026-05-02T00:00:00.000Z';
+    setStoredProviderCredential({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.parse('2026-05-02T01:00:00.000Z'),
+      accountId: 'account-1234567890',
+      createdAt: now,
+      updatedAt: now,
+    }, storePath);
+
+    const session = createControlPlaneChatSession({
+      sessionStoragePath: createControlPlaneSessionStoragePath(),
+      suggestedName: 'OAuth fallback test',
+      credentialStorePath: storePath,
+    });
+
+    expect(session.model).toBe('gpt-5.4');
+  });
+
+  it('preserves broader OpenAI model choices in API-key mode', () => {
+    vi.stubEnv('OPENAI_MODEL', 'gpt-4.1');
+    vi.stubEnv('OPENAI_API_KEY', 'test-openai-key');
+    const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-control-plane-api-key-')), 'auth.json');
+    const now = '2026-05-02T00:00:00.000Z';
+    setStoredProviderCredential({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.parse('2026-05-02T01:00:00.000Z'),
+      accountId: 'account-1234567890',
+      createdAt: now,
+      updatedAt: now,
+    }, storePath);
+
+    const session = createControlPlaneChatSession({
+      sessionStoragePath: createControlPlaneSessionStoragePath(),
+      suggestedName: 'API key model test',
+      preferApiKey: true,
+      credentialStorePath: storePath,
+    });
+
+    expect(session.model).toBe('gpt-4.1');
   });
 
   it('continues with the stored prompt while preserving continue-style transcript text', async () => {

--- a/src/server/features/control-plane/router.ts
+++ b/src/server/features/control-plane/router.ts
@@ -163,6 +163,7 @@ export const controlPlaneRouter = router({
       workspaceId: ctx.activeWorkspace.id,
       model: input?.model,
       apiKeyPresent: input?.apiKeyPresent,
+      preferApiKey: ctx.preferApiKey,
     });
   }),
   session: procedure.input(sessionInputSchema).query(({ ctx, input }) => {

--- a/src/server/features/control-plane/services/chat-sessions.ts
+++ b/src/server/features/control-plane/services/chat-sessions.ts
@@ -3,8 +3,10 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createChatSession, readChatSession, readChatSessionCatalog, saveChatSessions } from '../../../../core/chat/storage.js';
 import { DEFAULT_OPENAI_MODEL } from '../../../../core/config.js';
+import { credentialModeFromSource, resolveCompatibleActiveModel } from '../../../../core/llm/model-policy.js';
+import { inferProviderFromModel } from '../../../../core/llm/providers.js';
 import { parseUnifiedDiffFiles } from '../../../../core/review/diff-domain.js';
-import { hasProviderCredentialForModel } from '../../../../core/runtime/api-keys.js';
+import { hasProviderCredentialForModel, resolveProviderCredentialSourceForModel } from '../../../../core/runtime/api-keys.js';
 import type { ChatSessionLeaseOwner } from '../../../../core/chat/session-lease.js';
 import type { ChatSession, TurnSummary } from '../../../../core/chat/types.js';
 import { buildConversationMessages } from '../../../../core/chat/conversation-lines.js';
@@ -49,23 +51,52 @@ export function createControlPlaneChatSession(args: {
   workspaceId?: string;
   model?: string;
   apiKeyPresent?: boolean;
+  preferApiKey?: boolean;
+  credentialStorePath?: string;
 }): ChatSessionDetail {
   const existing = readChatSessionViews(args.sessionStoragePath);
   const nextNumber = existing.length + 1;
-  const model = args.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
+  const model = resolveControlPlaneSessionCreationModel(args);
+  const credentialRuntime = {
+    preferApiKey: args.preferApiKey,
+    credentialStorePath: args.credentialStorePath,
+  };
   const session = createChatSession({
     id: `session-${Date.now()}`,
     name: args.suggestedName?.trim() || `Session ${nextNumber}`,
-    apiKeyPresent: args.apiKeyPresent ?? hasProviderCredentialForModel(model),
+    apiKeyPresent: args.apiKeyPresent ?? hasProviderCredentialForModel(model, credentialRuntime),
     model,
     workspaceId: args.workspaceId,
   });
 
   const currentSessions = readChatSessionCatalog(args.sessionStoragePath)
-    .map((entry) => readChatSession(args.sessionStoragePath, entry.id, hasProviderCredentialForModel(model)))
+    .map((entry) => readChatSession(args.sessionStoragePath, entry.id, hasProviderCredentialForModel(model, credentialRuntime)))
     .filter((candidate): candidate is ChatSession => Boolean(candidate));
   saveChatSessions(args.sessionStoragePath, [session, ...currentSessions]);
   return projectChatSessionDetail(session)[0] as ChatSessionDetail;
+}
+
+function resolveControlPlaneSessionCreationModel(args: {
+  model?: string;
+  preferApiKey?: boolean;
+  credentialStorePath?: string;
+}): string {
+  const activeModel = firstNonEmpty(args.model, process.env.OPENAI_MODEL, process.env.ANTHROPIC_MODEL) ?? DEFAULT_OPENAI_MODEL;
+  const provider = inferProviderFromModel(activeModel);
+  const credentialMode = credentialModeFromSource(resolveProviderCredentialSourceForModel(activeModel, {
+    preferApiKey: args.preferApiKey,
+    credentialStorePath: args.credentialStorePath,
+  }));
+
+  return resolveCompatibleActiveModel({
+    activeModel,
+    provider,
+    credentialMode,
+  }).model;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find((value) => typeof value === 'string' && value.trim().length > 0);
 }
 
 export function updateControlPlaneChatSessionSettings(args: {


### PR DESCRIPTION
## Summary

- Route control-plane session creation through the credential-aware model compatibility policy before persisting a new session.
- Pass the server `preferApiKey` setting into session creation so OAuth and API-key modes resolve models consistently.
- Add integration coverage for default model selection, OAuth fallback, and API-key mode preserving broader model choices.

## Root Cause

The web control plane created sessions without specifying a model, and the server persisted a raw environment/default choice. That bypassed the compatibility logic used by the TUI, so new web sessions could keep an OAuth-incompatible configured model instead of falling back to `gpt-5.4`.

## Validation

- `yarn vitest run src/__tests__/integration/chat/chat-runtime.test.ts`
- `yarn typecheck`
- `yarn eslint`
- `yarn test`
- `yarn build`