### PR TITLE
feat awareness add extensible project signal detection

### DIFF
--- a/src/__tests__/integration/awareness/project-dashboard.test.ts
+++ b/src/__tests__/integration/awareness/project-dashboard.test.ts
@@ -37,6 +37,16 @@ describe('coding project dashboard awareness', () => {
           ]),
         }),
       }),
+      expect.objectContaining({
+        type: 'project_signals',
+        data: expect.objectContaining({
+          detectedProjects: [],
+        }),
+      }),
+      expect.objectContaining({
+        type: 'inspection_surfaces',
+        data: [],
+      }),
     ]));
     expect(snapshot.limits).toEqual(expect.arrayContaining([]));
   });
@@ -202,7 +212,18 @@ describe('coding project dashboard awareness', () => {
     const root = createGitWorkspace();
     const realRoot = realpathSync(root);
     writeFileSync(join(root, 'README.md'), 'hello\nworld\nmodified\n');
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'awareness-test',
+      scripts: {
+        build: 'tsc -p tsconfig.json',
+        lint: 'eslint .',
+        dev: 'vite',
+      },
+    }, null, 2));
+    writeFileSync(join(root, 'yarn.lock'), '# lockfile\n');
     mkdirSync(join(root, 'src'), { recursive: true });
+    mkdirSync(join(root, 'docs'), { recursive: true });
+    mkdirSync(join(root, 'scripts'), { recursive: true });
     writeFileSync(join(root, 'src', 'main.ts'), 'export const main = true;\n');
 
     const tool = createProjectDashboardTool({ workspaceRoot: root });
@@ -223,10 +244,166 @@ describe('coding project dashboard awareness', () => {
             expect.objectContaining({ path: 'README.md', kind: 'file' }),
           ]),
         }),
+        project_signals: expect.objectContaining({
+          detectedProjects: [
+            expect.objectContaining({
+              kind: 'javascript',
+              manifests: [
+                expect.objectContaining({ kind: 'package_json', path: 'package.json' }),
+              ],
+              lockfiles: [
+                expect.objectContaining({ kind: 'yarn_lock', path: 'yarn.lock' }),
+              ],
+              verificationSurfaces: [
+                expect.objectContaining({
+                  kind: 'script_names',
+                  label: 'package.json verification scripts',
+                  scriptNames: ['build', 'lint'],
+                }),
+              ],
+            }),
+          ],
+        }),
+        inspection_surfaces: expect.arrayContaining([
+          expect.objectContaining({ kind: 'manifest', paths: ['package.json'] }),
+          expect.objectContaining({ kind: 'directory', role: 'source', paths: ['src'] }),
+          expect.objectContaining({ kind: 'directory', role: 'docs', paths: ['docs'] }),
+          expect.objectContaining({ kind: 'directory', role: 'scripts', paths: ['scripts'] }),
+          expect.objectContaining({ kind: 'verification_surface', labels: ['package.json verification scripts'] }),
+        ]),
       },
       sources: expect.any(Array),
       limits: expect.any(Array),
     });
+  });
+
+  it('collects javascript project signals and inspection surfaces from package metadata and observed directories', async () => {
+    const root = createGitWorkspace();
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'awareness-test',
+      scripts: {
+        build: 'tsc -p tsconfig.json',
+        lint: 'eslint .',
+        dev: 'vite',
+        test: 'vitest run',
+      },
+    }, null, 2));
+    writeFileSync(join(root, 'yarn.lock'), '# lockfile\n');
+    writeFileSync(join(root, 'tsconfig.json'), '{}\n');
+    mkdirSync(join(root, 'src'), { recursive: true });
+    mkdirSync(join(root, 'tests'), { recursive: true });
+    mkdirSync(join(root, 'docs'), { recursive: true });
+    mkdirSync(join(root, 'examples'), { recursive: true });
+    mkdirSync(join(root, 'scripts'), { recursive: true });
+
+    const snapshot = await collectProjectDashboard(root);
+    const signals = snapshot.sections.find((section) => section.type === 'project_signals');
+    const surfaces = snapshot.sections.find((section) => section.type === 'inspection_surfaces');
+
+    expect(signals?.data).toEqual(expect.objectContaining({
+      detectedProjects: [
+        expect.objectContaining({
+          kind: 'javascript',
+          manifests: [
+            expect.objectContaining({ kind: 'package_json', path: 'package.json' }),
+          ],
+          lockfiles: [
+            expect.objectContaining({ kind: 'yarn_lock', path: 'yarn.lock' }),
+          ],
+          verificationSurfaces: [
+            expect.objectContaining({
+              kind: 'script_names',
+              label: 'package.json verification scripts',
+              scriptNames: ['build', 'lint', 'test'],
+            }),
+          ],
+        }),
+      ],
+      observedDirectories: expect.objectContaining({
+        source: ['src'],
+        tests: ['tests'],
+        docs: ['docs'],
+        examples: ['examples'],
+        scripts: ['scripts'],
+      }),
+      configFiles: ['tsconfig.json'],
+    }));
+    expect(surfaces?.data).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'manifest', paths: ['package.json'] }),
+      expect.objectContaining({ kind: 'directory', role: 'source', paths: ['src'] }),
+      expect.objectContaining({ kind: 'directory', role: 'tests', paths: ['tests'] }),
+      expect.objectContaining({ kind: 'config_file', paths: ['tsconfig.json'] }),
+      expect.objectContaining({ kind: 'verification_surface', labels: ['package.json verification scripts'] }),
+    ]));
+  });
+
+  it('collects python and go signals through bounded detectors instead of javascript-specific fields', async () => {
+    const root = createGitWorkspace();
+    writeFileSync(join(root, 'pyproject.toml'), [
+      '[project]',
+      'name = "py-go-workspace"',
+      '',
+      '[tool.pytest.ini_options]',
+      'addopts = "-q"',
+      '',
+      '[tool.ruff]',
+      'line-length = 100',
+      '',
+    ].join('\n'));
+    writeFileSync(join(root, 'go.mod'), 'module example.com/awareness\n\ngo 1.24.0\n');
+    writeFileSync(join(root, 'go.sum'), 'example.com/mod v1.0.0 h1:abc\n');
+    mkdirSync(join(root, 'cmd'), { recursive: true });
+    mkdirSync(join(root, 'internal'), { recursive: true });
+    mkdirSync(join(root, 'tests'), { recursive: true });
+
+    const snapshot = await collectProjectDashboard(root);
+    const signals = snapshot.sections.find((section) => section.type === 'project_signals');
+    const surfaces = snapshot.sections.find((section) => section.type === 'inspection_surfaces');
+
+    expect(signals?.data).toEqual(expect.objectContaining({
+      detectedProjects: expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'go',
+          manifests: [expect.objectContaining({ kind: 'go_mod', path: 'go.mod' })],
+          lockfiles: [expect.objectContaining({ kind: 'go_sum', path: 'go.sum' })],
+          verificationSurfaces: [
+            expect.objectContaining({
+              kind: 'command',
+              label: 'go module verification commands',
+              commands: ['go test ./...', 'go vet ./...'],
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          kind: 'python',
+          manifests: [expect.objectContaining({ kind: 'pyproject_toml', path: 'pyproject.toml' })],
+          verificationSurfaces: expect.arrayContaining([
+            expect.objectContaining({
+              kind: 'command',
+              label: 'pytest command surface',
+              commands: ['python -m pytest'],
+            }),
+            expect.objectContaining({
+              kind: 'command',
+              label: 'ruff command surface',
+              commands: ['ruff check .'],
+            }),
+          ]),
+        }),
+      ]),
+      observedDirectories: expect.objectContaining({
+        source: ['cmd', 'internal'],
+        tests: ['tests'],
+      }),
+    }));
+    expect(surfaces?.data).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'manifest', paths: ['go.mod', 'pyproject.toml'] }),
+      expect.objectContaining({ kind: 'directory', role: 'source', paths: ['cmd', 'internal'] }),
+      expect.objectContaining({
+        kind: 'verification_surface',
+        labels: ['go module verification commands', 'pytest command surface', 'ruff command surface'],
+      }),
+    ]));
   });
 });
 

--- a/src/__tests__/integration/tools/tools.test.ts
+++ b/src/__tests__/integration/tools/tools.test.ts
@@ -74,7 +74,7 @@ describe('tool input validation', () => {
 
     expect(result).toEqual({
       ok: false,
-      error: 'Invalid input for project_dashboard. Optional fields: includeSections (working_environment|workspace_tree), maxDepth (1-4), maxEntries (1-200). Use {} for the default full dashboard.',
+      error: 'Invalid input for project_dashboard. Optional fields: includeSections (working_environment|workspace_tree|project_signals|inspection_surfaces), maxDepth (1-4), maxEntries (1-200). Use {} for the default full dashboard.',
     });
   });
 
@@ -117,7 +117,9 @@ describe('tool input validation', () => {
     expect(searchFilesTool.description).toContain('{ "query": "createUser" }');
     expect(searchFilesTool.description).toContain('{ "query": "incident", "path": "../shared-notes" }');
     expect(projectDashboardTool.description).toContain('Collect the initial coding project dashboard');
-    expect(projectDashboardTool.description).toContain('current working-environment state and a bounded workspace tree');
+    expect(projectDashboardTool.description).toContain('current working-environment state, a bounded workspace tree');
+    expect(projectDashboardTool.description).toContain('cheap project signals');
+    expect(projectDashboardTool.description).toContain('deterministic inspection surfaces');
     expect(projectDashboardTool.description).toContain('orient in a single call');
     expect(projectDashboardTool.description).toContain('read_file or search_files only for task-specific details');
     expect(projectDashboardTool.description).toContain('includeSections');
@@ -287,6 +289,8 @@ describe('workspace-bound default tools', () => {
             gitRepositoryRoot: resolvedWorkspaceRoot,
           }),
           workspace_tree: expect.any(Object),
+          project_signals: expect.any(Object),
+          inspection_surfaces: expect.any(Array),
         },
       });
     } finally {

--- a/src/core/awareness/domains/coding/README.md
+++ b/src/core/awareness/domains/coding/README.md
@@ -23,6 +23,13 @@ Current `project_dashboard` output includes:
   - bounded directory/file tree for quick structural orientation
   - configurable depth and entry budget
   - omission/truncation surfaced through `limits`
+- `project_signals`
+  - grouped detected-project summaries, each with its own manifests, lockfiles, and verification surfaces
+  - current bounded detectors: `javascript`, `python`, `go`
+  - observed source/test/docs/examples/scripts/config surfaces
+- `inspection_surfaces`
+  - deterministic follow-up surfaces derived from observed metadata
+  - manifests, directories, config files, verification surfaces, and dirty-path counts
 
 ## Boundaries
 
@@ -86,11 +93,47 @@ Example tool result shape:
           },
           { "path": "README.md", "kind": "file" }
         ]
-      }
+      },
+      "project_signals": {
+        "detectedProjects": [
+          {
+            "kind": "javascript",
+            "manifests": [
+              { "kind": "package_json", "path": "package.json" }
+            ],
+            "lockfiles": [
+              { "kind": "yarn_lock", "path": "yarn.lock" }
+            ],
+            "verificationSurfaces": [
+              {
+                "kind": "script_names",
+                "label": "package.json verification scripts",
+                "sourcePath": "package.json",
+                "scriptNames": ["build", "lint", "test"]
+              }
+            ]
+          }
+        ],
+        "observedDirectories": {
+          "source": ["src"],
+          "tests": ["tests"],
+          "docs": ["docs"],
+          "examples": ["examples"],
+          "scripts": ["scripts"],
+          "config": []
+        },
+        "configFiles": ["tsconfig.json"]
+      },
+      "inspection_surfaces": [
+        { "kind": "manifest", "paths": ["package.json"] },
+        { "kind": "directory", "role": "source", "paths": ["src"] },
+        { "kind": "verification_surface", "labels": ["package.json verification scripts"] }
+      ]
     },
     "sources": [
       { "kind": "filesystem", "path": "/workspace/heddle", "note": "workspace root" },
-      { "kind": "git", "command": "git rev-parse --show-toplevel" }
+      { "kind": "git", "command": "git rev-parse --show-toplevel" },
+      { "kind": "package_metadata", "path": "/workspace/heddle/package.json" }
     ],
     "limits": [
       {
@@ -102,3 +145,9 @@ Example tool result shape:
   }
 }
 ```
+
+Detector boundary:
+
+- ecosystem-specific logic lives under `detectors/`
+- the `project_signals` contract stays generic
+- when Heddle needs broader project-type coverage, do not keep adding endless hardcoded rules blindly; consider a dedicated project-inspection agent or similarly bounded inspection subsystem

--- a/src/core/awareness/domains/coding/collectors/project-signals.ts
+++ b/src/core/awareness/domains/coding/collectors/project-signals.ts
@@ -144,9 +144,11 @@ function mergeProjectSignals(
     }
   }
 
+  const normalizedObservedDirectories = normalizeObservedDirectories(observedDirectories);
+
   return {
     detectedProjects: [...detectedProjects.values()].sort((left, right) => left.kind.localeCompare(right.kind)),
-    observedDirectories,
+    observedDirectories: normalizedObservedDirectories,
     configFiles: [...configFiles].sort(),
   };
 }
@@ -226,4 +228,17 @@ function dedupeSources(sources: AwarenessSource[]): AwarenessSource[] {
   }
 
   return deduped;
+}
+
+function normalizeObservedDirectories(
+  observedDirectories: CodingProjectSignals['observedDirectories'],
+): CodingProjectSignals['observedDirectories'] {
+  return {
+    source: [...observedDirectories.source].sort(),
+    tests: [...observedDirectories.tests].sort(),
+    docs: [...observedDirectories.docs].sort(),
+    examples: [...observedDirectories.examples].sort(),
+    scripts: [...observedDirectories.scripts].sort(),
+    config: [...observedDirectories.config].sort(),
+  };
 }

--- a/src/core/awareness/domains/coding/collectors/project-signals.ts
+++ b/src/core/awareness/domains/coding/collectors/project-signals.ts
@@ -1,0 +1,229 @@
+import type { Dirent } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import type { AwarenessLimit, AwarenessSource } from '../../../types.js';
+import type {
+  CodingInspectionSurface,
+  CodingProjectSignals,
+  CodingWorkingEnvironment,
+} from '../types.js';
+import { goProjectDetector } from '../detectors/go.js';
+import { javascriptProjectDetector } from '../detectors/javascript.js';
+import { pythonProjectDetector } from '../detectors/python.js';
+import type {
+  CodingProjectDetectorInput,
+  CodingProjectSignalContribution,
+} from '../detectors/types.js';
+import { OMITTED_PATH_SEGMENTS } from './git.js';
+
+const DIRECTORY_ROLES: Record<keyof CodingProjectSignals['observedDirectories'], string[]> = {
+  source: ['src', 'lib', 'app', 'cmd', 'internal', 'pkg'],
+  tests: ['test', 'tests', '__tests__'],
+  docs: ['docs'],
+  examples: ['examples'],
+  scripts: ['scripts'],
+  config: ['config', '.github'],
+};
+
+const SUPPORTED_PROJECT_DETECTORS = [
+  javascriptProjectDetector,
+  pythonProjectDetector,
+  goProjectDetector,
+];
+
+export async function collectCodingProjectSignals(input: {
+  workspaceRoot: string;
+  environment: CodingWorkingEnvironment;
+}): Promise<{
+  projectSignals: CodingProjectSignals;
+  inspectionSurfaces: CodingInspectionSurface[];
+  sources: AwarenessSource[];
+  limits: AwarenessLimit[];
+}> {
+  const sources: AwarenessSource[] = [];
+  const limits: AwarenessLimit[] = [];
+
+  const observedDirectories: CodingProjectSignals['observedDirectories'] = {
+    source: [],
+    tests: [],
+    docs: [],
+    examples: [],
+    scripts: [],
+    config: [],
+  };
+
+  let dirents: Dirent<string>[];
+  try {
+    dirents = await readdir(input.workspaceRoot, { withFileTypes: true });
+  } catch (error) {
+    limits.push({
+      kind: 'unavailable',
+      subject: 'project signals',
+      detail: `Could not read workspace root entries: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return {
+      projectSignals: {
+        detectedProjects: [],
+        observedDirectories,
+        configFiles: [],
+      },
+      inspectionSurfaces: buildInspectionSurfaces({
+        projectSignals: {
+          detectedProjects: [],
+          observedDirectories,
+          configFiles: [],
+        },
+        environment: input.environment,
+      }),
+      sources,
+      limits,
+    };
+  }
+
+  const visibleDirents = dirents.filter((dirent) => !OMITTED_PATH_SEGMENTS.has(dirent.name));
+  const rootEntries = visibleDirents.map((dirent) => dirent.name).sort();
+
+  for (const dirent of visibleDirents) {
+    if (!dirent.isDirectory()) {
+      continue;
+    }
+    for (const [role, names] of Object.entries(DIRECTORY_ROLES) as Array<
+      [keyof CodingProjectSignals['observedDirectories'], string[]]
+    >) {
+      if (names.includes(dirent.name)) {
+        observedDirectories[role].push(dirent.name);
+      }
+    }
+  }
+
+  const detectorInput: CodingProjectDetectorInput = {
+    workspaceRoot: input.workspaceRoot,
+    rootEntries,
+    readText: (relativePath) => readWorkspaceText(input.workspaceRoot, relativePath),
+  };
+
+  const contributions = (
+    await Promise.all(SUPPORTED_PROJECT_DETECTORS.map((detector) => detector.detect(detectorInput)))
+  ).filter((value): value is CodingProjectSignalContribution => value !== null);
+
+  const projectSignals = mergeProjectSignals(contributions, observedDirectories);
+  for (const contribution of contributions) {
+    sources.push(...contribution.sources);
+    limits.push(...contribution.limits);
+  }
+
+  return {
+    projectSignals,
+    inspectionSurfaces: buildInspectionSurfaces({
+      projectSignals,
+      environment: input.environment,
+    }),
+    sources: dedupeSources(sources),
+    limits,
+  };
+}
+
+async function readWorkspaceText(workspaceRoot: string, relativePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(`${workspaceRoot}/${relativePath}`, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+function mergeProjectSignals(
+  contributions: CodingProjectSignalContribution[],
+  observedDirectories: CodingProjectSignals['observedDirectories'],
+): CodingProjectSignals {
+  const detectedProjects = new Map<string, CodingProjectSignals['detectedProjects'][number]>();
+  const configFiles = new Set<string>();
+
+  for (const contribution of contributions) {
+    detectedProjects.set(contribution.project.kind, contribution.project);
+    for (const configFile of contribution.configFiles) {
+      configFiles.add(configFile);
+    }
+  }
+
+  return {
+    detectedProjects: [...detectedProjects.values()].sort((left, right) => left.kind.localeCompare(right.kind)),
+    observedDirectories,
+    configFiles: [...configFiles].sort(),
+  };
+}
+
+function buildInspectionSurfaces(args: {
+  projectSignals: CodingProjectSignals;
+  environment: CodingWorkingEnvironment;
+}): CodingInspectionSurface[] {
+  const surfaces: CodingInspectionSurface[] = [];
+
+  const manifestPaths = args.projectSignals.detectedProjects
+    .flatMap((project) => project.manifests.map((manifest) => manifest.path));
+  if (manifestPaths.length > 0) {
+    surfaces.push({
+      kind: 'manifest',
+      paths: manifestPaths.sort(),
+    });
+  }
+
+  for (const [role, paths] of Object.entries(args.projectSignals.observedDirectories) as Array<
+    [keyof CodingProjectSignals['observedDirectories'], string[]]
+  >) {
+    if (paths.length === 0) {
+      continue;
+    }
+    surfaces.push({
+      kind: 'directory',
+      role,
+      paths,
+    });
+  }
+
+  if (args.projectSignals.configFiles.length > 0) {
+    surfaces.push({
+      kind: 'config_file',
+      paths: args.projectSignals.configFiles,
+    });
+  }
+
+  const verificationLabels = args.projectSignals.detectedProjects
+    .flatMap((project) => project.verificationSurfaces.map((surface) => surface.label));
+  if (verificationLabels.length > 0) {
+    surfaces.push({
+      kind: 'verification_surface',
+      labels: verificationLabels.sort(),
+    });
+  }
+
+  const dirtyCounts = {
+    staged: args.environment.paths.staged.length,
+    modified: args.environment.paths.modified.length,
+    deleted: args.environment.paths.deleted.length,
+    untracked: args.environment.paths.untracked.length,
+    renamed: args.environment.paths.renamed.length,
+  };
+  if (Object.values(dirtyCounts).some((count) => count > 0)) {
+    surfaces.push({
+      kind: 'dirty_paths',
+      counts: dirtyCounts,
+    });
+  }
+
+  return surfaces;
+}
+
+function dedupeSources(sources: AwarenessSource[]): AwarenessSource[] {
+  const seen = new Set<string>();
+  const deduped: AwarenessSource[] = [];
+
+  for (const source of sources) {
+    const key = `${source.kind}|${source.command ?? ''}|${source.path ?? ''}|${source.note ?? ''}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(source);
+  }
+
+  return deduped;
+}

--- a/src/core/awareness/domains/coding/collectors/workspace.ts
+++ b/src/core/awareness/domains/coding/collectors/workspace.ts
@@ -1,6 +1,12 @@
 import type { AwarenessCollectInput, AwarenessLimit, AwarenessSource } from '../../../types.js';
-import type { CodingWorkingEnvironment, CodingWorkspaceTree } from '../types.js';
+import type {
+  CodingInspectionSurface,
+  CodingProjectSignals,
+  CodingWorkingEnvironment,
+  CodingWorkspaceTree,
+} from '../types.js';
 import { collectGitWorkingEnvironment } from './git.js';
+import { collectCodingProjectSignals } from './project-signals.js';
 import { collectCodingWorkspaceTree } from './workspace-tree.js';
 
 export async function collectCodingWorkingEnvironment(input: AwarenessCollectInput): Promise<{
@@ -37,40 +43,49 @@ export async function collectCodingWorkingEnvironment(input: AwarenessCollectInp
 export async function collectCodingProjectDashboard(input: AwarenessCollectInput): Promise<{
   environment: CodingWorkingEnvironment;
   workspaceTree: CodingWorkspaceTree;
+  projectSignals: CodingProjectSignals;
+  inspectionSurfaces: CodingInspectionSurface[];
   sources: AwarenessSource[];
   limits: AwarenessLimit[];
 }> {
-  const [environmentResult, treeResult] = await Promise.all([
-    collectCodingWorkingEnvironment(input),
+  const environmentResult = await collectCodingWorkingEnvironment(input);
+  const [treeResult, projectSignalsResult] = await Promise.all([
     collectCodingWorkspaceTree({
       workspaceRoot: input.workspaceRoot,
       maxDepth: input.maxDepth,
       maxEntries: input.maxEntries,
+    }),
+    collectCodingProjectSignals({
+      workspaceRoot: input.workspaceRoot,
+      environment: environmentResult.environment,
     }),
   ]);
 
   return {
     environment: environmentResult.environment,
     workspaceTree: treeResult.tree,
-    sources: mergeSources(environmentResult.sources, treeResult.sources),
-    limits: [...environmentResult.limits, ...treeResult.limits],
+    projectSignals: projectSignalsResult.projectSignals,
+    inspectionSurfaces: projectSignalsResult.inspectionSurfaces,
+    sources: mergeSources(environmentResult.sources, treeResult.sources, projectSignalsResult.sources),
+    limits: [...environmentResult.limits, ...treeResult.limits, ...projectSignalsResult.limits],
   };
 }
 
 function mergeSources(
-  left: AwarenessSource[],
-  right: AwarenessSource[],
+  ...sourceGroups: AwarenessSource[][]
 ): AwarenessSource[] {
   const seen = new Set<string>();
   const merged: AwarenessSource[] = [];
 
-  for (const source of [...left, ...right]) {
-    const key = `${source.kind}|${source.command ?? ''}|${source.path ?? ''}|${source.note ?? ''}`;
-    if (seen.has(key)) {
-      continue;
+  for (const sources of sourceGroups) {
+    for (const source of sources) {
+      const key = `${source.kind}|${source.command ?? ''}|${source.path ?? ''}|${source.note ?? ''}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      merged.push(source);
     }
-    seen.add(key);
-    merged.push(source);
   }
 
   return merged;

--- a/src/core/awareness/domains/coding/detectors/README.md
+++ b/src/core/awareness/domains/coding/detectors/README.md
@@ -1,0 +1,38 @@
+# Coding Project Detectors
+
+This folder owns ecosystem-specific project detection for coding awareness.
+
+## Responsibility
+
+- Detect supported project kinds from bounded, evidence-backed workspace signals.
+- Contribute normalized project signals to the coding awareness domain.
+- Keep ecosystem-specific rules out of the generic `project_signals` contract.
+
+## Boundary
+
+- Detectors may inspect a bounded set of known manifest or config files.
+- Detectors must not read arbitrary source files or guess frameworks from code content.
+- Hosts and tools must not call detectors directly; they are internal to coding awareness.
+- The coding awareness collector owns composition and output shaping; detectors only contribute normalized signals.
+
+## Current Supported Project Kinds
+
+- `javascript`
+- `python`
+- `go`
+
+## Roadmap
+
+Planned next additions when evidence justifies them:
+
+- `rust`
+- `ruby`
+- `java`
+- `android`
+- `ios`
+
+## Current Compromise
+
+These detectors are still hardcoded rules. That is acceptable for the first slice because the supported set is intentionally small and reviewable.
+
+Do not keep scaling this folder indefinitely by hand once project-type coverage becomes broad or brittle. When Heddle needs wider ecosystem coverage, the next architectural step should be a dedicated project-inspection agent or similarly bounded inspection subsystem that can derive project type and verification surfaces more flexibly without baking endless framework rules into core code.

--- a/src/core/awareness/domains/coding/detectors/go.ts
+++ b/src/core/awareness/domains/coding/detectors/go.ts
@@ -1,0 +1,53 @@
+import type { CodingProjectSignalDetector } from './types.js';
+
+export const goProjectDetector: CodingProjectSignalDetector = {
+  id: 'go',
+  async detect(input) {
+    const rootEntries = new Set(input.rootEntries);
+    const hasGoMod = rootEntries.has('go.mod');
+    const hasGoSum = rootEntries.has('go.sum');
+
+    if (!hasGoMod && !hasGoSum) {
+      return null;
+    }
+
+    const manifests = hasGoMod
+      ? [{
+          kind: 'go_mod',
+          path: 'go.mod',
+        }]
+      : [];
+    const lockfiles = hasGoSum
+      ? [{
+          kind: 'go_sum',
+          path: 'go.sum',
+        }]
+      : [];
+
+    const verificationSurfaces = hasGoMod
+      ? [{
+          kind: 'command' as const,
+          label: 'go module verification commands',
+          sourcePath: 'go.mod',
+          commands: ['go test ./...', 'go vet ./...'],
+        }]
+      : [];
+
+    return {
+      project: {
+        kind: 'go',
+        manifests,
+        lockfiles,
+        verificationSurfaces,
+      },
+      configFiles: [],
+      sources: hasGoMod
+        ? [{
+            kind: 'package_metadata' as const,
+            path: `${input.workspaceRoot}/go.mod`,
+          }]
+        : [],
+      limits: [],
+    };
+  },
+};

--- a/src/core/awareness/domains/coding/detectors/javascript.ts
+++ b/src/core/awareness/domains/coding/detectors/javascript.ts
@@ -1,0 +1,101 @@
+import type { CodingProjectSignalDetector } from './types.js';
+
+const LOCKFILES = [
+  { fileName: 'yarn.lock', kind: 'yarn_lock' },
+  { fileName: 'package-lock.json', kind: 'npm_lock' },
+  { fileName: 'pnpm-lock.yaml', kind: 'pnpm_lock' },
+  { fileName: 'bun.lock', kind: 'bun_lock' },
+  { fileName: 'bun.lockb', kind: 'bun_lockb' },
+] as const;
+
+export const javascriptProjectDetector: CodingProjectSignalDetector = {
+  id: 'javascript',
+  async detect(input) {
+    const rootEntries = new Set(input.rootEntries);
+    const hasPackageJson = rootEntries.has('package.json');
+    const presentLockfiles = LOCKFILES.filter((lockfile) => rootEntries.has(lockfile.fileName));
+
+    if (!hasPackageJson && presentLockfiles.length === 0) {
+      return null;
+    }
+
+    const sources = [];
+    const limits = [];
+    const manifests = [];
+
+    if (hasPackageJson) {
+      manifests.push({
+        kind: 'package_json',
+        path: 'package.json',
+      });
+      sources.push({
+        kind: 'package_metadata' as const,
+        path: `${input.workspaceRoot}/package.json`,
+      });
+    }
+
+    const lockfiles = presentLockfiles.map((lockfile) => ({
+      kind: lockfile.kind,
+      path: lockfile.fileName,
+    }));
+
+    const verificationSurfaces = [];
+    if (hasPackageJson) {
+      const packageJsonText = await input.readText('package.json');
+      if (packageJsonText) {
+        try {
+          const parsed = JSON.parse(packageJsonText) as { scripts?: Record<string, unknown> };
+          const scriptNames = Object.keys(parsed.scripts ?? {}).sort();
+          const verificationScriptNames = scriptNames.filter((name) =>
+            /^(test|lint|build|typecheck|check|verify|e2e)(:|$)/.test(name)
+          );
+          if (verificationScriptNames.length > 0) {
+            verificationSurfaces.push({
+              kind: 'script_names' as const,
+              label: 'package.json verification scripts',
+              sourcePath: 'package.json',
+              scriptNames: verificationScriptNames,
+            });
+          }
+        } catch (error) {
+          limits.push({
+            kind: 'unavailable' as const,
+            subject: 'package metadata',
+            detail: `Could not parse package.json: ${error instanceof Error ? error.message : String(error)}`,
+          });
+        }
+      }
+    }
+
+    const configFiles = input.rootEntries.filter((entry) => JAVASCRIPT_CONFIG_FILES.has(entry)).sort();
+
+    return {
+      project: {
+        kind: 'javascript',
+        manifests,
+        lockfiles,
+        verificationSurfaces,
+      },
+      configFiles,
+      sources,
+      limits,
+    };
+  },
+};
+
+const JAVASCRIPT_CONFIG_FILES = new Set([
+  'tsconfig.json',
+  'eslint.config.js',
+  'eslint.config.mjs',
+  'eslint.config.cjs',
+  '.eslintrc',
+  '.eslintrc.js',
+  '.eslintrc.cjs',
+  '.prettierrc',
+  '.prettierrc.json',
+  'prettier.config.js',
+  'vitest.config.ts',
+  'vite.config.ts',
+  'jest.config.js',
+  'jest.config.ts',
+]);

--- a/src/core/awareness/domains/coding/detectors/python.ts
+++ b/src/core/awareness/domains/coding/detectors/python.ts
@@ -1,0 +1,88 @@
+import type { CodingProjectSignalDetector } from './types.js';
+
+const PYTHON_MANIFESTS = [
+  { fileName: 'pyproject.toml', kind: 'pyproject_toml' },
+  { fileName: 'requirements.txt', kind: 'requirements_txt' },
+  { fileName: 'requirements-dev.txt', kind: 'requirements_dev_txt' },
+  { fileName: 'Pipfile', kind: 'pipfile' },
+] as const;
+
+const PYTHON_LOCKFILES = [
+  { fileName: 'poetry.lock', kind: 'poetry_lock' },
+  { fileName: 'uv.lock', kind: 'uv_lock' },
+  { fileName: 'Pipfile.lock', kind: 'pipfile_lock' },
+] as const;
+
+export const pythonProjectDetector: CodingProjectSignalDetector = {
+  id: 'python',
+  async detect(input) {
+    const rootEntries = new Set(input.rootEntries);
+    const manifests = PYTHON_MANIFESTS
+      .filter((manifest) => rootEntries.has(manifest.fileName))
+      .map((manifest) => ({
+        kind: manifest.kind,
+        path: manifest.fileName,
+      }));
+    const lockfiles = PYTHON_LOCKFILES
+      .filter((lockfile) => rootEntries.has(lockfile.fileName))
+      .map((lockfile) => ({
+        kind: lockfile.kind,
+        path: lockfile.fileName,
+      }));
+
+    const hasPytestIni = rootEntries.has('pytest.ini');
+    const hasRuffToml = rootEntries.has('ruff.toml');
+    const pyprojectText = rootEntries.has('pyproject.toml')
+      ? await input.readText('pyproject.toml')
+      : undefined;
+
+    const verificationSurfaces = [];
+    if (hasPytestIni || pyprojectText?.includes('[tool.pytest')) {
+      verificationSurfaces.push({
+        kind: 'command' as const,
+        label: 'pytest command surface',
+        sourcePath: hasPytestIni ? 'pytest.ini' : 'pyproject.toml',
+        commands: ['python -m pytest'],
+      });
+    }
+    if (hasRuffToml || pyprojectText?.includes('[tool.ruff')) {
+      verificationSurfaces.push({
+        kind: 'command' as const,
+        label: 'ruff command surface',
+        sourcePath: hasRuffToml ? 'ruff.toml' : 'pyproject.toml',
+        commands: ['ruff check .'],
+      });
+    }
+
+    if (manifests.length === 0 && lockfiles.length === 0 && verificationSurfaces.length === 0) {
+      return null;
+    }
+
+    const configFiles = input.rootEntries.filter((entry) => PYTHON_CONFIG_FILES.has(entry)).sort();
+
+    return {
+      project: {
+        kind: 'python',
+        manifests,
+        lockfiles,
+        verificationSurfaces,
+      },
+      configFiles,
+      sources: manifests
+        .filter((manifest) => manifest.path === 'pyproject.toml')
+        .map((manifest) => ({
+          kind: 'package_metadata' as const,
+          path: `${input.workspaceRoot}/${manifest.path}`,
+        })),
+      limits: [],
+    };
+  },
+};
+
+const PYTHON_CONFIG_FILES = new Set([
+  'pytest.ini',
+  'ruff.toml',
+  'mypy.ini',
+  'tox.ini',
+  '.python-version',
+]);

--- a/src/core/awareness/domains/coding/detectors/types.ts
+++ b/src/core/awareness/domains/coding/detectors/types.ts
@@ -1,10 +1,7 @@
 import type { AwarenessLimit, AwarenessSource } from '../../../types.js';
 import type {
   CodingDetectedProject,
-  CodingLockfileSignal,
-  CodingManifestSignal,
   CodingProjectKind,
-  CodingVerificationSurface,
 } from '../types.js';
 
 export type CodingProjectSignalContribution = {

--- a/src/core/awareness/domains/coding/detectors/types.ts
+++ b/src/core/awareness/domains/coding/detectors/types.ts
@@ -1,0 +1,26 @@
+import type { AwarenessLimit, AwarenessSource } from '../../../types.js';
+import type {
+  CodingDetectedProject,
+  CodingLockfileSignal,
+  CodingManifestSignal,
+  CodingProjectKind,
+  CodingVerificationSurface,
+} from '../types.js';
+
+export type CodingProjectSignalContribution = {
+  project: CodingDetectedProject;
+  configFiles: string[];
+  sources: AwarenessSource[];
+  limits: AwarenessLimit[];
+};
+
+export type CodingProjectDetectorInput = {
+  workspaceRoot: string;
+  rootEntries: string[];
+  readText: (relativePath: string) => Promise<string | undefined>;
+};
+
+export type CodingProjectSignalDetector = {
+  id: CodingProjectKind;
+  detect(input: CodingProjectDetectorInput): Promise<CodingProjectSignalContribution | null>;
+};

--- a/src/core/awareness/domains/coding/format.ts
+++ b/src/core/awareness/domains/coding/format.ts
@@ -10,6 +10,12 @@ export function formatCodingProjectDashboardSnapshot(snapshot: CodingAwarenessSn
     if (section.type === 'workspace_tree') {
       sections.workspace_tree = section.data;
     }
+    if (section.type === 'project_signals') {
+      sections.project_signals = section.data;
+    }
+    if (section.type === 'inspection_surfaces') {
+      sections.inspection_surfaces = section.data;
+    }
   }
 
   return {

--- a/src/core/awareness/domains/coding/provider.ts
+++ b/src/core/awareness/domains/coding/provider.ts
@@ -20,7 +20,12 @@ export function createCodingAwarenessProvider(
       const collectedAt = (options.now ?? (() => new Date()))().toISOString();
       const id = (options.nextId ?? defaultNextId)();
       const collected = await collectCodingProjectDashboard(input);
-      const requestedSections = new Set(input.requestedSections ?? ['working_environment', 'workspace_tree']);
+      const requestedSections = new Set(input.requestedSections ?? [
+        'working_environment',
+        'workspace_tree',
+        'project_signals',
+        'inspection_surfaces',
+      ]);
       const sections: CodingAwarenessSnapshot['sections'] = [];
 
       if (requestedSections.has('working_environment')) {
@@ -33,6 +38,18 @@ export function createCodingAwarenessProvider(
         sections.push({
           type: 'workspace_tree',
           data: collected.workspaceTree,
+        });
+      }
+      if (requestedSections.has('project_signals')) {
+        sections.push({
+          type: 'project_signals',
+          data: collected.projectSignals,
+        });
+      }
+      if (requestedSections.has('inspection_surfaces')) {
+        sections.push({
+          type: 'inspection_surfaces',
+          data: collected.inspectionSurfaces,
         });
       }
 

--- a/src/core/awareness/domains/coding/types.ts
+++ b/src/core/awareness/domains/coding/types.ts
@@ -32,6 +32,66 @@ export type CodingWorkspaceTree = {
   entries: CodingWorkspaceTreeEntry[];
 };
 
+export type CodingProjectKind = 'javascript' | 'python' | 'go';
+
+export type CodingManifestSignal = {
+  kind: string;
+  path: string;
+};
+
+export type CodingLockfileSignal = {
+  kind: string;
+  path: string;
+};
+
+export type CodingVerificationSurface = {
+  kind: 'script_names' | 'command';
+  label: string;
+  sourcePath?: string;
+  scriptNames?: string[];
+  commands?: string[];
+};
+
+export type CodingDetectedProject = {
+  kind: CodingProjectKind;
+  manifests: CodingManifestSignal[];
+  lockfiles: CodingLockfileSignal[];
+  verificationSurfaces: CodingVerificationSurface[];
+};
+
+export type CodingProjectSignals = {
+  detectedProjects: CodingDetectedProject[];
+  observedDirectories: {
+    source: string[];
+    tests: string[];
+    docs: string[];
+    examples: string[];
+    scripts: string[];
+    config: string[];
+  };
+  configFiles: string[];
+};
+
+export type CodingInspectionSurface =
+  | { kind: 'manifest'; paths: string[] }
+  | {
+      kind: 'directory';
+      role: keyof CodingProjectSignals['observedDirectories'];
+      paths: string[];
+    }
+  | { kind: 'config_file'; paths: string[] }
+  | { kind: 'verification_surface'; labels: string[] }
+  | {
+      kind: 'dirty_paths';
+      counts: {
+        staged: number;
+        modified: number;
+        deleted: number;
+        untracked: number;
+        renamed: number;
+      };
+    };
+
 export type CodingWorkingEnvironmentSection = {
   type: 'working_environment';
   data: CodingWorkingEnvironment;
@@ -42,9 +102,21 @@ export type CodingWorkspaceTreeSection = {
   data: CodingWorkspaceTree;
 };
 
+export type CodingProjectSignalsSection = {
+  type: 'project_signals';
+  data: CodingProjectSignals;
+};
+
+export type CodingInspectionSurfacesSection = {
+  type: 'inspection_surfaces';
+  data: CodingInspectionSurface[];
+};
+
 export type CodingAwarenessSection =
   | CodingWorkingEnvironmentSection
-  | CodingWorkspaceTreeSection;
+  | CodingWorkspaceTreeSection
+  | CodingProjectSignalsSection
+  | CodingInspectionSurfacesSection;
 
 export type CodingProjectDashboardOutput = {
   schemaVersion: 1;
@@ -55,6 +127,8 @@ export type CodingProjectDashboardOutput = {
   sections: Partial<{
     working_environment: CodingWorkingEnvironment;
     workspace_tree: CodingWorkspaceTree;
+    project_signals: CodingProjectSignals;
+    inspection_surfaces: CodingInspectionSurface[];
   }>;
   sources: AwarenessSnapshot['sources'];
   limits: AwarenessSnapshot['limits'];

--- a/src/core/awareness/types.ts
+++ b/src/core/awareness/types.ts
@@ -3,7 +3,7 @@ export type AwarenessDomain = 'coding';
 export type AwarenessProfile = 'project_dashboard';
 
 export type AwarenessSource = {
-  kind: 'filesystem' | 'git' | 'runtime_config';
+  kind: 'filesystem' | 'git' | 'runtime_config' | 'package_metadata';
   command?: string;
   path?: string;
   note?: string;

--- a/src/core/tools/toolkits/coding-awareness/project-dashboard.ts
+++ b/src/core/tools/toolkits/coding-awareness/project-dashboard.ts
@@ -4,12 +4,17 @@ import { createCodingAwarenessProvider } from '../../../awareness/domains/coding
 import { formatCodingProjectDashboardSnapshot } from '../../../awareness/domains/coding/format.js';
 import type { CodingAwarenessSnapshot } from '../../../awareness/domains/coding/types.js';
 
-const ALLOWED_SECTIONS = new Set(['working_environment', 'workspace_tree']);
+const ALLOWED_SECTIONS = new Set([
+  'working_environment',
+  'workspace_tree',
+  'project_signals',
+  'inspection_surfaces',
+]);
 const MAX_ALLOWED_DEPTH = 4;
 const MAX_ALLOWED_ENTRIES = 200;
 
 type ProjectDashboardInput = {
-  includeSections?: Array<'working_environment' | 'workspace_tree'>;
+  includeSections?: Array<'working_environment' | 'workspace_tree' | 'project_signals' | 'inspection_surfaces'>;
   maxDepth?: number;
   maxEntries?: number;
 };
@@ -27,7 +32,7 @@ export function createProjectDashboardTool(options: ProjectDashboardToolOptions 
   return {
     name: 'project_dashboard',
     description:
-      'Collect the initial coding project dashboard for the active workspace. Default output includes current working-environment state and a bounded workspace tree in one structured result, so you can orient in a single call before substantial coding, planning, or review work. Use this first, then follow with read_file or search_files only for task-specific details. Optional fields include includeSections, maxDepth, and maxEntries when you intentionally want a smaller dashboard.',
+      'Collect the initial coding project dashboard for the active workspace. Default output includes current working-environment state, a bounded workspace tree, cheap project signals, and deterministic inspection surfaces in one structured result, so you can orient in a single call before substantial coding, planning, or review work. Use this first, then follow with read_file or search_files only for task-specific details. Optional fields include includeSections, maxDepth, and maxEntries when you intentionally want a smaller dashboard.',
     parameters: {
       type: 'object',
       additionalProperties: false,
@@ -36,7 +41,7 @@ export function createProjectDashboardTool(options: ProjectDashboardToolOptions 
           type: 'array',
           items: {
             type: 'string',
-            enum: ['working_environment', 'workspace_tree'],
+            enum: ['working_environment', 'workspace_tree', 'project_signals', 'inspection_surfaces'],
           },
         },
         maxDepth: {
@@ -131,5 +136,5 @@ function isBoundedPositiveInteger(value: unknown, max: number): value is number 
 }
 
 function invalidProjectDashboardInput(): string {
-  return 'Invalid input for project_dashboard. Optional fields: includeSections (working_environment|workspace_tree), maxDepth (1-4), maxEntries (1-200). Use {} for the default full dashboard.';
+  return 'Invalid input for project_dashboard. Optional fields: includeSections (working_environment|workspace_tree|project_signals|inspection_surfaces), maxDepth (1-4), maxEntries (1-200). Use {} for the default full dashboard.';
 }


### PR DESCRIPTION
## Summary
- extend coding awareness project_dashboard with generic project signals and inspection surfaces
- add bounded project detectors for javascript, python, and go
- document the detector boundary and the future shift toward a project-inspection agent for broader coverage

## Verification
- node_modules/.bin/vitest run src/__tests__/integration/awareness/project-dashboard.test.ts src/__tests__/unit/core/awareness.service.test.ts src/__tests__/integration/tools/tools.test.ts -t "tool input validation|workspace-bound default tools|coding project dashboard awareness"
- yarn eslint src/core/awareness/types.ts src/core/awareness/domains/coding/types.ts src/core/awareness/domains/coding/format.ts src/core/awareness/domains/coding/provider.ts src/core/awareness/domains/coding/collectors/workspace.ts src/core/awareness/domains/coding/collectors/project-signals.ts src/core/awareness/domains/coding/detectors/types.ts src/core/awareness/domains/coding/detectors/javascript.ts src/core/awareness/domains/coding/detectors/python.ts src/core/awareness/domains/coding/detectors/go.ts src/core/tools/toolkits/coding-awareness/project-dashboard.ts src/__tests__/integration/awareness/project-dashboard.test.ts src/__tests__/integration/tools/tools.test.ts
- yarn typecheck