### PR TITLE
M15 candidate: harden conversation engine docs and conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ At a high level, Heddle helps with:
 
 If you want a terminal-first coding agent with local state, review traces, workspace memory, and a path toward longer-running workflows, that is the problem Heddle is trying to solve.
 
+## Programmatic Use Layers
+
+Heddle currently has two programmatic layers:
+
+- `createConversationEngine`: an alpha API for persisted multi-turn sessions with session storage, compaction, approvals, traces, semantic activity, and custom frontends or local hosts
+- `runAgentLoop`: a lower-level single-run execution loop for hosts that do not need persisted chat or session behavior
+
+If you want the programmatic surface, start with the [Programmatic use guide](docs/guides/programmatic-use.md).
+
 ## See Heddle
 
 ### Terminal coding workflow

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ Longer-term project context and design direction:
 
 ### I want to build on Heddle programmatically
 
-1. [Programmatic use](guides/programmatic-use.md)
+1. [Programmatic use](guides/programmatic-use.md) for the conversation engine alpha, persisted sessions, and turn submission
 2. [Capabilities and tools](reference/capabilities.md)
 3. [Providers and models](reference/providers-and-models.md)
 

--- a/docs/guides/programmatic-use.md
+++ b/docs/guides/programmatic-use.md
@@ -1,12 +1,264 @@
 # Programmatic Use
 
-The npm package exports runtime primitives for hosts that want to build on top of Heddle instead of only using the CLI.
+Heddle exports several runtime layers for hosts that want to build on top of the project instead of only using the CLI.
 
-## Main Entry Points
+If you want persisted conversations and session continuity, start with `createConversationEngine`.
 
-### `runAgentLoop`
+## Choose The Right API
 
-Use `runAgentLoop` when you want Heddle to assemble the model adapter, default tool bundle, memory tools, and event stream for a normal agent run:
+### Use `createConversationEngine` for persisted conversations and sessions
+
+`createConversationEngine` is the main alpha API for programmatic hosts that want Heddle's conversation/session behavior rather than a one-shot run.
+
+Use it when you want:
+
+- persisted sessions backed by a state root
+- create/read/list/rename/delete session operations
+- turn submission and continue behavior
+- automatic conversation compaction
+- approval handling through a host callback
+- assistant streaming, trace events, and semantic activity callbacks
+- memory maintenance and trace persistence without rebuilding the wiring yourself
+
+This is the best fit for custom frontends, local tools, daemon-like wrappers, or apps that want a real Heddle conversation engine instead of manually assembling the lower-level turn runner.
+
+### Use `runConversationTurn` for low-level persisted turn execution
+
+Use `runConversationTurn` when you want the persisted turn/session machinery, but you do not want to instantiate the higher-level engine service.
+
+It is useful when you already manage session ids and paths yourself and want direct control over one persisted turn at a time.
+
+Compared with `createConversationEngine`, this is lower-level and more manual:
+
+- you pass `workspaceRoot`, `stateRoot`, `sessionStoragePath`, `sessionId`, and other turn options directly
+- you are closer to the engine internals
+- you still get persisted session behavior, compaction, approvals, trace persistence, and memory maintenance
+
+### Use `runAgentLoop` for single-run embedding
+
+Use `runAgentLoop` when you want an evented agent run without the persisted conversation/session layer.
+
+This is the right choice when you want:
+
+- one bounded run for a goal
+- direct access to the loop event stream
+- default tools and model assembly without chat session persistence
+- checkpointable state that your own host will manage
+
+`runAgentLoop` is not the main persisted conversation API. It is the lower-level execution loop that the conversation engine builds on.
+
+### Use heartbeat APIs for scheduled or background wake cycles
+
+Use `runAgentHeartbeat`, `runStoredHeartbeat`, `runDueHeartbeatTasks`, and `runHeartbeatScheduler` when you want bounded autonomous work that wakes up from durable task/checkpoint state.
+
+Use heartbeat APIs when you want:
+
+- scheduled maintenance or monitoring tasks
+- repeated wake cycles around a durable task definition
+- host-managed task/run stores and review views
+- escalation-oriented background workflows
+
+Heartbeat is for task scheduling and bounded background work, not for ordinary interactive persisted chat sessions.
+
+## Main Entry Point: `createConversationEngine` Alpha
+
+The conversation engine API is alpha. It is intended for real use and examples, but it should still be treated as an evolving programmatic surface.
+
+```ts
+import { createConversationEngine } from '@roackb2/heddle'
+
+const engine = createConversationEngine({
+  workspaceRoot: process.cwd(),
+  stateRoot: `${process.cwd()}/.heddle`,
+  model: 'gpt-5.1-codex',
+})
+
+const session = engine.sessions.create({ name: 'Repo investigation' })
+
+const result = await engine.turns.submit({
+  sessionId: session.id,
+  prompt: 'Summarize the architecture of this repository.',
+})
+
+console.log(result.summary)
+```
+
+## Where State Is Stored
+
+The conversation engine is workspace-scoped and state-root-scoped.
+
+At a high level:
+
+- `workspaceRoot` is the repository or project the agent should work inside
+- `stateRoot` is the local Heddle state directory for the host using the engine
+
+By default, the normalized engine config derives these paths from `stateRoot`:
+
+- session catalog: `stateRoot/chat-sessions.catalog.json`
+- memory directory: `stateRoot/memory`
+- trace directory: `stateRoot/traces`
+
+For ordinary Heddle usage, that state root is typically the workspace-local `.heddle/` directory.
+
+## Host Callbacks
+
+`createConversationEngine` accepts host callbacks per submitted turn through `host`.
+
+The current host surface is organized around:
+
+- `events.onActivity`
+- `approvals.requestToolApproval`
+- `assistant.onText`
+- `trace.onEvent`
+- `compaction.onStatus`
+- `events.onAgentLoopEvent` as a lower-level escape hatch
+
+### `events.onActivity`
+
+`events.onActivity` receives semantic `ConversationActivity` records projected from runtime events, trace events, and compaction status updates.
+
+Use this when you want a UI timeline or host-visible progress without parsing raw loop or trace internals yourself.
+
+### `approvals.requestToolApproval`
+
+`approvals.requestToolApproval` is the host approval surface for approval-gated tools.
+
+Use this when your host wants to review and allow/deny tool calls such as shell mutation or file edits.
+
+### `assistant.onText`
+
+`assistant.onText` receives streamed assistant text chunks during the turn.
+
+Use this when you want streaming output in a custom UI or transport.
+
+### `trace.onEvent`
+
+`trace.onEvent` receives raw `TraceEvent` records.
+
+Use this when you want full run evidence, custom logging, analytics, or your own trace-backed review path.
+
+### `compaction.onStatus`
+
+`compaction.onStatus` receives semantic conversation compaction lifecycle updates.
+
+Use this when your host wants to show that history compaction is running, finished, or failed.
+
+## Realistic Conversation Engine Example
+
+This repository includes a realistic conversation-engine example:
+
+```bash
+yarn example:conversation-engine
+```
+
+The example:
+
+- creates an engine with `workspaceRoot`, `stateRoot`, `model`, and provider credential behavior
+- creates a session
+- submits a prompt
+- prints semantic activity, approval requests, assistant streaming, trace events, and compaction status
+- prints the final outcome and session summary
+- fails with a helpful message when the required provider key is missing
+
+See [`examples/conversation-engine.ts`](../../examples/conversation-engine.ts).
+
+## Example: persisted conversation with host callbacks
+
+```ts
+import {
+  createConversationEngine,
+  inferProviderFromModel,
+  resolveProviderApiKey,
+} from '@roackb2/heddle'
+
+const model = process.env.HEDDLE_EXAMPLE_MODEL ?? 'gpt-5.1-codex-mini'
+const provider = inferProviderFromModel(model)
+const apiKey = resolveProviderApiKey(provider)
+
+if (!apiKey) {
+  throw new Error(
+    `Missing API key for ${provider}. ` +
+      'Set OPENAI_API_KEY for OpenAI models or ANTHROPIC_API_KEY for Anthropic models before running this host.'
+  )
+}
+
+const workspaceRoot = process.cwd()
+const stateRoot = `${workspaceRoot}/.heddle`
+
+const engine = createConversationEngine({
+  workspaceRoot,
+  stateRoot,
+  model,
+  apiKey,
+  preferApiKey: true,
+})
+
+const session = engine.sessions.create({
+  name: 'Programmatic conversation example',
+})
+
+const result = await engine.turns.submit({
+  sessionId: session.id,
+  prompt: 'Summarize this repository and list the main verification commands.',
+  host: {
+    events: {
+      onActivity(activity) {
+        console.log('[activity]', activity.type)
+      },
+    },
+    approvals: {
+      async requestToolApproval(request) {
+        console.log('[approval]', request.call.tool)
+        return { approved: false, reason: 'Denied by example host policy.' }
+      },
+    },
+    assistant: {
+      onText(text) {
+        process.stdout.write(text)
+      },
+    },
+    trace: {
+      onEvent(event) {
+        console.log('\n[trace]', event.type)
+      },
+    },
+    compaction: {
+      onStatus(event) {
+        console.log('[compaction]', event.status)
+      },
+    },
+  },
+})
+
+console.log('\nOutcome:', result.outcome)
+console.log('Summary:', result.summary)
+console.log('Session:', result.session.id)
+```
+
+## `runConversationTurn`
+
+If you want one persisted turn without building the engine service first, call `runConversationTurn` directly:
+
+```ts
+import { runConversationTurn } from '@roackb2/heddle'
+
+const result = await runConversationTurn({
+  workspaceRoot: process.cwd(),
+  stateRoot: `${process.cwd()}/.heddle`,
+  sessionStoragePath: `${process.cwd()}/.heddle/chat-sessions.catalog.json`,
+  traceDir: `${process.cwd()}/.heddle/traces`,
+  sessionId: 'session-123',
+  prompt: 'Continue investigating the current issue.',
+})
+```
+
+`runConversationTurn` does not take a `model` argument directly. It resolves the active model from the stored session model plus runtime credential policy. If your host wants to set model defaults up front, `createConversationEngine` is the easier path.
+
+Choose this when your host already owns session creation/storage details and only needs the low-level persisted turn runner.
+
+## `runAgentLoop`
+
+Use `runAgentLoop` for lower-level single-run execution when you do not need persisted conversation sessions:
 
 ```ts
 import { runAgentLoop } from '@roackb2/heddle'
@@ -23,9 +275,9 @@ const result = await runAgentLoop({
 
 Persist `result.state` directly, or wrap it with `createAgentLoopCheckpoint(result.state)` when another host needs to continue later.
 
-### `runAgentHeartbeat`
+## Heartbeat APIs
 
-For autonomous background work, `runAgentHeartbeat` runs one bounded wake cycle from a durable task and optional checkpoint:
+For bounded autonomous background work, use `runAgentHeartbeat` and the scheduler/task-store helpers:
 
 ```ts
 import { runAgentHeartbeat } from '@roackb2/heddle'
@@ -37,16 +289,17 @@ const heartbeat = await runAgentHeartbeat({
 })
 ```
 
-## Scheduler Helpers
-
 For repeated local or hosted wake cycles, Heddle also exports:
 
 - `runDueHeartbeatTasks`
 - `runHeartbeatScheduler`
 - `createFileHeartbeatTaskStore`
 - `createFileHeartbeatCheckpointStore`
+- `runStoredHeartbeat`
+- `suggestNextHeartbeatDelayMs`
 - `listHeartbeatTaskViews`
 - `listHeartbeatRunViews`
+- `loadHeartbeatRunView`
 
 These are useful when you want to provide your own surrounding host, queue, cron, service manager, or control surface.
 
@@ -75,6 +328,7 @@ npm install cyberloop
 The repository includes example programs you can study or run directly:
 
 ```bash
+yarn example:conversation-engine
 yarn example:repo-investigator
 yarn example:programmatic
 yarn example:heartbeat
@@ -91,7 +345,7 @@ The public package API lives in [`src/index.ts`](../../src/index.ts).
 
 ## See Also
 
-- [Heartbeat guide](heartbeat.md)
-- [Providers and models](../reference/providers-and-models.md)
 - [Capabilities and tools](../reference/capabilities.md)
+- [Providers and models](../reference/providers-and-models.md)
+- [Heartbeat guide](heartbeat.md)
 - [Development and contributing](development.md)

--- a/examples/conversation-engine.ts
+++ b/examples/conversation-engine.ts
@@ -1,0 +1,151 @@
+// ---------------------------------------------------------------------------
+// Example: Conversation Engine Alpha
+//
+// Usage:
+//   OPENAI_API_KEY=sk-... yarn example:conversation-engine
+//
+// Optional:
+//   HEDDLE_EXAMPLE_MODEL=claude-3-5-haiku-latest ANTHROPIC_API_KEY=sk-ant-... yarn example:conversation-engine
+//
+// This example uses the alpha persisted conversation engine API. It creates an
+// engine, creates a session, submits a prompt, reports host callbacks, and
+// prints the final outcome.
+// ---------------------------------------------------------------------------
+
+import {
+  createConversationEngine,
+  inferProviderFromModel,
+  resolveProviderApiKey,
+  type ConversationActivity,
+  type ConversationCompactionStatus,
+  type ToolApprovalPolicyContext,
+  type TraceEvent,
+} from '../src/index.js';
+
+const DEFAULT_EXAMPLE_MODEL = 'gpt-5.1-codex-mini';
+
+async function main() {
+  const workspaceRoot = process.cwd();
+  const stateRoot = `${workspaceRoot}/.heddle`;
+  const model = process.env.HEDDLE_EXAMPLE_MODEL ?? process.env.OPENAI_MODEL ?? DEFAULT_EXAMPLE_MODEL;
+  const provider = inferProviderFromModel(model);
+  const apiKey = resolveProviderApiKey(provider);
+
+  if (!apiKey) {
+    throw new Error(
+      [
+        `Missing API key for ${provider}.`,
+        provider === 'openai'
+          ? 'Set OPENAI_API_KEY before running this example.'
+          : provider === 'anthropic'
+            ? 'Set ANTHROPIC_API_KEY before running this example.'
+            : `Configure credentials for provider ${provider} before running this example.`,
+        'This example uses a real provider and does not add a fake conversation-engine abstraction.',
+      ].join(' '),
+    );
+  }
+
+  const engine = createConversationEngine({
+    workspaceRoot,
+    stateRoot,
+    model,
+    apiKey,
+    preferApiKey: true,
+  });
+
+  const session = engine.sessions.create({
+    name: 'Programmatic conversation engine example',
+  });
+
+  console.log(`Starting session ${session.id} with model ${model} (${provider})`);
+  console.log(`workspaceRoot=${workspaceRoot}`);
+  console.log(`stateRoot=${stateRoot}`);
+
+  const result = await engine.turns.submit({
+    sessionId: session.id,
+    prompt:
+      'Summarize this repository, explain what Heddle is for, and list the main verification commands in a short bullet list.',
+    host: {
+      events: {
+        onActivity(activity) {
+          console.log(formatActivity(activity));
+        },
+      },
+      approvals: {
+        requestToolApproval: requestExampleToolApproval,
+      },
+      assistant: {
+        onText(text) {
+          process.stdout.write(text);
+        },
+      },
+      trace: {
+        onEvent(event) {
+          console.log(`\n[trace] ${formatTraceEvent(event)}`);
+        },
+      },
+      compaction: {
+        onStatus(event) {
+          console.log(`[compaction] ${formatCompactionStatus(event)}`);
+        },
+      },
+    },
+  });
+
+  console.log('\n\nFinal result');
+  console.log('------------');
+  console.log(`Outcome: ${result.outcome}`);
+  console.log(`Summary: ${result.summary}`);
+  console.log(`Session ID: ${result.session.id}`);
+  console.log(`Session name: ${result.session.name}`);
+  console.log(`Turns stored: ${result.session.turns.length}`);
+}
+
+const requestExampleToolApproval = async (request: ToolApprovalPolicyContext) => {
+  console.log(`\n[approval] tool=${request.call.tool} requires operator decision`);
+  return {
+    approved: false,
+    reason: 'Example host denies approval-gated tools by default.',
+  };
+};
+
+function formatActivity(activity: ConversationActivity): string {
+  switch (activity.type) {
+    case 'run.started':
+      return `[activity] run.started run=${activity.runId ?? 'unknown'}`;
+    case 'assistant.stream':
+      return activity.done
+        ? `[activity] assistant.stream done chars=${activity.text.length}`
+        : `[activity] assistant.stream chunk chars=${activity.text.length}`;
+    case 'tool.calling':
+      return `[activity] tool.calling tool=${activity.tool} step=${activity.step ?? 'n/a'}`;
+    case 'tool.approval_requested':
+      return `[activity] tool.approval_requested tool=${activity.tool} step=${activity.step ?? 'n/a'}`;
+    case 'memory.maintenance_started':
+      return `[activity] memory.maintenance_started candidates=${activity.candidateCount}`;
+    case 'run.finished':
+      return `[activity] run.finished outcome=${activity.outcome}`;
+    default:
+      return `[activity] ${activity.type}`;
+  }
+}
+
+function formatTraceEvent(event: TraceEvent): string {
+  return event.type;
+}
+
+function formatCompactionStatus(event: ConversationCompactionStatus): string {
+  switch (event.status) {
+    case 'running':
+      return event.archivePath ? `running archive=${event.archivePath}` : 'running';
+    case 'finished':
+      return event.summaryPath ? `finished summary=${event.summaryPath}` : 'finished';
+    case 'failed':
+      return event.error ? `failed error=${event.error}` : 'failed';
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "chat:dev:openai": "OPENAI_API_KEY=\"$PERSONAL_OPENAI_API_KEY\" tsx --no-cache src/cli/main.ts chat",
     "chat:dev:anthropic": "ANTHROPIC_API_KEY=\"$PERSONAL_ANTHROPIC_API_KEY\" tsx --no-cache src/cli/main.ts chat",
     "example:repo-investigator": "tsx --no-cache examples/repo-investigator.ts",
+    "example:conversation-engine": "tsx --no-cache examples/conversation-engine.ts",
     "example:programmatic": "tsx --no-cache examples/programmatic-loop.ts",
     "example:heartbeat": "tsx --no-cache examples/heartbeat.ts",
     "example:heartbeat-scheduler": "tsx --no-cache examples/heartbeat-scheduler.ts",

--- a/src/__tests__/unit/core/import-boundaries.test.ts
+++ b/src/__tests__/unit/core/import-boundaries.test.ts
@@ -3,6 +3,30 @@ import { join, relative, sep } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const SOURCE_ROOT = join(process.cwd(), 'src');
+const ENGINE_ROOT = 'core/chat/engine/';
+const REMOVED_CHAT_PATH_PREFIXES = [
+  'core/chat/session-submit',
+  'core/chat/trace',
+  'core/chat/storage',
+  'core/chat/session-lease',
+  'core/chat/session-turn-result',
+  'core/chat/turn-persistence',
+  'core/chat/conversation-turn',
+  'core/chat/compaction',
+  'core/chat/turn-host',
+  'core/chat/turn-host-bridge',
+];
+const FORBIDDEN_PRODUCTION_TOKENS = [
+  'submitChatSessionPrompt',
+  'executeOrdinaryChatTurn',
+  'clearOrdinaryChatTurnLease',
+];
+
+const PUBLIC_EXPORT_EXPECTATIONS = [
+  'createConversationEngine',
+  'runConversationTurn',
+  'clearConversationTurnLease',
+];
 
 describe('core import boundaries', () => {
   const sourceFiles = listSourceFiles(SOURCE_ROOT);
@@ -42,6 +66,58 @@ describe('core import boundaries', () => {
 
     expect(violations).toEqual([]);
   });
+
+  it('keeps conversation engine modules free of host and UI dependencies', () => {
+    const violations = findImportViolations(
+      sourceFiles.filter((file) => toSourcePath(file).startsWith(ENGINE_ROOT)),
+      [/^(?:\.\.\/)+(?:cli|web|server)\//, /^react$/, /^ink$/, /react/, /ink/],
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('does not reintroduce deleted flat chat module paths in production imports', () => {
+    const violations = findRemovedPathImportViolations(
+      sourceFiles.filter((file) => isProductionSource(file)),
+      REMOVED_CHAT_PATH_PREFIXES,
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('does not reintroduce obsolete ordinary-turn and session-submit names in production code', () => {
+    const violations = findForbiddenTokenUsages(
+      sourceFiles.filter((file) => isProductionSource(file)),
+      FORBIDDEN_PRODUCTION_TOKENS,
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps toolkit modules from importing command modules', () => {
+    const violations = findImportViolations(
+      sourceFiles.filter((file) => toSourcePath(file).startsWith('core/tools/toolkits/')),
+      [/core\/commands\//, /\.\.\/\.\.\/commands\//, /\.\.\/commands\//],
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps command modules from importing toolkit implementations directly', () => {
+    const violations = findImportViolations(
+      sourceFiles.filter((file) => toSourcePath(file).startsWith('core/commands/')),
+      [/core\/tools\/toolkits\//, /\.\.\/\.\.\/tools\/toolkits\//, /\.\.\/tools\/toolkits\//],
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps the package root exporting the alpha conversation engine entry points', () => {
+    const indexSource = readFileSync(join(SOURCE_ROOT, 'index.ts'), 'utf8');
+    for (const symbol of PUBLIC_EXPORT_EXPECTATIONS) {
+      expect(indexSource).toContain(symbol);
+    }
+  });
 });
 
 function listSourceFiles(dir: string): string[] {
@@ -58,12 +134,45 @@ function listSourceFiles(dir: string): string[] {
 
 function findImportViolations(files: string[], disallowed: RegExp[]): string[] {
   return files.flatMap((file) => {
-    const imports = [...readFileSync(file, 'utf8').matchAll(/\bfrom\s+['"]([^'"]+)['"]/g)]
-      .map((match) => match[1]!)
+    const imports = readImports(file)
       .filter((specifier) => disallowed.some((pattern) => pattern.test(specifier)));
 
     return imports.map((specifier) => `${toSourcePath(file)} imports ${specifier}`);
   });
+}
+
+function findRemovedPathImportViolations(files: string[], removedPrefixes: string[]): string[] {
+  return files.flatMap((file) => {
+    const imports = readImports(file)
+      .filter((specifier) => removedPrefixes.some((prefix) => normalizeImportSpecifier(specifier).startsWith(prefix)));
+
+    return imports.map((specifier) => `${toSourcePath(file)} imports removed path ${specifier}`);
+  });
+}
+
+function findForbiddenTokenUsages(files: string[], forbiddenTokens: string[]): string[] {
+  return files.flatMap((file) => {
+    const source = readFileSync(file, 'utf8');
+    return forbiddenTokens
+      .filter((token) => source.includes(token))
+      .map((token) => `${toSourcePath(file)} contains forbidden token ${token}`);
+  });
+}
+
+function readImports(file: string): string[] {
+  return [...readFileSync(file, 'utf8').matchAll(/\bfrom\s+['"]([^'"]+)['"]/g)]
+    .map((match) => match[1]!);
+}
+
+function normalizeImportSpecifier(specifier: string): string {
+  return specifier
+    .replace(/^\.\//, '')
+    .replace(/\.js$/, '')
+    .replace(/\\/g, '/');
+}
+
+function isProductionSource(file: string): boolean {
+  return !toSourcePath(file).startsWith('__tests__/');
 }
 
 function toSourcePath(file: string): string {


### PR DESCRIPTION
## Summary
- add product-facing docs for the alpha conversation engine vs runAgentLoop layers
- add a realistic conversation engine example and programmatic guide fixes
- extend import-boundary conformance checks for deleted chat paths and obsolete names

## Verification
- yarn build
- yarn test
- git diff --check
- yarn vitest run src/__tests__/unit/core/import-boundaries.test.ts src/__tests__/unit/core/conversation-engine.test.ts
- rg -n "core/chat/session-submit|core/chat/trace|core/chat/storage|core/chat/session-lease|core/chat/session-turn-result|core/chat/turn-persistence|core/chat/conversation-turn|core/chat/compaction|core/chat/turn-host|core/chat/turn-host-bridge|submitChatSessionPrompt|executeOrdinaryChatTurn|clearOrdinaryChatTurnLease" src docs README.md examples

## Notes
- candidate implementation only; not claiming M15 complete
- scope kept to docs, examples, and conformance tests only