### PR TITLE
[codex] Complete M11.5 consolidation

### DIFF
--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -654,6 +654,57 @@ describe('runAgent', () => {
     expect(result.trace.map((event) => event.type)).toContain('tool.approval_resolved');
   });
 
+  it('lets custom approval policies satisfy approval-gated tools before human approval', async () => {
+    const approveToolCall = vi.fn(async () => ({ approved: false, reason: 'should not be requested' }));
+    const fakeLlm: LlmAdapter = {
+      async chat(messages): Promise<LlmResponse> {
+        if (messages.some((message) => message.role === 'tool')) {
+          return { content: 'The command ran through policy approval.' };
+        }
+
+        return {
+          toolCalls: [{ id: 'call-1', tool: 'run_shell_mutate', input: { command: 'yarn test' } }],
+        };
+      },
+    };
+
+    const mutateTool: ToolDefinition = {
+      name: 'run_shell_mutate',
+      description: 'Runs a bounded workspace mutation command',
+      requiresApproval: true,
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        return { ok: true, output: { command: 'yarn test', exitCode: 0, stdout: '', stderr: '' } };
+      },
+    };
+
+    const result = await runAgent({
+      goal: 'Run tests if needed.',
+      llm: fakeLlm,
+      tools: [mutateTool],
+      maxSteps: 3,
+      logger: silentLogger,
+      approvalPolicies: [
+        ({ call }) => call.tool === 'run_shell_mutate' ? { type: 'allow', reason: 'custom CI policy' } : undefined,
+      ],
+      approveToolCall,
+    });
+
+    expect(result.outcome).toBe('done');
+    expect(approveToolCall).not.toHaveBeenCalled();
+    expect(result.trace.map((event) => event.type)).not.toContain('tool.approval_requested');
+    expect(result.trace).toContainEqual({
+      type: 'tool.result',
+      tool: 'run_shell_mutate',
+      result: {
+        ok: true,
+        output: { command: 'yarn test', exitCode: 0, stdout: '', stderr: '' },
+      },
+      step: 1,
+      timestamp: expect.any(String),
+    });
+  });
+
   it('requires approval before reading a file outside the workspace root', async () => {
     const externalRoot = await mkdtemp(join(tmpdir(), 'heddle-read-outside-'));
     const externalFile = join(externalRoot, 'secret.txt');

--- a/src/__tests__/unit/core/approval-policy-chain.test.ts
+++ b/src/__tests__/unit/core/approval-policy-chain.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   defaultToolApprovalPolicies,
   isOutsideWorkspaceInspectionCall,
   rememberedApprovalPolicy,
 } from '../../../core/approvals/default-policies.js';
-import { evaluateToolApprovalPolicies } from '../../../core/approvals/policy-chain.js';
+import { evaluateToolApprovalPolicies, resolveToolApproval } from '../../../core/approvals/policy-chain.js';
 import { humanApprovalPolicy } from '../../../core/approvals/surface.js';
 import type { ToolApprovalPolicyContext } from '../../../core/approvals/types.js';
 
@@ -101,5 +101,43 @@ describe('approval policy chain', () => {
       type: 'deny',
       reason: 'Denied by human',
     });
+  });
+
+  it('lets later allow policies satisfy earlier request policies before human approval', async () => {
+    const human = vi.fn(async () => ({ approved: false, reason: 'should not run' }));
+
+    await expect(resolveToolApproval({
+      policies: [
+        () => ({ type: 'request', reason: 'run_shell_mutate requires approval' }),
+        rememberedApprovalPolicy({
+          isApproved: ({ call }) => call.tool === 'run_shell_mutate',
+        }),
+      ],
+      context: context(),
+      requestHumanApproval: human,
+    })).resolves.toEqual({
+      approved: true,
+      reason: 'Approved by saved project rule',
+    });
+    expect(human).not.toHaveBeenCalled();
+  });
+
+  it('falls through to human approval when a request policy is not satisfied', async () => {
+    const human = vi.fn(async (_context: ToolApprovalPolicyContext, reason?: string) => ({
+      approved: true,
+      reason: `human approved: ${reason}`,
+    }));
+
+    await expect(resolveToolApproval({
+      policies: [
+        () => ({ type: 'request', reason: 'run_shell_mutate requires approval' }),
+      ],
+      context: context(),
+      requestHumanApproval: human,
+    })).resolves.toEqual({
+      approved: true,
+      reason: 'human approved: run_shell_mutate requires approval',
+    });
+    expect(human).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/unit/core/chat-turn-persistence.test.ts
+++ b/src/__tests__/unit/core/chat-turn-persistence.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createChatTurnPersistenceArtifacts } from '../../../core/chat/session-turn-result.js';
+import { createTraceSummarizerRegistry } from '../../../core/observability/trace-summarizers.js';
+import type { ChatSession } from '../../../core/chat/types.js';
+import type { RunResult } from '../../../core/types.js';
+
+describe('chat turn persistence', () => {
+  it('uses a supplied trace summarizer registry for persisted turn events', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-turn-persistence-'));
+    const session = createSession();
+    const result: RunResult = {
+      outcome: 'done',
+      summary: 'Done.',
+      trace: [
+        {
+          type: 'tool.call',
+          call: { id: 'call-1', tool: 'read_file', input: { path: 'README.md' } },
+          step: 1,
+          timestamp: '2026-05-02T00:00:00.000Z',
+        },
+      ],
+      transcript: [
+        { role: 'user', content: 'Read README.' },
+        { role: 'assistant', content: 'Done.' },
+      ],
+    };
+
+    const artifacts = await createChatTurnPersistenceArtifacts({
+      result,
+      prompt: 'Read README.',
+      session,
+      model: 'gpt-5.4',
+      stateRoot,
+      traceDir: join(stateRoot, 'traces'),
+      toolNames: ['read_file'],
+      historyForTokenEstimate: session.history,
+      summarizer: {},
+      traceSummarizerRegistry: createTraceSummarizerRegistry({
+        'tool.call': (event) => `custom summary for ${event.call.tool}`,
+      }),
+      createTurnId: () => 'turn-1',
+    });
+
+    expect(artifacts.turn.events).toEqual(['custom summary for read_file']);
+  });
+});
+
+function createSession(): ChatSession {
+  return {
+    id: 'session-1',
+    name: 'Session',
+    history: [],
+    messages: [],
+    turns: [],
+    createdAt: '2026-05-02T00:00:00.000Z',
+    updatedAt: '2026-05-02T00:00:00.000Z',
+  };
+}

--- a/src/__tests__/unit/core/conversation-activity.test.ts
+++ b/src/__tests__/unit/core/conversation-activity.test.ts
@@ -166,7 +166,16 @@ describe('conversation activity projection', () => {
     expect(summarizeToolCall('update_plan', { plan: [{ step: 'Refactor projection', status: 'in_progress' }] })).toBe(
       'update_plan (Refactor projection)',
     );
+    expect(summarizeToolCall('delete_file', { path: 'tmp/generated-report.md' })).toBe(
+      'delete_file (tmp/generated-report.md)',
+    );
+    expect(summarizeToolCall('move_file', { from: 'docs/old.md', to: 'docs/archive/old.md' })).toBe(
+      'move_file (docs/old.md -> docs/archive/old.md)',
+    );
     expect(summarizeToolResult('edit_file', { output: { path: 'src/index.ts' } })).toBe('edit_file (src/index.ts)');
+    expect(summarizeToolResult('delete_file', { output: { path: 'tmp/generated-report.md' } })).toBe(
+      'delete_file (tmp/generated-report.md)',
+    );
   });
 
   it('routes nested trace loop events through the trace projector', () => {

--- a/src/__tests__/unit/core/conversation-activity.test.ts
+++ b/src/__tests__/unit/core/conversation-activity.test.ts
@@ -3,7 +3,8 @@ import {
   projectAgentLoopEventToConversationActivities,
   projectCompactionStatusToConversationActivities,
   projectTraceEventToConversationActivities,
-  summarizeActivityToolCall,
+  summarizeToolCall,
+  summarizeToolResult,
 } from '../../../core/observability/conversation-activity.js';
 import type { AgentLoopEvent } from '../../../core/runtime/events.js';
 import type { TraceEvent } from '../../../core/types.js';
@@ -20,7 +21,7 @@ describe('conversation activity projection', () => {
     };
 
     expect(projectAgentLoopEventToConversationActivities(event)).toEqual([
-      { type: 'assistant.stream', text: 'Working', done: false },
+      expect.objectContaining({ type: 'assistant.stream', text: 'Working', done: false, runId: 'run-1', step: 1 }),
     ]);
   });
 
@@ -42,9 +43,9 @@ describe('conversation activity projection', () => {
       timestamp: '2026-05-02T00:00:01.000Z',
     };
 
-    expect(projectAgentLoopEventToConversationActivities(started)).toEqual([{ type: 'loop.started' }]);
+    expect(projectAgentLoopEventToConversationActivities(started)).toEqual([expect.objectContaining({ type: 'loop.started', runId: 'run-1' })]);
     expect(projectTraceEventToConversationActivities(finishedTrace)).toEqual([
-      { type: 'run.finished', outcome: 'max_steps' },
+      expect.objectContaining({ type: 'run.finished', outcome: 'max_steps', step: 5 }),
     ]);
   });
 
@@ -71,10 +72,10 @@ describe('conversation activity projection', () => {
     };
 
     expect(projectAgentLoopEventToConversationActivities(calling)).toEqual([
-      { type: 'tool.calling', tool: 'read_file', step: 2 },
+      expect.objectContaining({ type: 'tool.calling', tool: 'read_file', step: 2, runId: 'run-1' }),
     ]);
     expect(projectAgentLoopEventToConversationActivities(completed)).toEqual([
-      { type: 'tool.completed', tool: 'read_file', durationMs: 12.4 },
+      expect.objectContaining({ type: 'tool.completed', tool: 'read_file', durationMs: 12.4, step: 2, runId: 'run-1' }),
     ]);
   });
 
@@ -95,23 +96,24 @@ describe('conversation activity projection', () => {
     };
 
     expect(projectTraceEventToConversationActivities(approval)).toEqual([
-      {
+      expect.objectContaining({
         type: 'tool.approval_requested',
         tool: 'run_shell_mutate',
         toolSummary: 'run_shell_mutate (yarn test)',
         step: 3,
         call: approval.call,
-      },
+      }),
     ]);
     expect(projectTraceEventToConversationActivities(fallback)).toEqual([
-      {
+      expect.objectContaining({
         type: 'tool.fallback',
         fromTool: 'run_shell_inspect',
         toTool: 'run_shell_mutate',
         fromSummary: 'run_shell_inspect (git status --short)',
         toSummary: 'run_shell_mutate (git status --short)',
         reason: 'inspect policy rejected the command',
-      },
+        step: 4,
+      }),
     ]);
   });
 
@@ -135,10 +137,10 @@ describe('conversation activity projection', () => {
     };
 
     expect(projectTraceEventToConversationActivities(started)).toEqual([
-      { type: 'memory.maintenance_started', candidateCount: 2 },
+      expect.objectContaining({ type: 'memory.maintenance_started', candidateCount: 2, runId: 'memory-1', step: 5 }),
     ]);
     expect(projectTraceEventToConversationActivities(finished)).toEqual([
-      { type: 'memory.maintenance_finished', outcome: 'completed', summary: 'Stored project context.' },
+      expect.objectContaining({ type: 'memory.maintenance_finished', outcome: 'completed', summary: 'Stored project context.', runId: 'memory-1', step: 5 }),
     ]);
   });
 
@@ -158,12 +160,13 @@ describe('conversation activity projection', () => {
   });
 
   it('preserves TUI tool call summary details in the shared core helper', () => {
-    expect(summarizeActivityToolCall('search_files', { query: 'trace', path: '.heddle/traces' })).toBe(
+    expect(summarizeToolCall('search_files', { query: 'trace', path: '.heddle/traces' })).toBe(
       'search_files ("trace" in .heddle/traces)',
     );
-    expect(summarizeActivityToolCall('update_plan', { plan: [{ step: 'Refactor projection', status: 'in_progress' }] })).toBe(
+    expect(summarizeToolCall('update_plan', { plan: [{ step: 'Refactor projection', status: 'in_progress' }] })).toBe(
       'update_plan (Refactor projection)',
     );
+    expect(summarizeToolResult('edit_file', { output: { path: 'src/index.ts' } })).toBe('edit_file (src/index.ts)');
   });
 
   it('routes nested trace loop events through the trace projector', () => {
@@ -181,7 +184,7 @@ describe('conversation activity projection', () => {
     };
 
     expect(projectAgentLoopEventToConversationActivities(event)).toEqual([
-      { type: 'tool.call', toolSummary: 'read_file (README.md)' },
+      expect.objectContaining({ type: 'tool.call', toolSummary: 'read_file (README.md)', runId: 'run-1', step: 2 }),
     ]);
   });
 });

--- a/src/__tests__/unit/core/import-boundaries.test.ts
+++ b/src/__tests__/unit/core/import-boundaries.test.ts
@@ -1,0 +1,62 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SOURCE_ROOT = join(process.cwd(), 'src');
+
+describe('core import boundaries', () => {
+  const sourceFiles = listSourceFiles(SOURCE_ROOT);
+
+  it('keeps core modules independent from host adapters', () => {
+    const violations = findImportViolations(
+      sourceFiles.filter((file) => toSourcePath(file).startsWith('core/')),
+      [/^(?:\.\.\/)+(?:cli|web|server)\//],
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps command modules free of React and Ink UI dependencies', () => {
+    const violations = findImportViolations(
+      sourceFiles.filter((file) => toSourcePath(file).startsWith('core/commands/')),
+      [/^react$/, /^ink$/, /react/, /ink/],
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps approval core free of host code', () => {
+    const violations = findImportViolations(
+      sourceFiles.filter((file) => toSourcePath(file).startsWith('core/approvals/')),
+      [/^(?:\.\.\/)+(?:cli|web|server)\//],
+    );
+
+    expect(violations).toEqual([]);
+  });
+});
+
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const path = join(dir, name);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      return listSourceFiles(path);
+    }
+
+    return /\.(?:ts|tsx)$/.test(name) ? [path] : [];
+  });
+}
+
+function findImportViolations(files: string[], disallowed: RegExp[]): string[] {
+  return files.flatMap((file) => {
+    const imports = [...readFileSync(file, 'utf8').matchAll(/\bfrom\s+['"]([^'"]+)['"]/g)]
+      .map((match) => match[1]!)
+      .filter((specifier) => disallowed.some((pattern) => pattern.test(specifier)));
+
+    return imports.map((specifier) => `${toSourcePath(file)} imports ${specifier}`);
+  });
+}
+
+function toSourcePath(file: string): string {
+  return relative(SOURCE_ROOT, file).split(sep).join('/');
+}

--- a/src/__tests__/unit/core/trace-summarizers.test.ts
+++ b/src/__tests__/unit/core/trace-summarizers.test.ts
@@ -71,6 +71,12 @@ describe('trace summarizers', () => {
         timestamp: '2026-05-02T00:00:07.000Z',
       },
       {
+        type: 'tool.call',
+        call: { id: 'call-7', tool: 'delete_file', input: { path: 'tmp/generated-report.md' } },
+        step: 5,
+        timestamp: '2026-05-02T00:00:07.500Z',
+      },
+      {
         type: 'tool.result',
         tool: 'read_file',
         result: { ok: true, output: 'contents' },
@@ -149,6 +155,7 @@ describe('trace summarizers', () => {
       'approval denied for run_shell_mutate (yarn test) (User denied in test)',
       'fallback run_shell_inspect (git status --short) -> run_shell_mutate (git status --short) (inspect policy rejected the command)',
       'tool call read_file (src/index.ts)',
+      'tool call delete_file (tmp/generated-report.md)',
       'tool result read_file: ok',
       'tool result run_shell_inspect: exit code 1',
       'memory candidate recorded: candidate-1',

--- a/src/__tests__/unit/core/trace-summarizers.test.ts
+++ b/src/__tests__/unit/core/trace-summarizers.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TraceEvent } from '../../../core/types.js';
 import {
-  countAssistantSteps as countAssistantStepsFromCompatPath,
-  summarizeTrace as summarizeTraceFromCompatPath,
-} from '../../../core/chat/trace-summary.js';
-import {
   countAssistantSteps,
   createTraceSummarizerRegistry,
   summarizeTrace,
@@ -180,7 +176,7 @@ describe('trace summarizers', () => {
     ])).toEqual(['custom 0:read_file']);
   });
 
-  it('preserves assistant step counting and the chat compatibility path', () => {
+  it('preserves assistant step counting', () => {
     const trace: TraceEvent[] = [
       { type: 'assistant.turn', content: 'One', requestedTools: false, step: 1, timestamp: '2026-05-02T00:00:00.000Z' },
       { type: 'run.finished', outcome: 'completed', summary: 'Done.', step: 1, timestamp: '2026-05-02T00:00:01.000Z' },
@@ -188,7 +184,5 @@ describe('trace summarizers', () => {
     ];
 
     expect(countAssistantSteps(trace)).toBe(2);
-    expect(countAssistantStepsFromCompatPath(trace)).toBe(2);
-    expect(summarizeTraceFromCompatPath(trace)).toEqual(summarizeTrace(trace));
   });
 });

--- a/src/__tests__/unit/tui/chat-activity-format.test.ts
+++ b/src/__tests__/unit/tui/chat-activity-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { toLiveEvent } from '../../../cli/chat/adapters/conversation-activity-adapter.js';
-import { summarizeToolCall } from '../../../cli/chat/utils/format.js';
+import { summarizeToolCall } from '../../../core/observability/conversation-activity.js';
 import type { TraceEvent } from '../../../types.js';
 
 describe('chat activity formatting', () => {

--- a/src/cli/chat/adapters/conversation-activity-adapter.ts
+++ b/src/cli/chat/adapters/conversation-activity-adapter.ts
@@ -1,6 +1,8 @@
 import {
+  applyConversationActivityHandler,
   projectTraceEventToConversationActivities,
   type ConversationActivity,
+  type ConversationActivityHandlerMap,
 } from '../../../core/observability/conversation-activity.js';
 import type { TraceEvent } from '../../../index.js';
 import { truncate } from '../../../core/utils/text.js';
@@ -11,46 +13,39 @@ export function toLiveEvent(event: TraceEvent): string | undefined {
     .find((text): text is string => Boolean(text));
 }
 
-const tuiActivityFormatters: Partial<Record<ConversationActivity['type'], (activity: ConversationActivity) => string | undefined>> = {
+const tuiActivityFormatters = {
   'run.started': () => 'thinking',
   'assistant.turn': (activity) => {
-    const assistantActivity = activity as Extract<ConversationActivity, { type: 'assistant.turn' }>;
-    if (assistantActivity.rationale) {
-      return `reasoning: ${truncate(assistantActivity.rationale, 140)}`;
+    if (activity.rationale) {
+      return `reasoning: ${truncate(activity.rationale, 140)}`;
     }
-    return assistantActivity.requestedTools ? undefined : 'answer ready';
+    return activity.requestedTools ? undefined : 'answer ready';
   },
-  'tool.approval_requested': (activity) => `approval needed for ${(activity as Extract<ConversationActivity, { type: 'tool.approval_requested' }>).toolSummary}`,
+  'tool.approval_requested': (activity) => `approval needed for ${activity.toolSummary}`,
   'tool.approval_resolved': (activity) => {
-    const approvalActivity = activity as Extract<ConversationActivity, { type: 'tool.approval_resolved' }>;
-    return `approval ${approvalActivity.approved ? 'granted' : 'denied'} for ${approvalActivity.toolSummary}${approvalActivity.reason ? ` (${truncate(approvalActivity.reason, 80)})` : ''}`;
+    return `approval ${activity.approved ? 'granted' : 'denied'} for ${activity.toolSummary}${activity.reason ? ` (${truncate(activity.reason, 80)})` : ''}`;
   },
   'tool.fallback': (activity) => {
-    const fallbackActivity = activity as Extract<ConversationActivity, { type: 'tool.fallback' }>;
-    return `retrying with ${fallbackActivity.toSummary} after ${fallbackActivity.fromSummary} was blocked (${truncate(fallbackActivity.reason, 80)})`;
+    return `retrying with ${activity.toSummary} after ${activity.fromSummary} was blocked (${truncate(activity.reason, 80)})`;
   },
-  'tool.call': (activity) => `running ${(activity as Extract<ConversationActivity, { type: 'tool.call' }>).toolSummary}`,
+  'tool.call': (activity) => `running ${activity.toolSummary}`,
   'tool.result': (activity) => {
-    const toolActivity = activity as Extract<ConversationActivity, { type: 'tool.result' }>;
-    return `${toolActivity.toolSummary} ${toolActivity.ok ? 'completed' : `failed: ${toolActivity.error ?? 'error'}`}`;
+    return `${activity.toolSummary} ${activity.ok ? 'completed' : `failed: ${activity.error ?? 'error'}`}`;
   },
-  'memory.candidate_recorded': (activity) => `memory candidate recorded: ${(activity as Extract<ConversationActivity, { type: 'memory.candidate_recorded' }>).candidateId}`,
+  'memory.candidate_recorded': (activity) => `memory candidate recorded: ${activity.candidateId}`,
   'memory.maintenance_started': (activity) => {
-    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_started' }>;
-    return `memory maintenance started for ${memoryActivity.candidateCount} candidate${memoryActivity.candidateCount === 1 ? '' : 's'}`;
+    return `memory maintenance started for ${activity.candidateCount} candidate${activity.candidateCount === 1 ? '' : 's'}`;
   },
-  'memory.maintenance_finished': (activity) => `memory maintenance ${(activity as Extract<ConversationActivity, { type: 'memory.maintenance_finished' }>).outcome}`,
-  'memory.maintenance_failed': (activity) => `memory maintenance failed: ${truncate((activity as Extract<ConversationActivity, { type: 'memory.maintenance_failed' }>).error ?? 'error', 80)}`,
+  'memory.maintenance_finished': (activity) => `memory maintenance ${activity.outcome}`,
+  'memory.maintenance_failed': (activity) => `memory maintenance failed: ${truncate(activity.error ?? 'error', 80)}`,
   'cyberloop.annotation': (activity) => {
-    const cyberloopActivity = activity as Extract<ConversationActivity, { type: 'cyberloop.annotation' }>;
-    return `cyberloop drift=${cyberloopActivity.driftLevel}${cyberloopActivity.metrics}`;
+    return `cyberloop drift=${activity.driftLevel}${activity.metrics}`;
   },
   'run.finished': (activity) => {
-    const runActivity = activity as Extract<ConversationActivity, { type: 'run.finished' }>;
-    return runActivity.outcome === 'done' ? undefined : `stopped: ${runActivity.outcome}`;
+    return activity.outcome === 'done' ? undefined : `stopped: ${activity.outcome}`;
   },
-};
+} satisfies ConversationActivityHandlerMap<undefined, string | undefined>;
 
 export function formatConversationActivityForTui(activity: ConversationActivity): string | undefined {
-  return tuiActivityFormatters[activity.type]?.(activity);
+  return applyConversationActivityHandler(activity, tuiActivityFormatters, undefined);
 }

--- a/src/cli/chat/hooks/tui-direct-shell-result.ts
+++ b/src/cli/chat/hooks/tui-direct-shell-result.ts
@@ -1,4 +1,5 @@
-import { appendDirectShellHistory, buildConversationMessages, formatDirectShellResponse, summarizeToolCall } from '../utils/format.js';
+import { summarizeToolCall } from '../../../core/observability/conversation-activity.js';
+import { appendDirectShellHistory, buildConversationMessages, formatDirectShellResponse } from '../utils/format.js';
 import { compactChatHistoryWithArchive } from '../state/compaction.js';
 import type { ChatSession } from '../state/types.js';
 import type { ChatRuntimeConfig } from '../utils/runtime.js';

--- a/src/cli/chat/hooks/tui-direct-shell.ts
+++ b/src/cli/chat/hooks/tui-direct-shell.ts
@@ -1,10 +1,13 @@
 import { acquireSessionLease, getSessionLeaseConflict, releaseSessionLease } from '../../../core/chat/session-lease.js';
+import { rememberedApprovalPolicy } from '../../../core/approvals/default-policies.js';
+import { resolveToolApproval } from '../../../core/approvals/policy-chain.js';
+import { summarizeToolCall } from '../../../core/observability/conversation-activity.js';
 import { DEFAULT_INSPECT_RULES, DEFAULT_MUTATE_RULES, runShellCommand } from '../../../core/tools/run-shell.js';
 import type { ToolCall, ToolResult } from '../../../index.js';
 import { createProjectApprovalRuleForCall, describeProjectApprovalRule } from '../state/approval-rules.js';
 import { readChatSession, touchSession } from '../state/storage.js';
 import type { ChatSession } from '../state/types.js';
-import { shouldFallbackToMutate, summarizeToolCall } from '../utils/format.js';
+import { shouldFallbackToMutate } from '../utils/format.js';
 import type { ChatRuntimeConfig } from '../utils/runtime.js';
 import { beginTuiDirectShellAction, finishTuiDirectShellAction } from './tui-agent-turn-lifecycle.js';
 import { finalizeTuiDirectShellSuccess } from './tui-direct-shell-result.js';
@@ -101,10 +104,19 @@ export async function executeTuiDirectShell(args: {
           throw new Error('run_shell_mutate tool is not registered');
         }
 
-        const approval =
-          isProjectApproved(mutateCall) ?
-            { approved: true, reason: 'Approved by saved project rule' }
-          : await new Promise<{ approved: boolean; reason?: string }>((resolve) => {
+        const approval = await resolveToolApproval({
+          policies: [
+            () => ({ type: 'request', reason: 'Direct shell mutation requires approval' }),
+            rememberedApprovalPolicy({
+              isApproved: ({ call }) => isProjectApproved(call),
+            }),
+          ],
+          context: {
+            call: mutateCall,
+            tool: directShellTool,
+            workspaceRoot: runtime.workspaceRoot,
+          },
+          requestHumanApproval: async () => await new Promise<{ approved: boolean; reason?: string }>((resolve) => {
               const rememberedRule = createProjectApprovalRuleForCall(mutateCall);
               state.setPendingApproval({
                 call: mutateCall,
@@ -113,7 +125,8 @@ export async function executeTuiDirectShell(args: {
                 rememberLabel: rememberedRule ? describeProjectApprovalRule(rememberedRule) : undefined,
                 resolve,
               });
-            });
+            }),
+        });
 
         if (!approval.approved) {
           const denialMessage = approval.reason ? `Command denied.\n${approval.reason}` : 'Command denied.';

--- a/src/cli/chat/hooks/tui-ordinary-turn.ts
+++ b/src/cli/chat/hooks/tui-ordinary-turn.ts
@@ -5,7 +5,7 @@ import type { ChatRuntimeConfig } from '../utils/runtime.js';
 import { createTuiCompactionStatusPort } from './tui-compaction-status.js';
 import { finalizeSuccessfulTuiOrdinaryTurn } from './tui-agent-turn-result.js';
 import { createTuiRunLoopEventAdapter } from './tui-run-loop-events.js';
-import { createTuiToolApprovalPort } from './tui-tool-approval.js';
+import { createTuiRememberedApprovalPolicies, createTuiToolApprovalPort } from './tui-tool-approval.js';
 import type { ActionState } from './useAgentRun.js';
 import type { CyberLoopKinematicsObserver } from '../../../index.js';
 
@@ -22,7 +22,7 @@ export async function executeTuiOrdinaryTurn(args: {
   updateSessionById: SessionUpdater;
   parsePlanState: ParsePlanState;
   maybeAutoNameSession: (sessionId: string, prompt: string, responseText: string) => void;
-  isProjectApproved: Parameters<typeof createTuiToolApprovalPort>[0]['isProjectApproved'];
+  isProjectApproved: Parameters<typeof createTuiRememberedApprovalPolicies>[0]['isProjectApproved'];
   rememberProjectApproval: Parameters<typeof createTuiToolApprovalPort>[0]['rememberProjectApproval'];
   driftObserver: CyberLoopKinematicsObserver | undefined;
   turnAbortSignal: AbortSignal;
@@ -65,9 +65,9 @@ export async function executeTuiOrdinaryTurn(args: {
   });
   const approvalPort = createTuiToolApprovalPort({
     state,
-    isProjectApproved,
     rememberProjectApproval,
   });
+  const approvalPolicies = createTuiRememberedApprovalPolicies({ isProjectApproved });
 
   const result = await executeOrdinaryChatTurn({
     workspaceRoot: runtime.workspaceRoot,
@@ -89,6 +89,7 @@ export async function executeTuiOrdinaryTurn(args: {
       compaction: compactionPort,
       approvals: approvalPort,
     },
+    approvalPolicies,
     onAssistantStream: runLoopEvents.onAssistantStream,
     onTraceEvent: runLoopEvents.onTraceEvent,
     shouldStop: () => state.interruptRequestedRef.current,

--- a/src/cli/chat/hooks/tui-tool-approval.ts
+++ b/src/cli/chat/hooks/tui-tool-approval.ts
@@ -1,17 +1,18 @@
 import { rememberedApprovalPolicy } from '../../../core/approvals/default-policies.js';
-import { evaluateToolApprovalPolicies } from '../../../core/approvals/policy-chain.js';
 import { humanApprovalPolicy, requestToolApproval } from '../../../core/approvals/surface.js';
+import type { ToolApprovalPolicy } from '../../../core/approvals/types.js';
 import type { ChatTurnApprovalPort } from '../../../core/chat/turn-host.js';
 import { previewEditFileInput } from '../../../core/tools/edit-file.js';
 import { createProjectApprovalRuleForCall, describeProjectApprovalRule } from '../state/approval-rules.js';
 import type { ActionState } from './useAgentRun.js';
 
+type TuiApprovalCall = Parameters<NonNullable<ChatTurnApprovalPort['requestToolApproval']>>[0]['call'];
+
 export function createTuiToolApprovalPort(args: {
   state: ActionState;
-  isProjectApproved: (call: Parameters<NonNullable<ChatTurnApprovalPort['requestToolApproval']>>[0]['call']) => boolean;
-  rememberProjectApproval: (call: Parameters<NonNullable<ChatTurnApprovalPort['requestToolApproval']>>[0]['call']) => void;
+  rememberProjectApproval: (call: TuiApprovalCall) => void;
 }): ChatTurnApprovalPort {
-  const { state, isProjectApproved, rememberProjectApproval } = args;
+  const { state, rememberProjectApproval } = args;
 
   return {
     async requestToolApproval(request) {
@@ -19,34 +20,39 @@ export function createTuiToolApprovalPort(args: {
         return { approved: false, reason: 'Missing approval request.' };
       }
       const { call, tool } = request;
-      const decision = await evaluateToolApprovalPolicies([
-        rememberedApprovalPolicy({
-          isApproved: ({ call: policyCall }) => isProjectApproved(policyCall),
-        }),
-        humanApprovalPolicy(async () => {
-          const editPreview = call.tool === 'edit_file' ? await previewEditFileInput(call.input) : undefined;
+      const decision = await humanApprovalPolicy(async () => {
+        const editPreview = call.tool === 'edit_file' ? await previewEditFileInput(call.input) : undefined;
 
-          return await requestToolApproval({
-            call,
-            tool,
-            storePending: ({ resolve }) => {
-              const rememberedRule = createProjectApprovalRuleForCall(call);
-              state.setPendingApproval({
-                call,
-                tool,
-                editPreview,
-                rememberForProject: () => rememberProjectApproval(call),
-                rememberLabel: rememberedRule ? describeProjectApprovalRule(rememberedRule) : undefined,
-                resolve,
-              });
-            },
-          });
-        }),
-      ], { call, tool });
+        return await requestToolApproval({
+          call,
+          tool,
+          storePending: ({ resolve }) => {
+            const rememberedRule = createProjectApprovalRuleForCall(call);
+            state.setPendingApproval({
+              call,
+              tool,
+              editPreview,
+              rememberForProject: () => rememberProjectApproval(call),
+              rememberLabel: rememberedRule ? describeProjectApprovalRule(rememberedRule) : undefined,
+              resolve,
+            });
+          },
+        });
+      })({ call, tool });
       return {
         approved: decision?.type === 'allow',
         reason: decision?.reason,
       };
     },
   };
+}
+
+export function createTuiRememberedApprovalPolicies(args: {
+  isProjectApproved: (call: TuiApprovalCall) => boolean;
+}): ToolApprovalPolicy[] {
+  return [
+    rememberedApprovalPolicy({
+      isApproved: ({ call }) => args.isProjectApproved(call),
+    }),
+  ];
 }

--- a/src/cli/chat/utils/format.ts
+++ b/src/cli/chat/utils/format.ts
@@ -9,7 +9,7 @@ import { truncate } from '../../../core/utils/text.js';
 export { buildConversationMessages } from '../../../core/chat/conversation-lines.js';
 export { formatChatFailureMessage } from '../../../core/chat/failure-messages.js';
 export type { ChatFailureHintOptions } from '../../../core/chat/failure-messages.js';
-export { countAssistantSteps, summarizeTrace } from '../../../core/chat/trace-summary.js';
+export { countAssistantSteps, summarizeTrace } from '../../../core/observability/trace-summarizers.js';
 export {
   truncate,
 } from '../../../core/utils/text.js';
@@ -27,7 +27,7 @@ export type ApprovalSummary = {
 };
 
 const MAX_SHELL_OUTPUT_CHARS = 1400;
-const MAX_TOOL_CALL_SUMMARY_CHARS = 96;
+const APPROVAL_PATH_TOOLS = new Set(['read_file', 'list_files']);
 
 
 export function currentActivityText(
@@ -65,8 +65,8 @@ export function formatApprovalHint(pendingApproval: PendingApproval): string {
 
 export function summarizePendingApproval(pendingApproval: PendingApproval): ApprovalSummary {
   const policy = describePendingApprovalPolicy(pendingApproval);
-  const command = extractShellCommand(pendingApproval.call.input);
-  const editPath = extractEditPath(pendingApproval.call.input);
+  const command = readStringField(pendingApproval.call.input, 'command');
+  const editPath = readStringField(pendingApproval.call.input, 'path');
 
   if (command) {
     const title =
@@ -113,8 +113,8 @@ export function summarizePendingApproval(pendingApproval: PendingApproval): Appr
     };
   }
 
-  const path = extractPathField(pendingApproval.call.input);
-  if (isPathAwareTool(pendingApproval.call.tool) && path) {
+  const path = readStringField(pendingApproval.call.input, 'path');
+  if (APPROVAL_PATH_TOOLS.has(pendingApproval.call.tool) && path) {
     return {
       title: `Allow ${pendingApproval.call.tool}`,
       command: path,
@@ -131,83 +131,6 @@ export function summarizePendingApproval(pendingApproval: PendingApproval): Appr
     effects: ['tool-specific side effects are not yet summarized'],
     rememberLabel: pendingApproval.rememberLabel,
   };
-}
-
-export function summarizeToolCall(tool: string, input: unknown): string {
-  const planSummary = summarizePlanInput(tool, input);
-  if (planSummary) {
-    return planSummary;
-  }
-
-  const shellCommand = extractShellCommand(input);
-  if (shellCommand) {
-    return `${tool} (${truncate(shellCommand, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
-  }
-
-  const searchSummary = summarizeSearchInput(tool, input);
-  if (searchSummary) {
-    return searchSummary;
-  }
-
-  const path = extractPathField(input);
-  if (isPathAwareTool(tool) && path) {
-    return `${tool} (${truncate(path, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
-  }
-
-  return tool;
-}
-
-export function summarizeToolResult(tool: string, command: string | undefined, output?: unknown): string {
-  if (command) {
-    return `${tool} (${truncate(command, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
-  }
-
-  const outputPath = extractOutputPath(output);
-  if (tool === 'edit_file' && outputPath) {
-    return `${tool} (${truncate(outputPath, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
-  }
-
-  return tool;
-}
-
-export function extractShellCommand(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const command = (value as { command?: unknown }).command;
-  return typeof command === 'string' && command.trim() ? command.trim() : undefined;
-}
-
-export function extractEditPath(value: unknown): string | undefined {
-  return extractPathField(value);
-}
-
-export function extractPathField(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const path = (value as { path?: unknown }).path;
-  return typeof path === 'string' && path.trim() ? path.trim() : undefined;
-}
-
-export function extractQueryField(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const query = (value as { query?: unknown }).query;
-  return typeof query === 'string' && query.trim() ? query.trim() : undefined;
-}
-
-export function extractOutputPath(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const path = (value as { path?: unknown }).path;
-  return typeof path === 'string' && path.trim() ? path.trim() : undefined;
 }
 
 export function normalizeInlineText(value: string): string {
@@ -280,6 +203,10 @@ export function formatDirectShellResponse(toolName: string, command: string, res
 }
 
 export function extractTextOutput(value: unknown, field: 'stdout' | 'stderr'): string | undefined {
+  return readStringField(value, field);
+}
+
+function readStringField(value: unknown, field: string): string | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
   }
@@ -311,7 +238,7 @@ function describePendingApprovalPolicy(pendingApproval: PendingApproval): RunShe
     return undefined;
   }
 
-  const command = extractShellCommand(pendingApproval.call.input);
+  const command = readStringField(pendingApproval.call.input, 'command');
   if (!command) {
     return undefined;
   }
@@ -386,10 +313,6 @@ export function normalizeSessionTitle(value: string | undefined): string | undef
   return truncate(normalized, 48);
 }
 
-function isPathAwareTool(tool: string): boolean {
-  return tool === 'edit_file' || tool === 'read_file' || tool === 'list_files';
-}
-
 function describePathAwareToolEffect(tool: string, path: string): string {
   switch (tool) {
     case 'list_files':
@@ -399,44 +322,6 @@ function describePathAwareToolEffect(tool: string, path: string): string {
     default:
       return `uses ${tool} on ${path}`;
   }
-}
-
-function summarizeSearchInput(tool: string, input: unknown): string | undefined {
-  if (tool !== 'search_files') {
-    return undefined;
-  }
-
-  const query = extractQueryField(input);
-  if (!query) {
-    return tool;
-  }
-
-  const path = extractPathField(input);
-  const querySummary = truncate(JSON.stringify(query), Math.max(12, Math.floor(MAX_TOOL_CALL_SUMMARY_CHARS / 2)));
-  if (path) {
-    return `${tool} (${querySummary} in ${truncate(path, Math.max(12, Math.floor(MAX_TOOL_CALL_SUMMARY_CHARS / 2)))})`;
-  }
-
-  return `${tool} (${querySummary})`;
-}
-
-function summarizePlanInput(tool: string, input: unknown): string | undefined {
-  if (tool !== 'update_plan') {
-    return undefined;
-  }
-
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    return tool;
-  }
-
-  const plan = (input as { plan?: unknown }).plan;
-  if (!Array.isArray(plan) || plan.length === 0) {
-    return tool;
-  }
-
-  const current = plan.find((item) => item && typeof item === 'object' && !Array.isArray(item) && (item as { status?: unknown }).status === 'in_progress');
-  const currentStep = current && typeof (current as { step?: unknown }).step === 'string' ? (current as { step: string }).step : undefined;
-  return currentStep ? `${tool} (${truncate(currentStep, MAX_TOOL_CALL_SUMMARY_CHARS)})` : `${tool} (${plan.length} items)`;
 }
 
 function renderUpdatePlanHistoryMessage(output: unknown): string | undefined {

--- a/src/core/agent/run-agent.ts
+++ b/src/core/agent/run-agent.ts
@@ -20,6 +20,7 @@ import { createMutationState, trackToolResult } from './mutation-tracking.js';
 import { createProgressReminderState, buildProgressReminders } from './progress-reminders.js';
 import { maybeDenyToolCall, executeToolCallWithFallback } from './tool-dispatch.js';
 import type { PlanItem } from '../tools/update-plan.js';
+import type { ToolApprovalPolicy } from '../approvals/types.js';
 
 const PLAN_ITEM_STATUSES = new Set<PlanItem['status']>(['pending', 'in_progress', 'completed']);
 
@@ -40,6 +41,7 @@ export type RunAgentOptions = {
   onAssistantStream?: (update: { step: number; text: string; done: boolean }) => void;
   onToolCalling?: (call: ToolCall, step: number, toolDef: ToolDefinition) => void;
   onToolCompleted?: (call: ToolCall, result: ToolResult, step: number, durationMs: number) => void;
+  approvalPolicies?: ToolApprovalPolicy[];
   approveToolCall?: (call: ToolCall, tool: ToolDefinition) => Promise<{ approved: boolean; reason?: string }>;
   shouldStop?: () => boolean;
   abortSignal?: AbortSignal;
@@ -85,6 +87,7 @@ type RunContext = {
   onAssistantStream?: RunAgentOptions['onAssistantStream'];
   onToolCalling?: RunAgentOptions['onToolCalling'];
   onToolCompleted?: RunAgentOptions['onToolCompleted'];
+  approvalPolicies: ToolApprovalPolicy[];
   approveToolCall?: RunAgentOptions['approveToolCall'];
   shouldStop?: RunAgentOptions['shouldStop'];
   abortSignal?: AbortSignal;
@@ -168,6 +171,7 @@ function createRunContext(options: RunAgentOptions): RunContext {
     onAssistantStream: options.onAssistantStream,
     onToolCalling: options.onToolCalling,
     onToolCompleted: options.onToolCompleted,
+    approvalPolicies: options.approvalPolicies ?? [],
     approveToolCall: options.approveToolCall,
     shouldStop: options.shouldStop,
     abortSignal: options.abortSignal,
@@ -300,6 +304,7 @@ async function executeToolTurn(context: RunContext, call: ToolCall): Promise<Run
     step: context.state.step,
     now: context.now,
     approveToolCall: context.approveToolCall,
+    approvalPolicies: context.approvalPolicies,
     workspaceRoot: context.workspaceRoot,
     record: context.record,
     log: context.log,
@@ -317,6 +322,7 @@ async function executeToolTurn(context: RunContext, call: ToolCall): Promise<Run
     registry: context.registry,
     seenToolCalls: context.seenToolCalls,
     approveToolCall: context.approveToolCall,
+    approvalPolicies: context.approvalPolicies,
     workspaceRoot: context.workspaceRoot,
     record: context.record,
     log: context.log,

--- a/src/core/agent/tool-dispatch.ts
+++ b/src/core/agent/tool-dispatch.ts
@@ -9,8 +9,8 @@ import { createToolRegistry } from '../tools/registry.js';
 import { executeTool } from '../tools/execute-tool.js';
 import { stableSerialize, normalizeToolInput } from './util.js';
 import { defaultToolApprovalPolicies } from '../approvals/default-policies.js';
-import { evaluateToolApprovalPolicies } from '../approvals/policy-chain.js';
-import type { ToolApprovalPolicyDecision } from '../approvals/types.js';
+import { resolveToolApproval } from '../approvals/policy-chain.js';
+import type { ToolApprovalPolicy } from '../approvals/types.js';
 import type { Logger } from 'pino';
 
 export async function maybeDenyToolCall(args: {
@@ -18,6 +18,7 @@ export async function maybeDenyToolCall(args: {
   tool: ToolDefinition | undefined;
   step: number;
   now: () => string;
+  approvalPolicies?: ToolApprovalPolicy[];
   approveToolCall: RunAgentOptions['approveToolCall'];
   workspaceRoot?: string;
   record: (event: TraceEvent) => void;
@@ -28,16 +29,27 @@ export async function maybeDenyToolCall(args: {
     return undefined;
   }
 
-  const policyDecision = await evaluateToolApprovalPolicies(defaultToolApprovalPolicies, {
-    call,
-    tool,
-    workspaceRoot: args.workspaceRoot,
+  const approval = await resolveToolApproval({
+    policies: [...defaultToolApprovalPolicies, ...(args.approvalPolicies ?? [])],
+    context: {
+      call,
+      tool,
+      workspaceRoot: args.workspaceRoot,
+    },
+    requestHumanApproval: approveToolCall ? async () => {
+      record({ type: 'tool.approval_requested', call, step, timestamp: now() });
+      const humanDecision = await approveToolCall(call, tool);
+      record({
+        type: 'tool.approval_resolved',
+        call,
+        approved: humanDecision.approved,
+        reason: humanDecision.reason,
+        step,
+        timestamp: now(),
+      });
+      return humanDecision;
+    } : undefined,
   });
-  if (!policyDecision) {
-    return undefined;
-  }
-
-  const approval = await resolveToolApproval({ call, tool, step, now, approveToolCall, record, policyDecision });
   if (approval.approved) {
     return undefined;
   }
@@ -59,6 +71,7 @@ export async function executeToolCallWithFallback(args: {
   now: () => string;
   registry: ReturnType<typeof createToolRegistry>;
   seenToolCalls: Map<string, number>;
+  approvalPolicies?: ToolApprovalPolicy[];
   approveToolCall: RunAgentOptions['approveToolCall'];
   workspaceRoot?: string;
   record: (event: TraceEvent) => void;
@@ -94,6 +107,7 @@ export async function executeToolCallWithFallback(args: {
     step: args.step,
     now: args.now,
     approveToolCall: args.approveToolCall,
+    approvalPolicies: args.approvalPolicies,
     workspaceRoot: args.workspaceRoot,
     record: args.record,
     log: args.log,
@@ -138,42 +152,6 @@ async function executeRecordedToolCall(
   log.debug({ step, tool: call.tool, ok: result.ok }, 'Tool result');
   record({ type: 'tool.result', tool: call.tool, result, step, timestamp: now() });
   return { effectiveCall: call, result };
-}
-
-async function resolveToolApproval(args: {
-  call: ToolCall;
-  tool: ToolDefinition;
-  step: number;
-  now: () => string;
-  approveToolCall: RunAgentOptions['approveToolCall'];
-  record: (event: TraceEvent) => void;
-  policyDecision: ToolApprovalPolicyDecision;
-}): Promise<{ approved: boolean; reason?: string }> {
-  const { call, tool, step, now, approveToolCall, record, policyDecision } = args;
-  if (policyDecision.type === 'allow') {
-    return { approved: true, reason: policyDecision.reason };
-  }
-
-  if (policyDecision.type === 'deny') {
-    return { approved: false, reason: policyDecision.reason };
-  }
-
-  record({ type: 'tool.approval_requested', call, step, timestamp: now() });
-  const approval =
-    approveToolCall ? await approveToolCall(call, tool)
-    : {
-        approved: false,
-        reason: `No approval handler configured for ${call.tool}`,
-      };
-  record({
-    type: 'tool.approval_resolved',
-    call,
-    approved: approval.approved,
-    reason: approval.reason,
-    step,
-    timestamp: now(),
-  });
-  return approval;
 }
 
 function getInspectFallbackReason(

--- a/src/core/approvals/README.md
+++ b/src/core/approvals/README.md
@@ -1,7 +1,7 @@
 # Approvals
 
-The approvals domain is the planned home for approval policy, remembered
-approval rules, approval requests, and host approval surfaces.
+The approvals domain owns approval policy, remembered approval rules, approval
+requests, and host approval surfaces.
 
 ## Owns
 
@@ -20,7 +20,7 @@ approval rules, approval requests, and host approval surfaces.
 
 ## Current Source Locations
 
-Approval behavior is currently spread across:
+Approval behavior currently exists in these places:
 
 - `src/core/agent/tool-dispatch.ts`
 - `src/core/approvals/surface.ts`
@@ -29,20 +29,20 @@ Approval behavior is currently spread across:
 - `src/server/features/control-plane/services/chat-sessions.ts`
 - `src/server/features/control-plane/services/chat-session-events.ts`
 
-Future milestones should move stable policy behavior here while leaving host UI
-adapters in their host folders.
-
-## Planned Public Entry Points
+## Public Entry Points
 
 - `types.ts`: approval request, decision, policy, and surface types.
-- `policy-chain.ts`: ordered first-decision policy evaluation.
+- `policy-chain.ts`: ordered policy evaluation and request-to-human approval
+  resolution.
 - `default-policies.ts`: built-in tool, workspace-boundary, and remembered-rule policies.
 - `remembered-rules.ts`: project/user approval rule persistence and matching.
 - `surface.ts`: host human-approval surface interface.
 
 ## Extension Points
 
-- Add a new approval rule as an `ApprovalPolicy`.
+- Add a runtime approval rule by passing `approvalPolicies` into `runAgent`,
+  `runAgentLoop`, `runAgentHeartbeat`, `submitChatSessionPrompt`, or
+  `executeOrdinaryChatTurn`.
 - Add host UI by implementing an approval surface in the host adapter layer.
 - Add remembered approval storage behind a small store interface.
 
@@ -58,9 +58,9 @@ adapters in their host folders.
 ## Tests
 
 - `src/__tests__/unit/core/project-approval-rules.test.ts`
+- `src/__tests__/unit/core/approval-policy-chain.test.ts`
 - `src/__tests__/integration/core/run-agent.test.ts`
 - `src/__tests__/integration/tools/tools.test.ts`
-- Future approval policy-chain tests under `src/__tests__/unit/core`.
 
 ## Notes For Coding Agents
 

--- a/src/core/approvals/policy-chain.ts
+++ b/src/core/approvals/policy-chain.ts
@@ -1,4 +1,5 @@
 import type {
+  ToolApprovalDecision,
   ToolApprovalPolicy,
   ToolApprovalPolicyContext,
   ToolApprovalPolicyDecision,
@@ -16,4 +17,44 @@ export async function evaluateToolApprovalPolicies(
   }
 
   return undefined;
+}
+
+export type ResolveToolApprovalArgs = {
+  policies: ToolApprovalPolicy[];
+  context: ToolApprovalPolicyContext;
+  requestHumanApproval?: (context: ToolApprovalPolicyContext, reason?: string) => Promise<ToolApprovalDecision>;
+};
+
+export async function resolveToolApproval(args: ResolveToolApprovalArgs): Promise<ToolApprovalDecision> {
+  let requestReason: string | undefined;
+
+  for (const policy of args.policies) {
+    const decision = await policy(args.context);
+    if (!decision) {
+      continue;
+    }
+
+    if (decision.type === 'deny') {
+      return { approved: false, reason: decision.reason };
+    }
+
+    if (decision.type === 'allow') {
+      return { approved: true, reason: decision.reason };
+    }
+
+    requestReason ??= decision.reason;
+  }
+
+  if (!requestReason) {
+    return { approved: true };
+  }
+
+  if (!args.requestHumanApproval) {
+    return {
+      approved: false,
+      reason: `No approval handler configured for ${args.context.call.tool}${requestReason ? `: ${requestReason}` : ''}`,
+    };
+  }
+
+  return args.requestHumanApproval(args.context, requestReason);
 }

--- a/src/core/chat/README.md
+++ b/src/core/chat/README.md
@@ -41,8 +41,8 @@ maintenance, traces, and host ports.
 - `turn-host.ts`: semantic host ports for events, approvals, and compaction.
 - `compaction.ts`: history compaction and archive behavior.
 - `conversation-lines.ts`: user-facing chat message projection.
-- `trace.ts` and `trace-summary.ts`: current trace persistence and turn summary
-  compatibility wrappers.
+- `trace.ts`: chat trace persistence. Turn summary formatting lives in
+  `src/core/observability/trace-summarizers.ts`.
 
 ## Extension Points
 

--- a/src/core/chat/ordinary-turn.ts
+++ b/src/core/chat/ordinary-turn.ts
@@ -1,6 +1,8 @@
 import { runAgentLoop } from '../../index.js';
 import type { RunAgentLoopOptions } from '../runtime/agent-loop.js';
 import type { ToolCall, ToolDefinition } from '../types.js';
+import type { ToolApprovalPolicy } from '../approvals/types.js';
+import type { TraceSummarizerRegistry } from '../observability/trace-summarizers.js';
 import { buildCompactionRunningContext } from './compaction.js';
 import { buildConversationMessages } from './conversation-lines.js';
 import { releaseSessionLease, type ChatSessionLeaseOwner } from './session-lease.js';
@@ -25,6 +27,8 @@ export type ExecuteOrdinaryChatTurnArgs = {
   systemContext?: string;
   memoryMaintenanceMode?: 'none' | 'background' | 'inline';
   host?: ChatTurnHostPort;
+  approvalPolicies?: ToolApprovalPolicy[];
+  traceSummarizerRegistry?: TraceSummarizerRegistry;
   onCompactionStatus?: (event: { status: 'running' | 'finished' | 'failed'; archivePath?: string; summaryPath?: string; error?: string }) => void;
   onAssistantStream?: RunAgentLoopOptions['onAssistantStream'];
   onTraceEvent?: RunAgentLoopOptions['onTraceEvent'];
@@ -125,6 +129,7 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
       onAssistantStream: args.onAssistantStream,
       onTraceEvent: args.onTraceEvent,
       onEvent: args.host?.events?.onAgentLoopEvent,
+      approvalPolicies: args.approvalPolicies,
       approveToolCall: args.host?.approvals?.requestToolApproval ?
         ((call: ToolCall, tool: ToolDefinition) => args.host?.approvals?.requestToolApproval?.({ call, tool }) ?? Promise.resolve({ approved: false, reason: 'Missing approval port.' }))
       : undefined,
@@ -155,6 +160,7 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
       toolNames,
       historyForTokenEstimate: session.history,
       credentialSource: runtime.providerCredentialSource,
+      traceSummarizerRegistry: args.traceSummarizerRegistry,
       host: args.host,
       onCompactionStatus: args.onCompactionStatus,
     });

--- a/src/core/chat/session-submit.ts
+++ b/src/core/chat/session-submit.ts
@@ -1,4 +1,6 @@
 import type { ToolCall, ToolDefinition } from '../../index.js';
+import type { ToolApprovalPolicy } from '../approvals/types.js';
+import type { TraceSummarizerRegistry } from '../observability/trace-summarizers.js';
 import { executeOrdinaryChatTurn, clearOrdinaryChatTurnLease } from './ordinary-turn.js';
 import type { ChatSessionLeaseOwner } from './session-lease.js';
 import type { AgentLoopEvent } from '../../index.js';
@@ -15,6 +17,8 @@ export type SubmitChatSessionPromptArgs = {
   memoryMaintenanceMode?: 'none' | 'background' | 'inline';
   onEvent?: (event: AgentLoopEvent) => void;
   onCompactionStatus?: (event: { status: 'running' | 'finished' | 'failed'; archivePath?: string; summaryPath?: string; error?: string }) => void;
+  approvalPolicies?: ToolApprovalPolicy[];
+  traceSummarizerRegistry?: TraceSummarizerRegistry;
   approveToolCall?: (call: ToolCall, tool: ToolDefinition) => Promise<{ approved: boolean; reason?: string }>;
   abortSignal?: AbortSignal;
   leaseOwner?: ChatSessionLeaseOwner;
@@ -31,6 +35,8 @@ export async function submitChatSessionPrompt(args: SubmitChatSessionPromptArgs)
     preferApiKey: args.preferApiKey,
     systemContext: args.systemContext,
     memoryMaintenanceMode: args.memoryMaintenanceMode,
+    approvalPolicies: args.approvalPolicies,
+    traceSummarizerRegistry: args.traceSummarizerRegistry,
     host: {
       events: args.onEvent ? { onAgentLoopEvent: args.onEvent } : undefined,
       compaction: args.onCompactionStatus ? {

--- a/src/core/chat/session-turn-result.ts
+++ b/src/core/chat/session-turn-result.ts
@@ -3,10 +3,10 @@ import type { ChatMessage } from '../llm/types.js';
 import { compactChatHistoryWithArchive, estimateChatHistoryTokens } from './compaction.js';
 import { buildConversationMessages } from './conversation-lines.js';
 import { formatChatFailureMessage } from './failure-messages.js';
+import { countAssistantSteps, summarizeTrace, type TraceSummarizerRegistry } from '../observability/trace-summarizers.js';
 import { touchSession } from './storage.js';
 import type { ChatSession, TurnSummary } from './types.js';
 import { saveTrace } from './trace.js';
-import { countAssistantSteps, summarizeTrace } from './trace-summary.js';
 
 export type PersistChatTurnCompactionStatus = {
   status: 'running' | 'finished' | 'failed';
@@ -26,6 +26,7 @@ export type PersistChatTurnResultArgs = {
   toolNames: string[];
   historyForTokenEstimate: ChatMessage[];
   summarizer: Parameters<typeof compactChatHistoryWithArchive>[0]['summarizer'];
+  traceSummarizerRegistry?: TraceSummarizerRegistry;
   createTurnId: () => string;
   onCompactionStatus?: (event: PersistChatTurnCompactionStatus, sourceHistory: ChatMessage[]) => void;
 };
@@ -64,7 +65,7 @@ export async function createChatTurnPersistenceArtifacts(
     summary: args.result.summary,
     steps: countAssistantSteps(args.result.trace),
     traceFile,
-    events: summarizeTrace(args.result.trace),
+    events: args.traceSummarizerRegistry?.summarizeTrace(args.result.trace) ?? summarizeTrace(args.result.trace),
   };
   const summary =
     args.result.outcome === 'error' ?

--- a/src/core/chat/trace-summary.ts
+++ b/src/core/chat/trace-summary.ts
@@ -1,1 +1,0 @@
-export { countAssistantSteps, summarizeTrace } from '../observability/trace-summarizers.js';

--- a/src/core/chat/turn-memory-maintenance.ts
+++ b/src/core/chat/turn-memory-maintenance.ts
@@ -4,8 +4,8 @@ import type { AgentLoopResult } from '../runtime/agent-loop.js';
 import type { AgentLoopEvent } from '../runtime/events.js';
 import type { TraceEvent } from '../types.js';
 import { runMaintenanceForRecordedCandidates } from '../memory/maintenance-integration.js';
+import { summarizeTrace } from '../observability/trace-summarizers.js';
 import { loadChatSessions, saveChatSessions, touchSession } from './storage.js';
-import { summarizeTrace } from './trace-summary.js';
 
 export type RunInlineTurnMemoryMaintenanceArgs = {
   memoryRoot: string;

--- a/src/core/chat/turn-persistence.ts
+++ b/src/core/chat/turn-persistence.ts
@@ -7,6 +7,7 @@ import type { ChatTurnHostPort } from './turn-host.js';
 import type { AgentLoopResult } from '../runtime/agent-loop.js';
 import type { ChatMessage } from '../llm/types.js';
 import type { ProviderCredentialSource } from '../runtime/api-keys.js';
+import type { TraceSummarizerRegistry } from '../observability/trace-summarizers.js';
 
 export type PersistCompletedChatTurnArgs = {
   result: AgentLoopResult;
@@ -20,6 +21,7 @@ export type PersistCompletedChatTurnArgs = {
   toolNames: string[];
   historyForTokenEstimate: ChatMessage[];
   credentialSource: ProviderCredentialSource;
+  traceSummarizerRegistry?: TraceSummarizerRegistry;
   host?: ChatTurnHostPort;
   onCompactionStatus?: (event: { status: 'running' | 'finished' | 'failed'; archivePath?: string; summaryPath?: string; error?: string }) => void;
 };
@@ -36,6 +38,7 @@ export async function persistCompletedChatTurn(args: PersistCompletedChatTurnArg
     toolNames: args.toolNames,
     historyForTokenEstimate: args.historyForTokenEstimate,
     summarizer: { credentialSource: args.credentialSource },
+    traceSummarizerRegistry: args.traceSummarizerRegistry,
     createTurnId: () => `server-turn-${Date.now()}`,
     onCompactionStatus: (event) => {
       args.onCompactionStatus?.(event);

--- a/src/core/observability/README.md
+++ b/src/core/observability/README.md
@@ -28,25 +28,36 @@ Observability behavior currently exists in these places:
 - `src/core/chat/trace.ts` for persisted chat trace files.
 - `src/core/observability/trace-summarizers.ts` for turn summary evidence.
 - `src/core/observability/semantic-conventions.ts` for shared trace names.
-- `src/core/observability/conversation-activity.ts` for shared host activity projection.
+- `src/core/observability/conversation-activity.ts` for shared host activity
+  projection, typed activity handlers, and tool call/result activity summaries.
 - `src/cli/chat/hooks/tui-run-loop-events.ts` for TUI activity rendering.
 - `src/web/features/control-plane/hooks/sessions-screen/useSessionDetailSubscription.ts` for web activity rendering.
 - `src/server/features/control-plane/services/chat-session-events.ts`.
 
-Future milestones should centralize shared summarization and projection here
-while preserving compatibility wrappers for existing imports.
-
 ## Public Entry Points
 
+These APIs are exported from the package root for host authors. Treat the event
+names and core fields as stable, but treat new optional metadata fields as
+additive: consumers should ignore fields they do not use.
+
 - `semantic-conventions.ts`: event naming and correlation conventions.
-- `trace-summarizers.ts`: registry for trace event summaries.
-- `conversation-activity.ts`: shared host-agnostic activity projection.
+- `trace-summarizers.ts`: registry for durable trace event summaries. These
+  summaries feed turn/session evidence such as `TurnSummary.events`; they are
+  not the live TUI/web status layer.
+- `conversation-activity.ts`: shared host-agnostic activity projection and typed
+  handler-map helpers for frontend adapters. It also owns the small tool
+  call/result summaries used by projected activity. Activities include
+  correlation metadata such as `runId`, `step`, and `timestamp` when the source
+  event provides it.
 
 ## Extension Points
 
 - Add trace summaries by registering a summarizer for an event type.
 - Add UI activity by projecting raw runtime/trace events into host-agnostic
   activity events, then render those in TUI or web adapters.
+- Add host activity handlers with `satisfies ConversationActivityHandlerMap` so
+  each handler receives the narrowed activity type for its key. Use
+  `applyConversationActivityHandler` for dispatch.
 - Add new trace event families with compatibility tests and documented
   attributes.
 

--- a/src/core/observability/conversation-activity.ts
+++ b/src/core/observability/conversation-activity.ts
@@ -3,7 +3,6 @@ import type { TraceEvent, ToolCall } from '../types.js';
 import { truncate } from '../utils/text.js';
 
 const DEFAULT_MAX_TOOL_SUMMARY_CHARS = 96;
-const PATH_SUMMARY_TOOLS = new Set(['edit_file', 'read_file', 'list_files']);
 
 export type ConversationActivityCorrelation = {
   runId?: string;
@@ -227,8 +226,13 @@ export function summarizeToolCall(tool: string, input: unknown, maxChars = DEFAU
     return summarizeSearchInput(tool, input, maxChars);
   }
 
+  const moveSummary = summarizeMoveInput(tool, input, maxChars);
+  if (moveSummary) {
+    return moveSummary;
+  }
+
   const path = readStringField(input, 'path');
-  return PATH_SUMMARY_TOOLS.has(tool) && path ? `${tool} (${truncate(path, maxChars)})` : tool;
+  return path ? `${tool} (${truncate(path, maxChars)})` : tool;
 }
 
 export function summarizeToolResult(
@@ -241,12 +245,28 @@ export function summarizeToolResult(
     return `${tool} (${truncate(command, maxChars)})`;
   }
 
+  const moveSummary = summarizeMoveInput(tool, options.output, maxChars);
+  if (moveSummary) {
+    return moveSummary;
+  }
+
   const outputPath = readStringField(options.output, 'path');
-  if (tool === 'edit_file' && outputPath) {
+  if (outputPath) {
     return `${tool} (${truncate(outputPath, maxChars)})`;
   }
 
   return tool;
+}
+
+function summarizeMoveInput(tool: string, input: unknown, maxChars: number): string | undefined {
+  const from = readStringField(input, 'from');
+  const to = readStringField(input, 'to');
+  if (!from && !to) {
+    return undefined;
+  }
+
+  const segmentChars = Math.max(12, Math.floor(maxChars / 2));
+  return `${tool} (${from ? truncate(from, segmentChars) : '?'} -> ${to ? truncate(to, segmentChars) : '?'})`;
 }
 
 function summarizeSearchInput(tool: string, input: unknown, maxChars: number): string {

--- a/src/core/observability/conversation-activity.ts
+++ b/src/core/observability/conversation-activity.ts
@@ -2,18 +2,25 @@ import type { AgentLoopEvent } from '../runtime/events.js';
 import type { TraceEvent, ToolCall } from '../types.js';
 import { truncate } from '../utils/text.js';
 
-const MAX_TOOL_CALL_SUMMARY_CHARS = 96;
+const DEFAULT_MAX_TOOL_SUMMARY_CHARS = 96;
+const PATH_SUMMARY_TOOLS = new Set(['edit_file', 'read_file', 'list_files']);
 
-export type ConversationActivity =
+export type ConversationActivityCorrelation = {
+  runId?: string;
+  step?: number;
+  timestamp?: string;
+};
+
+export type ConversationActivity = ConversationActivityCorrelation & (
   | { type: 'loop.started' }
   | { type: 'loop.finished' }
   | { type: 'assistant.stream'; text: string; done: boolean }
   | { type: 'assistant.turn'; requestedTools: boolean; rationale?: string }
-  | { type: 'tool.calling'; tool: string; step?: number }
+  | { type: 'tool.calling'; tool: string }
   | { type: 'tool.completed'; tool: string; durationMs?: number }
   | { type: 'run.started' }
   | { type: 'run.finished'; outcome: string }
-  | { type: 'tool.approval_requested'; tool: string; toolSummary: string; step?: number; call: ToolCall }
+  | { type: 'tool.approval_requested'; tool: string; toolSummary: string; call: ToolCall }
   | { type: 'tool.approval_resolved'; tool: string; toolSummary: string; approved: boolean; reason?: string; call: ToolCall }
   | { type: 'tool.fallback'; fromTool: string; toTool: string; fromSummary: string; toSummary: string; reason: string }
   | { type: 'tool.call'; toolSummary: string }
@@ -25,12 +32,31 @@ export type ConversationActivity =
   | { type: 'cyberloop.annotation'; driftLevel: Exclude<Extract<TraceEvent, { type: 'cyberloop.annotation' }>['driftLevel'], 'unknown'>; metrics: string }
   | { type: 'compaction.running'; archivePath?: string }
   | { type: 'compaction.finished'; summaryPath?: string }
-  | { type: 'compaction.failed'; error?: string };
+  | { type: 'compaction.failed'; error?: string }
+);
 
 export type ConversationCompactionStatus =
   | { status: 'running'; archivePath?: string }
   | { status: 'finished'; summaryPath?: string }
   | { status: 'failed'; error?: string };
+
+export type ConversationActivityOf<Type extends ConversationActivity['type']> = Extract<
+  ConversationActivity,
+  { type: Type }
+>;
+
+export type ConversationActivityHandlerMap<Context, Result = void> = {
+  [Type in ConversationActivity['type']]?: (activity: ConversationActivityOf<Type>, context: Context) => Result;
+};
+
+export function applyConversationActivityHandler<Context, Result = void>(
+  activity: ConversationActivity,
+  handlers: ConversationActivityHandlerMap<Context, Result>,
+  context: Context,
+): Result | undefined {
+  const handler = handlers[activity.type] as ((activity: ConversationActivity, context: Context) => Result) | undefined;
+  return handler?.(activity, context);
+}
 
 type TraceProjectorMap = {
   [Type in TraceEvent['type']]: (event: Extract<TraceEvent, { type: Type }>) => ConversationActivity[];
@@ -45,70 +71,103 @@ type CompactionProjectorMap = {
 };
 
 const traceProjectors: TraceProjectorMap = {
-  'run.started': () => [{ type: 'run.started' }],
+  'run.started': (event) => [{ type: 'run.started', ...traceCorrelation(event) }],
   'assistant.turn': (event) => [{
     type: 'assistant.turn',
     requestedTools: event.requestedTools,
     rationale: event.diagnostics?.rationale,
+    ...traceCorrelation(event),
   }],
   'host.warning': () => [],
   'tool.approval_requested': (event) => [{
     type: 'tool.approval_requested',
     tool: event.call.tool,
-    toolSummary: summarizeActivityToolCall(event.call.tool, event.call.input),
-    step: event.step,
+    toolSummary: summarizeToolCall(event.call.tool, event.call.input),
     call: event.call,
+    ...traceCorrelation(event),
   }],
   'tool.approval_resolved': (event) => [{
     type: 'tool.approval_resolved',
     tool: event.call.tool,
-    toolSummary: summarizeActivityToolCall(event.call.tool, event.call.input),
+    toolSummary: summarizeToolCall(event.call.tool, event.call.input),
     approved: event.approved,
     reason: event.reason,
     call: event.call,
+    ...traceCorrelation(event),
   }],
   'tool.fallback': (event) => [{
     type: 'tool.fallback',
     fromTool: event.fromCall.tool,
     toTool: event.toCall.tool,
-    fromSummary: summarizeActivityToolCall(event.fromCall.tool, event.fromCall.input),
-    toSummary: summarizeActivityToolCall(event.toCall.tool, event.toCall.input),
+    fromSummary: summarizeToolCall(event.fromCall.tool, event.fromCall.input),
+    toSummary: summarizeToolCall(event.toCall.tool, event.toCall.input),
     reason: event.reason,
+    ...traceCorrelation(event),
   }],
-  'tool.call': (event) => [{ type: 'tool.call', toolSummary: summarizeActivityToolCall(event.call.tool, event.call.input) }],
+  'tool.call': (event) => [{
+    type: 'tool.call',
+    toolSummary: summarizeToolCall(event.call.tool, event.call.input),
+    ...traceCorrelation(event),
+  }],
   'tool.result': (event) => [{
     type: 'tool.result',
     tool: event.tool,
-    toolSummary: summarizeActivityToolResult(event.tool, extractShellCommand(event.result.output), event.result.output),
+    toolSummary: summarizeToolResult(event.tool, { output: event.result.output }),
     ok: event.result.ok,
     error: event.result.error,
+    ...traceCorrelation(event),
   }],
-  'memory.candidate_recorded': (event) => [{ type: 'memory.candidate_recorded', candidateId: event.candidateId }],
+  'memory.candidate_recorded': (event) => [{
+    type: 'memory.candidate_recorded',
+    candidateId: event.candidateId,
+    ...traceCorrelation(event),
+  }],
   'memory.checkpoint_skipped': () => [],
-  'memory.maintenance_started': (event) => [{ type: 'memory.maintenance_started', candidateCount: event.candidateIds.length }],
+  'memory.maintenance_started': (event) => [{
+    type: 'memory.maintenance_started',
+    candidateCount: event.candidateIds.length,
+    ...traceCorrelation(event),
+  }],
   'memory.maintenance_finished': (event) => [{
     type: 'memory.maintenance_finished',
     outcome: event.outcome,
     summary: event.summary,
+    ...traceCorrelation(event),
   }],
-  'memory.maintenance_failed': (event) => [{ type: 'memory.maintenance_failed', error: event.error }],
+  'memory.maintenance_failed': (event) => [{
+    type: 'memory.maintenance_failed',
+    error: event.error,
+    ...traceCorrelation(event),
+  }],
   'cyberloop.annotation': (event) => (
     event.driftLevel === 'unknown' ? [] : [{
       type: 'cyberloop.annotation',
       driftLevel: event.driftLevel,
       metrics: formatCyberLoopMetrics(event.metadata),
+      ...traceCorrelation(event),
     }]
   ),
-  'run.finished': (event) => [{ type: 'run.finished', outcome: event.outcome }],
+  'run.finished': (event) => [{ type: 'run.finished', outcome: event.outcome, ...traceCorrelation(event) }],
 };
 
 const agentLoopProjectors: AgentLoopProjectorMap = {
-  'loop.started': () => [{ type: 'loop.started' }],
-  'assistant.stream': (event) => [{ type: 'assistant.stream', text: event.text, done: event.done }],
-  'tool.calling': (event) => [{ type: 'tool.calling', tool: event.tool, step: event.step }],
-  'tool.completed': (event) => [{ type: 'tool.completed', tool: event.tool, durationMs: event.durationMs }],
-  trace: (event) => projectTraceEventToConversationActivities(event.event),
-  'loop.finished': () => [{ type: 'loop.finished' }],
+  'loop.started': (event) => [{ type: 'loop.started', ...agentLoopCorrelation(event) }],
+  'assistant.stream': (event) => [{
+    type: 'assistant.stream',
+    text: event.text,
+    done: event.done,
+    ...agentLoopCorrelation(event),
+  }],
+  'tool.calling': (event) => [{ type: 'tool.calling', tool: event.tool, ...agentLoopCorrelation(event) }],
+  'tool.completed': (event) => [{
+    type: 'tool.completed',
+    tool: event.tool,
+    durationMs: event.durationMs,
+    ...agentLoopCorrelation(event),
+  }],
+  trace: (event) => projectTraceEventToConversationActivities(event.event)
+    .map((activity) => ({ runId: event.runId, ...activity })),
+  'loop.finished': (event) => [{ type: 'loop.finished', ...agentLoopCorrelation(event) }],
 };
 
 const compactionProjectors: CompactionProjectorMap = {
@@ -118,7 +177,8 @@ const compactionProjectors: CompactionProjectorMap = {
 };
 
 export function projectTraceEventToConversationActivities(event: TraceEvent): ConversationActivity[] {
-  return traceProjectors[event.type](event as never);
+  const projector = traceProjectors[event.type] as (event: TraceEvent) => ConversationActivity[];
+  return projector(event);
 }
 
 export function projectAgentLoopEventToConversationActivities(event: AgentLoopEvent): ConversationActivity[] {
@@ -127,101 +187,83 @@ export function projectAgentLoopEventToConversationActivities(event: AgentLoopEv
 }
 
 export function projectCompactionStatusToConversationActivities(event: ConversationCompactionStatus): ConversationActivity[] {
-  return compactionProjectors[event.status](event as never);
+  const projector = compactionProjectors[event.status] as (event: ConversationCompactionStatus) => ConversationActivity[];
+  return projector(event);
 }
 
-export function summarizeActivityToolCall(tool: string, input: unknown): string {
-  const planSummary = summarizePlanInput(tool, input);
-  if (planSummary) {
-    return planSummary;
+function traceCorrelation(event: TraceEvent): ConversationActivityCorrelation {
+  const correlation: ConversationActivityCorrelation = { timestamp: event.timestamp };
+  if ('runId' in event) {
+    correlation.runId = event.runId;
   }
-
-  const shellCommand = extractShellCommand(input);
-  if (shellCommand) {
-    return `${tool} (${truncate(shellCommand, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
+  if ('step' in event) {
+    correlation.step = event.step;
   }
-
-  const searchSummary = summarizeSearchInput(tool, input);
-  if (searchSummary) {
-    return searchSummary;
-  }
-
-  const path = extractPathField(input);
-  if (isPathAwareTool(tool) && path) {
-    return `${tool} (${truncate(path, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
-  }
-
-  return tool;
+  return correlation;
 }
 
-export function summarizeActivityToolResult(tool: string, command: string | undefined, output?: unknown): string {
+function agentLoopCorrelation(event: AgentLoopEvent): ConversationActivityCorrelation {
+  const correlation: ConversationActivityCorrelation = {
+    runId: event.runId,
+    timestamp: event.timestamp,
+  };
+  if ('step' in event) {
+    correlation.step = event.step;
+  }
+  return correlation;
+}
+
+export function summarizeToolCall(tool: string, input: unknown, maxChars = DEFAULT_MAX_TOOL_SUMMARY_CHARS): string {
+  if (tool === 'update_plan') {
+    return summarizePlanInput(tool, input, maxChars);
+  }
+
+  const command = readStringField(input, 'command');
   if (command) {
-    return `${tool} (${truncate(command, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
+    return `${tool} (${truncate(command, maxChars)})`;
   }
 
-  const outputPath = extractPathField(output);
+  if (tool === 'search_files') {
+    return summarizeSearchInput(tool, input, maxChars);
+  }
+
+  const path = readStringField(input, 'path');
+  return PATH_SUMMARY_TOOLS.has(tool) && path ? `${tool} (${truncate(path, maxChars)})` : tool;
+}
+
+export function summarizeToolResult(
+  tool: string,
+  options: { output?: unknown; maxChars?: number } = {},
+): string {
+  const maxChars = options.maxChars ?? DEFAULT_MAX_TOOL_SUMMARY_CHARS;
+  const command = readStringField(options.output, 'command');
+  if (command) {
+    return `${tool} (${truncate(command, maxChars)})`;
+  }
+
+  const outputPath = readStringField(options.output, 'path');
   if (tool === 'edit_file' && outputPath) {
-    return `${tool} (${truncate(outputPath, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
+    return `${tool} (${truncate(outputPath, maxChars)})`;
   }
 
   return tool;
 }
 
-function extractShellCommand(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const command = (value as { command?: unknown }).command;
-  return typeof command === 'string' && command.trim() ? command.trim() : undefined;
-}
-
-function extractPathField(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const path = (value as { path?: unknown }).path;
-  return typeof path === 'string' && path.trim() ? path.trim() : undefined;
-}
-
-function extractQueryField(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const query = (value as { query?: unknown }).query;
-  return typeof query === 'string' && query.trim() ? query.trim() : undefined;
-}
-
-function isPathAwareTool(tool: string): boolean {
-  return tool === 'edit_file' || tool === 'read_file' || tool === 'list_files';
-}
-
-function summarizeSearchInput(tool: string, input: unknown): string | undefined {
-  if (tool !== 'search_files') {
-    return undefined;
-  }
-
-  const query = extractQueryField(input);
+function summarizeSearchInput(tool: string, input: unknown, maxChars: number): string {
+  const query = readStringField(input, 'query');
   if (!query) {
     return tool;
   }
 
-  const path = extractPathField(input);
-  const querySummary = truncate(JSON.stringify(query), Math.max(12, Math.floor(MAX_TOOL_CALL_SUMMARY_CHARS / 2)));
-  if (path) {
-    return `${tool} (${querySummary} in ${truncate(path, Math.max(12, Math.floor(MAX_TOOL_CALL_SUMMARY_CHARS / 2)))})`;
-  }
-
-  return `${tool} (${querySummary})`;
+  const path = readStringField(input, 'path');
+  const segmentChars = Math.max(12, Math.floor(maxChars / 2));
+  const querySummary = truncate(JSON.stringify(query), segmentChars);
+  return path ?
+      `${tool} (${querySummary} in ${truncate(path, segmentChars)})`
+    : `${tool} (${querySummary})`;
 }
 
-function summarizePlanInput(tool: string, input: unknown): string | undefined {
-  if (tool !== 'update_plan') {
-    return undefined;
-  }
-
+function summarizePlanInput(tool: string, input: unknown, maxChars: number): string {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     return tool;
   }
@@ -231,14 +273,28 @@ function summarizePlanInput(tool: string, input: unknown): string | undefined {
     return tool;
   }
 
-  const current = plan.find((item) => (
-    item
-    && typeof item === 'object'
-    && !Array.isArray(item)
-    && (item as { status?: unknown }).status === 'in_progress'
-  ));
-  const currentStep = current && typeof (current as { step?: unknown }).step === 'string' ? (current as { step: string }).step : undefined;
-  return currentStep ? `${tool} (${truncate(currentStep, MAX_TOOL_CALL_SUMMARY_CHARS)})` : `${tool} (${plan.length} items)`;
+  const currentStep = plan
+    .map((item) => getPlanItemStep(item, 'in_progress'))
+    .find((step): step is string => Boolean(step));
+  return currentStep ? `${tool} (${truncate(currentStep, maxChars)})` : `${tool} (${plan.length} items)`;
+}
+
+function getPlanItemStep(item: unknown, status: string): string | undefined {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) {
+    return undefined;
+  }
+
+  const candidate = item as { status?: unknown; step?: unknown };
+  return candidate.status === status && typeof candidate.step === 'string' ? candidate.step : undefined;
+}
+
+function readStringField(value: unknown, field: string): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const candidate = (value as Record<string, unknown>)[field];
+  return typeof candidate === 'string' && candidate.trim() ? candidate.trim() : undefined;
 }
 
 function formatCyberLoopMetrics(metadata: Record<string, unknown>): string {

--- a/src/core/observability/trace-summarizers.ts
+++ b/src/core/observability/trace-summarizers.ts
@@ -1,7 +1,6 @@
 import type { TraceEvent } from '../types.js';
 import { truncate } from '../utils/text.js';
-
-const MAX_TOOL_CALL_SUMMARY_CHARS = 96;
+import { summarizeToolCall } from './conversation-activity.js';
 
 export type TraceEventType = TraceEvent['type'];
 
@@ -95,36 +94,4 @@ function normalizeSummary(summary: string | string[] | undefined): string[] {
   }
 
   return summary ? [summary] : [];
-}
-
-function summarizeToolCall(tool: string, input: unknown): string {
-  const shellCommand = extractShellCommand(input);
-  if (shellCommand) {
-    return `${tool} (${truncate(shellCommand, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
-  }
-
-  const path = extractPathField(input);
-  if (path) {
-    return `${tool} (${truncate(path, MAX_TOOL_CALL_SUMMARY_CHARS)})`;
-  }
-
-  return tool;
-}
-
-function extractShellCommand(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const command = (value as { command?: unknown }).command;
-  return typeof command === 'string' && command.trim() ? command.trim() : undefined;
-}
-
-function extractPathField(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const path = (value as { path?: unknown }).path;
-  return typeof path === 'string' && path.trim() ? path.trim() : undefined;
 }

--- a/src/core/runtime/agent-loop.ts
+++ b/src/core/runtime/agent-loop.ts
@@ -6,6 +6,7 @@ import type { ChatMessage, LlmAdapter, LlmProvider } from '../llm/types.js';
 import { runAgent } from '../agent/run-agent.js';
 import type { RunAgentOptions } from '../agent/run-agent.js';
 import type { RunResult, ToolCall, ToolDefinition, TraceEvent } from '../types.js';
+import type { ToolApprovalPolicy } from '../approvals/types.js';
 import { createLogger } from '../utils/logger.js';
 import {
   resolveApiKeyForModel,
@@ -39,6 +40,7 @@ export type RunAgentLoopOptions = {
   onEvent?: (event: AgentLoopEvent) => void;
   onTraceEvent?: (event: TraceEvent) => void;
   onAssistantStream?: RunAgentOptions['onAssistantStream'];
+  approvalPolicies?: ToolApprovalPolicy[];
   approveToolCall?: (call: ToolCall, tool: ToolDefinition) => Promise<{ approved: boolean; reason?: string }>;
   shouldStop?: () => boolean;
   abortSignal?: AbortSignal;
@@ -157,6 +159,7 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<AgentL
         timestamp: now(),
       });
     },
+    approvalPolicies: options.approvalPolicies,
     approveToolCall: options.approveToolCall,
     shouldStop: options.shouldStop,
     abortSignal: options.abortSignal,

--- a/src/core/runtime/heartbeat.ts
+++ b/src/core/runtime/heartbeat.ts
@@ -3,6 +3,7 @@ import type { Logger } from 'pino';
 import { appendMemoryCatalogSystemContext } from '../memory/catalog.js';
 import type { ChatMessage, LlmAdapter } from '../llm/types.js';
 import type { ToolCall, ToolDefinition } from '../types.js';
+import type { ToolApprovalPolicy } from '../approvals/types.js';
 import { runAgentLoop } from './agent-loop.js';
 import { createAgentLoopCheckpoint } from './events.js';
 import type { AgentLoopCheckpoint, AgentLoopEvent, AgentLoopState } from './events.js';
@@ -30,6 +31,7 @@ export type RunAgentHeartbeatOptions = {
   includePlanTool?: boolean;
   logger?: Logger;
   onEvent?: (event: AgentLoopEvent) => void;
+  approvalPolicies?: ToolApprovalPolicy[];
   approveToolCall?: (call: ToolCall, tool: ToolDefinition) => Promise<{ approved: boolean; reason?: string }>;
   shouldStop?: () => boolean;
   abortSignal?: AbortSignal;
@@ -68,6 +70,7 @@ export async function runAgentHeartbeat(options: RunAgentHeartbeatOptions): Prom
     includePlanTool: options.includePlanTool,
     logger: options.logger,
     onEvent: options.onEvent,
+    approvalPolicies: options.approvalPolicies,
     approveToolCall: options.approveToolCall,
     shouldStop: options.shouldStop,
     abortSignal: options.abortSignal,

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,24 @@ export { createRunShellInspectTool, createRunShellMutateTool } from './core/tool
 export { createRunShellTool } from './core/tools/run-shell.js';
 export type { RunShellOptions } from './core/tools/run-shell.js';
 
+// Approvals
+export {
+  defaultToolApprovalPolicies,
+  isOutsideWorkspaceInspectionCall,
+  outsideWorkspaceInspectionPolicy,
+  rememberedApprovalPolicy,
+  toolRequiresApprovalPolicy,
+} from './core/approvals/default-policies.js';
+export { evaluateToolApprovalPolicies, resolveToolApproval } from './core/approvals/policy-chain.js';
+export { humanApprovalPolicy, requestToolApproval } from './core/approvals/surface.js';
+export type {
+  ToolApprovalDecision,
+  ToolApprovalPolicy,
+  ToolApprovalPolicyContext,
+  ToolApprovalPolicyDecision,
+  ToolApprovalSurface,
+} from './core/approvals/types.js';
+
 // Trace
 export { createTraceRecorder } from './core/trace/recorder.js';
 export type { TraceRecorder } from './core/trace/recorder.js';
@@ -256,11 +274,15 @@ export {
   projectAgentLoopEventToConversationActivities,
   projectCompactionStatusToConversationActivities,
   projectTraceEventToConversationActivities,
-  summarizeActivityToolCall,
-  summarizeActivityToolResult,
+  applyConversationActivityHandler,
+  summarizeToolCall,
+  summarizeToolResult,
 } from './core/observability/conversation-activity.js';
 export type {
   ConversationActivity,
+  ConversationActivityCorrelation,
+  ConversationActivityHandlerMap,
+  ConversationActivityOf,
   ConversationCompactionStatus,
 } from './core/observability/conversation-activity.js';
 

--- a/src/server/features/control-plane/services/chat-sessions.ts
+++ b/src/server/features/control-plane/services/chat-sessions.ts
@@ -11,8 +11,7 @@ import type { ChatSessionLeaseOwner } from '../../../../core/chat/session-lease.
 import type { ChatSession, TurnSummary } from '../../../../core/chat/types.js';
 import { buildConversationMessages } from '../../../../core/chat/conversation-lines.js';
 import { submitChatSessionPrompt } from '../../../../core/chat/session-submit.js';
-import { evaluateToolApprovalPolicies } from '../../../../core/approvals/policy-chain.js';
-import { humanApprovalPolicy, requestToolApproval } from '../../../../core/approvals/surface.js';
+import { requestToolApproval } from '../../../../core/approvals/surface.js';
 import {
   createControlPlanePendingApprovalView,
   createControlPlaneSessionEventPublisher,
@@ -166,27 +165,22 @@ export async function submitChatPrompt(args: SubmitChatPromptArgs) {
       leaseOwner: args.leaseOwner,
       onEvent: events.hostPort.events?.onAgentLoopEvent,
       approveToolCall: async (call, tool) => {
-        const decision = await evaluateToolApprovalPolicies([
-          humanApprovalPolicy(async () => await requestToolApproval({
-            call,
-            tool,
-            createView: createControlPlanePendingApprovalView,
-            storePending: ({ view, resolve }) => {
-              pendingApprovals.set(args.sessionId, {
-                approval: view,
-                resolve,
-              });
-            },
-            publish: (_view, callForEvent) => {
-              events.publishApprovalRequested(callForEvent);
-            },
-          })),
-        ], { call, tool, workspaceRoot: args.workspaceRoot });
+        const decision = await requestToolApproval({
+          call,
+          tool,
+          createView: createControlPlanePendingApprovalView,
+          storePending: ({ view, resolve }) => {
+            pendingApprovals.set(args.sessionId, {
+              approval: view,
+              resolve,
+            });
+          },
+          publish: (_view, callForEvent) => {
+            events.publishApprovalRequested(callForEvent);
+          },
+        });
         pendingApprovals.delete(args.sessionId);
-        return {
-          approved: decision?.type === 'allow',
-          reason: decision?.reason,
-        };
+        return decision;
       },
       onCompactionStatus: events.hostPort.compaction?.onFinalCompactionStatus,
     });

--- a/src/web/features/control-plane/hooks/sessions-screen/useSessionDetailSubscription.ts
+++ b/src/web/features/control-plane/hooks/sessions-screen/useSessionDetailSubscription.ts
@@ -1,8 +1,10 @@
 import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
 import {
+  applyConversationActivityHandler,
   projectAgentLoopEventToConversationActivities,
   projectCompactionStatusToConversationActivities,
   type ConversationActivity,
+  type ConversationActivityHandlerMap,
   type ConversationCompactionStatus,
 } from '../../../../../core/observability/conversation-activity';
 import type { AgentLoopEvent } from '../../../../../core/runtime/events';
@@ -187,28 +189,25 @@ function handleSessionEvent({
   projectLiveSessionEvent(event).forEach((activity) => applyWebConversationActivity(activity, context));
 }
 
-const webActivityHandlers: Partial<Record<ConversationActivity['type'], (activity: ConversationActivity, context: SessionEventContext) => void>> = {
+const webActivityHandlers = {
   'compaction.running': (activity, { liveMessages }) => {
-    const compactionActivity = activity as Extract<ConversationActivity, { type: 'compaction.running' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      compactionActivity.archivePath ? `Compacting earlier history… ${compactionActivity.archivePath}` : 'Compacting earlier history…',
+      activity.archivePath ? `Compacting earlier history… ${activity.archivePath}` : 'Compacting earlier history…',
       { pending: true, streaming: false },
     );
   },
   'compaction.failed': (activity, { liveMessages }) => {
-    const compactionActivity = activity as Extract<ConversationActivity, { type: 'compaction.failed' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      compactionActivity.error ? `Compaction failed: ${compactionActivity.error}` : 'Compaction failed.',
+      activity.error ? `Compaction failed: ${activity.error}` : 'Compaction failed.',
       { pending: false, streaming: false },
     );
   },
   'compaction.finished': (activity, { liveMessages }) => {
-    const compactionActivity = activity as Extract<ConversationActivity, { type: 'compaction.finished' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      compactionActivity.summaryPath ? `Compaction finished. Summary: ${compactionActivity.summaryPath}` : 'Compaction finished.',
+      activity.summaryPath ? `Compaction finished. Summary: ${activity.summaryPath}` : 'Compaction finished.',
       { pending: false, streaming: false },
     );
   },
@@ -217,25 +216,22 @@ const webActivityHandlers: Partial<Record<ConversationActivity['type'], (activit
     liveMessages.upsertLiveStatusMessage('live-run-status', 'Run started…', { pending: true, streaming: true });
   },
   'tool.calling': (activity, { liveMessages }) => {
-    const toolActivity = activity as Extract<ConversationActivity, { type: 'tool.calling' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Working… running ${toolActivity.tool}${typeof toolActivity.step === 'number' ? ` (step ${toolActivity.step})` : ''}`,
+      `Working… running ${activity.tool}${typeof activity.step === 'number' ? ` (step ${activity.step})` : ''}`,
       { pending: true, streaming: true },
     );
   },
   'tool.completed': (activity, { liveMessages }) => {
-    const toolActivity = activity as Extract<ConversationActivity, { type: 'tool.completed' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `${toolActivity.tool} finished${typeof toolActivity.durationMs === 'number' ? ` in ${Math.round(toolActivity.durationMs)}ms` : ''}`,
+      `${activity.tool} finished${typeof activity.durationMs === 'number' ? ` in ${Math.round(activity.durationMs)}ms` : ''}`,
       { pending: false, streaming: false },
     );
   },
   'assistant.stream': (activity, { liveMessages }) => {
-    const assistantActivity = activity as Extract<ConversationActivity, { type: 'assistant.stream' }>;
-    liveMessages.upsertLiveAssistantMessage(assistantActivity.text, assistantActivity.done);
-    if (assistantActivity.done) {
+    liveMessages.upsertLiveAssistantMessage(activity.text, activity.done);
+    if (activity.done) {
       liveMessages.removeLiveStatusMessage('live-run-status');
     }
   },
@@ -245,60 +241,54 @@ const webActivityHandlers: Partial<Record<ConversationActivity['type'], (activit
     void refresh();
   },
   'memory.maintenance_started': (activity, { setMemoryUpdating, liveMessages }) => {
-    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_started' }>;
     setMemoryUpdating(true);
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Memory updating… ${memoryActivity.candidateCount} candidate${memoryActivity.candidateCount === 1 ? '' : 's'}`,
+      `Memory updating… ${activity.candidateCount} candidate${activity.candidateCount === 1 ? '' : 's'}`,
       { pending: true, streaming: false },
     );
   },
   'memory.maintenance_finished': (activity, { setMemoryUpdating, liveMessages, refresh }) => {
-    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_finished' }>;
     setMemoryUpdating(false);
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      memoryActivity.summary ? `Memory updated. ${memoryActivity.summary}` : 'Memory updated.',
+      activity.summary ? `Memory updated. ${activity.summary}` : 'Memory updated.',
       { pending: false, streaming: false },
     );
     void refresh({ silent: true });
   },
   'memory.maintenance_failed': (activity, { setMemoryUpdating, liveMessages }) => {
-    const memoryActivity = activity as Extract<ConversationActivity, { type: 'memory.maintenance_failed' }>;
     setMemoryUpdating(false);
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      memoryActivity.error ? `Memory update failed: ${memoryActivity.error}` : 'Memory update failed.',
+      activity.error ? `Memory update failed: ${activity.error}` : 'Memory update failed.',
       { pending: false, streaming: false },
     );
   },
   'tool.approval_requested': (activity, { sessionId, setPendingApproval, liveMessages }) => {
-    const approvalActivity = activity as Extract<ConversationActivity, { type: 'tool.approval_requested' }>;
     void fetchPendingSessionApproval(sessionId).then((approval) => setPendingApproval(approval));
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Approval requested for ${approvalActivity.tool}${typeof approvalActivity.step === 'number' ? ` (step ${approvalActivity.step})` : ''}`,
+      `Approval requested for ${activity.tool}${typeof activity.step === 'number' ? ` (step ${activity.step})` : ''}`,
       { pending: true, streaming: false },
     );
   },
   'tool.approval_resolved': (activity, { setPendingApproval, liveMessages }) => {
-    const approvalActivity = activity as Extract<ConversationActivity, { type: 'tool.approval_resolved' }>;
     setPendingApproval(null);
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Approval ${approvalActivity.approved ? 'granted' : 'denied'} for ${approvalActivity.tool}${approvalActivity.reason ? ` — ${approvalActivity.reason}` : ''}`,
+      `Approval ${activity.approved ? 'granted' : 'denied'} for ${activity.tool}${activity.reason ? ` — ${activity.reason}` : ''}`,
       { pending: false, streaming: false },
     );
   },
   'tool.fallback': (activity, { liveMessages }) => {
-    const fallbackActivity = activity as Extract<ConversationActivity, { type: 'tool.fallback' }>;
     liveMessages.upsertLiveStatusMessage(
       'live-run-status',
-      `Fallback: ${fallbackActivity.fromTool} → ${fallbackActivity.toTool}`,
+      `Fallback: ${activity.fromTool} → ${activity.toTool}`,
       { pending: true, streaming: false },
     );
   },
-};
+} satisfies ConversationActivityHandlerMap<SessionEventContext>;
 
 function projectLiveSessionEvent(event: LiveSessionEvent): ConversationActivity[] {
   if (isCompactionStatusEvent(event)) {
@@ -309,7 +299,7 @@ function projectLiveSessionEvent(event: LiveSessionEvent): ConversationActivity[
 }
 
 function applyWebConversationActivity(activity: ConversationActivity, context: SessionEventContext) {
-  webActivityHandlers[activity.type]?.(activity, context);
+  applyConversationActivityHandler(activity, webActivityHandlers, context);
 }
 
 function isCompactionStatusEvent(event: LiveSessionEvent): event is ConversationCompactionStatus {


### PR DESCRIPTION
## Summary

This PR completes the M11.5 consolidation pass from the domain-module retro. It turns the prior structural refactor into materially cleaner architecture instead of leaving thin wrappers and half-adopted seams.

- Finish command-boundary cleanup already present on the branch: slash autocomplete delegates to core helpers, command result types live in the command domain, and command docs describe current behavior.
- Consolidate observability/activity projection: remove duplicated tool summary logic, delete the one-line `core/chat/trace-summary.ts` wrapper, carry `runId`/`step`/`timestamp` correlation metadata through projected conversation activities, and keep TUI/web adapters on typed activity handler maps.
- Make approval policy a real runtime extension seam: add `approvalPolicies` through `runAgent`, `runAgentLoop`, heartbeat, session submit, and ordinary chat turns; let built-in request policies be satisfied by remembered/custom policies before falling through to human approval; move TUI remembered approvals into the policy layer.
- Make trace summarizer registration real in production: chat turn persistence can now use a supplied `TraceSummarizerRegistry` instead of always using the default summarizer.
- Add import-boundary tests for core-to-host layering, command UI independence, and approval host independence.
- Update approvals, observability, and chat docs to reflect the current ownership boundaries.

## Why

The retro found that M0-M11 improved structure but did not fully reach the desired architectural outcome. This PR is the consolidation step: it removes fake seams, adopts the extension points in production paths, and adds guardrails so the same layering problems do not quietly return.

## Validation

- `yarn test:unit`
- `yarn typecheck`
- `yarn eslint`
- `yarn vitest run src/__tests__/integration/core/run-agent.test.ts`
- `yarn vitest run src/__tests__/integration/web/control-plane-sessions-state.test.tsx`
- `git diff --check`

Note: earlier, `yarn test:integration src/__tests__/integration/web/control-plane-sessions-state.test.tsx` expanded to the full integration suite in this repo. The broader run failed in unrelated sandbox/setup areas: temp git commits without identity and daemon tests blocked from listening on `127.0.0.1`. The exact web test passed when run directly with Vitest.