### PR TITLE
Improve TUI prompt editing history

### DIFF
--- a/docs/guides/chat-and-sessions.md
+++ b/docs/guides/chat-and-sessions.md
@@ -95,6 +95,16 @@ Useful chat commands:
 - `/drift off`: disable CyberLoop semantic drift detection
 - `!<command>`: run a shell command directly in chat
 
+Prompt editing shortcuts:
+
+- `Shift+Enter`: insert a newline without sending
+- `Ctrl+Z`: undo the last prompt edit
+- `Ctrl+Y`: redo a prompt edit
+- `Up` / `Down`: move through submitted prompt history when the cursor is on the first or last logical line
+- `Ctrl+A` / `Ctrl+E`: move to the start or end of the prompt
+- `Ctrl+W`: delete the previous word
+- `Ctrl+U` / `Ctrl+K`: delete before or after the cursor
+
 ## Direct Shell In Chat
 
 ```bash

--- a/src/__tests__/unit/tui/prompt-input.test.tsx
+++ b/src/__tests__/unit/tui/prompt-input.test.tsx
@@ -3,13 +3,17 @@ import { insertMentionSelection } from '../../../cli/chat/utils/file-mentions.js
 import { parseInlineSegments, parseMessageBlocks } from '../../../cli/chat/components/ConversationPanel.js';
 import {
   buildPromptRenderLines,
-  canNavigatePromptHistory,
   insertPromptText,
-  resolvePromptHistoryNavigation,
   resolvePromptInputRenderWidth,
+} from '../../../cli/chat/components/PromptInput.js';
+import {
+  canNavigatePromptHistory,
+  resolvePromptHistoryNavigation,
+} from '../../../cli/chat/hooks/usePromptHistory.js';
+import {
   resolvePromptRedo,
   resolvePromptUndo,
-} from '../../../cli/chat/components/PromptInput.js';
+} from '../../../cli/chat/hooks/usePromptUndoRedo.js';
 
 describe('prompt input related helpers', () => {
   it('places the inserted mention at the end of the current trailing mention token', () => {

--- a/src/__tests__/unit/tui/prompt-input.test.tsx
+++ b/src/__tests__/unit/tui/prompt-input.test.tsx
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { insertMentionSelection } from '../../../cli/chat/utils/file-mentions.js';
 import { parseInlineSegments, parseMessageBlocks } from '../../../cli/chat/components/ConversationPanel.js';
-import { buildPromptRenderLines, insertPromptText, resolvePromptInputRenderWidth } from '../../../cli/chat/components/PromptInput.js';
+import {
+  buildPromptRenderLines,
+  canNavigatePromptHistory,
+  insertPromptText,
+  resolvePromptHistoryNavigation,
+  resolvePromptInputRenderWidth,
+  resolvePromptRedo,
+  resolvePromptUndo,
+} from '../../../cli/chat/components/PromptInput.js';
 
 describe('prompt input related helpers', () => {
   it('places the inserted mention at the end of the current trailing mention token', () => {
@@ -16,6 +24,79 @@ describe('prompt input related helpers', () => {
     const afterC = insertPromptText(afterB, 'c');
 
     expect(afterC).toEqual({ value: 'abc', cursor: 3 });
+  });
+
+  it('resolves undo and redo draft states', () => {
+    const undo = resolvePromptUndo(
+      [{ value: '', cursor: 0 }, { value: 'hello', cursor: 5 }],
+      [],
+      { value: 'hello!', cursor: 6 },
+    );
+
+    expect(undo).toEqual({
+      state: { value: 'hello', cursor: 5 },
+      undoStack: [{ value: '', cursor: 0 }],
+      redoStack: [{ value: 'hello!', cursor: 6 }],
+    });
+
+    expect(resolvePromptRedo(
+      undo?.undoStack ?? [],
+      undo?.redoStack ?? [],
+      undo?.state ?? { value: '', cursor: 0 },
+    )).toEqual({
+      state: { value: 'hello!', cursor: 6 },
+      undoStack: [{ value: '', cursor: 0 }, { value: 'hello', cursor: 5 }],
+      redoStack: [],
+    });
+  });
+
+  it('navigates prompt history while preserving the in-progress draft', () => {
+    const history = ['first prompt', 'second prompt'];
+    const current = { value: 'draft in progress', cursor: 5 };
+    const previous = resolvePromptHistoryNavigation({
+      direction: 'previous',
+      history,
+      current,
+    });
+
+    expect(previous).toEqual({
+      state: { value: 'second prompt', cursor: 'second prompt'.length },
+      historyIndex: 1,
+      savedDraftBeforeHistory: current,
+    });
+
+    expect(resolvePromptHistoryNavigation({
+      direction: 'previous',
+      history,
+      current: previous?.state ?? current,
+      historyIndex: previous?.historyIndex,
+      savedDraftBeforeHistory: previous?.savedDraftBeforeHistory,
+    })).toEqual({
+      state: { value: 'first prompt', cursor: 'first prompt'.length },
+      historyIndex: 0,
+      savedDraftBeforeHistory: current,
+    });
+
+    expect(resolvePromptHistoryNavigation({
+      direction: 'next',
+      history,
+      current: previous?.state ?? current,
+      historyIndex: previous?.historyIndex,
+      savedDraftBeforeHistory: previous?.savedDraftBeforeHistory,
+    })).toEqual({
+      state: current,
+      historyIndex: undefined,
+      savedDraftBeforeHistory: undefined,
+    });
+  });
+
+  it('only uses up/down for multiline history navigation at first or last logical line', () => {
+    const value = 'first\nsecond\nthird';
+
+    expect(canNavigatePromptHistory('previous', { value, cursor: 2 })).toBe(true);
+    expect(canNavigatePromptHistory('previous', { value, cursor: 8 })).toBe(false);
+    expect(canNavigatePromptHistory('next', { value, cursor: 8 })).toBe(false);
+    expect(canNavigatePromptHistory('next', { value, cursor: value.length })).toBe(true);
   });
 
   it('renders the cursor at the end of the line after the last typed character', () => {

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -27,6 +27,7 @@ import { useChatSessions } from './hooks/useChatSessions.js';
 import { useChatStatusSummary } from './hooks/useChatStatusSummary.js';
 import { useLocalIds } from './hooks/useLocalIds.js';
 import { usePromptDraft } from './hooks/usePromptDraft.js';
+import { usePromptHistory } from './hooks/usePromptHistory.js';
 import { usePromptSubmission } from './hooks/usePromptSubmission.js';
 import { autocompleteLocalCommand } from './state/local-commands.js';
 import { listMentionableFiles } from './utils/file-mentions.js';
@@ -51,11 +52,10 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     setDraft,
     draftCursor,
     setDraftCursor,
-    promptHistory,
     clearDraft,
     replaceDraft,
-    recordPromptHistory,
   } = usePromptDraft();
+  const { promptHistory, recordPromptHistory } = usePromptHistory();
   const [activeReasoningEffort, setActiveReasoningEffort] = useState<ReasoningEffort | undefined>(undefined);
   const mentionableFiles = useState(() => listMentionableFiles(runtime.workspaceRoot, runtime.searchIgnoreDirs))[0];
 

--- a/src/cli/chat/App.tsx
+++ b/src/cli/chat/App.tsx
@@ -51,8 +51,10 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     setDraft,
     draftCursor,
     setDraftCursor,
+    promptHistory,
     clearDraft,
     replaceDraft,
+    recordPromptHistory,
   } = usePromptDraft();
   const [activeReasoningEffort, setActiveReasoningEffort] = useState<ReasoningEffort | undefined>(undefined);
   const mentionableFiles = useState(() => listMentionableFiles(runtime.workspaceRoot, runtime.searchIgnoreDirs))[0];
@@ -313,6 +315,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
     approvalChoice,
     draft,
     draftCursor,
+    promptHistory,
     pickers.model,
     pickers.reasoning,
     pickers.session,
@@ -514,6 +517,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
                   value={draft}
                   cursor={draftCursor}
                   width={promptInputWidth}
+                  promptHistory={promptHistory}
                   isDisabled={false}
                   placeholder={isRunning ? "Keep typing while Heddle works" : "Ask Heddle about this project"}
                   maxVisibleLines={10}
@@ -521,6 +525,7 @@ function EmbeddedChatApp({ runtime }: { runtime: ChatRuntimeConfig }) {
                   onCursorChange={setDraftCursor}
                   onSpecialKey={handlePromptSpecialKey}
                   onSubmit={(value) => {
+                    recordPromptHistory(value);
                     clearDraft();
                     void submitPrompt(value);
                   }}

--- a/src/cli/chat/components/PromptInput.tsx
+++ b/src/cli/chat/components/PromptInput.tsx
@@ -30,6 +30,7 @@ export function PromptInput({
   isDisabled,
   placeholder,
   width,
+  promptHistory = [],
   maxVisibleLines = DEFAULT_MAX_VISIBLE_INPUT_LINES,
   cursor,
   onChange,
@@ -41,6 +42,7 @@ export function PromptInput({
   isDisabled: boolean;
   placeholder: string;
   width?: number;
+  promptHistory?: string[];
   maxVisibleLines?: number;
   cursor: number;
   onChange: (value: string) => void;
@@ -50,10 +52,21 @@ export function PromptInput({
 }) {
   const valueRef = useRef(value);
   const cursorRef = useRef(cursor);
+  const undoStackRef = useRef<PromptDraftState[]>([]);
+  const redoStackRef = useRef<PromptDraftState[]>([]);
+  const promptHistoryRef = useRef(promptHistory);
+  const promptHistoryIndexRef = useRef<number | undefined>(undefined);
+  const savedDraftBeforeHistoryRef = useRef<PromptDraftState | undefined>(undefined);
   const { stdout } = useStdout();
   const renderWidth = resolvePromptInputRenderWidth(width, stdout.columns);
 
   useEffect(() => {
+    if (valueRef.current !== value) {
+      undoStackRef.current = [];
+      redoStackRef.current = [];
+      promptHistoryIndexRef.current = undefined;
+      savedDraftBeforeHistoryRef.current = undefined;
+    }
     valueRef.current = value;
   }, [value]);
 
@@ -61,7 +74,23 @@ export function PromptInput({
     cursorRef.current = cursor;
   }, [cursor]);
 
-  const applyDraft = (nextValue: string, nextCursor: number) => {
+  useEffect(() => {
+    promptHistoryRef.current = promptHistory;
+  }, [promptHistory]);
+
+  const applyDraft = (nextValue: string, nextCursor: number, options: { recordUndo?: boolean } = {}) => {
+    const current = {
+      value: valueRef.current,
+      cursor: Math.min(cursorRef.current, valueRef.current.length),
+    };
+    const next = { value: nextValue, cursor: nextCursor };
+    if (options.recordUndo !== false && !isSamePromptDraftState(current, next)) {
+      undoStackRef.current = [...undoStackRef.current, current].slice(-100);
+      redoStackRef.current = [];
+      promptHistoryIndexRef.current = undefined;
+      savedDraftBeforeHistoryRef.current = undefined;
+    }
+
     valueRef.current = nextValue;
     cursorRef.current = nextCursor;
     onChange(nextValue);
@@ -77,13 +106,49 @@ export function PromptInput({
       value: valueRef.current,
       cursor: Math.min(cursorRef.current, valueRef.current.length),
     };
+    const applyState = (nextState: PromptDraftState, options?: { recordUndo?: boolean }) =>
+      applyDraft(nextState.value, nextState.cursor, options);
     const actions: PromptInputActions = {
-      applyDraft,
+      applyDraft: applyState,
       moveCursor: (nextCursor) => {
         cursorRef.current = nextCursor;
         onCursorChange(nextCursor);
       },
       onSubmit,
+      undo: () => {
+        const previous = resolvePromptUndo(undoStackRef.current, redoStackRef.current, state);
+        if (!previous) {
+          return;
+        }
+        undoStackRef.current = previous.undoStack;
+        redoStackRef.current = previous.redoStack;
+        applyState(previous.state, { recordUndo: false });
+      },
+      redo: () => {
+        const next = resolvePromptRedo(undoStackRef.current, redoStackRef.current, state);
+        if (!next) {
+          return;
+        }
+        undoStackRef.current = next.undoStack;
+        redoStackRef.current = next.redoStack;
+        applyState(next.state, { recordUndo: false });
+      },
+      navigateHistory: (direction) => {
+        const next = resolvePromptHistoryNavigation({
+          direction,
+          history: promptHistoryRef.current,
+          current: state,
+          historyIndex: promptHistoryIndexRef.current,
+          savedDraftBeforeHistory: savedDraftBeforeHistoryRef.current,
+        });
+        if (!next) {
+          return;
+        }
+
+        promptHistoryIndexRef.current = next.historyIndex;
+        savedDraftBeforeHistoryRef.current = next.savedDraftBeforeHistory;
+        applyState(next.state, { recordUndo: false });
+      },
     };
 
     if (onSpecialKey?.({ input, key })) {
@@ -145,6 +210,9 @@ export type PromptDraftState = {
 type PromptInputCommand =
   | { kind: 'submit' }
   | { kind: 'insert'; input: string }
+  | { kind: 'undo' }
+  | { kind: 'redo' }
+  | { kind: 'history'; direction: 'previous' | 'next' }
   | { kind: 'deletePreviousChar' }
   | { kind: 'deletePreviousWord' }
   | { kind: 'deleteBeforeCursor' }
@@ -152,9 +220,12 @@ type PromptInputCommand =
   | { kind: 'move'; direction: 'start' | 'end' | 'previousChar' | 'nextChar' | 'previousWord' | 'nextWord' };
 
 type PromptInputActions = {
-  applyDraft: (value: string, cursor: number) => void;
+  applyDraft: (state: PromptDraftState, options?: { recordUndo?: boolean }) => void;
   moveCursor: (cursor: number) => void;
   onSubmit: (value: string) => void;
+  undo: () => void;
+  redo: () => void;
+  navigateHistory: (direction: 'previous' | 'next') => void;
 };
 
 const CTRL_COMMANDS = new Map<string, PromptInputCommand>([
@@ -163,6 +234,8 @@ const CTRL_COMMANDS = new Map<string, PromptInputCommand>([
   ['k', { kind: 'deleteAfterCursor' }],
   ['u', { kind: 'deleteBeforeCursor' }],
   ['w', { kind: 'deletePreviousWord' }],
+  ['y', { kind: 'redo' }],
+  ['z', { kind: 'undo' }],
 ]);
 
 const META_TEXT_COMMANDS = new Map<string, PromptInputCommand>([
@@ -214,6 +287,14 @@ function resolvePromptInputCommand(input: string, key: PromptKeyInput['key']): P
     return { kind: 'move', direction: 'nextChar' };
   }
 
+  if (key.upArrow) {
+    return { kind: 'history', direction: 'previous' };
+  }
+
+  if (key.downArrow) {
+    return { kind: 'history', direction: 'next' };
+  }
+
   if (key.home) {
     return { kind: 'move', direction: 'start' };
   }
@@ -234,34 +315,140 @@ function handlePromptInputCommand(
   state: PromptDraftState,
   actions: PromptInputActions,
 ): void {
-  const applyState = (next: PromptDraftState) => actions.applyDraft(next.value, next.cursor);
-
   switch (command.kind) {
     case 'submit':
       actions.onSubmit(state.value);
       return;
     case 'insert':
-      applyState(insertPromptText(state, command.input));
+      actions.applyDraft(insertPromptText(state, command.input));
+      return;
+    case 'undo':
+      actions.undo();
+      return;
+    case 'redo':
+      actions.redo();
+      return;
+    case 'history':
+      if (canNavigatePromptHistory(command.direction, state)) {
+        actions.navigateHistory(command.direction);
+      }
       return;
     case 'deletePreviousChar':
       if (state.cursor > 0) {
-        applyState({ value: removeRange(state.value, state.cursor - 1, state.cursor), cursor: state.cursor - 1 });
+        actions.applyDraft({ value: removeRange(state.value, state.cursor - 1, state.cursor), cursor: state.cursor - 1 });
       }
       return;
     case 'deletePreviousWord': {
       const nextCursor = findPreviousWordBoundary(state.value, state.cursor);
-      applyState({ value: removeRange(state.value, nextCursor, state.cursor), cursor: nextCursor });
+      actions.applyDraft({ value: removeRange(state.value, nextCursor, state.cursor), cursor: nextCursor });
       return;
     }
     case 'deleteBeforeCursor':
-      applyState({ value: state.value.slice(state.cursor), cursor: 0 });
+      actions.applyDraft({ value: state.value.slice(state.cursor), cursor: 0 });
       return;
     case 'deleteAfterCursor':
-      applyState({ value: state.value.slice(0, state.cursor), cursor: state.cursor });
+      actions.applyDraft({ value: state.value.slice(0, state.cursor), cursor: state.cursor });
       return;
     case 'move':
       actions.moveCursor(resolvePromptCursorMove(state, command.direction));
   }
+}
+
+function isSamePromptDraftState(left: PromptDraftState, right: PromptDraftState): boolean {
+  return left.value === right.value && left.cursor === right.cursor;
+}
+
+export function resolvePromptUndo(
+  undoStack: PromptDraftState[],
+  redoStack: PromptDraftState[],
+  current: PromptDraftState,
+): { state: PromptDraftState; undoStack: PromptDraftState[]; redoStack: PromptDraftState[] } | undefined {
+  const previous = undoStack[undoStack.length - 1];
+  if (!previous) {
+    return undefined;
+  }
+
+  return {
+    state: previous,
+    undoStack: undoStack.slice(0, -1),
+    redoStack: [...redoStack, current],
+  };
+}
+
+export function resolvePromptRedo(
+  undoStack: PromptDraftState[],
+  redoStack: PromptDraftState[],
+  current: PromptDraftState,
+): { state: PromptDraftState; undoStack: PromptDraftState[]; redoStack: PromptDraftState[] } | undefined {
+  const next = redoStack[redoStack.length - 1];
+  if (!next) {
+    return undefined;
+  }
+
+  return {
+    state: next,
+    undoStack: [...undoStack, current],
+    redoStack: redoStack.slice(0, -1),
+  };
+}
+
+export function canNavigatePromptHistory(direction: 'previous' | 'next', state: PromptDraftState): boolean {
+  if (!state.value.includes('\n')) {
+    return true;
+  }
+
+  if (direction === 'previous') {
+    const firstLineEnd = state.value.indexOf('\n');
+    return state.cursor <= firstLineEnd;
+  }
+
+  const lastLineStart = state.value.lastIndexOf('\n') + 1;
+  return state.cursor >= lastLineStart;
+}
+
+export function resolvePromptHistoryNavigation(args: {
+  direction: 'previous' | 'next';
+  history: string[];
+  current: PromptDraftState;
+  historyIndex?: number;
+  savedDraftBeforeHistory?: PromptDraftState;
+}): { state: PromptDraftState; historyIndex?: number; savedDraftBeforeHistory?: PromptDraftState } | undefined {
+  if (args.history.length === 0) {
+    return undefined;
+  }
+
+  if (args.direction === 'previous') {
+    const historyIndex =
+      args.historyIndex === undefined ?
+        args.history.length - 1
+      : Math.max(0, args.historyIndex - 1);
+    const value = args.history[historyIndex] ?? '';
+    return {
+      state: { value, cursor: value.length },
+      historyIndex,
+      savedDraftBeforeHistory: args.savedDraftBeforeHistory ?? args.current,
+    };
+  }
+
+  if (args.historyIndex === undefined) {
+    return undefined;
+  }
+
+  if (args.historyIndex < args.history.length - 1) {
+    const historyIndex = args.historyIndex + 1;
+    const value = args.history[historyIndex] ?? '';
+    return {
+      state: { value, cursor: value.length },
+      historyIndex,
+      savedDraftBeforeHistory: args.savedDraftBeforeHistory,
+    };
+  }
+
+  return {
+    state: args.savedDraftBeforeHistory ?? { value: '', cursor: 0 },
+    historyIndex: undefined,
+    savedDraftBeforeHistory: undefined,
+  };
 }
 
 function resolvePromptCursorMove(state: PromptDraftState, direction: Extract<PromptInputCommand, { kind: 'move' }>['direction']): number {

--- a/src/cli/chat/components/PromptInput.tsx
+++ b/src/cli/chat/components/PromptInput.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
+import { canNavigatePromptHistory, usePromptHistoryNavigation } from '../hooks/usePromptHistory.js';
+import { usePromptUndoRedo, type PromptDraftState } from '../hooks/usePromptUndoRedo.js';
 
 const DEFAULT_MAX_VISIBLE_INPUT_LINES = 8;
 const FALLBACK_WRAP_WIDTH = 80;
@@ -52,31 +54,30 @@ export function PromptInput({
 }) {
   const valueRef = useRef(value);
   const cursorRef = useRef(cursor);
-  const undoStackRef = useRef<PromptDraftState[]>([]);
-  const redoStackRef = useRef<PromptDraftState[]>([]);
-  const promptHistoryRef = useRef(promptHistory);
-  const promptHistoryIndexRef = useRef<number | undefined>(undefined);
-  const savedDraftBeforeHistoryRef = useRef<PromptDraftState | undefined>(undefined);
+  const {
+    resetUndoRedo,
+    recordUndoState,
+    undoPromptEdit,
+    redoPromptEdit,
+  } = usePromptUndoRedo();
+  const {
+    resetPromptHistoryNavigation,
+    navigatePromptHistory,
+  } = usePromptHistoryNavigation(promptHistory);
   const { stdout } = useStdout();
   const renderWidth = resolvePromptInputRenderWidth(width, stdout.columns);
 
   useEffect(() => {
     if (valueRef.current !== value) {
-      undoStackRef.current = [];
-      redoStackRef.current = [];
-      promptHistoryIndexRef.current = undefined;
-      savedDraftBeforeHistoryRef.current = undefined;
+      resetUndoRedo();
+      resetPromptHistoryNavigation();
     }
     valueRef.current = value;
-  }, [value]);
+  }, [resetPromptHistoryNavigation, resetUndoRedo, value]);
 
   useEffect(() => {
     cursorRef.current = cursor;
   }, [cursor]);
-
-  useEffect(() => {
-    promptHistoryRef.current = promptHistory;
-  }, [promptHistory]);
 
   const applyDraft = (nextValue: string, nextCursor: number, options: { recordUndo?: boolean } = {}) => {
     const current = {
@@ -84,11 +85,9 @@ export function PromptInput({
       cursor: Math.min(cursorRef.current, valueRef.current.length),
     };
     const next = { value: nextValue, cursor: nextCursor };
-    if (options.recordUndo !== false && !isSamePromptDraftState(current, next)) {
-      undoStackRef.current = [...undoStackRef.current, current].slice(-100);
-      redoStackRef.current = [];
-      promptHistoryIndexRef.current = undefined;
-      savedDraftBeforeHistoryRef.current = undefined;
+    if (options.recordUndo !== false) {
+      recordUndoState(current, next);
+      resetPromptHistoryNavigation();
     }
 
     valueRef.current = nextValue;
@@ -116,38 +115,26 @@ export function PromptInput({
       },
       onSubmit,
       undo: () => {
-        const previous = resolvePromptUndo(undoStackRef.current, redoStackRef.current, state);
+        const previous = undoPromptEdit(state);
         if (!previous) {
           return;
         }
-        undoStackRef.current = previous.undoStack;
-        redoStackRef.current = previous.redoStack;
-        applyState(previous.state, { recordUndo: false });
+        applyState(previous, { recordUndo: false });
       },
       redo: () => {
-        const next = resolvePromptRedo(undoStackRef.current, redoStackRef.current, state);
+        const next = redoPromptEdit(state);
         if (!next) {
           return;
         }
-        undoStackRef.current = next.undoStack;
-        redoStackRef.current = next.redoStack;
-        applyState(next.state, { recordUndo: false });
+        applyState(next, { recordUndo: false });
       },
       navigateHistory: (direction) => {
-        const next = resolvePromptHistoryNavigation({
-          direction,
-          history: promptHistoryRef.current,
-          current: state,
-          historyIndex: promptHistoryIndexRef.current,
-          savedDraftBeforeHistory: savedDraftBeforeHistoryRef.current,
-        });
+        const next = navigatePromptHistory(direction, state);
         if (!next) {
           return;
         }
 
-        promptHistoryIndexRef.current = next.historyIndex;
-        savedDraftBeforeHistoryRef.current = next.savedDraftBeforeHistory;
-        applyState(next.state, { recordUndo: false });
+        applyState(next, { recordUndo: false });
       },
     };
 
@@ -201,11 +188,6 @@ export function resolvePromptInputRenderWidth(width?: number, stdoutColumns?: nu
   const candidate = width ?? stdoutColumns ?? FALLBACK_WRAP_WIDTH;
   return Math.max(PROMPT_INPUT_PREFIX_WIDTH + 1, Math.floor(candidate));
 }
-
-export type PromptDraftState = {
-  value: string;
-  cursor: number;
-};
 
 type PromptInputCommand =
   | { kind: 'submit' }
@@ -352,103 +334,6 @@ function handlePromptInputCommand(
     case 'move':
       actions.moveCursor(resolvePromptCursorMove(state, command.direction));
   }
-}
-
-function isSamePromptDraftState(left: PromptDraftState, right: PromptDraftState): boolean {
-  return left.value === right.value && left.cursor === right.cursor;
-}
-
-export function resolvePromptUndo(
-  undoStack: PromptDraftState[],
-  redoStack: PromptDraftState[],
-  current: PromptDraftState,
-): { state: PromptDraftState; undoStack: PromptDraftState[]; redoStack: PromptDraftState[] } | undefined {
-  const previous = undoStack[undoStack.length - 1];
-  if (!previous) {
-    return undefined;
-  }
-
-  return {
-    state: previous,
-    undoStack: undoStack.slice(0, -1),
-    redoStack: [...redoStack, current],
-  };
-}
-
-export function resolvePromptRedo(
-  undoStack: PromptDraftState[],
-  redoStack: PromptDraftState[],
-  current: PromptDraftState,
-): { state: PromptDraftState; undoStack: PromptDraftState[]; redoStack: PromptDraftState[] } | undefined {
-  const next = redoStack[redoStack.length - 1];
-  if (!next) {
-    return undefined;
-  }
-
-  return {
-    state: next,
-    undoStack: [...undoStack, current],
-    redoStack: redoStack.slice(0, -1),
-  };
-}
-
-export function canNavigatePromptHistory(direction: 'previous' | 'next', state: PromptDraftState): boolean {
-  if (!state.value.includes('\n')) {
-    return true;
-  }
-
-  if (direction === 'previous') {
-    const firstLineEnd = state.value.indexOf('\n');
-    return state.cursor <= firstLineEnd;
-  }
-
-  const lastLineStart = state.value.lastIndexOf('\n') + 1;
-  return state.cursor >= lastLineStart;
-}
-
-export function resolvePromptHistoryNavigation(args: {
-  direction: 'previous' | 'next';
-  history: string[];
-  current: PromptDraftState;
-  historyIndex?: number;
-  savedDraftBeforeHistory?: PromptDraftState;
-}): { state: PromptDraftState; historyIndex?: number; savedDraftBeforeHistory?: PromptDraftState } | undefined {
-  if (args.history.length === 0) {
-    return undefined;
-  }
-
-  if (args.direction === 'previous') {
-    const historyIndex =
-      args.historyIndex === undefined ?
-        args.history.length - 1
-      : Math.max(0, args.historyIndex - 1);
-    const value = args.history[historyIndex] ?? '';
-    return {
-      state: { value, cursor: value.length },
-      historyIndex,
-      savedDraftBeforeHistory: args.savedDraftBeforeHistory ?? args.current,
-    };
-  }
-
-  if (args.historyIndex === undefined) {
-    return undefined;
-  }
-
-  if (args.historyIndex < args.history.length - 1) {
-    const historyIndex = args.historyIndex + 1;
-    const value = args.history[historyIndex] ?? '';
-    return {
-      state: { value, cursor: value.length },
-      historyIndex,
-      savedDraftBeforeHistory: args.savedDraftBeforeHistory,
-    };
-  }
-
-  return {
-    state: args.savedDraftBeforeHistory ?? { value: '', cursor: 0 },
-    historyIndex: undefined,
-    savedDraftBeforeHistory: undefined,
-  };
 }
 
 function resolvePromptCursorMove(state: PromptDraftState, direction: Extract<PromptInputCommand, { kind: 'move' }>['direction']): number {

--- a/src/cli/chat/hooks/usePromptDraft.ts
+++ b/src/cli/chat/hooks/usePromptDraft.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 export function usePromptDraft() {
   const [draft, setDraft] = useState('');
   const [draftCursor, setDraftCursor] = useState(0);
+  const [promptHistory, setPromptHistory] = useState<string[]>([]);
 
   const clearDraft = useCallback(() => {
     setDraft('');
@@ -14,12 +15,28 @@ export function usePromptDraft() {
     setDraftCursor(value.length);
   }, []);
 
+  const recordPromptHistory = useCallback((value: string) => {
+    if (!value.trim()) {
+      return;
+    }
+
+    setPromptHistory((current) => {
+      if (current[current.length - 1] === value) {
+        return current;
+      }
+
+      return [...current, value].slice(-100);
+    });
+  }, []);
+
   return {
     draft,
     setDraft,
     draftCursor,
     setDraftCursor,
+    promptHistory,
     clearDraft,
     replaceDraft,
+    recordPromptHistory,
   };
 }

--- a/src/cli/chat/hooks/usePromptDraft.ts
+++ b/src/cli/chat/hooks/usePromptDraft.ts
@@ -3,7 +3,6 @@ import { useCallback, useState } from 'react';
 export function usePromptDraft() {
   const [draft, setDraft] = useState('');
   const [draftCursor, setDraftCursor] = useState(0);
-  const [promptHistory, setPromptHistory] = useState<string[]>([]);
 
   const clearDraft = useCallback(() => {
     setDraft('');
@@ -15,28 +14,12 @@ export function usePromptDraft() {
     setDraftCursor(value.length);
   }, []);
 
-  const recordPromptHistory = useCallback((value: string) => {
-    if (!value.trim()) {
-      return;
-    }
-
-    setPromptHistory((current) => {
-      if (current[current.length - 1] === value) {
-        return current;
-      }
-
-      return [...current, value].slice(-100);
-    });
-  }, []);
-
   return {
     draft,
     setDraft,
     draftCursor,
     setDraftCursor,
-    promptHistory,
     clearDraft,
     replaceDraft,
-    recordPromptHistory,
   };
 }

--- a/src/cli/chat/hooks/usePromptHistory.ts
+++ b/src/cli/chat/hooks/usePromptHistory.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PromptDraftState } from './usePromptUndoRedo.js';
+
+const MAX_PROMPT_HISTORY_ENTRIES = 100;
+
+export function usePromptHistory() {
+  const [promptHistory, setPromptHistory] = useState<string[]>([]);
+
+  const recordPromptHistory = useCallback((value: string) => {
+    if (!value.trim()) {
+      return;
+    }
+
+    setPromptHistory((current) => {
+      if (current[current.length - 1] === value) {
+        return current;
+      }
+
+      return [...current, value].slice(-MAX_PROMPT_HISTORY_ENTRIES);
+    });
+  }, []);
+
+  return {
+    promptHistory,
+    recordPromptHistory,
+  };
+}
+
+export function usePromptHistoryNavigation(promptHistory: string[]) {
+  const promptHistoryRef = useRef(promptHistory);
+  const promptHistoryIndexRef = useRef<number | undefined>(undefined);
+  const savedDraftBeforeHistoryRef = useRef<PromptDraftState | undefined>(undefined);
+
+  useEffect(() => {
+    promptHistoryRef.current = promptHistory;
+  }, [promptHistory]);
+
+  const resetPromptHistoryNavigation = useCallback(() => {
+    promptHistoryIndexRef.current = undefined;
+    savedDraftBeforeHistoryRef.current = undefined;
+  }, []);
+
+  const navigatePromptHistory = useCallback((direction: 'previous' | 'next', current: PromptDraftState): PromptDraftState | undefined => {
+    const next = resolvePromptHistoryNavigation({
+      direction,
+      history: promptHistoryRef.current,
+      current,
+      historyIndex: promptHistoryIndexRef.current,
+      savedDraftBeforeHistory: savedDraftBeforeHistoryRef.current,
+    });
+    if (!next) {
+      return undefined;
+    }
+
+    promptHistoryIndexRef.current = next.historyIndex;
+    savedDraftBeforeHistoryRef.current = next.savedDraftBeforeHistory;
+    return next.state;
+  }, []);
+
+  return {
+    resetPromptHistoryNavigation,
+    navigatePromptHistory,
+  };
+}
+
+export function canNavigatePromptHistory(direction: 'previous' | 'next', state: PromptDraftState): boolean {
+  if (!state.value.includes('\n')) {
+    return true;
+  }
+
+  if (direction === 'previous') {
+    const firstLineEnd = state.value.indexOf('\n');
+    return state.cursor <= firstLineEnd;
+  }
+
+  const lastLineStart = state.value.lastIndexOf('\n') + 1;
+  return state.cursor >= lastLineStart;
+}
+
+export function resolvePromptHistoryNavigation(args: {
+  direction: 'previous' | 'next';
+  history: string[];
+  current: PromptDraftState;
+  historyIndex?: number;
+  savedDraftBeforeHistory?: PromptDraftState;
+}): { state: PromptDraftState; historyIndex?: number; savedDraftBeforeHistory?: PromptDraftState } | undefined {
+  if (args.history.length === 0) {
+    return undefined;
+  }
+
+  if (args.direction === 'previous') {
+    const historyIndex =
+      args.historyIndex === undefined ?
+        args.history.length - 1
+      : Math.max(0, args.historyIndex - 1);
+    const value = args.history[historyIndex] ?? '';
+    return {
+      state: { value, cursor: value.length },
+      historyIndex,
+      savedDraftBeforeHistory: args.savedDraftBeforeHistory ?? args.current,
+    };
+  }
+
+  if (args.historyIndex === undefined) {
+    return undefined;
+  }
+
+  if (args.historyIndex < args.history.length - 1) {
+    const historyIndex = args.historyIndex + 1;
+    const value = args.history[historyIndex] ?? '';
+    return {
+      state: { value, cursor: value.length },
+      historyIndex,
+      savedDraftBeforeHistory: args.savedDraftBeforeHistory,
+    };
+  }
+
+  return {
+    state: args.savedDraftBeforeHistory ?? { value: '', cursor: 0 },
+    historyIndex: undefined,
+    savedDraftBeforeHistory: undefined,
+  };
+}

--- a/src/cli/chat/hooks/usePromptUndoRedo.ts
+++ b/src/cli/chat/hooks/usePromptUndoRedo.ts
@@ -1,0 +1,94 @@
+import { useCallback, useRef } from 'react';
+
+export type PromptDraftState = {
+  value: string;
+  cursor: number;
+};
+
+const MAX_UNDO_STATES = 100;
+
+export function usePromptUndoRedo() {
+  const undoStackRef = useRef<PromptDraftState[]>([]);
+  const redoStackRef = useRef<PromptDraftState[]>([]);
+
+  const resetUndoRedo = useCallback(() => {
+    undoStackRef.current = [];
+    redoStackRef.current = [];
+  }, []);
+
+  const recordUndoState = useCallback((current: PromptDraftState, next: PromptDraftState) => {
+    if (isSamePromptDraftState(current, next)) {
+      return;
+    }
+
+    undoStackRef.current = [...undoStackRef.current, current].slice(-MAX_UNDO_STATES);
+    redoStackRef.current = [];
+  }, []);
+
+  const undoPromptEdit = useCallback((current: PromptDraftState): PromptDraftState | undefined => {
+    const previous = resolvePromptUndo(undoStackRef.current, redoStackRef.current, current);
+    if (!previous) {
+      return undefined;
+    }
+
+    undoStackRef.current = previous.undoStack;
+    redoStackRef.current = previous.redoStack;
+    return previous.state;
+  }, []);
+
+  const redoPromptEdit = useCallback((current: PromptDraftState): PromptDraftState | undefined => {
+    const next = resolvePromptRedo(undoStackRef.current, redoStackRef.current, current);
+    if (!next) {
+      return undefined;
+    }
+
+    undoStackRef.current = next.undoStack;
+    redoStackRef.current = next.redoStack;
+    return next.state;
+  }, []);
+
+  return {
+    resetUndoRedo,
+    recordUndoState,
+    undoPromptEdit,
+    redoPromptEdit,
+  };
+}
+
+function isSamePromptDraftState(left: PromptDraftState, right: PromptDraftState): boolean {
+  return left.value === right.value && left.cursor === right.cursor;
+}
+
+export function resolvePromptUndo(
+  undoStack: PromptDraftState[],
+  redoStack: PromptDraftState[],
+  current: PromptDraftState,
+): { state: PromptDraftState; undoStack: PromptDraftState[]; redoStack: PromptDraftState[] } | undefined {
+  const previous = undoStack[undoStack.length - 1];
+  if (!previous) {
+    return undefined;
+  }
+
+  return {
+    state: previous,
+    undoStack: undoStack.slice(0, -1),
+    redoStack: [...redoStack, current],
+  };
+}
+
+export function resolvePromptRedo(
+  undoStack: PromptDraftState[],
+  redoStack: PromptDraftState[],
+  current: PromptDraftState,
+): { state: PromptDraftState; undoStack: PromptDraftState[]; redoStack: PromptDraftState[] } | undefined {
+  const next = redoStack[redoStack.length - 1];
+  if (!next) {
+    return undefined;
+  }
+
+  return {
+    state: next,
+    undoStack: [...undoStack, current],
+    redoStack: redoStack.slice(0, -1),
+  };
+}


### PR DESCRIPTION
## Summary
- Add Ctrl+Z / Ctrl+Y undo and redo for TUI prompt drafting.
- Add Up/Down submitted prompt history navigation while preserving the in-progress draft.
- Keep multi-line behavior predictable by only using history navigation from the first or last logical line.
- Document prompt editing shortcuts in the chat guide.

Closes #52

## Testing
- ./node_modules/.bin/vitest run src/__tests__/unit/tui/prompt-input.test.tsx
- yarn typecheck
- yarn test:unit