### PR TITLE
Fix TUI prompt input wrapping

### DIFF
--- a/src/__tests__/unit/tui/prompt-input.test.tsx
+++ b/src/__tests__/unit/tui/prompt-input.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { insertMentionSelection } from '../../../cli/chat/utils/file-mentions.js';
 import { parseInlineSegments, parseMessageBlocks } from '../../../cli/chat/components/ConversationPanel.js';
-import { buildPromptRenderLines, insertPromptText } from '../../../cli/chat/components/PromptInput.js';
+import { buildPromptRenderLines, insertPromptText, resolvePromptInputRenderWidth } from '../../../cli/chat/components/PromptInput.js';
 
 describe('prompt input related helpers', () => {
   it('places the inserted mention at the end of the current trailing mention token', () => {
@@ -67,6 +67,24 @@ describe('prompt input related helpers', () => {
       },
       {
         before: 'def',
+        cursor: ' ',
+        after: '',
+        hasCursor: true,
+      },
+    ]);
+  });
+
+  it('prefers explicit parent width over stdout width for prompt wrapping', () => {
+    expect(resolvePromptInputRenderWidth(12, 120)).toBe(12);
+    expect(buildPromptRenderLines('abcdefghijklmnop', 16, 8, resolvePromptInputRenderWidth(12, 120))).toEqual([
+      {
+        before: 'abcdefghij',
+        cursor: '',
+        after: '',
+        hasCursor: false,
+      },
+      {
+        before: 'klmnop',
         cursor: ' ',
         after: '',
         hasCursor: true,

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -374,6 +374,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
 
   const promptPanelWidth = Math.max(20, columns - 2);
   const promptBodyWidth = Math.max(1, promptPanelWidth - 2);
+  const promptInputWidth = Math.max(1, promptBodyWidth - 2);
 
   const { pendingSubmittedPrompt, clearPendingSubmittedPrompt, submitPrompt } = usePromptSubmission({
     runtime,
@@ -512,6 +513,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
                 <PromptInput
                   value={draft}
                   cursor={draftCursor}
+                  width={promptInputWidth}
                   isDisabled={false}
                   placeholder={isRunning ? "Keep typing while Heddle works" : "Ask Heddle about this project"}
                   maxVisibleLines={10}

--- a/src/cli/chat/components/PromptInput.tsx
+++ b/src/cli/chat/components/PromptInput.tsx
@@ -29,6 +29,7 @@ export function PromptInput({
   value,
   isDisabled,
   placeholder,
+  width,
   maxVisibleLines = DEFAULT_MAX_VISIBLE_INPUT_LINES,
   cursor,
   onChange,
@@ -39,6 +40,7 @@ export function PromptInput({
   value: string;
   isDisabled: boolean;
   placeholder: string;
+  width?: number;
   maxVisibleLines?: number;
   cursor: number;
   onChange: (value: string) => void;
@@ -49,7 +51,7 @@ export function PromptInput({
   const valueRef = useRef(value);
   const cursorRef = useRef(cursor);
   const { stdout } = useStdout();
-  const columns = stdout.columns ?? FALLBACK_WRAP_WIDTH;
+  const renderWidth = resolvePromptInputRenderWidth(width, stdout.columns);
 
   useEffect(() => {
     valueRef.current = value;
@@ -97,8 +99,8 @@ export function PromptInput({
   }, { isActive: !isDisabled });
 
   const lines = useMemo(
-    () => buildPromptRenderLines(value, cursor, maxVisibleLines, Math.max(PROMPT_INPUT_PREFIX_WIDTH + 1, columns)),
-    [value, cursor, maxVisibleLines, columns],
+    () => buildPromptRenderLines(value, cursor, maxVisibleLines, renderWidth),
+    [value, cursor, maxVisibleLines, renderWidth],
   );
 
   if (!value) {
@@ -128,6 +130,11 @@ export function PromptInput({
       ))}
     </Box>
   );
+}
+
+export function resolvePromptInputRenderWidth(width?: number, stdoutColumns?: number): number {
+  const candidate = width ?? stdoutColumns ?? FALLBACK_WRAP_WIDTH;
+  return Math.max(PROMPT_INPUT_PREFIX_WIDTH + 1, Math.floor(candidate));
 }
 
 export type PromptDraftState = {


### PR DESCRIPTION
## Summary
- Pass PromptInput its actual parent content width instead of full stdout columns.
- Prevent terminal soft-wrap from creating tiny continuation lines in the separator prompt layout.
- Add regression coverage for explicit prompt wrapping width.

## Testing
- ./node_modules/.bin/vitest run src/__tests__/unit/tui/prompt-input.test.tsx
- yarn typecheck
- yarn test:unit