### PR TITLE
[codex] Restore TUI streaming activity

### DIFF
--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -184,7 +184,7 @@ describe('runAgentLoop', () => {
     expect(events).toContainEqual(expect.objectContaining({
       type: 'assistant.stream',
       step: 1,
-      text: 'Reasoning: Inspecting the request before choosing tools.',
+      text: 'Thinking: Inspecting the request before choosing tools.',
       done: false,
     }));
   });

--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -151,6 +151,44 @@ describe('runAgentLoop', () => {
     }));
   });
 
+  it('emits streamed reasoning summaries as assistant progress events', async () => {
+    const events: AgentLoopEvent[] = [];
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: true,
+          parallelToolCalls: true,
+        },
+      },
+      async chat(_messages, _tools, _signal, onStreamEvent): Promise<LlmResponse> {
+        onStreamEvent?.({ type: 'reasoning_summary.delta', delta: 'Inspecting the request' });
+        onStreamEvent?.({ type: 'reasoning_summary.done', text: 'Inspecting the request before choosing tools.' });
+        return { content: 'Done.' };
+      },
+    };
+
+    await runAgentLoop({
+      goal: 'Say hello.',
+      llm: fakeLlm,
+      tools: [],
+      includeDefaultTools: false,
+      maxSteps: 1,
+      logger: silentLogger,
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'assistant.stream',
+      step: 1,
+      text: 'Reasoning: Inspecting the request before choosing tools.',
+      done: false,
+    }));
+  });
+
   it('does not treat the workspace state directory as the OAuth credential store', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'heddle-loop-state-dir-'));
     await mkdir(join(workspaceRoot, '.heddle'));

--- a/src/__tests__/unit/core/conversation-activity.test.ts
+++ b/src/__tests__/unit/core/conversation-activity.test.ts
@@ -72,7 +72,14 @@ describe('conversation activity projection', () => {
     };
 
     expect(projectAgentLoopEventToConversationActivities(calling)).toEqual([
-      expect.objectContaining({ type: 'tool.calling', tool: 'read_file', step: 2, runId: 'run-1' }),
+      expect.objectContaining({
+        type: 'tool.calling',
+        tool: 'read_file',
+        toolSummary: 'read_file (README.md)',
+        requiresApproval: false,
+        step: 2,
+        runId: 'run-1',
+      }),
     ]);
     expect(projectAgentLoopEventToConversationActivities(completed)).toEqual([
       expect.objectContaining({ type: 'tool.completed', tool: 'read_file', durationMs: 12.4, step: 2, runId: 'run-1' }),

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -383,6 +383,62 @@ describe('OpenAI OAuth helpers', () => {
       },
     ]);
   });
+
+  it('streams OpenAI reasoning summary text events to the LLM stream callback', async () => {
+    const adapter = createOpenAiAdapter({
+      model: 'gpt-5.4',
+      credential: {
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 120_000,
+        accountId: 'account-123',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      },
+      fetchImpl: (async () => {
+        const body = [
+          'event: response.created',
+          'data: {"type":"response.created","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"in_progress","model":"gpt-5.4","output":[]}}',
+          '',
+          'event: response.reasoning_summary_text.delta',
+          'data: {"type":"response.reasoning_summary_text.delta","delta":"Inspecting ","item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":2}',
+          '',
+          'event: response.reasoning_summary_text.delta',
+          'data: {"type":"response.reasoning_summary_text.delta","delta":"the repo.","item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":3}',
+          '',
+          'event: response.reasoning_summary_text.done',
+          'data: {"type":"response.reasoning_summary_text.done","text":"Inspecting the repo.","item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":4}',
+          '',
+          'event: response.output_text.done',
+          'data: {"type":"response.output_text.done","text":"Done.","content_index":0,"item_id":"msg_1","output_index":1,"sequence_number":5}',
+          '',
+          'event: response.completed',
+          'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"completed","completed_at":1777301835,"model":"gpt-5.4","output_text":"Done.","output":[],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":1},"total_tokens":15}}}',
+          '',
+        ].join('\n');
+
+        return new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }) as typeof fetch,
+    });
+    const streamEvents: unknown[] = [];
+
+    const result = await adapter.chat([{ role: 'user', content: 'hello' }], [], undefined, (event) => {
+      streamEvents.push(event);
+    });
+
+    expect(streamEvents).toEqual([
+      { type: 'reasoning_summary.delta', delta: 'Inspecting ' },
+      { type: 'reasoning_summary.delta', delta: 'the repo.' },
+      { type: 'reasoning_summary.done', text: 'Inspecting the repo.' },
+      { type: 'content.done', content: 'Done.' },
+    ]);
+    expect(result.content).toBe('Done.');
+  });
 });
 
 function createJwt(payload: unknown): string {

--- a/src/__tests__/unit/tui/chat-activity-format.test.ts
+++ b/src/__tests__/unit/tui/chat-activity-format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { toLiveEvent } from '../../../cli/chat/adapters/conversation-activity-adapter.js';
-import { summarizeToolCall } from '../../../core/observability/conversation-activity.js';
+import { formatConversationActivityForTui, toLiveEvent } from '../../../cli/chat/adapters/conversation-activity-adapter.js';
+import { projectAgentLoopEventToConversationActivities, summarizeToolCall } from '../../../core/observability/conversation-activity.js';
+import type { AgentLoopEvent } from '../../../core/runtime/events.js';
 import type { TraceEvent } from '../../../types.js';
 
 describe('chat activity formatting', () => {
@@ -53,5 +54,22 @@ describe('chat activity formatting', () => {
     };
 
     expect(toLiveEvent(event)).toBe('running search_files ("trace" in .heddle/traces)');
+  });
+
+  it('formats loop-level tool calling events with input details for immediate TUI activity', () => {
+    const event: AgentLoopEvent = {
+      type: 'tool.calling',
+      runId: 'run-1',
+      step: 1,
+      tool: 'read_file',
+      toolCallId: 'call-1',
+      input: { path: 'README.md' },
+      requiresApproval: false,
+      timestamp: '2026-05-08T00:00:00.000Z',
+    };
+
+    expect(projectAgentLoopEventToConversationActivities(event).map(formatConversationActivityForTui)).toEqual([
+      'running read_file (README.md)',
+    ]);
   });
 });

--- a/src/cli/chat/adapters/conversation-activity-adapter.ts
+++ b/src/cli/chat/adapters/conversation-activity-adapter.ts
@@ -28,6 +28,8 @@ const tuiActivityFormatters = {
   'tool.fallback': (activity) => {
     return `retrying with ${activity.toSummary} after ${activity.fromSummary} was blocked (${truncate(activity.reason, 80)})`;
   },
+  'tool.calling': (activity) => `running ${activity.toolSummary}`,
+  'tool.completed': (activity) => `${activity.tool} completed${activity.durationMs === undefined ? '' : ` in ${Math.round(activity.durationMs)}ms`}`,
   'tool.call': (activity) => `running ${activity.toolSummary}`,
   'tool.result': (activity) => {
     return `${activity.toolSummary} ${activity.ok ? 'completed' : `failed: ${activity.error ?? 'error'}`}`;

--- a/src/cli/chat/components/ConversationPanel.tsx
+++ b/src/cli/chat/components/ConversationPanel.tsx
@@ -109,10 +109,14 @@ function MessageBody({
 
 function StreamingText({ text }: { text: string }) {
   const lines = text.split(/\r?\n/);
+  const isThinkingText = text.startsWith('Thinking:') || text === 'Thinking...';
+
   return (
     <Box flexDirection="column">
       {lines.map((line, index) => (
-        <Text key={`${index}-${line}`} color="white">{line || ' '}</Text>
+        <Text key={`${index}-${line}`} color={isThinkingText ? undefined : 'white'} dimColor={isThinkingText}>
+          {line || ' '}
+        </Text>
       ))}
     </Box>
   );

--- a/src/cli/chat/hooks/tui-ordinary-turn.ts
+++ b/src/cli/chat/hooks/tui-ordinary-turn.ts
@@ -85,6 +85,7 @@ export async function executeTuiOrdinaryTurn(args: {
       events: {
         onAgentLoopEvent: (event) => {
           driftObserver?.observer.handleEvent(event);
+          runLoopEvents.onAgentLoopEvent(event);
         },
       },
       compaction: compactionPort,

--- a/src/cli/chat/hooks/tui-run-loop-events.ts
+++ b/src/cli/chat/hooks/tui-run-loop-events.ts
@@ -1,5 +1,9 @@
 import type { TraceEvent } from '../../../index.js';
-import { projectTraceEventToConversationActivities } from '../../../core/observability/conversation-activity.js';
+import type { AgentLoopEvent } from '../../../core/runtime/events.js';
+import {
+  projectAgentLoopEventToConversationActivities,
+  projectTraceEventToConversationActivities,
+} from '../../../core/observability/conversation-activity.js';
 import { previewEditFileInput } from '../../../core/tools/toolkits/coding-files/edit-file.js';
 import { formatConversationActivityForTui } from '../adapters/conversation-activity-adapter.js';
 import { formatEditPreviewHistoryMessage, formatPlanHistoryMessage } from '../utils/format.js';
@@ -30,6 +34,19 @@ export function createTuiRunLoopEventAdapter(args: {
       if (update.done) {
         streamingBuffers.delete(update.step);
       }
+    },
+
+    onAgentLoopEvent(event: AgentLoopEvent) {
+      if (event.type === 'trace') {
+        return;
+      }
+
+      appendLiveEvents(
+        state,
+        projectAgentLoopEventToConversationActivities(event)
+          .map(formatConversationActivityForTui)
+          .filter((text): text is string => Boolean(text)),
+      );
     },
 
     onTraceEvent(event: TraceEvent) {
@@ -84,18 +101,22 @@ export function createTuiRunLoopEventAdapter(args: {
       const nextEvents = projectTraceEventToConversationActivities(event)
         .map(formatConversationActivityForTui)
         .filter((text): text is string => Boolean(text));
-      if (nextEvents.length === 0) {
-        return;
-      }
-
-      state.setLiveEvents((current) => {
-        const dedupedNextEvents = nextEvents.filter((next) => current[current.length - 1]?.text !== next);
-
-        return [
-          ...current,
-          ...dedupedNextEvents.map((text) => ({ id: state.nextLocalId(), text })),
-        ].slice(-8);
-      });
+      appendLiveEvents(state, nextEvents);
     },
   };
+}
+
+function appendLiveEvents(state: ActionState, nextEvents: string[]) {
+  if (nextEvents.length === 0) {
+    return;
+  }
+
+  state.setLiveEvents((current) => {
+    const dedupedNextEvents = nextEvents.filter((next) => current[current.length - 1]?.text !== next);
+
+    return [
+      ...current,
+      ...dedupedNextEvents.map((text) => ({ id: state.nextLocalId(), text })),
+    ].slice(-8);
+  });
 }

--- a/src/core/agent/run-agent.ts
+++ b/src/core/agent/run-agent.ts
@@ -220,6 +220,7 @@ async function requestModelTurn(context: RunContext): Promise<LlmResponse | RunR
 
   try {
     let streamedContent = '';
+    let streamedReasoningSummary = '';
     let lastStreamRecordAt = 0;
     const response = await context.llm.chat(
       context.messages,
@@ -242,6 +243,30 @@ async function requestModelTurn(context: RunContext): Promise<LlmResponse | RunR
         if (event.type === 'content.done') {
           streamedContent = event.content;
           context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: true });
+          return;
+        }
+
+        if (event.type === 'reasoning_summary.delta') {
+          streamedReasoningSummary += event.delta;
+          if (!streamedContent) {
+            context.onAssistantStream?.({
+              step: context.state.step,
+              text: formatReasoningSummaryStream(streamedReasoningSummary),
+              done: false,
+            });
+          }
+          return;
+        }
+
+        if (event.type === 'reasoning_summary.done') {
+          streamedReasoningSummary = event.text;
+          if (!streamedContent) {
+            context.onAssistantStream?.({
+              step: context.state.step,
+              text: formatReasoningSummaryStream(streamedReasoningSummary),
+              done: false,
+            });
+          }
         }
       },
     );
@@ -256,6 +281,11 @@ async function requestModelTurn(context: RunContext): Promise<LlmResponse | RunR
     context.log.error({ step: context.state.step, error: errorMessage }, 'LLM call failed');
     return finishRun(context, 'error', `LLM error: ${errorMessage}`);
   }
+}
+
+function formatReasoningSummaryStream(text: string): string {
+  const trimmed = text.trim();
+  return trimmed ? `Reasoning: ${trimmed}` : 'Reasoning...';
 }
 
 async function handleToolTurn(context: RunContext, response: LlmResponse): Promise<RunResult | 'continue'> {

--- a/src/core/agent/run-agent.ts
+++ b/src/core/agent/run-agent.ts
@@ -285,7 +285,7 @@ async function requestModelTurn(context: RunContext): Promise<LlmResponse | RunR
 
 function formatReasoningSummaryStream(text: string): string {
   const trimmed = text.trim();
-  return trimmed ? `Reasoning: ${trimmed}` : 'Reasoning...';
+  return trimmed ? `Thinking: ${trimmed}` : 'Thinking...';
 }
 
 async function handleToolTurn(context: RunContext, response: LlmResponse): Promise<RunResult | 'continue'> {

--- a/src/core/llm/openai.ts
+++ b/src/core/llm/openai.ts
@@ -108,6 +108,29 @@ export function createOpenAiAdapter(options: OpenAiAdapterOptions = {}): LlmAdap
           continue;
         }
 
+        if (event.type === 'response.reasoning_summary_text.delta' && event.delta) {
+          onStreamEvent?.({ type: 'reasoning_summary.delta', delta: event.delta });
+          continue;
+        }
+
+        if (event.type === 'response.reasoning_summary_text.done') {
+          onStreamEvent?.({ type: 'reasoning_summary.done', text: event.text });
+          continue;
+        }
+
+        if (event.type === 'response.reasoning_summary.delta') {
+          const delta = readReasoningSummaryDeltaText(event.delta);
+          if (delta) {
+            onStreamEvent?.({ type: 'reasoning_summary.delta', delta });
+          }
+          continue;
+        }
+
+        if (event.type === 'response.reasoning_summary.done') {
+          onStreamEvent?.({ type: 'reasoning_summary.done', text: event.text });
+          continue;
+        }
+
         if (event.type === 'response.output_item.added' || event.type === 'response.output_item.done') {
           const item = event.item;
           if (
@@ -198,6 +221,19 @@ function parseStreamedToolCalls(
   }
 
   return toolCalls;
+}
+
+function readReasoningSummaryDeltaText(delta: unknown): string | undefined {
+  if (typeof delta === 'string') {
+    return delta;
+  }
+
+  if (!delta || typeof delta !== 'object' || Array.isArray(delta)) {
+    return undefined;
+  }
+
+  const text = (delta as { text?: unknown }).text;
+  return typeof text === 'string' ? text : undefined;
 }
 
 function firstDefinedNonEmpty(...values: Array<string | undefined>): string | undefined {

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -6,7 +6,9 @@ import type { AssistantDiagnostics, ToolCall, ToolDefinition } from '../types.js
 
 export type LlmStreamEvent =
   | { type: 'content.delta'; delta: string }
-  | { type: 'content.done'; content: string };
+  | { type: 'content.done'; content: string }
+  | { type: 'reasoning_summary.delta'; delta: string }
+  | { type: 'reasoning_summary.done'; text: string };
 
 export type LlmProvider = 'openai' | 'anthropic' | 'google';
 

--- a/src/core/observability/conversation-activity.ts
+++ b/src/core/observability/conversation-activity.ts
@@ -15,7 +15,7 @@ export type ConversationActivity = ConversationActivityCorrelation & (
   | { type: 'loop.finished' }
   | { type: 'assistant.stream'; text: string; done: boolean }
   | { type: 'assistant.turn'; requestedTools: boolean; rationale?: string }
-  | { type: 'tool.calling'; tool: string }
+  | { type: 'tool.calling'; tool: string; toolSummary: string; requiresApproval: boolean }
   | { type: 'tool.completed'; tool: string; durationMs?: number }
   | { type: 'run.started' }
   | { type: 'run.finished'; outcome: string }
@@ -157,7 +157,13 @@ const agentLoopProjectors: AgentLoopProjectorMap = {
     done: event.done,
     ...agentLoopCorrelation(event),
   }],
-  'tool.calling': (event) => [{ type: 'tool.calling', tool: event.tool, ...agentLoopCorrelation(event) }],
+  'tool.calling': (event) => [{
+    type: 'tool.calling',
+    tool: event.tool,
+    toolSummary: summarizeToolCall(event.tool, event.input),
+    requiresApproval: event.requiresApproval,
+    ...agentLoopCorrelation(event),
+  }],
   'tool.completed': (event) => [{
     type: 'tool.completed',
     tool: event.tool,


### PR DESCRIPTION
## Summary

Restores visible in-flight TUI progress while Heddle is reasoning and calling tools.

## What changed

- Forward OpenAI reasoning summary stream events through the LLM stream path.
- Render streamed reasoning summaries as dim `Thinking: ...` progress text in the active turn.
- Feed loop-level `tool.calling` and `tool.completed` events into the TUI activity panel so users see tool execution promptly.
- Add regression coverage for reasoning summary streaming and immediate tool activity formatting.

## Why

A recent regression left the TUI quiet during long tool-using turns until the final assistant response arrived. This made it hard to tell whether Heddle was thinking, using tools, or stuck.

## Validation

- `yarn typecheck`
- `yarn test:unit`
- `yarn test`
