### PR TITLE
[codex] Add MIT license file and planning workflow docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jay / Fienna Liang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -419,4 +419,4 @@ See [Development and contributing](docs/guides/development.md) for the fuller co
 
 ## License
 
-MIT
+Heddle is licensed under the MIT License. See [LICENSE](LICENSE).

--- a/docs/agent-context.md
+++ b/docs/agent-context.md
@@ -17,8 +17,12 @@ When additional project context is needed, read in this order:
 2. `../heddle-workspace-notes/agent-memory/current-state/project-summary.md`
 3. This repo's live docs and code for the relevant capability area
 4. the relevant focused file under `../heddle-workspace-notes/agent-memory/current-state/`
-5. `../heddle-workspace-notes/agent-memory/project-context.md` only when broader long-form context is needed
-6. `../heddle-workspace-notes/analysis/` and `../heddle-workspace-notes/task-plans/` as supporting historical context only
+5. `../heddle-workspace-notes/agent-memory/workflows/feature-prd-to-technical-plan.md`
+   when the user asks for a broad feature, substantial refactor, PRD,
+   architecture direction, roadmap, technical plan, milestone plan, or
+   implementation/review workflow
+6. `../heddle-workspace-notes/agent-memory/project-context.md` only when broader long-form context is needed
+7. `../heddle-workspace-notes/analysis/` and `../heddle-workspace-notes/task-plans/` as supporting historical context only
 
 For first-run situation awareness, do not stop after reading high-level memory summaries. Before answering capability-depth questions such as "what is this project?", "how does Heddle work?", or "what can it really do?", inspect the implementation path named by `agent-memory/README.md` and `current-state/project-summary.md`. The sibling notes explain intent and current state; the live code is the source of truth for actual capability depth.
 
@@ -55,6 +59,7 @@ For first-run situation awareness, do not stop after reading high-level memory s
 - Prefer `docs/agent-context.md` for stable shared workflow instructions inside this repo.
 - Prefer `../heddle-workspace-notes/agent-memory/` for evolving cross-session memory, project-state notes, and reminders primarily meant for future agents rather than end users.
 - Prefer focused files under `../heddle-workspace-notes/agent-memory/current-state/` for active workstream handoff notes instead of putting every update only into `project-context.md`.
+- Use `../heddle-workspace-notes/agent-memory/workflows/feature-prd-to-technical-plan.md` for broad feature/refactor planning and for the worker/reviewer loop after a technical plan exists.
 - When the user asks to "note this down" or preserve working context, update the most appropriate file in `../heddle-workspace-notes/agent-memory/` unless the information is better treated as stable repo guidance in this repo.
 - After meaningful implementation progress, update the relevant task plan, the focused `current-state/` file if one exists, and `../heddle-workspace-notes/agent-memory/project-context.md` if the broader project summary changed.
 - Keep agent-memory entries concrete: current repo state, what changed, what remains, verification status, and the next recommended step.


### PR DESCRIPTION
## Summary

- Add a root `LICENSE` file containing the MIT License text.
- Update the README license section to point readers to the license file.
- Document the feature PRD to technical plan workflow in `docs/agent-context.md` so future agents know when to consult it.

## Impact

This keeps Heddle's published package metadata and user-facing repository documentation aligned around MIT licensing, while also preserving the current agent workflow guidance that was already staged locally.

## Validation

- Searched the README, docs, package metadata, and LICENSE file for stale Apache references.
- Reviewed the staged `docs/agent-context.md` diff before including it in the PR.
- Confirmed the PR branch now contains both the MIT license update and the agent context documentation update.