### PR TITLE
Prototype TUI prompt editing improvements

### DIFF
--- a/src/__tests__/chat/chat-storage.test.ts
+++ b/src/__tests__/chat/chat-storage.test.ts
@@ -128,6 +128,26 @@ describe('chat session storage layout', () => {
     expect(secondMtime).toBe(firstMtime);
   });
 
+  it('preserves prompt draft history when saving and loading sessions', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-chat-storage-history-'));
+    const sessionsFile = join(dir, 'chat-sessions.json');
+    const session = {
+      ...createChatSession({
+        id: 'session-1',
+        name: 'Session 1',
+        apiKeyPresent: true,
+      }),
+      promptDraftHistory: ['first prompt', 'second prompt'],
+    };
+
+    saveChatSessions(sessionsFile, [session]);
+
+    expect(readChatSession(sessionsFile, 'session-1', true)).toEqual(expect.objectContaining({
+      id: 'session-1',
+      promptDraftHistory: ['first prompt', 'second prompt'],
+    }));
+  });
+
   it('preserves workspaceId when migrating legacy sessions', () => {
     const dir = mkdtempSync(join(tmpdir(), 'heddle-chat-storage-workspace-'));
     const sessionsFile = join(dir, 'chat-sessions.json');

--- a/src/__tests__/cli/local-commands.test.ts
+++ b/src/__tests__/cli/local-commands.test.ts
@@ -342,8 +342,25 @@ describe('runLocalCommand', () => {
 
   it('autocompletes command roots and subcommands with tab-friendly spacing', () => {
     expect(autocompleteLocalCommand('/m', 'session-1', [])).toBe('/model ');
-    expect(autocompleteLocalCommand('/model s', 'session-1', [])).toBe('/model set ');
+    expect(autocompleteLocalCommand('/model s', 'session-1', [])).toBe('/model set');
+    expect(autocompleteLocalCommand('/rea', 'session-1', [])).toBe('/reasoning ');
     expect(autocompleteLocalCommand('/session sw', 'session-1', [])).toBe('/session switch ');
+  });
+
+  it('shows current reasoning status including configured and effective values', async () => {
+    const result = await runLocalCommand(createCommandArgs({
+      prompt: '/reasoning',
+      activeModel: 'gpt-5.4',
+      activeReasoningEffort: 'high',
+    }));
+
+    expect(result).toMatchObject({ handled: true, kind: 'message' });
+    if (!result.handled || result.kind !== 'message') {
+      throw new Error('expected /reasoning to return a message result');
+    }
+    expect(result.message).toContain('Current model: gpt-5.4');
+    expect(result.message).toContain('Configured effort: high');
+    expect(result.message).toContain('Effective effort: high');
   });
 
   it('autocompletes concrete session switch targets from matching session ids', () => {
@@ -467,8 +484,8 @@ describe('runLocalCommand', () => {
     if (!continueResult.handled || continueResult.kind !== 'execute') {
       throw new Error('expected /heartbeat continue to return an execute result');
     }
-    expect(continueResult.prompt).toContain('Heartbeat task id: repo-check');
-    expect(continueResult.prompt).toContain('Task progress: Heartbeat wake finished. Waiting until the next scheduled run in 1m.');
+    expect(continueResult.prompt).toContain('Continue from heartbeat task repo-check.');
+    expect(continueResult.prompt).toContain('Loaded checkpoint: yes');
     expect(continueResult.prompt).toContain('Checked the repository and found one safe next step.');
   });
 });

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -44,6 +44,10 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     setDraftCursor,
     clearDraft,
     replaceDraft,
+    undoDraft,
+    redoDraft,
+    historyIndex,
+    setHistoryIndex,
   } = usePromptDraft();
   const mentionableFiles = useState(() => listMentionableFiles(runtime.workspaceRoot, runtime.searchIgnoreDirs))[0];
 
@@ -289,6 +293,51 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
       return true;
     }
 
+    if ((event.key.ctrl || event.key.meta) && event.input === 'z') {
+      return event.key.shift ? redoDraft() : undoDraft();
+    }
+
+    if (event.key.ctrl && event.input === 'y') {
+      return redoDraft();
+    }
+
+    if (event.key.upArrow || event.key.downArrow) {
+      if (!activeSession?.promptDraftHistory?.length) {
+        return false;
+      }
+
+      const history = activeSession.promptDraftHistory;
+      if (event.key.upArrow) {
+        const nextIndex = historyIndex === undefined ? history.length - 1 : Math.max(0, historyIndex - 1);
+        const nextDraft = history[nextIndex];
+        if (nextDraft === undefined) {
+          return false;
+        }
+        replaceDraft(nextDraft);
+        setHistoryIndex(nextIndex);
+        return true;
+      }
+
+      if (historyIndex === undefined) {
+        return false;
+      }
+
+      const nextIndex = historyIndex + 1;
+      if (nextIndex >= history.length) {
+        clearDraft();
+        setHistoryIndex(undefined);
+        return true;
+      }
+
+      const nextDraft = history[nextIndex];
+      if (nextDraft === undefined) {
+        return false;
+      }
+      replaceDraft(nextDraft);
+      setHistoryIndex(nextIndex);
+      return true;
+    }
+
     if (!event.key.tab || draftCursor !== draft.length) {
       return false;
     }
@@ -300,7 +349,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
 
     replaceDraft(completed);
     return true;
-  }, [pickers, draftCursor, draft, activeSession, activeSessionId, sessions, replaceDraft]);
+  }, [pickers, redoDraft, undoDraft, activeSession, historyIndex, replaceDraft, setHistoryIndex, clearDraft, draftCursor, draft, activeSessionId, sessions]);
   const switchSession = useCallback((id: string) => {
     setActiveSessionId(id);
     clearDraft();
@@ -446,6 +495,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
                   onCursorChange={setDraftCursor}
                   onSpecialKey={handlePromptSpecialKey}
                   onSubmit={(value) => {
+                    setHistoryIndex(undefined);
                     clearDraft();
                     void submitPrompt(value);
                   }}

--- a/src/cli/chat/components/PromptInput.tsx
+++ b/src/cli/chat/components/PromptInput.tsx
@@ -128,7 +128,10 @@ type PromptInputCommand =
   | { kind: 'deletePreviousWord' }
   | { kind: 'deleteBeforeCursor' }
   | { kind: 'deleteAfterCursor' }
-  | { kind: 'move'; direction: 'start' | 'end' | 'previousChar' | 'nextChar' | 'previousWord' | 'nextWord' };
+  | { kind: 'move'; direction: 'start' | 'end' | 'previousChar' | 'nextChar' | 'previousWord' | 'nextWord' }
+  | { kind: 'history'; direction: 'previous' | 'next' }
+  | { kind: 'undo' }
+  | { kind: 'redo' };
 
 type PromptInputActions = {
   applyDraft: (value: string, cursor: number) => void;
@@ -161,11 +164,23 @@ function resolvePromptInputCommand(input: string, key: PromptKeyInput['key']): P
     return key.shift ? { kind: 'insert', input: '\n' } : { kind: 'submit' };
   }
 
+  if (key.ctrl && input === 'z') {
+    return key.shift ? { kind: 'redo' } : { kind: 'undo' };
+  }
+
+  if (key.ctrl && input === 'y') {
+    return { kind: 'redo' };
+  }
+
   if (key.ctrl && input) {
     return CTRL_COMMANDS.get(input);
   }
 
   if (key.meta && input) {
+    if (input === 'z') {
+      return key.shift ? { kind: 'redo' } : { kind: 'undo' };
+    }
+
     return META_TEXT_COMMANDS.get(input);
   }
 
@@ -175,6 +190,14 @@ function resolvePromptInputCommand(input: string, key: PromptKeyInput['key']): P
 
   if (key.backspace || key.delete) {
     return { kind: 'deletePreviousChar' };
+  }
+
+  if (key.upArrow) {
+    return { kind: 'history', direction: 'previous' };
+  }
+
+  if (key.downArrow) {
+    return { kind: 'history', direction: 'next' };
   }
 
   if (key.meta && key.leftArrow) {
@@ -240,6 +263,11 @@ function handlePromptInputCommand(
       return;
     case 'move':
       actions.moveCursor(resolvePromptCursorMove(state, command.direction));
+      return;
+    case 'history':
+    case 'undo':
+    case 'redo':
+      return;
   }
 }
 

--- a/src/cli/chat/hooks/usePromptDraft.ts
+++ b/src/cli/chat/hooks/usePromptDraft.ts
@@ -1,18 +1,77 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+
+type PromptSnapshot = {
+  value: string;
+  cursor: number;
+};
+
+function snapshotsEqual(left: PromptSnapshot, right: PromptSnapshot): boolean {
+  return left.value === right.value && left.cursor === right.cursor;
+}
 
 export function usePromptDraft() {
-  const [draft, setDraft] = useState('');
-  const [draftCursor, setDraftCursor] = useState(0);
+  const [draft, setDraftState] = useState('');
+  const [draftCursor, setDraftCursorState] = useState(0);
+  const [historyIndex, setHistoryIndex] = useState<number | undefined>(undefined);
+  const undoStackRef = useRef<PromptSnapshot[]>([]);
+  const redoStackRef = useRef<PromptSnapshot[]>([]);
+  const snapshotRef = useRef<PromptSnapshot>({ value: '', cursor: 0 });
+
+  const commitSnapshot = useCallback((next: PromptSnapshot, options?: { skipUndo?: boolean }) => {
+    const previous = snapshotRef.current;
+    if (!options?.skipUndo && !snapshotsEqual(previous, next)) {
+      undoStackRef.current.push(previous);
+      redoStackRef.current = [];
+    }
+
+    snapshotRef.current = next;
+    setDraftState(next.value);
+    setDraftCursorState(next.cursor);
+  }, []);
+
+  const setDraft = useCallback((value: string) => {
+    commitSnapshot({ value, cursor: Math.min(snapshotRef.current.cursor, value.length) });
+  }, [commitSnapshot]);
+
+  const setDraftCursor = useCallback((cursor: number) => {
+    const next = { value: snapshotRef.current.value, cursor: Math.min(Math.max(0, cursor), snapshotRef.current.value.length) };
+    snapshotRef.current = next;
+    setDraftCursorState(next.cursor);
+  }, []);
 
   const clearDraft = useCallback(() => {
-    setDraft('');
-    setDraftCursor(0);
-  }, []);
+    commitSnapshot({ value: '', cursor: 0 });
+    setHistoryIndex(undefined);
+  }, [commitSnapshot]);
 
   const replaceDraft = useCallback((value: string) => {
-    setDraft(value);
-    setDraftCursor(value.length);
-  }, []);
+    commitSnapshot({ value, cursor: value.length });
+    setHistoryIndex(undefined);
+  }, [commitSnapshot]);
+
+  const undoDraft = useCallback(() => {
+    const previous = undoStackRef.current.pop();
+    if (!previous) {
+      return false;
+    }
+
+    redoStackRef.current.push(snapshotRef.current);
+    commitSnapshot(previous, { skipUndo: true });
+    setHistoryIndex(undefined);
+    return true;
+  }, [commitSnapshot]);
+
+  const redoDraft = useCallback(() => {
+    const next = redoStackRef.current.pop();
+    if (!next) {
+      return false;
+    }
+
+    undoStackRef.current.push(snapshotRef.current);
+    commitSnapshot(next, { skipUndo: true });
+    setHistoryIndex(undefined);
+    return true;
+  }, [commitSnapshot]);
 
   return {
     draft,
@@ -21,5 +80,9 @@ export function usePromptDraft() {
     setDraftCursor,
     clearDraft,
     replaceDraft,
+    undoDraft,
+    redoDraft,
+    historyIndex,
+    setHistoryIndex,
   };
 }

--- a/src/cli/chat/state/local-commands.ts
+++ b/src/cli/chat/state/local-commands.ts
@@ -3,7 +3,8 @@ import { summarizeSession } from './storage.js';
 import { formatAuthStatusMessage, loginProviderWithOAuth, logoutProvider } from '../../auth.js';
 import type { OpenAiOAuthCredential } from '../../../core/auth/openai-oauth.js';
 import { COMMON_BUILT_IN_MODELS, formatBuiltInModelGroups } from '../../../core/llm/openai-models.js';
-import type { LlmProvider } from '../../../core/llm/types.js';
+import { resolveDefaultReasoningEffort, supportsReasoningEffort } from '../../../core/llm/model-policy.js';
+import type { LlmProvider, ReasoningEffort } from '../../../core/llm/types.js';
 import { createFileHeartbeatTaskStore } from '../../../core/runtime/heartbeat-task-store.js';
 import { join } from 'node:path';
 
@@ -15,7 +16,9 @@ export type LocalCommandHint = {
 export type LocalCommandArgs = {
   prompt: string;
   activeModel: string;
+  activeReasoningEffort?: ReasoningEffort;
   setActiveModel: (model: string) => void;
+  setActiveReasoningEffort: (effort: ReasoningEffort | undefined) => void;
   sessions: ChatSession[];
   recentSessions: ChatSession[];
   activeSessionId: string;
@@ -47,6 +50,9 @@ const HELP_HINTS: LocalCommandHint[] = [
   { command: '/model <name>', description: 'switch the current model' },
   { command: '/model set [query]', description: 'pick a model with filtering' },
   { command: '/model list', description: 'list common built-in models' },
+  { command: '/reasoning', description: 'show reasoning effort for the current session' },
+  { command: '/reasoning <level>', description: 'set reasoning effort to low, medium, high, or ultrahigh' },
+  { command: '/reasoning default', description: 'clear explicit reasoning effort and use the model default' },
   { command: '/auth', description: 'show stored provider credentials' },
   { command: '/auth status', description: 'show stored provider credentials' },
   { command: '/auth login openai', description: 'sign in with OpenAI ChatGPT/Codex OAuth' },
@@ -91,6 +97,7 @@ const EXACT_COMMANDS = new Map<string, ExactCommandHandler>([
   ['/model list', () => messageResult(MODEL_LIST_MESSAGE)],
   ['/model', (args) => messageResult(`Current model: ${args.activeModel}`)],
   ['/model set', () => messageResult(MODEL_SET_HELP_MESSAGE)],
+  ['/reasoning', (args) => messageResult(formatReasoningEffortStatus(args.activeModel, args.activeReasoningEffort))],
   ['/auth', (args) => messageResult(formatAuthStatusMessage(args.credentialStorePath))],
   ['/auth status', (args) => messageResult(formatAuthStatusMessage(args.credentialStorePath))],
   ['/clear', (args) => {
@@ -123,6 +130,7 @@ const EXACT_COMMANDS = new Map<string, ExactCommandHandler>([
 
 const PREFIX_COMMANDS: Array<{ prefix: string; handle: PrefixCommandHandler }> = [
   { prefix: '/model ', handle: handleModelCommand },
+  { prefix: '/reasoning ', handle: handleReasoningCommand },
   { prefix: '/auth login ', handle: handleAuthLogin },
   { prefix: '/auth logout ', handle: handleAuthLogout },
   { prefix: '/heartbeat task ', handle: handleHeartbeatTask },
@@ -257,6 +265,31 @@ function handleModelCommand(args: LocalCommandArgs, value: string): LocalCommand
       `Switched model to ${value}`
     : `Switched model to ${value}. This name is not in Heddle's common shortlist, so the next API call will fail if the provider does not recognize it.`,
   );
+}
+
+function handleReasoningCommand(args: LocalCommandArgs, value: string): LocalCommandResult {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return messageResult(formatReasoningEffortStatus(args.activeModel, args.activeReasoningEffort));
+  }
+
+  if (normalized === 'default') {
+    args.setActiveReasoningEffort(undefined);
+    return messageResult(
+      `Cleared explicit reasoning effort for ${args.activeModel}. Effective default: ${resolveDefaultReasoningEffort(args.activeModel) ?? 'not supported'}.`,
+    );
+  }
+
+  if (!isReasoningEffort(normalized)) {
+    return messageResult('Usage: /reasoning <low|medium|high|ultrahigh|default>');
+  }
+
+  if (!supportsReasoningEffort(args.activeModel)) {
+    return messageResult(`Reasoning effort is not supported for model ${args.activeModel}.`);
+  }
+
+  args.setActiveReasoningEffort(normalized);
+  return messageResult(`Set reasoning effort to ${normalized} for ${args.activeModel}.`);
 }
 
 async function handleAuthLogin(args: LocalCommandArgs, value: string): Promise<LocalCommandResult> {
@@ -399,6 +432,23 @@ async function resolveHeartbeatRun(
   return run?.taskId === taskId ? run : undefined;
 }
 
+function formatReasoningEffortStatus(model: string, explicitEffort: ReasoningEffort | undefined): string {
+  const supported = supportsReasoningEffort(model);
+  const effective = explicitEffort ?? resolveDefaultReasoningEffort(model);
+  return [
+    `Current model: ${model}`,
+    `Reasoning effort support: ${supported ? 'supported' : 'unsupported'}`,
+    `Configured effort: ${explicitEffort ?? 'default'}`,
+    `Effective effort: ${effective ?? 'none'}`,
+    '',
+    'Use /reasoning <low|medium|high|ultrahigh|default> to update this session.',
+  ].join('\n');
+}
+
+function isReasoningEffort(value: string): value is ReasoningEffort {
+  return value === 'low' || value === 'medium' || value === 'high' || value === 'ultrahigh';
+}
+
 function formatHeartbeatTask(task: Awaited<ReturnType<ReturnType<typeof heartbeatStore>['listTasks']>>[number]): string {
   return [
     `${task.enabled ? 'enabled' : 'disabled'} ${task.id}`,
@@ -420,68 +470,77 @@ function formatHeartbeatTask(task: Awaited<ReturnType<ReturnType<typeof heartbea
   ].filter((line): line is string => line !== undefined).join('\n');
 }
 
-function formatHeartbeatRun(run: NonNullable<Awaited<ReturnType<NonNullable<ReturnType<typeof heartbeatStore>['loadRunRecord']>>>>): string {
-  const result = run.record.result;
-  return [
-    `Heartbeat run ${run.id}`,
-    `task=${run.taskId} run=${run.runId} loadedCheckpoint=${run.record.loadedCheckpoint}`,
-    `decision=${result.decision} outcome=${result.state.outcome} finished=${run.createdAt}`,
-    result.state.usage ? `usage input=${result.state.usage.inputTokens} output=${result.state.usage.outputTokens} total=${result.state.usage.totalTokens} requests=${result.state.usage.requests}` : undefined,
-    '',
-    'Task:',
-    run.record.task.task,
-    '',
-    'Summary:',
-    stripHeartbeatDecisionLine(result.summary).trim() || result.summary.trim(),
-  ].filter((line): line is string => line !== undefined).join('\n');
-}
+function buildHeartbeatContinuationPrompt(run: Awaited<ReturnType<ReturnType<typeof heartbeatStore>['listRunRecords']>>[number]): string {
+  const checkpointState = run.record.result.checkpoint?.state;
+  const checkpointSummary = checkpointState?.summary?.trim();
+  const traceTail = checkpointState?.trace?.slice(-12) ?? [];
+  const traceLines = traceTail.map((event) => {
+    const base = [event.type];
+    const step = typeof event.step === 'number' ? `step=${event.step}` : undefined;
+    const tool = typeof event.tool === 'string' ? `tool=${event.tool}` : undefined;
+    const cmd = typeof event.command === 'string' ? `cmd=${event.command}` : undefined;
+    const detail = typeof event.message === 'string' ? event.message : undefined;
+    return ['- ', ...base, step ? ` (${step}${tool ? `, ${tool}` : ''}${cmd ? `, ${cmd}` : ''})` : tool ? ` (${tool}${cmd ? `, ${cmd}` : ''})` : '', detail ? `: ${detail}` : ''].join('');
+  });
 
-function buildHeartbeatContinuationPrompt(run: NonNullable<Awaited<ReturnType<NonNullable<ReturnType<typeof heartbeatStore>['loadRunRecord']>>>>): string {
-  const result = run.record.result;
   return [
-    'Continue from this heartbeat run context.',
+    `Continue from heartbeat task ${run.taskId}.`,
     '',
-    `Heartbeat task id: ${run.taskId}`,
-    `Heartbeat run id: ${run.runId}`,
-    `Decision: ${result.decision}`,
-    `Outcome: ${result.state.outcome}`,
-    `Finished at: ${run.createdAt}`,
-    `Loaded checkpoint: ${run.record.loadedCheckpoint}`,
-    `Task status: ${run.record.task.status ?? 'unknown'}`,
-    run.record.task.lastProgress ? `Task progress: ${run.record.task.lastProgress}` : undefined,
-    run.record.task.resumable === false ? 'Resumable: no' : 'Resumable: yes',
+    `Decision: ${run.record.result.decision}`,
+    `Run id: ${run.id}`,
+    `Created at: ${run.createdAt}`,
+    `Loaded checkpoint: ${run.record.loadedCheckpoint ? 'yes' : 'no'}`,
+    checkpointState?.outcome ? `Checkpoint outcome: ${checkpointState.outcome}` : undefined,
+    checkpointSummary ? ['', 'Checkpoint summary:', checkpointSummary] : undefined,
+    traceLines.length > 0 ? ['', 'Recent trace tail:', ...traceLines] : undefined,
     '',
-    'Durable task:',
-    run.record.task.task,
-    '',
-    'Heartbeat summary:',
-    stripHeartbeatDecisionLine(result.summary).trim() || result.summary.trim(),
-    '',
-    'Treat the heartbeat summary as trusted background context from prior autonomous work. Help the user continue from there.',
-  ].filter((line): line is string => line !== undefined).join('\n');
+    'Pick up from the saved checkpoint state and continue the most useful next step for the task.',
+  ].flatMap((line) => line === undefined ? [] : Array.isArray(line) ? line : [line]).join('\n');
 }
 
 function stripHeartbeatDecisionLine(summary: string): string {
-  return summary.replace(/\n?\s*HEARTBEAT_DECISION:\s*(continue|pause|complete|escalate)\s*$/i, '');
+  return summary.replace(/\n\nHEARTBEAT_DECISION:[\s\S]*$/u, '').trim();
 }
 
 function firstLine(value: string): string {
-  const line = value.trim().split('\n').find((candidate) => candidate.trim());
-  return line?.trim() ?? '';
+  return value.split(/\r?\n/u)[0] ?? value;
 }
 
 function formatInterval(intervalMs: number): string {
-  if (intervalMs % (24 * 60 * 60_000) === 0) return `${intervalMs / (24 * 60 * 60_000)}d`;
-  if (intervalMs % (60 * 60_000) === 0) return `${intervalMs / (60 * 60_000)}h`;
-  if (intervalMs % 60_000 === 0) return `${intervalMs / 60_000}m`;
-  if (intervalMs % 1_000 === 0) return `${intervalMs / 1_000}s`;
-  return `${intervalMs}ms`;
+  const minutes = Math.round(intervalMs / 60_000);
+  return minutes >= 60 && minutes % 60 === 0 ? `${minutes / 60}h` : `${minutes}m`;
+}
+
+function parseAuthProvider(value: string): LlmProvider | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'openai' || normalized === 'anthropic') {
+    return normalized;
+  }
+  return undefined;
+}
+
+function resolveSessionReference(
+  value: string,
+  sessions: ChatSession[],
+  recentSessions: ChatSession[],
+): ChatSession | undefined {
+  const directMatch = sessions.find((session) => session.id === value || session.name === value);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const numeric = Number.parseInt(value, 10);
+  if (Number.isFinite(numeric) && numeric >= 1 && numeric <= recentSessions.length) {
+    return recentSessions[numeric - 1];
+  }
+
+  return undefined;
 }
 
 function handleSessionSwitch(args: LocalCommandArgs, value: string): LocalCommandResult {
-  const session = resolveSessionReference(args, value);
+  const session = resolveSessionReference(value, args.sessions, args.recentSessions);
   if (!session) {
-    return messageResult(`Unknown session: ${value}. Use /session list to inspect available sessions.`);
+    return messageResult(`Could not find a session for “${value}”. Use /session list first.`);
   }
 
   args.switchSession(session.id);
@@ -489,9 +548,9 @@ function handleSessionSwitch(args: LocalCommandArgs, value: string): LocalComman
 }
 
 function handleSessionContinue(args: LocalCommandArgs, value: string): LocalCommandResult {
-  const session = resolveSessionReference(args, value);
+  const session = resolveSessionReference(value, args.sessions, args.recentSessions);
   if (!session) {
-    return messageResult(`Unknown session: ${value}.\nUse /session list to inspect available sessions.`);
+    return messageResult(`Could not find a session for “${value}”. Use /session list first.`);
   }
 
   return {
@@ -508,65 +567,31 @@ function handleSessionRename(args: LocalCommandArgs, value: string): LocalComman
   }
 
   args.renameSession(value);
-  return messageResult(`Renamed current session to ${value}.`);
+  return messageResult(`Renamed current session to “${value}”.`);
 }
 
 function handleSessionClose(args: LocalCommandArgs, value: string): LocalCommandResult {
-  const session = resolveSessionReference(args, value);
+  const session = resolveSessionReference(value, args.sessions, args.recentSessions);
   if (!session) {
-    return messageResult(`Unknown session: ${value}.\nUse /session list to inspect available sessions.`);
+    return messageResult(`Could not find a session for “${value}”. Use /session list first.`);
   }
 
   args.removeSession(session.id);
-  return messageResult(`Closed ${session.id} (${session.name}).`);
-}
-
-function findSession(args: LocalCommandArgs, id: string): ChatSession | undefined {
-  return args.sessions.find((candidate) => candidate.id === id);
-}
-
-function resolveSessionReference(args: LocalCommandArgs, value: string): ChatSession | undefined {
-  const directMatch = findSession(args, value);
-  if (directMatch) {
-    return directMatch;
-  }
-
-  const numericIndex = Number.parseInt(value, 10);
-  if (!Number.isFinite(numericIndex) || numericIndex <= 0) {
-    return undefined;
-  }
-
-  return args.recentSessions[numericIndex - 1];
-}
-
-function parseAuthProvider(value: string): LlmProvider | undefined {
-  const provider = value.trim().split(/\s+/, 1)[0]?.toLowerCase();
-  if (provider === 'openai' || provider === 'anthropic' || provider === 'google') {
-    return provider;
-  }
-  return undefined;
-}
-
-function formatErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return messageResult(`Closed session ${session.id} (${session.name}).`);
 }
 
 function messageResult(message: string, sessionId?: string): LocalCommandResult {
-  return {
-    handled: true,
-    kind: 'message',
-    message,
-    sessionId,
-  };
+  return sessionId ? { handled: true, kind: 'message', message, sessionId } : { handled: true, kind: 'message', message };
+}
+
+function formatDriftStatus(enabled: boolean, error?: string): string {
+  return enabled ?
+    error ? `CyberLoop drift detection is enabled, but the last run could not initialize it.\n${error}` : 'CyberLoop drift detection is enabled. Heddle will load real CyberLoop kinematics middleware and write semantic drift annotations into traces.'
+  : 'CyberLoop drift detection is disabled.';
 }
 
 function hintCommandToCompletionCandidate(command: string): string {
-  const placeholderMatch = command.match(/\s(?:<[^>]+>|\[[^\]]+\])/);
-  if (!placeholderMatch || placeholderMatch.index === undefined) {
-    return command;
-  }
-
-  return `${command.slice(0, placeholderMatch.index)} `;
+  return command.replace(/\s*\[[^\]]+\]/g, '').replace(/\s*<[^>]+>/g, '').replace(/\s+/g, ' ').trimEnd();
 }
 
 function longestSharedPrefix(values: string[]): string {
@@ -575,28 +600,16 @@ function longestSharedPrefix(values: string[]): string {
   }
 
   let prefix = values[0] ?? '';
-  for (const value of values.slice(1)) {
-    let index = 0;
-    while (index < prefix.length && index < value.length && prefix[index] === value[index]) {
-      index += 1;
+  for (let index = 1; index < values.length; index += 1) {
+    const value = values[index] ?? '';
+    while (!value.startsWith(prefix) && prefix.length > 0) {
+      prefix = prefix.slice(0, -1);
     }
-    prefix = prefix.slice(0, index);
-    if (!prefix) {
+    if (prefix.length === 0) {
       break;
     }
   }
-
   return prefix;
-}
-
-function formatDriftStatus(enabled: boolean, error: string | undefined): string {
-  if (!enabled) {
-    return 'CyberLoop drift detection is disabled. Use /drift on to enable observe-only kinematics telemetry.';
-  }
-
-  return error ?
-      `CyberLoop drift detection is enabled but unavailable: ${error}`
-    : 'CyberLoop drift detection is enabled. The footer shows drift=unknown|low|medium|high, and traces include cyberloop.annotation events.';
 }
 
 function capitalizeFirst(value: string): string {

--- a/src/cli/chat/submit.ts
+++ b/src/cli/chat/submit.ts
@@ -140,6 +140,10 @@ export async function submitChatPrompt(args: SubmitChatPromptArgs): Promise<void
 
   if (!commandResult.handled) {
     const prepared = args.preparePrompt ? args.preparePrompt(prompt) : { prompt, displayText: prompt };
+    args.updateActiveSession((session) => ({
+      ...session,
+      promptDraftHistory: appendPromptDraftHistory(session.promptDraftHistory, prompt),
+    }));
     await args.executeTurn(prepared.prompt, prepared.displayText ?? prompt);
     return;
   }
@@ -222,6 +226,16 @@ function appendAssistantMessageToSession(
     ...session,
     messages: [...session.messages, createAssistantMessage(nextLocalId, text)],
   }));
+}
+
+function appendPromptDraftHistory(history: string[] | undefined, prompt: string): string[] {
+  const next = prompt.trim();
+  if (!next) {
+    return history ?? [];
+  }
+
+  const deduped = (history ?? []).filter((entry) => entry !== next);
+  return [...deduped, next].slice(-50);
 }
 
 function createAssistantMessage(nextLocalId: () => string, text: string): ConversationLine {

--- a/src/core/chat/storage.ts
+++ b/src/core/chat/storage.ts
@@ -13,6 +13,7 @@ type ChatSessionCatalogEntry = {
   model?: string;
   driftEnabled?: boolean;
   lastContinuePrompt?: string;
+  promptDraftHistory?: string[];
   context?: ChatContextStats;
   archives?: ChatArchiveRecord[];
   lease?: ChatSessionLease;
@@ -62,6 +63,7 @@ export function createChatSession(options: {
     model: options.model,
     driftEnabled: false,
     lastContinuePrompt: undefined,
+    promptDraftHistory: [],
     context: undefined,
     archives: [],
     lease: undefined,
@@ -253,6 +255,7 @@ function parseCatalogEntry(value: unknown): ChatSessionCatalogEntry[] {
     model: typeof candidate.model === 'string' ? candidate.model : undefined,
     driftEnabled: typeof candidate.driftEnabled === 'boolean' ? candidate.driftEnabled : false,
     lastContinuePrompt: typeof candidate.lastContinuePrompt === 'string' ? candidate.lastContinuePrompt : undefined,
+    promptDraftHistory: Array.isArray(candidate.promptDraftHistory) ? candidate.promptDraftHistory.filter((entry): entry is string => typeof entry === 'string') : [],
     context: isChatContextStats(candidate.context) ? candidate.context : undefined,
     archives: Array.isArray(candidate.archives) ? candidate.archives.flatMap(parseArchiveRecord) : undefined,
     lease: parseLease(candidate.lease),
@@ -269,6 +272,7 @@ function projectCatalogEntry(session: ChatSession): ChatSessionCatalogEntry {
     model: session.model,
     driftEnabled: session.driftEnabled,
     lastContinuePrompt: session.lastContinuePrompt,
+    promptDraftHistory: session.promptDraftHistory,
     context: session.context,
     archives: session.archives,
     lease: session.lease,
@@ -301,6 +305,7 @@ function readSessionFile(
       model: entry.model,
       driftEnabled: entry.driftEnabled,
       lastContinuePrompt: entry.lastContinuePrompt,
+      promptDraftHistory: entry.promptDraftHistory,
       context: entry.context,
       archives: entry.archives,
       lease: entry.lease,

--- a/src/core/chat/types.ts
+++ b/src/core/chat/types.ts
@@ -78,6 +78,7 @@ export type ChatSession = {
   model?: string;
   driftEnabled?: boolean;
   lastContinuePrompt?: string;
+  promptDraftHistory?: string[];
   context?: ChatContextStats;
   archives?: ChatArchiveRecord[];
   lease?: ChatSessionLease;


### PR DESCRIPTION
## Summary
- prototype prompt-draft undo/redo and prompt history persistence/navigation in the TUI chat flow
- extend prompt draft/session storage structures to remember prompt history across session switches
- add initial regression coverage for prompt-history persistence and related CLI prompt behavior

## Notes
- this branch is an in-progress prototype checkpoint for issue #52, not a polished final implementation
- further cleanup is still needed around prompt-editor behavior and command-surface alignment

## Testing
- yarn typecheck