### PR TITLE
[codex] Complete conversation session service

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "clean": "node scripts/clean-dist.mjs",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "eslint": "eslint .",
+    "lint": "yarn eslint",
     "release:context": "node scripts/release-context.mjs",
     "build": "yarn clean && tsc -p tsconfig.build.json && yarn client:build",
     "client:build": "tsc -p src/web/tsconfig.json --noEmit && vite build --config src/web/vite.config.ts",

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -38,6 +38,17 @@ describe('createConversationEngine', () => {
       apiKeyPresent: true,
     });
 
+    const fallback = engine.sessions.latest();
+    expect(fallback).toEqual(expect.objectContaining({
+      id: 'session-1',
+      model: 'gpt-5.4',
+      workspaceId: 'workspace-1',
+    }));
+    expect(engine.sessions.require('session-1')).toEqual(expect.objectContaining({
+      id: 'session-1',
+      model: 'gpt-5.4',
+    }));
+
     const session = engine.sessions.create({ name: 'Repo investigation' });
 
     expect(readChatSessionCatalog(join(stateRoot, 'chat-sessions.catalog.json'))[0]).toEqual(expect.objectContaining({
@@ -67,7 +78,10 @@ describe('createConversationEngine', () => {
     const second = engine.sessions.create({ id: 'session-b', name: 'Second' });
 
     expect(engine.sessions.list().map((session) => session.id)).toEqual(['session-b', 'session-a', 'session-1']);
+    expect(engine.sessions.latest()?.id).toBe(engine.sessions.list()[0]?.id);
     expect(engine.sessions.read('missing')).toBeUndefined();
+    expect(engine.sessions.require(first.id).id).toBe(first.id);
+    expect(() => engine.sessions.require('missing')).toThrow('Chat session not found: missing');
 
     const updated = engine.sessions.update(first.id, (session) => ({
       ...session,
@@ -86,6 +100,49 @@ describe('createConversationEngine', () => {
     expect(engine.sessions.delete('session-1')).toBe(true);
     expect(engine.sessions.delete('missing')).toBe(false);
     expect(loadChatSessions(join(stateRoot, 'chat-sessions.catalog.json'), true).map((session) => session.id)).toEqual(['session-1']);
+  });
+
+  it('updates shared session settings for TUI and control-plane clients', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      reasoningEffort: 'medium',
+      apiKeyPresent: true,
+    });
+    const session = engine.sessions.create({
+      id: 'session-1',
+      name: 'Alpha',
+      model: 'gpt-5.4',
+      reasoningEffort: 'high',
+    });
+
+    const updated = engine.sessions.updateSettings(session.id, {
+      model: 'gpt-5.5',
+      reasoningEffort: null,
+      driftEnabled: true,
+    });
+
+    expect(updated).toEqual(expect.objectContaining({
+      id: session.id,
+      name: 'Alpha',
+      model: 'gpt-5.5',
+      reasoningEffort: undefined,
+      driftEnabled: true,
+      history: session.history,
+      messages: session.messages,
+      turns: session.turns,
+    }));
+    expect(engine.sessions.read(session.id)).toEqual(expect.objectContaining({
+      model: 'gpt-5.5',
+      reasoningEffort: undefined,
+      driftEnabled: true,
+    }));
+    expect(() => engine.sessions.updateSettings('missing', { driftEnabled: false })).toThrow(
+      'Chat session not found: missing',
+    );
   });
 
   it('submits turns with merged engine defaults, normalized host callbacks, and override options', async () => {

--- a/src/cli/chat/hooks/useChatSessions.ts
+++ b/src/cli/chat/hooks/useChatSessions.ts
@@ -96,16 +96,9 @@ export function useChatSessions({ sessionCatalogFile, apiKeyPresent, defaultMode
   }, [activeSessionId, updateSessionById]);
 
   const setSessionPreferences = useCallback((sessionId: string, preferences: SessionExecutionPreferences) => {
-    updateSessionById(sessionId, (session) => (
-      session.model === preferences.model && session.reasoningEffort === preferences.reasoningEffort ?
-        session
-      : {
-          ...session,
-          model: preferences.model,
-          reasoningEffort: preferences.reasoningEffort,
-        }
-    ));
-  }, [updateSessionById]);
+    sessionService.updateSettings(sessionId, preferences);
+    setSessions(sessionService.list());
+  }, [sessionService]);
 
   const createSession = useCallback((name?: string, preferences?: SessionExecutionPreferences) => {
     const nextPreferences = resolveNewSessionExecutionPreferences({
@@ -125,8 +118,9 @@ export function useChatSessions({ sessionCatalogFile, apiKeyPresent, defaultMode
   }, [apiKeyPresent, defaultModel, sessionService, workspaceId]);
 
   const renameSession = useCallback((name: string) => {
-    updateActiveSession((session) => ({ ...session, name }));
-  }, [updateActiveSession]);
+    sessionService.rename(activeSessionId, name);
+    setSessions(sessionService.list());
+  }, [activeSessionId, sessionService]);
 
   const removeSession = useCallback((id: string) => {
     const removedActive = id === activeSessionId;

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -12,4 +12,5 @@ export type {
   ContinueConversationTurnInput,
   SubmitConversationTurnInput,
   SubmitConversationTurnResult,
+  UpdateConversationSessionSettingsInput,
 } from './types.js';

--- a/src/core/chat/engine/sessions/README.md
+++ b/src/core/chat/engine/sessions/README.md
@@ -34,6 +34,14 @@ In this folder today:
 - `repository/file-chat-session-repository.ts` owns file persistence
 - `service.ts` owns session behavior and should be the main path that hosts call
 
+The service API should cover ordinary host needs directly:
+
+- use `list`, `read`, `require`, and `latest` for session lookup;
+- use `create`, `rename`, and `delete` for lifecycle changes;
+- use `updateSettings` for shared model, reasoning-effort, and drift settings;
+- reserve generic `update` for persisted session changes that are not yet
+  expressed as a named service operation.
+
 That rule applies even for local hosts like the TUI. The TUI may call core
 session services directly, but it should not call repositories or file-storage
 helpers directly. Treat the local TUI the same way you would treat a web client

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -27,7 +27,10 @@ import {
 import type { ChatSession } from '../../types.js';
 import type { ConversationEngineConfig } from '../types.js';
 import type { NormalizedConversationEngineConfig } from '../config.js';
-import type { ConversationSessionService } from '../types.js';
+import type {
+  ConversationSessionService,
+  UpdateConversationSessionSettingsInput,
+} from '../types.js';
 
 export function createConversationSessionService(args: {
   config: NormalizedConversationEngineConfig | ConversationSessionServiceConfig;
@@ -40,9 +43,48 @@ export function createConversationSessionService(args: {
   function loadSessions(apiKeyPresent = config.apiKeyPresent): ChatSession[] {
     const sessions = repository.list(apiKeyPresent);
     if (repository.readCatalog().length === 0) {
-      repository.save(sessions);
+      const fallback = createFallbackSession(config, apiKeyPresent);
+      repository.save([fallback]);
+      return [fallback];
     }
     return sessions;
+  }
+
+  function readSession(id: string): ChatSession | undefined {
+    return loadSessions().find((candidate) => candidate.id === id);
+  }
+
+  function requireSession(id: string): ChatSession {
+    const session = readSession(id);
+    if (!session) {
+      throw new Error(`Chat session not found: ${id}`);
+    }
+    return session;
+  }
+
+  function updateSession(id: string, updater: (session: ChatSession) => ChatSession): ChatSession | undefined {
+    const sessions = loadSessions();
+    const session = sessions.find((candidate) => candidate.id === id);
+    if (!session) {
+      return undefined;
+    }
+
+    const nextSession = updater(session);
+    if (nextSession === session) {
+      return session;
+    }
+
+    const touched = touchSession(nextSession);
+    repository.save(sessions.map((candidate) => (candidate.id === id ? touched : candidate)));
+    return touched;
+  }
+
+  function updateRequiredSession(id: string, updater: (session: ChatSession) => ChatSession): ChatSession {
+    const updated = updateSession(id, updater);
+    if (!updated) {
+      throw new Error(`Chat session not found: ${id}`);
+    }
+    return updated;
   }
 
   return {
@@ -50,7 +92,13 @@ export function createConversationSessionService(args: {
       return loadSessions();
     },
     read(id) {
-      return repository.read(id, config.apiKeyPresent);
+      return readSession(id);
+    },
+    require(id) {
+      return requireSession(id);
+    },
+    latest() {
+      return loadSessions()[0];
     },
     create(input) {
       const existing = loadSessions(input?.apiKeyPresent ?? config.apiKeyPresent);
@@ -66,30 +114,16 @@ export function createConversationSessionService(args: {
       return session;
     },
     update(id, updater) {
-      const sessions = loadSessions();
-      const session = sessions.find((candidate) => candidate.id === id);
-      if (!session) {
-        return undefined;
-      }
-
-      const nextSession = updater(session);
-      if (nextSession === session) {
-        return session;
-      }
-
-      const touched = touchSession(nextSession);
-      repository.save(sessions.map((candidate) => (candidate.id === id ? touched : candidate)));
-      return touched;
+      return updateSession(id, updater);
+    },
+    updateSettings(id, input) {
+      return updateRequiredSession(id, (session) => applySessionSettings(session, input));
     },
     rename(id, name) {
-      const renamed = this.update(id, (session) => ({
+      return updateRequiredSession(id, (session) => ({
         ...session,
         name,
       }));
-      if (!renamed) {
-        throw new Error(`Chat session not found: ${id}`);
-      }
-      return renamed;
     },
     delete(id) {
       const sessions = loadSessions();
@@ -106,6 +140,30 @@ export function createConversationSessionService(args: {
       repository.save([createFallbackSession(config)]);
       return true;
     },
+  };
+}
+
+function applySessionSettings(
+  session: ChatSession,
+  input: UpdateConversationSessionSettingsInput,
+): ChatSession {
+  const model = input.model ?? session.model;
+  const reasoningEffort = input.reasoningEffort === null ? undefined : input.reasoningEffort ?? session.reasoningEffort;
+  const driftEnabled = input.driftEnabled ?? session.driftEnabled;
+
+  if (
+    model === session.model &&
+    reasoningEffort === session.reasoningEffort &&
+    driftEnabled === session.driftEnabled
+  ) {
+    return session;
+  }
+
+  return {
+    ...session,
+    model,
+    reasoningEffort,
+    driftEnabled,
   };
 }
 
@@ -136,11 +194,12 @@ function normalizeConversationSessionServiceConfig(
 
 function createFallbackSession(
   config: Pick<NormalizedConversationEngineConfig, 'model' | 'reasoningEffort' | 'workspaceId' | 'apiKeyPresent'>,
+  apiKeyPresent = config.apiKeyPresent,
 ): ChatSession {
   return createChatSession({
     id: 'session-1',
     name: 'Session 1',
-    apiKeyPresent: config.apiKeyPresent,
+    apiKeyPresent,
     model: config.model,
     reasoningEffort: config.reasoningEffort,
     workspaceId: config.workspaceId,

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -36,8 +36,11 @@ export type ConversationEngine = {
 export type ConversationSessionService = {
   list(): ChatSession[];
   read(id: string): ChatSession | undefined;
+  require(id: string): ChatSession;
+  latest(): ChatSession | undefined;
   create(input?: CreateConversationSessionInput): ChatSession;
   update(id: string, updater: (session: ChatSession) => ChatSession): ChatSession | undefined;
+  updateSettings(id: string, input: UpdateConversationSessionSettingsInput): ChatSession;
   rename(id: string, name: string): ChatSession;
   delete(id: string): boolean;
 };
@@ -49,6 +52,12 @@ export type CreateConversationSessionInput = {
   reasoningEffort?: ReasoningEffort;
   workspaceId?: string;
   apiKeyPresent?: boolean;
+};
+
+export type UpdateConversationSessionSettingsInput = {
+  model?: string;
+  reasoningEffort?: ReasoningEffort | null;
+  driftEnabled?: boolean;
 };
 
 export type ConversationTurnService = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,6 +320,7 @@ export type {
   ContinueConversationTurnInput,
   SubmitConversationTurnInput,
   SubmitConversationTurnResult,
+  UpdateConversationSessionSettingsInput,
 } from './core/chat/engine/types.js';
 export {
   runConversationTurn,


### PR DESCRIPTION
## Summary

- Extend `ConversationSessionService` with `require`, `latest`, and `updateSettings` so shared session lookup and settings mutation live behind the core chat engine boundary.
- Make default fallback session creation carry engine model/workspace defaults instead of relying on repository-level bare defaults.
- Move TUI session preference and rename paths onto service operations instead of inline persisted-session mutation.
- Export the new session settings input type and document the host-facing session service API.
- Add `yarn lint` as an alias for the existing `yarn eslint` command.

## Why

The P0 boundary work needs TUI, ask, and web/control-plane surfaces to share the same session semantics. This PR completes the first small service slice without migrating the control-plane service yet, so later host refactors can reuse `engine.sessions` instead of growing parallel session logic.

## Validation

- `yarn test:unit src/__tests__/unit/core/conversation-engine.test.ts` passed; due the script shape it ran all unit tests: 300 passed.
- `yarn typecheck` passed.
- `yarn test:integration` passed outside the sandbox: 261 passed.
- `yarn build` passed.
- `yarn eslint` passed.
- `yarn lint` passed.
- `git diff --check` passed.

## Follow-up

Before web/control-plane migration, the next slice should make the TUI fully rely on `ConversationSessionService` and add any missing service operations discovered during that inventory.