### PR TITLE
[codex] Add conversation activity projection

### DIFF
--- a/src/__tests__/unit/core/conversation-activity.test.ts
+++ b/src/__tests__/unit/core/conversation-activity.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import {
+  projectAgentLoopEventToConversationActivities,
+  projectCompactionStatusToConversationActivities,
+  projectTraceEventToConversationActivities,
+  summarizeActivityToolCall,
+} from '../../../core/observability/conversation-activity.js';
+import type { AgentLoopEvent } from '../../../core/runtime/events.js';
+import type { TraceEvent } from '../../../core/types.js';
+
+describe('conversation activity projection', () => {
+  it('projects assistant stream events from the agent loop', () => {
+    const event: AgentLoopEvent = {
+      type: 'assistant.stream',
+      runId: 'run-1',
+      step: 1,
+      text: 'Working',
+      done: false,
+      timestamp: '2026-05-02T00:00:00.000Z',
+    };
+
+    expect(projectAgentLoopEventToConversationActivities(event)).toEqual([
+      { type: 'assistant.stream', text: 'Working', done: false },
+    ]);
+  });
+
+  it('projects loop started and finished events', () => {
+    const started: AgentLoopEvent = {
+      type: 'loop.started',
+      runId: 'run-1',
+      goal: 'answer',
+      model: 'gpt-5.4',
+      provider: 'openai',
+      workspaceRoot: '/repo',
+      timestamp: '2026-05-02T00:00:00.000Z',
+    };
+    const finishedTrace: TraceEvent = {
+      type: 'run.finished',
+      outcome: 'max_steps',
+      summary: 'Stopped.',
+      step: 5,
+      timestamp: '2026-05-02T00:00:01.000Z',
+    };
+
+    expect(projectAgentLoopEventToConversationActivities(started)).toEqual([{ type: 'loop.started' }]);
+    expect(projectTraceEventToConversationActivities(finishedTrace)).toEqual([
+      { type: 'run.finished', outcome: 'max_steps' },
+    ]);
+  });
+
+  it('projects tool calling and completion events from the agent loop', () => {
+    const calling: AgentLoopEvent = {
+      type: 'tool.calling',
+      runId: 'run-1',
+      step: 2,
+      tool: 'read_file',
+      toolCallId: 'call-1',
+      input: { path: 'README.md' },
+      requiresApproval: false,
+      timestamp: '2026-05-02T00:00:00.000Z',
+    };
+    const completed: AgentLoopEvent = {
+      type: 'tool.completed',
+      runId: 'run-1',
+      step: 2,
+      tool: 'read_file',
+      toolCallId: 'call-1',
+      result: { ok: true, output: 'contents' },
+      durationMs: 12.4,
+      timestamp: '2026-05-02T00:00:01.000Z',
+    };
+
+    expect(projectAgentLoopEventToConversationActivities(calling)).toEqual([
+      { type: 'tool.calling', tool: 'read_file', step: 2 },
+    ]);
+    expect(projectAgentLoopEventToConversationActivities(completed)).toEqual([
+      { type: 'tool.completed', tool: 'read_file', durationMs: 12.4 },
+    ]);
+  });
+
+  it('projects trace approval and fallback activities with reusable tool summaries', () => {
+    const approval: TraceEvent = {
+      type: 'tool.approval_requested',
+      call: { id: 'call-1', tool: 'run_shell_mutate', input: { command: 'yarn test' } },
+      step: 3,
+      timestamp: '2026-05-02T00:00:00.000Z',
+    };
+    const fallback: TraceEvent = {
+      type: 'tool.fallback',
+      fromCall: { id: 'call-2', tool: 'run_shell_inspect', input: { command: 'git status --short' } },
+      toCall: { id: 'call-3', tool: 'run_shell_mutate', input: { command: 'git status --short' } },
+      reason: 'inspect policy rejected the command',
+      step: 4,
+      timestamp: '2026-05-02T00:00:01.000Z',
+    };
+
+    expect(projectTraceEventToConversationActivities(approval)).toEqual([
+      {
+        type: 'tool.approval_requested',
+        tool: 'run_shell_mutate',
+        toolSummary: 'run_shell_mutate (yarn test)',
+        step: 3,
+        call: approval.call,
+      },
+    ]);
+    expect(projectTraceEventToConversationActivities(fallback)).toEqual([
+      {
+        type: 'tool.fallback',
+        fromTool: 'run_shell_inspect',
+        toTool: 'run_shell_mutate',
+        fromSummary: 'run_shell_inspect (git status --short)',
+        toSummary: 'run_shell_mutate (git status --short)',
+        reason: 'inspect policy rejected the command',
+      },
+    ]);
+  });
+
+  it('projects memory trace activities used by host adapters', () => {
+    const started: TraceEvent = {
+      type: 'memory.maintenance_started',
+      runId: 'memory-1',
+      candidateIds: ['candidate-1', 'candidate-2'],
+      step: 5,
+      timestamp: '2026-05-02T00:00:00.000Z',
+    };
+    const finished: TraceEvent = {
+      type: 'memory.maintenance_finished',
+      runId: 'memory-1',
+      outcome: 'completed',
+      summary: 'Stored project context.',
+      processedCandidateIds: ['candidate-1'],
+      failedCandidateIds: [],
+      step: 5,
+      timestamp: '2026-05-02T00:00:01.000Z',
+    };
+
+    expect(projectTraceEventToConversationActivities(started)).toEqual([
+      { type: 'memory.maintenance_started', candidateCount: 2 },
+    ]);
+    expect(projectTraceEventToConversationActivities(finished)).toEqual([
+      { type: 'memory.maintenance_finished', outcome: 'completed', summary: 'Stored project context.' },
+    ]);
+  });
+
+  it('projects compaction status activities', () => {
+    expect(projectCompactionStatusToConversationActivities({
+      status: 'running',
+      archivePath: '.heddle/chat-sessions/session-1/archive.jsonl',
+    })).toEqual([
+      { type: 'compaction.running', archivePath: '.heddle/chat-sessions/session-1/archive.jsonl' },
+    ]);
+    expect(projectCompactionStatusToConversationActivities({
+      status: 'failed',
+      error: 'summary failed',
+    })).toEqual([
+      { type: 'compaction.failed', error: 'summary failed' },
+    ]);
+  });
+
+  it('preserves TUI tool call summary details in the shared core helper', () => {
+    expect(summarizeActivityToolCall('search_files', { query: 'trace', path: '.heddle/traces' })).toBe(
+      'search_files ("trace" in .heddle/traces)',
+    );
+    expect(summarizeActivityToolCall('update_plan', { plan: [{ step: 'Refactor projection', status: 'in_progress' }] })).toBe(
+      'update_plan (Refactor projection)',
+    );
+  });
+
+  it('routes nested trace loop events through the trace projector', () => {
+    const trace: TraceEvent = {
+      type: 'tool.call',
+      call: { id: 'call-1', tool: 'read_file', input: { path: 'README.md' } },
+      step: 2,
+      timestamp: '2026-05-02T00:00:00.000Z',
+    };
+    const event: AgentLoopEvent = {
+      type: 'trace',
+      runId: 'run-1',
+      event: trace,
+      timestamp: '2026-05-02T00:00:01.000Z',
+    };
+
+    expect(projectAgentLoopEventToConversationActivities(event)).toEqual([
+      { type: 'tool.call', toolSummary: 'read_file (README.md)' },
+    ]);
+  });
+});

--- a/src/__tests__/unit/tui/chat-activity-format.test.ts
+++ b/src/__tests__/unit/tui/chat-activity-format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { summarizeToolCall, toLiveEvent } from '../../../cli/chat/utils/format.js';
+import { toLiveEvent } from '../../../cli/chat/adapters/conversation-activity-adapter.js';
+import { summarizeToolCall } from '../../../cli/chat/utils/format.js';
 import type { TraceEvent } from '../../../types.js';
 
 describe('chat activity formatting', () => {

--- a/src/cli/chat/adapters/conversation-activity-adapter.ts
+++ b/src/cli/chat/adapters/conversation-activity-adapter.ts
@@ -1,0 +1,56 @@
+import {
+  projectTraceEventToConversationActivities,
+  type ConversationActivity,
+} from '../../../core/observability/conversation-activity.js';
+import type { TraceEvent } from '../../../index.js';
+import { truncate } from '../../../core/utils/text.js';
+
+export function toLiveEvent(event: TraceEvent): string | undefined {
+  return projectTraceEventToConversationActivities(event)
+    .map(formatConversationActivityForTui)
+    .find((text): text is string => Boolean(text));
+}
+
+const tuiActivityFormatters: Partial<Record<ConversationActivity['type'], (activity: ConversationActivity) => string | undefined>> = {
+  'run.started': () => 'thinking',
+  'assistant.turn': (activity) => {
+    const assistantActivity = activity as Extract<ConversationActivity, { type: 'assistant.turn' }>;
+    if (assistantActivity.rationale) {
+      return `reasoning: ${truncate(assistantActivity.rationale, 140)}`;
+    }
+    return assistantActivity.requestedTools ? undefined : 'answer ready';
+  },
+  'tool.approval_requested': (activity) => `approval needed for ${(activity as Extract<ConversationActivity, { type: 'tool.approval_requested' }>).toolSummary}`,
+  'tool.approval_resolved': (activity) => {
+    const approvalActivity = activity as Extract<ConversationActivity, { type: 'tool.approval_resolved' }>;
+    return `approval ${approvalActivity.approved ? 'granted' : 'denied'} for ${approvalActivity.toolSummary}${approvalActivity.reason ? ` (${truncate(approvalActivity.reason, 80)})` : ''}`;
+  },
+  'tool.fallback': (activity) => {
+    const fallbackActivity = activity as Extract<ConversationActivity, { type: 'tool.fallback' }>;
+    return `retrying with ${fallbackActivity.toSummary} after ${fallbackActivity.fromSummary} was blocked (${truncate(fallbackActivity.reason, 80)})`;
+  },
+  'tool.call': (activity) => `running ${(activity as Extract<ConversationActivity, { type: 'tool.call' }>).toolSummary}`,
+  'tool.result': (activity) => {
+    const toolActivity = activity as Extract<ConversationActivity, { type: 'tool.result' }>;
+    return `${toolActivity.toolSummary} ${toolActivity.ok ? 'completed' : `failed: ${toolActivity.error ?? 'error'}`}`;
+  },
+  'memory.candidate_recorded': (activity) => `memory candidate recorded: ${(activity as Extract<ConversationActivity, { type: 'memory.candidate_recorded' }>).candidateId}`,
+  'memory.maintenance_started': (activity) => {
+    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_started' }>;
+    return `memory maintenance started for ${memoryActivity.candidateCount} candidate${memoryActivity.candidateCount === 1 ? '' : 's'}`;
+  },
+  'memory.maintenance_finished': (activity) => `memory maintenance ${(activity as Extract<ConversationActivity, { type: 'memory.maintenance_finished' }>).outcome}`,
+  'memory.maintenance_failed': (activity) => `memory maintenance failed: ${truncate((activity as Extract<ConversationActivity, { type: 'memory.maintenance_failed' }>).error ?? 'error', 80)}`,
+  'cyberloop.annotation': (activity) => {
+    const cyberloopActivity = activity as Extract<ConversationActivity, { type: 'cyberloop.annotation' }>;
+    return `cyberloop drift=${cyberloopActivity.driftLevel}${cyberloopActivity.metrics}`;
+  },
+  'run.finished': (activity) => {
+    const runActivity = activity as Extract<ConversationActivity, { type: 'run.finished' }>;
+    return runActivity.outcome === 'done' ? undefined : `stopped: ${runActivity.outcome}`;
+  },
+};
+
+export function formatConversationActivityForTui(activity: ConversationActivity): string | undefined {
+  return tuiActivityFormatters[activity.type]?.(activity);
+}

--- a/src/cli/chat/hooks/tui-agent-turn-result.ts
+++ b/src/cli/chat/hooks/tui-agent-turn-result.ts
@@ -5,7 +5,8 @@ import { createChatTurnPersistenceArtifacts } from '../../../core/chat/session-t
 import { estimateChatHistoryTokens } from '../state/compaction.js';
 import { touchSession } from '../state/storage.js';
 import type { ChatSession } from '../state/types.js';
-import { formatChatFailureMessage, summarizeTrace, toLiveEvent } from '../utils/format.js';
+import { toLiveEvent } from '../adapters/conversation-activity-adapter.js';
+import { formatChatFailureMessage, summarizeTrace } from '../utils/format.js';
 import type { ChatRuntimeConfig } from '../utils/runtime.js';
 import type { ActionState } from './useAgentRun.js';
 import type { TuiCompactionStatusEvent } from './tui-compaction-status.js';

--- a/src/cli/chat/hooks/tui-run-loop-events.ts
+++ b/src/cli/chat/hooks/tui-run-loop-events.ts
@@ -1,7 +1,8 @@
 import type { TraceEvent } from '../../../index.js';
 import { projectTraceEventToConversationActivities } from '../../../core/observability/conversation-activity.js';
 import { previewEditFileInput } from '../../../core/tools/edit-file.js';
-import { formatConversationActivityForTui, formatEditPreviewHistoryMessage, formatPlanHistoryMessage } from '../utils/format.js';
+import { formatConversationActivityForTui } from '../adapters/conversation-activity-adapter.js';
+import { formatEditPreviewHistoryMessage, formatPlanHistoryMessage } from '../utils/format.js';
 import type { ChatSession } from '../state/types.js';
 import type { ActionState } from './useAgentRun.js';
 

--- a/src/cli/chat/hooks/tui-run-loop-events.ts
+++ b/src/cli/chat/hooks/tui-run-loop-events.ts
@@ -1,6 +1,7 @@
 import type { TraceEvent } from '../../../index.js';
+import { projectTraceEventToConversationActivities } from '../../../core/observability/conversation-activity.js';
 import { previewEditFileInput } from '../../../core/tools/edit-file.js';
-import { formatEditPreviewHistoryMessage, formatPlanHistoryMessage, toLiveEvent } from '../utils/format.js';
+import { formatConversationActivityForTui, formatEditPreviewHistoryMessage, formatPlanHistoryMessage } from '../utils/format.js';
 import type { ChatSession } from '../state/types.js';
 import type { ActionState } from './useAgentRun.js';
 
@@ -79,18 +80,20 @@ export function createTuiRunLoopEventAdapter(args: {
         }
       }
 
-      const next = toLiveEvent(event);
-      if (!next) {
+      const nextEvents = projectTraceEventToConversationActivities(event)
+        .map(formatConversationActivityForTui)
+        .filter((text): text is string => Boolean(text));
+      if (nextEvents.length === 0) {
         return;
       }
 
       state.setLiveEvents((current) => {
-        const previous = current[current.length - 1];
-        if (previous?.text === next) {
-          return current;
-        }
+        const dedupedNextEvents = nextEvents.filter((next) => current[current.length - 1]?.text !== next);
 
-        return [...current, { id: state.nextLocalId(), text: next }].slice(-8);
+        return [
+          ...current,
+          ...dedupedNextEvents.map((text) => ({ id: state.nextLocalId(), text })),
+        ].slice(-8);
       });
     },
   };

--- a/src/cli/chat/utils/format.ts
+++ b/src/cli/chat/utils/format.ts
@@ -1,4 +1,8 @@
 import type { ChatMessage, TraceEvent, ToolResult } from '../../../index.js';
+import {
+  projectTraceEventToConversationActivities,
+  type ConversationActivity,
+} from '../../../core/observability/conversation-activity.js';
 import type { EditFilePreview } from '../../../core/tools/edit-file.js';
 import {
   classifyShellCommandPolicy,
@@ -31,77 +35,53 @@ const MAX_TOOL_CALL_SUMMARY_CHARS = 96;
 
 
 export function toLiveEvent(event: TraceEvent): string | undefined {
-  switch (event.type) {
-    case 'run.started':
-      return 'thinking';
-    case 'assistant.turn':
-      if (event.diagnostics?.rationale) {
-        return `reasoning: ${truncate(event.diagnostics.rationale, 140)}`;
-      }
-      if (event.requestedTools) {
-        return undefined;
-      }
-      return 'answer ready';
-    case 'tool.approval_requested':
-      return `approval needed for ${summarizeToolCall(event.call.tool, event.call.input)}`;
-    case 'tool.approval_resolved':
-      return `approval ${event.approved ? 'granted' : 'denied'} for ${summarizeToolCall(event.call.tool, event.call.input)}${event.reason ? ` (${truncate(event.reason, 80)})` : ''}`;
-    case 'tool.fallback':
-      return `retrying with ${summarizeToolCall(event.toCall.tool, event.toCall.input)} after ${summarizeToolCall(event.fromCall.tool, event.fromCall.input)} was blocked (${truncate(event.reason, 80)})`;
-    case 'tool.call':
-      return `running ${summarizeToolCall(event.call.tool, event.call.input)}`;
-    case 'tool.result':
-      return `${summarizeToolResult(event.tool, extractShellCommand(event.result.output), event.result.output)} ${event.result.ok ? 'completed' : `failed: ${event.result.error ?? 'error'}`}`;
-    case 'memory.candidate_recorded':
-      return `memory candidate recorded: ${event.candidateId}`;
-    case 'memory.maintenance_started':
-      return `memory maintenance started for ${event.candidateIds.length} candidate${event.candidateIds.length === 1 ? '' : 's'}`;
-    case 'memory.maintenance_finished':
-      return `memory maintenance ${event.outcome}`;
-    case 'memory.maintenance_failed':
-      return `memory maintenance failed: ${truncate(event.error, 80)}`;
-    case 'cyberloop.annotation':
-      return event.driftLevel === 'unknown' ? undefined : `cyberloop drift=${event.driftLevel}${formatCyberLoopMetrics(event.metadata)}`;
-    case 'run.finished':
-      return event.outcome === 'done' ? undefined : `stopped: ${event.outcome}`;
-    default:
-      return undefined;
-  }
+  return projectTraceEventToConversationActivities(event)
+    .map(formatConversationActivityForTui)
+    .find((text): text is string => Boolean(text));
 }
 
-function formatCyberLoopMetrics(metadata: Record<string, unknown>): string {
-  const kinematics = metadata.kinematics;
-  if (!kinematics || typeof kinematics !== 'object' || Array.isArray(kinematics)) {
-    return '';
-  }
+const tuiActivityFormatters: Partial<Record<ConversationActivity['type'], (activity: ConversationActivity) => string | undefined>> = {
+  'run.started': () => 'thinking',
+  'assistant.turn': (activity) => {
+    const assistantActivity = activity as Extract<ConversationActivity, { type: 'assistant.turn' }>;
+    if (assistantActivity.rationale) {
+      return `reasoning: ${truncate(assistantActivity.rationale, 140)}`;
+    }
+    return assistantActivity.requestedTools ? undefined : 'answer ready';
+  },
+  'tool.approval_requested': (activity) => `approval needed for ${(activity as Extract<ConversationActivity, { type: 'tool.approval_requested' }>).toolSummary}`,
+  'tool.approval_resolved': (activity) => {
+    const approvalActivity = activity as Extract<ConversationActivity, { type: 'tool.approval_resolved' }>;
+    return `approval ${approvalActivity.approved ? 'granted' : 'denied'} for ${approvalActivity.toolSummary}${approvalActivity.reason ? ` (${truncate(approvalActivity.reason, 80)})` : ''}`;
+  },
+  'tool.fallback': (activity) => {
+    const fallbackActivity = activity as Extract<ConversationActivity, { type: 'tool.fallback' }>;
+    return `retrying with ${fallbackActivity.toSummary} after ${fallbackActivity.fromSummary} was blocked (${truncate(fallbackActivity.reason, 80)})`;
+  },
+  'tool.call': (activity) => `running ${(activity as Extract<ConversationActivity, { type: 'tool.call' }>).toolSummary}`,
+  'tool.result': (activity) => {
+    const toolActivity = activity as Extract<ConversationActivity, { type: 'tool.result' }>;
+    return `${toolActivity.toolSummary} ${toolActivity.ok ? 'completed' : `failed: ${toolActivity.error ?? 'error'}`}`;
+  },
+  'memory.candidate_recorded': (activity) => `memory candidate recorded: ${(activity as Extract<ConversationActivity, { type: 'memory.candidate_recorded' }>).candidateId}`,
+  'memory.maintenance_started': (activity) => {
+    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_started' }>;
+    return `memory maintenance started for ${memoryActivity.candidateCount} candidate${memoryActivity.candidateCount === 1 ? '' : 's'}`;
+  },
+  'memory.maintenance_finished': (activity) => `memory maintenance ${(activity as Extract<ConversationActivity, { type: 'memory.maintenance_finished' }>).outcome}`,
+  'memory.maintenance_failed': (activity) => `memory maintenance failed: ${truncate((activity as Extract<ConversationActivity, { type: 'memory.maintenance_failed' }>).error ?? 'error', 80)}`,
+  'cyberloop.annotation': (activity) => {
+    const cyberloopActivity = activity as Extract<ConversationActivity, { type: 'cyberloop.annotation' }>;
+    return `cyberloop drift=${cyberloopActivity.driftLevel}${cyberloopActivity.metrics}`;
+  },
+  'run.finished': (activity) => {
+    const runActivity = activity as Extract<ConversationActivity, { type: 'run.finished' }>;
+    return runActivity.outcome === 'done' ? undefined : `stopped: ${runActivity.outcome}`;
+  },
+};
 
-  const snapshot = kinematics as {
-    errorMagnitude?: unknown;
-    correctionMagnitude?: unknown;
-    isStable?: unknown;
-  };
-  const parts: string[] = [];
-  if (typeof snapshot.errorMagnitude === 'number') {
-    parts.push(`err=${formatMetric(snapshot.errorMagnitude)}`);
-  }
-  if (typeof snapshot.correctionMagnitude === 'number') {
-    parts.push(`corr=${formatMetric(snapshot.correctionMagnitude)}`);
-  }
-  if (typeof snapshot.isStable === 'boolean') {
-    parts.push(`stable=${snapshot.isStable}`);
-  }
-
-  return parts.length ? ` (${parts.join(' ')})` : '';
-}
-
-function formatMetric(value: number): string {
-  if (!Number.isFinite(value)) {
-    return String(value);
-  }
-  if (Math.abs(value) < 0.001 && value !== 0) {
-    return value.toExponential(2);
-  }
-  return value.toFixed(3);
+export function formatConversationActivityForTui(activity: ConversationActivity): string | undefined {
+  return tuiActivityFormatters[activity.type]?.(activity);
 }
 
 export function currentActivityText(

--- a/src/cli/chat/utils/format.ts
+++ b/src/cli/chat/utils/format.ts
@@ -1,8 +1,4 @@
-import type { ChatMessage, TraceEvent, ToolResult } from '../../../index.js';
-import {
-  projectTraceEventToConversationActivities,
-  type ConversationActivity,
-} from '../../../core/observability/conversation-activity.js';
+import type { ChatMessage, ToolResult } from '../../../index.js';
 import type { EditFilePreview } from '../../../core/tools/edit-file.js';
 import {
   classifyShellCommandPolicy,
@@ -33,56 +29,6 @@ export type ApprovalSummary = {
 const MAX_SHELL_OUTPUT_CHARS = 1400;
 const MAX_TOOL_CALL_SUMMARY_CHARS = 96;
 
-
-export function toLiveEvent(event: TraceEvent): string | undefined {
-  return projectTraceEventToConversationActivities(event)
-    .map(formatConversationActivityForTui)
-    .find((text): text is string => Boolean(text));
-}
-
-const tuiActivityFormatters: Partial<Record<ConversationActivity['type'], (activity: ConversationActivity) => string | undefined>> = {
-  'run.started': () => 'thinking',
-  'assistant.turn': (activity) => {
-    const assistantActivity = activity as Extract<ConversationActivity, { type: 'assistant.turn' }>;
-    if (assistantActivity.rationale) {
-      return `reasoning: ${truncate(assistantActivity.rationale, 140)}`;
-    }
-    return assistantActivity.requestedTools ? undefined : 'answer ready';
-  },
-  'tool.approval_requested': (activity) => `approval needed for ${(activity as Extract<ConversationActivity, { type: 'tool.approval_requested' }>).toolSummary}`,
-  'tool.approval_resolved': (activity) => {
-    const approvalActivity = activity as Extract<ConversationActivity, { type: 'tool.approval_resolved' }>;
-    return `approval ${approvalActivity.approved ? 'granted' : 'denied'} for ${approvalActivity.toolSummary}${approvalActivity.reason ? ` (${truncate(approvalActivity.reason, 80)})` : ''}`;
-  },
-  'tool.fallback': (activity) => {
-    const fallbackActivity = activity as Extract<ConversationActivity, { type: 'tool.fallback' }>;
-    return `retrying with ${fallbackActivity.toSummary} after ${fallbackActivity.fromSummary} was blocked (${truncate(fallbackActivity.reason, 80)})`;
-  },
-  'tool.call': (activity) => `running ${(activity as Extract<ConversationActivity, { type: 'tool.call' }>).toolSummary}`,
-  'tool.result': (activity) => {
-    const toolActivity = activity as Extract<ConversationActivity, { type: 'tool.result' }>;
-    return `${toolActivity.toolSummary} ${toolActivity.ok ? 'completed' : `failed: ${toolActivity.error ?? 'error'}`}`;
-  },
-  'memory.candidate_recorded': (activity) => `memory candidate recorded: ${(activity as Extract<ConversationActivity, { type: 'memory.candidate_recorded' }>).candidateId}`,
-  'memory.maintenance_started': (activity) => {
-    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_started' }>;
-    return `memory maintenance started for ${memoryActivity.candidateCount} candidate${memoryActivity.candidateCount === 1 ? '' : 's'}`;
-  },
-  'memory.maintenance_finished': (activity) => `memory maintenance ${(activity as Extract<ConversationActivity, { type: 'memory.maintenance_finished' }>).outcome}`,
-  'memory.maintenance_failed': (activity) => `memory maintenance failed: ${truncate((activity as Extract<ConversationActivity, { type: 'memory.maintenance_failed' }>).error ?? 'error', 80)}`,
-  'cyberloop.annotation': (activity) => {
-    const cyberloopActivity = activity as Extract<ConversationActivity, { type: 'cyberloop.annotation' }>;
-    return `cyberloop drift=${cyberloopActivity.driftLevel}${cyberloopActivity.metrics}`;
-  },
-  'run.finished': (activity) => {
-    const runActivity = activity as Extract<ConversationActivity, { type: 'run.finished' }>;
-    return runActivity.outcome === 'done' ? undefined : `stopped: ${runActivity.outcome}`;
-  },
-};
-
-export function formatConversationActivityForTui(activity: ConversationActivity): string | undefined {
-  return tuiActivityFormatters[activity.type]?.(activity);
-}
 
 export function currentActivityText(
   liveEvents: LiveEvent[],

--- a/src/core/observability/README.md
+++ b/src/core/observability/README.md
@@ -28,8 +28,9 @@ Observability behavior currently exists in these places:
 - `src/core/chat/trace.ts` for persisted chat trace files.
 - `src/core/observability/trace-summarizers.ts` for turn summary evidence.
 - `src/core/observability/semantic-conventions.ts` for shared trace names.
-- `src/cli/chat/hooks/tui-run-loop-events.ts`.
-- `src/web/features/control-plane/hooks/sessions-screen/useSessionDetailSubscription.ts`.
+- `src/core/observability/conversation-activity.ts` for shared host activity projection.
+- `src/cli/chat/hooks/tui-run-loop-events.ts` for TUI activity rendering.
+- `src/web/features/control-plane/hooks/sessions-screen/useSessionDetailSubscription.ts` for web activity rendering.
 - `src/server/features/control-plane/services/chat-session-events.ts`.
 
 Future milestones should centralize shared summarization and projection here
@@ -39,9 +40,6 @@ while preserving compatibility wrappers for existing imports.
 
 - `semantic-conventions.ts`: event naming and correlation conventions.
 - `trace-summarizers.ts`: registry for trace event summaries.
-
-## Planned Public Entry Points
-
 - `conversation-activity.ts`: shared host-agnostic activity projection.
 
 ## Extension Points

--- a/src/core/observability/conversation-activity.ts
+++ b/src/core/observability/conversation-activity.ts
@@ -1,0 +1,277 @@
+import type { AgentLoopEvent } from '../runtime/events.js';
+import type { TraceEvent, ToolCall } from '../types.js';
+import { truncate } from '../utils/text.js';
+
+const MAX_TOOL_CALL_SUMMARY_CHARS = 96;
+
+export type ConversationActivity =
+  | { type: 'loop.started' }
+  | { type: 'loop.finished' }
+  | { type: 'assistant.stream'; text: string; done: boolean }
+  | { type: 'assistant.turn'; requestedTools: boolean; rationale?: string }
+  | { type: 'tool.calling'; tool: string; step?: number }
+  | { type: 'tool.completed'; tool: string; durationMs?: number }
+  | { type: 'run.started' }
+  | { type: 'run.finished'; outcome: string }
+  | { type: 'tool.approval_requested'; tool: string; toolSummary: string; step?: number; call: ToolCall }
+  | { type: 'tool.approval_resolved'; tool: string; toolSummary: string; approved: boolean; reason?: string; call: ToolCall }
+  | { type: 'tool.fallback'; fromTool: string; toTool: string; fromSummary: string; toSummary: string; reason: string }
+  | { type: 'tool.call'; toolSummary: string }
+  | { type: 'tool.result'; tool: string; toolSummary: string; ok: boolean; error?: string }
+  | { type: 'memory.candidate_recorded'; candidateId: string }
+  | { type: 'memory.maintenance_started'; candidateCount: number }
+  | { type: 'memory.maintenance_finished'; outcome: string; summary?: string }
+  | { type: 'memory.maintenance_failed'; error?: string }
+  | { type: 'cyberloop.annotation'; driftLevel: Exclude<Extract<TraceEvent, { type: 'cyberloop.annotation' }>['driftLevel'], 'unknown'>; metrics: string }
+  | { type: 'compaction.running'; archivePath?: string }
+  | { type: 'compaction.finished'; summaryPath?: string }
+  | { type: 'compaction.failed'; error?: string };
+
+export type ConversationCompactionStatus =
+  | { status: 'running'; archivePath?: string }
+  | { status: 'finished'; summaryPath?: string }
+  | { status: 'failed'; error?: string };
+
+type TraceProjectorMap = {
+  [Type in TraceEvent['type']]: (event: Extract<TraceEvent, { type: Type }>) => ConversationActivity[];
+};
+
+type AgentLoopProjectorMap = {
+  [Type in AgentLoopEvent['type']]?: (event: Extract<AgentLoopEvent, { type: Type }>) => ConversationActivity[];
+};
+
+type CompactionProjectorMap = {
+  [Status in ConversationCompactionStatus['status']]: (event: Extract<ConversationCompactionStatus, { status: Status }>) => ConversationActivity[];
+};
+
+const traceProjectors: TraceProjectorMap = {
+  'run.started': () => [{ type: 'run.started' }],
+  'assistant.turn': (event) => [{
+    type: 'assistant.turn',
+    requestedTools: event.requestedTools,
+    rationale: event.diagnostics?.rationale,
+  }],
+  'host.warning': () => [],
+  'tool.approval_requested': (event) => [{
+    type: 'tool.approval_requested',
+    tool: event.call.tool,
+    toolSummary: summarizeActivityToolCall(event.call.tool, event.call.input),
+    step: event.step,
+    call: event.call,
+  }],
+  'tool.approval_resolved': (event) => [{
+    type: 'tool.approval_resolved',
+    tool: event.call.tool,
+    toolSummary: summarizeActivityToolCall(event.call.tool, event.call.input),
+    approved: event.approved,
+    reason: event.reason,
+    call: event.call,
+  }],
+  'tool.fallback': (event) => [{
+    type: 'tool.fallback',
+    fromTool: event.fromCall.tool,
+    toTool: event.toCall.tool,
+    fromSummary: summarizeActivityToolCall(event.fromCall.tool, event.fromCall.input),
+    toSummary: summarizeActivityToolCall(event.toCall.tool, event.toCall.input),
+    reason: event.reason,
+  }],
+  'tool.call': (event) => [{ type: 'tool.call', toolSummary: summarizeActivityToolCall(event.call.tool, event.call.input) }],
+  'tool.result': (event) => [{
+    type: 'tool.result',
+    tool: event.tool,
+    toolSummary: summarizeActivityToolResult(event.tool, extractShellCommand(event.result.output), event.result.output),
+    ok: event.result.ok,
+    error: event.result.error,
+  }],
+  'memory.candidate_recorded': (event) => [{ type: 'memory.candidate_recorded', candidateId: event.candidateId }],
+  'memory.checkpoint_skipped': () => [],
+  'memory.maintenance_started': (event) => [{ type: 'memory.maintenance_started', candidateCount: event.candidateIds.length }],
+  'memory.maintenance_finished': (event) => [{
+    type: 'memory.maintenance_finished',
+    outcome: event.outcome,
+    summary: event.summary,
+  }],
+  'memory.maintenance_failed': (event) => [{ type: 'memory.maintenance_failed', error: event.error }],
+  'cyberloop.annotation': (event) => (
+    event.driftLevel === 'unknown' ? [] : [{
+      type: 'cyberloop.annotation',
+      driftLevel: event.driftLevel,
+      metrics: formatCyberLoopMetrics(event.metadata),
+    }]
+  ),
+  'run.finished': (event) => [{ type: 'run.finished', outcome: event.outcome }],
+};
+
+const agentLoopProjectors: AgentLoopProjectorMap = {
+  'loop.started': () => [{ type: 'loop.started' }],
+  'assistant.stream': (event) => [{ type: 'assistant.stream', text: event.text, done: event.done }],
+  'tool.calling': (event) => [{ type: 'tool.calling', tool: event.tool, step: event.step }],
+  'tool.completed': (event) => [{ type: 'tool.completed', tool: event.tool, durationMs: event.durationMs }],
+  trace: (event) => projectTraceEventToConversationActivities(event.event),
+  'loop.finished': () => [{ type: 'loop.finished' }],
+};
+
+const compactionProjectors: CompactionProjectorMap = {
+  running: (event) => [{ type: 'compaction.running', archivePath: event.archivePath }],
+  finished: (event) => [{ type: 'compaction.finished', summaryPath: event.summaryPath }],
+  failed: (event) => [{ type: 'compaction.failed', error: event.error }],
+};
+
+export function projectTraceEventToConversationActivities(event: TraceEvent): ConversationActivity[] {
+  return traceProjectors[event.type](event as never);
+}
+
+export function projectAgentLoopEventToConversationActivities(event: AgentLoopEvent): ConversationActivity[] {
+  const projector = agentLoopProjectors[event.type] as ((event: AgentLoopEvent) => ConversationActivity[]) | undefined;
+  return projector?.(event) ?? [];
+}
+
+export function projectCompactionStatusToConversationActivities(event: ConversationCompactionStatus): ConversationActivity[] {
+  return compactionProjectors[event.status](event as never);
+}
+
+export function summarizeActivityToolCall(tool: string, input: unknown): string {
+  const planSummary = summarizePlanInput(tool, input);
+  if (planSummary) {
+    return planSummary;
+  }
+
+  const shellCommand = extractShellCommand(input);
+  if (shellCommand) {
+    return `${tool} (${truncate(shellCommand, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
+  }
+
+  const searchSummary = summarizeSearchInput(tool, input);
+  if (searchSummary) {
+    return searchSummary;
+  }
+
+  const path = extractPathField(input);
+  if (isPathAwareTool(tool) && path) {
+    return `${tool} (${truncate(path, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
+  }
+
+  return tool;
+}
+
+export function summarizeActivityToolResult(tool: string, command: string | undefined, output?: unknown): string {
+  if (command) {
+    return `${tool} (${truncate(command, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
+  }
+
+  const outputPath = extractPathField(output);
+  if (tool === 'edit_file' && outputPath) {
+    return `${tool} (${truncate(outputPath, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
+  }
+
+  return tool;
+}
+
+function extractShellCommand(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const command = (value as { command?: unknown }).command;
+  return typeof command === 'string' && command.trim() ? command.trim() : undefined;
+}
+
+function extractPathField(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const path = (value as { path?: unknown }).path;
+  return typeof path === 'string' && path.trim() ? path.trim() : undefined;
+}
+
+function extractQueryField(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const query = (value as { query?: unknown }).query;
+  return typeof query === 'string' && query.trim() ? query.trim() : undefined;
+}
+
+function isPathAwareTool(tool: string): boolean {
+  return tool === 'edit_file' || tool === 'read_file' || tool === 'list_files';
+}
+
+function summarizeSearchInput(tool: string, input: unknown): string | undefined {
+  if (tool !== 'search_files') {
+    return undefined;
+  }
+
+  const query = extractQueryField(input);
+  if (!query) {
+    return tool;
+  }
+
+  const path = extractPathField(input);
+  const querySummary = truncate(JSON.stringify(query), Math.max(12, Math.floor(MAX_TOOL_CALL_SUMMARY_CHARS / 2)));
+  if (path) {
+    return `${tool} (${querySummary} in ${truncate(path, Math.max(12, Math.floor(MAX_TOOL_CALL_SUMMARY_CHARS / 2)))})`;
+  }
+
+  return `${tool} (${querySummary})`;
+}
+
+function summarizePlanInput(tool: string, input: unknown): string | undefined {
+  if (tool !== 'update_plan') {
+    return undefined;
+  }
+
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return tool;
+  }
+
+  const plan = (input as { plan?: unknown }).plan;
+  if (!Array.isArray(plan) || plan.length === 0) {
+    return tool;
+  }
+
+  const current = plan.find((item) => (
+    item
+    && typeof item === 'object'
+    && !Array.isArray(item)
+    && (item as { status?: unknown }).status === 'in_progress'
+  ));
+  const currentStep = current && typeof (current as { step?: unknown }).step === 'string' ? (current as { step: string }).step : undefined;
+  return currentStep ? `${tool} (${truncate(currentStep, MAX_TOOL_CALL_SUMMARY_CHARS)})` : `${tool} (${plan.length} items)`;
+}
+
+function formatCyberLoopMetrics(metadata: Record<string, unknown>): string {
+  const kinematics = metadata.kinematics;
+  if (!kinematics || typeof kinematics !== 'object' || Array.isArray(kinematics)) {
+    return '';
+  }
+
+  const snapshot = kinematics as {
+    errorMagnitude?: unknown;
+    correctionMagnitude?: unknown;
+    isStable?: unknown;
+  };
+  const parts: string[] = [];
+  if (typeof snapshot.errorMagnitude === 'number') {
+    parts.push(`err=${formatMetric(snapshot.errorMagnitude)}`);
+  }
+  if (typeof snapshot.correctionMagnitude === 'number') {
+    parts.push(`corr=${formatMetric(snapshot.correctionMagnitude)}`);
+  }
+  if (typeof snapshot.isStable === 'boolean') {
+    parts.push(`stable=${snapshot.isStable}`);
+  }
+
+  return parts.length ? ` (${parts.join(' ')})` : '';
+}
+
+function formatMetric(value: number): string {
+  if (!Number.isFinite(value)) {
+    return String(value);
+  }
+  if (Math.abs(value) < 0.001 && value !== 0) {
+    return value.toExponential(2);
+  }
+  return value.toFixed(3);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,6 +252,17 @@ export {
   TRACE_EVENT_DOMAINS,
   TRACE_EVENT_TYPES,
 } from './core/observability/semantic-conventions.js';
+export {
+  projectAgentLoopEventToConversationActivities,
+  projectCompactionStatusToConversationActivities,
+  projectTraceEventToConversationActivities,
+  summarizeActivityToolCall,
+  summarizeActivityToolResult,
+} from './core/observability/conversation-activity.js';
+export type {
+  ConversationActivity,
+  ConversationCompactionStatus,
+} from './core/observability/conversation-activity.js';
 
 // Prompts
 export { buildSystemPrompt } from './core/prompts/system-prompt.js';

--- a/src/web/features/control-plane/hooks/sessions-screen/useSessionDetailSubscription.ts
+++ b/src/web/features/control-plane/hooks/sessions-screen/useSessionDetailSubscription.ts
@@ -1,4 +1,11 @@
 import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
+import {
+  projectAgentLoopEventToConversationActivities,
+  projectCompactionStatusToConversationActivities,
+  type ConversationActivity,
+  type ConversationCompactionStatus,
+} from '../../../../../core/observability/conversation-activity';
+import type { AgentLoopEvent } from '../../../../../core/runtime/events';
 import type { TraceEvent } from '../../../../../core/types';
 import {
   fetchChatSessionDetail,
@@ -38,13 +45,6 @@ type SessionEventContext = {
   refresh: (options?: { silent?: boolean }) => Promise<void>;
   liveMessages: LiveSessionMessageActions;
 };
-
-type SessionEventHandler = {
-  matches: (event: LiveSessionEvent) => boolean;
-  handle: (event: LiveSessionEvent, context: SessionEventContext) => void;
-};
-
-type TraceEventContext = Pick<SessionEventContext, 'sessionId' | 'setMemoryUpdating' | 'setPendingApproval' | 'refresh' | 'liveMessages'>;
 
 export function useSessionDetailSubscription({
   selectedSessionId,
@@ -184,149 +184,138 @@ function handleSessionEvent({
     refresh,
     liveMessages,
   };
-  sessionEventHandlers.find((handler) => handler.matches(event))?.handle(event, context);
+  projectLiveSessionEvent(event).forEach((activity) => applyWebConversationActivity(activity, context));
 }
 
-const compactionStatusHandlers: Record<NonNullable<LiveSessionEvent['status']>, (event: LiveSessionEvent, context: SessionEventContext) => void> = {
-  running: (event, { liveMessages }) => {
+const webActivityHandlers: Partial<Record<ConversationActivity['type'], (activity: ConversationActivity, context: SessionEventContext) => void>> = {
+  'compaction.running': (activity, { liveMessages }) => {
+    const compactionActivity = activity as Extract<ConversationActivity, { type: 'compaction.running' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      event.archivePath ? `Compacting earlier history… ${event.archivePath}` : 'Compacting earlier history…',
+      compactionActivity.archivePath ? `Compacting earlier history… ${compactionActivity.archivePath}` : 'Compacting earlier history…',
       { pending: true, streaming: false },
     );
   },
-  failed: (event, { liveMessages }) => {
+  'compaction.failed': (activity, { liveMessages }) => {
+    const compactionActivity = activity as Extract<ConversationActivity, { type: 'compaction.failed' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      event.error ? `Compaction failed: ${event.error}` : 'Compaction failed.',
+      compactionActivity.error ? `Compaction failed: ${compactionActivity.error}` : 'Compaction failed.',
       { pending: false, streaming: false },
     );
   },
-  finished: (event, { liveMessages }) => {
+  'compaction.finished': (activity, { liveMessages }) => {
+    const compactionActivity = activity as Extract<ConversationActivity, { type: 'compaction.finished' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      event.summaryPath ? `Compaction finished. Summary: ${event.summaryPath}` : 'Compaction finished.',
+      compactionActivity.summaryPath ? `Compaction finished. Summary: ${compactionActivity.summaryPath}` : 'Compaction finished.',
       { pending: false, streaming: false },
     );
   },
-};
-
-const eventTypeHandlers: Record<string, SessionEventHandler['handle']> = {
-  'loop.started': (_event, { setRunInFlight, liveMessages }) => {
+  'loop.started': (_activity, { setRunInFlight, liveMessages }) => {
     setRunInFlight(true);
     liveMessages.upsertLiveStatusMessage('live-run-status', 'Run started…', { pending: true, streaming: true });
   },
-  'tool.calling': (event, { liveMessages }) => {
-    withStringValue(event.tool, (tool) => liveMessages.upsertLiveStatusMessage(
+  'tool.calling': (activity, { liveMessages }) => {
+    const toolActivity = activity as Extract<ConversationActivity, { type: 'tool.calling' }>;
+    liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Working… running ${tool}${typeof event.step === 'number' ? ` (step ${event.step})` : ''}`,
+      `Working… running ${toolActivity.tool}${typeof toolActivity.step === 'number' ? ` (step ${toolActivity.step})` : ''}`,
       { pending: true, streaming: true },
-    ));
+    );
   },
-  'tool.completed': (event, { liveMessages }) => {
-    withStringValue(event.tool, (tool) => liveMessages.upsertLiveStatusMessage(
+  'tool.completed': (activity, { liveMessages }) => {
+    const toolActivity = activity as Extract<ConversationActivity, { type: 'tool.completed' }>;
+    liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `${tool} finished${typeof event.durationMs === 'number' ? ` in ${Math.round(event.durationMs)}ms` : ''}`,
+      `${toolActivity.tool} finished${typeof toolActivity.durationMs === 'number' ? ` in ${Math.round(toolActivity.durationMs)}ms` : ''}`,
       { pending: false, streaming: false },
-    ));
+    );
   },
-  trace: (event, context) => {
-    withValue(event.event, (traceEvent) => handleTraceEvent(traceEvent, context));
+  'assistant.stream': (activity, { liveMessages }) => {
+    const assistantActivity = activity as Extract<ConversationActivity, { type: 'assistant.stream' }>;
+    liveMessages.upsertLiveAssistantMessage(assistantActivity.text, assistantActivity.done);
+    if (assistantActivity.done) {
+      liveMessages.removeLiveStatusMessage('live-run-status');
+    }
   },
-  'assistant.stream': (event, { liveMessages }) => {
-    withStringValue(event.text, (text) => liveMessages.upsertLiveAssistantMessage(text, Boolean(event.done)));
-    when(Boolean(event.done), () => liveMessages.removeLiveStatusMessage('live-run-status'));
-  },
-  'loop.finished': (_event, { setRunInFlight, liveMessages, refresh }) => {
+  'loop.finished': (_activity, { setRunInFlight, liveMessages, refresh }) => {
     setRunInFlight(false);
     liveMessages.removeLiveStatusMessage('live-run-status');
     void refresh();
   },
-};
-
-const sessionEventHandlers: SessionEventHandler[] = [
-  {
-    matches: (event) => Boolean(event.status && compactionStatusHandlers[event.status]),
-    handle: (event, context) => event.status && compactionStatusHandlers[event.status](event, context),
-  },
-  {
-    matches: (event) => Boolean(event.type && eventTypeHandlers[event.type]),
-    handle: (event, context) => event.type && eventTypeHandlers[event.type](event, context),
-  },
-];
-
-const traceEventHandlers: Partial<{
-  [EventType in TraceEvent['type']]: (event: Extract<TraceEvent, { type: EventType }>, context: TraceEventContext) => void;
-}> = {
-  'memory.maintenance_started': (event, { setMemoryUpdating, liveMessages }) => {
+  'memory.maintenance_started': (activity, { setMemoryUpdating, liveMessages }) => {
+    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_started' }>;
     setMemoryUpdating(true);
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Memory updating… ${event.candidateIds.length} candidate${event.candidateIds.length === 1 ? '' : 's'}`,
+      `Memory updating… ${memoryActivity.candidateCount} candidate${memoryActivity.candidateCount === 1 ? '' : 's'}`,
       { pending: true, streaming: false },
     );
   },
-  'memory.maintenance_finished': (event, { setMemoryUpdating, liveMessages, refresh }) => {
+  'memory.maintenance_finished': (activity, { setMemoryUpdating, liveMessages, refresh }) => {
+    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_finished' }>;
     setMemoryUpdating(false);
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      event.summary ? `Memory updated. ${event.summary}` : 'Memory updated.',
+      memoryActivity.summary ? `Memory updated. ${memoryActivity.summary}` : 'Memory updated.',
       { pending: false, streaming: false },
     );
     void refresh({ silent: true });
   },
-  'memory.maintenance_failed': (event, { setMemoryUpdating, liveMessages }) => {
+  'memory.maintenance_failed': (activity, { setMemoryUpdating, liveMessages }) => {
+    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_failed' }>;
     setMemoryUpdating(false);
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      event.error ? `Memory update failed: ${event.error}` : 'Memory update failed.',
+      memoryActivity.error ? `Memory update failed: ${memoryActivity.error}` : 'Memory update failed.',
       { pending: false, streaming: false },
     );
   },
-  'tool.approval_requested': (event, { sessionId, setPendingApproval, liveMessages }) => {
+  'tool.approval_requested': (activity, { sessionId, setPendingApproval, liveMessages }) => {
+    const approvalActivity = activity as Extract<ConversationActivity, { type: 'tool.approval_requested' }>;
     void fetchPendingSessionApproval(sessionId).then((approval) => setPendingApproval(approval));
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Approval requested for ${event.call.tool}${typeof event.step === 'number' ? ` (step ${event.step})` : ''}`,
+      `Approval requested for ${approvalActivity.tool}${typeof approvalActivity.step === 'number' ? ` (step ${approvalActivity.step})` : ''}`,
       { pending: true, streaming: false },
     );
   },
-  'tool.approval_resolved': (event, { setPendingApproval, liveMessages }) => {
+  'tool.approval_resolved': (activity, { setPendingApproval, liveMessages }) => {
+    const approvalActivity = activity as Extract<ConversationActivity, { type: 'tool.approval_resolved' }>;
     setPendingApproval(null);
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Approval ${event.approved ? 'granted' : 'denied'} for ${event.call.tool}${event.reason ? ` — ${event.reason}` : ''}`,
+      `Approval ${approvalActivity.approved ? 'granted' : 'denied'} for ${approvalActivity.tool}${approvalActivity.reason ? ` — ${approvalActivity.reason}` : ''}`,
       { pending: false, streaming: false },
     );
   },
-  'tool.fallback': (event, { liveMessages }) => {
+  'tool.fallback': (activity, { liveMessages }) => {
+    const fallbackActivity = activity as Extract<ConversationActivity, { type: 'tool.fallback' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Fallback: ${event.fromCall.tool} → ${event.toCall.tool}`,
+      `Fallback: ${fallbackActivity.fromTool} → ${fallbackActivity.toTool}`,
       { pending: true, streaming: false },
     );
   },
 };
 
-function handleTraceEvent(traceEvent: TraceEvent, context: TraceEventContext) {
-  const handler = traceEventHandlers[traceEvent.type] as ((event: TraceEvent, context: TraceEventContext) => void) | undefined;
-  handler?.(traceEvent, context);
+function projectLiveSessionEvent(event: LiveSessionEvent): ConversationActivity[] {
+  if (isCompactionStatusEvent(event)) {
+    return projectCompactionStatusToConversationActivities(event);
+  }
+
+  return isAgentLoopEventLike(event) ? projectAgentLoopEventToConversationActivities(event) : [];
 }
 
-function withValue<T>(value: T | undefined, callback: (value: T) => void) {
-  if (value !== undefined) {
-    callback(value);
-  }
+function applyWebConversationActivity(activity: ConversationActivity, context: SessionEventContext) {
+  webActivityHandlers[activity.type]?.(activity, context);
 }
 
-function withStringValue(value: unknown, callback: (value: string) => void) {
-  if (typeof value === 'string') {
-    callback(value);
-  }
+function isCompactionStatusEvent(event: LiveSessionEvent): event is ConversationCompactionStatus {
+  return event.status === 'running' || event.status === 'finished' || event.status === 'failed';
 }
 
-function when(condition: boolean, callback: () => void) {
-  if (condition) {
-    callback();
-  }
+function isAgentLoopEventLike(event: LiveSessionEvent): event is AgentLoopEvent {
+  return typeof event.type === 'string';
 }


### PR DESCRIPTION
## Summary

Adds the M9 shared conversation activity projection slice:

- introduces `src/core/observability/conversation-activity.ts` to project `AgentLoopEvent`, `TraceEvent`, and compaction status updates into host-agnostic `ConversationActivity` records
- adopts the shared projection in the TUI run-loop adapter and web session subscription hook
- keeps TUI wording in `src/cli/chat/adapters/conversation-activity-adapter.ts` instead of leaving the activity renderer in `utils/format.ts`
- exports the projection API for programmatic consumers
- adds focused unit coverage for assistant stream, tools, approvals, memory, compaction, nested trace events, run-finished, and shared tool summaries

## Why

This gives future hosts and programmatic users a stable semantic activity layer without depending on React, Ink, SSE payload details, or duplicated trace parsing.

## Validation

- `yarn test:unit src/__tests__/unit/core/conversation-activity.test.ts`
- `yarn test:unit src/__tests__/unit/tui/chat-activity-format.test.ts`
- `yarn vitest run src/__tests__/integration/web/control-plane-sessions-state.test.tsx`
- `yarn vitest run src/__tests__/integration/chat/chat-runtime.test.ts`
- `yarn eslint`
- `yarn typecheck`
- `yarn build`