### PR TITLE
Fix regex-heavy prompt rendering crash

### DIFF
--- a/src/__tests__/unit/tui/prompt-input.test.tsx
+++ b/src/__tests__/unit/tui/prompt-input.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { insertMentionSelection } from '../../../cli/chat/utils/file-mentions.js';
+import { parseInlineSegments, parseMessageBlocks } from '../../../cli/chat/components/ConversationPanel.js';
 import { buildPromptRenderLines, insertPromptText } from '../../../cli/chat/components/PromptInput.js';
 
 describe('prompt input related helpers', () => {
@@ -64,6 +65,59 @@ describe('prompt input related helpers', () => {
         after: '',
         hasCursor: true,
       },
+    ]);
+  });
+
+  it('does not hang while rendering unmatched inline markdown markers from regex-heavy prompts', () => {
+    const prompt = [
+      'Please review this follow-up without crashing.',
+      '',
+      '```sh',
+      "rg -n 'callbackFanout|old/path|useAgentRun\\(' src/cli/chat",
+      "rg -n \"match\\(/|replace\\(/^[-*]\\\\s+/\" src/cli/chat/components/ConversationPanel.tsx",
+      '```',
+      '',
+      'Also inspect literal backticks like `unterminated and bold markers like **missing close.',
+      'Shell-ish examples: foo && bar || baz; echo "quotes"; printf \'\\\\n\'; (cd src && rg "x")',
+    ].join('\n');
+
+    expect(parseInlineSegments('literal `unterminated marker')).toEqual([
+      { kind: 'text', text: 'literal ' },
+      { kind: 'text', text: '`' },
+      { kind: 'text', text: 'unterminated marker' },
+    ]);
+    expect(parseInlineSegments('literal **unterminated marker')).toEqual([
+      { kind: 'text', text: 'literal ' },
+      { kind: 'text', text: '**' },
+      { kind: 'text', text: 'unterminated marker' },
+    ]);
+    expect(buildPromptRenderLines(prompt, prompt.length, 10, 80).at(-1)).toMatchObject({
+      hasCursor: true,
+    });
+  });
+
+  it('parses mixed block content with code fences using the refactored block parser', () => {
+    expect(parseMessageBlocks([
+      '# Heading',
+      '',
+      'alpha',
+      'beta',
+      '- [x] done',
+      '- bullet',
+      '1. first',
+      '> quoted',
+      '```ts',
+      'const x = 1;',
+      '```',
+    ].join('\n'))).toEqual([
+      { kind: 'heading', text: 'Heading' },
+      { kind: 'blank', text: '' },
+      { kind: 'paragraph', text: 'alpha beta' },
+      { kind: 'task', marker: '[x]', text: 'done' },
+      { kind: 'bullet', text: 'bullet' },
+      { kind: 'numbered', marker: '1.', text: 'first' },
+      { kind: 'quote', text: 'quoted' },
+      { kind: 'code', info: 'ts', text: 'const x = 1;' },
     ]);
   });
 });

--- a/src/cli/chat/components/ConversationPanel.tsx
+++ b/src/cli/chat/components/ConversationPanel.tsx
@@ -128,92 +128,150 @@ type MessageBlock =
   | { kind: 'quote'; text: string }
   | { kind: 'code'; text: string; info?: string };
 
-function parseMessageBlocks(text: string): MessageBlock[] {
-  const lines = text.split(/\r?\n/);
-  const blocks: MessageBlock[] = [];
-  let inCodeBlock = false;
-  let codeLines: string[] = [];
-  let codeInfo: string | undefined;
+type MessageBlockParserState = {
+  blocks: MessageBlock[];
+  codeBlock?: {
+    info?: string;
+    lines: string[];
+  };
+};
 
-  for (const line of lines) {
-    if (line.trim().startsWith('```')) {
-      if (inCodeBlock) {
-        blocks.push({ kind: 'code', text: codeLines.join('\n'), info: codeInfo });
-        codeLines = [];
-        codeInfo = undefined;
-        inCodeBlock = false;
-      } else {
-        inCodeBlock = true;
-        codeInfo = line.trim().slice(3).trim() || undefined;
-      }
-      continue;
-    }
+const HEADING_PATTERN = /^#{1,3}\s+/;
+const BULLET_PATTERN = /^[-*]\s+/;
+const TASK_PATTERN = /^[-*]\s+(\[(?: |x|-)\])\s+(.*)$/i;
+const NUMBERED_PATTERN = /^(\d+\.)\s+(.*)$/;
+const QUOTE_PATTERN = /^>\s+/;
 
-    if (inCodeBlock) {
-      codeLines.push(line);
-      continue;
-    }
+export function parseMessageBlocks(text: string): MessageBlock[] {
+  const state = text
+    .split(/\r?\n/)
+    .reduce(parseMessageBlockLine, { blocks: [] } satisfies MessageBlockParserState);
 
-    const trimmed = line.trim();
-    if (!trimmed) {
-      blocks.push({ kind: 'blank', text: '' });
-      continue;
-    }
+  return collapseParagraphBlocks(finalizeMessageBlockParserState(state).blocks);
+}
 
-    if (/^#{1,3}\s+/.test(trimmed)) {
-      blocks.push({ kind: 'heading', text: trimmed.replace(/^#{1,3}\s+/, '') });
-      continue;
-    }
+function parseMessageBlockLine(state: MessageBlockParserState, line: string): MessageBlockParserState {
+  const trimmed = line.trim();
 
-    if (/^[-*]\s+/.test(trimmed)) {
-      const taskMatch = trimmed.match(/^[-*]\s+(\[(?: |x|-)\])\s+(.*)$/i);
-      if (taskMatch) {
-        const marker = normalizeTaskMarker(taskMatch[1]);
-        if (marker) {
-          blocks.push({ kind: 'task', marker, text: taskMatch[2] });
-          continue;
-        }
-      }
-
-      blocks.push({ kind: 'bullet', text: trimmed.replace(/^[-*]\s+/, '') });
-      continue;
-    }
-
-    const numberedMatch = trimmed.match(/^(\d+\.)\s+(.*)$/);
-    if (numberedMatch) {
-      blocks.push({ kind: 'numbered', marker: numberedMatch[1], text: numberedMatch[2] });
-      continue;
-    }
-
-    if (/^>\s+/.test(trimmed)) {
-      blocks.push({ kind: 'quote', text: trimmed.replace(/^>\s+/, '') });
-      continue;
-    }
-
-    blocks.push({ kind: 'paragraph', text: line });
+  if (trimmed.startsWith('```')) {
+    return toggleCodeBlock(state, trimmed);
   }
 
-  if (codeLines.length > 0) {
-    blocks.push({ kind: 'code', text: codeLines.join('\n'), info: codeInfo });
+  if (state.codeBlock) {
+    return {
+      ...state,
+      codeBlock: {
+        ...state.codeBlock,
+        lines: [...state.codeBlock.lines, line],
+      },
+    };
   }
 
-  return collapseParagraphBlocks(blocks);
+  return appendParsedMessageBlock(state, parseNonCodeMessageBlock(line, trimmed));
+}
+
+function toggleCodeBlock(state: MessageBlockParserState, trimmedLine: string): MessageBlockParserState {
+  if (state.codeBlock) {
+    return appendParsedMessageBlock({
+      ...state,
+      codeBlock: undefined,
+    }, {
+      kind: 'code',
+      text: state.codeBlock.lines.join('\n'),
+      info: state.codeBlock.info,
+    });
+  }
+
+  return {
+    ...state,
+    codeBlock: {
+      info: trimmedLine.slice(3).trim() || undefined,
+      lines: [],
+    },
+  };
+}
+
+function finalizeMessageBlockParserState(state: MessageBlockParserState): MessageBlockParserState {
+  if (!state.codeBlock) {
+    return state;
+  }
+
+  return appendParsedMessageBlock({
+    ...state,
+    codeBlock: undefined,
+  }, {
+    kind: 'code',
+    text: state.codeBlock.lines.join('\n'),
+    info: state.codeBlock.info,
+  });
+}
+
+function parseNonCodeMessageBlock(line: string, trimmed: string): MessageBlock {
+  if (!trimmed) {
+    return { kind: 'blank', text: '' };
+  }
+
+  if (HEADING_PATTERN.test(trimmed)) {
+    return { kind: 'heading', text: trimmed.replace(HEADING_PATTERN, '') };
+  }
+
+  const taskBlock = parseTaskMessageBlock(trimmed);
+  if (taskBlock) {
+    return taskBlock;
+  }
+
+  if (BULLET_PATTERN.test(trimmed)) {
+    return { kind: 'bullet', text: trimmed.replace(BULLET_PATTERN, '') };
+  }
+
+  const numberedMatch = trimmed.match(NUMBERED_PATTERN);
+  if (numberedMatch) {
+    return { kind: 'numbered', marker: numberedMatch[1], text: numberedMatch[2] };
+  }
+
+  if (QUOTE_PATTERN.test(trimmed)) {
+    return { kind: 'quote', text: trimmed.replace(QUOTE_PATTERN, '') };
+  }
+
+  return { kind: 'paragraph', text: line };
+}
+
+function parseTaskMessageBlock(trimmed: string): Extract<MessageBlock, { kind: 'task' }> | undefined {
+  const taskMatch = trimmed.match(TASK_PATTERN);
+  if (!taskMatch) {
+    return undefined;
+  }
+
+  const marker = normalizeTaskMarker(taskMatch[1]);
+  if (!marker) {
+    return undefined;
+  }
+
+  return { kind: 'task', marker, text: taskMatch[2] };
+}
+
+function appendParsedMessageBlock(state: MessageBlockParserState, block: MessageBlock): MessageBlockParserState {
+  return {
+    ...state,
+    blocks: [...state.blocks, block],
+  };
 }
 
 function collapseParagraphBlocks(blocks: MessageBlock[]): MessageBlock[] {
-  const collapsed: MessageBlock[] = [];
-
-  for (const block of blocks) {
+  return blocks.reduce<MessageBlock[]>((collapsed, block) => {
     const previous = collapsed.at(-1);
     if (block.kind === 'paragraph' && previous?.kind === 'paragraph') {
-      previous.text = `${previous.text} ${block.text.trim()}`;
-      continue;
+      return [
+        ...collapsed.slice(0, -1),
+        {
+          kind: 'paragraph',
+          text: `${previous.text} ${block.text.trim()}`,
+        },
+      ];
     }
 
-    collapsed.push(block);
-  }
-
-  return collapsed;
+    return [...collapsed, block];
+  }, []);
 }
 
 function renderBlock(
@@ -388,7 +446,7 @@ type InlineSegment =
   | { kind: 'bold'; text: string }
   | { kind: 'code'; text: string };
 
-function parseInlineSegments(text: string): InlineSegment[] {
+export function parseInlineSegments(text: string): InlineSegment[] {
   const segments: InlineSegment[] = [];
   let index = 0;
 
@@ -400,6 +458,10 @@ function parseInlineSegments(text: string): InlineSegment[] {
         index = end + 2;
         continue;
       }
+
+      segments.push({ kind: 'text', text: '**' });
+      index += 2;
+      continue;
     }
 
     if (text[index] === '`') {
@@ -409,11 +471,15 @@ function parseInlineSegments(text: string): InlineSegment[] {
         index = end + 1;
         continue;
       }
+
+      segments.push({ kind: 'text', text: '`' });
+      index += 1;
+      continue;
     }
 
     const nextBold = text.indexOf('**', index);
     const nextCode = text.indexOf('`', index);
-    const nextStopCandidates = [nextBold, nextCode].filter((candidate) => candidate !== -1);
+    const nextStopCandidates = [nextBold, nextCode].filter((candidate) => candidate > index);
     const nextStop = nextStopCandidates.length > 0 ? Math.min(...nextStopCandidates) : text.length;
     segments.push({ kind: 'text', text: text.slice(index, nextStop) });
     index = nextStop;


### PR DESCRIPTION
## Summary
- fix the chat renderer hang on unmatched inline markdown markers in regex-heavy prompts
- refactor parseMessageBlocks into smaller reducer-style helpers
- add regression coverage for regex-heavy prompt content and mixed block parsing

## Testing
- yarn vitest run src/__tests__/unit/tui/prompt-input.test.tsx
- yarn build
