### PR TITLE
Redesign TUI prompt composer layout

### DIFF
--- a/src/__tests__/unit/tui/prompt-input.test.tsx
+++ b/src/__tests__/unit/tui/prompt-input.test.tsx
@@ -41,7 +41,7 @@ describe('prompt input related helpers', () => {
   });
 
   it('places a wrapped-line boundary cursor at the start of the next visual segment', () => {
-    expect(buildPromptRenderLines('abcd', 2, 8, 2)).toEqual([
+    expect(buildPromptRenderLines('abcd', 2, 8, 4)).toEqual([
       {
         before: 'ab',
         cursor: '',
@@ -52,6 +52,23 @@ describe('prompt input related helpers', () => {
         before: '',
         cursor: 'c',
         after: 'd',
+        hasCursor: true,
+      },
+    ]);
+  });
+
+  it('reserves prompt-prefix width when wrapping long input in narrow terminals', () => {
+    expect(buildPromptRenderLines('abcdef', 6, 8, 5)).toEqual([
+      {
+        before: 'abc',
+        cursor: '',
+        after: '',
+        hasCursor: false,
+      },
+      {
+        before: 'def',
+        cursor: ' ',
+        after: '',
         hasCursor: true,
       },
     ]);

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 import {
   ApprovalComposer,
   CommandHintPanel,
@@ -36,6 +36,8 @@ export function App({ runtime }: { runtime: ChatRuntimeConfig }) {
 
 function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
   const nextLocalId = useLocalIds();
+  const { stdout } = useStdout();
+  const columns = stdout.columns ?? 80;
   const initialModelCompatibility = useMemo(() => resolveCompatibleActiveModel({
     activeModel: runtime.model,
     provider: runtime.model.startsWith('claude') ? 'anthropic' : 'openai',
@@ -357,6 +359,9 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     drift: drift.observer,
   });
 
+  const promptPanelWidth = Math.max(20, columns - 2);
+  const promptBodyWidth = Math.max(1, promptPanelWidth - 2);
+
   const { pendingSubmittedPrompt, clearPendingSubmittedPrompt, submitPrompt } = usePromptSubmission({
     runtime,
     activeModel,
@@ -421,52 +426,64 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
 
       <Box
         flexDirection="column"
-        borderStyle="round"
-        borderColor={pendingApproval ? 'yellow' : isRunning ? 'yellow' : 'cyan'}
-        paddingX={1}
+        borderStyle={pendingApproval ? 'round' : undefined}
+        borderColor={pendingApproval ? 'yellow' : undefined}
+        paddingX={pendingApproval ? 1 : 0}
         paddingY={0}
+        marginTop={1}
+        width={promptPanelWidth}
+        flexShrink={0}
       >
-        <Text bold color={pendingApproval ? 'yellow' : undefined}>
-          {pendingApproval ? 'Approval Required' : compacting ? `Compacting${workingFrames[workingFrame] ?? '...'}` : isRunning ? `Working${workingFrames[workingFrame]}` : 'Prompt'}
-        </Text>
         {pendingApproval ?
-          <ApprovalComposer pendingApproval={pendingApproval} approvalChoice={approvalChoice} />
-        : <>
-            {pickers.model.visible ?
-              <ModelPickerPanel
-                query={pickers.model.query ?? ''}
-                models={pickers.model.items}
-                activeModel={activeModel}
-                highlightedIndex={pickers.model.highlightedIndex}
-              />
-            : null}
-            {pickers.session.visible ?
-              <SessionPickerPanel
-                query={pickers.session.query ?? ''}
-                sessions={pickers.session.items}
-                activeSessionId={activeSessionId}
-                highlightedIndex={pickers.session.highlightedIndex}
-              />
-            : null}
-            {pickers.fileMention.visible ?
-              <FileMentionPickerPanel
-                query={pickers.fileMention.query ?? ''}
-                files={pickers.fileMention.items}
-                highlightedIndex={pickers.fileMention.highlightedIndex}
-              />
-            : null}
-            {shouldShowSlashHints(draft) ?
-              <SlashHintPanel draft={draft} activeSessionId={activeSession?.id ?? ''} sessions={sessions} />
-            : shouldShowCommandHint(draft) ?
-              <CommandHintPanel draft={draft} />
-            : null}
-            <Box>
-              <Text color="cyan">{'>'} </Text>
-              <Box flexGrow={1}>
+          <>
+            <Text bold color="yellow">
+              Approval Required
+            </Text>
+            <ApprovalComposer pendingApproval={pendingApproval} approvalChoice={approvalChoice} />
+          </>
+        : <Box flexDirection="column" width={promptPanelWidth} flexShrink={0}>
+            <Box width={promptPanelWidth} overflow="hidden">
+              <Text dimColor wrap="truncate-end">{repeatSeparator(promptPanelWidth)}</Text>
+            </Box>
+            <Box
+              flexDirection="column"
+              width={promptBodyWidth}
+              paddingX={1}
+              paddingY={0}
+            >
+              {pickers.model.visible ?
+                <ModelPickerPanel
+                  query={pickers.model.query ?? ''}
+                  models={pickers.model.items}
+                  activeModel={activeModel}
+                  highlightedIndex={pickers.model.highlightedIndex}
+                />
+              : null}
+              {pickers.session.visible ?
+                <SessionPickerPanel
+                  query={pickers.session.query ?? ''}
+                  sessions={pickers.session.items}
+                  activeSessionId={activeSessionId}
+                  highlightedIndex={pickers.session.highlightedIndex}
+                />
+              : null}
+              {pickers.fileMention.visible ?
+                <FileMentionPickerPanel
+                  query={pickers.fileMention.query ?? ''}
+                  files={pickers.fileMention.items}
+                  highlightedIndex={pickers.fileMention.highlightedIndex}
+                />
+              : null}
+              {shouldShowSlashHints(draft) ?
+                <SlashHintPanel draft={draft} activeSessionId={activeSession?.id ?? ''} sessions={sessions} />
+              : shouldShowCommandHint(draft) ?
+                <CommandHintPanel draft={draft} />
+              : null}
+              <Box>
                 <PromptInput
                   value={draft}
                   cursor={draftCursor}
-                  isDisabled={Boolean(pendingApproval)}
+                  isDisabled={false}
                   placeholder={isRunning ? "Keep typing while Heddle works" : "Ask Heddle about this project"}
                   maxVisibleLines={10}
                   onChange={setDraft}
@@ -478,26 +495,35 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
                   }}
                 />
               </Box>
+              <Box justifyContent="space-between" flexWrap="nowrap" width={promptBodyWidth}>
+                <Box flexShrink={1} marginRight={1}>
+                  <Text dimColor wrap="truncate-end">
+                    {draft ? `${draft.length} chars`
+                    : isRunning ? 'Enter to queue'
+                    : 'Enter to send'}
+                  </Text>
+                </Box>
+                <Box flexShrink={0}>
+                  <Text dimColor>
+                    {pendingSubmittedPrompt ? '1 queued'
+                    : isRunning ? `${elapsedSeconds}s elapsed`
+                    : ''}
+                  </Text>
+                </Box>
+              </Box>
             </Box>
-            <Box justifyContent="space-between">
-              <Text dimColor>
-                {draft ? `${draft.length} chars`
-                : isRunning ? 'Enter to queue'
-                : 'Enter to send'}
-              </Text>
-              <Text dimColor>
-                {pendingSubmittedPrompt ? '1 queued'
-                : isRunning ? `${elapsedSeconds}s elapsed`
-                : ''}
-              </Text>
+            <Box width={promptPanelWidth} overflow="hidden">
+              <Text dimColor wrap="truncate-end">{repeatSeparator(promptPanelWidth)}</Text>
             </Box>
-          </>}
+          </Box>}
       </Box>
-      <Text>
-        <Text dimColor>{`model=${activeModel} • ${authStatus} • ${contextStatus} • `}</Text>
-        <Text color={drift.color} dimColor={!drift.color}>{`drift=${drift.footer}`}</Text>
-        <Text dimColor>{` • ${sessionFooter}`}</Text>
-      </Text>
+      <Box width={promptPanelWidth} overflow="hidden">
+        <Text dimColor wrap="truncate-end">{`model=${activeModel} • ${authStatus} • ${contextStatus} • drift=${drift.footer} • ${sessionFooter}`}</Text>
+      </Box>
     </Box>
   );
+}
+
+function repeatSeparator(width: number): string {
+  return '─'.repeat(Math.max(0, width));
 }

--- a/src/cli/chat/components/PromptInput.tsx
+++ b/src/cli/chat/components/PromptInput.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo, useRef } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useStdout } from 'ink';
 
 const DEFAULT_MAX_VISIBLE_INPUT_LINES = 8;
 const FALLBACK_WRAP_WIDTH = 80;
+const PROMPT_INPUT_PREFIX_WIDTH = 2;
 
 export type PromptKeyInput = {
   input: string;
@@ -47,6 +48,8 @@ export function PromptInput({
 }) {
   const valueRef = useRef(value);
   const cursorRef = useRef(cursor);
+  const { stdout } = useStdout();
+  const columns = stdout.columns ?? FALLBACK_WRAP_WIDTH;
 
   useEffect(() => {
     valueRef.current = value;
@@ -93,24 +96,35 @@ export function PromptInput({
     handlePromptInputCommand(command, state, actions);
   }, { isActive: !isDisabled });
 
-  const lines = useMemo(() => buildPromptRenderLines(value, cursor, maxVisibleLines), [value, cursor, maxVisibleLines]);
+  const lines = useMemo(
+    () => buildPromptRenderLines(value, cursor, maxVisibleLines, Math.max(PROMPT_INPUT_PREFIX_WIDTH + 1, columns)),
+    [value, cursor, maxVisibleLines, columns],
+  );
 
   if (!value) {
-    return <Text dimColor>{placeholder}</Text>;
+    return (
+      <Box flexGrow={1} paddingX={0} paddingY={0}>
+        <Text color="cyan">{'› '}</Text>
+        <Text dimColor>{placeholder}</Text>
+      </Box>
+    );
   }
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" flexGrow={1} paddingX={0} paddingY={0}>
       {lines.map((line, index) => (
-        <Text key={`${index}-${line.before}-${line.cursor}-${line.after}-${line.hasCursor}`}>
-          {line.hasCursor ?
-            <>
-              {line.before}
-              <Text inverse>{line.cursor}</Text>
-              {line.after}
-            </>
-          : (line.before || ' ')}
-        </Text>
+        <Box key={`${index}-${line.before}-${line.cursor}-${line.after}-${line.hasCursor}`}>
+          <Text color="cyan">{index === 0 ? '› ' : '  '}</Text>
+          <Text>
+            {line.hasCursor ?
+              <>
+                {line.before}
+                <Text inverse>{line.cursor}</Text>
+                {line.after}
+              </>
+            : (line.before || ' ')}
+          </Text>
+        </Box>
       ))}
     </Box>
   );
@@ -275,11 +289,12 @@ export function buildPromptRenderLines(
 ): PromptRenderLine[] {
   const rawLines = value.split('\n');
   const rendered: PromptRenderLine[] = [];
+  const contentWidth = Math.max(1, width - PROMPT_INPUT_PREFIX_WIDTH);
   let logicalOffset = 0;
 
   for (let lineIndex = 0; lineIndex < rawLines.length; lineIndex += 1) {
     const line = rawLines[lineIndex] ?? '';
-    const wrapped = wrapLine(line, width);
+    const wrapped = wrapLine(line, contentWidth);
     const lineStart = logicalOffset;
     const lineEnd = lineStart + line.length;
     const isLastLogicalLine = lineIndex === rawLines.length - 1;


### PR DESCRIPTION
## Summary
- replace the boxed prompt composer with a Claude Code-style separator-line layout
- make prompt width and wrapping follow the live terminal width so multiline input stays aligned
- keep the approval flow boxed while preserving prompt prefix and continuation alignment

## Testing
- yarn vitest run src/__tests__/unit/tui/prompt-input.test.tsx
- yarn typecheck

Closes #51