### PR TITLE
[codex] Extract chat turn phases

### DIFF
--- a/src/__tests__/unit/core/chat-turn-memory-maintenance.test.ts
+++ b/src/__tests__/unit/core/chat-turn-memory-maintenance.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createChatSession, loadChatSessions, saveChatSessions } from '../../../core/chat/storage.js';
+import { appendAgentLoopTrace, appendTurnMemoryMaintenanceEvents } from '../../../core/chat/turn-memory-maintenance.js';
+import type { AgentLoopResult } from '../../../core/runtime/agent-loop.js';
+import type { TraceEvent } from '../../../core/types.js';
+
+describe('chat turn memory maintenance helpers', () => {
+  it('appends background maintenance events to the trace file and latest turn summary', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-maintenance-'));
+    const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');
+    const traceFile = join(root, 'trace.json');
+    const baseTrace: TraceEvent[] = [{
+      type: 'memory.candidate_recorded',
+      candidateId: 'candidate-1',
+      path: '_maintenance/candidates.jsonl',
+      step: 1,
+      timestamp: '2026-05-02T00:00:00.000Z',
+    }];
+    writeFileSync(traceFile, `${JSON.stringify(baseTrace, null, 2)}\n`, 'utf8');
+
+    const session = createChatSession({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.4',
+    });
+    saveChatSessions(sessionStoragePath, [{
+      ...session,
+      turns: [{
+        id: 'turn-1',
+        prompt: 'Remember this',
+        outcome: 'done',
+        summary: 'Done.',
+        steps: 1,
+        traceFile,
+        events: ['memory candidate recorded: candidate-1'],
+      }],
+    }]);
+
+    appendTurnMemoryMaintenanceEvents({
+      traceFile,
+      events: [{
+        type: 'memory.maintenance_finished',
+        runId: 'memory-run-1',
+        outcome: 'done',
+        summary: 'Stored memory.',
+        processedCandidateIds: ['candidate-1'],
+        failedCandidateIds: [],
+        step: 2,
+        timestamp: '2026-05-02T00:00:01.000Z',
+      }],
+      sessionStoragePath,
+      sessionId: 'session-1',
+    });
+
+    const nextTrace = JSON.parse(readFileSync(traceFile, 'utf8')) as TraceEvent[];
+    expect(nextTrace.map((event) => event.type)).toEqual([
+      'memory.candidate_recorded',
+      'memory.maintenance_finished',
+    ]);
+    expect(loadChatSessions(sessionStoragePath, true)[0]?.turns[0]?.events).toEqual([
+      'memory candidate recorded: candidate-1',
+      'memory maintenance finished: done',
+    ]);
+  });
+
+  it('appends inline maintenance events to both result trace locations', () => {
+    const baseTrace: TraceEvent[] = [{
+      type: 'run.started',
+      goal: 'test',
+      timestamp: '2026-05-02T00:00:00.000Z',
+    }];
+    const result: AgentLoopResult = {
+      outcome: 'done',
+      summary: 'Done.',
+      trace: baseTrace,
+      transcript: [],
+      model: 'gpt-5.4',
+      provider: 'openai',
+      workspaceRoot: '/repo',
+      state: {
+        status: 'finished',
+        runId: 'run-1',
+        goal: 'test',
+        model: 'gpt-5.4',
+        provider: 'openai',
+        workspaceRoot: '/repo',
+        startedAt: '2026-05-02T00:00:00.000Z',
+        finishedAt: '2026-05-02T00:00:01.000Z',
+        outcome: 'done',
+        summary: 'Done.',
+        transcript: [],
+        trace: baseTrace,
+      },
+    };
+
+    const next = appendAgentLoopTrace(result, [{
+      type: 'memory.maintenance_failed',
+      runId: 'memory-run-1',
+      error: 'failed',
+      candidateIds: [],
+      step: 2,
+      timestamp: '2026-05-02T00:00:02.000Z',
+    }]);
+
+    expect(next.trace.map((event) => event.type)).toEqual(['run.started', 'memory.maintenance_failed']);
+    expect(next.state.trace).toEqual(next.trace);
+    expect(result.trace).toEqual(baseTrace);
+  });
+});

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -1,0 +1,149 @@
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setStoredProviderCredential } from '../../../core/auth/provider-credentials.js';
+import { createChatSession, saveChatSessions } from '../../../core/chat/storage.js';
+import { loadChatTurnSession } from '../../../core/chat/turn-session.js';
+import { resolveChatTurnModel, resolveChatTurnRuntime } from '../../../core/chat/turn-runtime.js';
+import { createChatTurnTools, listChatTurnToolNames } from '../../../core/chat/turn-tools.js';
+import { DEFAULT_OPENAI_MODEL } from '../../../core/config.js';
+
+describe('chat turn preparation modules', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('loads the requested session or preserves the existing missing-session error', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-session-'));
+    const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');
+    const session = createChatSession({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.4',
+    });
+    saveChatSessions(sessionStoragePath, [session]);
+
+    expect(loadChatTurnSession({ sessionStoragePath, sessionId: 'session-1' }).session.id).toBe('session-1');
+    expect(() => loadChatTurnSession({ sessionStoragePath, sessionId: 'missing' })).toThrow(
+      'Chat session not found: missing',
+    );
+  });
+
+  it('resolves chat turn model precedence without changing defaults', () => {
+    expect(resolveChatTurnModel({
+      sessionModel: 'session-model',
+      env: { OPENAI_MODEL: 'openai-env', ANTHROPIC_MODEL: 'anthropic-env' },
+    })).toBe('session-model');
+    expect(resolveChatTurnModel({
+      env: { OPENAI_MODEL: 'openai-env', ANTHROPIC_MODEL: 'anthropic-env' },
+    })).toBe('openai-env');
+    expect(resolveChatTurnModel({
+      env: { OPENAI_MODEL: undefined, ANTHROPIC_MODEL: 'anthropic-env' },
+    })).toBe('anthropic-env');
+    expect(resolveChatTurnModel({
+      env: { OPENAI_MODEL: undefined, ANTHROPIC_MODEL: undefined },
+    })).toBe(DEFAULT_OPENAI_MODEL);
+  });
+
+  it('resolves explicit API-key runtime with memory context and credential source', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-runtime-'));
+    const stateRoot = join(root, '.heddle');
+    mkdirSync(join(stateRoot, 'memory'), { recursive: true });
+
+    const runtime = resolveChatTurnRuntime({
+      stateRoot,
+      sessionModel: 'gpt-5.4',
+      apiKey: 'explicit-key',
+      systemContext: 'System context',
+      env: { OPENAI_MODEL: undefined, ANTHROPIC_MODEL: undefined },
+    });
+
+    expect(runtime.model).toBe('gpt-5.4');
+    expect(runtime.provider).toBe('openai');
+    expect(runtime.apiKey).toBe('explicit-key');
+    expect(runtime.providerCredentialSource).toEqual({ type: 'explicit-api-key' });
+    expect(runtime.memoryDir).toBe(join(stateRoot, 'memory'));
+    expect(runtime.systemContext).toContain('System context');
+    expect(runtime.llm.info?.model).toBe('gpt-5.4');
+  });
+
+  it('preserves stored OAuth credential selection for OpenAI chat turns', () => {
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-oauth-'));
+    const credentialStorePath = join(root, 'auth.json');
+    const now = '2026-05-02T00:00:00.000Z';
+    setStoredProviderCredential({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.parse('2026-05-02T01:00:00.000Z'),
+      accountId: 'account-123',
+      createdAt: now,
+      updatedAt: now,
+    }, credentialStorePath);
+
+    const runtime = resolveChatTurnRuntime({
+      stateRoot: join(root, '.heddle'),
+      sessionModel: 'gpt-5.1-codex',
+      credentialStorePath,
+      env: { OPENAI_MODEL: undefined, ANTHROPIC_MODEL: undefined },
+    });
+
+    expect(runtime.apiKey).toBeUndefined();
+    expect(runtime.providerCredentialSource).toEqual({
+      type: 'oauth',
+      provider: 'openai',
+      accountId: 'account-123',
+      expiresAt: Date.parse('2026-05-02T01:00:00.000Z'),
+    });
+  });
+
+  it('preserves missing credential errors', () => {
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');
+    vi.stubEnv('ANTHROPIC_API_KEY', '');
+    vi.stubEnv('PERSONAL_ANTHROPIC_API_KEY', '');
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-missing-'));
+
+    expect(() => resolveChatTurnRuntime({
+      stateRoot: join(root, '.heddle'),
+      sessionModel: 'claude-sonnet-4-6',
+      credentialStorePath: join(root, 'missing-auth.json'),
+      env: { OPENAI_MODEL: undefined, ANTHROPIC_MODEL: undefined },
+    })).toThrow('Missing Anthropic credential. Set ANTHROPIC_API_KEY for Anthropic models.');
+  });
+
+  it('creates the ordinary chat turn tool bundle with the plan tool included', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-tools-'));
+    const tools = createChatTurnTools({
+      model: 'gpt-5.4',
+      apiKey: 'explicit-key',
+      providerCredentialSource: { type: 'explicit-api-key' },
+      workspaceRoot: root,
+      memoryDir: join(root, '.heddle', 'memory'),
+    });
+
+    expect(listChatTurnToolNames(tools)).toEqual([
+      'list_files',
+      'read_file',
+      'edit_file',
+      'delete_file',
+      'move_file',
+      'search_files',
+      'web_search',
+      'view_image',
+      'list_memory_notes',
+      'read_memory_note',
+      'search_memory_notes',
+      'memory_checkpoint',
+      'record_knowledge',
+      'update_plan',
+      'run_shell_inspect',
+      'run_shell_mutate',
+    ]);
+  });
+});

--- a/src/core/chat/README.md
+++ b/src/core/chat/README.md
@@ -31,6 +31,9 @@ maintenance, traces, and host ports.
 - `turn-runtime.ts`: model, credential, LLM, memory, and system-context
   preparation for ordinary chat turns.
 - `turn-tools.ts`: ordinary chat turn tool bundle creation.
+- `turn-memory-maintenance.ts`: inline/background turn memory maintenance and
+  trace summary updates.
+- `turn-persistence.ts`: final chat turn persistence orchestration.
 - `session-submit.ts`: server-facing submit adapter over ordinary turns.
 - `storage.ts`: file-backed chat session store.
 - `session-turn-preflight.ts`: lease acquisition and preflight compaction.

--- a/src/core/chat/README.md
+++ b/src/core/chat/README.md
@@ -27,6 +27,10 @@ maintenance, traces, and host ports.
 ## Public Entry Points
 
 - `ordinary-turn.ts`: current conversation-turn harness.
+- `turn-session.ts`: session loading for ordinary chat turns.
+- `turn-runtime.ts`: model, credential, LLM, memory, and system-context
+  preparation for ordinary chat turns.
+- `turn-tools.ts`: ordinary chat turn tool bundle creation.
 - `session-submit.ts`: server-facing submit adapter over ordinary turns.
 - `storage.ts`: file-backed chat session store.
 - `session-turn-preflight.ts`: lease acquisition and preflight compaction.
@@ -70,4 +74,3 @@ maintenance, traces, and host ports.
 - Keep host-specific wording in adapters. Core chat should emit semantics and
   persist durable evidence.
 - Do not import from TUI, web, or server code.
-

--- a/src/core/chat/ordinary-turn.ts
+++ b/src/core/chat/ordinary-turn.ts
@@ -1,14 +1,9 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import {
-  appendMemoryCatalogSystemContext,
-  createDefaultAgentTools,
-  createLlmAdapter,
-  DEFAULT_OPENAI_MODEL,
-  inferProviderFromModel,
-  runAgentLoop,
-} from '../../index.js';
-import type { AgentLoopResult, ToolCall, ToolDefinition } from '../../index.js';
+import { runAgentLoop } from '../../index.js';
+import type { AgentLoopResult, RunAgentLoopOptions } from '../runtime/agent-loop.js';
+import type { ToolCall, ToolDefinition } from '../types.js';
+import type { LlmAdapter } from '../llm/types.js';
 import { runMaintenanceForRecordedCandidates } from '../memory/maintenance-integration.js';
 import { buildCompactionRunningContext } from './compaction.js';
 import { buildConversationMessages } from './conversation-lines.js';
@@ -18,14 +13,10 @@ import { persistChatTurnResult } from './session-turn-result.js';
 import { loadChatSessions, saveChatSessions, touchSession } from './storage.js';
 import { summarizeTrace } from './trace-summary.js';
 import type { ChatTurnHostPort } from './turn-host.js';
-import type { RunAgentLoopOptions } from '../runtime/agent-loop.js';
-import {
-  formatMissingProviderCredentialMessage,
-  hasProviderCredentialForModel,
-  resolveApiKeyForModel,
-  resolveProviderCredentialSourceForModel,
-} from '../../core/runtime/api-keys.js';
-import type { AgentLoopEvent } from '../../index.js';
+import type { AgentLoopEvent } from '../runtime/events.js';
+import { loadChatTurnSession } from './turn-session.js';
+import { resolveChatTurnRuntime } from './turn-runtime.js';
+import { createChatTurnTools, listChatTurnToolNames } from './turn-tools.js';
 
 export type ExecuteOrdinaryChatTurnArgs = {
   workspaceRoot: string;
@@ -48,51 +39,33 @@ export type ExecuteOrdinaryChatTurnArgs = {
 };
 
 export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs) {
-  const sessions = loadChatSessions(args.sessionStoragePath, true);
-  const session = sessions.find((candidate) => candidate.id === args.sessionId);
-  if (!session) {
-    throw new Error(`Chat session not found: ${args.sessionId}`);
-  }
-
-  const model = session.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
-  const provider = inferProviderFromModel(model);
-  const apiKey = args.apiKey ?? resolveApiKeyForModel(model, { preferApiKey: args.preferApiKey });
-  const providerCredentialSource = resolveProviderCredentialSourceForModel(model, {
-    apiKey,
-    apiKeyProvider: args.apiKey ? 'explicit' : apiKey ? provider : undefined,
-    credentialStorePath: args.credentialStorePath,
-    preferApiKey: args.preferApiKey,
+  const { sessions, session } = loadChatTurnSession({
+    sessionStoragePath: args.sessionStoragePath,
+    sessionId: args.sessionId,
   });
-  if (!hasProviderCredentialForModel(model, {
+  const runtime = resolveChatTurnRuntime({
+    stateRoot: args.stateRoot,
+    sessionModel: session.model,
     apiKey: args.apiKey,
-    apiKeyProvider: args.apiKey ? 'explicit' : undefined,
-    credentialStorePath: args.credentialStorePath,
     preferApiKey: args.preferApiKey,
-  })) {
-    throw new Error(formatMissingProviderCredentialMessage(model));
-  }
+    credentialStorePath: args.credentialStorePath,
+    systemContext: args.systemContext,
+  });
+  const tools = createChatTurnTools({
+    model: runtime.model,
+    apiKey: runtime.apiKey,
+    providerCredentialSource: runtime.providerCredentialSource,
+    credentialStorePath: args.credentialStorePath,
+    workspaceRoot: args.workspaceRoot,
+    memoryDir: runtime.memoryDir,
+  });
+  const toolNames = listChatTurnToolNames(tools);
 
   const leaseOwner = args.leaseOwner ?? {
     ownerKind: 'ask' as const,
     ownerId: `submit-${process.pid}`,
     clientLabel: 'another Heddle client',
   };
-  const llm = createLlmAdapter({ model, apiKey, credentialStorePath: args.credentialStorePath });
-  const memoryDir = join(args.stateRoot, 'memory');
-  const systemContext = appendMemoryCatalogSystemContext({
-    systemContext: args.systemContext,
-    memoryRoot: memoryDir,
-  });
-  const tools = createDefaultAgentTools({
-    model,
-    apiKey,
-    providerCredentialSource,
-    credentialStorePath: args.credentialStorePath,
-    workspaceRoot: args.workspaceRoot,
-    memoryDir,
-    searchIgnoreDirs: [],
-    includePlanTool: true,
-  });
 
   try {
     const preflight = await prepareChatSessionTurn({
@@ -100,11 +73,11 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
       sessionId: session.id,
       fallbackHistory: session.history,
       prompt: args.prompt,
-      model,
+      model: runtime.model,
       stateRoot: args.stateRoot,
-      systemContext,
-      toolNames: tools.map((tool) => tool.name),
-      summarizer: { credentialSource: providerCredentialSource },
+      systemContext: runtime.systemContext,
+      toolNames,
+      summarizer: { credentialSource: runtime.providerCredentialSource },
       leaseOwner,
       onCompactionStatus: (event, _sourceHistory, leasedSession) => {
         args.onCompactionStatus?.(event);
@@ -144,16 +117,16 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
 
     const result = await runAgentLoop({
       goal: args.prompt,
-      model,
-      apiKey,
+      model: runtime.model,
+      apiKey: runtime.apiKey,
       workspaceRoot: args.workspaceRoot,
       stateDir: args.stateRoot,
-      memoryDir,
-      llm,
+      memoryDir: runtime.memoryDir,
+      llm: runtime.llm,
       tools,
       includeDefaultTools: false,
       history: preflightSession.history,
-      systemContext,
+      systemContext: runtime.systemContext,
       onAssistantStream: args.onAssistantStream,
       onTraceEvent: args.onTraceEvent,
       onEvent: args.host?.events?.onAgentLoopEvent,
@@ -167,8 +140,8 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
     const inlineMaintenance =
       maintenanceMode === 'inline' ?
         await runMaintenanceForRecordedCandidates({
-          memoryRoot: memoryDir,
-          llm,
+          memoryRoot: runtime.memoryDir,
+          llm: runtime.llm,
           source: `chat session ${session.id}`,
           trace: result.trace,
           maxSteps: 20,
@@ -197,13 +170,13 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
       result: resultForPersistence,
       prompt: args.prompt,
       session: preflightSession,
-      model,
+      model: runtime.model,
       stateRoot: args.stateRoot,
       traceDir: join(args.stateRoot, 'traces'),
-      systemContext,
-      toolNames: tools.map((tool) => tool.name),
+      systemContext: runtime.systemContext,
+      toolNames,
       historyForTokenEstimate: session.history,
-      summarizer: { credentialSource: providerCredentialSource },
+      summarizer: { credentialSource: runtime.providerCredentialSource },
       createTurnId: () => `server-turn-${Date.now()}`,
       onCompactionStatus: (event) => {
         args.onCompactionStatus?.(event);
@@ -232,8 +205,8 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
     saveChatSessions(args.sessionStoragePath, nextSessions);
     if (maintenanceMode === 'background') {
       scheduleBackgroundMemoryMaintenance({
-        memoryRoot: memoryDir,
-        llm,
+        memoryRoot: runtime.memoryDir,
+        llm: runtime.llm,
         source: `chat session ${session.id}`,
         trace: result.trace,
         traceFile: persisted.traceFile,
@@ -256,7 +229,7 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
 
 function scheduleBackgroundMemoryMaintenance(args: {
   memoryRoot: string;
-  llm: ReturnType<typeof createLlmAdapter>;
+  llm: LlmAdapter;
   source: string;
   trace: AgentLoopResult['trace'];
   traceFile: string;

--- a/src/core/chat/ordinary-turn.ts
+++ b/src/core/chat/ordinary-turn.ts
@@ -1,19 +1,14 @@
-import { readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { runAgentLoop } from '../../index.js';
-import type { AgentLoopResult, RunAgentLoopOptions } from '../runtime/agent-loop.js';
+import type { RunAgentLoopOptions } from '../runtime/agent-loop.js';
 import type { ToolCall, ToolDefinition } from '../types.js';
-import type { LlmAdapter } from '../llm/types.js';
-import { runMaintenanceForRecordedCandidates } from '../memory/maintenance-integration.js';
 import { buildCompactionRunningContext } from './compaction.js';
 import { buildConversationMessages } from './conversation-lines.js';
 import { releaseSessionLease, type ChatSessionLeaseOwner } from './session-lease.js';
 import { prepareChatSessionTurn } from './session-turn-preflight.js';
-import { persistChatTurnResult } from './session-turn-result.js';
 import { loadChatSessions, saveChatSessions, touchSession } from './storage.js';
-import { summarizeTrace } from './trace-summary.js';
 import type { ChatTurnHostPort } from './turn-host.js';
-import type { AgentLoopEvent } from '../runtime/events.js';
+import { runInlineTurnMemoryMaintenance, scheduleBackgroundTurnMemoryMaintenance } from './turn-memory-maintenance.js';
+import { persistCompletedChatTurn } from './turn-persistence.js';
 import { loadChatTurnSession } from './turn-session.js';
 import { resolveChatTurnRuntime } from './turn-runtime.js';
 import { createChatTurnTools, listChatTurnToolNames } from './turn-tools.js';
@@ -137,74 +132,37 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
       abortSignal: args.abortSignal,
     });
     const maintenanceMode = args.memoryMaintenanceMode ?? 'background';
-    const inlineMaintenance =
+    const resultForPersistence =
       maintenanceMode === 'inline' ?
-        await runMaintenanceForRecordedCandidates({
+        await runInlineTurnMemoryMaintenance({
           memoryRoot: runtime.memoryDir,
           llm: runtime.llm,
           source: `chat session ${session.id}`,
-          trace: result.trace,
-          maxSteps: 20,
-          onTraceEvent: (event) => args.host?.events?.onAgentLoopEvent?.({
-            type: 'trace',
-            runId: result.state.runId,
-            event,
-            timestamp: new Date().toISOString(),
-          } satisfies AgentLoopEvent),
+          result,
+          onEvent: args.host?.events?.onAgentLoopEvent,
         })
-      : undefined;
-    const resultTrace =
-      inlineMaintenance && inlineMaintenance.events.length > 0 ?
-        [...result.trace, ...inlineMaintenance.events]
-      : result.trace;
-    const resultForPersistence: AgentLoopResult = {
-      ...result,
-      trace: resultTrace,
-      state: {
-        ...result.state,
-        trace: resultTrace,
-      },
-    };
+      : result;
 
-    const persisted = await persistChatTurnResult({
+    const persisted = await persistCompletedChatTurn({
       result: resultForPersistence,
       prompt: args.prompt,
       session: preflightSession,
+      sessions,
+      sessionStoragePath: args.sessionStoragePath,
       model: runtime.model,
       stateRoot: args.stateRoot,
-      traceDir: join(args.stateRoot, 'traces'),
       systemContext: runtime.systemContext,
       toolNames,
       historyForTokenEstimate: session.history,
-      summarizer: { credentialSource: runtime.providerCredentialSource },
-      createTurnId: () => `server-turn-${Date.now()}`,
-      onCompactionStatus: (event) => {
-        args.onCompactionStatus?.(event);
-        args.host?.compaction?.onFinalCompactionStatus?.(event);
-        if (event.status === 'running') {
-          const compactionSeed = touchSession({
-            ...preflightSession,
-            history: result.transcript,
-            context: buildCompactionRunningContext({
-              history: resultForPersistence.transcript,
-              previous: preflightSession.context,
-              archiveCount: preflightSession.archives?.length,
-              currentSummaryPath: preflightSession.context?.currentSummaryPath,
-              lastArchivePath: event.archivePath,
-            }),
-          });
-          saveChatSessions(
-            args.sessionStoragePath,
-            sessions.map((candidate) => candidate.id === session.id ? compactionSeed : candidate),
-          );
-        }
-      },
+      credentialSource: runtime.providerCredentialSource,
+      host: args.host,
+      onCompactionStatus: args.onCompactionStatus,
     });
 
     const nextSessions = sessions.map((candidate) => candidate.id === session.id ? persisted.session : candidate);
     saveChatSessions(args.sessionStoragePath, nextSessions);
     if (maintenanceMode === 'background') {
-      scheduleBackgroundMemoryMaintenance({
+      scheduleBackgroundTurnMemoryMaintenance({
         memoryRoot: runtime.memoryDir,
         llm: runtime.llm,
         source: `chat session ${session.id}`,
@@ -225,83 +183,6 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
   } finally {
     clearOrdinaryChatTurnLease(args.sessionStoragePath, session.id, leaseOwner);
   }
-}
-
-function scheduleBackgroundMemoryMaintenance(args: {
-  memoryRoot: string;
-  llm: LlmAdapter;
-  source: string;
-  trace: AgentLoopResult['trace'];
-  traceFile: string;
-  sessionStoragePath: string;
-  sessionId: string;
-  runId: string;
-  onEvent?: (event: AgentLoopEvent) => void;
-}) {
-  void (async () => {
-    const maintenance = await runMaintenanceForRecordedCandidates({
-      memoryRoot: args.memoryRoot,
-      llm: args.llm,
-      source: args.source,
-      trace: args.trace,
-      maxSteps: 20,
-      onTraceEvent: (event) => args.onEvent?.({ type: 'trace', runId: args.runId, event, timestamp: new Date().toISOString() }),
-    });
-    if (maintenance.events.length === 0) {
-      return;
-    }
-
-    const currentTrace = readTraceEvents(args.traceFile);
-    const nextTrace = [...currentTrace, ...maintenance.events];
-    writeFileSync(args.traceFile, `${JSON.stringify(nextTrace, null, 2)}\n`, 'utf8');
-
-    const sessions = loadChatSessions(args.sessionStoragePath, true);
-    const nextSessions = sessions.map((session) => {
-      if (session.id !== args.sessionId) {
-        return session;
-      }
-
-      return touchSession({
-        ...session,
-        turns: session.turns.map((turn, index) => (
-          index === session.turns.length - 1 ?
-            {
-              ...turn,
-              events: summarizeTrace(nextTrace),
-            }
-          : turn
-        )),
-      });
-    });
-    saveChatSessions(args.sessionStoragePath, nextSessions);
-  })().catch((error) => {
-    args.onEvent?.({
-      type: 'trace',
-      runId: args.runId,
-      event: {
-        type: 'memory.maintenance_failed',
-        runId: `memory-run-${Date.now()}`,
-        error: error instanceof Error ? error.message : String(error),
-        candidateIds: [],
-        step: nextTraceStep(args.trace),
-        timestamp: new Date().toISOString(),
-      },
-      timestamp: new Date().toISOString(),
-    });
-  });
-}
-
-function readTraceEvents(path: string): AgentLoopResult['trace'] {
-  try {
-    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
-    return Array.isArray(parsed) ? parsed as AgentLoopResult['trace'] : [];
-  } catch {
-    return [];
-  }
-}
-
-function nextTraceStep(trace: AgentLoopResult['trace']): number {
-  return trace.reduce((max, event) => 'step' in event ? Math.max(max, event.step) : max, 0) + 1;
 }
 
 export function clearOrdinaryChatTurnLease(sessionStoragePath: string, sessionId: string, owner: ChatSessionLeaseOwner) {

--- a/src/core/chat/turn-memory-maintenance.ts
+++ b/src/core/chat/turn-memory-maintenance.ts
@@ -1,0 +1,167 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import type { LlmAdapter } from '../llm/types.js';
+import type { AgentLoopResult } from '../runtime/agent-loop.js';
+import type { AgentLoopEvent } from '../runtime/events.js';
+import type { TraceEvent } from '../types.js';
+import { runMaintenanceForRecordedCandidates } from '../memory/maintenance-integration.js';
+import { loadChatSessions, saveChatSessions, touchSession } from './storage.js';
+import { summarizeTrace } from './trace-summary.js';
+
+export type RunInlineTurnMemoryMaintenanceArgs = {
+  memoryRoot: string;
+  llm: LlmAdapter;
+  source: string;
+  result: AgentLoopResult;
+  onEvent?: (event: AgentLoopEvent) => void;
+};
+
+export async function runInlineTurnMemoryMaintenance(
+  args: RunInlineTurnMemoryMaintenanceArgs,
+): Promise<AgentLoopResult> {
+  const maintenance = await runMaintenanceForRecordedCandidates({
+    memoryRoot: args.memoryRoot,
+    llm: args.llm,
+    source: args.source,
+    trace: args.result.trace,
+    maxSteps: 20,
+    onTraceEvent: (event) => args.onEvent?.({
+      type: 'trace',
+      runId: args.result.state.runId,
+      event,
+      timestamp: new Date().toISOString(),
+    }),
+  });
+
+  return appendAgentLoopTrace(args.result, maintenance.events);
+}
+
+export type ScheduleBackgroundTurnMemoryMaintenanceArgs = {
+  memoryRoot: string;
+  llm: LlmAdapter;
+  source: string;
+  trace: AgentLoopResult['trace'];
+  traceFile: string;
+  sessionStoragePath: string;
+  sessionId: string;
+  runId: string;
+  onEvent?: (event: AgentLoopEvent) => void;
+};
+
+export function scheduleBackgroundTurnMemoryMaintenance(args: ScheduleBackgroundTurnMemoryMaintenanceArgs) {
+  void runBackgroundTurnMemoryMaintenance(args).catch((error) => {
+    args.onEvent?.({
+      type: 'trace',
+      runId: args.runId,
+      event: createMemoryMaintenanceFailureEvent({
+        error,
+        trace: args.trace,
+      }),
+      timestamp: new Date().toISOString(),
+    });
+  });
+}
+
+export async function runBackgroundTurnMemoryMaintenance(args: ScheduleBackgroundTurnMemoryMaintenanceArgs) {
+  const maintenance = await runMaintenanceForRecordedCandidates({
+    memoryRoot: args.memoryRoot,
+    llm: args.llm,
+    source: args.source,
+    trace: args.trace,
+    maxSteps: 20,
+    onTraceEvent: (event) => args.onEvent?.({
+      type: 'trace',
+      runId: args.runId,
+      event,
+      timestamp: new Date().toISOString(),
+    }),
+  });
+  if (maintenance.events.length === 0) {
+    return;
+  }
+
+  appendTurnMemoryMaintenanceEvents({
+    traceFile: args.traceFile,
+    events: maintenance.events,
+    sessionStoragePath: args.sessionStoragePath,
+    sessionId: args.sessionId,
+  });
+}
+
+export function appendTurnMemoryMaintenanceEvents(args: {
+  traceFile: string;
+  events: TraceEvent[];
+  sessionStoragePath: string;
+  sessionId: string;
+}) {
+  const nextTrace = [...readTraceEvents(args.traceFile), ...args.events];
+  writeFileSync(args.traceFile, `${JSON.stringify(nextTrace, null, 2)}\n`, 'utf8');
+
+  const sessions = loadChatSessions(args.sessionStoragePath, true);
+  const nextSessions = sessions.map((session) => {
+    if (session.id !== args.sessionId) {
+      return session;
+    }
+
+    return touchSession({
+      ...session,
+      turns: session.turns.map((turn, index) => (
+        index === session.turns.length - 1 ?
+          {
+            ...turn,
+            events: summarizeTrace(nextTrace),
+          }
+        : turn
+      )),
+    });
+  });
+  saveChatSessions(args.sessionStoragePath, nextSessions);
+}
+
+export function appendAgentLoopTrace(result: AgentLoopResult, events: TraceEvent[]): AgentLoopResult {
+  if (events.length === 0) {
+    return {
+      ...result,
+      state: {
+        ...result.state,
+        trace: result.trace,
+      },
+    };
+  }
+
+  const trace = [...result.trace, ...events];
+  return {
+    ...result,
+    trace,
+    state: {
+      ...result.state,
+      trace,
+    },
+  };
+}
+
+function readTraceEvents(path: string): AgentLoopResult['trace'] {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    return Array.isArray(parsed) ? parsed as AgentLoopResult['trace'] : [];
+  } catch {
+    return [];
+  }
+}
+
+function createMemoryMaintenanceFailureEvent(args: {
+  error: unknown;
+  trace: TraceEvent[];
+}): Extract<TraceEvent, { type: 'memory.maintenance_failed' }> {
+  return {
+    type: 'memory.maintenance_failed',
+    runId: `memory-run-${Date.now()}`,
+    error: args.error instanceof Error ? args.error.message : String(args.error),
+    candidateIds: [],
+    step: nextTraceStep(args.trace),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function nextTraceStep(trace: TraceEvent[]): number {
+  return trace.reduce((max, event) => 'step' in event ? Math.max(max, event.step) : max, 0) + 1;
+}

--- a/src/core/chat/turn-persistence.ts
+++ b/src/core/chat/turn-persistence.ts
@@ -1,0 +1,71 @@
+import { join } from 'node:path';
+import { buildCompactionRunningContext } from './compaction.js';
+import { persistChatTurnResult, type PersistChatTurnResult } from './session-turn-result.js';
+import { saveChatSessions, touchSession } from './storage.js';
+import type { ChatSession } from './types.js';
+import type { ChatTurnHostPort } from './turn-host.js';
+import type { AgentLoopResult } from '../runtime/agent-loop.js';
+import type { ChatMessage } from '../llm/types.js';
+import type { ProviderCredentialSource } from '../runtime/api-keys.js';
+
+export type PersistCompletedChatTurnArgs = {
+  result: AgentLoopResult;
+  prompt: string;
+  session: ChatSession;
+  sessions: ChatSession[];
+  sessionStoragePath: string;
+  model: string;
+  stateRoot: string;
+  systemContext?: string;
+  toolNames: string[];
+  historyForTokenEstimate: ChatMessage[];
+  credentialSource: ProviderCredentialSource;
+  host?: ChatTurnHostPort;
+  onCompactionStatus?: (event: { status: 'running' | 'finished' | 'failed'; archivePath?: string; summaryPath?: string; error?: string }) => void;
+};
+
+export async function persistCompletedChatTurn(args: PersistCompletedChatTurnArgs): Promise<PersistChatTurnResult> {
+  return await persistChatTurnResult({
+    result: args.result,
+    prompt: args.prompt,
+    session: args.session,
+    model: args.model,
+    stateRoot: args.stateRoot,
+    traceDir: join(args.stateRoot, 'traces'),
+    systemContext: args.systemContext,
+    toolNames: args.toolNames,
+    historyForTokenEstimate: args.historyForTokenEstimate,
+    summarizer: { credentialSource: args.credentialSource },
+    createTurnId: () => `server-turn-${Date.now()}`,
+    onCompactionStatus: (event) => {
+      args.onCompactionStatus?.(event);
+      args.host?.compaction?.onFinalCompactionStatus?.(event);
+      if (event.status === 'running') {
+        persistFinalCompactionRunningSeed({
+          ...args,
+          archivePath: event.archivePath,
+        });
+      }
+    },
+  });
+}
+
+function persistFinalCompactionRunningSeed(args: PersistCompletedChatTurnArgs & {
+  archivePath?: string;
+}) {
+  const compactionSeed = touchSession({
+    ...args.session,
+    history: args.result.transcript,
+    context: buildCompactionRunningContext({
+      history: args.result.transcript,
+      previous: args.session.context,
+      archiveCount: args.session.archives?.length,
+      currentSummaryPath: args.session.context?.currentSummaryPath,
+      lastArchivePath: args.archivePath,
+    }),
+  });
+  saveChatSessions(
+    args.sessionStoragePath,
+    args.sessions.map((candidate) => candidate.id === args.session.id ? compactionSeed : candidate),
+  );
+}

--- a/src/core/chat/turn-runtime.ts
+++ b/src/core/chat/turn-runtime.ts
@@ -1,0 +1,95 @@
+import { join } from 'node:path';
+import { DEFAULT_OPENAI_MODEL } from '../config.js';
+import { createLlmAdapter } from '../llm/factory.js';
+import { inferProviderFromModel } from '../llm/providers.js';
+import type { LlmAdapter, LlmProvider } from '../llm/types.js';
+import {
+  formatMissingProviderCredentialMessage,
+  hasProviderCredentialForModel,
+  resolveApiKeyForModel,
+  resolveProviderCredentialSourceForModel,
+  type ProviderCredentialSource,
+} from '../runtime/api-keys.js';
+import { appendMemoryCatalogSystemContext } from '../memory/catalog.js';
+
+export type ChatTurnRuntime = {
+  model: string;
+  provider: LlmProvider;
+  apiKey: string | undefined;
+  providerCredentialSource: ProviderCredentialSource;
+  memoryDir: string;
+  systemContext: string | undefined;
+  llm: LlmAdapter;
+};
+
+export type ResolveChatTurnRuntimeArgs = {
+  stateRoot: string;
+  sessionModel?: string;
+  apiKey?: string;
+  preferApiKey?: boolean;
+  credentialStorePath?: string;
+  systemContext?: string;
+  env?: Pick<NodeJS.ProcessEnv, 'OPENAI_MODEL' | 'ANTHROPIC_MODEL'>;
+};
+
+export function resolveChatTurnModel(args: {
+  sessionModel?: string;
+  env?: Pick<NodeJS.ProcessEnv, 'OPENAI_MODEL' | 'ANTHROPIC_MODEL'>;
+}): string {
+  const env = args.env ?? process.env;
+  return args.sessionModel ?? env.OPENAI_MODEL ?? env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
+}
+
+export function resolveChatTurnRuntime(args: ResolveChatTurnRuntimeArgs): ChatTurnRuntime {
+  const model = resolveChatTurnModel({
+    sessionModel: args.sessionModel,
+    env: args.env,
+  });
+  const provider = inferProviderFromModel(model);
+  const apiKey = args.apiKey ?? resolveApiKeyForModel(model, { preferApiKey: args.preferApiKey });
+  const providerCredentialSource = resolveProviderCredentialSourceForModel(model, {
+    apiKey,
+    apiKeyProvider: args.apiKey ? 'explicit' : apiKey ? provider : undefined,
+    credentialStorePath: args.credentialStorePath,
+    preferApiKey: args.preferApiKey,
+  });
+
+  assertChatTurnCredential({
+    model,
+    apiKey: args.apiKey,
+    credentialStorePath: args.credentialStorePath,
+    preferApiKey: args.preferApiKey,
+  });
+
+  const memoryDir = join(args.stateRoot, 'memory');
+  return {
+    model,
+    provider,
+    apiKey,
+    providerCredentialSource,
+    memoryDir,
+    systemContext: appendMemoryCatalogSystemContext({
+      systemContext: args.systemContext,
+      memoryRoot: memoryDir,
+    }),
+    llm: createLlmAdapter({ model, apiKey, credentialStorePath: args.credentialStorePath }),
+  };
+}
+
+function assertChatTurnCredential(args: {
+  model: string;
+  apiKey?: string;
+  credentialStorePath?: string;
+  preferApiKey?: boolean;
+}) {
+  const hasCredential = hasProviderCredentialForModel(args.model, {
+    apiKey: args.apiKey,
+    apiKeyProvider: args.apiKey ? 'explicit' : undefined,
+    credentialStorePath: args.credentialStorePath,
+    preferApiKey: args.preferApiKey,
+  });
+
+  if (!hasCredential) {
+    throw new Error(formatMissingProviderCredentialMessage(args.model));
+  }
+}

--- a/src/core/chat/turn-session.ts
+++ b/src/core/chat/turn-session.ts
@@ -1,0 +1,20 @@
+import { loadChatSessions } from './storage.js';
+import type { ChatSession } from './types.js';
+
+export type LoadedChatTurnSession = {
+  sessions: ChatSession[];
+  session: ChatSession;
+};
+
+export function loadChatTurnSession(args: {
+  sessionStoragePath: string;
+  sessionId: string;
+}): LoadedChatTurnSession {
+  const sessions = loadChatSessions(args.sessionStoragePath, true);
+  const session = sessions.find((candidate) => candidate.id === args.sessionId);
+  if (!session) {
+    throw new Error(`Chat session not found: ${args.sessionId}`);
+  }
+
+  return { sessions, session };
+}

--- a/src/core/chat/turn-tools.ts
+++ b/src/core/chat/turn-tools.ts
@@ -1,0 +1,29 @@
+import { createDefaultAgentTools } from '../runtime/default-tools.js';
+import type { ProviderCredentialSource } from '../runtime/api-keys.js';
+import type { ToolDefinition } from '../types.js';
+
+export type CreateChatTurnToolsArgs = {
+  model: string;
+  apiKey?: string;
+  providerCredentialSource: ProviderCredentialSource;
+  credentialStorePath?: string;
+  workspaceRoot: string;
+  memoryDir: string;
+};
+
+export function createChatTurnTools(args: CreateChatTurnToolsArgs): ToolDefinition[] {
+  return createDefaultAgentTools({
+    model: args.model,
+    apiKey: args.apiKey,
+    providerCredentialSource: args.providerCredentialSource,
+    credentialStorePath: args.credentialStorePath,
+    workspaceRoot: args.workspaceRoot,
+    memoryDir: args.memoryDir,
+    searchIgnoreDirs: [],
+    includePlanTool: true,
+  });
+}
+
+export function listChatTurnToolNames(tools: ToolDefinition[]): string[] {
+  return tools.map((tool) => tool.name);
+}


### PR DESCRIPTION
## Summary

Extracts M10 and M11 chat turn orchestration phases:

- adds `turn-session.ts`, `turn-runtime.ts`, and `turn-tools.ts` for ordinary turn session/runtime/tool preparation
- adds `turn-memory-maintenance.ts` for inline/background maintenance, trace appending, latest-turn event summary updates, and background failure trace events
- adds `turn-persistence.ts` for final turn persistence orchestration and final-compaction running seed updates
- keeps `ordinary-turn.ts` as high-level phase orchestration with lease cleanup still in the `finally` path
- documents the new chat modules in `src/core/chat/README.md`
- adds focused unit tests for runtime preparation and memory-maintenance trace update behavior

## Why

This advances the domain-module refactor by shrinking the ordinary chat turn harness into named core-only phase modules while preserving public turn behavior.

## Validation

- `yarn test:unit src/__tests__/unit/core/chat-turn-runtime.test.ts`
- `yarn test:unit src/__tests__/unit/core/chat-turn-memory-maintenance.test.ts`
- `yarn vitest run src/__tests__/integration/memory/memory-integration.test.ts`
- `yarn vitest run src/__tests__/integration/chat/chat-runtime.test.ts`
- `yarn vitest run src/__tests__/integration/chat/session-submit.test.ts`
- `yarn vitest run src/__tests__/integration/core/agent-loop.test.ts`
- `yarn test:integration` outside the sandbox
- `yarn eslint`
- `yarn typecheck`
- `yarn build`