### PR TITLE
Render streaming TUI assistant markdown in real time

### DIFF
--- a/src/__tests__/unit/tui/conversation-panel.test.tsx
+++ b/src/__tests__/unit/tui/conversation-panel.test.tsx
@@ -1,0 +1,85 @@
+/** @vitest-environment jsdom */
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { isThinkingText, parseInlineSegments, parseMessageBlocks } from '../../../cli/chat/components/ConversationPanel.js';
+
+describe('ConversationPanel markdown parsing', () => {
+  it('parses stable markdown structures for assistant text', () => {
+    const blocks = parseMessageBlocks([
+      '# Heading',
+      '',
+      '- bullet item',
+      '- [x] completed item',
+      '1. numbered item',
+      '> quoted line',
+      '```ts',
+      'const value = 42;',
+      '```',
+    ].join('\n'));
+
+    expect(blocks).toEqual([
+      { kind: 'heading', text: 'Heading' },
+      { kind: 'blank', text: '' },
+      { kind: 'bullet', text: 'bullet item' },
+      { kind: 'task', marker: '[x]', text: 'completed item' },
+      { kind: 'numbered', marker: '1.', text: 'numbered item' },
+      { kind: 'quote', text: 'quoted line' },
+      { kind: 'code', info: 'ts', text: 'const value = 42;' },
+    ]);
+  });
+
+  it('keeps incomplete markdown readable while streaming', () => {
+    const blocks = parseMessageBlocks([
+      '**unfinished bold',
+      '`unfinished code',
+      '- [x',
+      '```diff',
+      '+added line',
+    ].join('\n'));
+
+    expect(blocks).toEqual([
+      { kind: 'paragraph', text: '**unfinished bold `unfinished code' },
+      { kind: 'bullet', text: '[x' },
+      { kind: 'code', info: 'diff', text: '+added line' },
+    ]);
+  });
+
+  it('parses inline segments conservatively when markdown is incomplete', () => {
+    expect(parseInlineSegments('prefix **bold** `code` suffix')).toEqual([
+      { kind: 'text', text: 'prefix ' },
+      { kind: 'bold', text: 'bold' },
+      { kind: 'text', text: ' ' },
+      { kind: 'code', text: 'code' },
+      { kind: 'text', text: ' suffix' },
+    ]);
+
+    expect(parseInlineSegments('prefix **unfinished and `still open')).toEqual([
+      { kind: 'text', text: 'prefix ' },
+      { kind: 'text', text: '**' },
+      { kind: 'text', text: 'unfinished and ' },
+      { kind: 'text', text: '`' },
+      { kind: 'text', text: 'still open' },
+    ]);
+  });
+
+  it('recognizes thinking-status text separately from assistant markdown content', () => {
+    expect(isThinkingText('Thinking: planning the next step')).toBe(true);
+    expect(isThinkingText('Thinking...')).toBe(true);
+    expect(isThinkingText('# Heading\n- bullet')).toBe(false);
+  });
+
+  it('allows the streaming assistant surface to be rendered in jsdom without crashing', () => {
+    const view = render(
+      <div>
+        {parseMessageBlocks('# Heading\n\n- bullet\n```ts\nconst x = 1\n```').map((block, index) => (
+          <div key={`${block.kind}-${index}`}>{block.kind}</div>
+        ))}
+      </div>,
+    );
+
+    expect(view.container.textContent).toContain('heading');
+    expect(view.container.textContent).toContain('bullet');
+    expect(view.container.textContent).toContain('code');
+  });
+});

--- a/src/cli/chat/components/ConversationPanel.tsx
+++ b/src/cli/chat/components/ConversationPanel.tsx
@@ -37,7 +37,7 @@ export function ConversationPanel({
             ))}
             {activeTurn.currentAssistantText ?
               <Box marginTop={1}>
-                <StreamingText text={activeTurn.currentAssistantText} />
+                <StreamingAssistantBody text={activeTurn.currentAssistantText} />
               </Box>
             : null}
             {activeTurn.currentPlan ? <ActivePlanPanel plan={activeTurn.currentPlan} /> : null}
@@ -107,19 +107,25 @@ function MessageBody({
   );
 }
 
-function StreamingText({ text }: { text: string }) {
-  const lines = text.split(/\r?\n/);
-  const isThinkingText = text.startsWith('Thinking:') || text === 'Thinking...';
+function StreamingAssistantBody({ text }: { text: string }) {
+  if (isThinkingText(text)) {
+    const lines = text.split(/\r?\n/);
+    return (
+      <Box flexDirection="column">
+        {lines.map((line, index) => (
+          <Text key={`${index}-${line}`} dimColor>
+            {line || ' '}
+          </Text>
+        ))}
+      </Box>
+    );
+  }
 
-  return (
-    <Box flexDirection="column">
-      {lines.map((line, index) => (
-        <Text key={`${index}-${line}`} color={isThinkingText ? undefined : 'white'} dimColor={isThinkingText}>
-          {line || ' '}
-        </Text>
-      ))}
-    </Box>
-  );
+  return <MessageBody role="assistant" text={text} />;
+}
+
+export function isThinkingText(text: string): boolean {
+  return text.startsWith('Thinking:') || text === 'Thinking...';
 }
 
 type MessageBlock =


### PR DESCRIPTION
## Summary
- render streaming TUI assistant output with the same markdown/block renderer used for completed assistant messages
- keep `Thinking:` status text on its simpler dimmed rendering path
- add focused parser tests for partial markdown tolerance and thinking-status detection

## Changes
- replace the old raw `StreamingText(...)` path in `ConversationPanel.tsx` with `StreamingAssistantBody(...)`
- route non-thinking streaming assistant text through `MessageBody role="assistant" text={text}` so headings, bullets, tasks, quotes, inline formatting, and code blocks render progressively during streaming
- export `isThinkingText(...)` to preserve the special-case status rendering for `Thinking:` and `Thinking...`
- add `src/__tests__/unit/tui/conversation-panel.test.tsx` covering stable markdown parsing, incomplete markdown behavior, inline parsing, and thinking detection

## Verification
- `yarn vitest run src/__tests__/unit/tui/conversation-panel.test.tsx`
- `yarn build`
