### PR TITLE
Fix search_files and approval remember UX

### DIFF
--- a/src/__tests__/integration/tools/tools.test.ts
+++ b/src/__tests__/integration/tools/tools.test.ts
@@ -305,7 +305,7 @@ describe('readFileTool', () => {
 });
 
 describe('searchFilesTool', () => {
-  it('ignores generated directories like dist and node_modules by default', async () => {
+  it('uses fallback excludes when no project ignore file is present', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-'));
     await mkdir(join(root, 'src'));
     await mkdir(join(root, 'dist'));
@@ -320,6 +320,26 @@ describe('searchFilesTool', () => {
     expect(result.output).toContain('src/main.ts');
     expect(result.output).not.toContain('dist/generated.ts');
     expect(result.output).not.toContain('node_modules/pkg.ts');
+  });
+
+  it('uses project ignore files as the primary ignore source when present on the current search path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-gitignore-'));
+    await mkdir(join(root, 'packages'));
+    await mkdir(join(root, 'packages', 'app'));
+    await mkdir(join(root, 'packages', 'app', 'src'));
+    await mkdir(join(root, 'packages', 'app', 'dist'));
+    await mkdir(join(root, 'packages', 'app', 'node_modules'));
+    await writeFile(join(root, 'packages', 'app', '.gitignore'), 'dist\n');
+    await writeFile(join(root, 'packages', 'app', 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'packages', 'app', 'dist', 'generated.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'packages', 'app', 'node_modules', 'pkg.ts'), 'const needle = true;\n');
+
+    const result = await searchFilesTool.execute({ query: 'needle', path: join(root, 'packages', 'app') });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).not.toContain('dist/generated.ts');
+    expect(result.output).toContain('node_modules/pkg.ts');
   });
 
   it('supports project-specific excluded directories', async () => {
@@ -337,10 +357,43 @@ describe('searchFilesTool', () => {
     expect(result.output).not.toContain('vendor/hidden.ts');
   });
 
+  it('keeps grep fallback aligned with .gitignore dir ignores', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-gitignore-'));
+    await mkdir(join(root, 'src'));
+    await mkdir(join(root, 'dist'));
+    await writeFile(join(root, '.gitignore'), 'dist\n');
+    await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
+
+    const tool = createSearchFilesTool({ backend: 'grep' });
+    const result = await tool.execute({ query: 'needle', path: root });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).not.toContain('dist/generated.ts');
+  });
+
+  it('keeps grep fallback aligned with .gitignore dir ignores that use trailing slashes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-gitignore-slash-'));
+    await mkdir(join(root, 'src'));
+    await mkdir(join(root, 'dist'));
+    await writeFile(join(root, '.gitignore'), 'dist/\n');
+    await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
+
+    const tool = createSearchFilesTool({ backend: 'grep' });
+    const result = await tool.execute({ query: 'needle', path: root });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).not.toContain('dist/generated.ts');
+  });
+
   it('allows ignored dependency folders when includeIgnored is true', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-include-ignored-'));
     await mkdir(join(root, 'src'));
     await mkdir(join(root, 'node_modules'));
+    await writeFile(join(root, '.gitignore'), 'node_modules\n');
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
@@ -351,11 +404,28 @@ describe('searchFilesTool', () => {
     expect(result.output).toContain('node_modules/pkg.ts');
   });
 
-  it('keeps state folders excluded with includeIgnored unless explicitly targeted', async () => {
+  it('allows ignored dependency folders through grep fallback when includeIgnored is true', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-include-ignored-'));
+    await mkdir(join(root, 'src'));
+    await mkdir(join(root, 'node_modules'));
+    await writeFile(join(root, '.gitignore'), 'node_modules\n');
+    await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
+
+    const tool = createSearchFilesTool({ backend: 'grep' });
+    const result = await tool.execute({ query: 'needle', path: root, includeIgnored: true });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).toContain('node_modules/pkg.ts');
+  });
+
+  it('keeps protected state folders excluded with includeIgnored unless explicitly targeted', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-state-default-'));
     await mkdir(join(root, 'src'));
     await mkdir(join(root, '.heddle'), { recursive: true });
     await mkdir(join(root, '.heddle', 'traces'));
+    await writeFile(join(root, '.gitignore'), '.heddle\n');
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, '.heddle', 'traces', 'trace-1.json'), '{"needle":true}\n');
 
@@ -366,7 +436,24 @@ describe('searchFilesTool', () => {
     expect(result.output).not.toContain('.heddle/traces/trace-1.json');
   });
 
-  it('searches inside an explicitly targeted excluded directory', async () => {
+  it('keeps .heddle excluded through grep fallback unless explicitly targeted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-heddle-'));
+    await mkdir(join(root, 'src'));
+    await mkdir(join(root, '.heddle'), { recursive: true });
+    await mkdir(join(root, '.heddle', 'traces'));
+    await writeFile(join(root, '.gitignore'), '.heddle\n');
+    await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, '.heddle', 'traces', 'trace-1.json'), '{"needle":true}\n');
+
+    const tool = createSearchFilesTool({ backend: 'grep' });
+    const result = await tool.execute({ query: 'needle', path: root });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).not.toContain('trace-1.json');
+  });
+
+  it('searches inside an explicitly targeted protected directory', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-state-'));
     await mkdir(join(root, '.heddle'));
     await mkdir(join(root, '.heddle', 'traces'));
@@ -375,7 +462,7 @@ describe('searchFilesTool', () => {
     const result = await searchFilesTool.execute({ query: 'needle', path: join(root, '.heddle') });
 
     expect(result.ok).toBe(true);
-    expect(result.output).toContain('.heddle/traces/trace-1.json');
+    expect(result.output).toContain('traces/trace-1.json');
   });
 
   it('rejects invalid includeIgnored input', async () => {

--- a/src/__tests__/integration/tools/tools.test.ts
+++ b/src/__tests__/integration/tools/tools.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -314,7 +315,7 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
-    const result = await searchFilesTool.execute({ query: 'needle', path: root });
+    const result = await createSearchFilesTool({ backend: 'grep' }).execute({ query: 'needle', path: root });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -322,19 +323,62 @@ describe('searchFilesTool', () => {
     expect(result.output).not.toContain('node_modules/pkg.ts');
   });
 
-  it('uses project ignore files as the primary ignore source when present on the current search path', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'heddle-search-gitignore-'));
+  it('uses fallback excludes with rg when no project ignore file is present', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-rg-no-ignore-'));
+    await mkdir(join(root, 'src'));
+    await mkdir(join(root, 'dist'));
+    await mkdir(join(root, 'node_modules'));
+    await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
+
+    const result = await createSearchFilesTool({ backend: 'rg' }).execute({ query: 'needle', path: root });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).not.toContain('dist/generated.ts');
+    expect(result.output).not.toContain('node_modules/pkg.ts');
+  });
+
+  it('lets rg use its default ignore behavior inside a git repo without custom ignore discovery', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-rg-gitignore-'));
+    execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
     await mkdir(join(root, 'packages'));
     await mkdir(join(root, 'packages', 'app'));
     await mkdir(join(root, 'packages', 'app', 'src'));
     await mkdir(join(root, 'packages', 'app', 'dist'));
     await mkdir(join(root, 'packages', 'app', 'node_modules'));
-    await writeFile(join(root, 'packages', 'app', '.gitignore'), 'dist\n');
+    await writeFile(join(root, '.gitignore'), 'packages/app/dist\n');
     await writeFile(join(root, 'packages', 'app', 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'packages', 'app', 'dist', 'generated.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'packages', 'app', 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
-    const result = await searchFilesTool.execute({ query: 'needle', path: join(root, 'packages', 'app') });
+    const result = await createSearchFilesTool({ backend: 'rg' }).execute({
+      query: 'needle',
+      path: join(root, 'packages', 'app'),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).not.toContain('dist/generated.ts');
+    expect(result.output).toContain('node_modules/pkg.ts');
+  });
+
+  it('treats initialized default searchIgnoreDirs as fallback when project ignore files are present', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-rg-default-config-'));
+    execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
+    await mkdir(join(root, 'src'));
+    await mkdir(join(root, 'dist'));
+    await mkdir(join(root, 'node_modules'));
+    await writeFile(join(root, '.gitignore'), 'dist\n');
+    await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
+
+    const result = await createSearchFilesTool({
+      backend: 'rg',
+      excludedDirs: ['.git', 'dist', 'node_modules', '.heddle'],
+    }).execute({ query: 'needle', path: root });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -357,12 +401,15 @@ describe('searchFilesTool', () => {
     expect(result.output).not.toContain('vendor/hidden.ts');
   });
 
-  it('keeps grep fallback aligned with .gitignore dir ignores', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-gitignore-'));
+  it('uses Git-backed grep fallback to exclude ignored directories inside a git repo', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-git-'));
+    execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
     await mkdir(join(root, 'src'));
     await mkdir(join(root, 'dist'));
     await writeFile(join(root, '.gitignore'), 'dist\n');
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'src', 'tool.py'), 'needle = True\n');
+    await writeFile(join(root, 'src', 'Cargo.toml'), 'needle = "yes"\n');
     await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
 
     const tool = createSearchFilesTool({ backend: 'grep' });
@@ -370,26 +417,29 @@ describe('searchFilesTool', () => {
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
+    expect(result.output).toContain('src/tool.py');
+    expect(result.output).toContain('src/Cargo.toml');
     expect(result.output).not.toContain('dist/generated.ts');
   });
 
-  it('keeps grep fallback aligned with .gitignore dir ignores that use trailing slashes', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-gitignore-slash-'));
+  it('keeps grep fallback language agnostic inside a git repo', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-git-agnostic-'));
+    execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
     await mkdir(join(root, 'src'));
-    await mkdir(join(root, 'dist'));
-    await writeFile(join(root, '.gitignore'), 'dist/\n');
+    await writeFile(join(root, 'src', '.env'), 'needle=true\n');
+    await writeFile(join(root, 'src', 'Makefile'), 'needle: all\n');
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
-    await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
 
     const tool = createSearchFilesTool({ backend: 'grep' });
     const result = await tool.execute({ query: 'needle', path: root });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
-    expect(result.output).not.toContain('dist/generated.ts');
+    expect(result.output).toContain('src/.env');
+    expect(result.output).toContain('src/Makefile');
   });
 
-  it('allows ignored dependency folders when includeIgnored is true', async () => {
+  it('allows ignored dependency folders when includeIgnored is true with rg', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-include-ignored-'));
     await mkdir(join(root, 'src'));
     await mkdir(join(root, 'node_modules'));
@@ -397,7 +447,11 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
-    const result = await searchFilesTool.execute({ query: 'needle', path: root, includeIgnored: true });
+    const result = await createSearchFilesTool({ backend: 'rg' }).execute({
+      query: 'needle',
+      path: root,
+      includeIgnored: true,
+    });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -406,6 +460,7 @@ describe('searchFilesTool', () => {
 
   it('allows ignored dependency folders through grep fallback when includeIgnored is true', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-include-ignored-'));
+    execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
     await mkdir(join(root, 'src'));
     await mkdir(join(root, 'node_modules'));
     await writeFile(join(root, '.gitignore'), 'node_modules\n');
@@ -429,7 +484,11 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, '.heddle', 'traces', 'trace-1.json'), '{"needle":true}\n');
 
-    const result = await searchFilesTool.execute({ query: 'needle', path: root, includeIgnored: true });
+    const result = await createSearchFilesTool({ backend: 'rg' }).execute({
+      query: 'needle',
+      path: root,
+      includeIgnored: true,
+    });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -438,6 +497,7 @@ describe('searchFilesTool', () => {
 
   it('keeps .heddle excluded through grep fallback unless explicitly targeted', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-heddle-'));
+    execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
     await mkdir(join(root, 'src'));
     await mkdir(join(root, '.heddle'), { recursive: true });
     await mkdir(join(root, '.heddle', 'traces'));
@@ -453,13 +513,33 @@ describe('searchFilesTool', () => {
     expect(result.output).not.toContain('trace-1.json');
   });
 
+  it('uses non-git grep fallback excludes outside a git repo', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-grep-non-git-'));
+    await mkdir(join(root, 'src'));
+    await mkdir(join(root, 'dist'));
+    await mkdir(join(root, 'node_modules'));
+    await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'src', 'tool.py'), 'needle = True\n');
+    await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
+
+    const tool = createSearchFilesTool({ backend: 'grep' });
+    const result = await tool.execute({ query: 'needle', path: root });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).toContain('src/tool.py');
+    expect(result.output).not.toContain('dist/generated.ts');
+    expect(result.output).not.toContain('node_modules/pkg.ts');
+  });
+
   it('searches inside an explicitly targeted protected directory', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-state-'));
     await mkdir(join(root, '.heddle'));
     await mkdir(join(root, '.heddle', 'traces'));
     await writeFile(join(root, '.heddle', 'traces', 'trace-1.json'), '{"needle":true}\n');
 
-    const result = await searchFilesTool.execute({ query: 'needle', path: join(root, '.heddle') });
+    const result = await createSearchFilesTool({ backend: 'rg' }).execute({ query: 'needle', path: join(root, '.heddle') });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('traces/trace-1.json');
@@ -1522,4 +1602,3 @@ describe('runShell tools', () => {
     expect(toPath).not.toBe(fromPath);
   });
 });
-

--- a/src/__tests__/integration/tools/tools.test.ts
+++ b/src/__tests__/integration/tools/tools.test.ts
@@ -100,7 +100,9 @@ describe('tool input validation', () => {
     expect(searchFilesTool.description).toContain('locate a specific symbol or text string');
     expect(searchFilesTool.description).toContain('Prefer searching for concrete terms');
     expect(searchFilesTool.description).toContain('may also point to nearby parent or sibling folders');
+    expect(searchFilesTool.description).toContain('Prefer rg when available');
     expect(searchFilesTool.description).toContain('grep-style path:line:content format');
+    expect(searchFilesTool.description).toContain('includeIgnored');
     expect(searchFilesTool.description).toContain('{ "query": "createUser" }');
     expect(searchFilesTool.description).toContain('{ "query": "incident", "path": "../shared-notes" }');
     expect(webSearchTool.description).toContain('Search the public web');
@@ -335,6 +337,35 @@ describe('searchFilesTool', () => {
     expect(result.output).not.toContain('vendor/hidden.ts');
   });
 
+  it('allows ignored dependency folders when includeIgnored is true', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-include-ignored-'));
+    await mkdir(join(root, 'src'));
+    await mkdir(join(root, 'node_modules'));
+    await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
+
+    const result = await searchFilesTool.execute({ query: 'needle', path: root, includeIgnored: true });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).toContain('node_modules/pkg.ts');
+  });
+
+  it('keeps state folders excluded with includeIgnored unless explicitly targeted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-search-state-default-'));
+    await mkdir(join(root, 'src'));
+    await mkdir(join(root, '.heddle'), { recursive: true });
+    await mkdir(join(root, '.heddle', 'traces'));
+    await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
+    await writeFile(join(root, '.heddle', 'traces', 'trace-1.json'), '{"needle":true}\n');
+
+    const result = await searchFilesTool.execute({ query: 'needle', path: root, includeIgnored: true });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('src/main.ts');
+    expect(result.output).not.toContain('.heddle/traces/trace-1.json');
+  });
+
   it('searches inside an explicitly targeted excluded directory', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-state-'));
     await mkdir(join(root, '.heddle'));
@@ -345,6 +376,15 @@ describe('searchFilesTool', () => {
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('.heddle/traces/trace-1.json');
+  });
+
+  it('rejects invalid includeIgnored input', async () => {
+    const result = await searchFilesTool.execute({ query: 'needle', includeIgnored: 'yes' });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Invalid input for search_files. Required field: query. Optional fields: path, includeIgnored.',
+    });
   });
 });
 

--- a/src/__tests__/unit/chat/chat-format.test.ts
+++ b/src/__tests__/unit/chat/chat-format.test.ts
@@ -171,7 +171,7 @@ describe('summarizePendingApproval', () => {
     expect(formatApprovalHint(pendingApproval)).toBe('Y approve once • N deny • Enter confirms selected choice');
   });
 
-  it('includes the concrete remember label only when the approval can be remembered', () => {
+  it('uses a short path-tool remember label while keeping the path in the summary', () => {
     const pendingApproval: PendingApproval = {
       call: { id: 'call-1', tool: 'read_file', input: { path: '../notes/summary.md' } },
       tool: { name: 'read_file', description: 'Read file', parameters: { type: 'object', properties: {} } },
@@ -181,7 +181,39 @@ describe('summarizePendingApproval', () => {
     };
 
     expect(canRememberPendingApproval(pendingApproval)).toBe(true);
-    expect(formatApprovalHint(pendingApproval)).toContain('A allow read_file ../notes/summary.md for this project');
+    expect(formatApprovalHint(pendingApproval)).toContain('A allow read_file for this project');
+    expect(formatApprovalHint(pendingApproval)).not.toContain('../notes/summary.md');
+    expect(summarizePendingApproval(pendingApproval).command).toBe('../notes/summary.md');
+  });
+
+  it('uses a short remember label for exact shell commands without duplicating the full command', () => {
+    const pendingApproval: PendingApproval = {
+      call: { id: 'call-1', tool: 'run_shell_mutate', input: { command: 'git status --short --branch && git show --stat --oneline --no-patch HEAD' } },
+      tool: { name: 'run_shell_mutate', description: 'Mutate shell', parameters: { type: 'object', properties: {} } },
+      rememberForProject: () => undefined,
+      rememberLabel: 'allow exact command',
+      resolve: () => undefined,
+    };
+
+    const hint = formatApprovalHint(pendingApproval);
+    expect(hint).toContain('A allow exact command');
+    expect(hint).not.toContain('git status --short --branch');
+    expect(summarizePendingApproval(pendingApproval).command).toBe('git status --short --branch && git show --stat --oneline --no-patch HEAD');
+  });
+
+  it('defensively shortens legacy exact-command remember labels that include the raw command', () => {
+    const command = 'git status --short --branch && git show --stat --oneline --no-patch HEAD';
+    const pendingApproval: PendingApproval = {
+      call: { id: 'call-1', tool: 'run_shell_mutate', input: { command } },
+      tool: { name: 'run_shell_mutate', description: 'Mutate shell', parameters: { type: 'object', properties: {} } },
+      rememberForProject: () => undefined,
+      rememberLabel: `allow exact command ${command} for this project`,
+      resolve: () => undefined,
+    };
+
+    expect(formatApprovalHint(pendingApproval)).toBe('Y approve once • A allow exact command • N deny • Enter confirms selected choice');
+    expect(summarizePendingApproval(pendingApproval).rememberLabel).toBe('allow exact command');
+    expect(summarizePendingApproval(pendingApproval).command).toBe(command);
   });
 });
 

--- a/src/__tests__/unit/chat/chat-format.test.ts
+++ b/src/__tests__/unit/chat/chat-format.test.ts
@@ -160,6 +160,22 @@ describe('summarizePendingApproval', () => {
     expect(summary.effects).toContain('lists entries under src/cli/chat');
   });
 
+  it('shows the search query for search_files approvals', () => {
+    const pendingApproval: PendingApproval = {
+      call: { id: 'call-1', tool: 'search_files', input: { query: 'approvalSubject', path: '../notes' } },
+      tool: { name: 'search_files', description: 'Search files', parameters: { type: 'object', properties: {} } },
+      resolve: () => undefined,
+    };
+
+    const summary = summarizePendingApproval(pendingApproval);
+
+    expect(summary.title).toBe('Allow search_files');
+    expect(summary.command).toBe('approvalSubject');
+    expect(summary.scope).toBe('external');
+    expect(summary.why).toBe('search_files for "approvalSubject" in ../notes');
+    expect(summary.effects).toContain('searches ../notes for "approvalSubject"');
+  });
+
   it('omits remember hint text when the approval cannot actually be remembered', () => {
     const pendingApproval: PendingApproval = {
       call: { id: 'call-1', tool: 'run_shell_inspect', input: { command: 'pwd' } },

--- a/src/__tests__/unit/chat/chat-format.test.ts
+++ b/src/__tests__/unit/chat/chat-format.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildConversationMessages,
+  canRememberPendingApproval,
+  formatApprovalHint,
   formatChatFailureMessage,
   formatEditPreviewHistoryMessage,
   formatPlanHistoryMessage,
@@ -156,6 +158,30 @@ describe('summarizePendingApproval', () => {
     expect(summary.command).toBe('src/cli/chat');
     expect(summary.why).toBe('list_files on src/cli/chat');
     expect(summary.effects).toContain('lists entries under src/cli/chat');
+  });
+
+  it('omits remember hint text when the approval cannot actually be remembered', () => {
+    const pendingApproval: PendingApproval = {
+      call: { id: 'call-1', tool: 'run_shell_inspect', input: { command: 'pwd' } },
+      tool: { name: 'run_shell_inspect', description: 'Inspect shell', parameters: { type: 'object', properties: {} } },
+      resolve: () => undefined,
+    };
+
+    expect(canRememberPendingApproval(pendingApproval)).toBe(false);
+    expect(formatApprovalHint(pendingApproval)).toBe('Y approve once • N deny • Enter confirms selected choice');
+  });
+
+  it('includes the concrete remember label only when the approval can be remembered', () => {
+    const pendingApproval: PendingApproval = {
+      call: { id: 'call-1', tool: 'read_file', input: { path: '../notes/summary.md' } },
+      tool: { name: 'read_file', description: 'Read file', parameters: { type: 'object', properties: {} } },
+      rememberForProject: () => undefined,
+      rememberLabel: 'allow read_file ../notes/summary.md for this project',
+      resolve: () => undefined,
+    };
+
+    expect(canRememberPendingApproval(pendingApproval)).toBe(true);
+    expect(formatApprovalHint(pendingApproval)).toContain('A allow read_file ../notes/summary.md for this project');
   });
 });
 

--- a/src/__tests__/unit/core/approval-policy-chain.test.ts
+++ b/src/__tests__/unit/core/approval-policy-chain.test.ts
@@ -103,6 +103,34 @@ describe('approval policy chain', () => {
     });
   });
 
+  it('lets remembered outside-workspace read_file approvals satisfy request policies before human approval', async () => {
+    const human = vi.fn(async () => ({ approved: false, reason: 'should not run' }));
+    const readOutside = context({
+      call: { id: 'call-1', tool: 'read_file', input: { path: '../notes/summary.md' } },
+      tool: {
+        name: 'read_file',
+        description: 'reads files',
+        parameters: {},
+        execute: async () => ({ ok: true }),
+      },
+    });
+
+    await expect(resolveToolApproval({
+      policies: [
+        ...defaultToolApprovalPolicies,
+        rememberedApprovalPolicy({
+          isApproved: ({ call }) => call.tool === 'read_file',
+        }),
+      ],
+      context: readOutside,
+      requestHumanApproval: human,
+    })).resolves.toEqual({
+      approved: true,
+      reason: 'Approved by saved project rule',
+    });
+    expect(human).not.toHaveBeenCalled();
+  });
+
   it('lets later allow policies satisfy earlier request policies before human approval', async () => {
     const human = vi.fn(async () => ({ approved: false, reason: 'should not run' }));
 

--- a/src/__tests__/unit/core/project-approval-rules.test.ts
+++ b/src/__tests__/unit/core/project-approval-rules.test.ts
@@ -238,9 +238,9 @@ describe('project approval rules', () => {
     };
 
     expect(describeProjectApprovalRule(editRule)).toContain('allow edit_file');
-    expect(describeProjectApprovalRule(readRule)).toContain('allow read_file ../notes/summary.md');
-    expect(describeProjectApprovalRule(prefixRule)).toContain('command family');
-    expect(describeProjectApprovalRule(exactRule)).toContain('exact command');
+    expect(describeProjectApprovalRule(readRule)).toBe('allow read_file for this project');
+    expect(describeProjectApprovalRule(prefixRule)).toContain('allow yarn lint command family for this project');
+    expect(describeProjectApprovalRule(exactRule)).toBe('allow exact command');
   });
 
   it('normalizes run shell and edit file approvals', () => {

--- a/src/__tests__/unit/core/project-approval-rules.test.ts
+++ b/src/__tests__/unit/core/project-approval-rules.test.ts
@@ -91,6 +91,81 @@ describe('project approval rules', () => {
     expect(findMatchingApprovalRule([rule!], 'edit_file', { path: 'src/another.ts', content: 'x', createIfMissing: true })).toBeDefined();
   });
 
+  it('creates exact remembered approvals for outside-workspace read_file and list_files calls', () => {
+    const readRule = createProjectApprovalRuleForCall({
+      id: 'tool-1',
+      tool: 'read_file',
+      input: { path: '../notes/summary.md' },
+    });
+    const listRule = createProjectApprovalRuleForCall({
+      id: 'tool-2',
+      tool: 'list_files',
+      input: { path: '../notes/' },
+    });
+
+    expect(readRule).toMatchObject({
+      tool: 'read_file',
+      mode: 'exact',
+      command: '../notes/summary.md',
+      scope: 'outside_workspace',
+      capability: 'file_inspection',
+    });
+    expect(listRule).toMatchObject({
+      tool: 'list_files',
+      mode: 'exact',
+      command: '../notes',
+      scope: 'outside_workspace',
+      capability: 'file_inspection',
+    });
+    expect(findMatchingApprovalRule([readRule!], 'read_file', { path: '../notes/summary.md' })).toBeDefined();
+    expect(findMatchingApprovalRule([readRule!], 'read_file', { path: '../notes/other.md' })).toBeUndefined();
+    expect(findMatchingApprovalRule([listRule!], 'list_files', { path: '../notes' })).toBeDefined();
+  });
+
+  it('loads remembered outside-workspace file inspection approvals from disk', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-approval-rules-files-'));
+    const filePath = join(root, 'command-approvals.json');
+    const createdAt = new Date().toISOString();
+
+    writeFileSync(filePath, `${JSON.stringify([
+      {
+        tool: 'read_file',
+        mode: 'exact',
+        command: '../notes/summary.md',
+        scope: 'outside_workspace',
+        capability: 'file_inspection',
+        createdAt,
+      },
+      {
+        tool: 'list_files',
+        mode: 'exact',
+        command: '../notes/',
+        scope: 'outside_workspace',
+        capability: 'file_inspection',
+        createdAt,
+      },
+    ], null, 2)}\n`);
+
+    expect(loadProjectApprovalRules(filePath)).toEqual([
+      {
+        tool: 'read_file',
+        mode: 'exact',
+        command: '../notes/summary.md',
+        scope: 'outside_workspace',
+        capability: 'file_inspection',
+        createdAt,
+      },
+      {
+        tool: 'list_files',
+        mode: 'exact',
+        command: '../notes',
+        scope: 'outside_workspace',
+        capability: 'file_inspection',
+        createdAt,
+      },
+    ]);
+  });
+
   it('loads legacy mutate approval rules from disk without dropping them', () => {
     const root = mkdtempSync(join(tmpdir(), 'heddle-approval-rules-legacy-'));
     const filePath = join(root, 'command-approvals.json');
@@ -135,6 +210,15 @@ describe('project approval rules', () => {
       createdAt: new Date().toISOString(),
     };
 
+    const readRule: ProjectApprovalRule = {
+      tool: 'read_file',
+      mode: 'exact',
+      command: '../notes/summary.md',
+      scope: 'outside_workspace',
+      capability: 'file_inspection',
+      createdAt: new Date().toISOString(),
+    };
+
     const prefixRule: ProjectApprovalRule = {
       tool: 'run_shell_mutate',
       mode: 'prefix',
@@ -154,6 +238,7 @@ describe('project approval rules', () => {
     };
 
     expect(describeProjectApprovalRule(editRule)).toContain('allow edit_file');
+    expect(describeProjectApprovalRule(readRule)).toContain('allow read_file ../notes/summary.md');
     expect(describeProjectApprovalRule(prefixRule)).toContain('command family');
     expect(describeProjectApprovalRule(exactRule)).toContain('exact command');
   });
@@ -169,6 +254,8 @@ describe('project approval rules', () => {
     expect(extractApprovalTarget('edit_file', './src/')).toBe('./src');
     expect(extractApprovalTarget('edit_file', { path: './foo/bar/' })).toBe('./foo/bar');
     expect(extractApprovalTarget('edit_file', { path: '' })).toBeUndefined();
+    expect(extractApprovalTarget('read_file', { path: '../notes/summary.md' })).toBe('../notes/summary.md');
+    expect(extractApprovalTarget('list_files', { path: '../notes/' })).toBe('../notes');
   });
 
   it('falls back to unknown workspace rules when the shell command is blocked', () => {

--- a/src/__tests__/unit/tui/approval-flow.test.tsx
+++ b/src/__tests__/unit/tui/approval-flow.test.tsx
@@ -30,7 +30,7 @@ describe('approval flow helpers', () => {
   it('includes allow_project in available choices when remember is supported', () => {
     const pendingApproval = createPendingApproval({
       rememberForProject: () => undefined,
-      rememberLabel: 'allow exact command yarn test for this project',
+      rememberLabel: 'allow exact command',
     });
 
     expect(resolveAvailableApprovalChoices(pendingApproval)).toEqual(['approve', 'allow_project', 'deny']);
@@ -48,7 +48,7 @@ describe('approval flow helpers', () => {
     const remember = vi.fn();
     const supported = createPendingApproval({
       rememberForProject: remember,
-      rememberLabel: 'allow exact command yarn test for this project',
+      rememberLabel: 'allow exact command',
     });
     const unsupported = createPendingApproval();
 
@@ -77,7 +77,37 @@ describe('ApprovalComposer', () => {
     expect(view.container.textContent).not.toContain('allow exact command');
   });
 
-  it('renders the concrete remember label when remember is supported', () => {
+  it('renders a short exact-command remember label without duplicating the full command', () => {
+    const fullCommand = 'git status --short --branch && git show --stat --oneline --no-patch HEAD';
+    const pendingApproval = createPendingApproval({
+      call: { id: 'call-2', tool: 'run_shell_mutate', input: { command: fullCommand } },
+      tool: { name: 'run_shell_mutate', description: 'Mutate shell', parameters: { type: 'object', properties: {} } },
+      rememberForProject: () => undefined,
+      rememberLabel: 'allow exact command',
+    });
+    const view = render(<ApprovalComposer pendingApproval={pendingApproval} approvalChoice="allow_project" />);
+
+    expect(view.container.textContent).toContain('allow exact command');
+    expect(view.container.textContent).toContain(fullCommand);
+    expect(view.container.textContent).not.toContain(`allow exact command ${fullCommand}`);
+  });
+
+  it('renders legacy exact-command remember labels without the raw command in the label', () => {
+    const fullCommand = 'git status --short --branch && git show --stat --oneline --no-patch HEAD';
+    const pendingApproval = createPendingApproval({
+      call: { id: 'call-2', tool: 'run_shell_mutate', input: { command: fullCommand } },
+      tool: { name: 'run_shell_mutate', description: 'Mutate shell', parameters: { type: 'object', properties: {} } },
+      rememberForProject: () => undefined,
+      rememberLabel: `allow exact command ${fullCommand} for this project`,
+    });
+    const view = render(<ApprovalComposer pendingApproval={pendingApproval} approvalChoice="allow_project" />);
+
+    expect(view.container.textContent).toContain('allow exact command');
+    expect(view.container.textContent).toContain(fullCommand);
+    expect(view.container.textContent).not.toContain(`allow exact command ${fullCommand}`);
+  });
+
+  it('renders a short remember label when remember is supported for path-based approvals', () => {
     const pendingApproval = createPendingApproval({
       call: { id: 'call-2', tool: 'read_file', input: { path: '../notes/summary.md' } },
       tool: { name: 'read_file', description: 'Read file', parameters: { type: 'object', properties: {} } },
@@ -86,6 +116,8 @@ describe('ApprovalComposer', () => {
     });
     const view = render(<ApprovalComposer pendingApproval={pendingApproval} approvalChoice="allow_project" />);
 
-    expect(view.container.textContent).toContain('allow read_file ../notes/summary.md for this project');
+    expect(view.container.textContent).toContain('allow read_file for this project');
+    expect(view.container.textContent).toContain('../notes/summary.md');
+    expect(view.container.textContent).not.toContain('allow read_file ../notes/summary.md for this project');
   });
 });

--- a/src/__tests__/unit/tui/approval-flow.test.tsx
+++ b/src/__tests__/unit/tui/approval-flow.test.tsx
@@ -1,0 +1,91 @@
+/** @vitest-environment jsdom */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApprovalComposer } from '../../../cli/chat/components/ApprovalComposer.js';
+import {
+  cycleApprovalChoice,
+  resolveApprovalDecision,
+  resolveAvailableApprovalChoices,
+} from '../../../cli/chat/hooks/useApprovalFlow.js';
+import type { PendingApproval } from '../../../core/chat/types.js';
+
+function createPendingApproval(overrides: Partial<PendingApproval> = {}): PendingApproval {
+  return {
+    call: { id: 'call-1', tool: 'run_shell_inspect', input: { command: 'pwd' } },
+    tool: { name: 'run_shell_inspect', description: 'Inspect shell', parameters: { type: 'object', properties: {} } },
+    resolve: () => undefined,
+    ...overrides,
+  };
+}
+
+describe('approval flow helpers', () => {
+  it('does not include allow_project in available choices when remember is unavailable', () => {
+    const pendingApproval = createPendingApproval();
+
+    expect(resolveAvailableApprovalChoices(pendingApproval)).toEqual(['approve', 'deny']);
+  });
+
+  it('includes allow_project in available choices when remember is supported', () => {
+    const pendingApproval = createPendingApproval({
+      rememberForProject: () => undefined,
+      rememberLabel: 'allow exact command yarn test for this project',
+    });
+
+    expect(resolveAvailableApprovalChoices(pendingApproval)).toEqual(['approve', 'allow_project', 'deny']);
+  });
+
+  it('skips unavailable remember while cycling approval choices', () => {
+    const pendingApproval = createPendingApproval();
+
+    expect(cycleApprovalChoice('approve', 1, pendingApproval)).toBe('deny');
+    expect(cycleApprovalChoice('deny', 1, pendingApproval)).toBe('approve');
+    expect(cycleApprovalChoice('allow_project', 1, pendingApproval)).toBe('deny');
+  });
+
+  it('remembers and returns the remembered reason only for supported approvals', () => {
+    const remember = vi.fn();
+    const supported = createPendingApproval({
+      rememberForProject: remember,
+      rememberLabel: 'allow exact command yarn test for this project',
+    });
+    const unsupported = createPendingApproval();
+
+    expect(resolveApprovalDecision('allow_project', supported)).toEqual({
+      approved: true,
+      reason: 'Approved and remembered for this project in chat UI',
+    });
+    expect(remember).toHaveBeenCalledTimes(1);
+
+    expect(resolveApprovalDecision('allow_project', unsupported)).toEqual({
+      approved: true,
+      reason: 'Approved in chat UI',
+    });
+  });
+});
+
+describe('ApprovalComposer', () => {
+  it('does not render a remember option or remembered hint when remember is unavailable', () => {
+    const pendingApproval = createPendingApproval();
+    const view = render(<ApprovalComposer pendingApproval={pendingApproval} approvalChoice="approve" />);
+
+    expect(view.container.textContent).toContain('Approve once');
+    expect(view.container.textContent).toContain('Deny');
+    expect(view.container.textContent).not.toContain('Remember for project');
+    expect(view.container.textContent).not.toContain('Approved and remembered');
+    expect(view.container.textContent).not.toContain('allow exact command');
+  });
+
+  it('renders the concrete remember label when remember is supported', () => {
+    const pendingApproval = createPendingApproval({
+      call: { id: 'call-2', tool: 'read_file', input: { path: '../notes/summary.md' } },
+      tool: { name: 'read_file', description: 'Read file', parameters: { type: 'object', properties: {} } },
+      rememberForProject: () => undefined,
+      rememberLabel: 'allow read_file ../notes/summary.md for this project',
+    });
+    const view = render(<ApprovalComposer pendingApproval={pendingApproval} approvalChoice="allow_project" />);
+
+    expect(view.container.textContent).toContain('allow read_file ../notes/summary.md for this project');
+  });
+});

--- a/src/__tests__/unit/tui/approval-flow.test.tsx
+++ b/src/__tests__/unit/tui/approval-flow.test.tsx
@@ -120,4 +120,16 @@ describe('ApprovalComposer', () => {
     expect(view.container.textContent).toContain('../notes/summary.md');
     expect(view.container.textContent).not.toContain('allow read_file ../notes/summary.md for this project');
   });
+
+  it('renders the search query in the approval preview for search_files', () => {
+    const pendingApproval = createPendingApproval({
+      call: { id: 'call-2', tool: 'search_files', input: { query: 'approvalSubject', path: '../notes' } },
+      tool: { name: 'search_files', description: 'Search files', parameters: { type: 'object', properties: {} } },
+    });
+    const view = render(<ApprovalComposer pendingApproval={pendingApproval} approvalChoice="approve" />);
+
+    expect(view.container.textContent).toContain('Allow search_files');
+    expect(view.container.textContent).toContain('approvalSubject');
+    expect(view.container.textContent).toContain('search_files for "approvalSubject" in ../notes');
+  });
 });

--- a/src/cli/chat/components/ApprovalComposer.tsx
+++ b/src/cli/chat/components/ApprovalComposer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import { formatApprovalHint, summarizePendingApproval } from '../utils/format.js';
+import { canRememberPendingApproval, formatApprovalHint, summarizePendingApproval } from '../utils/format.js';
 import type { ApprovalChoice, PendingApproval } from '../state/types.js';
 
 export function ApprovalComposer({
@@ -11,6 +11,7 @@ export function ApprovalComposer({
   approvalChoice: ApprovalChoice;
 }) {
   const summary = summarizePendingApproval(pendingApproval);
+  const canRemember = canRememberPendingApproval(pendingApproval);
 
   return (
     <>
@@ -53,7 +54,7 @@ export function ApprovalComposer({
         </Box>
       : null}
       <Text dimColor>{formatApprovalHint(pendingApproval)}</Text>
-      <ApprovalSelector choice={approvalChoice} />
+      <ApprovalSelector choice={approvalChoice} canRemember={canRemember} rememberLabel={summary.rememberLabel} />
       <Box justifyContent="space-between">
         <Text dimColor>Use ←/→ then Enter</Text>
         <Text dimColor>Approval stays in the conversation flow</Text>
@@ -62,16 +63,28 @@ export function ApprovalComposer({
   );
 }
 
-function ApprovalSelector({ choice }: { choice: ApprovalChoice }) {
+function ApprovalSelector({
+  choice,
+  canRemember,
+  rememberLabel,
+}: {
+  choice: ApprovalChoice;
+  canRemember: boolean;
+  rememberLabel?: string;
+}) {
   return (
     <Box marginBottom={0} flexWrap="wrap">
       <Text color={choice === 'approve' ? 'green' : 'gray'}>
         {choice === 'approve' ? '◉ Approve once' : '○ Approve once'}
       </Text>
-      <Text dimColor>   </Text>
-      <Text color={choice === 'allow_project' ? 'cyan' : 'gray'}>
-        {choice === 'allow_project' ? '◉ Remember for project' : '○ Remember for project'}
-      </Text>
+      {canRemember ? (
+        <>
+          <Text dimColor>   </Text>
+          <Text color={choice === 'allow_project' ? 'cyan' : 'gray'}>
+            {choice === 'allow_project' ? `◉ ${rememberLabel}` : `○ ${rememberLabel}`}
+          </Text>
+        </>
+      ) : null}
       <Text dimColor>   </Text>
       <Text color={choice === 'deny' ? 'red' : 'gray'}>
         {choice === 'deny' ? '◉ Deny' : '○ Deny'}

--- a/src/cli/chat/hooks/tui-direct-shell.ts
+++ b/src/cli/chat/hooks/tui-direct-shell.ts
@@ -121,7 +121,7 @@ export async function executeTuiDirectShell(args: {
               state.setPendingApproval({
                 call: mutateCall,
                 tool: directShellTool,
-                rememberForProject: () => rememberProjectApproval(mutateCall),
+                rememberForProject: rememberedRule ? () => rememberProjectApproval(mutateCall) : undefined,
                 rememberLabel: rememberedRule ? describeProjectApprovalRule(rememberedRule) : undefined,
                 resolve,
               });

--- a/src/cli/chat/hooks/tui-tool-approval.ts
+++ b/src/cli/chat/hooks/tui-tool-approval.ts
@@ -32,7 +32,7 @@ export function createTuiToolApprovalPort(args: {
               call,
               tool,
               editPreview,
-              rememberForProject: () => rememberProjectApproval(call),
+              rememberForProject: rememberedRule ? () => rememberProjectApproval(call) : undefined,
               rememberLabel: rememberedRule ? describeProjectApprovalRule(rememberedRule) : undefined,
               resolve,
             });

--- a/src/cli/chat/hooks/useApprovalFlow.ts
+++ b/src/cli/chat/hooks/useApprovalFlow.ts
@@ -4,9 +4,10 @@ import type { ActionState } from './useAgentRun.js';
 import type { ApprovalChoice, LiveEvent, PendingApproval } from '../state/types.js';
 import type { EditFilePreview } from '../../../core/tools/toolkits/coding-files/edit-file.js';
 import type { PlanItem } from '../../../core/tools/toolkits/internal/update-plan.js';
+import { canRememberPendingApproval } from '../utils/format.js';
 
 const WORKING_FRAMES = ['.', '..', '...'];
-const APPROVAL_CHOICES: ApprovalChoice[] = ['approve', 'allow_project', 'deny'];
+const BASE_APPROVAL_CHOICES: ApprovalChoice[] = ['approve', 'allow_project', 'deny'];
 
 export function useApprovalFlow(nextLocalId: () => string) {
   const [status, setStatus] = useState('Idle');
@@ -37,27 +38,18 @@ export function useApprovalFlow(nextLocalId: () => string) {
       }
 
       if (key.leftArrow || key.upArrow) {
-        setApprovalChoice((current) => cycleApprovalChoice(current, -1));
+        setApprovalChoice((current) => cycleApprovalChoice(current, -1, pendingApproval));
         return;
       }
 
       if (key.rightArrow || key.downArrow || key.tab) {
-        setApprovalChoice((current) => cycleApprovalChoice(current, 1));
+        setApprovalChoice((current) => cycleApprovalChoice(current, 1, pendingApproval));
         return;
       }
 
       if (key.return) {
-        const approved = approvalChoice !== 'deny';
-        if (approvalChoice === 'allow_project') {
-          pendingApproval.rememberForProject?.();
-        }
-        pendingApproval.resolve({
-          approved,
-          reason:
-            approvalChoice === 'allow_project' ? 'Approved and remembered for this project in chat UI'
-            : approved ? 'Approved in chat UI'
-            : 'Denied in chat UI',
-        });
+        const decision = resolveApprovalDecision(approvalChoice, pendingApproval);
+        pendingApproval.resolve(decision);
         setPendingApproval(undefined);
         setApprovalChoice('approve');
         return;
@@ -70,7 +62,9 @@ export function useApprovalFlow(nextLocalId: () => string) {
       }
 
       if (normalized === 'a') {
-        setApprovalChoice('allow_project');
+        if (canRememberPendingApproval(pendingApproval)) {
+          setApprovalChoice('allow_project');
+        }
         return;
       }
 
@@ -169,8 +163,45 @@ export function useApprovalFlow(nextLocalId: () => string) {
   };
 }
 
-function cycleApprovalChoice(current: ApprovalChoice, direction: -1 | 1): ApprovalChoice {
-  const index = APPROVAL_CHOICES.indexOf(current);
-  const nextIndex = (index + direction + APPROVAL_CHOICES.length) % APPROVAL_CHOICES.length;
-  return APPROVAL_CHOICES[nextIndex] ?? 'approve';
+export function resolveAvailableApprovalChoices(pendingApproval: PendingApproval): ApprovalChoice[] {
+  return canRememberPendingApproval(pendingApproval)
+    ? BASE_APPROVAL_CHOICES
+    : BASE_APPROVAL_CHOICES.filter((choice) => choice !== 'allow_project');
+}
+
+export function cycleApprovalChoice(
+  current: ApprovalChoice,
+  direction: -1 | 1,
+  pendingApproval: PendingApproval,
+): ApprovalChoice {
+  const choices = resolveAvailableApprovalChoices(pendingApproval);
+  const index = choices.indexOf(current);
+  const safeIndex = index >= 0 ? index : 0;
+  const nextIndex = (safeIndex + direction + choices.length) % choices.length;
+  return choices[nextIndex] ?? 'approve';
+}
+
+export function resolveApprovalDecision(
+  choice: ApprovalChoice,
+  pendingApproval: PendingApproval,
+): { approved: boolean; reason?: string } {
+  if (choice === 'allow_project' && canRememberPendingApproval(pendingApproval)) {
+    pendingApproval.rememberForProject?.();
+    return {
+      approved: true,
+      reason: 'Approved and remembered for this project in chat UI',
+    };
+  }
+
+  if (choice === 'deny') {
+    return {
+      approved: false,
+      reason: 'Denied in chat UI',
+    };
+  }
+
+  return {
+    approved: true,
+    reason: 'Approved in chat UI',
+  };
 }

--- a/src/cli/chat/utils/format.ts
+++ b/src/cli/chat/utils/format.ts
@@ -104,7 +104,7 @@ export function summarizePendingApproval(pendingApproval: PendingApproval): Appr
       capability: policy?.capability,
       why,
       effects,
-      rememberLabel: pendingApproval.rememberLabel,
+      rememberLabel: formatRememberLabel(pendingApproval.rememberLabel),
     };
   }
 
@@ -121,7 +121,7 @@ export function summarizePendingApproval(pendingApproval: PendingApproval): Appr
         editPath ? `modifies ${editPath}` : `modifies a ${scope} file`,
         scope === 'external' ? 'writes outside the current repository' : 'stays inside the current repository',
       ],
-      rememberLabel: pendingApproval.rememberLabel,
+      rememberLabel: formatRememberLabel(pendingApproval.rememberLabel),
     };
   }
 
@@ -133,7 +133,7 @@ export function summarizePendingApproval(pendingApproval: PendingApproval): Appr
       scope: path.startsWith('../') || path.startsWith('/') || path.includes('..\\') ? 'external' : 'workspace',
       why: `${pendingApproval.call.tool} on ${path}`,
       effects: [describePathAwareToolEffect(pendingApproval.call.tool, path)],
-      rememberLabel: pendingApproval.rememberLabel,
+      rememberLabel: formatRememberLabel(pendingApproval.rememberLabel),
     };
   }
 
@@ -141,8 +141,24 @@ export function summarizePendingApproval(pendingApproval: PendingApproval): Appr
     title: `Allow ${pendingApproval.call.tool}`,
     why: 'approval required for this tool call',
     effects: ['tool-specific side effects are not yet summarized'],
-    rememberLabel: pendingApproval.rememberLabel,
+    rememberLabel: formatRememberLabel(pendingApproval.rememberLabel),
   };
+}
+
+function formatRememberLabel(label: string | undefined): string | undefined {
+  if (!label) {
+    return undefined;
+  }
+
+  if (/^allow exact command .+ for this project$/.test(label)) {
+    return 'allow exact command';
+  }
+
+  if (/^allow (read_file|list_files) .+ for this project$/.test(label)) {
+    return label.replace(/^allow (read_file|list_files) .+ for this project$/, 'allow $1 for this project');
+  }
+
+  return label;
 }
 
 export function normalizeInlineText(value: string): string {

--- a/src/cli/chat/utils/format.ts
+++ b/src/cli/chat/utils/format.ts
@@ -79,6 +79,7 @@ export function summarizePendingApproval(pendingApproval: PendingApproval): Appr
   const policy = describePendingApprovalPolicy(pendingApproval);
   const command = readStringField(pendingApproval.call.input, 'command');
   const editPath = readStringField(pendingApproval.call.input, 'path');
+  const searchQuery = readStringField(pendingApproval.call.input, 'query');
 
   if (command) {
     const title =
@@ -121,6 +122,18 @@ export function summarizePendingApproval(pendingApproval: PendingApproval): Appr
         editPath ? `modifies ${editPath}` : `modifies a ${scope} file`,
         scope === 'external' ? 'writes outside the current repository' : 'stays inside the current repository',
       ],
+      rememberLabel: formatRememberLabel(pendingApproval.rememberLabel),
+    };
+  }
+
+  if (pendingApproval.call.tool === 'search_files') {
+    const path = readStringField(pendingApproval.call.input, 'path') ?? '.';
+    return {
+      title: 'Allow search_files',
+      command: searchQuery,
+      scope: path.startsWith('../') || path.startsWith('/') || path.includes('..\\') ? 'external' : 'workspace',
+      why: searchQuery ? `search_files for "${searchQuery}" in ${path}` : `search_files in ${path}`,
+      effects: [searchQuery ? `searches ${path} for "${searchQuery}"` : `searches ${path}`],
       rememberLabel: formatRememberLabel(pendingApproval.rememberLabel),
     };
   }

--- a/src/cli/chat/utils/format.ts
+++ b/src/cli/chat/utils/format.ts
@@ -57,10 +57,22 @@ export function formatApprovalPrompt(pendingApproval: PendingApproval): string {
   return summarizePendingApproval(pendingApproval).title;
 }
 
+export function canRememberPendingApproval(pendingApproval: PendingApproval): boolean {
+  return typeof pendingApproval.rememberForProject === 'function'
+    && typeof pendingApproval.rememberLabel === 'string'
+    && pendingApproval.rememberLabel.trim().length > 0;
+}
+
 export function formatApprovalHint(pendingApproval: PendingApproval): string {
   const summary = summarizePendingApproval(pendingApproval);
-  const rememberLabel = summary.rememberLabel ? `A ${summary.rememberLabel}` : 'A remember for project';
-  return `Y approve once • ${rememberLabel} • N deny • Enter confirms selected choice`;
+  const parts = ['Y approve once'];
+
+  if (canRememberPendingApproval(pendingApproval) && summary.rememberLabel) {
+    parts.push(`A ${summary.rememberLabel}`);
+  }
+
+  parts.push('N deny', 'Enter confirms selected choice');
+  return parts.join(' • ');
 }
 
 export function summarizePendingApproval(pendingApproval: PendingApproval): ApprovalSummary {

--- a/src/core/approvals/remembered-rules.ts
+++ b/src/core/approvals/remembered-rules.ts
@@ -120,14 +120,14 @@ export function describeProjectApprovalRule(rule: ProjectApprovalRule): string {
   }
 
   if (rule.tool === 'read_file' || rule.tool === 'list_files') {
-    return `allow ${rule.tool} ${rule.command} for this project`;
+    return `allow ${rule.tool} for this project`;
   }
 
   if (rule.mode === 'prefix') {
     return `allow ${rule.command} command family for this project`;
   }
 
-  return `allow exact command ${rule.command} for this project`;
+  return 'allow exact command';
 }
 
 export function extractApprovalTarget(tool: string, input: unknown): string | undefined {

--- a/src/core/approvals/remembered-rules.ts
+++ b/src/core/approvals/remembered-rules.ts
@@ -9,13 +9,14 @@ import {
 } from '../tools/toolkits/shell-process/run-shell.js';
 
 type ApprovalMode = 'exact' | 'prefix' | 'tool';
+type ApprovalRuleTool = 'run_shell_mutate' | 'edit_file' | 'read_file' | 'list_files';
 
 export type ProjectApprovalRule = {
-  tool: 'run_shell_mutate' | 'edit_file';
+  tool: ApprovalRuleTool;
   mode: ApprovalMode;
   command: string;
-  scope: RunShellScope | 'workspace';
-  capability: RunShellCapability | 'file_edit';
+  scope: RunShellScope | 'workspace' | 'outside_workspace';
+  capability: RunShellCapability | 'file_edit' | 'file_inspection';
   createdAt: string;
 };
 
@@ -93,6 +94,18 @@ export function createProjectApprovalRuleForCall(call: ToolCall): ProjectApprova
     };
   }
 
+  if (call.tool === 'read_file' || call.tool === 'list_files') {
+    const target = extractApprovalTarget(call.tool, call.input);
+    return target ? {
+      tool: call.tool,
+      mode: 'exact',
+      command: target,
+      scope: 'outside_workspace',
+      capability: 'file_inspection',
+      createdAt: new Date().toISOString(),
+    } : undefined;
+  }
+
   if (call.tool !== 'run_shell_mutate') {
     return undefined;
   }
@@ -104,6 +117,10 @@ export function createProjectApprovalRuleForCall(call: ToolCall): ProjectApprova
 export function describeProjectApprovalRule(rule: ProjectApprovalRule): string {
   if (rule.tool === 'edit_file') {
     return 'allow edit_file for this project';
+  }
+
+  if (rule.tool === 'read_file' || rule.tool === 'list_files') {
+    return `allow ${rule.tool} ${rule.command} for this project`;
   }
 
   if (rule.mode === 'prefix') {
@@ -127,7 +144,7 @@ export function extractApprovalTarget(tool: string, input: unknown): string | un
     return typeof command === 'string' && command.trim() ? normalizeApprovedCommand(command) : undefined;
   }
 
-  if (tool === 'edit_file') {
+  if (tool === 'edit_file' || tool === 'read_file' || tool === 'list_files') {
     if (typeof input === 'string') {
       return normalizeApprovalPath(input);
     }
@@ -317,6 +334,22 @@ function parseProjectApprovalRule(value: unknown): ProjectApprovalRule[] {
         createdAt: candidate.createdAt,
       }];
     }
+  }
+
+  if (
+    (candidate.tool === 'read_file' || candidate.tool === 'list_files') &&
+    candidate.mode === 'exact' &&
+    typeof candidate.command === 'string' &&
+    typeof candidate.createdAt === 'string'
+  ) {
+    return [{
+      tool: candidate.tool,
+      mode: 'exact',
+      command: normalizeApprovalPath(candidate.command),
+      scope: 'outside_workspace',
+      capability: 'file_inspection',
+      createdAt: candidate.createdAt,
+    }];
   }
 
   return [];

--- a/src/core/tools/toolkits/coding-files/search-files.ts
+++ b/src/core/tools/toolkits/coding-files/search-files.ts
@@ -151,7 +151,7 @@ function selectSearchBackend(preferred: SearchBackend, dir: string): 'rg' | 'gre
   }
 
   if (preferred === 'rg') {
-    return 'rg';
+    return isRipgrepAvailableForDir(dir) ? 'rg' : 'grep';
   }
 
   return isRipgrepAvailableForDir(dir) ? 'rg' : 'grep';

--- a/src/core/tools/toolkits/coding-files/search-files.ts
+++ b/src/core/tools/toolkits/coding-files/search-files.ts
@@ -4,8 +4,9 @@
 // ---------------------------------------------------------------------------
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { existsSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, relative, resolve } from 'node:path';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
 
 type SearchFilesInput = {
@@ -16,17 +17,12 @@ type SearchFilesInput = {
 
 type SearchBackend = 'auto' | 'rg' | 'grep';
 
-type IgnoreContext = {
-  root: string;
-  ignoreFilePaths: string[];
-};
-
 export const DEFAULT_SEARCH_EXCLUDED_DIRS = ['dist', 'node_modules', 'local'];
 const PROTECTED_STATE_DIRS = ['.git', '.heddle'];
-const IGNORE_FILE_NAMES = ['.rgignore', '.ignore', '.gitignore'];
-const GREP_TEXT_FILE_GLOBS = ['*.ts', '*.js', '*.json', '*.md', '*.txt', '*.yaml', '*.yml'];
 const SEARCH_TIMEOUT_MS = 15_000;
 const SEARCH_MAX_BUFFER = 1024 * 1024;
+const GREP_BATCH_SIZE = 200;
+const PROJECT_IGNORE_FILE_NAMES = ['.gitignore', '.ignore', '.rgignore'];
 
 export type SearchFilesOptions = {
   excludedDirs?: string[];
@@ -39,6 +35,7 @@ let cachedRipgrepAvailable: boolean | undefined;
 export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDefinition {
   const hasCustomExcludedDirs = Array.isArray(options.excludedDirs) && options.excludedDirs.length > 0;
   const configuredExcludedDirNames = sanitizeExcludedDirs(options.excludedDirs);
+  const customExcludedDirNames = getCustomExcludedDirs(configuredExcludedDirNames, hasCustomExcludedDirs);
   const configuredWorkspaceRoot = options.workspaceRoot ? resolve(options.workspaceRoot) : undefined;
   const backend = options.backend ?? 'auto';
 
@@ -76,38 +73,44 @@ export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDef
       const input: SearchFilesInput = raw;
       const workspaceRoot = configuredWorkspaceRoot ?? process.cwd();
       const dir = resolve(workspaceRoot, input.path ?? '.');
-      const nearestIgnoreContext = findNearestIgnoreContext(dir);
-      const searchRoot = determineSearchRoot(dir, nearestIgnoreContext);
-      const searchTarget = determineSearchTarget(dir, searchRoot);
-      const ignoreFilesPresent = Boolean(nearestIgnoreContext);
       const explicitlyTargetedConfiguredDirs = configuredExcludedDirNames.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
       const explicitlyTargetedProtectedDirs = PROTECTED_STATE_DIRS.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
       const includeIgnored = input.includeIgnored === true || explicitlyTargetedConfiguredDirs.length > 0 || explicitlyTargetedProtectedDirs.length > 0;
-      const excludedDirs = getEffectiveExcludedDirs({
-        configuredExcludedDirs: configuredExcludedDirNames,
-        hasCustomExcludedDirs,
-        ignoreFilesPresent,
+      const protectedExcludedDirs = getProtectedExcludedDirs(dir);
+      const customExcludedDirs = customExcludedDirNames.filter((name) => !isExplicitlyTargetingExcludedDir(dir, name));
+      const fallbackExcludedDirs = getFallbackExcludedDirs({
         dir,
-        includeIgnored,
+        fallbackExcludedDirs: customExcludedDirNames.length > 0 ? customExcludedDirNames : DEFAULT_SEARCH_EXCLUDED_DIRS,
       });
-      const selectedBackend = selectSearchBackend(backend);
+      const selectedBackend = selectSearchBackend(backend, dir);
+      const gitRepoRoot = findGitRepoRoot(dir);
+      const hasProjectIgnoreFile = findProjectIgnoreFile(dir, gitRepoRoot ?? workspaceRoot) !== undefined;
+      const fallbackExcludesApply = !includeIgnored && !hasProjectIgnoreFile;
 
       try {
         const output = selectedBackend === 'rg'
           ? runRipgrepSearch({
               query: input.query,
-              searchRoot,
-              searchTarget,
+              dir,
               includeIgnored,
-              excludedDirs,
-              ignoreFilePaths: includeIgnored ? [] : nearestIgnoreContext?.ignoreFilePaths ?? [],
+              excludedDirs:
+                includeIgnored ? protectedExcludedDirs
+                : [
+                    ...new Set([
+                      ...protectedExcludedDirs,
+                      ...customExcludedDirs,
+                      ...(fallbackExcludesApply ? fallbackExcludedDirs : []),
+                    ]),
+                  ],
             })
           : runGrepFallbackSearch({
               query: input.query,
-              searchRoot,
-              searchTarget,
-              excludedDirs,
-              ignoredDirNames: includeIgnored ? [] : parseSimpleIgnoredDirNames(nearestIgnoreContext?.ignoreFilePaths ?? []),
+              dir,
+              includeIgnored,
+              gitRepoRoot,
+              fallbackExcludesApply,
+              protectedExcludedDirs,
+              fallbackExcludedDirs,
             });
         return { ok: true, output: output.trim() || 'No matches found.' };
       } catch (err) {
@@ -142,16 +145,16 @@ function isSearchFilesInput(raw: unknown): raw is SearchFilesInput {
   return validPath && validIncludeIgnored;
 }
 
-function selectSearchBackend(preferred: SearchBackend): 'rg' | 'grep' {
+function selectSearchBackend(preferred: SearchBackend, dir: string): 'rg' | 'grep' {
   if (preferred === 'grep') {
     return 'grep';
   }
 
-  if (preferred === 'rg' || isRipgrepAvailable()) {
-    return isRipgrepAvailable() ? 'rg' : 'grep';
+  if (preferred === 'rg') {
+    return 'rg';
   }
 
-  return 'grep';
+  return isRipgrepAvailableForDir(dir) ? 'rg' : 'grep';
 }
 
 function isRipgrepAvailable(): boolean {
@@ -169,13 +172,29 @@ function isRipgrepAvailable(): boolean {
   return cachedRipgrepAvailable;
 }
 
+function isRipgrepAvailableForDir(dir: string): boolean {
+  if (!isRipgrepAvailable()) {
+    return false;
+  }
+
+  try {
+    execFileSync('rg', ['--version'], {
+      cwd: dir,
+      stdio: 'ignore',
+      timeout: 2_000,
+      maxBuffer: SEARCH_MAX_BUFFER,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function runRipgrepSearch(args: {
   query: string;
-  searchRoot: string;
-  searchTarget: string;
+  dir: string;
   includeIgnored: boolean;
   excludedDirs: string[];
-  ignoreFilePaths: string[];
 }): string {
   const commandArgs = [
     '--line-number',
@@ -183,16 +202,15 @@ function runRipgrepSearch(args: {
     '--color',
     'never',
     ...args.excludedDirs.flatMap((name) => ['--glob', `!**/${name}/**`]),
-    ...args.ignoreFilePaths.flatMap((ignorePath) => ['--ignore-file', ignorePath]),
   ];
 
   if (args.includeIgnored) {
     commandArgs.push('--no-ignore', '--hidden');
   }
 
-  commandArgs.push('--', args.query, args.searchTarget);
+  commandArgs.push('--', args.query, '.');
   return execFileSync('rg', commandArgs, {
-    cwd: args.searchRoot,
+    cwd: args.dir,
     encoding: 'utf-8',
     timeout: SEARCH_TIMEOUT_MS,
     maxBuffer: SEARCH_MAX_BUFFER,
@@ -201,30 +219,155 @@ function runRipgrepSearch(args: {
 
 function runGrepFallbackSearch(args: {
   query: string;
-  searchRoot: string;
-  searchTarget: string;
-  excludedDirs: string[];
-  ignoredDirNames: string[];
+  dir: string;
+  includeIgnored: boolean;
+  gitRepoRoot: string | undefined;
+  fallbackExcludesApply: boolean;
+  protectedExcludedDirs: string[];
+  fallbackExcludedDirs: string[];
 }): string {
-  const effectiveExcludedDirs = [...new Set([...args.excludedDirs, ...args.ignoredDirNames])];
+  if (args.includeIgnored) {
+    return runBroadGrepSearch({
+      query: args.query,
+      dir: args.dir,
+      excludedDirs: args.protectedExcludedDirs,
+    });
+  }
 
+  if (args.gitRepoRoot) {
+    const targetPathspec = determineGitPathspec(args.gitRepoRoot, args.dir);
+    const searchableFiles = listGitSearchableFiles(args.gitRepoRoot, targetPathspec);
+    const filteredFiles = filterSearchableFiles(
+      searchableFiles,
+      args.fallbackExcludesApply ?
+        [...new Set([...args.protectedExcludedDirs, ...args.fallbackExcludedDirs])]
+      : args.protectedExcludedDirs,
+    );
+    return runGrepOnFiles({
+      query: args.query,
+      cwd: args.gitRepoRoot,
+      files: filteredFiles,
+    });
+  }
+
+  return runBroadGrepSearch({
+    query: args.query,
+    dir: args.dir,
+    excludedDirs: args.fallbackExcludedDirs,
+  });
+}
+
+function runBroadGrepSearch(args: { query: string; dir: string; excludedDirs: string[] }): string {
   return execFileSync(
     'grep',
     [
       '-rnI',
-      ...effectiveExcludedDirs.map((name) => `--exclude-dir=${name}`),
-      ...GREP_TEXT_FILE_GLOBS.map((glob) => `--include=${glob}`),
+      ...args.excludedDirs.map((name) => `--exclude-dir=${name}`),
       '--',
       args.query,
-      args.searchTarget,
+      '.',
     ],
     {
-      cwd: args.searchRoot,
+      cwd: args.dir,
       encoding: 'utf-8',
       timeout: SEARCH_TIMEOUT_MS,
       maxBuffer: SEARCH_MAX_BUFFER,
     },
   );
+}
+
+function runGrepOnFiles(args: { query: string; cwd: string; files: string[] }): string {
+  if (args.files.length === 0) {
+    return '';
+  }
+
+  const outputs: string[] = [];
+  for (let index = 0; index < args.files.length; index += GREP_BATCH_SIZE) {
+    const batch = args.files.slice(index, index + GREP_BATCH_SIZE);
+    try {
+      const output = execFileSync(
+        'grep',
+        ['-nI', '--', args.query, ...batch],
+        {
+          cwd: args.cwd,
+          encoding: 'utf-8',
+          timeout: SEARCH_TIMEOUT_MS,
+          maxBuffer: SEARCH_MAX_BUFFER,
+        },
+      );
+      if (output.trim()) {
+        outputs.push(output.trim());
+      }
+    } catch (err) {
+      if (!isSearchNoMatchError(err)) {
+        throw err;
+      }
+    }
+  }
+
+  return outputs.join('\n');
+}
+
+function findGitRepoRoot(dir: string): string | undefined {
+  try {
+    const output = execFileSync(
+      'git',
+      ['-C', dir, 'rev-parse', '--show-toplevel'],
+      {
+        encoding: 'utf-8',
+        timeout: 2_000,
+        maxBuffer: SEARCH_MAX_BUFFER,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    ).trim();
+    return output ? realpathSync(output) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function determineGitPathspec(repoRoot: string, dir: string): string {
+  const normalizedRepoRoot = realpathSync(repoRoot);
+  const normalizedDir = realpathSync(dir);
+  const pathspec = relative(normalizedRepoRoot, normalizedDir).replace(/\\/g, '/');
+  return pathspec && pathspec !== '' ? pathspec : '.';
+}
+
+function listGitSearchableFiles(repoRoot: string, pathspec: string): string[] {
+  const output = execFileSync(
+    'git',
+    ['-C', repoRoot, 'ls-files', '-co', '--exclude-standard', '--', pathspec],
+    {
+      encoding: 'utf-8',
+      timeout: SEARCH_TIMEOUT_MS,
+      maxBuffer: SEARCH_MAX_BUFFER,
+    },
+  );
+
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function filterSearchableFiles(files: string[], excludedDirNames: string[]): string[] {
+  if (excludedDirNames.length === 0) {
+    return files;
+  }
+
+  return files.filter((filePath) =>
+    excludedDirNames.every((dirName) => !isPathInsideExcludedDir(filePath, dirName))
+  );
+}
+
+function isPathInsideExcludedDir(filePath: string, excludedDirName: string): boolean {
+  const normalizedExcludedName = excludedDirName.trim().replace(/^\.?\//, '').replace(/\/+$/, '');
+  if (!normalizedExcludedName) {
+    return false;
+  }
+
+  const segments = filePath.split(/[/\\]+/).filter(Boolean);
+  return segments.includes(normalizedExcludedName);
 }
 
 function isSearchNoMatchError(err: unknown): boolean {
@@ -244,113 +387,59 @@ function sanitizeExcludedDirs(custom: string[] | undefined): string[] {
   return normalized.length > 0 ? normalized : DEFAULT_SEARCH_EXCLUDED_DIRS;
 }
 
-function getEffectiveExcludedDirs(args: {
-  configuredExcludedDirs: string[];
-  hasCustomExcludedDirs: boolean;
-  ignoreFilesPresent: boolean;
-  dir: string;
-  includeIgnored: boolean;
-}): string[] {
-  const protectedDirs = PROTECTED_STATE_DIRS.filter((name) => !isExplicitlyTargetingExcludedDir(args.dir, name));
-
-  if (args.includeIgnored) {
-    return protectedDirs;
+function getCustomExcludedDirs(configuredExcludedDirs: string[], hasCustomExcludedDirs: boolean): string[] {
+  if (!hasCustomExcludedDirs) {
+    return [];
   }
 
-  const shouldUseConfiguredExcludedDirs = args.hasCustomExcludedDirs || !args.ignoreFilesPresent;
-  if (!shouldUseConfiguredExcludedDirs) {
-    return protectedDirs;
+  const nonProtectedDirs = configuredExcludedDirs.filter((name) => !PROTECTED_STATE_DIRS.includes(name));
+  if (nonProtectedDirs.every((name) => DEFAULT_SEARCH_EXCLUDED_DIRS.includes(name))) {
+    return [];
   }
 
-  const configuredDirs = args.configuredExcludedDirs.filter((name) => !isExplicitlyTargetingExcludedDir(args.dir, name));
-  return [...new Set([...protectedDirs, ...configuredDirs])];
+  return nonProtectedDirs;
 }
 
-function findNearestIgnoreContext(startDir: string): IgnoreContext | undefined {
+function getProtectedExcludedDirs(dir: string): string[] {
+  return PROTECTED_STATE_DIRS.filter((name) => !isExplicitlyTargetingExcludedDir(dir, name));
+}
+
+function getFallbackExcludedDirs(args: {
+  dir: string;
+  fallbackExcludedDirs: string[];
+}): string[] {
+  return [
+    ...new Set([
+      ...getProtectedExcludedDirs(args.dir),
+      ...args.fallbackExcludedDirs.filter((name) => !isExplicitlyTargetingExcludedDir(args.dir, name)),
+    ]),
+  ];
+}
+
+function findProjectIgnoreFile(startDir: string, stopDir: string): string | undefined {
   let currentDir = resolve(startDir);
+  const normalizedStopDir = resolve(stopDir);
+  const homeDir = homedir();
 
   while (true) {
-    const ignoreFilePaths = IGNORE_FILE_NAMES
-      .map((fileName) => resolve(currentDir, fileName))
-      .filter((filePath) => existsSync(filePath));
-    if (ignoreFilePaths.length > 0) {
-      return { root: currentDir, ignoreFilePaths };
+    for (const fileName of PROJECT_IGNORE_FILE_NAMES) {
+      const ignoreFilePath = resolve(currentDir, fileName);
+      if (existsSync(ignoreFilePath)) {
+        return ignoreFilePath;
+      }
+    }
+
+    if (currentDir === normalizedStopDir || currentDir === homeDir) {
+      return undefined;
     }
 
     const parentDir = dirname(currentDir);
     if (parentDir === currentDir) {
       return undefined;
     }
+
     currentDir = parentDir;
   }
-}
-
-function determineSearchRoot(dir: string, ignoreContext: IgnoreContext | undefined): string {
-  return ignoreContext?.root ?? dir;
-}
-
-function determineSearchTarget(dir: string, searchRoot: string): string {
-  if (searchRoot === dir) {
-    return '.';
-  }
-
-  const normalizedRoot = searchRoot.replace(/[/\\]+$/, '');
-  const normalizedDir = dir.replace(/[/\\]+$/, '');
-  if (normalizedDir.startsWith(`${normalizedRoot}/`) || normalizedDir.startsWith(`${normalizedRoot}\\`)) {
-    return normalizedDir.slice(normalizedRoot.length + 1);
-  }
-
-  return dir;
-}
-
-function parseSimpleIgnoredDirNames(ignoreFilePaths: string[]): string[] {
-  const names = new Set<string>();
-
-  for (const ignoreFilePath of ignoreFilePaths) {
-    const fileText = readIgnoreFile(ignoreFilePath);
-    if (!fileText) {
-      continue;
-    }
-
-    for (const rawLine of fileText.split(/\r?\n/)) {
-      const parsed = parseSimpleIgnoredDirName(rawLine);
-      if (parsed) {
-        names.add(parsed);
-      }
-    }
-  }
-
-  return [...names];
-}
-
-function readIgnoreFile(filePath: string): string | undefined {
-  try {
-    return readFileSync(filePath, 'utf8');
-  } catch {
-    return undefined;
-  }
-}
-
-function parseSimpleIgnoredDirName(rawLine: string): string | undefined {
-  const trimmed = rawLine.trim();
-  if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('!')) {
-    return undefined;
-  }
-
-  const withoutLeadingSlash = trimmed.replace(/^\//, '');
-  const normalized = withoutLeadingSlash.endsWith('/')
-    ? withoutLeadingSlash.slice(0, -1)
-    : withoutLeadingSlash;
-
-  if (!normalized || normalized.includes('/') || normalized.includes('\\')) {
-    return undefined;
-  }
-
-  if (/[*?[\]{}]/.test(normalized)) {
-    return undefined;
-  }
-
-  return normalized;
 }
 
 function isExplicitlyTargetingExcludedDir(dir: string, excludedName: string): boolean {

--- a/src/core/tools/toolkits/coding-files/search-files.ts
+++ b/src/core/tools/toolkits/coding-files/search-files.ts
@@ -4,7 +4,8 @@
 // ---------------------------------------------------------------------------
 
 import { execFileSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
 
 type SearchFilesInput = {
@@ -13,8 +14,16 @@ type SearchFilesInput = {
   includeIgnored?: boolean;
 };
 
-export const DEFAULT_SEARCH_EXCLUDED_DIRS = ['.git', 'dist', 'node_modules', 'local', '.heddle'];
+type SearchBackend = 'auto' | 'rg' | 'grep';
+
+type IgnoreContext = {
+  root: string;
+  ignoreFilePaths: string[];
+};
+
+export const DEFAULT_SEARCH_EXCLUDED_DIRS = ['dist', 'node_modules', 'local'];
 const PROTECTED_STATE_DIRS = ['.git', '.heddle'];
+const IGNORE_FILE_NAMES = ['.rgignore', '.ignore', '.gitignore'];
 const GREP_TEXT_FILE_GLOBS = ['*.ts', '*.js', '*.json', '*.md', '*.txt', '*.yaml', '*.yml'];
 const SEARCH_TIMEOUT_MS = 15_000;
 const SEARCH_MAX_BUFFER = 1024 * 1024;
@@ -22,18 +31,21 @@ const SEARCH_MAX_BUFFER = 1024 * 1024;
 export type SearchFilesOptions = {
   excludedDirs?: string[];
   workspaceRoot?: string;
+  backend?: SearchBackend;
 };
 
 let cachedRipgrepAvailable: boolean | undefined;
 
 export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDefinition {
-  const excludedDirNames = sanitizeExcludedDirs(options.excludedDirs);
+  const hasCustomExcludedDirs = Array.isArray(options.excludedDirs) && options.excludedDirs.length > 0;
+  const configuredExcludedDirNames = sanitizeExcludedDirs(options.excludedDirs);
   const configuredWorkspaceRoot = options.workspaceRoot ? resolve(options.workspaceRoot) : undefined;
+  const backend = options.backend ?? 'auto';
 
   return {
     name: 'search_files',
     description:
-      'Search for a text pattern in files. Prefer rg when available for fast ignored-aware search, with a grep fallback. Use this when you need to locate a specific symbol or text string, not when a likely folder or file is already obvious from the workspace structure. Prefer searching for concrete terms such as tool names, symbols, or filenames rather than copying broad question text. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Returns newline-separated matches in grep-style path:line:content format, or "No matches found.". By default, search honors ignore files when rg is available and avoids expensive/generated/state folders like .git, dist, node_modules, local, and .heddle. Set includeIgnored: true only when intentionally searching ignored or dependency content such as node_modules; .git and .heddle are still avoided unless explicitly targeted via path. Example inputs: { "query": "createUser" }, { "query": "incident", "path": "../shared-notes" }, { "query": "packageName", "path": "node_modules", "includeIgnored": true }',
+      'Search for a text pattern in files. Prefer rg when available for fast ignored-aware search, with a grep fallback. Use this when you need to locate a specific symbol or text string, not when a likely folder or file is already obvious from the workspace structure. Prefer searching for concrete terms such as tool names, symbols, or filenames rather than copying broad question text. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Returns newline-separated matches in grep-style path:line:content format, or "No matches found.". By default, search honors project ignore files such as .gitignore when rg is available; when no ignore file is present, fallback excludes avoid expensive/generated folders like dist, node_modules, and local. .git and .heddle stay protected from accidental broad searches unless explicitly targeted. Set includeIgnored: true only when intentionally searching ignored/dependency content such as node_modules. Example inputs: { "query": "createUser" }, { "query": "incident", "path": "../shared-notes" }, { "query": "packageName", "path": "node_modules", "includeIgnored": true }',
     parameters: {
       type: 'object',
       additionalProperties: false,
@@ -64,18 +76,39 @@ export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDef
       const input: SearchFilesInput = raw;
       const workspaceRoot = configuredWorkspaceRoot ?? process.cwd();
       const dir = resolve(workspaceRoot, input.path ?? '.');
-      const explicitlyTargetedExcludedDirs = excludedDirNames.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
-      const includeIgnored = input.includeIgnored === true || explicitlyTargetedExcludedDirs.length > 0;
+      const nearestIgnoreContext = findNearestIgnoreContext(dir);
+      const searchRoot = determineSearchRoot(dir, nearestIgnoreContext);
+      const searchTarget = determineSearchTarget(dir, searchRoot);
+      const ignoreFilesPresent = Boolean(nearestIgnoreContext);
+      const explicitlyTargetedConfiguredDirs = configuredExcludedDirNames.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
+      const explicitlyTargetedProtectedDirs = PROTECTED_STATE_DIRS.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
+      const includeIgnored = input.includeIgnored === true || explicitlyTargetedConfiguredDirs.length > 0 || explicitlyTargetedProtectedDirs.length > 0;
       const excludedDirs = getEffectiveExcludedDirs({
-        configuredExcludedDirs: excludedDirNames,
+        configuredExcludedDirs: configuredExcludedDirNames,
+        hasCustomExcludedDirs,
+        ignoreFilesPresent,
         dir,
         includeIgnored,
       });
+      const selectedBackend = selectSearchBackend(backend);
 
       try {
-        const output = isRipgrepAvailable()
-          ? runRipgrepSearch({ query: input.query, dir, includeIgnored, excludedDirs })
-          : runGrepFallbackSearch({ query: input.query, dir, excludedDirs });
+        const output = selectedBackend === 'rg'
+          ? runRipgrepSearch({
+              query: input.query,
+              searchRoot,
+              searchTarget,
+              includeIgnored,
+              excludedDirs,
+              ignoreFilePaths: includeIgnored ? [] : nearestIgnoreContext?.ignoreFilePaths ?? [],
+            })
+          : runGrepFallbackSearch({
+              query: input.query,
+              searchRoot,
+              searchTarget,
+              excludedDirs,
+              ignoredDirNames: includeIgnored ? [] : parseSimpleIgnoredDirNames(nearestIgnoreContext?.ignoreFilePaths ?? []),
+            });
         return { ok: true, output: output.trim() || 'No matches found.' };
       } catch (err) {
         if (isSearchNoMatchError(err)) {
@@ -109,6 +142,18 @@ function isSearchFilesInput(raw: unknown): raw is SearchFilesInput {
   return validPath && validIncludeIgnored;
 }
 
+function selectSearchBackend(preferred: SearchBackend): 'rg' | 'grep' {
+  if (preferred === 'grep') {
+    return 'grep';
+  }
+
+  if (preferred === 'rg' || isRipgrepAvailable()) {
+    return isRipgrepAvailable() ? 'rg' : 'grep';
+  }
+
+  return 'grep';
+}
+
 function isRipgrepAvailable(): boolean {
   if (cachedRipgrepAvailable !== undefined) {
     return cachedRipgrepAvailable;
@@ -126,9 +171,11 @@ function isRipgrepAvailable(): boolean {
 
 function runRipgrepSearch(args: {
   query: string;
-  dir: string;
+  searchRoot: string;
+  searchTarget: string;
   includeIgnored: boolean;
   excludedDirs: string[];
+  ignoreFilePaths: string[];
 }): string {
   const commandArgs = [
     '--line-number',
@@ -136,32 +183,47 @@ function runRipgrepSearch(args: {
     '--color',
     'never',
     ...args.excludedDirs.flatMap((name) => ['--glob', `!**/${name}/**`]),
+    ...args.ignoreFilePaths.flatMap((ignorePath) => ['--ignore-file', ignorePath]),
   ];
 
   if (args.includeIgnored) {
     commandArgs.push('--no-ignore', '--hidden');
   }
 
-  commandArgs.push('--', args.query, args.dir);
+  commandArgs.push('--', args.query, args.searchTarget);
   return execFileSync('rg', commandArgs, {
+    cwd: args.searchRoot,
     encoding: 'utf-8',
     timeout: SEARCH_TIMEOUT_MS,
     maxBuffer: SEARCH_MAX_BUFFER,
   });
 }
 
-function runGrepFallbackSearch(args: { query: string; dir: string; excludedDirs: string[] }): string {
+function runGrepFallbackSearch(args: {
+  query: string;
+  searchRoot: string;
+  searchTarget: string;
+  excludedDirs: string[];
+  ignoredDirNames: string[];
+}): string {
+  const effectiveExcludedDirs = [...new Set([...args.excludedDirs, ...args.ignoredDirNames])];
+
   return execFileSync(
     'grep',
     [
       '-rnI',
-      ...args.excludedDirs.map((name) => `--exclude-dir=${name}`),
+      ...effectiveExcludedDirs.map((name) => `--exclude-dir=${name}`),
       ...GREP_TEXT_FILE_GLOBS.map((glob) => `--include=${glob}`),
       '--',
       args.query,
-      args.dir,
+      args.searchTarget,
     ],
-    { encoding: 'utf-8', timeout: SEARCH_TIMEOUT_MS, maxBuffer: SEARCH_MAX_BUFFER },
+    {
+      cwd: args.searchRoot,
+      encoding: 'utf-8',
+      timeout: SEARCH_TIMEOUT_MS,
+      maxBuffer: SEARCH_MAX_BUFFER,
+    },
   );
 }
 
@@ -184,14 +246,111 @@ function sanitizeExcludedDirs(custom: string[] | undefined): string[] {
 
 function getEffectiveExcludedDirs(args: {
   configuredExcludedDirs: string[];
+  hasCustomExcludedDirs: boolean;
+  ignoreFilesPresent: boolean;
   dir: string;
   includeIgnored: boolean;
 }): string[] {
-  if (!args.includeIgnored) {
-    return args.configuredExcludedDirs.filter((name) => !isExplicitlyTargetingExcludedDir(args.dir, name));
+  const protectedDirs = PROTECTED_STATE_DIRS.filter((name) => !isExplicitlyTargetingExcludedDir(args.dir, name));
+
+  if (args.includeIgnored) {
+    return protectedDirs;
   }
 
-  return PROTECTED_STATE_DIRS.filter((name) => !isExplicitlyTargetingExcludedDir(args.dir, name));
+  const shouldUseConfiguredExcludedDirs = args.hasCustomExcludedDirs || !args.ignoreFilesPresent;
+  if (!shouldUseConfiguredExcludedDirs) {
+    return protectedDirs;
+  }
+
+  const configuredDirs = args.configuredExcludedDirs.filter((name) => !isExplicitlyTargetingExcludedDir(args.dir, name));
+  return [...new Set([...protectedDirs, ...configuredDirs])];
+}
+
+function findNearestIgnoreContext(startDir: string): IgnoreContext | undefined {
+  let currentDir = resolve(startDir);
+
+  while (true) {
+    const ignoreFilePaths = IGNORE_FILE_NAMES
+      .map((fileName) => resolve(currentDir, fileName))
+      .filter((filePath) => existsSync(filePath));
+    if (ignoreFilePaths.length > 0) {
+      return { root: currentDir, ignoreFilePaths };
+    }
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) {
+      return undefined;
+    }
+    currentDir = parentDir;
+  }
+}
+
+function determineSearchRoot(dir: string, ignoreContext: IgnoreContext | undefined): string {
+  return ignoreContext?.root ?? dir;
+}
+
+function determineSearchTarget(dir: string, searchRoot: string): string {
+  if (searchRoot === dir) {
+    return '.';
+  }
+
+  const normalizedRoot = searchRoot.replace(/[/\\]+$/, '');
+  const normalizedDir = dir.replace(/[/\\]+$/, '');
+  if (normalizedDir.startsWith(`${normalizedRoot}/`) || normalizedDir.startsWith(`${normalizedRoot}\\`)) {
+    return normalizedDir.slice(normalizedRoot.length + 1);
+  }
+
+  return dir;
+}
+
+function parseSimpleIgnoredDirNames(ignoreFilePaths: string[]): string[] {
+  const names = new Set<string>();
+
+  for (const ignoreFilePath of ignoreFilePaths) {
+    const fileText = readIgnoreFile(ignoreFilePath);
+    if (!fileText) {
+      continue;
+    }
+
+    for (const rawLine of fileText.split(/\r?\n/)) {
+      const parsed = parseSimpleIgnoredDirName(rawLine);
+      if (parsed) {
+        names.add(parsed);
+      }
+    }
+  }
+
+  return [...names];
+}
+
+function readIgnoreFile(filePath: string): string | undefined {
+  try {
+    return readFileSync(filePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+function parseSimpleIgnoredDirName(rawLine: string): string | undefined {
+  const trimmed = rawLine.trim();
+  if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('!')) {
+    return undefined;
+  }
+
+  const withoutLeadingSlash = trimmed.replace(/^\//, '');
+  const normalized = withoutLeadingSlash.endsWith('/')
+    ? withoutLeadingSlash.slice(0, -1)
+    : withoutLeadingSlash;
+
+  if (!normalized || normalized.includes('/') || normalized.includes('\\')) {
+    return undefined;
+  }
+
+  if (/[*?[\]{}]/.test(normalized)) {
+    return undefined;
+  }
+
+  return normalized;
 }
 
 function isExplicitlyTargetingExcludedDir(dir: string, excludedName: string): boolean {

--- a/src/core/tools/toolkits/coding-files/search-files.ts
+++ b/src/core/tools/toolkits/coding-files/search-files.ts
@@ -1,23 +1,30 @@
 // ---------------------------------------------------------------------------
 // Tool: search_files
-// Uses grep — the real human tool, per project philosophy.
+// Uses mature local search tools while keeping defaults focused and bounded.
 // ---------------------------------------------------------------------------
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
 
 type SearchFilesInput = {
   query: string;
   path?: string;
+  includeIgnored?: boolean;
 };
 
 export const DEFAULT_SEARCH_EXCLUDED_DIRS = ['.git', 'dist', 'node_modules', 'local', '.heddle'];
+const PROTECTED_STATE_DIRS = ['.git', '.heddle'];
+const GREP_TEXT_FILE_GLOBS = ['*.ts', '*.js', '*.json', '*.md', '*.txt', '*.yaml', '*.yml'];
+const SEARCH_TIMEOUT_MS = 15_000;
+const SEARCH_MAX_BUFFER = 1024 * 1024;
 
 export type SearchFilesOptions = {
   excludedDirs?: string[];
   workspaceRoot?: string;
 };
+
+let cachedRipgrepAvailable: boolean | undefined;
 
 export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDefinition {
   const excludedDirNames = sanitizeExcludedDirs(options.excludedDirs);
@@ -26,7 +33,7 @@ export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDef
   return {
     name: 'search_files',
     description:
-      'Search for a text pattern in files using grep. Use this when you need to locate a specific symbol or text string, not when a likely folder or file is already obvious from the workspace structure. Prefer searching for concrete terms such as tool names, symbols, or filenames rather than copying broad question text. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Returns newline-separated matches in grep-style path:line:content format, or "No matches found.". Ignores generated or state directories like .git, dist, node_modules, local, and .heddle by default, but if you explicitly target one of those directories via path then that path is searched. Example inputs: { "query": "createUser" }, { "query": "incident", "path": "../shared-notes" }',
+      'Search for a text pattern in files. Prefer rg when available for fast ignored-aware search, with a grep fallback. Use this when you need to locate a specific symbol or text string, not when a likely folder or file is already obvious from the workspace structure. Prefer searching for concrete terms such as tool names, symbols, or filenames rather than copying broad question text. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Returns newline-separated matches in grep-style path:line:content format, or "No matches found.". By default, search honors ignore files when rg is available and avoids expensive/generated/state folders like .git, dist, node_modules, local, and .heddle. Set includeIgnored: true only when intentionally searching ignored or dependency content such as node_modules; .git and .heddle are still avoided unless explicitly targeted via path. Example inputs: { "query": "createUser" }, { "query": "incident", "path": "../shared-notes" }, { "query": "packageName", "path": "node_modules", "includeIgnored": true }',
     parameters: {
       type: 'object',
       additionalProperties: false,
@@ -39,29 +46,39 @@ export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDef
           type: 'string',
           description: 'Directory to search in. Defaults to "."',
         },
+        includeIgnored: {
+          type: 'boolean',
+          description: 'Whether to include ignored/dependency content such as node_modules. Defaults to false.',
+        },
       },
       required: ['query'],
     },
     async execute(raw: unknown): Promise<ToolResult> {
       if (!isSearchFilesInput(raw)) {
-        return { ok: false, error: 'Invalid input for search_files. Required field: query. Optional field: path.' };
+        return {
+          ok: false,
+          error: 'Invalid input for search_files. Required field: query. Optional fields: path, includeIgnored.',
+        };
       }
 
       const input: SearchFilesInput = raw;
       const workspaceRoot = configuredWorkspaceRoot ?? process.cwd();
       const dir = resolve(workspaceRoot, input.path ?? '.');
-      const effectiveExcludedDirs = excludedDirNames.filter((name) => !isExplicitlyTargetingExcludedDir(dir, name));
-      const excludedDirs = effectiveExcludedDirs.map((name) => `--exclude-dir=${escapeShellArg(name)}`).join(' ');
+      const explicitlyTargetedExcludedDirs = excludedDirNames.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
+      const includeIgnored = input.includeIgnored === true || explicitlyTargetedExcludedDirs.length > 0;
+      const excludedDirs = getEffectiveExcludedDirs({
+        configuredExcludedDirs: excludedDirNames,
+        dir,
+        includeIgnored,
+      });
 
       try {
-        // -r recursive, -n line numbers, -I skip binary, --include common text files
-        const output = execSync(
-          `grep -rnI ${excludedDirs} --include='*.ts' --include='*.js' --include='*.json' --include='*.md' --include='*.txt' --include='*.yaml' --include='*.yml' ${escapeShellArg(input.query)} ${escapeShellArg(dir)}`,
-          { encoding: 'utf-8', timeout: 15_000, maxBuffer: 1024 * 1024 },
-        );
-        return { ok: true, output: output.trim() };
+        const output = isRipgrepAvailable()
+          ? runRipgrepSearch({ query: input.query, dir, includeIgnored, excludedDirs })
+          : runGrepFallbackSearch({ query: input.query, dir, excludedDirs });
+        return { ok: true, output: output.trim() || 'No matches found.' };
       } catch (err) {
-        if (err && typeof err === 'object' && 'status' in err && err.status === 1) {
+        if (isSearchNoMatchError(err)) {
           return { ok: true, output: 'No matches found.' };
         }
         return { ok: false, error: `Search failed: ${err instanceof Error ? err.message : String(err)}` };
@@ -79,7 +96,7 @@ function isSearchFilesInput(raw: unknown): raw is SearchFilesInput {
 
   const input = raw as Record<string, unknown>;
   const keys = Object.keys(input);
-  if (keys.some((key) => key !== 'query' && key !== 'path')) {
+  if (keys.some((key) => key !== 'query' && key !== 'path' && key !== 'includeIgnored')) {
     return false;
   }
 
@@ -87,11 +104,69 @@ function isSearchFilesInput(raw: unknown): raw is SearchFilesInput {
     return false;
   }
 
-  return input.path === undefined || typeof input.path === 'string';
+  const validPath = input.path === undefined || typeof input.path === 'string';
+  const validIncludeIgnored = input.includeIgnored === undefined || typeof input.includeIgnored === 'boolean';
+  return validPath && validIncludeIgnored;
 }
 
-function escapeShellArg(arg: string): string {
-  return `'${arg.replace(/'/g, "'\\''")}'`;
+function isRipgrepAvailable(): boolean {
+  if (cachedRipgrepAvailable !== undefined) {
+    return cachedRipgrepAvailable;
+  }
+
+  try {
+    execFileSync('rg', ['--version'], { stdio: 'ignore', timeout: 2_000 });
+    cachedRipgrepAvailable = true;
+  } catch {
+    cachedRipgrepAvailable = false;
+  }
+
+  return cachedRipgrepAvailable;
+}
+
+function runRipgrepSearch(args: {
+  query: string;
+  dir: string;
+  includeIgnored: boolean;
+  excludedDirs: string[];
+}): string {
+  const commandArgs = [
+    '--line-number',
+    '--no-heading',
+    '--color',
+    'never',
+    ...args.excludedDirs.flatMap((name) => ['--glob', `!**/${name}/**`]),
+  ];
+
+  if (args.includeIgnored) {
+    commandArgs.push('--no-ignore', '--hidden');
+  }
+
+  commandArgs.push('--', args.query, args.dir);
+  return execFileSync('rg', commandArgs, {
+    encoding: 'utf-8',
+    timeout: SEARCH_TIMEOUT_MS,
+    maxBuffer: SEARCH_MAX_BUFFER,
+  });
+}
+
+function runGrepFallbackSearch(args: { query: string; dir: string; excludedDirs: string[] }): string {
+  return execFileSync(
+    'grep',
+    [
+      '-rnI',
+      ...args.excludedDirs.map((name) => `--exclude-dir=${name}`),
+      ...GREP_TEXT_FILE_GLOBS.map((glob) => `--include=${glob}`),
+      '--',
+      args.query,
+      args.dir,
+    ],
+    { encoding: 'utf-8', timeout: SEARCH_TIMEOUT_MS, maxBuffer: SEARCH_MAX_BUFFER },
+  );
+}
+
+function isSearchNoMatchError(err: unknown): boolean {
+  return Boolean(err && typeof err === 'object' && 'status' in err && err.status === 1);
 }
 
 function sanitizeExcludedDirs(custom: string[] | undefined): string[] {
@@ -105,6 +180,18 @@ function sanitizeExcludedDirs(custom: string[] | undefined): string[] {
     .map((value) => value.replace(/^\.?\//, '').replace(/\/+$/, ''));
 
   return normalized.length > 0 ? normalized : DEFAULT_SEARCH_EXCLUDED_DIRS;
+}
+
+function getEffectiveExcludedDirs(args: {
+  configuredExcludedDirs: string[];
+  dir: string;
+  includeIgnored: boolean;
+}): string[] {
+  if (!args.includeIgnored) {
+    return args.configuredExcludedDirs.filter((name) => !isExplicitlyTargetingExcludedDir(args.dir, name));
+  }
+
+  return PROTECTED_STATE_DIRS.filter((name) => !isExplicitlyTargetingExcludedDir(args.dir, name));
 }
 
 function isExplicitlyTargetingExcludedDir(dir: string, excludedName: string): boolean {


### PR DESCRIPTION
## Summary
- make `search_files` prefer `rg`, add `includeIgnored`, and keep `.git`/`.heddle` protected unless explicitly targeted
- make fallback excludes apply to `rg` when no project ignore file exists, while treating generated default `searchIgnoreDirs` as fallback instead of authoritative rules when `.gitignore`/ignore files are present
- extend remembered approval rules to support outside-workspace `read_file` / `list_files`
- align the TUI approval UI so remember is only shown when a real project approval rule can be stored
- shorten exact-command and path inspection remember option labels while keeping the command/path visible in the approval details
- show the `search_files` query in the approval preview box so users can see what keyword is being searched before approving

## Testing
- `yarn vitest run src/__tests__/unit/chat/chat-format.test.ts src/__tests__/unit/tui/approval-flow.test.tsx`
- `yarn vitest run src/__tests__/unit/chat/chat-format.test.ts src/__tests__/unit/tui/approval-flow.test.tsx src/__tests__/unit/core/project-approval-rules.test.ts src/__tests__/integration/tools/tools.test.ts`
- `yarn test:unit`
- `yarn build`
- `git diff --check`
