### PR TITLE
Support reasoning effort for reasoning models

### DIFF
--- a/src/__tests__/chat/chat-storage.test.ts
+++ b/src/__tests__/chat/chat-storage.test.ts
@@ -108,6 +108,34 @@ describe('chat session storage layout', () => {
     }));
   });
 
+  it('persists reasoning effort in catalog and per-session storage when configured', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-chat-storage-reasoning-'));
+    const sessionsFile = join(dir, 'chat-sessions.json');
+    const session = {
+      ...createChatSession({
+        id: 'session-1',
+        name: 'Session 1',
+        apiKeyPresent: true,
+        workspaceId: 'workspace-1',
+        reasoningEffort: 'high',
+      }),
+      model: 'gpt-5.5',
+    };
+
+    saveChatSessions(sessionsFile, [session]);
+
+    expect(readChatSessionCatalog(sessionsFile)[0]).toEqual(expect.objectContaining({
+      id: 'session-1',
+      model: 'gpt-5.5',
+      reasoningEffort: 'high',
+    }));
+    expect(readChatSession(sessionsFile, 'session-1', true)).toEqual(expect.objectContaining({
+      id: 'session-1',
+      model: 'gpt-5.5',
+      reasoningEffort: 'high',
+    }));
+  });
+
   it('does not rewrite unchanged session files when saving again', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'heddle-chat-storage-'));
     const sessionsFile = join(dir, 'chat-sessions.json');

--- a/src/__tests__/cli/local-commands.test.ts
+++ b/src/__tests__/cli/local-commands.test.ts
@@ -9,7 +9,9 @@ function createCommandArgs(overrides: Partial<Parameters<typeof runLocalCommand>
   return {
     prompt: '/help',
     activeModel: 'gpt-5.1-codex',
+    activeReasoningEffort: undefined,
     setActiveModel: vi.fn(),
+    setActiveReasoningEffort: vi.fn(),
     sessions: [],
     recentSessions: [],
     activeSessionId: 'session-1',
@@ -88,6 +90,55 @@ describe('runLocalCommand', () => {
       handled: true,
       kind: 'message',
       message: 'Switched model to gpt-5.4-mini',
+    });
+  });
+
+  it('sets reasoning effort for the current session via slash command', async () => {
+    const setActiveReasoningEffort = vi.fn();
+    const result = await runLocalCommand(createCommandArgs({
+      prompt: '/reasoning high',
+      activeModel: 'gpt-5.5',
+      setActiveReasoningEffort,
+    }));
+
+    expect(setActiveReasoningEffort).toHaveBeenCalledWith('high');
+    expect(result).toEqual({
+      handled: true,
+      kind: 'message',
+      message: 'Set reasoning effort to high for gpt-5.5.',
+    });
+  });
+
+  it('clears explicit reasoning effort back to default via slash command', async () => {
+    const setActiveReasoningEffort = vi.fn();
+    const result = await runLocalCommand(createCommandArgs({
+      prompt: '/reasoning default',
+      activeModel: 'gpt-5.4',
+      activeReasoningEffort: 'ultrahigh',
+      setActiveReasoningEffort,
+    }));
+
+    expect(setActiveReasoningEffort).toHaveBeenCalledWith(undefined);
+    expect(result).toEqual({
+      handled: true,
+      kind: 'message',
+      message: 'Cleared explicit reasoning effort for gpt-5.4. Effective default: medium.',
+    });
+  });
+
+  it('reports unsupported reasoning effort models clearly', async () => {
+    const setActiveReasoningEffort = vi.fn();
+    const result = await runLocalCommand(createCommandArgs({
+      prompt: '/reasoning high',
+      activeModel: 'claude-sonnet-4-6',
+      setActiveReasoningEffort,
+    }));
+
+    expect(setActiveReasoningEffort).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      handled: true,
+      kind: 'message',
+      message: 'Reasoning effort is not supported for model claude-sonnet-4-6.',
     });
   });
 
@@ -327,6 +378,10 @@ describe('runLocalCommand', () => {
       description: 'compact earlier session history for the next run',
     });
     expect(hints).toContainEqual({
+      command: '/reasoning',
+      description: 'show reasoning effort for the current session',
+    });
+    expect(hints).toContainEqual({
       command: '/drift',
       description: 'show CyberLoop semantic drift detection status',
     });
@@ -343,6 +398,7 @@ describe('runLocalCommand', () => {
   it('autocompletes command roots and subcommands with tab-friendly spacing', () => {
     expect(autocompleteLocalCommand('/m', 'session-1', [])).toBe('/model ');
     expect(autocompleteLocalCommand('/model s', 'session-1', [])).toBe('/model set ');
+    expect(autocompleteLocalCommand('/rea', 'session-1', [])).toBe('/reasoning ');
     expect(autocompleteLocalCommand('/session sw', 'session-1', [])).toBe('/session switch ');
   });
 

--- a/src/__tests__/core/openai-oauth.test.ts
+++ b/src/__tests__/core/openai-oauth.test.ts
@@ -171,6 +171,30 @@ describe('OpenAI OAuth helpers', () => {
     );
   });
 
+  it('rejects reasoning effort for unsupported models', async () => {
+    const adapter = createOpenAiAdapter({
+      model: 'claude-sonnet-4-6',
+      reasoningEffort: 'high',
+      credential: {
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 120_000,
+        accountId: 'account-123',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      },
+      fetchImpl: (async () => {
+        throw new Error('fetch should not be called');
+      }) as typeof fetch,
+    });
+
+    await expect(adapter.chat([{ role: 'user', content: 'hello' }], [])).rejects.toThrow(
+      'OpenAI Responses reasoning effort is not supported for model claude-sonnet-4-6.',
+    );
+  });
+
   it('fails clearly before routing gpt-5.1-codex-mini through account sign-in', async () => {
     const adapter = createOpenAiAdapter({
       model: 'gpt-5.1-codex-mini',
@@ -223,17 +247,45 @@ describe('OpenAI OAuth helpers', () => {
     const body = JSON.parse(requests[0]?.body ?? '{}') as {
       model?: string;
       store?: boolean;
-      reasoning?: { summary?: string };
+      reasoning?: { effort?: string; summary?: string };
       instructions?: string;
       input?: Array<{ type?: string; role?: string; content?: string }>;
     };
     expect(body.model).toBe('gpt-5.4');
     expect(body.store).toBe(false);
     expect(body.reasoning?.summary).toBe('auto');
+    expect(body.reasoning?.effort).toBe('medium');
     expect(body.instructions).toBe('You are Heddle. Reply with OK only.');
     expect(body.input).toEqual([
       { type: 'message', role: 'user', content: 'hello' },
     ]);
+  });
+
+  it('sends explicit reasoning effort when configured for a supported model', async () => {
+    const requests: Array<{ url: string; body: string }> = [];
+    const adapter = createOpenAiAdapter({
+      model: 'gpt-5.5',
+      reasoningEffort: 'high',
+      credential: {
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 120_000,
+        accountId: 'account-123',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      },
+      fetchImpl: (async (url, init) => {
+        requests.push({ url: String(url), body: String((init as RequestInit | undefined)?.body ?? '') });
+        return new Response('bad request', { status: 400 });
+      }) as typeof fetch,
+    });
+
+    await expect(adapter.chat([{ role: 'user', content: 'hello' }], [])).rejects.toThrow();
+
+    const body = JSON.parse(requests[0]?.body ?? '{}') as { reasoning?: { effort?: string } };
+    expect(body.reasoning?.effort).toBe('high');
   });
 
   it('reconstructs tool calls from streamed Codex OAuth events when final response output is empty', async () => {

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -37,6 +37,7 @@ export function App({ runtime }: { runtime: ChatRuntimeConfig }) {
 function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
   const nextLocalId = useLocalIds();
   const [activeModel, setActiveModel] = useState(runtime.model);
+  const [activeReasoningEffort, setActiveReasoningEffort] = useState(runtime.reasoningEffort);
   const {
     draft,
     setDraft,
@@ -57,6 +58,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     updateSessionById,
     updateActiveSession,
     setSessionModel,
+    setSessionReasoningEffort,
     createSession: createSessionWithDefaultModel,
     renameSession,
     removeSession,
@@ -125,6 +127,10 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
       setSessionModel(activeSession.id, activeModel);
     }
 
+    if (activeSession.reasoningEffort !== activeReasoningEffort) {
+      setSessionReasoningEffort(activeSession.id, activeReasoningEffort);
+    }
+
     const previousModel = previousActiveModelRef.current;
     previousActiveModelRef.current = activeModel;
     if (previousModel === activeModel) {
@@ -181,7 +187,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
       }));
       setStatus('Idle');
     });
-  }, [activeModel, activeSession, runtime.providerCredentialSource, runtime.stateRoot, runtime.systemContext, setStatus, setSessionModel, updateSessionById]);
+  }, [activeModel, activeReasoningEffort, activeSession, runtime.providerCredentialSource, runtime.stateRoot, runtime.systemContext, setSessionModel, setSessionReasoningEffort, setStatus, updateSessionById]);
 
   const messages = useMemo(() => activeSession?.messages ?? [], [activeSession?.messages]);
   const sessionTitleModel = resolveSystemSelectedModel({
@@ -194,6 +200,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     compacting,
     contextStatus,
     authStatus,
+    reasoningStatus,
     sessionFooter,
     renderedStatus,
     statusHint,
@@ -314,6 +321,13 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     }
   }, [activeSession, setSessionModel]);
 
+  const applyActiveReasoningEffort = useCallback((reasoningEffort: typeof activeReasoningEffort) => {
+    setActiveReasoningEffort(reasoningEffort);
+    if (activeSession && activeSession.reasoningEffort !== reasoningEffort) {
+      setSessionReasoningEffort(activeSession.id, reasoningEffort);
+    }
+  }, [activeReasoningEffort, activeSession, setSessionReasoningEffort]);
+
   const closeSession = (id: string) => {
     const removedActive = removeSession(id);
     if (removedActive) {
@@ -338,7 +352,9 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
   const { pendingSubmittedPrompt, clearPendingSubmittedPrompt, submitPrompt } = usePromptSubmission({
     runtime,
     activeModel,
+    activeReasoningEffort,
     setActiveModel: applyActiveModel,
+    setActiveReasoningEffort: applyActiveReasoningEffort,
     sessions,
     recentSessions,
     activeSessionId,
@@ -467,7 +483,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
           </>}
       </Box>
       <Text>
-        <Text dimColor>{`model=${activeModel} • ${authStatus} • ${contextStatus} • `}</Text>
+        <Text dimColor>{`model=${activeModel} • ${reasoningStatus} • ${authStatus} • ${contextStatus} • `}</Text>
         <Text color={drift.color} dimColor={!drift.color}>{`drift=${drift.footer}`}</Text>
         <Text dimColor>{` • ${sessionFooter}`}</Text>
       </Text>

--- a/src/cli/chat/hooks/useChatSessions.ts
+++ b/src/cli/chat/hooks/useChatSessions.ts
@@ -106,6 +106,15 @@ export function useChatSessions({ sessionCatalogFile, apiKeyPresent, defaultMode
     ));
   }, [updateSessionById]);
 
+  const setSessionReasoningEffort = useCallback((
+    sessionId: string,
+    reasoningEffort: ChatSession['reasoningEffort'],
+  ) => {
+    updateSessionById(sessionId, (session) => (
+      session.reasoningEffort === reasoningEffort ? session : { ...session, reasoningEffort }
+    ));
+  }, [updateSessionById]);
+
   const createSession = useCallback((name?: string, model = defaultModel) => {
     const id = `session-${Date.now()}`;
     const nextSession = createChatSession({
@@ -163,6 +172,7 @@ export function useChatSessions({ sessionCatalogFile, apiKeyPresent, defaultMode
     updateSessionById,
     updateActiveSession,
     setSessionModel,
+    setSessionReasoningEffort,
     createSession,
     renameSession,
     removeSession,

--- a/src/cli/chat/hooks/useChatStatusSummary.ts
+++ b/src/cli/chat/hooks/useChatStatusSummary.ts
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
+import { resolveDefaultReasoningEffort, supportsReasoningEffort } from '../../../core/llm/model-policy.js';
 import { estimateBuiltInContextWindow } from '../../../core/llm/openai-models.js';
 import type { ProviderCredentialSource } from '../utils/runtime.js';
 import type { ResolvedRuntimeHost } from '../../../core/runtime/runtime-hosts.js';
 import { currentActivityText } from '../utils/format.js';
 import type { ApprovalChoice, LiveEvent, PendingApproval } from '../state/types.js';
 import type { PlanItem } from '../../../core/tools/update-plan.js';
+import type { ReasoningEffort } from '../../../core/llm/types.js';
 
 type ActiveTurnSummary = {
   title: string;
@@ -23,6 +25,7 @@ export function useChatStatusSummary(args: {
   activeSession?: {
     id: string;
     name: string;
+    reasoningEffort?: ReasoningEffort;
     context?: {
       compactionStatus?: 'idle' | 'running' | 'failed';
       lastRunInputTokens?: number;
@@ -62,6 +65,7 @@ export function useChatStatusSummary(args: {
       args.activeSession?.context?.lastRunInputTokens ?? args.activeSession?.context?.estimatedRequestTokens,
     );
     const authStatus = formatAuthStatus(args.credentialSource);
+    const reasoningStatus = formatReasoningStatus(args.activeModel, args.activeSession?.reasoningEffort);
     const sessionFooter = `session=${args.activeSession?.id ?? args.activeSessionId}${args.activeSession?.name ? ` (${args.activeSession.name})` : ''}`;
     const renderedStatus =
       args.pendingApproval ? 'awaiting approval'
@@ -112,6 +116,7 @@ export function useChatStatusSummary(args: {
       activityText,
       contextStatus,
       authStatus,
+      reasoningStatus,
       sessionFooter,
       renderedStatus,
       statusHint,
@@ -135,6 +140,18 @@ function formatContextStatus(model: string, estimatedTokens: number | undefined)
   const ratio = Math.min(1, estimatedTokens / window);
   const percent = Math.round(ratio * 100);
   return `estimated input ${estimatedTokens.toLocaleString()} / ${window.toLocaleString()} tokens (${percent}%)`;
+}
+
+function formatReasoningStatus(model: string, configuredEffort: ReasoningEffort | undefined): string {
+  if (!supportsReasoningEffort(model)) {
+    return 'reasoning=unsupported';
+  }
+
+  if (configuredEffort) {
+    return `reasoning=${configuredEffort}`;
+  }
+
+  return `reasoning=default(${resolveDefaultReasoningEffort(model) ?? 'none'})`;
 }
 
 function formatAuthStatus(source: ProviderCredentialSource): string {

--- a/src/cli/chat/hooks/usePromptSubmission.ts
+++ b/src/cli/chat/hooks/usePromptSubmission.ts
@@ -10,7 +10,9 @@ type ActiveSessionUpdater = (updater: (session: ChatSession) => ChatSession) => 
 export function usePromptSubmission({
   runtime,
   activeModel,
+  activeReasoningEffort,
   setActiveModel,
+  setActiveReasoningEffort,
   sessions,
   recentSessions,
   activeSessionId,
@@ -41,7 +43,9 @@ export function usePromptSubmission({
 }: {
   runtime: ChatRuntimeConfig;
   activeModel: string;
+  activeReasoningEffort?: ChatSession['reasoningEffort'];
   setActiveModel: (model: string) => void;
+  setActiveReasoningEffort: (effort: ChatSession['reasoningEffort']) => void;
   sessions: ChatSession[];
   recentSessions: ChatSession[];
   activeSessionId: string;
@@ -147,7 +151,9 @@ export function usePromptSubmission({
     const submitArgs = {
       isRunning: effectiveIsRunning,
       activeModel,
+      activeReasoningEffort,
       setActiveModel,
+      setActiveReasoningEffort,
       sessions,
       recentSessions,
       activeSessionId,
@@ -208,7 +214,9 @@ export function usePromptSubmission({
     pendingApproval,
     pendingSubmittedPrompt,
     activeModel,
+    activeReasoningEffort,
     setActiveModel,
+    setActiveReasoningEffort,
     sessions,
     recentSessions,
     activeSessionId,

--- a/src/cli/chat/state/local-commands.ts
+++ b/src/cli/chat/state/local-commands.ts
@@ -3,7 +3,8 @@ import { summarizeSession } from './storage.js';
 import { formatAuthStatusMessage, loginProviderWithOAuth, logoutProvider } from '../../auth.js';
 import type { OpenAiOAuthCredential } from '../../../core/auth/openai-oauth.js';
 import { COMMON_BUILT_IN_MODELS, formatBuiltInModelGroups } from '../../../core/llm/openai-models.js';
-import type { LlmProvider } from '../../../core/llm/types.js';
+import { resolveDefaultReasoningEffort, supportsReasoningEffort } from '../../../core/llm/model-policy.js';
+import type { LlmProvider, ReasoningEffort } from '../../../core/llm/types.js';
 import { createFileHeartbeatTaskStore } from '../../../core/runtime/heartbeat-task-store.js';
 import { join } from 'node:path';
 
@@ -15,7 +16,9 @@ export type LocalCommandHint = {
 export type LocalCommandArgs = {
   prompt: string;
   activeModel: string;
+  activeReasoningEffort?: ReasoningEffort;
   setActiveModel: (model: string) => void;
+  setActiveReasoningEffort: (effort: ReasoningEffort | undefined) => void;
   sessions: ChatSession[];
   recentSessions: ChatSession[];
   activeSessionId: string;
@@ -47,6 +50,9 @@ const HELP_HINTS: LocalCommandHint[] = [
   { command: '/model <name>', description: 'switch the current model' },
   { command: '/model set [query]', description: 'pick a model with filtering' },
   { command: '/model list', description: 'list common built-in models' },
+  { command: '/reasoning', description: 'show reasoning effort for the current session' },
+  { command: '/reasoning <level>', description: 'set reasoning effort to low, medium, high, or ultrahigh' },
+  { command: '/reasoning default', description: 'clear explicit reasoning effort and use the model default' },
   { command: '/auth', description: 'show stored provider credentials' },
   { command: '/auth status', description: 'show stored provider credentials' },
   { command: '/auth login openai', description: 'sign in with OpenAI ChatGPT/Codex OAuth' },
@@ -91,6 +97,7 @@ const EXACT_COMMANDS = new Map<string, ExactCommandHandler>([
   ['/model list', () => messageResult(MODEL_LIST_MESSAGE)],
   ['/model', (args) => messageResult(`Current model: ${args.activeModel}`)],
   ['/model set', () => messageResult(MODEL_SET_HELP_MESSAGE)],
+  ['/reasoning', (args) => messageResult(formatReasoningEffortStatus(args.activeModel, args.activeReasoningEffort))],
   ['/auth', (args) => messageResult(formatAuthStatusMessage(args.credentialStorePath))],
   ['/auth status', (args) => messageResult(formatAuthStatusMessage(args.credentialStorePath))],
   ['/clear', (args) => {
@@ -123,6 +130,7 @@ const EXACT_COMMANDS = new Map<string, ExactCommandHandler>([
 
 const PREFIX_COMMANDS: Array<{ prefix: string; handle: PrefixCommandHandler }> = [
   { prefix: '/model ', handle: handleModelCommand },
+  { prefix: '/reasoning ', handle: handleReasoningCommand },
   { prefix: '/auth login ', handle: handleAuthLogin },
   { prefix: '/auth logout ', handle: handleAuthLogout },
   { prefix: '/heartbeat task ', handle: handleHeartbeatTask },
@@ -257,6 +265,31 @@ function handleModelCommand(args: LocalCommandArgs, value: string): LocalCommand
       `Switched model to ${value}`
     : `Switched model to ${value}. This name is not in Heddle's common shortlist, so the next API call will fail if the provider does not recognize it.`,
   );
+}
+
+function handleReasoningCommand(args: LocalCommandArgs, value: string): LocalCommandResult {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return messageResult(formatReasoningEffortStatus(args.activeModel, args.activeReasoningEffort));
+  }
+
+  if (normalized === 'default') {
+    args.setActiveReasoningEffort(undefined);
+    return messageResult(
+      `Cleared explicit reasoning effort for ${args.activeModel}. Effective default: ${resolveDefaultReasoningEffort(args.activeModel) ?? 'not supported'}.`,
+    );
+  }
+
+  if (!isReasoningEffort(normalized)) {
+    return messageResult('Usage: /reasoning <low|medium|high|ultrahigh|default>');
+  }
+
+  if (!supportsReasoningEffort(args.activeModel)) {
+    return messageResult(`Reasoning effort is not supported for model ${args.activeModel}.`);
+  }
+
+  args.setActiveReasoningEffort(normalized);
+  return messageResult(`Set reasoning effort to ${normalized} for ${args.activeModel}.`);
 }
 
 async function handleAuthLogin(args: LocalCommandArgs, value: string): Promise<LocalCommandResult> {
@@ -397,6 +430,23 @@ async function resolveHeartbeatRun(
   }
   const run = await store.loadRunRecord?.(runRef);
   return run?.taskId === taskId ? run : undefined;
+}
+
+function formatReasoningEffortStatus(model: string, explicitEffort: ReasoningEffort | undefined): string {
+  const supported = supportsReasoningEffort(model);
+  const effective = explicitEffort ?? resolveDefaultReasoningEffort(model);
+  return [
+    `Current model: ${model}`,
+    `Reasoning effort support: ${supported ? 'supported' : 'unsupported'}`,
+    `Configured effort: ${explicitEffort ?? 'default'}`,
+    `Effective effort: ${effective ?? 'none'}`,
+    '',
+    'Use /reasoning <low|medium|high|ultrahigh|default> to update this session.',
+  ].join('\n');
+}
+
+function isReasoningEffort(value: string): value is ReasoningEffort {
+  return value === 'low' || value === 'medium' || value === 'high' || value === 'ultrahigh';
 }
 
 function formatHeartbeatTask(task: Awaited<ReturnType<ReturnType<typeof heartbeatStore>['listTasks']>>[number]): string {

--- a/src/cli/chat/submit.ts
+++ b/src/cli/chat/submit.ts
@@ -15,7 +15,9 @@ type SubmitChatPromptArgs = {
   value: string;
   isRunning: boolean;
   activeModel: string;
+  activeReasoningEffort?: ChatSession['reasoningEffort'];
   setActiveModel: (model: string) => void;
+  setActiveReasoningEffort: (effort: ChatSession['reasoningEffort']) => void;
   sessions: ChatSession[];
   recentSessions: ChatSession[];
   activeSessionId: string;
@@ -57,7 +59,9 @@ export async function submitChatPrompt(args: SubmitChatPromptArgs): Promise<void
   const commandResult = await runLocalCommand({
     prompt,
     activeModel: args.activeModel,
+    activeReasoningEffort: args.activeReasoningEffort,
     setActiveModel: args.setActiveModel,
+    setActiveReasoningEffort: args.setActiveReasoningEffort,
     sessions: args.sessions,
     recentSessions: args.recentSessions,
     activeSessionId: args.activeSessionId,

--- a/src/cli/chat/utils/runtime.ts
+++ b/src/cli/chat/utils/runtime.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'node:path';
-import { appendMemoryCatalogSystemContext, DEFAULT_OPENAI_MODEL, inferProviderFromModel } from '../../../index.js';
+import { appendMemoryCatalogSystemContext, DEFAULT_OPENAI_MODEL, inferProviderFromModel, type ReasoningEffort } from '../../../index.js';
 import { saveTrace } from '../../../core/chat/trace.js';
 import type { LlmProvider } from '../../../index.js';
 import type { ResolvedRuntimeHost } from '../../../core/runtime/runtime-hosts.js';
@@ -16,6 +16,7 @@ import { parsePositiveInt } from './format.js';
 
 export type ChatCliOptions = {
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   maxSteps?: number;
   apiKey?: string;
   preferApiKey?: boolean;
@@ -30,6 +31,7 @@ export type ChatCliOptions = {
 
 export type ChatRuntimeConfig = {
   model: string;
+  reasoningEffort?: ReasoningEffort;
   maxSteps: number;
   apiKey?: string;
   apiKeyProvider?: LlmProvider | 'explicit';
@@ -84,6 +86,7 @@ export function resolveChatRuntimeConfig(options: ChatCliOptions): ChatRuntimeCo
 
   return {
     model,
+    reasoningEffort: options.reasoningEffort,
     maxSteps: options.maxSteps ?? parsePositiveInt(process.env.HEDDLE_MAX_STEPS) ?? 100,
     apiKey,
     apiKeyProvider,

--- a/src/core/chat/ordinary-turn.ts
+++ b/src/core/chat/ordinary-turn.ts
@@ -77,7 +77,12 @@ export async function executeOrdinaryChatTurn(args: ExecuteOrdinaryChatTurnArgs)
     ownerId: `submit-${process.pid}`,
     clientLabel: 'another Heddle client',
   };
-  const llm = createLlmAdapter({ model, apiKey, credentialStorePath: args.credentialStorePath });
+  const llm = createLlmAdapter({
+    model,
+    apiKey,
+    credentialStorePath: args.credentialStorePath,
+    reasoningEffort: session.reasoningEffort,
+  });
   const memoryDir = join(args.stateRoot, 'memory');
   const systemContext = appendMemoryCatalogSystemContext({
     systemContext: args.systemContext,

--- a/src/core/chat/storage.ts
+++ b/src/core/chat/storage.ts
@@ -11,6 +11,7 @@ type ChatSessionCatalogEntry = {
   createdAt: string;
   updatedAt: string;
   model?: string;
+  reasoningEffort?: import('../llm/types.js').ReasoningEffort;
   driftEnabled?: boolean;
   lastContinuePrompt?: string;
   context?: ChatContextStats;
@@ -47,6 +48,7 @@ export function createChatSession(options: {
   name: string;
   apiKeyPresent: boolean;
   model?: string;
+  reasoningEffort?: import('../llm/types.js').ReasoningEffort;
   workspaceId?: string;
 }): ChatSession {
   const now = new Date().toISOString();
@@ -60,6 +62,7 @@ export function createChatSession(options: {
     createdAt: now,
     updatedAt: now,
     model: options.model,
+    reasoningEffort: options.reasoningEffort,
     driftEnabled: false,
     lastContinuePrompt: undefined,
     context: undefined,
@@ -251,6 +254,13 @@ function parseCatalogEntry(value: unknown): ChatSessionCatalogEntry[] {
     createdAt,
     updatedAt,
     model: typeof candidate.model === 'string' ? candidate.model : undefined,
+    reasoningEffort:
+      candidate.reasoningEffort === 'low'
+      || candidate.reasoningEffort === 'medium'
+      || candidate.reasoningEffort === 'high'
+      || candidate.reasoningEffort === 'ultrahigh' ?
+        candidate.reasoningEffort
+      : undefined,
     driftEnabled: typeof candidate.driftEnabled === 'boolean' ? candidate.driftEnabled : false,
     lastContinuePrompt: typeof candidate.lastContinuePrompt === 'string' ? candidate.lastContinuePrompt : undefined,
     context: isChatContextStats(candidate.context) ? candidate.context : undefined,
@@ -267,6 +277,7 @@ function projectCatalogEntry(session: ChatSession): ChatSessionCatalogEntry {
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
     model: session.model,
+    reasoningEffort: session.reasoningEffort,
     driftEnabled: session.driftEnabled,
     lastContinuePrompt: session.lastContinuePrompt,
     context: session.context,
@@ -299,6 +310,7 @@ function readSessionFile(
       createdAt: entry.createdAt,
       updatedAt: entry.updatedAt,
       model: entry.model,
+      reasoningEffort: entry.reasoningEffort,
       driftEnabled: entry.driftEnabled,
       lastContinuePrompt: entry.lastContinuePrompt,
       context: entry.context,

--- a/src/core/chat/types.ts
+++ b/src/core/chat/types.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, ToolCall, ToolDefinition } from '../../index.js';
+import type { ReasoningEffort } from '../llm/types.js';
 import type { EditFilePreview } from '../tools/edit-file.js';
 
 export type TurnSummary = {
@@ -76,6 +77,7 @@ export type ChatSession = {
   createdAt: string;
   updatedAt: string;
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   driftEnabled?: boolean;
   lastContinuePrompt?: string;
   context?: ChatContextStats;

--- a/src/core/llm/factory.ts
+++ b/src/core/llm/factory.ts
@@ -6,7 +6,7 @@
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_LLM_PROVIDER, DEFAULT_OPENAI_MODEL } from '../config.js';
 import { createAnthropicAdapter } from './anthropic.js';
 import { createOpenAiAdapter } from './openai.js';
-import type { LlmAdapter, LlmProvider } from './types.js';
+import type { LlmAdapter, LlmProvider, ReasoningEffort } from './types.js';
 import { inferProviderFromModel } from './providers.js';
 import type { StoredProviderCredential } from '../auth/provider-credentials.js';
 import { resolveOAuthCredentialForModel } from '../runtime/api-keys.js';
@@ -17,6 +17,7 @@ export type CreateLlmAdapterOptions = {
   apiKey?: string;
   credential?: StoredProviderCredential;
   credentialStorePath?: string;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export function createLlmAdapter(options: CreateLlmAdapterOptions = {}): LlmAdapter {
@@ -37,6 +38,7 @@ export function createLlmAdapter(options: CreateLlmAdapterOptions = {}): LlmAdap
         model,
         credential,
         credentialStorePath: options.credentialStorePath,
+        reasoningEffort: options.reasoningEffort,
       });
     case 'anthropic':
       return createAnthropicAdapter({

--- a/src/core/llm/model-policy.ts
+++ b/src/core/llm/model-policy.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from '../config.js';
 import type { ProviderCredentialSource } from '../runtime/api-keys.js';
 import { isOpenAiAccountSignInModel, OPENAI_ACCOUNT_SIGN_IN_MODELS } from './openai-models.js';
-import type { LlmProvider } from './types.js';
+import type { LlmProvider, ReasoningEffort } from './types.js';
 
 export type SystemModelPurpose = 'chat-compaction' | 'session-title';
 export type ModelCredentialMode = 'api-key' | 'oauth' | 'missing';
@@ -71,6 +71,47 @@ export function assertModelCredentialCompatibility(args: {
   if (!result.ok) {
     throw new Error(result.error);
   }
+}
+
+export function validateReasoningEffortCompatibility(args: {
+  model: string;
+  provider: LlmProvider;
+  reasoningEffort?: ReasoningEffort;
+  usageLabel?: string;
+}): { ok: true } | { ok: false; error: string } {
+  if (!args.reasoningEffort) {
+    return { ok: true };
+  }
+
+  if (args.provider !== 'openai' || !supportsReasoningEffort(args.model)) {
+    return {
+      ok: false,
+      error: `${args.usageLabel ? `${args.usageLabel} ` : ''}reasoning effort is not supported for model ${args.model}.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export function assertReasoningEffortCompatibility(args: {
+  model: string;
+  provider: LlmProvider;
+  reasoningEffort?: ReasoningEffort;
+  usageLabel?: string;
+}) {
+  const result = validateReasoningEffortCompatibility(args);
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+}
+
+export function supportsReasoningEffort(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return normalized.startsWith('gpt-5') || normalized.startsWith('o3') || normalized.startsWith('o4');
+}
+
+export function resolveDefaultReasoningEffort(model: string): ReasoningEffort | undefined {
+  return supportsReasoningEffort(model) ? 'medium' : undefined;
 }
 
 export function resolveOpenAiOAuthImageCandidateModels(activeModel: string): string[] {

--- a/src/core/llm/openai.ts
+++ b/src/core/llm/openai.ts
@@ -10,8 +10,9 @@ import type {
   Response as OpenAiResponse,
   ResponseStreamEvent,
 } from 'openai/resources/responses/responses.js';
+import type { ReasoningEffort as OpenAiReasoningEffort } from 'openai/resources/shared.js';
 import type { Fetch as OpenAiFetch } from 'openai/core.js';
-import type { LlmAdapter, ChatMessage, LlmResponse, LlmAdapterCapabilities, LlmUsage, LlmStreamEvent } from './types.js';
+import type { LlmAdapter, ChatMessage, LlmResponse, LlmAdapterCapabilities, LlmUsage, LlmStreamEvent, ReasoningEffort } from './types.js';
 import type { AssistantDiagnostics, ToolDefinition, ToolCall } from '../types.js';
 import { DEFAULT_OPENAI_MODEL } from '../config.js';
 import {
@@ -23,7 +24,7 @@ import {
   setStoredProviderCredential,
   type StoredProviderCredential,
 } from '../auth/provider-credentials.js';
-import { assertModelCredentialCompatibility } from './model-policy.js';
+import { assertModelCredentialCompatibility, assertReasoningEffortCompatibility, resolveDefaultReasoningEffort } from './model-policy.js';
 
 export type OpenAiAdapterOptions = {
   apiKey?: string;
@@ -31,6 +32,7 @@ export type OpenAiAdapterOptions = {
   credential?: StoredProviderCredential;
   credentialStorePath?: string;
   fetchImpl?: CompatibleFetch;
+  reasoningEffort?: ReasoningEffort;
 };
 
 type CompatibleFetch = (url: unknown, init?: unknown) => Promise<globalThis.Response>;
@@ -69,6 +71,13 @@ export function createOpenAiAdapter(options: OpenAiAdapterOptions = {}): LlmAdap
       signal?: AbortSignal,
       onStreamEvent?: (event: LlmStreamEvent) => void,
     ): Promise<LlmResponse> {
+      assertReasoningEffortCompatibility({
+        model,
+        provider: 'openai',
+        reasoningEffort: options.reasoningEffort,
+        usageLabel: 'OpenAI Responses',
+      });
+
       if (oauthCredential) {
         assertModelCredentialCompatibility({
           model,
@@ -81,6 +90,7 @@ export function createOpenAiAdapter(options: OpenAiAdapterOptions = {}): LlmAdap
         model,
         tools,
         oauthMode: Boolean(oauthCredential),
+        reasoningEffort: options.reasoningEffort,
       });
       const stream = await client.responses.stream({
         ...request,
@@ -390,13 +400,14 @@ function buildOpenAiResponsesRequest(
     model: string;
     tools: ToolDefinition[];
     oauthMode: boolean;
+    reasoningEffort?: ReasoningEffort;
   },
 ): {
   model: string;
   input: ResponseInputItem[];
   tools?: FunctionTool[];
   store: boolean;
-  reasoning: { summary: 'auto' | 'detailed' };
+  reasoning: { effort?: OpenAiReasoningEffort; summary: 'auto' | 'detailed' };
   instructions?: string;
 } {
   const systemMessages = options.oauthMode ? messages.filter((message): message is Extract<ChatMessage, { role: 'system' }> => message.role === 'system') : [];
@@ -412,10 +423,19 @@ function buildOpenAiResponsesRequest(
     tools: options.tools.length > 0 ? options.tools.map(toResponseTool) : undefined,
     store: false,
     reasoning: {
+      effort: mapReasoningEffort(options.reasoningEffort ?? resolveDefaultReasoningEffort(options.model)),
       summary: options.oauthMode ? 'auto' : 'detailed',
     },
     ...(instructions ? { instructions } : {}),
   };
+}
+
+function mapReasoningEffort(effort: ReasoningEffort | undefined): OpenAiReasoningEffort | undefined {
+  if (!effort) {
+    return undefined;
+  }
+
+  return effort === 'ultrahigh' ? 'high' : effort;
 }
 
 function toResponseInputItems(msg: ChatMessage): ResponseInputItem[] {

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -9,6 +9,7 @@ export type LlmStreamEvent =
   | { type: 'content.done'; content: string };
 
 export type LlmProvider = 'openai' | 'anthropic' | 'google';
+export type ReasoningEffort = 'low' | 'medium' | 'high' | 'ultrahigh';
 
 export type LlmAdapterCapabilities = {
   toolCalls: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,7 @@ export type {
   LlmAdapterCapabilities,
   LlmAdapterInfo,
   LlmUsage,
+  ReasoningEffort,
 } from './core/llm/types.js';
 export { createLlmAdapter, inferProviderFromModel, resolveLlmProvider } from './core/llm/factory.js';
 export type { CreateLlmAdapterOptions } from './core/llm/factory.js';

--- a/src/server/features/control-plane/router.ts
+++ b/src/server/features/control-plane/router.ts
@@ -42,9 +42,12 @@ const sessionInputSchema = z.object({
   preferApiKey: z.boolean().optional(),
 });
 
+const reasoningEffortSchema = z.enum(['low', 'medium', 'high', 'ultrahigh']);
+
 const createSessionInputSchema = z.object({
   name: z.string().min(1).optional(),
   model: z.string().min(1).optional(),
+  reasoningEffort: reasoningEffortSchema.optional(),
   apiKeyPresent: z.boolean().optional(),
 }).optional();
 
@@ -81,6 +84,7 @@ const sessionApprovalDecisionSchema = z.object({
 const sessionSettingsInputSchema = z.object({
   id: z.string().min(1),
   model: z.string().min(1).optional(),
+  reasoningEffort: reasoningEffortSchema.optional(),
   driftEnabled: z.boolean().optional(),
 });
 
@@ -159,6 +163,7 @@ export const controlPlaneRouter = router({
       suggestedName: input?.name,
       workspaceId: ctx.activeWorkspace.id,
       model: input?.model,
+      reasoningEffort: input?.reasoningEffort,
       apiKeyPresent: input?.apiKeyPresent,
     });
   }),
@@ -175,6 +180,7 @@ export const controlPlaneRouter = router({
       sessionStoragePath: resolve(ctx.activeWorkspace.stateRoot, 'chat-sessions.catalog.json'),
       sessionId: input.id,
       model: input.model,
+      reasoningEffort: input.reasoningEffort,
       driftEnabled: input.driftEnabled,
     });
   }),

--- a/src/server/features/control-plane/services/chat-sessions.ts
+++ b/src/server/features/control-plane/services/chat-sessions.ts
@@ -49,6 +49,7 @@ export function createControlPlaneChatSession(args: {
   workspaceId?: string;
   model?: string;
   apiKeyPresent?: boolean;
+  reasoningEffort?: import('../../../../core/llm/types.js').ReasoningEffort;
 }): ChatSessionDetail {
   const existing = readChatSessionViews(args.sessionStoragePath);
   const nextNumber = existing.length + 1;
@@ -58,6 +59,7 @@ export function createControlPlaneChatSession(args: {
     name: args.suggestedName?.trim() || `Session ${nextNumber}`,
     apiKeyPresent: args.apiKeyPresent ?? hasProviderCredentialForModel(model),
     model,
+    reasoningEffort: args.reasoningEffort,
     workspaceId: args.workspaceId,
   });
 
@@ -72,6 +74,7 @@ export function updateControlPlaneChatSessionSettings(args: {
   sessionStoragePath: string;
   sessionId: string;
   model?: string;
+  reasoningEffort?: import('../../../../core/llm/types.js').ReasoningEffort;
   driftEnabled?: boolean;
 }): ChatSessionDetail {
   const currentSessions = readChatSessionCatalog(args.sessionStoragePath)
@@ -82,6 +85,7 @@ export function updateControlPlaneChatSessionSettings(args: {
       {
         ...session,
         model: args.model ?? session.model,
+        reasoningEffort: args.reasoningEffort ?? session.reasoningEffort,
         driftEnabled: args.driftEnabled ?? session.driftEnabled,
         updatedAt: new Date().toISOString(),
       }
@@ -385,6 +389,13 @@ export function projectChatSessionView(raw: unknown | ChatSession): ChatSessionV
     createdAt: readString(candidate.createdAt),
     updatedAt: readString(candidate.updatedAt),
     model: readString(candidate.model),
+    reasoningEffort:
+      candidate.reasoningEffort === 'low'
+      || candidate.reasoningEffort === 'medium'
+      || candidate.reasoningEffort === 'high'
+      || candidate.reasoningEffort === 'ultrahigh' ?
+        candidate.reasoningEffort
+      : undefined,
     driftEnabled: typeof candidate.driftEnabled === 'boolean' ? candidate.driftEnabled : undefined,
     driftLevel: readLatestDriftLevel(turns),
     messageCount: messages.length,

--- a/src/server/features/control-plane/types.ts
+++ b/src/server/features/control-plane/types.ts
@@ -5,6 +5,7 @@ import type { WorkspaceDescriptor } from '../../../core/runtime/workspaces.js';
 import type { MemoryStatusView } from '../../../core/memory/visibility.js';
 import type { ReviewDiffFile } from '../../../core/review/diff-domain.js';
 import type { ProviderCredentialSource } from '../../../core/runtime/api-keys.js';
+import type { ReasoningEffort } from '../../../core/llm/types.js';
 
 export type ChatSessionView = {
   id: string;
@@ -13,6 +14,7 @@ export type ChatSessionView = {
   createdAt?: string;
   updatedAt?: string;
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   driftEnabled?: boolean;
   driftLevel?: 'unknown' | 'low' | 'medium' | 'high';
   messageCount: number;

--- a/src/web/features/control-plane/hooks/useSessionsScreenState.ts
+++ b/src/web/features/control-plane/hooks/useSessionsScreenState.ts
@@ -39,7 +39,7 @@ export type SessionsScreenState = {
   createSession: () => Promise<void>;
   continueSession: () => Promise<void>;
   cancelSessionRun: () => Promise<void>;
-  updateSessionSettings: (settings: { model?: string; driftEnabled?: boolean }) => Promise<void>;
+  updateSessionSettings: (settings: { model?: string; reasoningEffort?: 'low' | 'medium' | 'high' | 'ultrahigh'; driftEnabled?: boolean }) => Promise<void>;
   pendingApproval: PendingSessionApproval;
   resolveApproval: (approved: boolean) => Promise<void>;
   selectedTurnId?: string;
@@ -661,7 +661,7 @@ export function useSessionsScreenState(
     }
   }, [notify, removeLiveStatusMessage, runInFlight, selectedSessionId]);
 
-  const updateSessionSettings = useCallback(async (settings: { model?: string; driftEnabled?: boolean }) => {
+  const updateSessionSettings = useCallback(async (settings: { model?: string; reasoningEffort?: 'low' | 'medium' | 'high' | 'ultrahigh'; driftEnabled?: boolean }) => {
     if (!selectedSessionId || runInFlight || sendingPrompt) {
       return;
     }
@@ -673,6 +673,7 @@ export function useSessionsScreenState(
         title: 'Session settings updated',
         body: [
           settings.model ? `model ${settings.model}` : undefined,
+          settings.reasoningEffort ? `reasoning ${settings.reasoningEffort}` : undefined,
           typeof settings.driftEnabled === 'boolean' ? `drift ${settings.driftEnabled ? 'on' : 'off'}` : undefined,
         ].filter(Boolean).join(', '),
         tone: 'success',

--- a/src/web/features/control-plane/screens/SessionsScreen.tsx
+++ b/src/web/features/control-plane/screens/SessionsScreen.tsx
@@ -32,6 +32,10 @@ const LEFT_PANEL_MAX_WIDTH = 520;
 const RIGHT_PANEL_MIN_WIDTH = 280;
 const RIGHT_PANEL_MAX_WIDTH = 620;
 
+const REASONING_EFFORT_OPTIONS = ['low', 'medium', 'high', 'ultrahigh'] as const;
+
+type ReasoningEffortOption = (typeof REASONING_EFFORT_OPTIONS)[number];
+
 export type SessionsScreenProps = {
   sessions: ControlPlaneState['sessions'];
   activeSession?: ControlPlaneState['sessions'][number];
@@ -57,7 +61,7 @@ export type SessionsScreenProps = {
   onCreateSession: () => Promise<void>;
   onContinueSession: () => Promise<void>;
   onCancelSessionRun: () => Promise<void>;
-  onUpdateSessionSettings: (settings: { model?: string; driftEnabled?: boolean }) => Promise<void>;
+  onUpdateSessionSettings: (settings: { model?: string; reasoningEffort?: ReasoningEffortOption; driftEnabled?: boolean }) => Promise<void>;
   pendingApproval: { tool: string; callId: string; input?: unknown; requestedAt: string } | null;
   onResolveApproval: (approved: boolean) => Promise<void>;
 };
@@ -597,6 +601,20 @@ export function SessionsScreen({
                   {!modelOptions ? <option value={sessionDetail?.model ?? activeSession.model ?? ''}>{modelOptionsError ? 'models unavailable' : sessionDetail?.model ?? activeSession.model ?? 'loading models'}</option> : null}
                 </select>
               </label>
+              <label className="select-control">
+                <span>reasoning</span>
+                <select
+                  value={sessionDetail?.reasoningEffort ?? activeSession.reasoningEffort ?? ''}
+                  disabled={runActive}
+                  onChange={(event) => {
+                    const value = event.target.value as ReasoningEffortOption | '';
+                    void onUpdateSessionSettings({ reasoningEffort: value || undefined });
+                  }}
+                >
+                  <option value="">default</option>
+                  {REASONING_EFFORT_OPTIONS.map((effort) => <option key={effort} value={effort}>{effort}</option>)}
+                </select>
+              </label>
               <Pill>turns {activeSession.turnCount}</Pill>
               {compactionStatus === 'running' ? <Pill tone="warn">compacting</Pill> : null}
               <button
@@ -705,6 +723,7 @@ export function SessionsScreen({
               <div className="pills compact-pills">
                 <Pill tone={creatingSession ? 'warn' : runActive ? 'warn' : 'good'}>{creatingSession ? 'creating session' : runActive ? 'run active' : 'idle'}</Pill>
                 {memoryUpdating ? <Pill tone="warn">memory updating</Pill> : null}
+                <Pill>{formatReasoningPill(sessionDetail?.model ?? activeSession?.model, sessionDetail?.reasoningEffort ?? activeSession?.reasoningEffort)}</Pill>
                 {authStatus ? <Pill>{authStatus}</Pill> : null}
                 {sessionDetail?.lastContinuePrompt ? <Pill>continue available</Pill> : <Pill>no continue state yet</Pill>}
               </div>
@@ -819,6 +838,21 @@ function readStoredPanelWidths(): PanelWidths {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), Math.max(min, max));
+}
+
+function formatReasoningPill(
+  model: string | undefined,
+  reasoningEffort: ReasoningEffortOption | undefined,
+): string {
+  if (!model) {
+    return 'reasoning unknown';
+  }
+
+  if (reasoningEffort) {
+    return `reasoning ${reasoningEffort}`;
+  }
+
+  return `reasoning ${model.startsWith('gpt-5') || model.startsWith('o3') || model.startsWith('o4') ? 'default' : 'unsupported'}`;
 }
 
 function formatDriftLabel(enabled: boolean | undefined, level: ControlPlaneState['sessions'][number]['driftLevel']): string {

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -42,7 +42,7 @@ export async function fetchModelOptions(): Promise<ModelOptions> {
 
 export async function updateChatSessionSettings(
   sessionId: string,
-  settings: { model?: string; driftEnabled?: boolean },
+  settings: { model?: string; reasoningEffort?: 'low' | 'medium' | 'high' | 'ultrahigh'; driftEnabled?: boolean },
 ): Promise<Exclude<ChatSessionDetail, null>> {
   return await trpc.controlPlane.sessionSettingsUpdate.mutate({ id: sessionId, ...settings });
 }


### PR DESCRIPTION
## Summary
- add shared reasoning effort configuration and validation for supported reasoning-capable models
- persist reasoning effort with chat sessions and expose it through TUI and control-plane session controls
- add regression-focused coverage for request behavior, slash commands, and session storage

## Testing
- yarn typecheck
- yarn vitest run src/__tests__/cli/local-commands.test.ts src/__tests__/chat/chat-storage.test.ts src/__tests__/core/openai-oauth.test.ts