### PR TITLE
Classify Playwright suite as browser integration

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -89,3 +89,27 @@ jobs:
 
       - name: Run integration tests
         run: yarn test:integration
+
+  test-browser-integration:
+    name: test-browser-integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: yarn test:browser-integration:install --with-deps
+
+      - name: Run browser integration tests
+        run: yarn test:browser-integration

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ local/
 .heddle.*/
 coverage/
 .e2e/
+.browser-integration/
 evals/results/
 playwright-report/
 test-results/

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ yarn build
 yarn test
 ```
 
-`yarn test` runs the default unit and integration suites. Browser e2e coverage lives under `src/__tests__/e2e` and stays out of the default test command; run it explicitly with `yarn e2e` or `yarn test:e2e`.
+`yarn test` runs the default unit and integration suites. Browser integration coverage lives under `src/__tests__/browser-integration` and runs on PRs; run it locally with `yarn test:browser-integration`.
 
 See [Development and contributing](docs/guides/development.md) for the fuller contributor workflow.
 

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -30,7 +30,8 @@ Run the default fast test suites:
 yarn test
 ```
 
-That runs unit and integration suites, but excludes browser e2e by default.
+That runs unit and integration suites, but excludes browser integration by
+default.
 
 Run focused suites by test layer:
 
@@ -39,20 +40,27 @@ yarn test:unit
 yarn test:integration
 ```
 
-Run browser workflow tests explicitly:
+Run browser integration tests explicitly:
 
 ```bash
-yarn e2e:install
-yarn e2e
-yarn e2e:headed
-yarn test:e2e
+yarn test:browser-integration:install
+yarn test:browser-integration
+yarn test:browser-integration:headed
 ```
 
-`yarn e2e` runs Playwright against an isolated fixture daemon on `127.0.0.1:9876` and a Vite client on `127.0.0.1:5174`. It does not call live LLM providers. The first suite covers control-plane loading, route persistence, workspace switching, current Git diff review, and mobile navigation.
+`yarn test:browser-integration` runs Playwright against an isolated fixture
+daemon on `127.0.0.1:9876` and a Vite client on `127.0.0.1:5174`. It does not
+call live LLM providers; agent execution is mocked so the suite can run on every
+PR. The first suite covers control-plane loading, route persistence, workspace
+switching, current Git diff review, and mobile navigation.
 
-Use `yarn e2e:headed` when you want to watch the browser execute the workflow live.
+Use `yarn test:browser-integration:headed` when you want to watch the browser execute the workflow live.
 
-Use `yarn e2e:ui` when you want Playwright's timeline, trace, and selector tooling. If the preview pane shows `about:blank` after a completed run, select a specific test action in the left/timeline panels or rerun the selected test from the UI; the deterministic pass/fail result is still authoritative.
+Use `yarn test:browser-integration:ui` when you want Playwright's timeline,
+trace, and selector tooling. If the preview pane shows `about:blank` after a
+completed run, select a specific test action in the left/timeline panels or
+rerun the selected test from the UI; the deterministic pass/fail result is still
+authoritative.
 
 Run lint and type checking when you are making code changes:
 
@@ -144,7 +152,9 @@ High-level areas:
 - `src/web/`: control-plane frontend
 - `src/__tests__/unit/`: fast unit suites organized by product surface
 - `src/__tests__/integration/`: higher-level integration suites organized by product surface
-- `src/__tests__/e2e/`: Playwright/browser end-to-end suites excluded from default `yarn test`
+- `src/__tests__/browser-integration/`: Playwright browser suites that use a
+  fixture daemon and mocked agent execution
+- `src/__tests__/e2e/`: reserved for future true end-to-end suites
 - `examples/`: programmatic and workflow examples
 - `docs/`: user, operator, and project documentation
 

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "verify:tui-session-switch": "yarn verify:tui-behavior",
     "eval:agent": "tsx --no-cache src/cli/main.ts eval agent",
     "eval:clean": "tsx --no-cache src/cli/main.ts eval clean",
-    "e2e": "playwright test",
-    "e2e:ui": "playwright test --ui",
-    "e2e:headed": "playwright test --headed",
-    "e2e:install": "playwright install chromium",
+    "test:browser-integration": "playwright test",
+    "test:browser-integration:ui": "playwright test --ui",
+    "test:browser-integration:headed": "playwright test --headed",
+    "test:browser-integration:install": "playwright install chromium",
     "cli:dev": "tsx --no-cache src/cli/main.ts",
     "chat:dev": "tsx --no-cache src/cli/main.ts chat",
     "chat:dev:openai": "OPENAI_API_KEY=\"$PERSONAL_OPENAI_API_KEY\" tsx --no-cache src/cli/main.ts chat",
@@ -65,7 +65,6 @@
     "test": "yarn test:unit && yarn test:integration",
     "test:unit": "vitest run src/__tests__/unit",
     "test:integration": "vitest run src/__tests__/integration",
-    "test:e2e": "playwright test",
     "prepare": "yarn build"
   },
   "keywords": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const clientPort = process.env.HEDDLE_E2E_CLIENT_PORT ?? '5174';
-const controlPlaneUrl = process.env.HEDDLE_E2E_BASE_URL ?? `http://127.0.0.1:${clientPort}`;
-const serverPort = process.env.HEDDLE_E2E_SERVER_PORT ?? '9876';
+const clientPort = process.env.HEDDLE_BROWSER_INTEGRATION_CLIENT_PORT ?? '5174';
+const controlPlaneUrl = process.env.HEDDLE_BROWSER_INTEGRATION_BASE_URL ?? `http://127.0.0.1:${clientPort}`;
+const serverPort = process.env.HEDDLE_BROWSER_INTEGRATION_SERVER_PORT ?? '9876';
 const serverUrl = `http://127.0.0.1:${serverPort}`;
 
 export default defineConfig({
-  testDir: './src/__tests__/e2e',
+  testDir: './src/__tests__/browser-integration',
   timeout: 30_000,
   expect: {
     timeout: 10_000,
@@ -21,12 +21,12 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: 'node scripts/e2e-daemon.mjs',
+      command: 'node scripts/browser-integration-daemon.mjs',
       url: `${serverUrl}/trpc/controlPlane.state?batch=1&input=%7B%7D`,
       reuseExistingServer: false,
       timeout: 30_000,
       env: {
-        HEDDLE_E2E_SERVER_PORT: serverPort,
+        HEDDLE_BROWSER_INTEGRATION_SERVER_PORT: serverPort,
       },
     },
     {

--- a/scripts/browser-integration-daemon.mjs
+++ b/scripts/browser-integration-daemon.mjs
@@ -6,18 +6,18 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const fixtureRoot = resolve(repoRoot, '.e2e');
+const fixtureRoot = resolve(repoRoot, '.browser-integration');
 const homeRoot = join(fixtureRoot, 'home');
 const workspacesRoot = join(fixtureRoot, 'workspaces');
 const primaryWorkspace = join(workspacesRoot, 'primary');
 const secondaryWorkspace = join(workspacesRoot, 'secondary');
 
 prepareFixtureWorkspace(primaryWorkspace, {
-  name: 'Primary E2E Workspace',
-  extraReadmeLine: 'This line is an uncommitted E2E change.',
+  name: 'Primary Browser Integration Workspace',
+  extraReadmeLine: 'This line is an uncommitted browser integration change.',
 });
 prepareFixtureWorkspace(secondaryWorkspace, {
-  name: 'Secondary E2E Workspace',
+  name: 'Secondary Browser Integration Workspace',
 });
 mkdirSync(homeRoot, { recursive: true });
 
@@ -33,16 +33,16 @@ const child = spawn(
     '--host',
     '127.0.0.1',
     '--port',
-    process.env.HEDDLE_E2E_SERVER_PORT ?? '9876',
+    process.env.HEDDLE_BROWSER_INTEGRATION_SERVER_PORT ?? '9876',
   ],
   {
     cwd: repoRoot,
     env: {
       ...process.env,
       HOME: homeRoot,
-      HEDDLE_E2E_PRIMARY_WORKSPACE: primaryWorkspace,
-      HEDDLE_E2E_SECONDARY_WORKSPACE: secondaryWorkspace,
-      HEDDLE_E2E_FAKE_AGENT: '1',
+      HEDDLE_BROWSER_INTEGRATION_PRIMARY_WORKSPACE: primaryWorkspace,
+      HEDDLE_BROWSER_INTEGRATION_SECONDARY_WORKSPACE: secondaryWorkspace,
+      HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT: '1',
     },
     stdio: 'inherit',
   },
@@ -68,7 +68,7 @@ function prepareFixtureWorkspace(workspaceRoot, options) {
   mkdirSync(workspaceRoot, { recursive: true });
   writeFileSync(
     join(workspaceRoot, 'README.md'),
-    `# ${options.name}\n\nThis workspace is used by Heddle Playwright tests.\n`,
+    `# ${options.name}\n\nThis workspace is used by Heddle browser integration tests.\n`,
     'utf8',
   );
   writeFileSync(
@@ -81,9 +81,9 @@ function prepareFixtureWorkspace(workspaceRoot, options) {
   execGit(workspaceRoot, ['add', 'README.md', 'package.json']);
   execGit(workspaceRoot, [
     '-c',
-    'user.name=Heddle E2E',
+    'user.name=Heddle Browser Integration',
     '-c',
-    'user.email=heddle-e2e@example.com',
+    'user.email=heddle-browser-integration@example.com',
     '-c',
     'commit.gpgsign=false',
     'commit',
@@ -94,7 +94,7 @@ function prepareFixtureWorkspace(workspaceRoot, options) {
   if (options.extraReadmeLine) {
     writeFileSync(
       join(workspaceRoot, 'README.md'),
-      `# ${options.name}\n\nThis workspace is used by Heddle Playwright tests.\n\n${options.extraReadmeLine}\n`,
+      `# ${options.name}\n\nThis workspace is used by Heddle browser integration tests.\n\n${options.extraReadmeLine}\n`,
       'utf8',
     );
   }

--- a/src/__tests__/browser-integration/README.md
+++ b/src/__tests__/browser-integration/README.md
@@ -1,0 +1,12 @@
+# Browser Integration Tests
+
+This folder contains Playwright tests that exercise the browser control plane
+against a real Vite client and fixture daemon.
+
+These tests are intended to run on every PR. They verify browser behavior,
+frontend/server wiring, and file-backed fixture state without calling live model
+providers. Agent execution is intentionally mocked by the fixture daemon.
+
+Use `src/__tests__/e2e/` only for future true end-to-end tests that exercise
+production-like runtime behavior without the browser-integration fake agent
+path.

--- a/src/__tests__/browser-integration/control-plane.spec.ts
+++ b/src/__tests__/browser-integration/control-plane.spec.ts
@@ -2,8 +2,8 @@ import { expect, test } from '@playwright/test';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
-const secondaryWorkspace = resolve(repoRoot, '.e2e/workspaces/secondary');
+const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
+const secondaryWorkspace = resolve(repoRoot, '.browser-integration/workspaces/secondary');
 
 test('loads overview with fixture workspace state', async ({ page }) => {
   await page.goto('/overview');
@@ -57,12 +57,12 @@ test('creates a session and sends a mocked prompt through the browser flow', asy
   await page.getByTestId('new-session-button').click();
   await expect(page.locator('textarea')).toBeVisible();
 
-  await page.locator('textarea').fill('Explain this mocked E2E run');
+  await page.locator('textarea').fill('Explain this mocked browser integration run');
   await page.getByRole('button', { name: 'Send' }).click();
 
   const conversation = page.getByTestId('session-conversation');
-  await expect(conversation.getByText('Explain this mocked E2E run', { exact: true })).toBeVisible();
-  await expect(conversation.getByText('Mocked E2E agent response: Explain this mocked E2E run', { exact: true })).toBeVisible();
+  await expect(conversation.getByText('Explain this mocked browser integration run', { exact: true })).toBeVisible();
+  await expect(conversation.getByText('Mocked browser integration agent response: Explain this mocked browser integration run', { exact: true })).toBeVisible();
 });
 
 test('continues a mocked browser session after an initial prompt', async ({ page }) => {
@@ -75,14 +75,14 @@ test('continues a mocked browser session after an initial prompt', async ({ page
   await page.getByRole('button', { name: 'Send' }).click();
 
   const conversation = page.getByTestId('session-conversation');
-  await expect(conversation.getByText('Mocked E2E agent response: Start a mocked continuation flow', { exact: true })).toBeVisible();
+  await expect(conversation.getByText('Mocked browser integration agent response: Start a mocked continuation flow', { exact: true })).toBeVisible();
 
   const continueButton = page.getByTestId('session-composer-actions').getByRole('button', { name: 'Continue', exact: true });
   await expect(continueButton).toBeEnabled();
   await continueButton.click();
 
   await expect(conversation.getByText('Start a mocked continuation flow', { exact: true })).toHaveCount(2);
-  await expect(conversation.getByText('Mocked E2E agent response: Start a mocked continuation flow', { exact: true })).toHaveCount(2);
+  await expect(conversation.getByText('Mocked browser integration agent response: Start a mocked continuation flow', { exact: true })).toHaveCount(2);
 });
 
 test('mobile navigation exposes the primary sections', async ({ page }) => {

--- a/src/__tests__/e2e/README.md
+++ b/src/__tests__/e2e/README.md
@@ -1,0 +1,10 @@
+# End-To-End Tests
+
+This folder is reserved for true end-to-end tests.
+
+Use it for tests that exercise the packaged or production-like Heddle path with
+real runtime behavior across the CLI, daemon/server, browser, storage, and agent
+execution boundaries.
+
+Do not put browser tests here when they use a fixture daemon or mocked agent
+execution. Those belong in `src/__tests__/browser-integration/`.

--- a/src/server/features/control-plane/controllers/chat-sessions-controller.ts
+++ b/src/server/features/control-plane/controllers/chat-sessions-controller.ts
@@ -8,7 +8,7 @@
  * DTO projection.
  *
  * Current compromise:
- * the fake E2E shortcut below still mutates file-backed session storage
+ * the fake browser-integration shortcut below still mutates file-backed session storage
  * directly. Keep that path isolated until test fakes can be injected through
  * the engine turn boundary.
  */
@@ -110,8 +110,8 @@ export class ControlPlaneChatSessionsController {
   }
 
   async submitPrompt(args: SubmitChatPromptArgs) {
-    if (process.env.HEDDLE_E2E_FAKE_AGENT === '1') {
-      return await this.runFakeE2eSessionPrompt(args);
+    if (process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1') {
+      return await this.runFakeBrowserIntegrationSessionPrompt(args);
     }
 
     return await this.runEngineTurn(args, async ({ engine, host, abortSignal }) => {
@@ -129,13 +129,13 @@ export class ControlPlaneChatSessionsController {
   }
 
   async continuePrompt(args: ContinueChatPromptArgs) {
-    if (process.env.HEDDLE_E2E_FAKE_AGENT === '1') {
+    if (process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1') {
       const session = this.createEngine(args).sessions.require(args.sessionId);
       if (!session.history.length || !session.lastContinuePrompt) {
         throw new Error('There is no interrupted or prior run to continue yet.');
       }
 
-      return await this.runFakeE2eSessionPrompt({
+      return await this.runFakeBrowserIntegrationSessionPrompt({
         ...args,
         prompt: session.lastContinuePrompt,
       });
@@ -292,8 +292,8 @@ export class ControlPlaneChatSessionsController {
     };
   }
 
-  private async runFakeE2eSessionPrompt(args: SubmitChatPromptArgs) {
-    // Desired shape: fake E2E should become an injectable engine test host.
+  private async runFakeBrowserIntegrationSessionPrompt(args: SubmitChatPromptArgs) {
+    // Desired shape: fake browser integration should become an injectable engine test host.
     // This is the only control-plane session path that should mutate the file
     // repository directly.
     const repository = new FileChatSessionRepository({ sessionStoragePath: args.sessionStoragePath });
@@ -303,20 +303,20 @@ export class ControlPlaneChatSessionsController {
     }
 
     const timestamp = new Date().toISOString();
-    const assistantText = `Mocked E2E agent response: ${args.prompt}`;
+    const assistantText = `Mocked browser integration agent response: ${args.prompt}`;
     const nextHistory = [
       ...session.history,
       { role: 'user' as const, content: args.prompt },
       { role: 'assistant' as const, content: assistantText },
     ];
     const nextTurn: TurnSummary = {
-      id: `e2e-turn-${Date.now()}`,
+      id: `browser-integration-turn-${Date.now()}`,
       prompt: args.prompt,
       outcome: 'done',
       summary: assistantText,
       steps: 1,
-      traceFile: 'e2e-fake-trace.jsonl',
-      events: ['Mocked E2E session run completed.'],
+      traceFile: 'browser-integration-fake-trace.jsonl',
+      events: ['Mocked browser integration session run completed.'],
     };
     const updatedSession: ChatSession = {
       ...session,
@@ -340,7 +340,7 @@ export class ControlPlaneChatSessionsController {
       timestamp,
       event: {
         type: 'trace',
-        runId: `e2e-${args.sessionId}`,
+        runId: `browser-integration-${args.sessionId}`,
         timestamp,
         event: {
           type: 'run.finished',


### PR DESCRIPTION
## Summary
- move the current Playwright control-plane suite from e2e to browser-integration
- rename the fixture daemon and fake-agent environment variables to match browser integration semantics
- remove misleading e2e package scripts and reserve src/__tests__/e2e for future true end-to-end coverage
- add the browser integration suite to PR checks and update public development docs

## Verification
- yarn lint
- yarn typecheck
- yarn test:browser-integration