### PR TITLE
Support reasoning effort for reasoning models

### DIFF
--- a/docs/guides/programmatic-use.md
+++ b/docs/guides/programmatic-use.md
@@ -70,7 +70,8 @@ import { createConversationEngine } from '@roackb2/heddle'
 const engine = createConversationEngine({
   workspaceRoot: process.cwd(),
   stateRoot: `${process.cwd()}/.heddle`,
-  model: 'gpt-5.1-codex',
+  model: 'gpt-5.4',
+  reasoningEffort: 'medium',
 })
 
 const session = engine.sessions.create({ name: 'Repo investigation' })
@@ -82,6 +83,18 @@ const result = await engine.turns.submit({
 
 console.log(result.summary)
 ```
+
+`reasoningEffort` can also be set per session:
+
+```ts
+const session = engine.sessions.create({
+  name: 'Deep repo investigation',
+  model: 'gpt-5.5',
+  reasoningEffort: 'high',
+})
+```
+
+Supported OpenAI request values are `low`, `medium`, and `high`. `ultrahigh` is reserved in Heddle's persisted type surface, but current OpenAI Responses API requests reject it instead of silently falling back to a default.
 
 ## Where State Is Stored
 
@@ -265,7 +278,8 @@ import { runAgentLoop } from '@roackb2/heddle'
 
 const result = await runAgentLoop({
   goal: 'Inspect this repo and summarize the main architecture',
-  model: 'gpt-5.1-codex',
+  model: 'gpt-5.4',
+  reasoningEffort: 'medium',
   workspaceRoot: process.cwd(),
   onEvent(event) {
     console.log(event.type)

--- a/src/__tests__/integration/chat/chat-runtime.test.ts
+++ b/src/__tests__/integration/chat/chat-runtime.test.ts
@@ -12,7 +12,7 @@ import { runConversationTurn } from '../../../core/chat/engine/turns/run-convers
 import { createChatSession as createCoreChatSession, loadChatSessions, saveChatSessions } from '../../../core/chat/engine/sessions/storage.js';
 import * as agentLoopModule from '../../../core/runtime/agent-loop.js';
 import type { ToolApprovalPolicy } from '../../../core/approvals/types.js';
-import { continueChatPrompt, createControlPlaneChatSession, readChatSessionDetail, submitChatPrompt } from '../../../server/features/control-plane/services/chat-sessions.js';
+import { continueChatPrompt, createControlPlaneChatSession, readChatSessionDetail, submitChatPrompt, updateControlPlaneChatSessionSettings } from '../../../server/features/control-plane/services/chat-sessions.js';
 
 describe('resolveChatRuntimeConfig', () => {
   afterEach(() => {
@@ -441,6 +441,27 @@ describe('control-plane shared chat runtime integration', () => {
     });
 
     expect(session.model).toBe('gpt-4.1');
+  });
+
+  it('clears explicit reasoning effort when control-plane settings send null', () => {
+    const sessionStoragePath = createControlPlaneSessionStoragePath();
+    const session = createCoreChatSession({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.5',
+      reasoningEffort: 'high',
+    });
+    saveChatSessions(sessionStoragePath, [session]);
+
+    const updated = updateControlPlaneChatSessionSettings({
+      sessionStoragePath,
+      sessionId: 'session-1',
+      reasoningEffort: null,
+    });
+
+    expect(updated.reasoningEffort).toBeUndefined();
+    expect(readChatSessionDetail(sessionStoragePath, 'session-1')?.reasoningEffort).toBeUndefined();
   });
 
   it('continues with the stored prompt while preserving continue-style transcript text', async () => {

--- a/src/__tests__/integration/chat/chat-storage.test.ts
+++ b/src/__tests__/integration/chat/chat-storage.test.ts
@@ -58,6 +58,7 @@ describe('chat session storage layout', () => {
         workspaceId: 'workspace-1',
       }),
       model: 'gpt-5.1-codex-mini',
+      reasoningEffort: 'high',
       lastContinuePrompt: 'continue',
       context: { estimatedHistoryTokens: 42 },
       messages: [{ id: 'm1', role: 'assistant' as const, text: 'hello there' }],
@@ -87,6 +88,7 @@ describe('chat session storage layout', () => {
       name: 'Session 1',
       workspaceId: 'workspace-1',
       model: 'gpt-5.1-codex-mini',
+      reasoningEffort: 'high',
       lastContinuePrompt: 'continue',
       context: { estimatedHistoryTokens: 42 },
     }));
@@ -94,6 +96,7 @@ describe('chat session storage layout', () => {
     expect(storedSession).toEqual(expect.objectContaining({
       id: 'session-1',
       workspaceId: 'workspace-1',
+      reasoningEffort: 'high',
       history: [],
       messages: [{ id: 'm1', role: 'assistant', text: 'hello there' }],
       turns: [{
@@ -105,6 +108,34 @@ describe('chat session storage layout', () => {
         traceFile: '/tmp/trace-1.json',
         events: ['said hello'],
       }],
+    }));
+  });
+
+  it('persists reasoning effort in catalog and per-session storage when configured', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-chat-storage-reasoning-'));
+    const sessionsFile = join(dir, 'chat-sessions.json');
+    const session = {
+      ...createChatSession({
+        id: 'session-1',
+        name: 'Session 1',
+        apiKeyPresent: true,
+        workspaceId: 'workspace-1',
+      }),
+      model: 'gpt-5.5',
+      reasoningEffort: 'high' as const,
+    };
+
+    saveChatSessions(sessionsFile, [session]);
+
+    expect(readChatSessionCatalog(sessionsFile)[0]).toEqual(expect.objectContaining({
+      id: 'session-1',
+      model: 'gpt-5.5',
+      reasoningEffort: 'high',
+    }));
+    expect(readChatSession(sessionsFile, 'session-1', true)).toEqual(expect.objectContaining({
+      id: 'session-1',
+      model: 'gpt-5.5',
+      reasoningEffort: 'high',
     }));
   });
 

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -82,6 +82,29 @@ describe('chat turn preparation modules', () => {
     expect(runtime.llm.info?.model).toBe('gpt-5.4');
   });
 
+  it('carries stored session reasoning effort into the turn runtime', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-reasoning-'));
+    const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');
+    const session = createChatSession({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.5',
+      reasoningEffort: 'medium',
+    });
+    saveChatSessions(sessionStoragePath, [session]);
+
+    const context = prepareConversationTurnContext({
+      workspaceRoot: root,
+      stateRoot: join(root, '.heddle'),
+      sessionStoragePath,
+      sessionId: 'session-1',
+      apiKey: 'explicit-key',
+    });
+
+    expect(context.runtime.reasoningEffort).toBe('medium');
+  });
+
   it('preserves stored OAuth credential selection for OpenAI chat turns', () => {
     vi.stubEnv('OPENAI_API_KEY', '');
     vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -194,6 +194,31 @@ describe('OpenAI OAuth helpers', () => {
     );
   });
 
+  it('includes the default reasoning effort for supported reasoning models', async () => {
+    const requests: Array<{ url: string; body: string }> = [];
+    const adapter = createOpenAiAdapter({
+      model: 'gpt-5.4',
+      credential: {
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 120_000,
+        accountId: 'account-123',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      },
+      fetchImpl: (async (url, init) => {
+        requests.push({ url: String(url), body: String((init as RequestInit | undefined)?.body ?? '') });
+        return new Response('bad request', { status: 400 });
+      }) as typeof fetch,
+    });
+
+    await expect(adapter.chat([{ role: 'user', content: 'hello' }], [])).rejects.toThrow();
+    const body = JSON.parse(requests[0]?.body ?? '{}') as { reasoning?: { effort?: string } };
+    expect(body.reasoning?.effort).toBe('high');
+  });
+
   it('uses the Codex-compatible Responses payload shape for account sign-in models', async () => {
     const requests: Array<{ url: string; body: string }> = [];
     const adapter = createOpenAiAdapter({
@@ -234,6 +259,32 @@ describe('OpenAI OAuth helpers', () => {
     expect(body.input).toEqual([
       { type: 'message', role: 'user', content: 'hello' },
     ]);
+  });
+
+  it('includes explicit reasoning effort when configured', async () => {
+    const requests: Array<{ url: string; body: string }> = [];
+    const adapter = createOpenAiAdapter({
+      model: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      credential: {
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 120_000,
+        accountId: 'account-123',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      },
+      fetchImpl: (async (url, init) => {
+        requests.push({ url: String(url), body: String((init as RequestInit | undefined)?.body ?? '') });
+        return new Response('bad request', { status: 400 });
+      }) as typeof fetch,
+    });
+
+    await expect(adapter.chat([{ role: 'user', content: 'hello' }], [])).rejects.toThrow();
+    const body = JSON.parse(requests[0]?.body ?? '{}') as { reasoning?: { effort?: string } };
+    expect(body.reasoning?.effort).toBe('medium');
   });
 
   it('reconstructs tool calls from streamed Codex OAuth events when final response output is empty', async () => {

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -287,6 +287,31 @@ describe('OpenAI OAuth helpers', () => {
     expect(body.reasoning?.effort).toBe('medium');
   });
 
+  it('rejects ultrahigh reasoning effort instead of silently dropping it', async () => {
+    const requests: Array<{ url: string; body: string }> = [];
+    const adapter = createOpenAiAdapter({
+      model: 'gpt-5.5',
+      reasoningEffort: 'ultrahigh',
+      credential: {
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 120_000,
+        accountId: 'account-123',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      },
+      fetchImpl: (async (url, init) => {
+        requests.push({ url: String(url), body: String((init as RequestInit | undefined)?.body ?? '') });
+        return new Response('bad request', { status: 400 });
+      }) as typeof fetch,
+    });
+
+    await expect(adapter.chat([{ role: 'user', content: 'hello' }], [])).rejects.toThrow('ultrahigh');
+    expect(requests).toEqual([]);
+  });
+
   it('reconstructs tool calls from streamed Codex OAuth events when final response output is empty', async () => {
     const adapter = createOpenAiAdapter({
       model: 'gpt-5.4',

--- a/src/__tests__/unit/tui/local-commands.test.ts
+++ b/src/__tests__/unit/tui/local-commands.test.ts
@@ -9,7 +9,9 @@ function createCommandArgs(overrides: Partial<Parameters<typeof runLocalCommand>
   return {
     prompt: '/help',
     activeModel: 'gpt-5.1-codex',
+    activeReasoningEffort: undefined,
     setActiveModel: vi.fn(),
+    setActiveReasoningEffort: vi.fn(),
     sessions: [],
     recentSessions: [],
     activeSessionId: 'session-1',
@@ -518,7 +520,24 @@ describe('runLocalCommand', () => {
   it('autocompletes command roots and subcommands with tab-friendly spacing', () => {
     expect(autocompleteLocalCommand('/m', 'session-1', [])).toBe('/model ');
     expect(autocompleteLocalCommand('/model s', 'session-1', [])).toBe('/model set ');
+    expect(autocompleteLocalCommand('/rea', 'session-1', [])).toBe('/reasoning ');
     expect(autocompleteLocalCommand('/session sw', 'session-1', [])).toBe('/session switch ');
+  });
+
+  it('shows current reasoning status including configured and effective values', async () => {
+    const result = await runLocalCommand(createCommandArgs({
+      prompt: '/reasoning',
+      activeModel: 'gpt-5.4',
+      activeReasoningEffort: 'high',
+    }));
+
+    expect(result).toMatchObject({ handled: true, kind: 'message' });
+    if (!result.handled || result.kind !== 'message') {
+      throw new Error('expected /reasoning to return a message result');
+    }
+    expect(result.message).toContain('Current model: gpt-5.4');
+    expect(result.message).toContain('Configured effort: high');
+    expect(result.message).toContain('Effective effort: high');
   });
 
   it('autocompletes shared prefixes while preserving leading whitespace', () => {

--- a/src/__tests__/unit/tui/local-commands.test.ts
+++ b/src/__tests__/unit/tui/local-commands.test.ts
@@ -521,6 +521,7 @@ describe('runLocalCommand', () => {
     expect(autocompleteLocalCommand('/m', 'session-1', [])).toBe('/model ');
     expect(autocompleteLocalCommand('/model s', 'session-1', [])).toBe('/model set ');
     expect(autocompleteLocalCommand('/rea', 'session-1', [])).toBe('/reasoning ');
+    expect(autocompleteLocalCommand('/reasoning s', 'session-1', [])).toBe('/reasoning set ');
     expect(autocompleteLocalCommand('/session sw', 'session-1', [])).toBe('/session switch ');
   });
 
@@ -538,6 +539,32 @@ describe('runLocalCommand', () => {
     expect(result.message).toContain('Current model: gpt-5.4');
     expect(result.message).toContain('Configured effort: high');
     expect(result.message).toContain('Effective effort: high');
+    expect(result.message).toContain('Use /reasoning set to choose an effort');
+  });
+
+  it('shows picker help for reasoning set', async () => {
+    await expect(runLocalCommand(createCommandArgs({
+      prompt: '/reasoning set',
+      activeModel: 'gpt-5.4',
+    }))).resolves.toEqual({
+      handled: true,
+      kind: 'message',
+      message: 'Use /reasoning set <query> to filter reasoning efforts, then use arrows and Enter to choose one.',
+    });
+  });
+
+  it('accepts direct reasoning set values for compatibility with picker submissions', async () => {
+    const setActiveReasoningEffort = vi.fn();
+    await expect(runLocalCommand(createCommandArgs({
+      prompt: '/reasoning set medium',
+      activeModel: 'gpt-5.4',
+      setActiveReasoningEffort,
+    }))).resolves.toEqual({
+      handled: true,
+      kind: 'message',
+      message: 'Set reasoning effort to medium for gpt-5.4.',
+    });
+    expect(setActiveReasoningEffort).toHaveBeenCalledWith('medium');
   });
 
   it('rejects reserved ultrahigh reasoning effort before a run starts', async () => {

--- a/src/__tests__/unit/tui/local-commands.test.ts
+++ b/src/__tests__/unit/tui/local-commands.test.ts
@@ -540,6 +540,22 @@ describe('runLocalCommand', () => {
     expect(result.message).toContain('Effective effort: high');
   });
 
+  it('rejects reserved ultrahigh reasoning effort before a run starts', async () => {
+    const setActiveReasoningEffort = vi.fn();
+    const result = await runLocalCommand(createCommandArgs({
+      prompt: '/reasoning ultrahigh',
+      activeModel: 'gpt-5.4',
+      setActiveReasoningEffort,
+    }));
+
+    expect(result).toMatchObject({
+      handled: true,
+      kind: 'message',
+      message: expect.stringContaining('ultrahigh'),
+    });
+    expect(setActiveReasoningEffort).not.toHaveBeenCalled();
+  });
+
   it('autocompletes shared prefixes while preserving leading whitespace', () => {
     expect(autocompleteLocalCommand('  /sess', 'session-1', [])).toBe('  /session ');
     expect(autocompleteLocalCommand('/hea', 'session-1', [])).toBe('/heartbeat ');

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -17,6 +17,7 @@ import { buildConversationMessages } from './utils/format.js';
 import { buildCompactionRunningContext, compactChatHistoryWithArchive } from './state/compaction.js';
 import { estimateBuiltInContextWindow } from '../../core/llm/openai-models.js';
 import { credentialModeFromSource, resolveCompatibleActiveModel, resolveSystemSelectedModel } from '../../core/llm/model-policy.js';
+import type { ReasoningEffort } from '../../core/llm/types.js';
 import { useApprovalFlow } from './hooks/useApprovalFlow.js';
 import { useAgentRun } from './hooks/useAgentRun.js';
 import { useChatDrift } from './hooks/useChatDrift.js';
@@ -52,6 +53,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     clearDraft,
     replaceDraft,
   } = usePromptDraft();
+  const [activeReasoningEffort, setActiveReasoningEffort] = useState<ReasoningEffort | undefined>(undefined);
   const mentionableFiles = useState(() => listMentionableFiles(runtime.workspaceRoot, runtime.searchIgnoreDirs))[0];
 
   const {
@@ -113,6 +115,10 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     actionState,
     workingFrames,
   } = useApprovalFlow(nextLocalId);
+  useEffect(() => {
+    setActiveReasoningEffort(activeSession?.reasoningEffort);
+  }, [activeSession?.id, activeSession?.reasoningEffort]);
+
   useEffect(() => {
     if (!activeSession) {
       previousActiveModelRef.current = activeModel;
@@ -217,6 +223,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
   const {
     compacting,
     contextStatus,
+    reasoningStatus,
     authStatus,
     sessionFooter,
     renderedStatus,
@@ -225,6 +232,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     activeTurn,
   } = useChatStatusSummary({
     activeModel,
+    activeReasoningEffort,
     activeSessionId,
     activeSession,
     runtimeHostWarningSource: runtime.runtimeHost,
@@ -365,7 +373,14 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
   const { pendingSubmittedPrompt, clearPendingSubmittedPrompt, submitPrompt } = usePromptSubmission({
     runtime,
     activeModel,
+    activeReasoningEffort,
     setActiveModel: applyActiveModel,
+    setActiveReasoningEffort: (effort) => {
+      setActiveReasoningEffort(effort);
+      if (activeSession) {
+        updateSessionById(activeSession.id, (session) => ({ ...session, reasoningEffort: effort }));
+      }
+    },
     sessions,
     recentSessions,
     activeSessionId,
@@ -518,7 +533,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
           </Box>}
       </Box>
       <Box width={promptPanelWidth} overflow="hidden">
-        <Text dimColor wrap="truncate-end">{`model=${activeModel} • ${authStatus} • ${contextStatus} • drift=${drift.footer} • ${sessionFooter}`}</Text>
+        <Text dimColor wrap="truncate-end">{`model=${activeModel} • reasoning=${reasoningStatus} • ${authStatus} • ${contextStatus} • drift=${drift.footer} • ${sessionFooter}`}</Text>
       </Box>
     </Box>
   );

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -7,6 +7,7 @@ import {
   FileMentionPickerPanel,
   ModelPickerPanel,
   PromptInput,
+  ReasoningEffortPickerPanel,
   SessionPickerPanel,
   shouldShowCommandHint,
   shouldShowSlashHints,
@@ -87,6 +88,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     clearDraft,
     replaceDraft,
     providerCredentialSource: resolveProviderCredentialSourceForModel(activeModel, runtime),
+    activeModel,
   });
   const drift = useChatDrift({
     activeSession,
@@ -283,6 +285,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
         showSlashHints: shouldShowSlashHints(draft),
         showCommandHint: shouldShowCommandHint(draft),
         modelPicker: pickers.model,
+        reasoningPicker: pickers.reasoning,
         sessionPicker: pickers.session,
         fileMentionPicker: pickers.fileMention,
       }),
@@ -311,6 +314,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     draft,
     draftCursor,
     pickers.model,
+    pickers.reasoning,
     pickers.session,
     pickers.fileMention,
     renderedStatus,
@@ -406,6 +410,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     executeDirectShellCommand,
     mentionableFiles,
     modelPicker: pickers.model,
+    reasoningPicker: pickers.reasoning,
     sessionPicker: pickers.session,
     fileMentionPicker: pickers.fileMention,
     resetPickerIndexes: pickers.resetPickerIndexes,
@@ -473,6 +478,14 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
                   models={pickers.model.items}
                   activeModel={activeModel}
                   highlightedIndex={pickers.model.highlightedIndex}
+                />
+              : null}
+              {pickers.reasoning.visible ?
+                <ReasoningEffortPickerPanel
+                  query={pickers.reasoning.query ?? ''}
+                  options={pickers.reasoning.items}
+                  activeReasoningEffort={activeReasoningEffort}
+                  highlightedIndex={pickers.reasoning.highlightedIndex}
                 />
               : null}
               {pickers.session.visible ?

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -358,6 +358,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
   const { executeTurn, executeDirectShellCommand } = useAgentRun({
     runtime,
     activeModel,
+    activeReasoningEffort,
     sessionTitleModel,
     activeSessionId,
     sessions,

--- a/src/cli/chat/adapters/slash-command-context.ts
+++ b/src/cli/chat/adapters/slash-command-context.ts
@@ -14,6 +14,8 @@ export function createTuiSlashCommandContext(args: LocalCommandArgs): SlashComma
     model: {
       active: () => args.activeModel,
       setActive: args.setActiveModel,
+      activeReasoningEffort: () => args.activeReasoningEffort,
+      setReasoningEffort: args.setActiveReasoningEffort,
       credentialSource: () => args.providerCredentialSource,
     },
     auth: {

--- a/src/cli/chat/components/ReasoningEffortPickerPanel.tsx
+++ b/src/cli/chat/components/ReasoningEffortPickerPanel.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { ReasoningEffortPickerOption } from '../hooks/useChatPickers.js';
+import type { ReasoningEffort } from '../../../core/llm/types.js';
+
+const MAX_VISIBLE_EFFORTS = 6;
+
+export function ReasoningEffortPickerPanel({
+  query,
+  options,
+  activeReasoningEffort,
+  highlightedIndex,
+}: {
+  query: string;
+  options: ReasoningEffortPickerOption[];
+  activeReasoningEffort?: ReasoningEffort;
+  highlightedIndex: number;
+}) {
+  const { visibleOptions, startIndex } = getVisibleOptions(options, highlightedIndex);
+  const activeId = activeReasoningEffort ?? 'default';
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text dimColor>Reasoning effort picker</Text>
+      <Text dimColor>
+        {query ? `Search: ${query}` : 'Type after /reasoning set to filter. Use ↑/↓ or Tab to choose.'}
+      </Text>
+      {visibleOptions.length > 0 ?
+        visibleOptions.map((option, index) => {
+          const absoluteIndex = startIndex + index;
+          const isHighlighted = absoluteIndex === highlightedIndex;
+          const isActive = option.id === activeId;
+          const marker = isHighlighted ? '◉' : '○';
+          const suffix = [
+            isActive ? '(current)' : undefined,
+            option.disabled ? `(${option.disabledReason ?? 'unavailable'})` : undefined,
+          ].filter(Boolean).join(' ');
+
+          return (
+            <Text
+              key={option.id}
+              color={isHighlighted ? 'cyan' : option.disabled ? 'yellow' : undefined}
+              dimColor={!isHighlighted && !option.disabled}
+            >
+              {`${marker} ${option.label}${suffix ? ` ${suffix}` : ''} — ${option.description}`}
+            </Text>
+          );
+        })
+      : <Text dimColor>No matching reasoning efforts.</Text>}
+    </Box>
+  );
+}
+
+function getVisibleOptions(
+  options: ReasoningEffortPickerOption[],
+  highlightedIndex: number,
+): { visibleOptions: ReasoningEffortPickerOption[]; startIndex: number } {
+  if (options.length <= MAX_VISIBLE_EFFORTS) {
+    return { visibleOptions: options, startIndex: 0 };
+  }
+
+  const half = Math.floor(MAX_VISIBLE_EFFORTS / 2);
+  let startIndex = Math.max(0, highlightedIndex - half);
+  const maxStart = Math.max(0, options.length - MAX_VISIBLE_EFFORTS);
+  if (startIndex > maxStart) {
+    startIndex = maxStart;
+  }
+
+  return {
+    visibleOptions: options.slice(startIndex, startIndex + MAX_VISIBLE_EFFORTS),
+    startIndex,
+  };
+}

--- a/src/cli/chat/components/index.ts
+++ b/src/cli/chat/components/index.ts
@@ -6,6 +6,7 @@ export { FileMentionPickerPanel } from './FileMentionPickerPanel.js';
 export { ModelPickerPanel } from './ModelPickerPanel.js';
 export { PromptInput } from './PromptInput.js';
 export { RecentTurnsPanel } from './RecentTurnsPanel.js';
+export { ReasoningEffortPickerPanel } from './ReasoningEffortPickerPanel.js';
 export { RuntimeHostInterstitial } from './RuntimeHostInterstitial.js';
 export { SessionPickerPanel } from './SessionPickerPanel.js';
 export { SlashHintPanel, shouldShowSlashHints } from './SlashHintPanel.js';

--- a/src/cli/chat/debug/tui-debug-snapshot.ts
+++ b/src/cli/chat/debug/tui-debug-snapshot.ts
@@ -1,6 +1,7 @@
 import { buildPromptRenderLines } from '../components/PromptInput.js';
 import { OPENAI_OAUTH_MODE_DESCRIPTION, type CredentialAwareModelOption } from '../../../core/llm/model-policy.js';
 import { getLocalCommandHints } from '../state/local-commands.js';
+import type { ReasoningEffortPickerOption } from '../hooks/useChatPickers.js';
 import type { ChatSession, ConversationLine, PendingApproval } from '../state/types.js';
 import { formatApprovalHint, summarizePendingApproval, truncate } from '../utils/format.js';
 
@@ -33,6 +34,12 @@ export function buildTuiDebugSnapshot(args: {
     visible: boolean;
     query?: string;
     items: CredentialAwareModelOption[];
+    highlightedIndex: number;
+  };
+  reasoningPicker?: {
+    visible: boolean;
+    query?: string;
+    items: ReasoningEffortPickerOption[];
     highlightedIndex: number;
   };
   sessionPicker?: {
@@ -123,6 +130,13 @@ export function buildTuiDebugSnapshot(args: {
     lines.push('');
   }
 
+  if (args.reasoningPicker?.visible) {
+    lines.push('Reasoning effort picker');
+    lines.push(args.reasoningPicker.query ? `Search: ${args.reasoningPicker.query}` : 'Type after /reasoning set to filter. Use ↑/↓ or Tab to choose.');
+    lines.push(...renderReasoningEffortPickerLines(args.reasoningPicker.items, args.reasoningPicker.highlightedIndex));
+    lines.push('');
+  }
+
   if (args.sessionPicker?.visible) {
     lines.push('Session picker');
     lines.push(args.sessionPicker.query ? `Search: ${args.sessionPicker.query}` : 'Type after /session choose to filter. Use ↑/↓ or Tab to choose.');
@@ -158,6 +172,17 @@ export function buildTuiDebugSnapshot(args: {
 function renderMessageText(text: string): string[] {
   const normalized = text.split(/\r?\n/);
   return normalized.length > 0 ? normalized : [''];
+}
+
+function renderReasoningEffortPickerLines(items: ReasoningEffortPickerOption[], highlightedIndex: number): string[] {
+  if (items.length === 0) {
+    return ['No matching entries.'];
+  }
+
+  return items.slice(0, 8).map((item, index) => {
+    const suffix = item.disabled ? ` (${item.disabledReason ?? 'unavailable'})` : '';
+    return `${index === highlightedIndex ? '◉' : '○'} ${item.label}${suffix} — ${item.description}`;
+  });
 }
 
 function renderPickerLines(items: string[], highlightedIndex: number): string[] {

--- a/src/cli/chat/hooks/useAgentRun.ts
+++ b/src/cli/chat/hooks/useAgentRun.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { MutableRefObject } from 'react';
 import type { Logger } from 'pino';
 import type { ChatMessage, LlmAdapter, RunResult, ToolCall, ToolDefinition } from '../../../index.js';
+import type { ReasoningEffort } from '../../../core/llm/types.js';
 import {
   createLogger,
   createLlmAdapter,
@@ -93,6 +94,7 @@ type ExecuteDirectShellArgs = {
 type UseAgentRunArgs = {
   runtime: ChatRuntimeConfig;
   activeModel: string;
+  activeReasoningEffort?: ReasoningEffort;
   sessionTitleModel: string;
   activeSessionId: string;
   sessions: ChatSession[];
@@ -110,7 +112,7 @@ export type ChatDriftObserverOptions = {
 };
 
 export function useAgentRun(args: UseAgentRunArgs) {
-  const { runtime, activeModel, sessionTitleModel, activeSessionId, sessions, state, updateSessionById, updateActiveSession } = args;
+  const { runtime, activeModel, activeReasoningEffort, sessionTitleModel, activeSessionId, sessions, state, updateSessionById, updateActiveSession } = args;
   const projectApprovals = useProjectApprovals(runtime.approvalsFile);
   const activeApiKey = resolveApiKeyForModel(activeModel, runtime);
   const titleApiKey = resolveApiKeyForModel(sessionTitleModel, runtime);
@@ -124,8 +126,13 @@ export function useAgentRun(args: UseAgentRunArgs) {
   );
 
   const llm = useMemo(
-    () => createLlmAdapter({ model: activeModel, apiKey: activeApiKey, credentialStorePath: runtime.credentialStorePath }),
-    [activeApiKey, activeModel, runtime.credentialStorePath],
+    () => createLlmAdapter({
+      model: activeModel,
+      apiKey: activeApiKey,
+      credentialStorePath: runtime.credentialStorePath,
+      reasoningEffort: activeReasoningEffort,
+    }),
+    [activeApiKey, activeModel, activeReasoningEffort, runtime.credentialStorePath],
   );
   const titleLlm = useMemo(
     () => createLlmAdapter({ model: sessionTitleModel, apiKey: titleApiKey, credentialStorePath: runtime.credentialStorePath }),

--- a/src/cli/chat/hooks/useChatPickers.ts
+++ b/src/cli/chat/hooks/useChatPickers.ts
@@ -3,8 +3,12 @@ import { BUILT_IN_MODEL_GROUPS, filterBuiltInModels } from '../../../core/llm/op
 import {
   buildCredentialAwareModelOption,
   credentialModeFromSource,
+  resolveDefaultReasoningEffort,
+  supportsOpenAiRequestReasoningEffort,
+  supportsReasoningEffort,
   type CredentialAwareModelOption,
 } from '../../../core/llm/model-policy.js';
+import type { ReasoningEffort } from '../../../core/llm/types.js';
 import type { ProviderCredentialSource } from '../utils/runtime.js';
 import type { PromptKeyInput } from '../components/PromptInput.js';
 import type { ChatSession } from '../state/types.js';
@@ -17,6 +21,7 @@ export function useChatPickers({
   clearDraft,
   replaceDraft,
   providerCredentialSource,
+  activeModel,
 }: {
   draft: string;
   recentSessions: ChatSession[];
@@ -24,8 +29,10 @@ export function useChatPickers({
   clearDraft: () => void;
   replaceDraft: (value: string) => void;
   providerCredentialSource: ProviderCredentialSource;
+  activeModel: string;
 }) {
   const [modelPickerIndex, setModelPickerIndex] = useState(0);
+  const [reasoningPickerIndex, setReasoningPickerIndex] = useState(0);
   const [sessionPickerIndex, setSessionPickerIndex] = useState(0);
   const [fileMentionPickerIndex, setFileMentionPickerIndex] = useState(0);
 
@@ -52,6 +59,13 @@ export function useChatPickers({
   const safeModelPickerIndex = clampPickerIndex(modelPickerIndex, filteredModels.length);
   const highlightedModel = filteredModels[safeModelPickerIndex];
 
+  const reasoningPickerQuery = getReasoningPickerQuery(draft);
+  const reasoningPickerVisible = reasoningPickerQuery !== undefined;
+  const reasoningOptions = useMemo(() => buildReasoningEffortOptions(activeModel), [activeModel]);
+  const filteredReasoningOptions = reasoningPickerVisible ? filterReasoningEffortOptions(reasoningOptions, reasoningPickerQuery) : [];
+  const safeReasoningPickerIndex = clampPickerIndex(reasoningPickerIndex, filteredReasoningOptions.length);
+  const highlightedReasoningEffort = filteredReasoningOptions[safeReasoningPickerIndex];
+
   const sessionPickerQuery = getSessionPickerQuery(draft);
   const sessionPickerVisible = sessionPickerQuery !== undefined;
   const filteredSessions = sessionPickerVisible ? filterSessionsForPicker(recentSessions, sessionPickerQuery) : [];
@@ -60,6 +74,7 @@ export function useChatPickers({
 
   const resetPickerIndexes = () => {
     setModelPickerIndex(0);
+    setReasoningPickerIndex(0);
     setSessionPickerIndex(0);
     setFileMentionPickerIndex(0);
   };
@@ -97,6 +112,17 @@ export function useChatPickers({
       });
     }
 
+    if (reasoningPickerVisible) {
+      return handlePickerKeys({
+        key,
+        itemCount: filteredReasoningOptions.length,
+        resetDraft: clearDraft,
+        resetIndex: () => setReasoningPickerIndex(0),
+        advance: () => setReasoningPickerIndex((current) => (current + 1) % filteredReasoningOptions.length),
+        retreat: () => setReasoningPickerIndex((current) => (current <= 0 ? filteredReasoningOptions.length - 1 : current - 1)),
+      });
+    }
+
     if (fileMentionPickerVisible) {
       return handlePickerKeys({
         key,
@@ -128,6 +154,14 @@ export function useChatPickers({
       highlighted: highlightedSession,
       resetIndex: () => setSessionPickerIndex(0),
     },
+    reasoning: {
+      query: reasoningPickerQuery,
+      visible: reasoningPickerVisible,
+      items: filteredReasoningOptions,
+      highlightedIndex: safeReasoningPickerIndex,
+      highlighted: highlightedReasoningEffort,
+      resetIndex: () => setReasoningPickerIndex(0),
+    },
     fileMention: {
       query: mentionQuery,
       visible: fileMentionPickerVisible,
@@ -142,6 +176,14 @@ export function useChatPickers({
   };
 }
 
+export type ReasoningEffortPickerOption = {
+  id: 'default' | ReasoningEffort;
+  label: string;
+  description: string;
+  disabled: boolean;
+  disabledReason?: string;
+};
+
 function getModelPickerQuery(draft: string): string | undefined {
   const trimmedStart = draft.trimStart();
   if (!trimmedStart.startsWith('/model set')) {
@@ -149,6 +191,16 @@ function getModelPickerQuery(draft: string): string | undefined {
   }
 
   const remainder = trimmedStart.slice('/model set'.length);
+  return remainder.trim();
+}
+
+function getReasoningPickerQuery(draft: string): string | undefined {
+  const trimmedStart = draft.trimStart();
+  if (!trimmedStart.startsWith('/reasoning set')) {
+    return undefined;
+  }
+
+  const remainder = trimmedStart.slice('/reasoning set'.length);
   return remainder.trim();
 }
 
@@ -165,6 +217,55 @@ function getSessionPickerQuery(draft: string): string | undefined {
 function filterCredentialAwareModels(models: CredentialAwareModelOption[], query: string): CredentialAwareModelOption[] {
   const matchingIds = new Set(filterBuiltInModels(query));
   return models.filter((model) => matchingIds.has(model.id));
+}
+
+function buildReasoningEffortOptions(model: string): ReasoningEffortPickerOption[] {
+  const requestSupported = supportsOpenAiRequestReasoningEffort(model);
+  const reasoningSupported = supportsReasoningEffort(model);
+  const defaultEffort = resolveDefaultReasoningEffort(model);
+  const disabledReason =
+    reasoningSupported ?
+      'Not supported by request path'
+    : 'Not supported';
+
+  return [
+    {
+      id: 'default',
+      label: 'default',
+      description: defaultEffort ? `Use ${model} default (${defaultEffort})` : `Do not send reasoning effort for ${model}`,
+      disabled: false,
+    },
+    ...(['low', 'medium', 'high'] as const).map((effort) => ({
+      id: effort,
+      label: effort,
+      description: `Set explicit ${effort} effort`,
+      disabled: !requestSupported,
+      disabledReason: requestSupported ? undefined : disabledReason,
+    })),
+    {
+      id: 'ultrahigh' as const,
+      label: 'ultrahigh',
+      description: 'Reserved; not accepted by current OpenAI requests',
+      disabled: true,
+      disabledReason: 'Reserved',
+    },
+  ];
+}
+
+function filterReasoningEffortOptions(
+  options: ReasoningEffortPickerOption[],
+  query: string,
+): ReasoningEffortPickerOption[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return options;
+  }
+
+  return options.filter((option) =>
+    option.id.toLowerCase().includes(normalized)
+    || option.label.toLowerCase().includes(normalized)
+    || option.description.toLowerCase().includes(normalized),
+  );
 }
 
 function filterSessionsForPicker(

--- a/src/cli/chat/hooks/useChatStatusSummary.ts
+++ b/src/cli/chat/hooks/useChatStatusSummary.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 import { estimateBuiltInContextWindow } from '../../../core/llm/openai-models.js';
+import { resolveDefaultReasoningEffort, supportsReasoningEffort } from '../../../core/llm/model-policy.js';
+import type { ReasoningEffort } from '../../../core/llm/types.js';
 import type { ProviderCredentialSource } from '../utils/runtime.js';
 import type { ResolvedRuntimeHost } from '../../../core/runtime/runtime-hosts.js';
 import { currentActivityText } from '../utils/format.js';
@@ -19,6 +21,7 @@ type ActiveTurnSummary = {
 
 export function useChatStatusSummary(args: {
   activeModel: string;
+  activeReasoningEffort?: ReasoningEffort;
   activeSessionId: string;
   activeSession?: {
     id: string;
@@ -61,6 +64,7 @@ export function useChatStatusSummary(args: {
       args.activeModel,
       args.activeSession?.context?.lastRunInputTokens ?? args.activeSession?.context?.estimatedRequestTokens,
     );
+    const reasoningStatus = formatReasoningStatus(args.activeModel, args.activeReasoningEffort);
     const authStatus = formatAuthStatus(args.credentialSource);
     const sessionFooter = `session=${args.activeSession?.id ?? args.activeSessionId}${args.activeSession?.name ? ` (${args.activeSession.name})` : ''}`;
     const renderedStatus =
@@ -111,6 +115,7 @@ export function useChatStatusSummary(args: {
       compacting,
       activityText,
       contextStatus,
+      reasoningStatus,
       authStatus,
       sessionFooter,
       renderedStatus,
@@ -135,6 +140,14 @@ function formatContextStatus(model: string, estimatedTokens: number | undefined)
   const ratio = Math.min(1, estimatedTokens / window);
   const percent = Math.round(ratio * 100);
   return `estimated input ${estimatedTokens.toLocaleString()} / ${window.toLocaleString()} tokens (${percent}%)`;
+}
+
+function formatReasoningStatus(model: string, explicitEffort: ReasoningEffort | undefined): string {
+  if (!supportsReasoningEffort(model)) {
+    return 'unsupported';
+  }
+
+  return explicitEffort ?? resolveDefaultReasoningEffort(model) ?? 'default';
 }
 
 function formatAuthStatus(source: ProviderCredentialSource): string {

--- a/src/cli/chat/hooks/usePromptSubmission.ts
+++ b/src/cli/chat/hooks/usePromptSubmission.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { CredentialAwareModelOption } from '../../../core/llm/model-policy.js';
+import type { ReasoningEffort } from '../../../core/llm/types.js';
 import type { ConversationLine, ChatSession } from '../state/types.js';
 import { submitChatPrompt } from '../submit.js';
 import { buildPromptWithFileMentions } from '../utils/file-mentions.js';
@@ -11,7 +12,9 @@ type ActiveSessionUpdater = (updater: (session: ChatSession) => ChatSession) => 
 export function usePromptSubmission({
   runtime,
   activeModel,
+  activeReasoningEffort,
   setActiveModel,
+  setActiveReasoningEffort,
   sessions,
   recentSessions,
   activeSessionId,
@@ -42,7 +45,9 @@ export function usePromptSubmission({
 }: {
   runtime: ChatRuntimeConfig;
   activeModel: string;
+  activeReasoningEffort?: ReasoningEffort;
   setActiveModel: (model: string) => void;
+  setActiveReasoningEffort: (effort: ReasoningEffort | undefined) => void;
   sessions: ChatSession[];
   recentSessions: ChatSession[];
   activeSessionId: string;
@@ -148,7 +153,9 @@ export function usePromptSubmission({
     const submitArgs = {
       isRunning: effectiveIsRunning,
       activeModel,
+      activeReasoningEffort,
       setActiveModel,
+      setActiveReasoningEffort,
       sessions,
       recentSessions,
       activeSessionId,

--- a/src/cli/chat/hooks/usePromptSubmission.ts
+++ b/src/cli/chat/hooks/usePromptSubmission.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { CredentialAwareModelOption } from '../../../core/llm/model-policy.js';
 import type { ReasoningEffort } from '../../../core/llm/types.js';
+import type { ReasoningEffortPickerOption } from './useChatPickers.js';
 import type { ConversationLine, ChatSession } from '../state/types.js';
 import { submitChatPrompt } from '../submit.js';
 import { buildPromptWithFileMentions } from '../utils/file-mentions.js';
@@ -39,6 +40,7 @@ export function usePromptSubmission({
   pendingApproval,
   mentionableFiles,
   modelPicker,
+  reasoningPicker,
   sessionPicker,
   fileMentionPicker,
   resetPickerIndexes,
@@ -74,6 +76,11 @@ export function usePromptSubmission({
   modelPicker: {
     visible: boolean;
     highlighted?: CredentialAwareModelOption;
+    resetIndex: () => void;
+  };
+  reasoningPicker: {
+    visible: boolean;
+    highlighted?: ReasoningEffortPickerOption;
     resetIndex: () => void;
   };
   sessionPicker: {
@@ -195,6 +202,18 @@ export function usePromptSubmission({
       return;
     }
 
+    if (reasoningPicker.visible && reasoningPicker.highlighted) {
+      reasoningPicker.resetIndex();
+      if (reasoningPicker.highlighted.disabled) {
+        return;
+      }
+      await submitChatPrompt({
+        ...submitArgs,
+        value: reasoningPicker.highlighted.id === 'default' ? '/reasoning default' : `/reasoning ${reasoningPicker.highlighted.id}`,
+      });
+      return;
+    }
+
     if (sessionPicker.visible && sessionPicker.highlighted) {
       sessionPicker.resetIndex();
       await submitChatPrompt({
@@ -221,6 +240,7 @@ export function usePromptSubmission({
     activeModel,
     activeReasoningEffort,
     setActiveModel,
+    setActiveReasoningEffort,
     sessions,
     recentSessions,
     activeSessionId,
@@ -247,6 +267,7 @@ export function usePromptSubmission({
     executeDirectShellCommand,
     saveTuiSnapshot,
     modelPicker,
+    reasoningPicker,
     sessionPicker,
     fileMentionPicker,
     resetPickerIndexes,

--- a/src/cli/chat/hooks/usePromptSubmission.ts
+++ b/src/cli/chat/hooks/usePromptSubmission.ts
@@ -219,6 +219,7 @@ export function usePromptSubmission({
     pendingApproval,
     pendingSubmittedPrompt,
     activeModel,
+    activeReasoningEffort,
     setActiveModel,
     sessions,
     recentSessions,

--- a/src/cli/chat/state/local-commands.ts
+++ b/src/cli/chat/state/local-commands.ts
@@ -1,5 +1,6 @@
 import type { ChatSession } from './types.js';
 import type { OpenAiOAuthCredential } from '../../../core/auth/openai-oauth.js';
+import type { ReasoningEffort } from '../../../core/llm/types.js';
 import type { ProviderCredentialSource } from '../utils/runtime.js';
 import { autocompleteSlashCommand, filterSlashCommandHints } from '../../../core/commands/slash/autocomplete.js';
 import { createSlashCommandRegistry } from '../../../core/commands/slash/registry.js';
@@ -16,7 +17,9 @@ export type LocalCommandHint = {
 export type LocalCommandArgs = {
   prompt: string;
   activeModel: string;
+  activeReasoningEffort?: ReasoningEffort;
   setActiveModel: (model: string) => void;
+  setActiveReasoningEffort: (effort: ReasoningEffort | undefined) => void;
   sessions: ChatSession[];
   recentSessions: ChatSession[];
   activeSessionId: string;

--- a/src/cli/chat/submit.ts
+++ b/src/cli/chat/submit.ts
@@ -1,6 +1,7 @@
 import { runLocalCommand } from './state/local-commands.js';
 import { buildCompactionRunningContext, compactChatHistoryWithArchive } from './state/compaction.js';
 import { createInitialMessages } from './state/storage.js';
+import type { ReasoningEffort } from '../../core/llm/types.js';
 import type { ChatSession, ConversationLine } from './state/types.js';
 import { buildConversationMessages, normalizeInlineText } from './utils/format.js';
 import type { ProviderCredentialSource } from './utils/runtime.js';
@@ -15,7 +16,9 @@ type SubmitChatPromptArgs = {
   value: string;
   isRunning: boolean;
   activeModel: string;
+  activeReasoningEffort?: ReasoningEffort;
   setActiveModel: (model: string) => void;
+  setActiveReasoningEffort: (effort: ReasoningEffort | undefined) => void;
   sessions: ChatSession[];
   recentSessions: ChatSession[];
   activeSessionId: string;
@@ -57,7 +60,9 @@ export async function submitChatPrompt(args: SubmitChatPromptArgs): Promise<void
   const commandResult = await runLocalCommand({
     prompt,
     activeModel: args.activeModel,
+    activeReasoningEffort: args.activeReasoningEffort,
     setActiveModel: args.setActiveModel,
+    setActiveReasoningEffort: args.setActiveReasoningEffort,
     sessions: args.sessions,
     recentSessions: args.recentSessions,
     activeSessionId: args.activeSessionId,

--- a/src/core/chat/engine/config.ts
+++ b/src/core/chat/engine/config.ts
@@ -1,5 +1,6 @@
 import { join, resolve } from 'node:path';
 import type { ToolApprovalPolicy } from '../../approvals/types.js';
+import type { ReasoningEffort } from '../../llm/types.js';
 import type { TraceSummarizerRegistry } from '../../observability/trace-summarizers.js';
 import type { ConversationEngineConfig } from './types.js';
 
@@ -7,6 +8,7 @@ export type NormalizedConversationEngineConfig = {
   workspaceRoot: string;
   stateRoot: string;
   model: string;
+  reasoningEffort?: ReasoningEffort;
   apiKey?: string;
   preferApiKey?: boolean;
   credentialStorePath?: string;
@@ -33,6 +35,7 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     workspaceRoot,
     stateRoot,
     model: config.model,
+    reasoningEffort: config.reasoningEffort,
     apiKey: config.apiKey,
     preferApiKey: config.preferApiKey,
     credentialStorePath,

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -27,6 +27,7 @@ export function createConversationSessionService(args: {
         name: input?.name?.trim() || `Session ${nextNumber}`,
         apiKeyPresent: input?.apiKeyPresent ?? config.apiKeyPresent,
         model: input?.model ?? config.model,
+        reasoningEffort: input?.reasoningEffort ?? config.reasoningEffort,
         workspaceId: input?.workspaceId ?? config.workspaceId,
       });
       saveChatSessions(config.sessionStoragePath, [session, ...existing]);

--- a/src/core/chat/engine/sessions/storage.ts
+++ b/src/core/chat/engine/sessions/storage.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import type { ChatMessage } from '../../../llm/types.js';
+import type { ChatMessage, ReasoningEffort } from '../../../llm/types.js';
 import type { ChatArchiveRecord, ChatContextStats, ChatSession, ChatSessionLease, ConversationLine, TurnSummary } from '../../types.js';
 import { truncate } from '../../../utils/text.js';
 
@@ -11,6 +11,7 @@ type ChatSessionCatalogEntry = {
   createdAt: string;
   updatedAt: string;
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   driftEnabled?: boolean;
   lastContinuePrompt?: string;
   context?: ChatContextStats;
@@ -251,6 +252,10 @@ function parseCatalogEntry(value: unknown): ChatSessionCatalogEntry[] {
     createdAt,
     updatedAt,
     model: typeof candidate.model === 'string' ? candidate.model : undefined,
+    reasoningEffort:
+      candidate.reasoningEffort === 'low' || candidate.reasoningEffort === 'medium' || candidate.reasoningEffort === 'high' || candidate.reasoningEffort === 'ultrahigh' ?
+        candidate.reasoningEffort
+      : undefined,
     driftEnabled: typeof candidate.driftEnabled === 'boolean' ? candidate.driftEnabled : false,
     lastContinuePrompt: typeof candidate.lastContinuePrompt === 'string' ? candidate.lastContinuePrompt : undefined,
     context: isChatContextStats(candidate.context) ? candidate.context : undefined,
@@ -267,6 +272,7 @@ function projectCatalogEntry(session: ChatSession): ChatSessionCatalogEntry {
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
     model: session.model,
+    reasoningEffort: session.reasoningEffort,
     driftEnabled: session.driftEnabled,
     lastContinuePrompt: session.lastContinuePrompt,
     context: session.context,
@@ -299,6 +305,7 @@ function readSessionFile(
       createdAt: entry.createdAt,
       updatedAt: entry.updatedAt,
       model: entry.model,
+      reasoningEffort: entry.reasoningEffort,
       driftEnabled: entry.driftEnabled,
       lastContinuePrompt: entry.lastContinuePrompt,
       context: entry.context,
@@ -448,6 +455,10 @@ function parseSavedSession(value: unknown, apiKeyPresent: boolean): ChatSession[
     createdAt,
     updatedAt,
     model: typeof candidate.model === 'string' ? candidate.model : undefined,
+    reasoningEffort:
+      candidate.reasoningEffort === 'low' || candidate.reasoningEffort === 'medium' || candidate.reasoningEffort === 'high' || candidate.reasoningEffort === 'ultrahigh' ?
+        candidate.reasoningEffort
+      : undefined,
     driftEnabled: typeof candidate.driftEnabled === 'boolean' ? candidate.driftEnabled : false,
     lastContinuePrompt: typeof candidate.lastContinuePrompt === 'string' ? candidate.lastContinuePrompt : undefined,
     context: isChatContextStats(candidate.context) ? candidate.context : undefined,

--- a/src/core/chat/engine/sessions/storage.ts
+++ b/src/core/chat/engine/sessions/storage.ts
@@ -48,6 +48,7 @@ export function createChatSession(options: {
   name: string;
   apiKeyPresent: boolean;
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   workspaceId?: string;
 }): ChatSession {
   const now = new Date().toISOString();
@@ -61,6 +62,7 @@ export function createChatSession(options: {
     createdAt: now,
     updatedAt: now,
     model: options.model,
+    reasoningEffort: options.reasoningEffort,
     driftEnabled: false,
     lastContinuePrompt: undefined,
     context: undefined,

--- a/src/core/chat/engine/turns/context.ts
+++ b/src/core/chat/engine/turns/context.ts
@@ -36,6 +36,7 @@ export function prepareConversationTurnContext(args: PrepareConversationTurnCont
   const runtime = resolveConversationTurnRuntime({
     stateRoot: args.stateRoot,
     sessionModel: session.model,
+    sessionReasoningEffort: session.reasoningEffort,
     apiKey: args.apiKey,
     preferApiKey: args.preferApiKey,
     credentialStorePath: args.credentialStorePath,

--- a/src/core/chat/engine/turns/runtime.ts
+++ b/src/core/chat/engine/turns/runtime.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 import { DEFAULT_OPENAI_MODEL } from '../../../config.js';
 import { createLlmAdapter } from '../../../llm/factory.js';
 import { inferProviderFromModel } from '../../../llm/providers.js';
-import type { LlmAdapter, LlmProvider } from '../../../llm/types.js';
+import type { LlmAdapter, LlmProvider, ReasoningEffort } from '../../../llm/types.js';
 import {
   formatMissingProviderCredentialMessage,
   hasProviderCredentialForModel,
@@ -14,6 +14,7 @@ import { appendMemoryCatalogSystemContext } from '../../../memory/catalog.js';
 
 export type ChatTurnRuntime = {
   model: string;
+  reasoningEffort?: ReasoningEffort;
   provider: LlmProvider;
   apiKey: string | undefined;
   providerCredentialSource: ProviderCredentialSource;
@@ -25,6 +26,7 @@ export type ChatTurnRuntime = {
 export type ResolveConversationTurnRuntimeArgs = {
   stateRoot: string;
   sessionModel?: string;
+  sessionReasoningEffort?: ReasoningEffort;
   apiKey?: string;
   preferApiKey?: boolean;
   credentialStorePath?: string;
@@ -72,7 +74,13 @@ export function resolveConversationTurnRuntime(args: ResolveConversationTurnRunt
       systemContext: args.systemContext,
       memoryRoot: memoryDir,
     }),
-    llm: createLlmAdapter({ model, apiKey, credentialStorePath: args.credentialStorePath }),
+    reasoningEffort: args.sessionReasoningEffort,
+    llm: createLlmAdapter({
+      model,
+      apiKey,
+      credentialStorePath: args.credentialStorePath,
+      reasoningEffort: args.sessionReasoningEffort,
+    }),
   };
 }
 

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../observability/conversation-activity.js';
 import type { TraceSummarizerRegistry } from '../../observability/trace-summarizers.js';
 import type { AgentLoopEvent, RunAgentLoopOptions } from '../../runtime/agent-loop.js';
+import type { ReasoningEffort } from '../../llm/types.js';
 import type { TraceEvent } from '../../types.js';
 import type { ChatSessionLeaseOwner } from './sessions/lease.js';
 import type { ChatSession } from '../types.js';
@@ -13,6 +14,7 @@ export type ConversationEngineConfig = {
   workspaceRoot: string;
   stateRoot: string;
   model: string;
+  reasoningEffort?: ReasoningEffort;
   apiKey?: string;
   preferApiKey?: boolean;
   credentialStorePath?: string;
@@ -43,6 +45,7 @@ export type CreateConversationSessionInput = {
   id?: string;
   name?: string;
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   workspaceId?: string;
   apiKeyPresent?: boolean;
 };

--- a/src/core/chat/types.ts
+++ b/src/core/chat/types.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from '../llm/types.js';
+import type { ChatMessage, ReasoningEffort } from '../llm/types.js';
 import type { ToolCall, ToolDefinition } from '../types.js';
 import type { EditFilePreview } from '../tools/toolkits/coding-files/edit-file.js';
 
@@ -77,6 +77,7 @@ export type ChatSession = {
   createdAt: string;
   updatedAt: string;
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   driftEnabled?: boolean;
   lastContinuePrompt?: string;
   context?: ChatContextStats;

--- a/src/core/commands/slash/modules/context.ts
+++ b/src/core/commands/slash/modules/context.ts
@@ -1,5 +1,5 @@
 import type { ChatSession } from '../../../chat/types.js';
-import type { LlmProvider } from '../../../llm/types.js';
+import type { LlmProvider, ReasoningEffort } from '../../../llm/types.js';
 import type { ProviderCredentialSource } from '../../../runtime/api-keys.js';
 import type {
   HeartbeatTask,
@@ -11,6 +11,8 @@ export type SlashCommandExecutionContext = {
   model: {
     active: () => string;
     setActive: (model: string) => void;
+    activeReasoningEffort: () => ReasoningEffort | undefined;
+    setReasoningEffort: (effort: ReasoningEffort | undefined) => void;
     credentialSource: () => ProviderCredentialSource | undefined;
   };
   auth: {

--- a/src/core/commands/slash/modules/core-command-modules.ts
+++ b/src/core/commands/slash/modules/core-command-modules.ts
@@ -5,7 +5,7 @@ import { createAuthSlashCommandModule } from './auth/auth-commands.js';
 import { createCompactionSlashCommandModule } from './compaction/compaction-commands.js';
 import { createDriftSlashCommandModule } from './drift/drift-commands.js';
 import { createHeartbeatSlashCommandModule } from './heartbeat/heartbeat-commands.js';
-import { createModelSlashCommandModule } from './model/model-commands.js';
+import { createModelSlashCommandModule, createReasoningSlashCommandModule } from './model/model-commands.js';
 import { createSessionSlashCommandModule } from './session/session-commands.js';
 
 export function createCoreSlashCommandModules(): SlashCommandModule<
@@ -14,6 +14,7 @@ export function createCoreSlashCommandModules(): SlashCommandModule<
 >[] {
   return [
     createModelSlashCommandModule(),
+    createReasoningSlashCommandModule(),
     createAuthSlashCommandModule(),
     createCompactionSlashCommandModule(),
     createDriftSlashCommandModule(),

--- a/src/core/commands/slash/modules/model/model-commands.ts
+++ b/src/core/commands/slash/modules/model/model-commands.ts
@@ -4,8 +4,13 @@ import type { SlashCommandModule } from '../../types.js';
 import type { SlashCommandExecutionContext } from '../context.js';
 import { argumentAfterPrefix, slashMessageResult } from '../results.js';
 import { COMMON_BUILT_IN_MODELS, formatBuiltInModelGroups } from '../../../../llm/openai-models.js';
-import { credentialModeFromSource, validateModelCredentialCompatibility } from '../../../../llm/model-policy.js';
-import type { LlmProvider } from '../../../../llm/types.js';
+import {
+  credentialModeFromSource,
+  resolveDefaultReasoningEffort,
+  supportsReasoningEffort,
+  validateModelCredentialCompatibility,
+} from '../../../../llm/model-policy.js';
+import type { LlmProvider, ReasoningEffort } from '../../../../llm/types.js';
 
 export const MODEL_LIST_MESSAGE = ['Common built-in model choices', '', formatBuiltInModelGroups()].join('\n');
 export const MODEL_SET_HELP_MESSAGE = 'Use /model set <query> to filter models, then use arrows and Enter to choose one.';
@@ -58,6 +63,36 @@ export function createModelSlashCommandModule(): SlashCommandModule<SlashCommand
   };
 }
 
+export function createReasoningSlashCommandModule(): SlashCommandModule<SlashCommandResult, SlashCommandExecutionContext> {
+  return {
+    id: 'reasoning',
+    hints: [
+      { command: '/reasoning', description: 'show reasoning effort for the current session' },
+      { command: '/reasoning low', description: 'set reasoning effort to low' },
+      { command: '/reasoning medium', description: 'set reasoning effort to medium' },
+      { command: '/reasoning high', description: 'set reasoning effort to high' },
+      { command: '/reasoning ultrahigh', description: 'set reasoning effort to ultrahigh' },
+      { command: '/reasoning default', description: 'clear explicit reasoning effort and use the model default' },
+    ],
+    commands: [
+      {
+        id: 'reasoning.current',
+        syntax: '/reasoning',
+        description: 'show reasoning effort for the current session',
+        match: matchesExactSlashCommand('/reasoning'),
+        run: (context) => slashMessageResult(formatReasoningEffortStatus(context.model.active(), context.model.activeReasoningEffort())),
+      },
+      {
+        id: 'reasoning.set',
+        syntax: '/reasoning <low|medium|high|ultrahigh|default>',
+        description: 'set reasoning effort for the current session',
+        match: matchesSlashCommandPrefix('/reasoning'),
+        run: (context, input) => setReasoningEffort(context, argumentAfterPrefix(input, '/reasoning')),
+      },
+    ],
+  };
+}
+
 function switchModel(
   context: SlashCommandExecutionContext,
   value: string,
@@ -86,6 +121,51 @@ function switchModel(
       `Switched model to ${value}`
     : `Switched model to ${value}. This name is not in Heddle's common shortlist, so the next API call will fail if the provider does not recognize it.`,
   );
+}
+
+function setReasoningEffort(
+  context: SlashCommandExecutionContext,
+  value: string,
+): SlashCommandResult {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return slashMessageResult(formatReasoningEffortStatus(context.model.active(), context.model.activeReasoningEffort()));
+  }
+
+  if (normalized === 'default') {
+    context.model.setReasoningEffort(undefined);
+    return slashMessageResult(
+      `Cleared explicit reasoning effort for ${context.model.active()}. Effective default: ${resolveDefaultReasoningEffort(context.model.active()) ?? 'not supported'}.`,
+    );
+  }
+
+  if (!isReasoningEffort(normalized)) {
+    return slashMessageResult('Usage: /reasoning <low|medium|high|ultrahigh|default>');
+  }
+
+  if (!supportsReasoningEffort(context.model.active())) {
+    return slashMessageResult(`Reasoning effort is not supported for model ${context.model.active()}.`);
+  }
+
+  context.model.setReasoningEffort(normalized);
+  return slashMessageResult(`Set reasoning effort to ${normalized} for ${context.model.active()}.`);
+}
+
+function formatReasoningEffortStatus(model: string, explicitEffort: ReasoningEffort | undefined): string {
+  const supported = supportsReasoningEffort(model);
+  const effective = explicitEffort ?? resolveDefaultReasoningEffort(model);
+  return [
+    `Current model: ${model}`,
+    `Reasoning effort support: ${supported ? 'supported' : 'unsupported'}`,
+    `Configured effort: ${explicitEffort ?? 'default'}`,
+    `Effective effort: ${effective ?? 'none'}`,
+    '',
+    'Use /reasoning <low|medium|high|ultrahigh|default> to update this session.',
+  ].join('\n');
+}
+
+function isReasoningEffort(value: string): value is ReasoningEffort {
+  return value === 'low' || value === 'medium' || value === 'high' || value === 'ultrahigh';
 }
 
 function inferProviderForModel(model: string): LlmProvider {

--- a/src/core/commands/slash/modules/model/model-commands.ts
+++ b/src/core/commands/slash/modules/model/model-commands.ts
@@ -7,6 +7,7 @@ import { COMMON_BUILT_IN_MODELS, formatBuiltInModelGroups } from '../../../../ll
 import {
   credentialModeFromSource,
   resolveDefaultReasoningEffort,
+  supportsOpenAiRequestReasoningEffort,
   supportsReasoningEffort,
   validateModelCredentialCompatibility,
 } from '../../../../llm/model-policy.js';
@@ -71,7 +72,6 @@ export function createReasoningSlashCommandModule(): SlashCommandModule<SlashCom
       { command: '/reasoning low', description: 'set reasoning effort to low' },
       { command: '/reasoning medium', description: 'set reasoning effort to medium' },
       { command: '/reasoning high', description: 'set reasoning effort to high' },
-      { command: '/reasoning ultrahigh', description: 'set reasoning effort to ultrahigh' },
       { command: '/reasoning default', description: 'clear explicit reasoning effort and use the model default' },
     ],
     commands: [
@@ -145,6 +145,14 @@ function setReasoningEffort(
 
   if (!supportsReasoningEffort(context.model.active())) {
     return slashMessageResult(`Reasoning effort is not supported for model ${context.model.active()}.`);
+  }
+
+  if (normalized === 'ultrahigh') {
+    return slashMessageResult('Reasoning effort "ultrahigh" is reserved but is not supported by the current OpenAI request path. Use low, medium, high, or default.');
+  }
+
+  if (!supportsOpenAiRequestReasoningEffort(context.model.active())) {
+    return slashMessageResult(`Reasoning effort settings are not supported by the OpenAI request path for model ${context.model.active()}.`);
   }
 
   context.model.setReasoningEffort(normalized);

--- a/src/core/commands/slash/modules/model/model-commands.ts
+++ b/src/core/commands/slash/modules/model/model-commands.ts
@@ -15,6 +15,7 @@ import type { LlmProvider, ReasoningEffort } from '../../../../llm/types.js';
 
 export const MODEL_LIST_MESSAGE = ['Common built-in model choices', '', formatBuiltInModelGroups()].join('\n');
 export const MODEL_SET_HELP_MESSAGE = 'Use /model set <query> to filter models, then use arrows and Enter to choose one.';
+export const REASONING_SET_HELP_MESSAGE = 'Use /reasoning set <query> to filter reasoning efforts, then use arrows and Enter to choose one.';
 
 const MODEL_SUBCOMMAND_RESULTS = new Map<string, SlashCommandResult>([
   ['list', slashMessageResult(MODEL_LIST_MESSAGE)],
@@ -69,9 +70,7 @@ export function createReasoningSlashCommandModule(): SlashCommandModule<SlashCom
     id: 'reasoning',
     hints: [
       { command: '/reasoning', description: 'show reasoning effort for the current session' },
-      { command: '/reasoning low', description: 'set reasoning effort to low' },
-      { command: '/reasoning medium', description: 'set reasoning effort to medium' },
-      { command: '/reasoning high', description: 'set reasoning effort to high' },
+      { command: '/reasoning set [query]', description: 'pick reasoning effort with filtering' },
       { command: '/reasoning default', description: 'clear explicit reasoning effort and use the model default' },
     ],
     commands: [
@@ -83,8 +82,15 @@ export function createReasoningSlashCommandModule(): SlashCommandModule<SlashCom
         run: (context) => slashMessageResult(formatReasoningEffortStatus(context.model.active(), context.model.activeReasoningEffort())),
       },
       {
+        id: 'reasoning.set.help',
+        syntax: '/reasoning set',
+        description: 'pick reasoning effort with filtering',
+        match: matchesExactSlashCommand('/reasoning set'),
+        run: () => slashMessageResult(REASONING_SET_HELP_MESSAGE),
+      },
+      {
         id: 'reasoning.set',
-        syntax: '/reasoning <low|medium|high|ultrahigh|default>',
+        syntax: '/reasoning <low|medium|high|default>',
         description: 'set reasoning effort for the current session',
         match: matchesSlashCommandPrefix('/reasoning'),
         run: (context, input) => setReasoningEffort(context, argumentAfterPrefix(input, '/reasoning')),
@@ -132,22 +138,24 @@ function setReasoningEffort(
     return slashMessageResult(formatReasoningEffortStatus(context.model.active(), context.model.activeReasoningEffort()));
   }
 
-  if (normalized === 'default') {
+  const selected = normalized.startsWith('set ') ? normalized.slice('set '.length).trim() : normalized;
+
+  if (selected === 'default') {
     context.model.setReasoningEffort(undefined);
     return slashMessageResult(
       `Cleared explicit reasoning effort for ${context.model.active()}. Effective default: ${resolveDefaultReasoningEffort(context.model.active()) ?? 'not supported'}.`,
     );
   }
 
-  if (!isReasoningEffort(normalized)) {
-    return slashMessageResult('Usage: /reasoning <low|medium|high|ultrahigh|default>');
+  if (!isReasoningEffort(selected)) {
+    return slashMessageResult('Usage: /reasoning set <query> or /reasoning <low|medium|high|default>');
   }
 
   if (!supportsReasoningEffort(context.model.active())) {
     return slashMessageResult(`Reasoning effort is not supported for model ${context.model.active()}.`);
   }
 
-  if (normalized === 'ultrahigh') {
+  if (selected === 'ultrahigh') {
     return slashMessageResult('Reasoning effort "ultrahigh" is reserved but is not supported by the current OpenAI request path. Use low, medium, high, or default.');
   }
 
@@ -155,8 +163,8 @@ function setReasoningEffort(
     return slashMessageResult(`Reasoning effort settings are not supported by the OpenAI request path for model ${context.model.active()}.`);
   }
 
-  context.model.setReasoningEffort(normalized);
-  return slashMessageResult(`Set reasoning effort to ${normalized} for ${context.model.active()}.`);
+  context.model.setReasoningEffort(selected);
+  return slashMessageResult(`Set reasoning effort to ${selected} for ${context.model.active()}.`);
 }
 
 function formatReasoningEffortStatus(model: string, explicitEffort: ReasoningEffort | undefined): string {
@@ -168,7 +176,7 @@ function formatReasoningEffortStatus(model: string, explicitEffort: ReasoningEff
     `Configured effort: ${explicitEffort ?? 'default'}`,
     `Effective effort: ${effective ?? 'none'}`,
     '',
-    'Use /reasoning <low|medium|high|ultrahigh|default> to update this session.',
+    'Use /reasoning set to choose an effort, or /reasoning default to clear it.',
   ].join('\n');
 }
 

--- a/src/core/llm/factory.ts
+++ b/src/core/llm/factory.ts
@@ -6,7 +6,7 @@
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_LLM_PROVIDER, DEFAULT_OPENAI_MODEL } from '../config.js';
 import { createAnthropicAdapter } from './anthropic.js';
 import { createOpenAiAdapter } from './openai.js';
-import type { LlmAdapter, LlmProvider } from './types.js';
+import type { LlmAdapter, LlmProvider, ReasoningEffort } from './types.js';
 import { inferProviderFromModel } from './providers.js';
 import type { StoredProviderCredential } from '../auth/provider-credentials.js';
 import { resolveOAuthCredentialForModel } from '../runtime/api-keys.js';
@@ -17,6 +17,7 @@ export type CreateLlmAdapterOptions = {
   apiKey?: string;
   credential?: StoredProviderCredential;
   credentialStorePath?: string;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export function createLlmAdapter(options: CreateLlmAdapterOptions = {}): LlmAdapter {
@@ -37,6 +38,7 @@ export function createLlmAdapter(options: CreateLlmAdapterOptions = {}): LlmAdap
         model,
         credential,
         credentialStorePath: options.credentialStorePath,
+        reasoningEffort: options.reasoningEffort,
       });
     case 'anthropic':
       return createAnthropicAdapter({

--- a/src/core/llm/model-policy.ts
+++ b/src/core/llm/model-policy.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from '../config.js';
 import type { ProviderCredentialSource } from '../runtime/api-keys.js';
 import { isOpenAiAccountSignInModel, OPENAI_ACCOUNT_SIGN_IN_MODELS } from './openai-models.js';
-import type { LlmProvider } from './types.js';
+import type { LlmProvider, ReasoningEffort } from './types.js';
 
 export type SystemModelPurpose = 'chat-compaction' | 'session-title';
 export type ModelCredentialMode = 'api-key' | 'oauth' | 'missing';
@@ -20,6 +20,29 @@ const OPENAI_OAUTH_DISABLED_REASON = 'Not supported';
 export const OPENAI_OAUTH_MODE_DESCRIPTION = 'OAuth mode supports a smaller OpenAI allowlist.';
 
 const OPENAI_OAUTH_IMAGE_MODEL_PREFERENCES = ['gpt-5.4', 'gpt-5.4-mini'];
+const REASONING_EFFORT_CAPABLE_OPENAI_MODELS = [
+  'gpt-5.4',
+  'gpt-5.4-pro',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
+  'gpt-5.5',
+  'gpt-5.5-pro',
+] as const;
+const OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS = [
+  'gpt-5.4',
+  'gpt-5.4-pro',
+  'gpt-5.4-mini',
+  'gpt-5.5',
+  'gpt-5.5-pro',
+] as const;
+const DEFAULT_OPENAI_REASONING_EFFORT: Record<string, ReasoningEffort> = {
+  'gpt-5.4': 'high',
+  'gpt-5.4-pro': 'high',
+  'gpt-5.4-mini': 'medium',
+  'gpt-5.4-nano': 'low',
+  'gpt-5.5': 'high',
+  'gpt-5.5-pro': 'high',
+};
 
 export function credentialModeFromSource(source: ProviderCredentialSource | undefined): ModelCredentialMode {
   if (source?.type === 'oauth') {
@@ -150,6 +173,18 @@ export function resolveCompatibleActiveModel(args: {
     model: fallback,
     warning: `Model ${args.activeModel} is not supported with OpenAI account sign-in. Switched to ${fallback} for this session.`,
   };
+}
+
+export function supportsReasoningEffort(model: string): boolean {
+  return REASONING_EFFORT_CAPABLE_OPENAI_MODELS.includes(model as (typeof REASONING_EFFORT_CAPABLE_OPENAI_MODELS)[number]);
+}
+
+export function supportsOpenAiRequestReasoningEffort(model: string): boolean {
+  return OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS.includes(model as (typeof OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS)[number]);
+}
+
+export function resolveDefaultReasoningEffort(model: string): ReasoningEffort | undefined {
+  return DEFAULT_OPENAI_REASONING_EFFORT[model];
 }
 
 export function formatOpenAiAccountSignInModels(): string {

--- a/src/core/llm/openai.ts
+++ b/src/core/llm/openai.ts
@@ -10,8 +10,9 @@ import type {
   Response as OpenAiResponse,
   ResponseStreamEvent,
 } from 'openai/resources/responses/responses.js';
+import type { ReasoningEffort as OpenAiReasoningEffort } from 'openai/resources/shared.js';
 import type { Fetch as OpenAiFetch } from 'openai/core.js';
-import type { LlmAdapter, ChatMessage, LlmResponse, LlmAdapterCapabilities, LlmUsage, LlmStreamEvent } from './types.js';
+import type { LlmAdapter, ChatMessage, LlmResponse, LlmAdapterCapabilities, LlmUsage, LlmStreamEvent, ReasoningEffort } from './types.js';
 import type { AssistantDiagnostics, ToolDefinition, ToolCall } from '../types.js';
 import { DEFAULT_OPENAI_MODEL } from '../config.js';
 import {
@@ -23,7 +24,11 @@ import {
   setStoredProviderCredential,
   type StoredProviderCredential,
 } from '../auth/provider-credentials.js';
-import { assertModelCredentialCompatibility } from './model-policy.js';
+import {
+  assertModelCredentialCompatibility,
+  resolveDefaultReasoningEffort,
+  supportsOpenAiRequestReasoningEffort,
+} from './model-policy.js';
 
 export type OpenAiAdapterOptions = {
   apiKey?: string;
@@ -31,6 +36,7 @@ export type OpenAiAdapterOptions = {
   credential?: StoredProviderCredential;
   credentialStorePath?: string;
   fetchImpl?: CompatibleFetch;
+  reasoningEffort?: ReasoningEffort;
 };
 
 type CompatibleFetch = (url: unknown, init?: unknown) => Promise<globalThis.Response>;
@@ -81,6 +87,7 @@ export function createOpenAiAdapter(options: OpenAiAdapterOptions = {}): LlmAdap
         model,
         tools,
         oauthMode: Boolean(oauthCredential),
+        reasoningEffort: options.reasoningEffort,
       });
       const stream = await client.responses.stream({
         ...request,
@@ -323,65 +330,73 @@ export function extractOpenAiCodexSseItems<T>(
   return items;
 }
 
-// ---------------------------------------------------------------------------
-// Internal converters
-// ---------------------------------------------------------------------------
-
-function extractAssistantContent(response: OpenAiResponse, hasToolCalls: boolean): string | undefined {
-  if (response.output_text) {
-    return response.output_text;
+function extractAssistantContent(response: OpenAiResponse, preferToolCalls: boolean): string | undefined {
+  const text = response.output_text?.trim();
+  if (text) {
+    return text;
   }
 
-  if (!hasToolCalls) {
+  if (preferToolCalls) {
     return undefined;
   }
 
-  const reasoningSummary = response.output
-    .filter((item): item is ResponseReasoningItem => item.type === 'reasoning')
-    .flatMap((item) => item.summary)
-    .map((summary) => summary.text.trim())
-    .filter(Boolean)
-    .join(' ');
+  for (const item of response.output) {
+    if (item.type !== 'message') {
+      continue;
+    }
 
-  return reasoningSummary || undefined;
+    const segment = item.content.find((part) => part.type === 'output_text');
+    if (segment?.text?.trim()) {
+      return segment.text.trim();
+    }
+  }
+
+  return undefined;
 }
 
-function extractAssistantDiagnostics(response: OpenAiResponse, hasToolCalls: boolean): AssistantDiagnostics | undefined {
-  if (!hasToolCalls) {
+function extractAssistantDiagnostics(
+  response: OpenAiResponse,
+  preferToolCalls: boolean,
+): AssistantDiagnostics | undefined {
+  const reasoning = response.output.find((item): item is ResponseReasoningItem => item.type === 'reasoning');
+  if (!reasoning || !Array.isArray(reasoning.summary)) {
     return undefined;
   }
 
-  const rationale = response.output
-    .filter((item): item is ResponseReasoningItem => item.type === 'reasoning')
-    .flatMap((item) => item.summary)
-    .map((summary) => summary.text.trim())
-    .filter(Boolean)
-    .join(' ');
-
+  const rationale = reasoning.summary
+    .map((summary) => summary.type === 'summary_text' ? summary.text.trim() : '')
+    .find(Boolean);
   if (!rationale) {
     return undefined;
   }
 
-  return { rationale };
+  if (preferToolCalls) {
+    return { rationale };
+  }
+
+  return {
+    rationale,
+  };
 }
 
 function extractUsage(response: OpenAiResponse): LlmUsage | undefined {
-  if (!response.usage) {
+  const usage = response.usage;
+  if (!usage) {
     return undefined;
   }
 
   return {
-    inputTokens: response.usage.input_tokens,
-    outputTokens: response.usage.output_tokens,
-    totalTokens: response.usage.total_tokens,
-    cachedInputTokens: response.usage.input_tokens_details.cached_tokens || undefined,
-    reasoningTokens: response.usage.output_tokens_details.reasoning_tokens || undefined,
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    totalTokens: usage.total_tokens,
+    cachedInputTokens: usage.input_tokens_details?.cached_tokens,
+    reasoningTokens: usage.output_tokens_details?.reasoning_tokens,
     requests: 1,
   };
 }
 
 function toResponseInput(messages: ChatMessage[]): ResponseInputItem[] {
-  return messages.flatMap((message) => toResponseInputItems(message));
+  return messages.flatMap(toResponseInputItems);
 }
 
 function buildOpenAiResponsesRequest(
@@ -390,13 +405,14 @@ function buildOpenAiResponsesRequest(
     model: string;
     tools: ToolDefinition[];
     oauthMode: boolean;
+    reasoningEffort?: ReasoningEffort;
   },
 ): {
   model: string;
   input: ResponseInputItem[];
   tools?: FunctionTool[];
   store: boolean;
-  reasoning: { summary: 'auto' | 'detailed' };
+  reasoning: { summary: 'auto' | 'detailed'; effort?: OpenAiReasoningEffort };
   instructions?: string;
 } {
   const systemMessages = options.oauthMode ? messages.filter((message): message is Extract<ChatMessage, { role: 'system' }> => message.role === 'system') : [];
@@ -404,6 +420,10 @@ function buildOpenAiResponsesRequest(
   const instructions =
     options.oauthMode ?
       systemMessages.map((message) => message.content.trim()).filter(Boolean).join('\n\n')
+    : undefined;
+  const reasoningEffort =
+    supportsOpenAiRequestReasoningEffort(options.model) ?
+      toOpenAiReasoningEffort(options.reasoningEffort ?? resolveDefaultReasoningEffort(options.model))
     : undefined;
 
   return {
@@ -413,9 +433,18 @@ function buildOpenAiResponsesRequest(
     store: false,
     reasoning: {
       summary: options.oauthMode ? 'auto' : 'detailed',
+      ...(reasoningEffort ? { effort: reasoningEffort } : {}),
     },
     ...(instructions ? { instructions } : {}),
   };
+}
+
+function toOpenAiReasoningEffort(value: ReasoningEffort | undefined): OpenAiReasoningEffort | undefined {
+  if (value === 'low' || value === 'medium' || value === 'high') {
+    return value;
+  }
+
+  return undefined;
 }
 
 function toResponseInputItems(msg: ChatMessage): ResponseInputItem[] {

--- a/src/core/llm/openai.ts
+++ b/src/core/llm/openai.ts
@@ -421,10 +421,10 @@ function buildOpenAiResponsesRequest(
     options.oauthMode ?
       systemMessages.map((message) => message.content.trim()).filter(Boolean).join('\n\n')
     : undefined;
-  const reasoningEffort =
-    supportsOpenAiRequestReasoningEffort(options.model) ?
-      toOpenAiReasoningEffort(options.reasoningEffort ?? resolveDefaultReasoningEffort(options.model))
-    : undefined;
+  const reasoningEffort = resolveOpenAiRequestReasoningEffort({
+    model: options.model,
+    explicitEffort: options.reasoningEffort,
+  });
 
   return {
     model: options.model,
@@ -439,12 +439,31 @@ function buildOpenAiResponsesRequest(
   };
 }
 
-function toOpenAiReasoningEffort(value: ReasoningEffort | undefined): OpenAiReasoningEffort | undefined {
+function resolveOpenAiRequestReasoningEffort(args: {
+  model: string;
+  explicitEffort?: ReasoningEffort;
+}): OpenAiReasoningEffort | undefined {
+  const effectiveEffort = args.explicitEffort ?? resolveDefaultReasoningEffort(args.model);
+  if (!effectiveEffort) {
+    return undefined;
+  }
+
+  if (!supportsOpenAiRequestReasoningEffort(args.model)) {
+    if (args.explicitEffort) {
+      throw new Error(`Reasoning effort is not supported for OpenAI model ${args.model}.`);
+    }
+    return undefined;
+  }
+
+  return toOpenAiReasoningEffort(effectiveEffort);
+}
+
+function toOpenAiReasoningEffort(value: ReasoningEffort): OpenAiReasoningEffort {
   if (value === 'low' || value === 'medium' || value === 'high') {
     return value;
   }
 
-  return undefined;
+  throw new Error('Reasoning effort "ultrahigh" is not supported by the current OpenAI Responses API. Use low, medium, high, or default.');
 }
 
 function toResponseInputItems(msg: ChatMessage): ResponseInputItem[] {

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -10,6 +10,8 @@ export type LlmStreamEvent =
 
 export type LlmProvider = 'openai' | 'anthropic' | 'google';
 
+export type ReasoningEffort = 'low' | 'medium' | 'high' | 'ultrahigh';
+
 export type LlmAdapterCapabilities = {
   toolCalls: boolean;
   systemMessages: boolean;

--- a/src/core/runtime/agent-loop.ts
+++ b/src/core/runtime/agent-loop.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import type { Logger } from 'pino';
 import { DEFAULT_OPENAI_MODEL } from '../config.js';
 import { inferProviderFromModel } from '../llm/providers.js';
-import type { ChatMessage, LlmAdapter, LlmProvider } from '../llm/types.js';
+import type { ChatMessage, LlmAdapter, LlmProvider, ReasoningEffort } from '../llm/types.js';
 import { runAgent } from '../agent/run-agent.js';
 import type { RunAgentOptions } from '../agent/run-agent.js';
 import type { RunResult, ToolCall, ToolDefinition, TraceEvent } from '../types.js';
@@ -22,6 +22,7 @@ export type { AgentLoopCheckpoint, AgentLoopEvent, AgentLoopState } from './even
 export type RunAgentLoopOptions = {
   goal: string;
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   apiKey?: string;
   maxSteps?: number;
   workspaceRoot?: string;
@@ -71,6 +72,7 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<AgentL
     model,
     apiKey,
     credentialStorePath,
+    reasoningEffort: options.reasoningEffort,
   });
   const logger = options.logger ?? createLogger({ pretty: false, level: 'info', console: false });
   const tools = await resolveTools({
@@ -232,7 +234,12 @@ function getResumeMetadata(
   };
 }
 
-async function createLoopLlmAdapter(options: { model: string; apiKey?: string; credentialStorePath?: string }): Promise<LlmAdapter> {
+async function createLoopLlmAdapter(options: {
+  model: string;
+  apiKey?: string;
+  credentialStorePath?: string;
+  reasoningEffort?: ReasoningEffort;
+}): Promise<LlmAdapter> {
   const { createLlmAdapter } = await import('../llm/factory.js');
   return createLlmAdapter(options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,7 @@ export type {
   ChatMessage,
   LlmResponse,
   LlmProvider,
+  ReasoningEffort,
   LlmAdapterCapabilities,
   LlmAdapterInfo,
   LlmUsage,

--- a/src/server/features/control-plane/router.ts
+++ b/src/server/features/control-plane/router.ts
@@ -84,6 +84,7 @@ const sessionApprovalDecisionSchema = z.object({
 const sessionSettingsInputSchema = z.object({
   id: z.string().min(1),
   model: z.string().min(1).optional(),
+  reasoningEffort: z.enum(['low', 'medium', 'high', 'ultrahigh']).optional().nullable(),
   driftEnabled: z.boolean().optional(),
 });
 
@@ -190,6 +191,7 @@ export const controlPlaneRouter = router({
       sessionStoragePath: resolve(ctx.activeWorkspace.stateRoot, 'chat-sessions.catalog.json'),
       sessionId: input.id,
       model: input.model,
+      reasoningEffort: input.reasoningEffort ?? undefined,
       driftEnabled: input.driftEnabled,
     });
   }),

--- a/src/server/features/control-plane/router.ts
+++ b/src/server/features/control-plane/router.ts
@@ -191,7 +191,7 @@ export const controlPlaneRouter = router({
       sessionStoragePath: resolve(ctx.activeWorkspace.stateRoot, 'chat-sessions.catalog.json'),
       sessionId: input.id,
       model: input.model,
-      reasoningEffort: input.reasoningEffort ?? undefined,
+      reasoningEffort: input.reasoningEffort,
       driftEnabled: input.driftEnabled,
     });
   }),

--- a/src/server/features/control-plane/services/chat-sessions.ts
+++ b/src/server/features/control-plane/services/chat-sessions.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { createChatSession, readChatSession, readChatSessionCatalog, saveChatSessions } from '../../../../core/chat/engine/sessions/storage.js';
 import { DEFAULT_OPENAI_MODEL } from '../../../../core/config.js';
 import { credentialModeFromSource, resolveCompatibleActiveModel } from '../../../../core/llm/model-policy.js';
+import type { ReasoningEffort } from '../../../../core/llm/types.js';
 import { inferProviderFromModel } from '../../../../core/llm/providers.js';
 import { parseUnifiedDiffFiles } from '../../../../core/review/diff-domain.js';
 import { hasProviderCredentialForModel, resolveProviderCredentialSourceForModel } from '../../../../core/runtime/api-keys.js';
@@ -104,6 +105,7 @@ export function updateControlPlaneChatSessionSettings(args: {
   sessionStoragePath: string;
   sessionId: string;
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   driftEnabled?: boolean;
 }): ChatSessionDetail {
   const currentSessions = readChatSessionCatalog(args.sessionStoragePath)
@@ -114,6 +116,7 @@ export function updateControlPlaneChatSessionSettings(args: {
       {
         ...session,
         model: args.model ?? session.model,
+        reasoningEffort: args.reasoningEffort ?? session.reasoningEffort,
         driftEnabled: args.driftEnabled ?? session.driftEnabled,
         updatedAt: new Date().toISOString(),
       }
@@ -427,6 +430,7 @@ export function projectChatSessionView(raw: unknown | ChatSession): ChatSessionV
     createdAt: readString(candidate.createdAt),
     updatedAt: readString(candidate.updatedAt),
     model: readString(candidate.model),
+    reasoningEffort: readReasoningEffort(candidate.reasoningEffort),
     driftEnabled: typeof candidate.driftEnabled === 'boolean' ? candidate.driftEnabled : undefined,
     driftLevel: readLatestDriftLevel(turns),
     messageCount: messages.length,
@@ -437,6 +441,10 @@ export function projectChatSessionView(raw: unknown | ChatSession): ChatSessionV
     context: contextView && Object.keys(contextView).length > 0 ? contextView : undefined,
     archives: archiveViews.length > 0 ? archiveViews : undefined,
   })];
+}
+
+function readReasoningEffort(value: unknown): ReasoningEffort | undefined {
+  return value === 'low' || value === 'medium' || value === 'high' || value === 'ultrahigh' ? value : undefined;
 }
 
 function readLatestDriftLevel(turns: unknown[]): ChatSessionView['driftLevel'] {

--- a/src/server/features/control-plane/services/chat-sessions.ts
+++ b/src/server/features/control-plane/services/chat-sessions.ts
@@ -105,7 +105,7 @@ export function updateControlPlaneChatSessionSettings(args: {
   sessionStoragePath: string;
   sessionId: string;
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoningEffort?: ReasoningEffort | null;
   driftEnabled?: boolean;
 }): ChatSessionDetail {
   const currentSessions = readChatSessionCatalog(args.sessionStoragePath)
@@ -116,7 +116,7 @@ export function updateControlPlaneChatSessionSettings(args: {
       {
         ...session,
         model: args.model ?? session.model,
-        reasoningEffort: args.reasoningEffort ?? session.reasoningEffort,
+        reasoningEffort: args.reasoningEffort === null ? undefined : args.reasoningEffort ?? session.reasoningEffort,
         driftEnabled: args.driftEnabled ?? session.driftEnabled,
         updatedAt: new Date().toISOString(),
       }

--- a/src/server/features/control-plane/types.ts
+++ b/src/server/features/control-plane/types.ts
@@ -5,6 +5,7 @@ import type { WorkspaceDescriptor } from '../../../core/runtime/workspaces.js';
 import type { MemoryStatusView } from '../../../core/memory/visibility.js';
 import type { ReviewDiffFile } from '../../../core/review/diff-domain.js';
 import type { ProviderCredentialSource } from '../../../core/runtime/api-keys.js';
+import type { ReasoningEffort } from '../../../core/llm/types.js';
 
 export type ChatSessionView = {
   id: string;
@@ -13,6 +14,7 @@ export type ChatSessionView = {
   createdAt?: string;
   updatedAt?: string;
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   driftEnabled?: boolean;
   driftLevel?: 'unknown' | 'low' | 'medium' | 'high';
   messageCount: number;

--- a/src/web/features/control-plane/hooks/sessions-screen/useSessionModelOptions.ts
+++ b/src/web/features/control-plane/hooks/sessions-screen/useSessionModelOptions.ts
@@ -9,10 +9,12 @@ import { useCredentialAwareModelOptions } from '../useCredentialAwareModelOption
 export function useSessionModelOptions({
   auth,
   selectedModel,
+  selectedReasoningEffort,
   runActive,
 }: {
   auth: ControlPlaneState['auth'];
   selectedModel: string;
+  selectedReasoningEffort?: 'low' | 'medium' | 'high' | 'ultrahigh';
   runActive: boolean;
 }) {
   const [modelOptions, setModelOptions] = useState<ModelOptions | null>(null);
@@ -20,11 +22,14 @@ export function useSessionModelOptions({
   const {
     groups: modelOptionGroups,
     selectedModelOption,
+    reasoningEffortOptions,
+    selectedReasoningEffortOption,
     selectorDisabled: modelSelectorDisabled,
   } = useCredentialAwareModelOptions({
     modelOptions,
     auth,
     selectedModel,
+    selectedReasoningEffort,
     runActive,
   });
 
@@ -52,6 +57,8 @@ export function useSessionModelOptions({
     modelOptionsError,
     modelOptionGroups,
     selectedModelOption,
+    reasoningEffortOptions,
+    selectedReasoningEffortOption,
     modelSelectorDisabled,
   };
 }

--- a/src/web/features/control-plane/hooks/useCredentialAwareModelOptions.ts
+++ b/src/web/features/control-plane/hooks/useCredentialAwareModelOptions.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type { ModelOptions } from '../../../lib/api.js';
 import { isOpenAiAccountSignInModel } from '../../../../core/llm/openai-models.js';
+import { resolveDefaultReasoningEffort, supportsReasoningEffort } from '../../../../core/llm/model-policy.js';
 import type { ControlPlaneState } from '../../../lib/api.js';
 
 export type CredentialAwareModelGroup = {
@@ -13,10 +14,17 @@ export type CredentialAwareModelGroup = {
   }>;
 };
 
+export type ReasoningEffortOption = {
+  id: 'default' | 'low' | 'medium' | 'high' | 'ultrahigh';
+  disabled: boolean;
+  label: string;
+};
+
 export function useCredentialAwareModelOptions(args: {
   modelOptions: ModelOptions | null;
   auth?: ControlPlaneState['auth'];
   selectedModel?: string;
+  selectedReasoningEffort?: 'low' | 'medium' | 'high' | 'ultrahigh';
   runActive: boolean;
 }) {
   const openAiOauthActive = args.auth?.openai?.type === 'oauth';
@@ -45,9 +53,27 @@ export function useCredentialAwareModelOptions(args: {
     groups.flatMap((group) => group.resolvedOptions).find((option) => option.id === args.selectedModel)
   ), [groups, args.selectedModel]);
 
+  const reasoningEffortOptions = useMemo<ReasoningEffortOption[]>(() => {
+    const supported = args.selectedModel ? supportsReasoningEffort(args.selectedModel) : false;
+    const defaultEffort = args.selectedModel ? resolveDefaultReasoningEffort(args.selectedModel) : undefined;
+    return [
+      { id: 'default', disabled: !supported, label: defaultEffort ? `Default (${defaultEffort})` : 'Default' },
+      { id: 'low', disabled: !supported, label: 'Low' },
+      { id: 'medium', disabled: !supported, label: 'Medium' },
+      { id: 'high', disabled: !supported, label: 'High' },
+      { id: 'ultrahigh', disabled: true, label: 'Ultra high (reserved)' },
+    ];
+  }, [args.selectedModel]);
+
+  const selectedReasoningEffortOption = useMemo(() => (
+    reasoningEffortOptions.find((option) => option.id === (args.selectedReasoningEffort ?? 'default'))
+  ), [reasoningEffortOptions, args.selectedReasoningEffort]);
+
   return {
     groups,
     selectedModelOption,
+    reasoningEffortOptions,
+    selectedReasoningEffortOption,
     selectorDisabled: args.runActive || !args.modelOptions,
   };
 }

--- a/src/web/features/control-plane/screens/SessionsScreen.tsx
+++ b/src/web/features/control-plane/screens/SessionsScreen.tsx
@@ -47,7 +47,7 @@ export type SessionsScreenProps = {
   onCreateSession: () => Promise<void>;
   onContinueSession: () => Promise<void>;
   onCancelSessionRun: () => Promise<void>;
-  onUpdateSessionSettings: (settings: { model?: string; driftEnabled?: boolean }) => Promise<void>;
+  onUpdateSessionSettings: (settings: { model?: string; reasoningEffort?: 'low' | 'medium' | 'high' | 'ultrahigh' | null; driftEnabled?: boolean }) => Promise<void>;
   pendingApproval: { tool: string; callId: string; input?: unknown; requestedAt: string } | null;
   onResolveApproval: (approved: boolean) => Promise<void>;
 };
@@ -116,15 +116,19 @@ export function SessionsScreen({
   const authStatus = formatControlPlaneAuthStatus(sessionDetail?.model ?? activeSession?.model, auth);
   const compactionStatus = sessionDetail?.context?.compactionStatus ?? activeSession?.context?.compactionStatus;
   const selectedModel = sessionDetail?.model ?? activeSession?.model ?? '';
+  const selectedReasoningEffort = sessionDetail?.reasoningEffort ?? activeSession?.reasoningEffort;
   const {
     modelOptions,
     modelOptionsError,
     modelOptionGroups,
     selectedModelOption,
+    reasoningEffortOptions,
+    selectedReasoningEffortOption,
     modelSelectorDisabled,
   } = useSessionModelOptions({
     auth,
     selectedModel,
+    selectedReasoningEffort,
     runActive,
   });
   const {
@@ -295,6 +299,22 @@ export function SessionsScreen({
                 </label>
                 {!modelOptions ? <p className="model-select-description">{modelOptionsError ? 'models unavailable' : 'loading models'}</p> : null}
               </div>
+              <label className="select-control">
+                <span>reasoning</span>
+                <select
+                  value={selectedReasoningEffortOption?.id ?? 'default'}
+                  disabled={modelSelectorDisabled}
+                  onChange={(event) => void onUpdateSessionSettings({
+                    reasoningEffort: event.target.value === 'default' ? null : event.target.value as 'low' | 'medium' | 'high' | 'ultrahigh',
+                  })}
+                >
+                  {reasoningEffortOptions.map((option) => (
+                    <option key={option.id} value={option.id} disabled={option.disabled}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
               <Pill>turns {activeSession.turnCount}</Pill>
               {compactionStatus === 'running' ? <Pill tone="warn">compacting</Pill> : null}
               <button

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -42,7 +42,7 @@ export async function fetchModelOptions(): Promise<ModelOptions> {
 
 export async function updateChatSessionSettings(
   sessionId: string,
-  settings: { model?: string; driftEnabled?: boolean },
+  settings: { model?: string; reasoningEffort?: 'low' | 'medium' | 'high' | 'ultrahigh' | null; driftEnabled?: boolean },
 ): Promise<Exclude<ChatSessionDetail, null>> {
   return await trpc.controlPlane.sessionSettingsUpdate.mutate({ id: sessionId, ...settings });
 }


### PR DESCRIPTION
## Summary
- port reasoning-effort support onto current main across shared llm/session/TUI/control-plane surfaces
- restore  status and slash-command hints plus visible TUI footer status
- add web session reasoning selector groundwork and regression-focused test updates

## Testing
- yarn typecheck

Closes #49