### PR TITLE
[codex] Add HEDDLE project instructions discovery

### DIFF
--- a/HEDDLE.md
+++ b/HEDDLE.md
@@ -1,0 +1,3 @@
+# Heddle Agent Instructions
+
+Read [docs/agent-context.md](docs/agent-context.md) first.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ The terminal composer supports multiline prompts, prompt undo/redo, prompt histo
 
 More: [Chat and sessions guide](docs/guides/chat-and-sessions.md)
 
+### Project instructions
+
+Heddle can load a short project instruction file at startup so a fresh session starts with the repository's operating context. By default it loads the first non-empty file found in this order: `HEDDLE.md`, `AGENTS.md`, `CLAUDE.md`.
+
+Only one default file is loaded to preserve context space. If a project needs a different path or intentionally wants multiple files, set `agentContextPaths` in `heddle.config.json`.
+
+More: [Project config](docs/reference/config.md)
+
 ### Sessions and continuity
 
 Heddle keeps saved sessions under `.heddle/` so longer work does not have to reset every time. That means you can come back to an interrupted task, continue a previous debugging thread, or preserve project-specific context across runs.

--- a/docs/guides/chat-and-sessions.md
+++ b/docs/guides/chat-and-sessions.md
@@ -43,6 +43,8 @@ heddle chat --model gpt-5.4-mini --max-steps 20
 
 Heddle uses the current directory as the workspace root unless you pass `--cwd`.
 
+At startup, Heddle also looks for one project instruction file. The default priority is `HEDDLE.md`, then `AGENTS.md`, then `CLAUDE.md`; the first non-empty file is appended to the system prompt. Set `agentContextPaths` in `heddle.config.json` only when a project needs custom paths or multiple instruction files.
+
 If you keep both OpenAI OAuth and an API key configured, Heddle prefers OAuth by default. For explicit API-key testing, start a run with:
 
 ```bash

--- a/docs/project-posture.md
+++ b/docs/project-posture.md
@@ -2,6 +2,8 @@
 
 This is the short orientation doc for coding agents working in Heddle. Read it
 after `docs/agent-context.md` and before changing non-trivial behavior.
+`HEDDLE.md` is the Heddle-native project instruction entrypoint and should stay
+small enough to route agents here instead of duplicating this document.
 
 ## Identity
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -10,8 +10,7 @@ Heddle can store project defaults in `heddle.config.json` so you do not have to 
   "maxSteps": 100,
   "stateDir": ".heddle",
   "directShellApproval": "never",
-  "searchIgnoreDirs": [".git", "dist", "node_modules", ".heddle"],
-  "agentContextPaths": ["AGENTS.md"]
+  "searchIgnoreDirs": [".git", "dist", "node_modules", ".heddle"]
 }
 ```
 
@@ -30,7 +29,7 @@ Configuration is applied in this order:
 - `stateDir`: where Heddle stores sessions, traces, approvals, logs, and memory
 - `directShellApproval`: whether explicit `!command` usage in chat still requires approval
 - `searchIgnoreDirs`: directories excluded from routine `search_files` calls
-- `agentContextPaths`: project instruction files injected into the system prompt
+- `agentContextPaths`: optional project instruction files injected into the system prompt. When omitted, Heddle loads the first non-empty file found in this order: `HEDDLE.md`, `AGENTS.md`, `CLAUDE.md`. Only one default file is loaded to preserve context space. If configured, Heddle uses the listed paths exactly, so advanced projects can opt into custom names or multiple files.
 
 ## When To Use Config
 
@@ -40,7 +39,7 @@ Configuration is applied in this order:
 - you want a non-default state directory
 - you want predictable shell approval behavior in a shared workflow
 - your repository has directories that should stay out of routine search unless explicitly targeted
-- the project relies on one or more instruction files such as `AGENTS.md`
+- the project relies on custom instruction paths beyond the default `HEDDLE.md`, `AGENTS.md`, or `CLAUDE.md` discovery order
 
 ## See Also
 

--- a/src/__tests__/integration/chat/chat-runtime.test.ts
+++ b/src/__tests__/integration/chat/chat-runtime.test.ts
@@ -165,6 +165,9 @@ describe('resolveChatRuntimeConfig', () => {
     expect(runtime.systemContext).toContain('Source: AGENTS.md');
     expect(runtime.systemContext).toContain('## Workspace Memory Catalog');
     expect(runtime.systemContext).toContain('- Read current-state first.');
+    expect(runtime.systemContext!.indexOf('## Workspace Memory Catalog')).toBeLessThan(
+      runtime.systemContext!.indexOf('Source: AGENTS.md')
+    );
   });
 
   it('resolves the default credential store to an auth file path', () => {

--- a/src/__tests__/integration/memory/memory-catalog.test.ts
+++ b/src/__tests__/integration/memory/memory-catalog.test.ts
@@ -86,6 +86,8 @@ describe('memory catalog', () => {
     expect(context).toContain(`Source: ${join(memoryRoot, 'README.md')}`);
     expect(context).toContain('Startup memory policy: this is the only memory document loaded automatically.');
     expect(context).not.toContain('# Current State');
+    expect(context.indexOf('## Heddle-Managed Memory Domain')).toBeLessThan(context.indexOf('Source: AGENTS.md'));
+    expect(context.indexOf('## Workspace Memory Catalog')).toBeLessThan(context.indexOf('Source: AGENTS.md'));
   });
 
   it('reports missing folder catalogs', () => {

--- a/src/__tests__/unit/cli/project-agent-context.test.ts
+++ b/src/__tests__/unit/cli/project-agent-context.test.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadProjectAgentContext, resolveAgentContextPaths } from '../../../cli/project-agent-context.js';
+
+describe('project agent context', () => {
+  it('prefers HEDDLE.md when multiple default instruction files exist', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-agent-context-'));
+    writeFileSync(join(workspaceRoot, 'HEDDLE.md'), 'Read Heddle instructions.\n', 'utf8');
+    writeFileSync(join(workspaceRoot, 'AGENTS.md'), 'Read agent instructions.\n', 'utf8');
+    writeFileSync(join(workspaceRoot, 'CLAUDE.md'), 'Read Claude instructions.\n', 'utf8');
+
+    expect(resolveAgentContextPaths(workspaceRoot, undefined)).toEqual(['HEDDLE.md']);
+  });
+
+  it('falls back to AGENTS.md and CLAUDE.md when higher-priority defaults are absent or empty', () => {
+    const agentsWorkspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-agent-context-agents-'));
+    writeFileSync(join(agentsWorkspaceRoot, 'HEDDLE.md'), '\n', 'utf8');
+    writeFileSync(join(agentsWorkspaceRoot, 'AGENTS.md'), 'Read agent instructions.\n', 'utf8');
+
+    const claudeWorkspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-agent-context-claude-'));
+    writeFileSync(join(claudeWorkspaceRoot, 'CLAUDE.md'), 'Read Claude instructions.\n', 'utf8');
+
+    expect(resolveAgentContextPaths(agentsWorkspaceRoot, undefined)).toEqual(['AGENTS.md']);
+    expect(resolveAgentContextPaths(claudeWorkspaceRoot, undefined)).toEqual(['CLAUDE.md']);
+  });
+
+  it('respects configured paths exactly instead of applying defaults', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-agent-context-config-'));
+    writeFileSync(join(workspaceRoot, 'HEDDLE.md'), 'Read Heddle instructions.\n', 'utf8');
+
+    expect(resolveAgentContextPaths(workspaceRoot, ['CUSTOM.md', 'OTHER.md'])).toEqual(['CUSTOM.md', 'OTHER.md']);
+  });
+
+  it('loads readable configured project context files', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-agent-context-load-'));
+    writeFileSync(join(workspaceRoot, 'HEDDLE.md'), 'Read docs/agent-context.md first.\n', 'utf8');
+
+    const context = loadProjectAgentContext(workspaceRoot, ['HEDDLE.md', 'MISSING.md']);
+
+    expect(context).toBe('Source: HEDDLE.md\nRead docs/agent-context.md first.');
+  });
+});

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -27,6 +27,7 @@ import { startChatCli } from './chat/index.js';
 import { runDaemonCli } from './daemon.js';
 import { runEvalCli } from './eval/index.js';
 import { parseHeartbeatArgs, runHeartbeatCli } from './heartbeat.js';
+import { loadProjectAgentContext, resolveAgentContextPaths } from './project-agent-context.js';
 import { runSessionCli } from './session.js';
 import {
   daemonStartConflictMessage,
@@ -516,7 +517,10 @@ function resolveCliOptions(flags: RootCliOptions): ResolvedCliOptions {
     stateDir: projectConfig.stateDir ?? '.heddle',
     directShellApproval: projectConfig.directShellApproval ?? 'never',
     searchIgnoreDirs: projectConfig.searchIgnoreDirs ?? [],
-    systemContext: loadProjectAgentContext(workspaceRoot, projectConfig.agentContextPaths ?? ['AGENTS.md']),
+    systemContext: loadProjectAgentContext(
+      workspaceRoot,
+      resolveAgentContextPaths(workspaceRoot, projectConfig.agentContextPaths)
+    ),
     runtimeHost: resolveWorkspaceRuntimeHost({
       workspaceRoot,
       stateRoot,
@@ -662,31 +666,9 @@ function initializeProjectConfig(workspaceRoot: string) {
     stateDir: '.heddle',
     directShellApproval: 'never',
     searchIgnoreDirs: ['.git', 'dist', 'node_modules', '.heddle'],
-    agentContextPaths: ['AGENTS.md'],
   };
   writeFileSync(configPath, `${JSON.stringify(template, null, 2)}\n`);
   process.stdout.write(`Created ${configPath}\n`);
-}
-
-function loadProjectAgentContext(workspaceRoot: string, paths: string[]): string | undefined {
-  const sections = paths.flatMap((relativePath) => {
-    const filePath = resolve(workspaceRoot, relativePath);
-    if (!existsSync(filePath)) {
-      return [];
-    }
-
-    try {
-      const content = readFileSync(filePath, 'utf8').trim();
-      if (!content) {
-        return [];
-      }
-      return [`Source: ${relativePath}\n${truncate(content, 12000)}`];
-    } catch {
-      return [];
-    }
-  });
-
-  return sections.length > 0 ? sections.join('\n\n') : undefined;
 }
 
 function parsePositiveInt(raw: string | undefined): number | undefined {
@@ -702,13 +684,6 @@ function parsePositiveInt(raw: string | undefined): number | undefined {
   return value;
 }
 
-function truncate(value: string, maxLength: number): string {
-  if (value.length <= maxLength) {
-    return value;
-  }
-
-  return `${value.slice(0, maxLength - 1)}…`;
-}
 
 main().catch((error) => {
   const message = error instanceof Error ? error.message : String(error);

--- a/src/cli/project-agent-context.ts
+++ b/src/cli/project-agent-context.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export const DEFAULT_AGENT_CONTEXT_PATHS = ['HEDDLE.md', 'AGENTS.md', 'CLAUDE.md'];
+
+export function resolveAgentContextPaths(workspaceRoot: string, configuredPaths: string[] | undefined): string[] {
+  if (configuredPaths) {
+    return configuredPaths;
+  }
+
+  const defaultPath = DEFAULT_AGENT_CONTEXT_PATHS.find((relativePath) =>
+    hasReadableProjectAgentContext(workspaceRoot, relativePath)
+  );
+  return defaultPath ? [defaultPath] : [];
+}
+
+export function loadProjectAgentContext(workspaceRoot: string, paths: string[]): string | undefined {
+  const sections = paths.flatMap((relativePath) => {
+    const content = readProjectAgentContextFile(workspaceRoot, relativePath);
+    return content ? [`Source: ${relativePath}\n${truncate(content, 12000)}`] : [];
+  });
+
+  return sections.length > 0 ? sections.join('\n\n') : undefined;
+}
+
+function hasReadableProjectAgentContext(workspaceRoot: string, relativePath: string): boolean {
+  return readProjectAgentContextFile(workspaceRoot, relativePath) !== undefined;
+}
+
+function readProjectAgentContextFile(workspaceRoot: string, relativePath: string): string | undefined {
+  const filePath = resolve(workspaceRoot, relativePath);
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+
+  try {
+    const content = readFileSync(filePath, 'utf8').trim();
+    return content || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1)}…`;
+}

--- a/src/core/memory/catalog.ts
+++ b/src/core/memory/catalog.ts
@@ -174,7 +174,7 @@ export function appendMemoryCatalogSystemContext(options: {
   const memoryContext = formatMemoryCatalogSystemContext(catalog);
   const domainContext = buildMemoryDomainSystemContext();
   const context = `${domainContext}\n\n${memoryContext}`;
-  return options.systemContext ? `${options.systemContext}\n\n${context}` : context;
+  return options.systemContext ? `${context}\n\n${options.systemContext}` : context;
 }
 
 export function validateMemoryCatalogShape(options: { memoryRoot: string }): MemoryCatalogShapeValidation {


### PR DESCRIPTION
## Summary

- Add HEDDLE.md as the first default project instruction file, before AGENTS.md and CLAUDE.md.
- Preserve explicit `heddle.config.json` `agentContextPaths` as the highest-priority override.
- Load only one default instruction file to preserve context space.
- Append project instructions after memory context so the dynamic project-specific block sits at the end of the system prompt.
- Document the behavior in README, chat/session docs, and config reference.

## Validation

- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn eslint` passed with one existing warning in `src/cli/chat/App.tsx`.

## Trace note

A fresh Heddle run for `what is this project about?` read `docs/agent-context.md`, `README.md`, `docs/project-posture.md`, plus relevant memory catalog notes. Current traces show tool-observed context but do not persist the exact full system prompt sent to the model.