### PR TITLE
[codex] Refactor core slash command modules

### DIFF
--- a/src/__tests__/unit/core/slash-command-modules.test.ts
+++ b/src/__tests__/unit/core/slash-command-modules.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSlashCommandRegistry } from '../../../core/commands/slash/registry.js';
+import { createCoreSlashCommandModules } from '../../../core/commands/slash/modules/core-command-modules.js';
+import type { SlashCommandExecutionContext } from '../../../core/commands/slash/modules/context.js';
+
+function createContext(overrides: Partial<SlashCommandExecutionContext> = {}): SlashCommandExecutionContext {
+  let activeModel = 'gpt-5.4';
+  let driftEnabled = false;
+
+  return {
+    model: {
+      active: () => activeModel,
+      setActive: (model) => {
+        activeModel = model;
+      },
+      credentialSource: () => undefined,
+    },
+    auth: {
+      status: () => 'Auth store: test\nStored credentials: none',
+      login: async (provider) => `Logged in ${provider}`,
+      logout: (provider) => `Logged out ${provider}`,
+    },
+    compaction: {
+      compactActive: () => 'Compacted history.',
+    },
+    drift: {
+      status: () => ({ enabled: driftEnabled }),
+      setEnabled: (enabled) => {
+        driftEnabled = enabled;
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('core slash command modules', () => {
+  const registry = createSlashCommandRegistry(createCoreSlashCommandModules());
+
+  it('runs model commands through the registry and preserves compatibility aliases', async () => {
+    const context = createContext();
+
+    await expect(registry.run(context, '/model')).resolves.toMatchObject({
+      kind: 'message',
+      message: 'Current model: gpt-5.4',
+    });
+    await expect(registry.run(context, '/models')).resolves.toMatchObject({
+      kind: 'message',
+      message: expect.stringContaining('Common built-in model choices'),
+    });
+    await expect(registry.run(context, '/model gpt-5.4-mini')).resolves.toMatchObject({
+      kind: 'message',
+      message: 'Switched model to gpt-5.4-mini',
+    });
+    await expect(registry.run(context, '/model')).resolves.toMatchObject({
+      message: 'Current model: gpt-5.4-mini',
+    });
+  });
+
+  it('uses shared model credential policy before switching models', async () => {
+    const setActive = vi.fn();
+    const context = createContext({
+      model: {
+        active: () => 'gpt-5.4',
+        setActive,
+        credentialSource: () => ({
+          type: 'oauth',
+          provider: 'openai',
+          accountId: 'acct',
+          expiresAt: Date.now() + 60_000,
+        }),
+      },
+    });
+
+    await expect(registry.run(context, '/model gpt-5.4-pro')).resolves.toMatchObject({
+      kind: 'message',
+      message: expect.stringContaining('OpenAI account sign-in is not enabled for model gpt-5.4-pro'),
+    });
+    expect(setActive).not.toHaveBeenCalled();
+  });
+
+  it('routes auth, compaction, and drift commands through host ports', async () => {
+    const context = createContext();
+
+    await expect(registry.run(context, '/auth login openai')).resolves.toMatchObject({
+      message: 'Logged in openai',
+    });
+    await expect(registry.run(context, '/compact')).resolves.toMatchObject({
+      message: 'Compacted history.',
+    });
+    await expect(registry.run(context, '/drift on')).resolves.toMatchObject({
+      message: expect.stringContaining('Enabled CyberLoop semantic drift detection'),
+    });
+    await expect(registry.run(context, '/drift status')).resolves.toMatchObject({
+      message: expect.stringContaining('CyberLoop drift detection is enabled'),
+    });
+  });
+
+  it('publishes module-owned help hints for host command surfaces', () => {
+    expect(registry.hints()).toEqual(expect.arrayContaining([
+      { command: '/model <name>', description: 'switch the current model' },
+      { command: '/auth login openai', description: 'sign in with OpenAI ChatGPT/Codex OAuth' },
+      { command: '/compact', description: 'compact earlier session history for the next run' },
+      { command: '/drift', description: 'show CyberLoop semantic drift detection status' },
+    ]));
+  });
+});

--- a/src/cli/chat/adapters/slash-command-context.ts
+++ b/src/cli/chat/adapters/slash-command-context.ts
@@ -1,0 +1,29 @@
+import { formatAuthStatusMessage, loginProviderWithOAuth, logoutProvider } from '../../auth.js';
+import type { SlashCommandExecutionContext } from '../../../core/commands/slash/modules/context.js';
+import type { LocalCommandArgs } from '../state/local-commands.js';
+
+export function createTuiSlashCommandContext(args: LocalCommandArgs): SlashCommandExecutionContext {
+  return {
+    model: {
+      active: () => args.activeModel,
+      setActive: args.setActiveModel,
+      credentialSource: () => args.providerCredentialSource,
+    },
+    auth: {
+      status: () => formatAuthStatusMessage(args.credentialStorePath),
+      login: (provider) =>
+        loginProviderWithOAuth(provider, {
+          storePath: args.credentialStorePath,
+          openAiLogin: args.openAiLogin,
+        }),
+      logout: (provider) => logoutProvider(provider, args.credentialStorePath),
+    },
+    compaction: {
+      compactActive: args.compactConversation,
+    },
+    drift: {
+      status: () => ({ enabled: args.driftEnabled, error: args.driftError }),
+      setEnabled: args.setDriftEnabled,
+    },
+  };
+}

--- a/src/cli/chat/state/local-commands.ts
+++ b/src/cli/chat/state/local-commands.ts
@@ -1,12 +1,11 @@
 import type { ChatSession, LocalCommandResult } from './types.js';
 import { summarizeSession } from './storage.js';
-import { formatAuthStatusMessage, loginProviderWithOAuth, logoutProvider } from '../../auth.js';
 import type { OpenAiOAuthCredential } from '../../../core/auth/openai-oauth.js';
-import { COMMON_BUILT_IN_MODELS, formatBuiltInModelGroups } from '../../../core/llm/openai-models.js';
-import { credentialModeFromSource, validateModelCredentialCompatibility } from '../../../core/llm/model-policy.js';
-import type { LlmProvider } from '../../../core/llm/types.js';
 import type { ProviderCredentialSource } from '../utils/runtime.js';
 import { createFileHeartbeatTaskStore } from '../../../core/runtime/heartbeat-task-store.js';
+import { createSlashCommandRegistry } from '../../../core/commands/slash/registry.js';
+import { createCoreSlashCommandModules } from '../../../core/commands/slash/modules/core-command-modules.js';
+import { createTuiSlashCommandContext } from '../adapters/slash-command-context.js';
 import { join } from 'node:path';
 
 export type LocalCommandHint = {
@@ -42,25 +41,12 @@ export type LocalCommandArgs = {
 type ExactCommandHandler = (args: LocalCommandArgs) => Promise<LocalCommandResult> | LocalCommandResult;
 type PrefixCommandHandler = (args: LocalCommandArgs, value: string) => Promise<LocalCommandResult> | LocalCommandResult;
 
-const MODEL_LIST_MESSAGE = ['Common built-in model choices', '', formatBuiltInModelGroups()].join('\n');
-const MODEL_SET_HELP_MESSAGE = 'Use /model set <query> to filter models, then use arrows and Enter to choose one.';
-const HELP_HINTS: LocalCommandHint[] = [
+const CORE_COMMAND_REGISTRY = createSlashCommandRegistry(createCoreSlashCommandModules());
+const LOCAL_COMMAND_HINTS: LocalCommandHint[] = [
   { command: '/help', description: 'show available local commands' },
-  { command: '/model', description: 'show the active model' },
-  { command: '/model <name>', description: 'switch the current model' },
-  { command: '/model set [query]', description: 'pick a model with filtering' },
-  { command: '/model list', description: 'list common built-in models' },
-  { command: '/auth', description: 'show stored provider credentials' },
-  { command: '/auth status', description: 'show stored provider credentials' },
-  { command: '/auth login openai', description: 'sign in with OpenAI ChatGPT/Codex OAuth' },
-  { command: '/auth logout <provider>', description: 'remove a stored provider credential' },
   { command: '/continue', description: 'resume from the current transcript' },
   { command: '/clear', description: 'reset the current session transcript' },
-  { command: '/compact', description: 'compact earlier session history for the next run' },
   { command: '/debug tui-snapshot', description: 'save the latest rendered TUI frame for inspection' },
-  { command: '/drift', description: 'show CyberLoop semantic drift detection status' },
-  { command: '/drift on', description: 'enable CyberLoop semantic drift detection for chat runs' },
-  { command: '/drift off', description: 'disable CyberLoop semantic drift detection' },
   { command: '/heartbeat tasks', description: 'list heartbeat tasks' },
   { command: '/heartbeat task <id>', description: 'show one heartbeat task' },
   { command: '/heartbeat runs [task]', description: 'list recent heartbeat runs' },
@@ -74,6 +60,11 @@ const HELP_HINTS: LocalCommandHint[] = [
   { command: '/session rename <name>', description: 'rename the current session' },
   { command: '/session close <id>', description: 'remove a saved session' },
   { command: '!<command>', description: 'run a shell command directly in chat using the current policy' },
+];
+const HELP_HINTS: LocalCommandHint[] = [
+  LOCAL_COMMAND_HINTS[0]!,
+  ...CORE_COMMAND_REGISTRY.hints(),
+  ...LOCAL_COMMAND_HINTS.slice(1),
 ];
 const COMMAND_ROOTS = Array.from(
   new Set(
@@ -90,31 +81,14 @@ const HELP_MESSAGE = [
 
 const EXACT_COMMANDS = new Map<string, ExactCommandHandler>([
   ['/help', () => messageResult(HELP_MESSAGE)],
-  ['/models', () => messageResult(MODEL_LIST_MESSAGE)],
-  ['/model list', () => messageResult(MODEL_LIST_MESSAGE)],
-  ['/model', (args) => messageResult(`Current model: ${args.activeModel}`)],
-  ['/model set', () => messageResult(MODEL_SET_HELP_MESSAGE)],
-  ['/auth', (args) => messageResult(formatAuthStatusMessage(args.credentialStorePath))],
-  ['/auth status', (args) => messageResult(formatAuthStatusMessage(args.credentialStorePath))],
   ['/clear', (args) => {
     args.clearConversation();
     return messageResult('Cleared the current chat transcript.');
   }],
-  ['/compact', async (args) => messageResult(await args.compactConversation())],
   ['/debug tui-snapshot', async (args) =>
     messageResult(
       args.saveTuiSnapshot ? await args.saveTuiSnapshot() : 'TUI snapshots are not available in this runtime.',
     )],
-  ['/drift', (args) => messageResult(formatDriftStatus(args.driftEnabled, args.driftError))],
-  ['/drift status', (args) => messageResult(formatDriftStatus(args.driftEnabled, args.driftError))],
-  ['/drift on', (args) => {
-    args.setDriftEnabled(true);
-    return messageResult('Enabled CyberLoop semantic drift detection for chat runs. Heddle will load real CyberLoop kinematics middleware and write annotations into traces.');
-  }],
-  ['/drift off', (args) => {
-    args.setDriftEnabled(false);
-    return messageResult('Disabled CyberLoop semantic drift detection.');
-  }],
   ['/heartbeat tasks', (args) => listHeartbeatTasksMessage(args)],
   ['/heartbeat runs', (args) => listHeartbeatRunsMessage(args, '')],
   ['/continue', () => ({ handled: true, kind: 'continue' })],
@@ -125,9 +99,6 @@ const EXACT_COMMANDS = new Map<string, ExactCommandHandler>([
 ]);
 
 const PREFIX_COMMANDS: Array<{ prefix: string; handle: PrefixCommandHandler }> = [
-  { prefix: '/model ', handle: handleModelCommand },
-  { prefix: '/auth login ', handle: handleAuthLogin },
-  { prefix: '/auth logout ', handle: handleAuthLogout },
   { prefix: '/heartbeat task ', handle: handleHeartbeatTask },
   { prefix: '/heartbeat runs ', handle: handleHeartbeatRuns },
   { prefix: '/heartbeat run ', handle: handleHeartbeatRun },
@@ -155,6 +126,10 @@ export function isLikelyLocalCommand(prompt: string): boolean {
   }
 
   if (COMMAND_ROOTS.some((root) => root.startsWith(firstToken))) {
+    return true;
+  }
+
+  if (CORE_COMMAND_REGISTRY.find(trimmed)) {
     return true;
   }
 
@@ -225,6 +200,11 @@ export async function runLocalCommand(args: LocalCommandArgs): Promise<LocalComm
     return { handled: false };
   }
 
+  const coreResult = await CORE_COMMAND_REGISTRY.run(createTuiSlashCommandContext(args), trimmed);
+  if (coreResult) {
+    return coreResult;
+  }
+
   const exact = EXACT_COMMANDS.get(trimmed);
   if (exact) {
     return await exact(args);
@@ -237,73 +217,6 @@ export async function runLocalCommand(args: LocalCommandArgs): Promise<LocalComm
   }
 
   return messageResult(`Unknown command: ${trimmed}. Use /help for available commands.`);
-}
-
-function handleModelCommand(args: LocalCommandArgs, value: string): LocalCommandResult {
-  if (!value) {
-    return messageResult('Usage: /model <name>');
-  }
-
-  const modelCommandAliases = new Map<string, LocalCommandResult>([
-    ['list', messageResult(MODEL_LIST_MESSAGE)],
-    ['set', messageResult(MODEL_SET_HELP_MESSAGE)],
-  ]);
-
-  const aliased = modelCommandAliases.get(value);
-  if (aliased) {
-    return aliased;
-  }
-
-  const provider = inferProviderForModel(value);
-  const compatibility = validateModelCredentialCompatibility({
-    model: value,
-    provider,
-    credentialMode: credentialModeFromSource(args.providerCredentialSource),
-  });
-  if (!compatibility.ok) {
-    return messageResult(compatibility.error);
-  }
-
-  args.setActiveModel(value);
-  return messageResult(
-    COMMON_BUILT_IN_MODELS.includes(value) ?
-      `Switched model to ${value}`
-    : `Switched model to ${value}. This name is not in Heddle's common shortlist, so the next API call will fail if the provider does not recognize it.`,
-  );
-}
-
-function inferProviderForModel(model: string): LlmProvider {
-  return model.startsWith('claude') ? 'anthropic' : 'openai';
-}
-
-async function handleAuthLogin(args: LocalCommandArgs, value: string): Promise<LocalCommandResult> {
-  const provider = parseAuthProvider(value);
-  if (!provider) {
-    return messageResult('Usage: /auth login <provider>');
-  }
-
-  try {
-    const message = await loginProviderWithOAuth(provider, {
-      storePath: args.credentialStorePath,
-      openAiLogin: args.openAiLogin,
-    });
-    return messageResult(message);
-  } catch (error) {
-    return messageResult(`Auth login failed. ${formatErrorMessage(error)}`);
-  }
-}
-
-function handleAuthLogout(args: LocalCommandArgs, value: string): LocalCommandResult {
-  const provider = parseAuthProvider(value);
-  if (!provider) {
-    return messageResult('Usage: /auth logout <provider>');
-  }
-
-  try {
-    return messageResult(logoutProvider(provider, args.credentialStorePath));
-  } catch (error) {
-    return messageResult(`Auth logout failed. ${formatErrorMessage(error)}`);
-  }
 }
 
 async function handleHeartbeatTask(args: LocalCommandArgs, value: string): Promise<LocalCommandResult> {
@@ -556,18 +469,6 @@ function resolveSessionReference(args: LocalCommandArgs, value: string): ChatSes
   return args.recentSessions[numericIndex - 1];
 }
 
-function parseAuthProvider(value: string): LlmProvider | undefined {
-  const provider = value.trim().split(/\s+/, 1)[0]?.toLowerCase();
-  if (provider === 'openai' || provider === 'anthropic' || provider === 'google') {
-    return provider;
-  }
-  return undefined;
-}
-
-function formatErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function messageResult(message: string, sessionId?: string): LocalCommandResult {
   return {
     handled: true,
@@ -604,16 +505,6 @@ function longestSharedPrefix(values: string[]): string {
   }
 
   return prefix;
-}
-
-function formatDriftStatus(enabled: boolean, error: string | undefined): string {
-  if (!enabled) {
-    return 'CyberLoop drift detection is disabled. Use /drift on to enable observe-only kinematics telemetry.';
-  }
-
-  return error ?
-      `CyberLoop drift detection is enabled but unavailable: ${error}`
-    : 'CyberLoop drift detection is enabled. The footer shows drift=unknown|low|medium|high, and traces include cyberloop.annotation events.';
 }
 
 function capitalizeFirst(value: string): string {

--- a/src/core/commands/slash/modules/auth/auth-commands.ts
+++ b/src/core/commands/slash/modules/auth/auth-commands.ts
@@ -1,0 +1,80 @@
+import { matchesAnyExactSlashCommand, matchesSlashCommandPrefix } from '../../parser.js';
+import type { SlashCommandModule } from '../../types.js';
+import type { CoreSlashCommandResult, SlashCommandExecutionContext } from '../context.js';
+import { argumentAfterPrefix, formatCommandError, slashMessageResult } from '../results.js';
+import type { LlmProvider } from '../../../../llm/types.js';
+
+const AUTH_PROVIDERS = new Set<LlmProvider>(['openai', 'anthropic', 'google']);
+
+export function createAuthSlashCommandModule(): SlashCommandModule<CoreSlashCommandResult, SlashCommandExecutionContext> {
+  return {
+    id: 'auth',
+    hints: [
+      { command: '/auth', description: 'show stored provider credentials' },
+      { command: '/auth status', description: 'show stored provider credentials' },
+      { command: '/auth login openai', description: 'sign in with OpenAI ChatGPT/Codex OAuth' },
+      { command: '/auth logout <provider>', description: 'remove a stored provider credential' },
+    ],
+    commands: [
+      {
+        id: 'auth.status',
+        syntax: '/auth status',
+        aliases: ['/auth'],
+        description: 'show stored provider credentials',
+        match: matchesAnyExactSlashCommand(['/auth', '/auth status']),
+        run: (context) => slashMessageResult(context.auth.status()),
+      },
+      {
+        id: 'auth.login',
+        syntax: '/auth login <provider>',
+        description: 'sign in with a provider',
+        match: matchesSlashCommandPrefix('/auth login'),
+        run: (context, input) => login(context, argumentAfterPrefix(input, '/auth login')),
+      },
+      {
+        id: 'auth.logout',
+        syntax: '/auth logout <provider>',
+        description: 'remove a stored provider credential',
+        match: matchesSlashCommandPrefix('/auth logout'),
+        run: (context, input) => logout(context, argumentAfterPrefix(input, '/auth logout')),
+      },
+    ],
+  };
+}
+
+async function login(
+  context: SlashCommandExecutionContext,
+  value: string,
+): Promise<CoreSlashCommandResult> {
+  const provider = parseAuthProvider(value);
+  if (!provider) {
+    return slashMessageResult('Usage: /auth login <provider>');
+  }
+
+  try {
+    return slashMessageResult(await context.auth.login(provider));
+  } catch (error) {
+    return slashMessageResult(`Auth login failed. ${formatCommandError(error)}`);
+  }
+}
+
+function logout(
+  context: SlashCommandExecutionContext,
+  value: string,
+): CoreSlashCommandResult {
+  const provider = parseAuthProvider(value);
+  if (!provider) {
+    return slashMessageResult('Usage: /auth logout <provider>');
+  }
+
+  try {
+    return slashMessageResult(context.auth.logout(provider));
+  } catch (error) {
+    return slashMessageResult(`Auth logout failed. ${formatCommandError(error)}`);
+  }
+}
+
+function parseAuthProvider(value: string): LlmProvider | undefined {
+  const provider = value.trim().split(/\s+/, 1)[0]?.toLowerCase();
+  return AUTH_PROVIDERS.has(provider as LlmProvider) ? provider as LlmProvider : undefined;
+}

--- a/src/core/commands/slash/modules/compaction/compaction-commands.ts
+++ b/src/core/commands/slash/modules/compaction/compaction-commands.ts
@@ -1,0 +1,22 @@
+import { matchesExactSlashCommand } from '../../parser.js';
+import type { SlashCommandModule } from '../../types.js';
+import type { CoreSlashCommandResult, SlashCommandExecutionContext } from '../context.js';
+import { slashMessageResult } from '../results.js';
+
+export function createCompactionSlashCommandModule(): SlashCommandModule<CoreSlashCommandResult, SlashCommandExecutionContext> {
+  return {
+    id: 'compaction',
+    hints: [
+      { command: '/compact', description: 'compact earlier session history for the next run' },
+    ],
+    commands: [
+      {
+        id: 'compaction.compact',
+        syntax: '/compact',
+        description: 'compact earlier session history for the next run',
+        match: matchesExactSlashCommand('/compact'),
+        run: async (context) => slashMessageResult(await context.compaction.compactActive()),
+      },
+    ],
+  };
+}

--- a/src/core/commands/slash/modules/context.ts
+++ b/src/core/commands/slash/modules/context.ts
@@ -1,0 +1,25 @@
+import type { LocalCommandResult } from '../../../chat/types.js';
+import type { LlmProvider } from '../../../llm/types.js';
+import type { ProviderCredentialSource } from '../../../runtime/api-keys.js';
+
+export type SlashCommandExecutionContext = {
+  model: {
+    active: () => string;
+    setActive: (model: string) => void;
+    credentialSource: () => ProviderCredentialSource | undefined;
+  };
+  auth: {
+    status: () => string;
+    login: (provider: LlmProvider) => Promise<string>;
+    logout: (provider: LlmProvider) => string;
+  };
+  compaction: {
+    compactActive: () => Promise<string> | string;
+  };
+  drift: {
+    status: () => { enabled: boolean; error?: string };
+    setEnabled: (enabled: boolean) => void;
+  };
+};
+
+export type CoreSlashCommandResult = LocalCommandResult;

--- a/src/core/commands/slash/modules/core-command-modules.ts
+++ b/src/core/commands/slash/modules/core-command-modules.ts
@@ -1,0 +1,18 @@
+import type { SlashCommandModule } from '../types.js';
+import type { CoreSlashCommandResult, SlashCommandExecutionContext } from './context.js';
+import { createAuthSlashCommandModule } from './auth/auth-commands.js';
+import { createCompactionSlashCommandModule } from './compaction/compaction-commands.js';
+import { createDriftSlashCommandModule } from './drift/drift-commands.js';
+import { createModelSlashCommandModule } from './model/model-commands.js';
+
+export function createCoreSlashCommandModules(): SlashCommandModule<
+  CoreSlashCommandResult,
+  SlashCommandExecutionContext
+>[] {
+  return [
+    createModelSlashCommandModule(),
+    createAuthSlashCommandModule(),
+    createCompactionSlashCommandModule(),
+    createDriftSlashCommandModule(),
+  ];
+}

--- a/src/core/commands/slash/modules/drift/drift-commands.ts
+++ b/src/core/commands/slash/modules/drift/drift-commands.ts
@@ -1,0 +1,58 @@
+import { matchesAnyExactSlashCommand, matchesExactSlashCommand } from '../../parser.js';
+import type { SlashCommandModule } from '../../types.js';
+import type { CoreSlashCommandResult, SlashCommandExecutionContext } from '../context.js';
+import { slashMessageResult } from '../results.js';
+
+export function createDriftSlashCommandModule(): SlashCommandModule<CoreSlashCommandResult, SlashCommandExecutionContext> {
+  return {
+    id: 'drift',
+    hints: [
+      { command: '/drift', description: 'show CyberLoop semantic drift detection status' },
+      { command: '/drift on', description: 'enable CyberLoop semantic drift detection for chat runs' },
+      { command: '/drift off', description: 'disable CyberLoop semantic drift detection' },
+    ],
+    commands: [
+      {
+        id: 'drift.status',
+        syntax: '/drift',
+        aliases: ['/drift status'],
+        description: 'show CyberLoop semantic drift detection status',
+        match: matchesAnyExactSlashCommand(['/drift', '/drift status']),
+        run: (context) => {
+          const status = context.drift.status();
+          return slashMessageResult(formatDriftStatus(status.enabled, status.error));
+        },
+      },
+      {
+        id: 'drift.enable',
+        syntax: '/drift on',
+        description: 'enable CyberLoop semantic drift detection for chat runs',
+        match: matchesExactSlashCommand('/drift on'),
+        run: (context) => {
+          context.drift.setEnabled(true);
+          return slashMessageResult('Enabled CyberLoop semantic drift detection for chat runs. Heddle will load real CyberLoop kinematics middleware and write annotations into traces.');
+        },
+      },
+      {
+        id: 'drift.disable',
+        syntax: '/drift off',
+        description: 'disable CyberLoop semantic drift detection',
+        match: matchesExactSlashCommand('/drift off'),
+        run: (context) => {
+          context.drift.setEnabled(false);
+          return slashMessageResult('Disabled CyberLoop semantic drift detection.');
+        },
+      },
+    ],
+  };
+}
+
+export function formatDriftStatus(enabled: boolean, error: string | undefined): string {
+  if (!enabled) {
+    return 'CyberLoop drift detection is disabled. Use /drift on to enable observe-only kinematics telemetry.';
+  }
+
+  return error ?
+      `CyberLoop drift detection is enabled but unavailable: ${error}`
+    : 'CyberLoop drift detection is enabled. The footer shows drift=unknown|low|medium|high, and traces include cyberloop.annotation events.';
+}

--- a/src/core/commands/slash/modules/model/model-commands.ts
+++ b/src/core/commands/slash/modules/model/model-commands.ts
@@ -1,0 +1,92 @@
+import { matchesAnyExactSlashCommand, matchesExactSlashCommand, matchesSlashCommandPrefix } from '../../parser.js';
+import type { SlashCommandModule } from '../../types.js';
+import type { CoreSlashCommandResult, SlashCommandExecutionContext } from '../context.js';
+import { argumentAfterPrefix, slashMessageResult } from '../results.js';
+import { COMMON_BUILT_IN_MODELS, formatBuiltInModelGroups } from '../../../../llm/openai-models.js';
+import { credentialModeFromSource, validateModelCredentialCompatibility } from '../../../../llm/model-policy.js';
+import type { LlmProvider } from '../../../../llm/types.js';
+
+export const MODEL_LIST_MESSAGE = ['Common built-in model choices', '', formatBuiltInModelGroups()].join('\n');
+export const MODEL_SET_HELP_MESSAGE = 'Use /model set <query> to filter models, then use arrows and Enter to choose one.';
+
+const MODEL_SUBCOMMAND_RESULTS = new Map<string, CoreSlashCommandResult>([
+  ['list', slashMessageResult(MODEL_LIST_MESSAGE)],
+  ['set', slashMessageResult(MODEL_SET_HELP_MESSAGE)],
+]);
+
+export function createModelSlashCommandModule(): SlashCommandModule<CoreSlashCommandResult, SlashCommandExecutionContext> {
+  return {
+    id: 'model',
+    hints: [
+      { command: '/model', description: 'show the active model' },
+      { command: '/model <name>', description: 'switch the current model' },
+      { command: '/model set [query]', description: 'pick a model with filtering' },
+      { command: '/model list', description: 'list common built-in models' },
+    ],
+    commands: [
+      {
+        id: 'model.list',
+        syntax: '/model list',
+        aliases: ['/models'],
+        description: 'list common built-in models',
+        match: matchesAnyExactSlashCommand(['/model list', '/models']),
+        run: () => slashMessageResult(MODEL_LIST_MESSAGE),
+      },
+      {
+        id: 'model.current',
+        syntax: '/model',
+        description: 'show the active model',
+        match: matchesExactSlashCommand('/model'),
+        run: (context) => slashMessageResult(`Current model: ${context.model.active()}`),
+      },
+      {
+        id: 'model.set.help',
+        syntax: '/model set',
+        description: 'pick a model with filtering',
+        match: matchesExactSlashCommand('/model set'),
+        run: () => slashMessageResult(MODEL_SET_HELP_MESSAGE),
+      },
+      {
+        id: 'model.switch',
+        syntax: '/model <name>',
+        description: 'switch the current model',
+        match: matchesSlashCommandPrefix('/model'),
+        run: (context, input) => switchModel(context, argumentAfterPrefix(input, '/model')),
+      },
+    ],
+  };
+}
+
+function switchModel(
+  context: SlashCommandExecutionContext,
+  value: string,
+): CoreSlashCommandResult {
+  if (!value) {
+    return slashMessageResult('Usage: /model <name>');
+  }
+
+  const aliased = MODEL_SUBCOMMAND_RESULTS.get(value);
+  if (aliased) {
+    return aliased;
+  }
+
+  const compatibility = validateModelCredentialCompatibility({
+    model: value,
+    provider: inferProviderForModel(value),
+    credentialMode: credentialModeFromSource(context.model.credentialSource()),
+  });
+  if (!compatibility.ok) {
+    return slashMessageResult(compatibility.error);
+  }
+
+  context.model.setActive(value);
+  return slashMessageResult(
+    COMMON_BUILT_IN_MODELS.includes(value) ?
+      `Switched model to ${value}`
+    : `Switched model to ${value}. This name is not in Heddle's common shortlist, so the next API call will fail if the provider does not recognize it.`,
+  );
+}
+
+function inferProviderForModel(model: string): LlmProvider {
+  return model.startsWith('claude') ? 'anthropic' : 'openai';
+}

--- a/src/core/commands/slash/modules/results.ts
+++ b/src/core/commands/slash/modules/results.ts
@@ -1,0 +1,19 @@
+import type { ParsedSlashCommand } from '../types.js';
+import type { CoreSlashCommandResult } from './context.js';
+
+export function slashMessageResult(message: string, sessionId?: string): CoreSlashCommandResult {
+  return {
+    handled: true,
+    kind: 'message',
+    message,
+    sessionId,
+  };
+}
+
+export function argumentAfterPrefix(input: ParsedSlashCommand, prefix: string): string {
+  return input.raw.slice(prefix.length).trim();
+}
+
+export function formatCommandError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/core/commands/slash/registry.ts
+++ b/src/core/commands/slash/registry.ts
@@ -18,6 +18,7 @@ export function createSlashCommandRegistry<Result, Context>(
   modules: SlashCommandModule<Result, Context>[],
 ): SlashCommandRegistry<Result, Context> {
   const commands = flattenModules(modules);
+  const hints = flattenModuleHints(modules);
   validateSlashCommandRegistry(modules, commands);
 
   return {
@@ -26,10 +27,7 @@ export function createSlashCommandRegistry<Result, Context>(
     },
 
     hints() {
-      return commands.map((command) => ({
-        command: command.syntax,
-        description: command.description,
-      }));
+      return [...hints];
     },
 
     find(input) {
@@ -47,6 +45,17 @@ export function createSlashCommandRegistry<Result, Context>(
       return matched ? await matched.command.run(context, matched.input) : undefined;
     },
   };
+}
+
+function flattenModuleHints<Result, Context>(
+  modules: SlashCommandModule<Result, Context>[],
+): SlashCommandHint[] {
+  return modules.flatMap((module) =>
+    module.hints ?? module.commands.map((command) => ({
+      command: command.syntax,
+      description: command.description,
+    })),
+  );
 }
 
 function flattenModules<Result, Context>(
@@ -76,4 +85,3 @@ function assertUnique(label: string, values: string[]) {
     seen.add(value);
   }
 }
-

--- a/src/core/commands/slash/types.ts
+++ b/src/core/commands/slash/types.ts
@@ -21,6 +21,7 @@ export type SlashCommand<Result, Context> = {
 
 export type SlashCommandModule<Result, Context> = {
   id: string;
+  hints?: SlashCommandHint[];
   commands: SlashCommand<Result, Context>[];
 };
 
@@ -28,4 +29,3 @@ export type SlashCommandMatch<Result, Context> = {
   command: SlashCommand<Result, Context>;
   input: ParsedSlashCommand;
 };
-


### PR DESCRIPTION
## Summary

Refactors the M3 slash-command slice so model, auth, compaction, and drift commands live in registered core slash modules instead of the TUI local command switchboard.

Changes include:

- Added module-owned command implementations for `/model`, `/models`, `/model list`, `/model set`, `/auth`, `/auth status`, `/auth login`, `/auth logout`, `/compact`, `/drift`, `/drift status`, `/drift on`, and `/drift off`.
- Added a TUI slash command context adapter so `local-commands.ts` can delegate to the core registry while keeping the existing TUI API stable.
- Extended `SlashCommandModule` with module-owned `hints`, so help/autocomplete entries for migrated commands no longer need to be duplicated in `local-commands.ts`.
- Added direct core module tests for command routing, model credential policy, host ports, and module-owned hints.

## Impact

This keeps current TUI behavior stable while proving the domain-module command pattern. Future command modules can now own both behavior and help metadata, and `local-commands.ts` remains focused on compatibility and commands not yet migrated.

## Validation

- `yarn test:unit src/__tests__/unit/core/slash-command-modules.test.ts`
- `yarn test:unit src/__tests__/unit/tui/local-commands.test.ts`
- `yarn test:unit src/__tests__/unit/core/llm-factory.test.ts`
- `yarn eslint`
- `yarn typecheck`
- `yarn test`