### PR TITLE
[codex] Refactor heartbeat slash command module

### DIFF
--- a/src/__tests__/unit/core/slash-command-modules.test.ts
+++ b/src/__tests__/unit/core/slash-command-modules.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createSlashCommandRegistry } from '../../../core/commands/slash/registry.js';
 import { createCoreSlashCommandModules } from '../../../core/commands/slash/modules/core-command-modules.js';
+import { buildHeartbeatContinuationPrompt } from '../../../core/commands/slash/modules/heartbeat/heartbeat-commands.js';
 import { resolveSessionReference } from '../../../core/commands/slash/modules/session/session-commands.js';
 import type { ChatSession } from '../../../core/chat/types.js';
 import type { SlashCommandExecutionContext } from '../../../core/commands/slash/modules/context.js';
+import type { HeartbeatTask, HeartbeatTaskRunRecordEntry } from '../../../core/runtime/heartbeat-task-store.js';
 
 function testSession(overrides: Partial<ChatSession> & Pick<ChatSession, 'id' | 'name'>): ChatSession {
   return {
@@ -12,6 +14,73 @@ function testSession(overrides: Partial<ChatSession> & Pick<ChatSession, 'id' | 
     turns: [],
     createdAt: '2024-01-01',
     updatedAt: '2024-01-01',
+    ...overrides,
+  };
+}
+
+function testHeartbeatTask(overrides: Partial<HeartbeatTask> & Pick<HeartbeatTask, 'id'>): HeartbeatTask {
+  return {
+    task: 'Check repository state',
+    enabled: true,
+    intervalMs: 60_000,
+    ...overrides,
+  };
+}
+
+function testHeartbeatRun(overrides: Partial<HeartbeatTaskRunRecordEntry> = {}): HeartbeatTaskRunRecordEntry {
+  const task = testHeartbeatTask({
+    id: 'repo-check',
+    status: 'waiting',
+    lastProgress: 'Heartbeat wake finished. Waiting until the next scheduled run in 1m.',
+    resumable: true,
+  });
+  return {
+    id: '2026-04-14T00-00-00.000Z-repo-check',
+    path: '/tmp/run.json',
+    taskId: 'repo-check',
+    runId: 'run_heartbeat_1',
+    createdAt: '2026-04-14T00:00:00.000Z',
+    record: {
+      task,
+      loadedCheckpoint: true,
+      result: {
+        decision: 'continue',
+        summary: 'Checked the repository and found one safe next step.\n\nHEARTBEAT_DECISION: continue',
+        checkpoint: {
+          version: 1,
+          runId: 'run_heartbeat_1',
+          createdAt: '2026-04-14T00:00:00.000Z',
+          state: {
+            status: 'finished',
+            runId: 'run_heartbeat_1',
+            goal: 'Heartbeat wake cycle',
+            model: 'gpt-5.4',
+            provider: 'openai',
+            workspaceRoot: '/tmp/workspace',
+            startedAt: '2026-04-13T23:59:00.000Z',
+            finishedAt: '2026-04-14T00:00:00.000Z',
+            outcome: 'done',
+            summary: 'Checked the repository and found one safe next step.\n\nHEARTBEAT_DECISION: continue',
+            transcript: [],
+            trace: [],
+          },
+        },
+        state: {
+          status: 'finished',
+          runId: 'run_heartbeat_1',
+          goal: 'Heartbeat wake cycle',
+          model: 'gpt-5.4',
+          provider: 'openai',
+          workspaceRoot: '/tmp/workspace',
+          startedAt: '2026-04-13T23:59:00.000Z',
+          finishedAt: '2026-04-14T00:00:00.000Z',
+          outcome: 'done',
+          summary: 'Checked the repository and found one safe next step.\n\nHEARTBEAT_DECISION: continue',
+          transcript: [],
+          trace: [],
+        },
+      },
+    },
     ...overrides,
   };
 }
@@ -56,6 +125,11 @@ function createContext(overrides: Partial<SlashCommandExecutionContext> = {}): S
       remove: vi.fn(),
       clear: vi.fn(),
       summarize: (session) => `Summary for ${session.id}`,
+    },
+    heartbeat: {
+      listTasks: async () => [],
+      listRunRecords: async () => [],
+      loadRunRecord: async () => undefined,
     },
     ...overrides,
   };
@@ -130,6 +204,7 @@ describe('core slash command modules', () => {
       { command: '/compact', description: 'compact earlier session history for the next run' },
       { command: '/drift', description: 'show CyberLoop semantic drift detection status' },
       { command: '/session switch <id>', description: 'switch to another session' },
+      { command: '/heartbeat continue <task> [run-id|latest]', description: 'continue in chat from a heartbeat run summary' },
     ]));
   });
 
@@ -201,5 +276,54 @@ describe('core slash command modules', () => {
     expect(resolveSessionReference({ sessions, recentSessions, value: '1' })?.id).toBe('1');
     expect(resolveSessionReference({ sessions, recentSessions, value: '2' })?.id).toBe('session-b');
     expect(resolveSessionReference({ sessions, recentSessions, value: 'missing' })).toBeUndefined();
+  });
+
+  it('routes heartbeat commands through host ports', async () => {
+    const task = testHeartbeatTask({
+      id: 'repo-check',
+      status: 'waiting',
+      nextRunAt: '2026-04-14T00:00:00.000Z',
+      lastDecision: 'continue',
+      lastProgress: 'Heartbeat wake finished.',
+    });
+    const run = testHeartbeatRun();
+    const context = createContext({
+      heartbeat: {
+        listTasks: async () => [task],
+        listRunRecords: async (options) => options?.taskId === 'repo-check' ? [run] : [],
+        loadRunRecord: async (id) => id === run.id ? run : undefined,
+      },
+    });
+
+    await expect(registry.run(context, '/heartbeat tasks')).resolves.toMatchObject({
+      kind: 'message',
+      message: expect.stringContaining('enabled repo-check'),
+    });
+    await expect(registry.run(context, '/heartbeat task repo-check')).resolves.toMatchObject({
+      kind: 'message',
+      message: expect.stringContaining('Task:\nCheck repository state'),
+    });
+    await expect(registry.run(context, '/heartbeat runs repo-check')).resolves.toMatchObject({
+      kind: 'message',
+      message: expect.stringContaining('summary=Checked the repository and found one safe next step.'),
+    });
+    await expect(registry.run(context, '/heartbeat run repo-check latest')).resolves.toMatchObject({
+      kind: 'message',
+      message: expect.stringContaining('Heartbeat run 2026-04-14T00-00-00.000Z-repo-check'),
+    });
+    await expect(registry.run(context, '/heartbeat continue repo-check latest')).resolves.toMatchObject({
+      kind: 'execute',
+      displayText: 'Continue heartbeat repo-check',
+      prompt: expect.stringContaining('Heartbeat task id: repo-check'),
+    });
+  });
+
+  it('keeps heartbeat continuation prompt formatting pure', () => {
+    const prompt = buildHeartbeatContinuationPrompt(testHeartbeatRun());
+
+    expect(prompt).toContain('Heartbeat run id: run_heartbeat_1');
+    expect(prompt).toContain('Task progress: Heartbeat wake finished.');
+    expect(prompt).toContain('Checked the repository and found one safe next step.');
+    expect(prompt).not.toContain('HEARTBEAT_DECISION');
   });
 });

--- a/src/cli/chat/adapters/slash-command-context.ts
+++ b/src/cli/chat/adapters/slash-command-context.ts
@@ -1,9 +1,15 @@
 import { formatAuthStatusMessage, loginProviderWithOAuth, logoutProvider } from '../../auth.js';
 import { summarizeSession } from '../state/storage.js';
 import type { SlashCommandExecutionContext } from '../../../core/commands/slash/modules/context.js';
+import { createFileHeartbeatTaskStore } from '../../../core/runtime/heartbeat-task-store.js';
 import type { LocalCommandArgs } from '../state/local-commands.js';
+import { join } from 'node:path';
 
 export function createTuiSlashCommandContext(args: LocalCommandArgs): SlashCommandExecutionContext {
+  const heartbeatStore = createFileHeartbeatTaskStore({
+    dir: join(args.stateRoot, 'heartbeat'),
+  });
+
   return {
     model: {
       active: () => args.activeModel,
@@ -36,6 +42,11 @@ export function createTuiSlashCommandContext(args: LocalCommandArgs): SlashComma
       remove: args.removeSession,
       clear: args.clearConversation,
       summarize: summarizeSession,
+    },
+    heartbeat: {
+      listTasks: heartbeatStore.listTasks,
+      listRunRecords: async (options) => await heartbeatStore.listRunRecords?.(options) ?? [],
+      loadRunRecord: async (id) => await heartbeatStore.loadRunRecord?.(id),
     },
   };
 }

--- a/src/cli/chat/commands/debug-snapshot-command.ts
+++ b/src/cli/chat/commands/debug-snapshot-command.ts
@@ -1,0 +1,34 @@
+import { matchesExactSlashCommand } from '../../../core/commands/slash/parser.js';
+import type { SlashCommandModule } from '../../../core/commands/slash/types.js';
+import type { LocalCommandResult } from '../state/types.js';
+
+export type TuiSlashCommandContext = {
+  saveTuiSnapshot?: () => Promise<string> | string;
+};
+
+export function createTuiDebugSnapshotCommandModule(): SlashCommandModule<
+  LocalCommandResult,
+  TuiSlashCommandContext
+> {
+  return {
+    id: 'tui.debug-snapshot',
+    hints: [
+      { command: '/debug tui-snapshot', description: 'save the latest rendered TUI frame for inspection' },
+    ],
+    commands: [
+      {
+        id: 'tui.debug-snapshot.save',
+        syntax: '/debug tui-snapshot',
+        description: 'save the latest rendered TUI frame for inspection',
+        match: matchesExactSlashCommand('/debug tui-snapshot'),
+        run: async (context) => ({
+          handled: true,
+          kind: 'message',
+          message: context.saveTuiSnapshot ?
+            await context.saveTuiSnapshot()
+          : 'TUI snapshots are not available in this runtime.',
+        }),
+      },
+    ],
+  };
+}

--- a/src/cli/chat/state/local-commands.ts
+++ b/src/cli/chat/state/local-commands.ts
@@ -1,11 +1,10 @@
 import type { ChatSession, LocalCommandResult } from './types.js';
 import type { OpenAiOAuthCredential } from '../../../core/auth/openai-oauth.js';
 import type { ProviderCredentialSource } from '../utils/runtime.js';
-import { createFileHeartbeatTaskStore } from '../../../core/runtime/heartbeat-task-store.js';
 import { createSlashCommandRegistry } from '../../../core/commands/slash/registry.js';
 import { createCoreSlashCommandModules } from '../../../core/commands/slash/modules/core-command-modules.js';
 import { createTuiSlashCommandContext } from '../adapters/slash-command-context.js';
-import { join } from 'node:path';
+import { createTuiDebugSnapshotCommandModule } from '../commands/debug-snapshot-command.js';
 
 export type LocalCommandHint = {
   command: string;
@@ -37,23 +36,16 @@ export type LocalCommandArgs = {
   openAiLogin?: () => Promise<OpenAiOAuthCredential>;
 };
 
-type ExactCommandHandler = (args: LocalCommandArgs) => Promise<LocalCommandResult> | LocalCommandResult;
-type PrefixCommandHandler = (args: LocalCommandArgs, value: string) => Promise<LocalCommandResult> | LocalCommandResult;
-
 const CORE_COMMAND_REGISTRY = createSlashCommandRegistry(createCoreSlashCommandModules());
+const TUI_COMMAND_REGISTRY = createSlashCommandRegistry([createTuiDebugSnapshotCommandModule()]);
 const LOCAL_COMMAND_HINTS: LocalCommandHint[] = [
   { command: '/help', description: 'show available local commands' },
-  { command: '/debug tui-snapshot', description: 'save the latest rendered TUI frame for inspection' },
-  { command: '/heartbeat tasks', description: 'list heartbeat tasks' },
-  { command: '/heartbeat task <id>', description: 'show one heartbeat task' },
-  { command: '/heartbeat runs [task]', description: 'list recent heartbeat runs' },
-  { command: '/heartbeat run <task> [run-id|latest]', description: 'show one heartbeat run' },
-  { command: '/heartbeat continue <task> [run-id|latest]', description: 'continue in chat from a heartbeat run summary' },
   { command: '!<command>', description: 'run a shell command directly in chat using the current policy' },
 ];
 const HELP_HINTS: LocalCommandHint[] = [
   LOCAL_COMMAND_HINTS[0]!,
   ...CORE_COMMAND_REGISTRY.hints(),
+  ...TUI_COMMAND_REGISTRY.hints(),
   ...LOCAL_COMMAND_HINTS.slice(1),
 ];
 const COMMAND_ROOTS = Array.from(
@@ -68,23 +60,6 @@ const HELP_MESSAGE = [
   '',
   ...HELP_HINTS.flatMap((hint) => [hint.command, capitalizeFirst(hint.description), '']),
 ].join('\n');
-
-const EXACT_COMMANDS = new Map<string, ExactCommandHandler>([
-  ['/help', () => messageResult(HELP_MESSAGE)],
-  ['/debug tui-snapshot', async (args) =>
-    messageResult(
-      args.saveTuiSnapshot ? await args.saveTuiSnapshot() : 'TUI snapshots are not available in this runtime.',
-    )],
-  ['/heartbeat tasks', (args) => listHeartbeatTasksMessage(args)],
-  ['/heartbeat runs', (args) => listHeartbeatRunsMessage(args, '')],
-]);
-
-const PREFIX_COMMANDS: Array<{ prefix: string; handle: PrefixCommandHandler }> = [
-  { prefix: '/heartbeat task ', handle: handleHeartbeatTask },
-  { prefix: '/heartbeat runs ', handle: handleHeartbeatRuns },
-  { prefix: '/heartbeat run ', handle: handleHeartbeatRun },
-  { prefix: '/heartbeat continue ', handle: handleHeartbeatContinue },
-];
 
 export function isLikelyLocalCommand(prompt: string): boolean {
   const trimmed = prompt.trim();
@@ -109,11 +84,11 @@ export function isLikelyLocalCommand(prompt: string): boolean {
     return true;
   }
 
-  if (EXACT_COMMANDS.has(trimmed)) {
+  if (TUI_COMMAND_REGISTRY.find(trimmed)) {
     return true;
   }
 
-  return PREFIX_COMMANDS.some((entry) => trimmed === entry.prefix.trimEnd() || trimmed.startsWith(entry.prefix));
+  return false;
 }
 
 export function getLocalCommandHints(
@@ -176,207 +151,21 @@ export async function runLocalCommand(args: LocalCommandArgs): Promise<LocalComm
     return { handled: false };
   }
 
+  if (trimmed === '/help') {
+    return messageResult(HELP_MESSAGE);
+  }
+
   const coreResult = await CORE_COMMAND_REGISTRY.run(createTuiSlashCommandContext(args), trimmed);
   if (coreResult) {
     return coreResult;
   }
 
-  const exact = EXACT_COMMANDS.get(trimmed);
-  if (exact) {
-    return await exact(args);
-  }
-
-  const matchedPrefix = PREFIX_COMMANDS.find((entry) => trimmed.startsWith(entry.prefix));
-  if (matchedPrefix) {
-    const value = trimmed.slice(matchedPrefix.prefix.length).trim();
-    return await matchedPrefix.handle(args, value);
+  const tuiResult = await TUI_COMMAND_REGISTRY.run(args, trimmed);
+  if (tuiResult) {
+    return tuiResult;
   }
 
   return messageResult(`Unknown command: ${trimmed}. Use /help for available commands.`);
-}
-
-async function handleHeartbeatTask(args: LocalCommandArgs, value: string): Promise<LocalCommandResult> {
-  const taskId = value.trim();
-  if (!taskId) {
-    return messageResult('Usage: /heartbeat task <id>');
-  }
-
-  const store = heartbeatStore(args);
-  const tasks = await store.listTasks();
-  const task = tasks.find((candidate) => candidate.id === taskId);
-  if (!task) {
-    return messageResult(`Heartbeat task not found: ${taskId}`);
-  }
-
-  return messageResult(formatHeartbeatTask(task));
-}
-
-async function handleHeartbeatRuns(args: LocalCommandArgs, value: string): Promise<LocalCommandResult> {
-  return listHeartbeatRunsMessage(args, value.trim());
-}
-
-async function handleHeartbeatRun(args: LocalCommandArgs, value: string): Promise<LocalCommandResult> {
-  const [taskId, runRef = 'latest'] = value.split(/\s+/, 2);
-  if (!taskId) {
-    return messageResult('Usage: /heartbeat run <task> [run-id|latest]');
-  }
-
-  const run = await resolveHeartbeatRun(args, taskId, runRef);
-  if (!run) {
-    return messageResult(`Heartbeat run not found for task ${taskId}: ${runRef}`);
-  }
-
-  return messageResult(formatHeartbeatRun(run));
-}
-
-async function handleHeartbeatContinue(args: LocalCommandArgs, value: string): Promise<LocalCommandResult> {
-  const [taskId, runRef = 'latest'] = value.split(/\s+/, 2);
-  if (!taskId) {
-    return messageResult('Usage: /heartbeat continue <task> [run-id|latest]');
-  }
-
-  const run = await resolveHeartbeatRun(args, taskId, runRef);
-  if (!run) {
-    return messageResult(`Heartbeat run not found for task ${taskId}: ${runRef}`);
-  }
-
-  return {
-    handled: true,
-    kind: 'execute',
-    displayText: `Continue heartbeat ${taskId}`,
-    message: `Loaded heartbeat run ${run.id} for task ${taskId}. Continuing from that background summary.`,
-    prompt: buildHeartbeatContinuationPrompt(run),
-  };
-}
-
-async function listHeartbeatTasksMessage(args: LocalCommandArgs): Promise<LocalCommandResult> {
-  const tasks = await heartbeatStore(args).listTasks();
-  if (!tasks.length) {
-    return messageResult('No heartbeat tasks found.');
-  }
-
-  return messageResult(tasks.map((task) => {
-    const next = task.nextRunAt ?? 'none';
-    const decision = task.lastDecision ?? 'none';
-    return [
-      `${task.enabled ? 'enabled' : 'disabled'} ${task.id}`,
-      `  status=${task.status ?? 'idle'} every=${formatInterval(task.intervalMs)} next=${next} decision=${decision}`,
-      task.lastProgress ? `  progress=${task.lastProgress}` : undefined,
-    ].filter((line): line is string => line !== undefined).join('\n');
-  }).join('\n'));
-}
-
-async function listHeartbeatRunsMessage(args: LocalCommandArgs, taskId: string): Promise<LocalCommandResult> {
-  const runs = await heartbeatStore(args).listRunRecords?.({
-    taskId: taskId || undefined,
-    limit: 10,
-  });
-  if (!runs?.length) {
-    return messageResult(taskId ? `No heartbeat runs found for task ${taskId}.` : 'No heartbeat runs found.');
-  }
-
-  return messageResult(runs.map((run) => {
-    const summary = firstLine(stripHeartbeatDecisionLine(run.record.result.summary));
-    return `${run.id}\n  task=${run.taskId} decision=${run.record.result.decision} outcome=${run.record.result.state.outcome} finished=${run.createdAt}\n  summary=${summary}`;
-  }).join('\n'));
-}
-
-function heartbeatStore(args: Pick<LocalCommandArgs, 'stateRoot'>) {
-  return createFileHeartbeatTaskStore({
-    dir: join(args.stateRoot, 'heartbeat'),
-  });
-}
-
-async function resolveHeartbeatRun(
-  args: Pick<LocalCommandArgs, 'stateRoot'>,
-  taskId: string,
-  runRef: string,
-) {
-  const store = heartbeatStore(args);
-  if (runRef === 'latest') {
-    return (await store.listRunRecords?.({ taskId, limit: 1 }))?.[0];
-  }
-  const run = await store.loadRunRecord?.(runRef);
-  return run?.taskId === taskId ? run : undefined;
-}
-
-function formatHeartbeatTask(task: Awaited<ReturnType<ReturnType<typeof heartbeatStore>['listTasks']>>[number]): string {
-  return [
-    `${task.enabled ? 'enabled' : 'disabled'} ${task.id}`,
-    `status=${task.status ?? 'idle'} every=${formatInterval(task.intervalMs)} next=${task.nextRunAt ?? 'none'} model=${task.model ?? 'default'}`,
-    '',
-    'Task:',
-    task.task,
-    '',
-    task.lastProgress ? `Progress: ${task.lastProgress}` : undefined,
-    `Last decision: ${task.lastDecision ?? 'none'}`,
-    task.lastOutcome ? `Last outcome: ${task.lastOutcome}` : undefined,
-    task.lastRunAt ? `Last run: ${task.lastRunAt}` : undefined,
-    task.lastRunId ? `Last run id: ${task.lastRunId}` : undefined,
-    task.lastRunId ? `Resumable: ${task.resumable === false ? 'no' : 'yes'}` : undefined,
-    task.lastRunId ? `Loaded checkpoint: ${task.lastLoadedCheckpoint ? 'yes' : 'no'}` : undefined,
-    task.lastUsage ? `Usage: input=${task.lastUsage.inputTokens} output=${task.lastUsage.outputTokens} total=${task.lastUsage.totalTokens} requests=${task.lastUsage.requests}` : undefined,
-    task.lastError ? `Last error: ${task.lastError}` : undefined,
-    task.lastSummary ? ['', 'Last summary:', stripHeartbeatDecisionLine(task.lastSummary).trim() || task.lastSummary.trim()].join('\n') : undefined,
-  ].filter((line): line is string => line !== undefined).join('\n');
-}
-
-function formatHeartbeatRun(run: NonNullable<Awaited<ReturnType<NonNullable<ReturnType<typeof heartbeatStore>['loadRunRecord']>>>>): string {
-  const result = run.record.result;
-  return [
-    `Heartbeat run ${run.id}`,
-    `task=${run.taskId} run=${run.runId} loadedCheckpoint=${run.record.loadedCheckpoint}`,
-    `decision=${result.decision} outcome=${result.state.outcome} finished=${run.createdAt}`,
-    result.state.usage ? `usage input=${result.state.usage.inputTokens} output=${result.state.usage.outputTokens} total=${result.state.usage.totalTokens} requests=${result.state.usage.requests}` : undefined,
-    '',
-    'Task:',
-    run.record.task.task,
-    '',
-    'Summary:',
-    stripHeartbeatDecisionLine(result.summary).trim() || result.summary.trim(),
-  ].filter((line): line is string => line !== undefined).join('\n');
-}
-
-function buildHeartbeatContinuationPrompt(run: NonNullable<Awaited<ReturnType<NonNullable<ReturnType<typeof heartbeatStore>['loadRunRecord']>>>>): string {
-  const result = run.record.result;
-  return [
-    'Continue from this heartbeat run context.',
-    '',
-    `Heartbeat task id: ${run.taskId}`,
-    `Heartbeat run id: ${run.runId}`,
-    `Decision: ${result.decision}`,
-    `Outcome: ${result.state.outcome}`,
-    `Finished at: ${run.createdAt}`,
-    `Loaded checkpoint: ${run.record.loadedCheckpoint}`,
-    `Task status: ${run.record.task.status ?? 'unknown'}`,
-    run.record.task.lastProgress ? `Task progress: ${run.record.task.lastProgress}` : undefined,
-    run.record.task.resumable === false ? 'Resumable: no' : 'Resumable: yes',
-    '',
-    'Durable task:',
-    run.record.task.task,
-    '',
-    'Heartbeat summary:',
-    stripHeartbeatDecisionLine(result.summary).trim() || result.summary.trim(),
-    '',
-    'Treat the heartbeat summary as trusted background context from prior autonomous work. Help the user continue from there.',
-  ].filter((line): line is string => line !== undefined).join('\n');
-}
-
-function stripHeartbeatDecisionLine(summary: string): string {
-  return summary.replace(/\n?\s*HEARTBEAT_DECISION:\s*(continue|pause|complete|escalate)\s*$/i, '');
-}
-
-function firstLine(value: string): string {
-  const line = value.trim().split('\n').find((candidate) => candidate.trim());
-  return line?.trim() ?? '';
-}
-
-function formatInterval(intervalMs: number): string {
-  if (intervalMs % (24 * 60 * 60_000) === 0) return `${intervalMs / (24 * 60 * 60_000)}d`;
-  if (intervalMs % (60 * 60_000) === 0) return `${intervalMs / (60 * 60_000)}h`;
-  if (intervalMs % 60_000 === 0) return `${intervalMs / 60_000}m`;
-  if (intervalMs % 1_000 === 0) return `${intervalMs / 1_000}s`;
-  return `${intervalMs}ms`;
 }
 
 function messageResult(message: string, sessionId?: string): LocalCommandResult {

--- a/src/core/commands/slash/modules/context.ts
+++ b/src/core/commands/slash/modules/context.ts
@@ -1,6 +1,10 @@
 import type { ChatSession, LocalCommandResult } from '../../../chat/types.js';
 import type { LlmProvider } from '../../../llm/types.js';
 import type { ProviderCredentialSource } from '../../../runtime/api-keys.js';
+import type {
+  HeartbeatTask,
+  HeartbeatTaskRunRecordEntry,
+} from '../../../runtime/heartbeat-task-store.js';
 
 export type SlashCommandExecutionContext = {
   model: {
@@ -30,6 +34,11 @@ export type SlashCommandExecutionContext = {
     remove: (id: string) => void;
     clear: () => void;
     summarize: (session: ChatSession) => string;
+  };
+  heartbeat: {
+    listTasks: () => Promise<HeartbeatTask[]>;
+    listRunRecords: (options?: { taskId?: string; limit?: number }) => Promise<HeartbeatTaskRunRecordEntry[]>;
+    loadRunRecord: (id: string) => Promise<HeartbeatTaskRunRecordEntry | undefined>;
   };
 };
 

--- a/src/core/commands/slash/modules/core-command-modules.ts
+++ b/src/core/commands/slash/modules/core-command-modules.ts
@@ -3,6 +3,7 @@ import type { CoreSlashCommandResult, SlashCommandExecutionContext } from './con
 import { createAuthSlashCommandModule } from './auth/auth-commands.js';
 import { createCompactionSlashCommandModule } from './compaction/compaction-commands.js';
 import { createDriftSlashCommandModule } from './drift/drift-commands.js';
+import { createHeartbeatSlashCommandModule } from './heartbeat/heartbeat-commands.js';
 import { createModelSlashCommandModule } from './model/model-commands.js';
 import { createSessionSlashCommandModule } from './session/session-commands.js';
 
@@ -16,5 +17,6 @@ export function createCoreSlashCommandModules(): SlashCommandModule<
     createCompactionSlashCommandModule(),
     createDriftSlashCommandModule(),
     createSessionSlashCommandModule(),
+    createHeartbeatSlashCommandModule(),
   ];
 }

--- a/src/core/commands/slash/modules/heartbeat/heartbeat-commands.ts
+++ b/src/core/commands/slash/modules/heartbeat/heartbeat-commands.ts
@@ -1,0 +1,238 @@
+import { matchesExactSlashCommand, matchesSlashCommandPrefix } from '../../parser.js';
+import type { SlashCommandModule } from '../../types.js';
+import type {
+  HeartbeatTask,
+  HeartbeatTaskRunRecordEntry,
+} from '../../../../runtime/heartbeat-task-store.js';
+import type { CoreSlashCommandResult, SlashCommandExecutionContext } from '../context.js';
+import { argumentAfterPrefix, slashMessageResult } from '../results.js';
+
+export function createHeartbeatSlashCommandModule(): SlashCommandModule<CoreSlashCommandResult, SlashCommandExecutionContext> {
+  return {
+    id: 'heartbeat',
+    hints: [
+      { command: '/heartbeat tasks', description: 'list heartbeat tasks' },
+      { command: '/heartbeat task <id>', description: 'show one heartbeat task' },
+      { command: '/heartbeat runs [task]', description: 'list recent heartbeat runs' },
+      { command: '/heartbeat run <task> [run-id|latest]', description: 'show one heartbeat run' },
+      { command: '/heartbeat continue <task> [run-id|latest]', description: 'continue in chat from a heartbeat run summary' },
+    ],
+    commands: [
+      {
+        id: 'heartbeat.tasks',
+        syntax: '/heartbeat tasks',
+        description: 'list heartbeat tasks',
+        match: matchesExactSlashCommand('/heartbeat tasks'),
+        run: (context) => listHeartbeatTasksMessage(context),
+      },
+      {
+        id: 'heartbeat.task',
+        syntax: '/heartbeat task <id>',
+        description: 'show one heartbeat task',
+        match: matchesRequiredHeartbeatArgument('/heartbeat task'),
+        run: (context, input) => showHeartbeatTask(context, argumentAfterPrefix(input, '/heartbeat task')),
+      },
+      {
+        id: 'heartbeat.runs.list',
+        syntax: '/heartbeat runs [task]',
+        description: 'list recent heartbeat runs',
+        match: matchesSlashCommandPrefix('/heartbeat runs'),
+        run: (context, input) => listHeartbeatRunsMessage(context, argumentAfterPrefix(input, '/heartbeat runs')),
+      },
+      {
+        id: 'heartbeat.run.show',
+        syntax: '/heartbeat run <task> [run-id|latest]',
+        description: 'show one heartbeat run',
+        match: matchesRequiredHeartbeatArgument('/heartbeat run'),
+        run: (context, input) => showHeartbeatRun(context, argumentAfterPrefix(input, '/heartbeat run')),
+      },
+      {
+        id: 'heartbeat.continue',
+        syntax: '/heartbeat continue <task> [run-id|latest]',
+        description: 'continue in chat from a heartbeat run summary',
+        match: matchesRequiredHeartbeatArgument('/heartbeat continue'),
+        run: (context, input) => continueHeartbeatRun(context, argumentAfterPrefix(input, '/heartbeat continue')),
+      },
+    ],
+  };
+}
+
+export async function listHeartbeatTasksMessage(
+  context: Pick<SlashCommandExecutionContext, 'heartbeat'>,
+): Promise<CoreSlashCommandResult> {
+  const tasks = await context.heartbeat.listTasks();
+  if (!tasks.length) {
+    return slashMessageResult('No heartbeat tasks found.');
+  }
+
+  return slashMessageResult(tasks.map(formatHeartbeatTaskListItem).join('\n'));
+}
+
+export async function listHeartbeatRunsMessage(
+  context: Pick<SlashCommandExecutionContext, 'heartbeat'>,
+  taskId: string,
+): Promise<CoreSlashCommandResult> {
+  const trimmedTaskId = taskId.trim();
+  const runs = await context.heartbeat.listRunRecords({
+    taskId: trimmedTaskId || undefined,
+    limit: 10,
+  });
+  if (!runs.length) {
+    return slashMessageResult(trimmedTaskId ? `No heartbeat runs found for task ${trimmedTaskId}.` : 'No heartbeat runs found.');
+  }
+
+  return slashMessageResult(runs.map(formatHeartbeatRunListItem).join('\n'));
+}
+
+export function formatHeartbeatTask(task: HeartbeatTask): string {
+  return [
+    `${task.enabled ? 'enabled' : 'disabled'} ${task.id}`,
+    `status=${task.status ?? 'idle'} every=${formatInterval(task.intervalMs)} next=${task.nextRunAt ?? 'none'} model=${task.model ?? 'default'}`,
+    '',
+    'Task:',
+    task.task,
+    '',
+    task.lastProgress ? `Progress: ${task.lastProgress}` : undefined,
+    `Last decision: ${task.lastDecision ?? 'none'}`,
+    task.lastOutcome ? `Last outcome: ${task.lastOutcome}` : undefined,
+    task.lastRunAt ? `Last run: ${task.lastRunAt}` : undefined,
+    task.lastRunId ? `Last run id: ${task.lastRunId}` : undefined,
+    task.lastRunId ? `Resumable: ${task.resumable === false ? 'no' : 'yes'}` : undefined,
+    task.lastRunId ? `Loaded checkpoint: ${task.lastLoadedCheckpoint ? 'yes' : 'no'}` : undefined,
+    task.lastUsage ? `Usage: input=${task.lastUsage.inputTokens} output=${task.lastUsage.outputTokens} total=${task.lastUsage.totalTokens} requests=${task.lastUsage.requests}` : undefined,
+    task.lastError ? `Last error: ${task.lastError}` : undefined,
+    task.lastSummary ? ['', 'Last summary:', stripHeartbeatDecisionLine(task.lastSummary).trim() || task.lastSummary.trim()].join('\n') : undefined,
+  ].filter((line): line is string => line !== undefined).join('\n');
+}
+
+export function formatHeartbeatRun(run: HeartbeatTaskRunRecordEntry): string {
+  const result = run.record.result;
+  return [
+    `Heartbeat run ${run.id}`,
+    `task=${run.taskId} run=${run.runId} loadedCheckpoint=${run.record.loadedCheckpoint}`,
+    `decision=${result.decision} outcome=${result.state.outcome} finished=${run.createdAt}`,
+    result.state.usage ? `usage input=${result.state.usage.inputTokens} output=${result.state.usage.outputTokens} total=${result.state.usage.totalTokens} requests=${result.state.usage.requests}` : undefined,
+    '',
+    'Task:',
+    run.record.task.task,
+    '',
+    'Summary:',
+    stripHeartbeatDecisionLine(result.summary).trim() || result.summary.trim(),
+  ].filter((line): line is string => line !== undefined).join('\n');
+}
+
+export function buildHeartbeatContinuationPrompt(run: HeartbeatTaskRunRecordEntry): string {
+  const result = run.record.result;
+  return [
+    'Continue from this heartbeat run context.',
+    '',
+    `Heartbeat task id: ${run.taskId}`,
+    `Heartbeat run id: ${run.runId}`,
+    `Decision: ${result.decision}`,
+    `Outcome: ${result.state.outcome}`,
+    `Finished at: ${run.createdAt}`,
+    `Loaded checkpoint: ${run.record.loadedCheckpoint}`,
+    `Task status: ${run.record.task.status ?? 'unknown'}`,
+    run.record.task.lastProgress ? `Task progress: ${run.record.task.lastProgress}` : undefined,
+    run.record.task.resumable === false ? 'Resumable: no' : 'Resumable: yes',
+    '',
+    'Durable task:',
+    run.record.task.task,
+    '',
+    'Heartbeat summary:',
+    stripHeartbeatDecisionLine(result.summary).trim() || result.summary.trim(),
+    '',
+    'Treat the heartbeat summary as trusted background context from prior autonomous work. Help the user continue from there.',
+  ].filter((line): line is string => line !== undefined).join('\n');
+}
+
+export function stripHeartbeatDecisionLine(summary: string): string {
+  return summary.replace(/\n?\s*HEARTBEAT_DECISION:\s*(continue|pause|complete|escalate)\s*$/i, '');
+}
+
+function matchesRequiredHeartbeatArgument(prefix: string): (input: { raw: string }) => boolean {
+  return (input) => input.raw.startsWith(`${prefix} `);
+}
+
+async function showHeartbeatTask(
+  context: Pick<SlashCommandExecutionContext, 'heartbeat'>,
+  value: string,
+): Promise<CoreSlashCommandResult> {
+  const taskId = value.trim();
+  const tasks = await context.heartbeat.listTasks();
+  const task = tasks.find((candidate) => candidate.id === taskId);
+  return task ? slashMessageResult(formatHeartbeatTask(task)) : slashMessageResult(`Heartbeat task not found: ${taskId}`);
+}
+
+async function showHeartbeatRun(
+  context: Pick<SlashCommandExecutionContext, 'heartbeat'>,
+  value: string,
+): Promise<CoreSlashCommandResult> {
+  const request = parseHeartbeatRunRequest(value);
+  const run = await resolveHeartbeatRun(context, request);
+  return run ? slashMessageResult(formatHeartbeatRun(run)) : slashMessageResult(`Heartbeat run not found for task ${request.taskId}: ${request.runRef}`);
+}
+
+async function continueHeartbeatRun(
+  context: Pick<SlashCommandExecutionContext, 'heartbeat'>,
+  value: string,
+): Promise<CoreSlashCommandResult> {
+  const request = parseHeartbeatRunRequest(value);
+  const run = await resolveHeartbeatRun(context, request);
+  if (!run) {
+    return slashMessageResult(`Heartbeat run not found for task ${request.taskId}: ${request.runRef}`);
+  }
+
+  return {
+    handled: true,
+    kind: 'execute',
+    displayText: `Continue heartbeat ${request.taskId}`,
+    message: `Loaded heartbeat run ${run.id} for task ${request.taskId}. Continuing from that background summary.`,
+    prompt: buildHeartbeatContinuationPrompt(run),
+  };
+}
+
+async function resolveHeartbeatRun(
+  context: Pick<SlashCommandExecutionContext, 'heartbeat'>,
+  request: { taskId: string; runRef: string },
+): Promise<HeartbeatTaskRunRecordEntry | undefined> {
+  if (request.runRef === 'latest') {
+    return (await context.heartbeat.listRunRecords({ taskId: request.taskId, limit: 1 }))[0];
+  }
+
+  const run = await context.heartbeat.loadRunRecord(request.runRef);
+  return run?.taskId === request.taskId ? run : undefined;
+}
+
+function parseHeartbeatRunRequest(value: string): { taskId: string; runRef: string } {
+  const [taskId = '', runRef = 'latest'] = value.split(/\s+/, 2);
+  return { taskId, runRef };
+}
+
+function formatHeartbeatTaskListItem(task: HeartbeatTask): string {
+  const next = task.nextRunAt ?? 'none';
+  const decision = task.lastDecision ?? 'none';
+  return [
+    `${task.enabled ? 'enabled' : 'disabled'} ${task.id}`,
+    `  status=${task.status ?? 'idle'} every=${formatInterval(task.intervalMs)} next=${next} decision=${decision}`,
+    task.lastProgress ? `  progress=${task.lastProgress}` : undefined,
+  ].filter((line): line is string => line !== undefined).join('\n');
+}
+
+function formatHeartbeatRunListItem(run: HeartbeatTaskRunRecordEntry): string {
+  const summary = firstLine(stripHeartbeatDecisionLine(run.record.result.summary));
+  return `${run.id}\n  task=${run.taskId} decision=${run.record.result.decision} outcome=${run.record.result.state.outcome} finished=${run.createdAt}\n  summary=${summary}`;
+}
+
+function firstLine(value: string): string {
+  const line = value.trim().split('\n').find((candidate) => candidate.trim());
+  return line?.trim() ?? '';
+}
+
+function formatInterval(intervalMs: number): string {
+  if (intervalMs % (24 * 60 * 60_000) === 0) return `${intervalMs / (24 * 60 * 60_000)}d`;
+  if (intervalMs % (60 * 60_000) === 0) return `${intervalMs / (60 * 60_000)}h`;
+  if (intervalMs % 60_000 === 0) return `${intervalMs / 60_000}m`;
+  if (intervalMs % 1_000 === 0) return `${intervalMs / 1_000}s`;
+  return `${intervalMs}ms`;
+}


### PR DESCRIPTION
## Summary

Completes the M5 slash-command migration slice by moving heartbeat commands into core modules and isolating the TUI-only debug snapshot command outside core.

Changes include:

- Added `src/core/commands/slash/modules/heartbeat/heartbeat-commands.ts` for `/heartbeat tasks`, `/heartbeat task`, `/heartbeat runs`, `/heartbeat run`, and `/heartbeat continue`.
- Added heartbeat ports to `SlashCommandExecutionContext` and wired the TUI adapter to `createFileHeartbeatTaskStore`.
- Added `src/cli/chat/commands/debug-snapshot-command.ts` so `/debug tui-snapshot` is registered from the TUI layer rather than core.
- Reduced `local-commands.ts` to compatibility exports, composed hints, autocomplete, `/help`, and registry orchestration.
- Added direct unit coverage for heartbeat routing and the pure continuation prompt builder.

## Impact

Heartbeat command behavior is now reusable through the core slash registry while keeping store access host-supplied. The TUI-only debug command is explicitly host-owned, which keeps core command modules focused on reusable domains.

## Validation

- `yarn test:unit src/__tests__/unit/core/slash-command-modules.test.ts`
- `yarn test:unit src/__tests__/unit/tui/local-commands.test.ts`
- `yarn test:unit src/__tests__/unit/tui/heartbeat-cli.test.ts`
- `yarn vitest run src/__tests__/integration/core/heartbeat-scheduler.test.ts`
- `yarn eslint`
- `yarn typecheck`
- `yarn test` outside the sandbox, because the full integration suite needs localhost binding and normal git identity for temp repositories