### PR TITLE
[codex] fix TUI chat observability logs

### DIFF
--- a/examples/programmatic-loop.ts
+++ b/examples/programmatic-loop.ts
@@ -106,6 +106,8 @@ function formatTraceEvent(event: TraceEvent): string {
   switch (event.type) {
     case 'run.started':
       return `[trace] run.started goal=${JSON.stringify(shorten(event.goal))}`;
+    case 'assistant.progress':
+      return `[trace] assistant.progress step=${event.step} kind=${event.kind} done=${event.done} text=${JSON.stringify(shorten(event.text))}`;
     case 'assistant.turn':
       return `[trace] assistant.turn step=${event.step} tools=${event.requestedTools ? event.toolCalls?.map((call) => call.tool).join(',') || 'yes' : 'none'} content=${JSON.stringify(shorten(event.content))}`;
     case 'host.warning':

--- a/src/__tests__/integration/chat/chat-runtime.test.ts
+++ b/src/__tests__/integration/chat/chat-runtime.test.ts
@@ -324,7 +324,7 @@ describe('executeAgentTurn final message persistence', () => {
 
     const runAgentLoopCall = runAgentLoopSpy.mock.calls.at(-1)?.[0];
     runAgentLoopSpy.mockRestore();
-    return { session, state, runAgentLoopCall };
+    return { session, state, runAgentLoopCall, logger };
   }
 
   it('persists one final assistant summary for done runs', async () => {
@@ -353,6 +353,12 @@ describe('executeAgentTurn final message persistence', () => {
     expect(runAgentLoopCall?.goal).toBe('inspect file with expanded mention contents');
     expect(session.messages.map((message) => message.text)).toEqual(['inspect @README.md', 'Done.']);
     expect(session.lastContinuePrompt).toBe('inspect file with expanded mention contents');
+  });
+
+  it('passes the TUI chat logger into the runtime loop', async () => {
+    const { logger, runAgentLoopCall } = await runTurn('done', 'Done.');
+
+    expect(runAgentLoopCall?.logger).toBe(logger);
   });
 
 
@@ -585,6 +591,7 @@ describe('conversation turn lifecycle', () => {
       prompt: 'Edit safely.',
       summary: 'Done.',
     }) as never);
+    const logger = createLogger({ level: 'silent', console: false });
     const policy: ToolApprovalPolicy = () => ({ type: 'allow', reason: 'test policy' });
     const requestToolApproval = vi.fn(async () => ({ approved: true, reason: 'approved by host' }));
 
@@ -596,6 +603,7 @@ describe('conversation turn lifecycle', () => {
       sessionId: storage.sessionId,
       prompt: 'Edit safely.',
       apiKey: 'explicit-key',
+      logger,
       memoryMaintenanceMode: 'none',
       approvalPolicies: [policy],
       host: {
@@ -606,6 +614,7 @@ describe('conversation turn lifecycle', () => {
     });
 
     const runOptions = loopSpy.mock.calls[0]?.[0];
+    expect(runOptions?.logger).toBe(logger);
     expect(runOptions?.approvalPolicies).toEqual([policy]);
     const call: ToolCall = { id: 'call-1', tool: 'edit_file', input: { path: 'README.md' } };
     const tool: ToolDefinition = {

--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -1,7 +1,8 @@
 import { mkdir, mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import type { Logger } from 'pino';
+import { describe, expect, it, vi } from 'vitest';
 import { runAgentLoop } from '../../../core/runtime/agent-loop.js';
 import { createAgentLoopCheckpoint, getHistoryFromAgentLoopCheckpoint, getHistoryFromAgentLoopState } from '../../../core/runtime/events.js';
 import { createDefaultAgentTools } from '../../../core/runtime/default-tools.js';
@@ -187,6 +188,47 @@ describe('runAgentLoop', () => {
       text: 'Thinking: Inspecting the request before choosing tools.',
       done: false,
     }));
+  });
+
+  it('logs streamed reasoning summaries for live run diagnostics', async () => {
+    const logger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger;
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: true,
+          parallelToolCalls: true,
+        },
+      },
+      async chat(_messages, _tools, _signal, onStreamEvent): Promise<LlmResponse> {
+        onStreamEvent?.({ type: 'reasoning_summary.done', text: 'Checking current files before editing.' });
+        return { content: 'Done.' };
+      },
+    };
+
+    await runAgentLoop({
+      goal: 'Say hello.',
+      llm: fakeLlm,
+      tools: [],
+      includeDefaultTools: false,
+      maxSteps: 1,
+      logger,
+    });
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Thinking: Checking current files before editing.',
+      }),
+      'Assistant stream update',
+    );
   });
 
   it('does not treat the workspace state directory as the OAuth credential store', async () => {

--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -149,6 +149,7 @@ describe('runAgentLoop', () => {
       step: 1,
       text: 'Hello',
       done: true,
+      kind: 'content',
     }));
   });
 
@@ -187,6 +188,7 @@ describe('runAgentLoop', () => {
       step: 1,
       text: 'Thinking: Inspecting the request before choosing tools.',
       done: false,
+      kind: 'reasoning_summary',
     }));
   });
 
@@ -223,8 +225,9 @@ describe('runAgentLoop', () => {
       logger,
     });
 
-    expect(logger.debug).toHaveBeenCalledWith(
+    expect(logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
+        kind: 'reasoning_summary',
         text: 'Thinking: Checking current files before editing.',
       }),
       'Assistant stream update',

--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -192,7 +192,7 @@ describe('runAgentLoop', () => {
     }));
   });
 
-  it('logs streamed reasoning summaries for live run diagnostics', async () => {
+  it('keeps assistant progress snapshots out of info logs', async () => {
     const logger = {
       info: vi.fn(),
       debug: vi.fn(),
@@ -225,10 +225,16 @@ describe('runAgentLoop', () => {
       logger,
     });
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.debug).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: 'reasoning_summary',
         text: 'Thinking: Checking current files before editing.',
+      }),
+      'Assistant stream update',
+    );
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'reasoning_summary',
       }),
       'Assistant stream update',
     );

--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
+import type { Logger } from 'pino';
 import { runAgent } from '../../../core/agent/run-agent.js';
 import type { ChatMessage, LlmAdapter, LlmResponse } from '../../../core/llm/types.js';
 import type { ToolDefinition } from '../../../core/types.js';
@@ -87,6 +88,66 @@ describe('runAgent', () => {
       content: 'The repo contains README.md and src/.',
       requestedTools: false,
     });
+  });
+
+  it('logs bounded tool inputs and results for live debugging', async () => {
+    const logger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger;
+    const seenMessages: ChatMessage[][] = [];
+    const fakeLlm: LlmAdapter = {
+      async chat(messages): Promise<LlmResponse> {
+        seenMessages.push(messages);
+
+        if (seenMessages.length === 1) {
+          return {
+            content: 'I will inspect the repo first.',
+            toolCalls: [{ id: 'call-1', tool: 'list_files', input: { path: '.' } }],
+          };
+        }
+
+        return { content: 'Done.' };
+      },
+    };
+    const listFilesTool: ToolDefinition = {
+      name: 'list_files',
+      description: 'Lists files in a directory',
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        return { ok: true, output: 'README.md\nsrc/' };
+      },
+    };
+
+    await runAgent({
+      goal: 'Inspect this repo.',
+      llm: fakeLlm,
+      tools: [listFilesTool],
+      maxSteps: 3,
+      logger,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        step: 1,
+        tool: 'list_files',
+        toolCallId: 'call-1',
+        input: '{"path":"."}',
+      }),
+      'Executing tool',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        step: 1,
+        tool: 'list_files',
+        toolCallId: 'call-1',
+        ok: true,
+        output: 'README.md\nsrc/',
+      }),
+      'Tool result',
+    );
   });
 
   it('records an error outcome when the LLM chat throws a non-abort error', async () => {

--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -330,6 +330,51 @@ describe('runAgent', () => {
       text: 'Hello world',
       done: true,
     });
+    expect(result.trace).toContainEqual(expect.objectContaining({
+      type: 'assistant.progress',
+      step: 1,
+      text: 'Hello world',
+      done: true,
+      kind: 'content',
+    }));
+  });
+
+  it('records coalesced reasoning progress snapshots instead of every reasoning delta', async () => {
+    const streamUpdates: Array<{ text: string; done: boolean; kind: string }> = [];
+    const fakeLlm: LlmAdapter = {
+      async chat(_messages, _tools, _signal, onStreamEvent): Promise<LlmResponse> {
+        for (const delta of ['Inspecting', ' the', ' current', ' files', ' before', ' editing']) {
+          onStreamEvent?.({ type: 'reasoning_summary.delta', delta });
+        }
+        onStreamEvent?.({ type: 'reasoning_summary.done', text: 'Inspecting the current files before editing.' });
+        return {
+          content: 'Done.',
+        };
+      },
+    };
+
+    const result = await runAgent({
+      goal: 'Work carefully.',
+      llm: fakeLlm,
+      tools: [],
+      maxSteps: 1,
+      logger: silentLogger,
+      onAssistantStream: (update) => {
+        streamUpdates.push(update);
+      },
+    });
+
+    const progressEvents = result.trace.filter((event) => event.type === 'assistant.progress');
+    expect(result.outcome).toBe('done');
+    expect(streamUpdates).toHaveLength(2);
+    expect(progressEvents).toHaveLength(2);
+    expect(progressEvents.at(-1)).toMatchObject({
+      type: 'assistant.progress',
+      step: 1,
+      text: 'Thinking: Inspecting the current files before editing.',
+      done: false,
+      kind: 'reasoning_summary',
+    });
   });
 
   it('allows one repeated identical tool call, then blocks excessive repetition', async () => {

--- a/src/__tests__/unit/core/chat-turn-persistence.test.ts
+++ b/src/__tests__/unit/core/chat-turn-persistence.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp } from 'node:fs/promises';
+import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { createChatTurnPersistenceArtifacts } from '../../../core/chat/engine/turns/result.js';
+import { createLiveTraceWriter } from '../../../core/chat/engine/turns/trace.js';
 import { loadChatSessions, saveChatSessions } from '../../../core/chat/engine/sessions/storage.js';
 import { persistCompletedChatTurn } from '../../../core/chat/engine/turns/persistence.js';
 import { createTraceSummarizerRegistry } from '../../../core/observability/trace-summarizers.js';
@@ -11,6 +12,44 @@ import type { ChatSession } from '../../../core/chat/types.js';
 import type { RunResult } from '../../../core/types.js';
 
 describe('chat turn persistence', () => {
+  it('writes live trace snapshots before final turn persistence', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-live-trace-'));
+    const writer = createLiveTraceWriter(join(stateRoot, 'traces'));
+
+    writer.record({
+      type: 'assistant.progress',
+      kind: 'reasoning_summary',
+      text: 'Thinking: Inspecting project context.',
+      done: false,
+      step: 1,
+      timestamp: '2026-05-02T00:00:00.000Z',
+    });
+
+    await expect(readTraceFile(writer.traceFile)).resolves.toEqual([
+      expect.objectContaining({
+        type: 'assistant.progress',
+        text: 'Thinking: Inspecting project context.',
+      }),
+    ]);
+
+    writer.replace([
+      {
+        type: 'run.finished',
+        outcome: 'done',
+        summary: 'Done.',
+        step: 1,
+        timestamp: '2026-05-02T00:00:01.000Z',
+      },
+    ]);
+
+    await expect(readTraceFile(writer.traceFile)).resolves.toEqual([
+      expect.objectContaining({
+        type: 'run.finished',
+        outcome: 'done',
+      }),
+    ]);
+  });
+
   it('uses a supplied trace summarizer registry for persisted turn events', async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-turn-persistence-'));
     const session = createSession();
@@ -136,4 +175,8 @@ function createSession(): ChatSession {
     createdAt: '2026-05-02T00:00:00.000Z',
     updatedAt: '2026-05-02T00:00:00.000Z',
   };
+}
+
+async function readTraceFile(path: string): Promise<unknown[]> {
+  return JSON.parse(await readFile(path, 'utf8')) as unknown[];
 }

--- a/src/__tests__/unit/core/chat-turn-persistence.test.ts
+++ b/src/__tests__/unit/core/chat-turn-persistence.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { createChatTurnPersistenceArtifacts } from '../../../core/chat/engine/turns/result.js';
-import { createLiveTraceWriter } from '../../../core/chat/engine/turns/trace.js';
+import { compactTraceForPersistence, createLiveTraceWriter } from '../../../core/chat/engine/turns/trace.js';
 import { loadChatSessions, saveChatSessions } from '../../../core/chat/engine/sessions/storage.js';
 import { persistCompletedChatTurn } from '../../../core/chat/engine/turns/persistence.js';
 import { createTraceSummarizerRegistry } from '../../../core/observability/trace-summarizers.js';
@@ -19,10 +19,18 @@ describe('chat turn persistence', () => {
     writer.record({
       type: 'assistant.progress',
       kind: 'reasoning_summary',
-      text: 'Thinking: Inspecting project context.',
+      text: 'Thinking: Inspecting',
       done: false,
       step: 1,
       timestamp: '2026-05-02T00:00:00.000Z',
+    });
+    writer.record({
+      type: 'assistant.progress',
+      kind: 'reasoning_summary',
+      text: 'Thinking: Inspecting project context.',
+      done: false,
+      step: 1,
+      timestamp: '2026-05-02T00:00:00.500Z',
     });
 
     await expect(readTraceFile(writer.traceFile)).resolves.toEqual([
@@ -46,6 +54,53 @@ describe('chat turn persistence', () => {
       expect.objectContaining({
         type: 'run.finished',
         outcome: 'done',
+      }),
+    ]);
+  });
+
+  it('compacts consecutive assistant progress snapshots before saving the final trace', async () => {
+    expect(compactTraceForPersistence([
+      {
+        type: 'assistant.progress',
+        kind: 'reasoning_summary',
+        text: 'Thinking: Inspecting',
+        done: false,
+        step: 1,
+        timestamp: '2026-05-02T00:00:00.000Z',
+      },
+      {
+        type: 'assistant.progress',
+        kind: 'reasoning_summary',
+        text: 'Thinking: Inspecting project context.',
+        done: false,
+        step: 1,
+        timestamp: '2026-05-02T00:00:00.500Z',
+      },
+      {
+        type: 'tool.call',
+        call: { id: 'call-1', tool: 'read_file', input: { path: 'README.md' } },
+        step: 1,
+        timestamp: '2026-05-02T00:00:01.000Z',
+      },
+      {
+        type: 'assistant.progress',
+        kind: 'reasoning_summary',
+        text: 'Thinking: Summarizing findings.',
+        done: false,
+        step: 2,
+        timestamp: '2026-05-02T00:00:02.000Z',
+      },
+    ])).toEqual([
+      expect.objectContaining({
+        type: 'assistant.progress',
+        text: 'Thinking: Inspecting project context.',
+      }),
+      expect.objectContaining({
+        type: 'tool.call',
+      }),
+      expect.objectContaining({
+        type: 'assistant.progress',
+        text: 'Thinking: Summarizing findings.',
       }),
     ]);
   });

--- a/src/__tests__/unit/core/trace-format.test.ts
+++ b/src/__tests__/unit/core/trace-format.test.ts
@@ -44,6 +44,7 @@ describe('formatTraceForConsole', () => {
         type: 'assistant.turn',
         content: 'I need to inspect the environment before answering.',
         diagnostics: {
+          rationale: 'I should inspect before making a claim.',
           missing: ['Need the current directory contents'],
           wantedTools: ['list_files'],
           wantedInputs: ['path=.'],
@@ -55,6 +56,7 @@ describe('formatTraceForConsole', () => {
       },
     ]);
 
+    expect(output).toContain('Rationale: I should inspect before making a claim.');
     expect(output).toContain('Missing: Need the current directory contents');
     expect(output).toContain('Wanted Tools: list_files');
     expect(output).toContain('Wanted Inputs: path=.');

--- a/src/cli/chat/hooks/tui-ordinary-turn.ts
+++ b/src/cli/chat/hooks/tui-ordinary-turn.ts
@@ -1,3 +1,4 @@
+import type { Logger } from 'pino';
 import type { RunResult } from '../../../index.js';
 import { runConversationTurn } from '../../../core/chat/engine/turns/run-conversation-turn.js';
 import type { ChatSession } from '../state/types.js';
@@ -18,6 +19,7 @@ export async function executeTuiOrdinaryTurn(args: {
   displayText?: string;
   sessionId: string;
   runtime: ChatRuntimeConfig;
+  logger: Logger;
   state: ActionState;
   updateSessionById: SessionUpdater;
   parsePlanState: ParsePlanState;
@@ -33,6 +35,7 @@ export async function executeTuiOrdinaryTurn(args: {
     displayText,
     sessionId,
     runtime,
+    logger,
     state,
     updateSessionById,
     parsePlanState,
@@ -80,6 +83,7 @@ export async function executeTuiOrdinaryTurn(args: {
     preferApiKey: runtime.preferApiKey,
     credentialStorePath: runtime.credentialStorePath,
     systemContext: runtime.systemContext,
+    logger,
     memoryMaintenanceMode: 'background',
     host: {
       events: {

--- a/src/cli/chat/hooks/useAgentRun.ts
+++ b/src/cli/chat/hooks/useAgentRun.ts
@@ -297,6 +297,7 @@ export async function executeAgentTurn(args: ExecuteTurnArgs): Promise<RunResult
       displayText,
       sessionId,
       runtime,
+      logger,
       state,
       updateSessionById,
       parsePlanState: parsePlanStateFromToolResult,

--- a/src/core/agent/run-agent.ts
+++ b/src/core/agent/run-agent.ts
@@ -38,13 +38,22 @@ export type RunAgentOptions = {
   history?: ChatMessage[];
   systemContext?: string;
   onEvent?: (event: TraceEvent) => void;
-  onAssistantStream?: (update: { step: number; text: string; done: boolean }) => void;
+  onAssistantStream?: (update: AssistantStreamUpdate) => void;
   onToolCalling?: (call: ToolCall, step: number, toolDef: ToolDefinition) => void;
   onToolCompleted?: (call: ToolCall, result: ToolResult, step: number, durationMs: number) => void;
   approvalPolicies?: ToolApprovalPolicy[];
   approveToolCall?: (call: ToolCall, tool: ToolDefinition) => Promise<{ approved: boolean; reason?: string }>;
   shouldStop?: () => boolean;
   abortSignal?: AbortSignal;
+};
+
+export type AssistantStreamKind = 'content' | 'reasoning_summary';
+
+export type AssistantStreamUpdate = {
+  step: number;
+  text: string;
+  done: boolean;
+  kind: AssistantStreamKind;
 };
 
 type RunState = {
@@ -231,18 +240,18 @@ async function requestModelTurn(context: RunContext): Promise<LlmResponse | RunR
           const nowMs = Date.now();
           if (nowMs - lastStreamRecordAt < STREAM_UPDATE_INTERVAL_MS) {
             streamedContent += event.delta;
-            context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: false });
+            context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: false, kind: 'content' });
             return;
           }
           lastStreamRecordAt = nowMs;
           streamedContent += event.delta;
-          context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: false });
+          context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: false, kind: 'content' });
           return;
         }
 
         if (event.type === 'content.done') {
           streamedContent = event.content;
-          context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: true });
+          context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: true, kind: 'content' });
           return;
         }
 
@@ -253,6 +262,7 @@ async function requestModelTurn(context: RunContext): Promise<LlmResponse | RunR
               step: context.state.step,
               text: formatReasoningSummaryStream(streamedReasoningSummary),
               done: false,
+              kind: 'reasoning_summary',
             });
           }
           return;
@@ -265,6 +275,7 @@ async function requestModelTurn(context: RunContext): Promise<LlmResponse | RunR
               step: context.state.step,
               text: formatReasoningSummaryStream(streamedReasoningSummary),
               done: false,
+              kind: 'reasoning_summary',
             });
           }
         }

--- a/src/core/agent/run-agent.ts
+++ b/src/core/agent/run-agent.ts
@@ -25,7 +25,7 @@ import type { ToolApprovalPolicy } from '../approvals/types.js';
 const PLAN_ITEM_STATUSES = new Set<PlanItem['status']>(['pending', 'in_progress', 'completed']);
 
 const DEFAULT_MAX_STEPS = 100;
-const STREAM_UPDATE_INTERVAL_MS = 75;
+const STREAM_UPDATE_INTERVAL_MS = 500;
 const INTERRUPTED_SUMMARY = 'Run interrupted by host request';
 
 export type RunAgentOptions = {
@@ -230,40 +230,55 @@ async function requestModelTurn(context: RunContext): Promise<LlmResponse | RunR
   try {
     let streamedContent = '';
     let streamedReasoningSummary = '';
-    let lastStreamRecordAt = 0;
+    let lastContentStreamRecordAt = 0;
+    let lastReasoningStreamRecordAt = 0;
+    const emitStreamProgress = (
+      kind: AssistantStreamKind,
+      text: string,
+      done: boolean,
+      options: { force?: boolean } = {},
+    ) => {
+      const nowMs = Date.now();
+      const lastStreamRecordAt = kind === 'content' ? lastContentStreamRecordAt : lastReasoningStreamRecordAt;
+      if (!options.force && nowMs - lastStreamRecordAt < STREAM_UPDATE_INTERVAL_MS) {
+        return;
+      }
+
+      if (kind === 'content') {
+        lastContentStreamRecordAt = nowMs;
+      } else {
+        lastReasoningStreamRecordAt = nowMs;
+      }
+
+      const update: AssistantStreamUpdate = { step: context.state.step, text, done, kind };
+      context.record({
+        type: 'assistant.progress',
+        ...update,
+        timestamp: context.now(),
+      });
+      context.onAssistantStream?.(update);
+    };
     const response = await context.llm.chat(
       context.messages,
       context.registry.list(),
       context.abortSignal,
       (event: LlmStreamEvent) => {
         if (event.type === 'content.delta') {
-          const nowMs = Date.now();
-          if (nowMs - lastStreamRecordAt < STREAM_UPDATE_INTERVAL_MS) {
-            streamedContent += event.delta;
-            context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: false, kind: 'content' });
-            return;
-          }
-          lastStreamRecordAt = nowMs;
           streamedContent += event.delta;
-          context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: false, kind: 'content' });
+          emitStreamProgress('content', streamedContent, false);
           return;
         }
 
         if (event.type === 'content.done') {
           streamedContent = event.content;
-          context.onAssistantStream?.({ step: context.state.step, text: streamedContent, done: true, kind: 'content' });
+          emitStreamProgress('content', streamedContent, true, { force: true });
           return;
         }
 
         if (event.type === 'reasoning_summary.delta') {
           streamedReasoningSummary += event.delta;
           if (!streamedContent) {
-            context.onAssistantStream?.({
-              step: context.state.step,
-              text: formatReasoningSummaryStream(streamedReasoningSummary),
-              done: false,
-              kind: 'reasoning_summary',
-            });
+            emitStreamProgress('reasoning_summary', formatReasoningSummaryStream(streamedReasoningSummary), false);
           }
           return;
         }
@@ -271,12 +286,7 @@ async function requestModelTurn(context: RunContext): Promise<LlmResponse | RunR
         if (event.type === 'reasoning_summary.done') {
           streamedReasoningSummary = event.text;
           if (!streamedContent) {
-            context.onAssistantStream?.({
-              step: context.state.step,
-              text: formatReasoningSummaryStream(streamedReasoningSummary),
-              done: false,
-              kind: 'reasoning_summary',
-            });
+            emitStreamProgress('reasoning_summary', formatReasoningSummaryStream(streamedReasoningSummary), false, { force: true });
           }
         }
       },

--- a/src/core/agent/tool-dispatch.ts
+++ b/src/core/agent/tool-dispatch.ts
@@ -12,6 +12,7 @@ import { defaultToolApprovalPolicies } from '../approvals/default-policies.js';
 import { resolveToolApproval } from '../approvals/policy-chain.js';
 import type { ToolApprovalPolicy } from '../approvals/types.js';
 import type { Logger } from 'pino';
+import { truncate } from '../utils/text.js';
 
 export async function maybeDenyToolCall(args: {
   call: ToolCall;
@@ -135,7 +136,12 @@ async function executeRecordedToolCall(
   },
 ): Promise<{ effectiveCall: ToolCall; result: Awaited<ReturnType<typeof executeTool>> }> {
   const { step, now, registry, seenToolCalls, record, log } = args;
-  log.info({ step, tool: call.tool }, 'Executing tool');
+  log.info({
+    step,
+    tool: call.tool,
+    toolCallId: call.id,
+    input: summarizeDiagnosticValue(call.input, 1_000),
+  }, 'Executing tool');
   record({ type: 'tool.call', call, step, timestamp: now() });
 
   const signature = `${call.tool}:${stableSerialize(normalizeToolInput(call.tool, call.input))}`;
@@ -149,9 +155,32 @@ async function executeRecordedToolCall(
 
   const result = await executeTool(registry, call);
   seenToolCalls.set(signature, seenCount + 1);
-  log.debug({ step, tool: call.tool, ok: result.ok }, 'Tool result');
+  log.info({
+    step,
+    tool: call.tool,
+    toolCallId: call.id,
+    ok: result.ok,
+    output: result.ok ? summarizeDiagnosticValue(result.output, 1_500) : undefined,
+    error: result.ok ? undefined : result.error,
+  }, 'Tool result');
   record({ type: 'tool.result', tool: call.tool, result, step, timestamp: now() });
   return { effectiveCall: call, result };
+}
+
+function summarizeDiagnosticValue(value: unknown, maxLength: number): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return truncate(value, maxLength);
+  }
+
+  try {
+    return truncate(JSON.stringify(value), maxLength);
+  } catch {
+    return truncate(String(value), maxLength);
+  }
 }
 
 function getInspectFallbackReason(

--- a/src/core/chat/engine/turns/persistence.ts
+++ b/src/core/chat/engine/turns/persistence.ts
@@ -17,6 +17,7 @@ export type PersistCompletedChatTurnArgs = {
   model: string;
   stateRoot: string;
   traceDir: string;
+  traceFile?: string;
   systemContext?: string;
   toolNames: string[];
   historyForTokenEstimate: ChatMessage[];
@@ -33,6 +34,7 @@ export async function persistCompletedChatTurn(args: PersistCompletedChatTurnArg
     model: args.model,
     stateRoot: args.stateRoot,
     traceDir: args.traceDir,
+    traceFile: args.traceFile,
     systemContext: args.systemContext,
     toolNames: args.toolNames,
     historyForTokenEstimate: args.historyForTokenEstimate,

--- a/src/core/chat/engine/turns/result.ts
+++ b/src/core/chat/engine/turns/result.ts
@@ -22,6 +22,7 @@ export type PersistChatTurnResultArgs = {
   model: string;
   stateRoot: string;
   traceDir: string;
+  traceFile?: string;
   systemContext?: string;
   toolNames: string[];
   historyForTokenEstimate: ChatMessage[];
@@ -57,7 +58,7 @@ export async function createChatTurnPersistenceArtifacts(
     summarizer: args.summarizer,
     onStatusChange: (event) => args.onCompactionStatus?.(event, args.result.transcript),
   });
-  const traceFile = saveTrace(args.traceDir, args.result.trace);
+  const traceFile = saveTrace(args.traceDir, args.result.trace, { traceFile: args.traceFile });
   const turn: TurnSummary = {
     id: args.createTurnId(),
     prompt: args.prompt,

--- a/src/core/chat/engine/turns/run-conversation-turn.ts
+++ b/src/core/chat/engine/turns/run-conversation-turn.ts
@@ -8,6 +8,7 @@ import { createChatTurnHostBridge } from './host-bridge.js';
 import { prepareChatSessionTurn } from './preflight.js';
 import { runInlineTurnMemoryMaintenance, scheduleBackgroundTurnMemoryMaintenance } from './memory-maintenance.js';
 import { persistCompletedChatTurn } from './persistence.js';
+import { createLiveTraceWriter } from './trace.js';
 import { releaseSessionLease, type ChatSessionLeaseOwner } from '../sessions/lease.js';
 import { loadChatSessions, saveChatSessions, touchSession } from '../sessions/storage.js';
 import type { ChatTurnHostPort } from './host-bridge.js';
@@ -79,6 +80,7 @@ export async function runConversationTurn(args: RunConversationTurnArgs): Promis
       throw new Error(preflight.message);
     }
 
+    const liveTrace = createLiveTraceWriter(args.traceDir);
     const result = await runAgentLoop({
       goal: args.prompt,
       model: runtime.model,
@@ -93,7 +95,10 @@ export async function runConversationTurn(args: RunConversationTurnArgs): Promis
       systemContext: runtime.systemContext,
       logger: args.logger,
       onAssistantStream: args.onAssistantStream,
-      onTraceEvent: args.onTraceEvent,
+      onTraceEvent: (event) => {
+        liveTrace.record(event);
+        args.onTraceEvent?.(event);
+      },
       onEvent: hostBridge.onAgentLoopEvent,
       approvalPolicies: args.approvalPolicies,
       approveToolCall: hostBridge.approveToolCall,
@@ -121,6 +126,7 @@ export async function runConversationTurn(args: RunConversationTurnArgs): Promis
       model: runtime.model,
       stateRoot: args.stateRoot,
       traceDir: args.traceDir,
+      traceFile: liveTrace.traceFile,
       systemContext: runtime.systemContext,
       toolNames,
       historyForTokenEstimate: session.history,

--- a/src/core/chat/engine/turns/run-conversation-turn.ts
+++ b/src/core/chat/engine/turns/run-conversation-turn.ts
@@ -1,3 +1,4 @@
+import type { Logger } from 'pino';
 import { runAgentLoop } from '../../../runtime/agent-loop.js';
 import type { ToolApprovalPolicy } from '../../../approvals/types.js';
 import type { TraceSummarizerRegistry } from '../../../observability/trace-summarizers.js';
@@ -26,6 +27,7 @@ export type RunConversationTurnArgs = {
   host?: ChatTurnHostPort;
   approvalPolicies?: ToolApprovalPolicy[];
   traceSummarizerRegistry?: TraceSummarizerRegistry;
+  logger?: Logger;
   onCompactionStatus?: (event: ConversationCompactionStatus) => void;
   onAssistantStream?: Parameters<typeof runAgentLoop>[0]['onAssistantStream'];
   onTraceEvent?: Parameters<typeof runAgentLoop>[0]['onTraceEvent'];
@@ -89,6 +91,7 @@ export async function runConversationTurn(args: RunConversationTurnArgs): Promis
       includeDefaultTools: false,
       history: preflight.historyForRun,
       systemContext: runtime.systemContext,
+      logger: args.logger,
       onAssistantStream: args.onAssistantStream,
       onTraceEvent: args.onTraceEvent,
       onEvent: hostBridge.onAgentLoopEvent,

--- a/src/core/chat/engine/turns/trace.ts
+++ b/src/core/chat/engine/turns/trace.ts
@@ -2,9 +2,36 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { TraceEvent } from '../../../types.js';
 
-export function saveTrace(traceDir: string, trace: TraceEvent[]): string {
+export type SaveTraceOptions = {
+  traceFile?: string;
+};
+
+export type LiveTraceWriter = {
+  traceFile: string;
+  record: (event: TraceEvent) => void;
+  replace: (trace: TraceEvent[]) => string;
+};
+
+export function saveTrace(traceDir: string, trace: TraceEvent[], options: SaveTraceOptions = {}): string {
   mkdirSync(traceDir, { recursive: true });
-  const traceFile = join(traceDir, `trace-${Date.now()}.json`);
+  const traceFile = options.traceFile ?? join(traceDir, `trace-${Date.now()}.json`);
   writeFileSync(traceFile, JSON.stringify(trace, null, 2));
   return traceFile;
+}
+
+export function createLiveTraceWriter(traceDir: string): LiveTraceWriter {
+  const traceFile = saveTrace(traceDir, []);
+  const events: TraceEvent[] = [];
+
+  return {
+    traceFile,
+    record(event) {
+      events.push(event);
+      saveTrace(traceDir, events, { traceFile });
+    },
+    replace(trace) {
+      events.splice(0, events.length, ...trace);
+      return saveTrace(traceDir, events, { traceFile });
+    },
+  };
 }

--- a/src/core/chat/engine/turns/trace.ts
+++ b/src/core/chat/engine/turns/trace.ts
@@ -15,7 +15,7 @@ export type LiveTraceWriter = {
 export function saveTrace(traceDir: string, trace: TraceEvent[], options: SaveTraceOptions = {}): string {
   mkdirSync(traceDir, { recursive: true });
   const traceFile = options.traceFile ?? join(traceDir, `trace-${Date.now()}.json`);
-  writeFileSync(traceFile, JSON.stringify(trace, null, 2));
+  writeFileSync(traceFile, JSON.stringify(compactTraceForPersistence(trace), null, 2));
   return traceFile;
 }
 
@@ -34,4 +34,29 @@ export function createLiveTraceWriter(traceDir: string): LiveTraceWriter {
       return saveTrace(traceDir, events, { traceFile });
     },
   };
+}
+
+export function compactTraceForPersistence(trace: TraceEvent[]): TraceEvent[] {
+  const compacted: TraceEvent[] = [];
+
+  for (const event of trace) {
+    if (event.type !== 'assistant.progress') {
+      compacted.push(event);
+      continue;
+    }
+
+    const previous = compacted.at(-1);
+    if (
+      previous?.type === 'assistant.progress'
+      && previous.step === event.step
+      && previous.kind === event.kind
+    ) {
+      compacted[compacted.length - 1] = event;
+      continue;
+    }
+
+    compacted.push(event);
+  }
+
+  return compacted;
 }

--- a/src/core/observability/conversation-activity.ts
+++ b/src/core/observability/conversation-activity.ts
@@ -71,6 +71,7 @@ type CompactionProjectorMap = {
 
 const traceProjectors: TraceProjectorMap = {
   'run.started': (event) => [{ type: 'run.started', ...traceCorrelation(event) }],
+  'assistant.progress': () => [],
   'assistant.turn': (event) => [{
     type: 'assistant.turn',
     requestedTools: event.requestedTools,

--- a/src/core/observability/trace-summarizers.ts
+++ b/src/core/observability/trace-summarizers.ts
@@ -28,6 +28,7 @@ export type TraceSummarizerRegistry = {
 
 export const DEFAULT_TRACE_SUMMARIZERS: TraceSummarizerMap = {
   'run.started': () => undefined,
+  'assistant.progress': () => undefined,
   'assistant.turn': (event) => [
     ...(event.diagnostics?.rationale ? [`reasoning: ${truncate(event.diagnostics.rationale, 140)}`] : []),
     event.requestedTools ?

--- a/src/core/runtime/agent-loop.ts
+++ b/src/core/runtime/agent-loop.ts
@@ -126,9 +126,10 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<AgentL
     history: resolveHistory(options),
     systemContext: options.systemContext,
     onAssistantStream: (update) => {
-      logger.debug({
+      logger.info({
         runId,
         step: update.step,
+        kind: update.kind,
         done: update.done,
         text: truncate(update.text, 500),
       }, 'Assistant stream update');
@@ -208,7 +209,7 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<AgentL
 
 function logTraceEvent(logger: Logger, runId: string, event: TraceEvent) {
   if (event.type === 'assistant.turn') {
-    logger.debug({
+    logger.info({
       runId,
       step: event.step,
       requestedTools: event.requestedTools,

--- a/src/core/runtime/agent-loop.ts
+++ b/src/core/runtime/agent-loop.ts
@@ -8,6 +8,7 @@ import type { RunAgentOptions } from '../agent/run-agent.js';
 import type { RunResult, ToolCall, ToolDefinition, TraceEvent } from '../types.js';
 import type { ToolApprovalPolicy } from '../approvals/types.js';
 import { createLogger } from '../utils/logger.js';
+import { truncate } from '../utils/text.js';
 import {
   resolveApiKeyForModel,
   resolveProviderCredentialSourceForModel,
@@ -125,6 +126,12 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<AgentL
     history: resolveHistory(options),
     systemContext: options.systemContext,
     onAssistantStream: (update) => {
+      logger.debug({
+        runId,
+        step: update.step,
+        done: update.done,
+        text: truncate(update.text, 500),
+      }, 'Assistant stream update');
       options.onEvent?.({
         type: 'assistant.stream',
         runId,
@@ -134,6 +141,7 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<AgentL
       options.onAssistantStream?.(update);
     },
     onEvent: (event) => {
+      logTraceEvent(logger, runId, event);
       options.onEvent?.({ type: 'trace', runId, event, timestamp: now() });
       options.onTraceEvent?.(event);
     },
@@ -196,6 +204,29 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<AgentL
     workspaceRoot,
     state,
   };
+}
+
+function logTraceEvent(logger: Logger, runId: string, event: TraceEvent) {
+  if (event.type === 'assistant.turn') {
+    logger.debug({
+      runId,
+      step: event.step,
+      requestedTools: event.requestedTools,
+      toolCalls: event.toolCalls?.map((call) => call.tool),
+      content: event.content ? truncate(event.content, 500) : undefined,
+      rationale: event.diagnostics?.rationale ? truncate(event.diagnostics.rationale, 500) : undefined,
+    }, 'Trace assistant turn');
+    return;
+  }
+
+  if (event.type === 'run.finished') {
+    logger.info({
+      runId,
+      step: event.step,
+      outcome: event.outcome,
+      summary: truncate(event.summary, 500),
+    }, 'Agent run finished');
+  }
 }
 
 function resolveHistory(options: Pick<RunAgentLoopOptions, 'history' | 'resumeFrom'>): ChatMessage[] | undefined {

--- a/src/core/runtime/agent-loop.ts
+++ b/src/core/runtime/agent-loop.ts
@@ -126,13 +126,14 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<AgentL
     history: resolveHistory(options),
     systemContext: options.systemContext,
     onAssistantStream: (update) => {
-      logger.info({
+      const logStreamUpdate = update.done ? logger.info.bind(logger) : logger.debug.bind(logger);
+      logStreamUpdate({
         runId,
         step: update.step,
         kind: update.kind,
         done: update.done,
         text: truncate(update.text, 500),
-      }, 'Assistant stream update');
+      }, update.done ? 'Assistant stream complete' : 'Assistant stream update');
       options.onEvent?.({
         type: 'assistant.stream',
         runId,

--- a/src/core/runtime/events.ts
+++ b/src/core/runtime/events.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, LlmProvider, LlmUsage } from '../llm/types.js';
+import type { AssistantStreamKind } from '../agent/run-agent.js';
 import type { RunResult, StopReason, TraceEvent } from '../types.js';
 
 export type AgentLoopStatus = 'finished';
@@ -54,6 +55,7 @@ export type AgentLoopEvent =
       step: number;
       text: string;
       done: boolean;
+      kind: AssistantStreamKind;
       timestamp: string;
     }
   | {

--- a/src/core/trace/format.ts
+++ b/src/core/trace/format.ts
@@ -31,6 +31,14 @@ export function formatTraceForConsole(trace: TraceEvent[]): string {
         );
         break;
 
+      case 'assistant.progress':
+        lines.push(
+          `${COLORS.magenta}  [step ${event.step}]${COLORS.reset} ${COLORS.bold}Assistant Progress:${COLORS.reset} ${event.kind}${event.done ? ' done' : ''}`,
+          `  ${truncate(event.text, 500)}`,
+          '',
+        );
+        break;
+
       case 'assistant.turn': {
         const requestedToolNames = event.toolCalls?.map((call) => call.tool) ?? [];
         lines.push(

--- a/src/core/trace/format.ts
+++ b/src/core/trace/format.ts
@@ -48,6 +48,9 @@ export function formatTraceForConsole(trace: TraceEvent[]): string {
             `  Requested Tools: ${requestedToolNames.join(', ')} (${requestedToolNames.length})`,
           );
         }
+        if (event.diagnostics?.rationale) {
+          lines.push(`  Rationale: ${truncate(event.diagnostics.rationale, 500)}`);
+        }
         if (event.diagnostics?.missing?.length) {
           lines.push(`  Missing: ${event.diagnostics.missing.join('; ')}`);
         }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -63,6 +63,14 @@ export type StopReason = 'done' | 'max_steps' | 'error' | 'interrupted';
 export type TraceEvent =
   | { type: 'run.started'; goal: string; timestamp: string }
   | {
+      type: 'assistant.progress';
+      kind: 'content' | 'reasoning_summary';
+      text: string;
+      done: boolean;
+      step: number;
+      timestamp: string;
+    }
+  | {
       type: 'assistant.turn';
       content: string;
       requestedTools: boolean;


### PR DESCRIPTION
## Summary

This fixes the TUI chat observability gap that left `.heddle/logs/chat-*.log` empty during agent runs.

## Root Cause

The TUI created a per-session logger, but the shared conversation-turn path did not pass that logger into `runAgentLoop`. Normal runtime, streaming, and assistant-turn diagnostics were therefore visible only through live UI and end-of-turn traces, not the chat log.

## Changes

- Pass the TUI chat logger through `executeTuiOrdinaryTurn` and `runConversationTurn` into `runAgentLoop`.
- Log streamed assistant/reasoning updates while the run is active.
- Log assistant-turn content/rationale previews and run completion metadata.
- Render assistant rationale in console trace formatting.
- Add regression coverage for logger wiring, streamed reasoning logging, and rationale rendering.

## Validation

- `yarn test src/__tests__/integration/core/agent-loop.test.ts`
- `yarn test src/__tests__/integration/chat/chat-runtime.test.ts`
- `yarn test src/__tests__/unit/core/trace-format.test.ts`
- `yarn build`
- `git diff --check`