### PR TITLE
Refactor auth service boundary

### DIFF
--- a/src/__tests__/integration/chat/chat-runtime.test.ts
+++ b/src/__tests__/integration/chat/chat-runtime.test.ts
@@ -7,7 +7,7 @@ import type { ChatSession } from '../../../cli/chat/state/types.js';
 import { resolveApiKeyForModel, resolveChatRuntimeConfig, resolveProviderCredentialSourceForModel } from '../../../cli/chat/utils/runtime.js';
 import { createLogger } from '../../../core/utils/logger.js';
 import type { LlmAdapter, RunResult, ToolCall, ToolDefinition } from '../../../index.js';
-import { setStoredProviderCredential } from '../../../core/auth/provider-credentials.js';
+import { ProviderCredentialRepository } from '../../../core/auth/index.js';
 import { EngineConversationTurnService } from '../../../core/chat/engine/turns/service.js';
 import { FileConversationSessionService } from '../../../core/chat/engine/sessions/service.js';
 import { ChatSessionRecords } from '../../../core/chat/engine/sessions/records/index.js';
@@ -73,7 +73,7 @@ describe('resolveChatRuntimeConfig', () => {
     vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-chat-oauth-')), 'auth.json');
     const now = '2026-04-27T00:00:00.000Z';
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token',
@@ -82,7 +82,7 @@ describe('resolveChatRuntimeConfig', () => {
       accountId: 'account-1234567890',
       createdAt: now,
       updatedAt: now,
-    }, storePath);
+    });
 
     const runtime = resolveChatRuntimeConfig({
       workspaceRoot: '/tmp/heddle-test',
@@ -125,7 +125,7 @@ describe('resolveChatRuntimeConfig', () => {
     vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-chat-prefer-key-')), 'auth.json');
     const now = '2026-04-27T00:00:00.000Z';
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token',
@@ -134,7 +134,7 @@ describe('resolveChatRuntimeConfig', () => {
       accountId: 'account-1234567890',
       createdAt: now,
       updatedAt: now,
-    }, storePath);
+    });
 
     const runtime = resolveChatRuntimeConfig({
       workspaceRoot: '/tmp/heddle-test',
@@ -410,7 +410,7 @@ describe('control-plane shared chat runtime integration', () => {
     vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-control-plane-oauth-')), 'auth.json');
     const now = '2026-05-02T00:00:00.000Z';
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token',
@@ -419,7 +419,7 @@ describe('control-plane shared chat runtime integration', () => {
       accountId: 'account-1234567890',
       createdAt: now,
       updatedAt: now,
-    }, storePath);
+    });
 
     const session = controlPlaneChatSessionsController.createSession({
       ...createControlPlaneSessionEngineArgs(),
@@ -435,7 +435,7 @@ describe('control-plane shared chat runtime integration', () => {
     vi.stubEnv('OPENAI_API_KEY', 'test-openai-key');
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-control-plane-api-key-')), 'auth.json');
     const now = '2026-05-02T00:00:00.000Z';
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token',
@@ -444,7 +444,7 @@ describe('control-plane shared chat runtime integration', () => {
       accountId: 'account-1234567890',
       createdAt: now,
       updatedAt: now,
-    }, storePath);
+    });
 
     const session = controlPlaneChatSessionsController.createSession({
       ...createControlPlaneSessionEngineArgs(),

--- a/src/__tests__/integration/core/provider-credentials.test.ts
+++ b/src/__tests__/integration/core/provider-credentials.test.ts
@@ -2,26 +2,19 @@ import { mkdtempSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import {
-  getStoredProviderCredential,
-  listStoredProviderCredentialSummaries,
-  readProviderCredentialStore,
-  redactProviderCredential,
-  removeStoredProviderCredential,
-  resolveProviderCredentialStorePath,
-  setStoredProviderCredential,
-} from '../../../core/auth/provider-credentials.js';
+import { ProviderCredentialRepository } from '../../../core/auth/index.js';
 
 describe('provider credential store', () => {
   it('resolves the user auth store path under the Heddle base directory', () => {
-    expect(resolveProviderCredentialStorePath('/tmp/heddle-auth')).toBe('/tmp/heddle-auth/auth.json');
+    expect(ProviderCredentialRepository.resolveStorePath('/tmp/heddle-auth')).toBe('/tmp/heddle-auth/auth.json');
   });
 
   it('stores OAuth credentials with private file permissions and redacted display helpers', () => {
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-auth-store-')), 'auth.json');
     const now = '2026-04-27T00:00:00.000Z';
 
-    setStoredProviderCredential({
+    const repository = new ProviderCredentialRepository({ storePath });
+    repository.set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token-secret',
@@ -30,16 +23,16 @@ describe('provider credential store', () => {
       accountId: 'account-123',
       createdAt: now,
       updatedAt: now,
-    }, storePath);
+    });
 
     const stat = statSync(storePath);
     expect(stat.mode & 0o777).toBe(0o600);
-    expect(getStoredProviderCredential('openai', storePath)).toMatchObject({
+    expect(repository.get('openai')).toMatchObject({
       type: 'oauth',
       provider: 'openai',
       accountId: 'account-123',
     });
-    expect(listStoredProviderCredentialSummaries(storePath)).toEqual([
+    expect(repository.listSummaries()).toEqual([
       expect.objectContaining({
         provider: 'openai',
         type: 'oauth',
@@ -48,11 +41,11 @@ describe('provider credential store', () => {
       }),
     ]);
 
-    const credential = getStoredProviderCredential('openai', storePath);
+    const credential = repository.get('openai');
     if (!credential) {
       throw new Error('expected stored credential');
     }
-    expect(redactProviderCredential(credential)).toMatchObject({
+    expect(ProviderCredentialRepository.redact(credential)).toMatchObject({
       accessToken: 'acce…cret',
       refreshToken: 'refr…cret',
     });
@@ -60,18 +53,19 @@ describe('provider credential store', () => {
 
   it('ignores malformed credentials instead of surfacing token-shaped junk', () => {
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-auth-store-')), 'auth.json');
-    setStoredProviderCredential({
+    const repository = new ProviderCredentialRepository({ storePath });
+    repository.set({
       type: 'bearer',
       provider: 'anthropic',
       token: 'bearer-secret',
       createdAt: '2026-04-27T00:00:00.000Z',
       updatedAt: '2026-04-27T00:00:00.000Z',
-    }, storePath);
+    });
 
-    const store = readProviderCredentialStore(storePath);
+    const store = repository.read();
     expect(store.credentials.anthropic).toMatchObject({ type: 'bearer' });
-    expect(removeStoredProviderCredential('anthropic', storePath)).toBe(true);
-    expect(removeStoredProviderCredential('anthropic', storePath)).toBe(false);
-    expect(listStoredProviderCredentialSummaries(storePath)).toEqual([]);
+    expect(repository.remove('anthropic')).toBe(true);
+    expect(repository.remove('anthropic')).toBe(false);
+    expect(repository.listSummaries()).toEqual([]);
   });
 });

--- a/src/__tests__/integration/tools/tools.test.ts
+++ b/src/__tests__/integration/tools/tools.test.ts
@@ -29,7 +29,7 @@ import {
 import { createMemoryCheckpointTool } from '../../../core/tools/toolkits/knowledge/memory-checkpoint.js';
 import { createRecordKnowledgeTool } from '../../../core/tools/toolkits/knowledge/record-knowledge.js';
 import { RuntimeToolService } from '@/core/runtime/tools/index.js';
-import { setStoredProviderCredential } from '../../../core/auth/provider-credentials.js';
+import { ProviderCredentialRepository } from '../../../core/auth/index.js';
 
 describe('tool input validation', () => {
   it('rejects unexpected fields for list_files', async () => {
@@ -646,7 +646,7 @@ describe('webSearchTool', () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-web-search-oauth-success-'));
     const credentialStorePath = join(root, 'auth.json');
     writeFileSync(credentialStorePath, '{}\n');
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath: credentialStorePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token',
@@ -655,7 +655,7 @@ describe('webSearchTool', () => {
       accountId: 'account-123',
       createdAt: '2026-04-27T00:00:00.000Z',
       updatedAt: '2026-04-27T00:00:00.000Z',
-    }, credentialStorePath);
+    });
 
     const requests: Array<{ url: string; headers: Headers; body: string }> = [];
     const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
@@ -796,7 +796,7 @@ describe('viewImageTool', () => {
     const credentialStorePath = join(root, 'auth.json');
     await writeFile(imagePath, 'fake');
     writeFileSync(credentialStorePath, '{}\n');
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath: credentialStorePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token',
@@ -805,7 +805,7 @@ describe('viewImageTool', () => {
       accountId: 'account-123',
       createdAt: '2026-04-27T00:00:00.000Z',
       updatedAt: '2026-04-27T00:00:00.000Z',
-    }, credentialStorePath);
+    });
 
     const result = await createViewImageTool({
       model: 'o3',
@@ -832,7 +832,7 @@ describe('viewImageTool', () => {
     const credentialStorePath = join(root, 'auth.json');
     await writeFile(imagePath, 'fake-image-data');
     writeFileSync(credentialStorePath, '{}\n');
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath: credentialStorePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token',
@@ -841,7 +841,7 @@ describe('viewImageTool', () => {
       accountId: 'account-123',
       createdAt: '2026-04-27T00:00:00.000Z',
       updatedAt: '2026-04-27T00:00:00.000Z',
-    }, credentialStorePath);
+    });
 
     const requests: Array<{ url: string; headers: Headers; body: string }> = [];
     const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
@@ -908,7 +908,7 @@ describe('viewImageTool', () => {
     const credentialStorePath = join(root, 'auth.json');
     await writeFile(imagePath, 'fake-image-data');
     writeFileSync(credentialStorePath, '{}\n');
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath: credentialStorePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token',
@@ -917,7 +917,7 @@ describe('viewImageTool', () => {
       accountId: 'account-123',
       createdAt: '2026-04-27T00:00:00.000Z',
       updatedAt: '2026-04-27T00:00:00.000Z',
-    }, credentialStorePath);
+    });
 
     vi.stubGlobal('fetch', vi.fn(async () => {
       return new Response('', { status: 400 });

--- a/src/__tests__/integration/tui/auth-cli.test.ts
+++ b/src/__tests__/integration/tui/auth-cli.test.ts
@@ -2,10 +2,10 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { runAuthCli } from '../../../cli/auth.js';
-import { setStoredProviderCredential } from '../../../core/auth/provider-credentials.js';
+import { AuthCliController } from '../../../cli/auth.js';
+import { ProviderCredentialRepository } from '../../../core/auth/index.js';
 
-describe('runAuthCli', () => {
+describe('AuthCliController', () => {
   const writes: string[] = [];
   const originalWrite = process.stdout.write;
 
@@ -26,7 +26,7 @@ describe('runAuthCli', () => {
     captureStdout();
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-auth-cli-')), 'auth.json');
 
-    await runAuthCli('status', undefined, { storePath });
+    await AuthCliController.run('status', undefined, { storePath });
 
     expect(writes.join('')).toContain(`Auth store: ${storePath}`);
     expect(writes.join('')).toContain('Stored credentials: none');
@@ -35,7 +35,7 @@ describe('runAuthCli', () => {
   it('prints stored credential summaries without secrets and removes provider credentials', async () => {
     captureStdout();
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-auth-cli-')), 'auth.json');
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-secret',
@@ -44,10 +44,10 @@ describe('runAuthCli', () => {
       accountId: 'account-123',
       createdAt: '2026-04-27T00:00:00.000Z',
       updatedAt: '2026-04-27T00:00:00.000Z',
-    }, storePath);
+    });
 
-    await runAuthCli('status', undefined, { storePath });
-    await runAuthCli('logout', 'openai', { storePath });
+    await AuthCliController.run('status', undefined, { storePath });
+    await AuthCliController.run('logout', 'openai', { storePath });
 
     const output = writes.join('');
     expect(output).toContain('- openai: type=oauth account=account-123');
@@ -60,7 +60,7 @@ describe('runAuthCli', () => {
     captureStdout();
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-auth-cli-')), 'auth.json');
 
-    await runAuthCli('login', 'openai', {
+    await AuthCliController.run('login', 'openai', {
       storePath,
       openAiLogin: async () => ({
         type: 'oauth',
@@ -74,7 +74,7 @@ describe('runAuthCli', () => {
         label: 'ChatGPT/Codex OAuth',
       }),
     });
-    await runAuthCli('status', undefined, { storePath });
+    await AuthCliController.run('status', undefined, { storePath });
 
     const output = writes.join('');
     expect(output).toContain('Starting OpenAI ChatGPT/Codex OAuth login...');

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { setStoredProviderCredential } from '../../../core/auth/provider-credentials.js';
+import { ProviderCredentialRepository } from '../../../core/auth/index.js';
 import { ChatSessionRecords } from '../../../core/chat/engine/sessions/records/index.js';
 import { FileChatSessionRepository } from '../../../core/chat/engine/sessions/repository/index.js';
 import { ConversationTurnPreflightService } from '../../../core/chat/engine/turns/preflight/index.js';
@@ -117,7 +117,7 @@ describe('chat turn preparation modules', () => {
     const root = mkdtempSync(join(tmpdir(), 'heddle-turn-oauth-'));
     const credentialStorePath = join(root, 'auth.json');
     const now = '2026-05-02T00:00:00.000Z';
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath: credentialStorePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-token',
@@ -126,7 +126,7 @@ describe('chat turn preparation modules', () => {
       accountId: 'account-123',
       createdAt: now,
       updatedAt: now,
-    }, credentialStorePath);
+    });
 
     const runtime = ConversationTurnRuntimeResolver.resolve({
       config: {

--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import {
   OPENAI_CODEX_RESPONSES_ENDPOINT,
 } from '../../../core/auth/openai-oauth.js';
-import { setStoredProviderCredential } from '../../../core/auth/provider-credentials.js';
+import { ProviderCredentialRepository } from '../../../core/auth/index.js';
 import { AnthropicAdapter } from '../../../core/llm/adapters/anthropic/index.js';
 import { LlmAdapterService } from '../../../core/llm/index.js';
 import { ModelPolicyService } from '../../../core/llm/models/index.js';
@@ -38,7 +38,7 @@ describe('llm adapter factory', () => {
 
   it('loads stored OpenAI OAuth credentials when creating an adapter without an API key', async () => {
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-llm-oauth-')), 'auth.json');
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'stored-access-token',
@@ -47,7 +47,7 @@ describe('llm adapter factory', () => {
       accountId: 'account-123',
       createdAt: '2026-05-17T00:00:00.000Z',
       updatedAt: '2026-05-17T00:00:00.000Z',
-    }, storePath);
+    });
     const requests: Array<{ url: string; headers: Headers }> = [];
     const adapter = LlmAdapterService.create({
       model: 'gpt-5.4',

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -6,21 +6,15 @@ import {
   OPENAI_AUTH_ISSUER,
   OPENAI_CODEX_RESPONSES_ENDPOINT,
   OPENAI_CODEX_CLIENT_ID,
-  buildOpenUrlCommand,
-  buildOpenAiAuthorizeUrl,
-  createOpenAiOAuthCredential,
-  exchangeOpenAiOAuthCode,
-  extractOpenAiAccountId,
-  generatePkceCodes,
-  refreshOpenAiOAuthToken,
-  type OpenAiOAuthTokenResponse,
+  OpenAiOAuthService,
 } from '../../../core/auth/openai-oauth.js';
+import type { OpenAiOAuthTokenResponse } from '../../../core/auth/index.js';
 import { OpenAiAdapter, OpenAiOAuthFetchService } from '../../../core/llm/adapters/openai/index.js';
 import type { ReasoningEffort } from '../../../core/llm/types.js';
 
 describe('OpenAI OAuth helpers', () => {
   it('generates PKCE verifier and challenge values', () => {
-    const pkce = generatePkceCodes();
+    const pkce = OpenAiOAuthService.generatePkceCodes();
 
     expect(pkce.verifier).toMatch(/^[A-Za-z0-9_-]+$/);
     expect(pkce.challenge).toMatch(/^[A-Za-z0-9_-]+$/);
@@ -29,7 +23,7 @@ describe('OpenAI OAuth helpers', () => {
   });
 
   it('builds the Codex OAuth authorize URL', () => {
-    const url = new URL(buildOpenAiAuthorizeUrl({
+    const url = new URL(OpenAiOAuthService.buildAuthorizeUrl({
       redirectUri: 'http://localhost:1455/auth/callback',
       pkce: { verifier: 'verifier', challenge: 'challenge' },
       state: 'state',
@@ -46,7 +40,7 @@ describe('OpenAI OAuth helpers', () => {
 
   it('opens OAuth URLs on Windows without routing query separators through cmd.exe', () => {
     const authorizeUrl = 'https://auth.openai.com/oauth/authorize?response_type=code&client_id=client&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback';
-    const command = buildOpenUrlCommand(authorizeUrl, 'win32');
+    const command = OpenAiOAuthService.buildOpenUrlCommand(authorizeUrl, 'win32');
     const encodedCommand = command.args.at(-1);
 
     expect(command.command).toBe('powershell.exe');
@@ -63,8 +57,8 @@ describe('OpenAI OAuth helpers', () => {
       refresh_token: 'refresh',
     };
 
-    expect(extractOpenAiAccountId(tokens)).toBe('account-nested');
-    expect(createOpenAiOAuthCredential(tokens, Date.parse('2026-04-27T00:00:00.000Z'))).toMatchObject({
+    expect(OpenAiOAuthService.extractAccountId(tokens)).toBe('account-nested');
+    expect(OpenAiOAuthService.createCredential(tokens, Date.parse('2026-04-27T00:00:00.000Z'))).toMatchObject({
       type: 'oauth',
       provider: 'openai',
       accountId: 'account-nested',
@@ -87,13 +81,13 @@ describe('OpenAI OAuth helpers', () => {
       });
     }) as typeof fetch;
 
-    await exchangeOpenAiOAuthCode({
+    await OpenAiOAuthService.exchangeCode({
       code: 'code',
       redirectUri: 'http://localhost:1455/auth/callback',
       codeVerifier: 'verifier',
       fetchImpl,
     });
-    await refreshOpenAiOAuthToken({
+    await OpenAiOAuthService.refreshToken({
       refreshToken: 'refresh-token',
       fetchImpl,
     });

--- a/src/__tests__/unit/tui/local-commands.test.ts
+++ b/src/__tests__/unit/tui/local-commands.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { autocompleteLocalCommand, getLocalCommandHints, isLikelyLocalCommand, runLocalCommand } from '../../../cli/chat/state/local-commands.js';
-import { getStoredProviderCredential, setStoredProviderCredential } from '../../../core/auth/provider-credentials.js';
+import { ProviderCredentialRepository } from '../../../core/auth/index.js';
 import { FileHeartbeatTaskRepository } from '@/core/heartbeat/index.js';
 
 const absoluteScreenshotFixturePath = join(process.cwd(), 'src/__tests__/fixtures/screenshot.png');
@@ -466,7 +466,7 @@ describe('runLocalCommand', () => {
     expect(login.message).toContain('Stored OpenAI OAuth credential.');
     expect(login.message).toContain('Account: account-123');
     expect(login.message).not.toContain('access-secret');
-    expect(getStoredProviderCredential('openai', storePath)).toMatchObject({
+    expect(new ProviderCredentialRepository({ storePath }).get('openai')).toMatchObject({
       type: 'oauth',
       provider: 'openai',
       accountId: 'account-123',
@@ -475,7 +475,7 @@ describe('runLocalCommand', () => {
 
   it('supports provider credential logout from chat', async () => {
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-chat-auth-')), 'auth.json');
-    setStoredProviderCredential({
+    new ProviderCredentialRepository({ storePath }).set({
       type: 'oauth',
       provider: 'openai',
       accessToken: 'access-secret',
@@ -484,7 +484,7 @@ describe('runLocalCommand', () => {
       accountId: 'account-123',
       createdAt: '2026-04-27T00:00:00.000Z',
       updatedAt: '2026-04-27T00:00:00.000Z',
-    }, storePath);
+    });
 
     const logout = await runLocalCommand(createCommandArgs({
       prompt: '/auth logout openai',
@@ -496,7 +496,7 @@ describe('runLocalCommand', () => {
       kind: 'message',
       message: 'Removed stored openai credential.',
     });
-    expect(getStoredProviderCredential('openai', storePath)).toBeUndefined();
+    expect(new ProviderCredentialRepository({ storePath }).get('openai')).toBeUndefined();
   });
 
   it('includes /compact and /drift in shared slash-command hints', () => {

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,11 +1,9 @@
 import type { LlmProvider } from '../core/llm/types.js';
-import { runOpenAiBrowserOAuthLogin, type OpenAiOAuthCredential } from '../core/auth/openai-oauth.js';
 import {
-  listStoredProviderCredentialSummaries,
-  removeStoredProviderCredential,
-  resolveProviderCredentialStorePath,
-  setStoredProviderCredential,
-} from '../core/auth/provider-credentials.js';
+  OpenAiOAuthService,
+  ProviderCredentialRepository,
+  type OpenAiOAuthCredential,
+} from '../core/auth/index.js';
 
 export type AuthCliCommand = 'status' | 'logout' | 'login';
 
@@ -17,94 +15,100 @@ export type AuthCliOptions = {
 
 const SUPPORTED_PROVIDERS = new Set<LlmProvider>(['openai', 'anthropic', 'google']);
 
-export async function runAuthCli(command: AuthCliCommand, provider?: string, options: AuthCliOptions = {}) {
-  const storePath = options.storePath ?? resolveProviderCredentialStorePath();
+/**
+ * CLI controller for auth commands. Core auth owns persistence and OAuth; this
+ * class owns command parsing plus terminal-oriented status/login/logout output.
+ */
+export class AuthCliController {
+  static async run(command: AuthCliCommand, provider?: string, options: AuthCliOptions = {}) {
+    const storePath = options.storePath ?? ProviderCredentialRepository.resolveStorePath();
 
-  if (command === 'status') {
-    process.stdout.write(formatAuthStatusMessage(storePath));
+    if (command === 'status') {
+      process.stdout.write(AuthCliController.formatStatusMessage(storePath));
+      process.stdout.write('\n');
+      return;
+    }
+
+    const normalizedProvider = AuthCliController.parseProvider(provider);
+    if (command === 'login') {
+      process.stdout.write('Starting OpenAI ChatGPT/Codex OAuth login...\n');
+      process.stdout.write(await AuthCliController.loginProviderWithOAuth(normalizedProvider, {
+        ...options,
+        storePath,
+        onAuthorizeUrl: (url) => {
+          process.stdout.write(`Open this URL to authorize Heddle:\n${url}\n`);
+        },
+      }));
+      process.stdout.write('\n');
+      return;
+    }
+
+    process.stdout.write(AuthCliController.logoutProvider(normalizedProvider, storePath));
     process.stdout.write('\n');
-    return;
   }
 
-  const normalizedProvider = parseProvider(provider);
-  if (command === 'login') {
-    process.stdout.write('Starting OpenAI ChatGPT/Codex OAuth login...\n');
-    process.stdout.write(await loginProviderWithOAuth(normalizedProvider, {
-      ...options,
-      storePath,
-      onAuthorizeUrl: (url) => {
-        process.stdout.write(`Open this URL to authorize Heddle:\n${url}\n`);
-      },
-    }));
-    process.stdout.write('\n');
-    return;
+  static formatStatusMessage(storePath = ProviderCredentialRepository.resolveStorePath()): string {
+    const summaries = new ProviderCredentialRepository({ storePath }).listSummaries();
+    const lines = [`Auth store: ${storePath}`];
+
+    if (summaries.length === 0) {
+      return [...lines, 'Stored credentials: none'].join('\n');
+    }
+
+    lines.push('Stored credentials:');
+    for (const summary of summaries) {
+      const details = [
+        `type=${summary.type}`,
+        summary.label ? `label=${summary.label}` : undefined,
+        summary.accountId ? `account=${summary.accountId}` : undefined,
+        summary.expiresAt ? `expires=${new Date(summary.expiresAt).toISOString()}` : undefined,
+        summary.expired === true ? 'expired=true' : undefined,
+        `updated=${summary.updatedAt}`,
+      ].filter(Boolean);
+      lines.push(`- ${summary.provider}: ${details.join(' ')}`);
+    }
+    return lines.join('\n');
   }
 
-  process.stdout.write(logoutProvider(normalizedProvider, storePath));
-  process.stdout.write('\n');
-}
+  static async loginProviderWithOAuth(
+    provider: LlmProvider,
+    options: AuthCliOptions & { onAuthorizeUrl?: (url: string) => void } = {},
+  ): Promise<string> {
+    const storePath = options.storePath ?? ProviderCredentialRepository.resolveStorePath();
+    if (provider !== 'openai') {
+      throw new Error(`OAuth login is not available for ${provider}. Use API keys or supported provider credentials.`);
+    }
 
-export function formatAuthStatusMessage(storePath = resolveProviderCredentialStorePath()): string {
-  const summaries = listStoredProviderCredentialSummaries(storePath);
-  const lines = [`Auth store: ${storePath}`];
+    const credential = await (options.openAiLogin ?? (() => OpenAiOAuthService.runBrowserLogin({
+      openBrowser: options.openBrowser,
+      onAuthorizeUrl: options.onAuthorizeUrl,
+    })))();
+    new ProviderCredentialRepository({ storePath }).set(credential);
 
-  if (summaries.length === 0) {
-    return [...lines, 'Stored credentials: none'].join('\n');
+    return [
+      'Stored OpenAI OAuth credential.',
+      credential.accountId ? `Account: ${credential.accountId}` : undefined,
+      `Expires: ${new Date(credential.expiresAt).toISOString()}`,
+    ].filter((line): line is string => Boolean(line)).join('\n');
   }
 
-  lines.push('Stored credentials:');
-  for (const summary of summaries) {
-    const details = [
-      `type=${summary.type}`,
-      summary.label ? `label=${summary.label}` : undefined,
-      summary.accountId ? `account=${summary.accountId}` : undefined,
-      summary.expiresAt ? `expires=${new Date(summary.expiresAt).toISOString()}` : undefined,
-      summary.expired === true ? 'expired=true' : undefined,
-      `updated=${summary.updatedAt}`,
-    ].filter(Boolean);
-    lines.push(`- ${summary.provider}: ${details.join(' ')}`);
-  }
-  return lines.join('\n');
-}
-
-export async function loginProviderWithOAuth(
-  provider: LlmProvider,
-  options: AuthCliOptions & { onAuthorizeUrl?: (url: string) => void } = {},
-): Promise<string> {
-  const storePath = options.storePath ?? resolveProviderCredentialStorePath();
-  if (provider !== 'openai') {
-    throw new Error(`OAuth login is not available for ${provider}. Use API keys or supported provider credentials.`);
+  static logoutProvider(provider: LlmProvider, storePath = ProviderCredentialRepository.resolveStorePath()): string {
+    const removed = new ProviderCredentialRepository({ storePath }).remove(provider);
+    return removed ?
+        `Removed stored ${provider} credential.`
+      : `No stored ${provider} credential found.`;
   }
 
-  const credential = await (options.openAiLogin ?? (() => runOpenAiBrowserOAuthLogin({
-    openBrowser: options.openBrowser,
-    onAuthorizeUrl: options.onAuthorizeUrl,
-  })))();
-  setStoredProviderCredential(credential, storePath);
+  private static parseProvider(provider: string | undefined): LlmProvider {
+    if (!provider) {
+      throw new Error('Usage: heddle auth logout <provider>');
+    }
 
-  return [
-    'Stored OpenAI OAuth credential.',
-    credential.accountId ? `Account: ${credential.accountId}` : undefined,
-    `Expires: ${new Date(credential.expiresAt).toISOString()}`,
-  ].filter((line): line is string => Boolean(line)).join('\n');
-}
+    const normalized = provider.trim().toLowerCase();
+    if (!SUPPORTED_PROVIDERS.has(normalized as LlmProvider)) {
+      throw new Error(`Unsupported auth provider: ${provider}`);
+    }
 
-export function logoutProvider(provider: LlmProvider, storePath = resolveProviderCredentialStorePath()): string {
-  const removed = removeStoredProviderCredential(provider, storePath);
-  return removed ?
-      `Removed stored ${provider} credential.`
-    : `No stored ${provider} credential found.`;
-}
-
-function parseProvider(provider: string | undefined): LlmProvider {
-  if (!provider) {
-    throw new Error('Usage: heddle auth logout <provider>');
+    return normalized as LlmProvider;
   }
-
-  const normalized = provider.trim().toLowerCase();
-  if (!SUPPORTED_PROVIDERS.has(normalized as LlmProvider)) {
-    throw new Error(`Unsupported auth provider: ${provider}`);
-  }
-
-  return normalized as LlmProvider;
 }

--- a/src/cli/chat/adapters/slash-command-context.ts
+++ b/src/cli/chat/adapters/slash-command-context.ts
@@ -1,4 +1,4 @@
-import { formatAuthStatusMessage, loginProviderWithOAuth, logoutProvider } from '../../auth.js';
+import { AuthCliController } from '../../auth.js';
 import { FileHeartbeatTaskRepository } from '@/core/heartbeat/index.js';
 import { ChatSessionRecords } from '../../../core/chat/engine/sessions/records/index.js';
 import type { SlashCommandExecutionContext } from '../../../core/commands/slash/modules/context.js';
@@ -19,13 +19,13 @@ export function createTuiSlashCommandContext(args: LocalCommandArgs): SlashComma
       credentialSource: () => args.providerCredentialSource,
     },
     auth: {
-      status: () => formatAuthStatusMessage(args.credentialStorePath),
+      status: () => AuthCliController.formatStatusMessage(args.credentialStorePath),
       login: (provider) =>
-        loginProviderWithOAuth(provider, {
+        AuthCliController.loginProviderWithOAuth(provider, {
           storePath: args.credentialStorePath,
           openAiLogin: args.openAiLogin,
         }),
-      logout: (provider) => logoutProvider(provider, args.credentialStorePath),
+      logout: (provider) => AuthCliController.logoutProvider(provider, args.credentialStorePath),
     },
     compaction: {
       compactActive: args.compactConversation,

--- a/src/cli/chat/state/local-commands.ts
+++ b/src/cli/chat/state/local-commands.ts
@@ -1,5 +1,5 @@
 import type { ChatSession } from './types.js';
-import type { OpenAiOAuthCredential } from '../../../core/auth/openai-oauth.js';
+import type { OpenAiOAuthCredential } from '@/core/auth/index.js';
 import type { ReasoningEffort } from '../../../core/llm/types.js';
 import type { ProviderCredentialSource } from '../utils/runtime.js';
 import { autocompleteSlashCommand, filterSlashCommandHints } from '../../../core/commands/slash/autocomplete.js';

--- a/src/cli/chat/utils/runtime.ts
+++ b/src/cli/chat/utils/runtime.ts
@@ -2,7 +2,7 @@ import { join, resolve } from 'node:path';
 import { appendMemoryCatalogSystemContext, DEFAULT_OPENAI_MODEL, LlmAdapterService } from '../../../index.js';
 import type { LlmProvider } from '../../../index.js';
 import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
-import { resolveProviderCredentialStorePath } from '../../../core/auth/provider-credentials.js';
+import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import {
   RuntimeCredentialService,
   type ProviderCredentialSource,
@@ -61,7 +61,7 @@ export function resolveChatRuntimeConfig(options: ChatCliOptions): ChatRuntimeCo
   const sessionId = `chat-${Date.now()}`;
   const stateRoot = resolve(workspaceRoot, options.stateDir ?? '.heddle');
   const memoryDir = join(stateRoot, 'memory');
-  const credentialStorePath = options.credentialStorePath ?? resolveProviderCredentialStorePath();
+  const credentialStorePath = options.credentialStorePath ?? ProviderCredentialRepository.resolveStorePath();
   const model = options.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
   const provider = LlmAdapterService.inferProvider(model);
   const preferApiKey = Boolean(options.preferApiKey);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -21,7 +21,7 @@ import {
   validateMemoryWorkspace,
 } from '../core/memory/validation.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
-import { runAuthCli } from './auth.js';
+import { AuthCliController } from './auth.js';
 import { AskCliHost } from './ask.js';
 import { startChatCli } from './chat/index.js';
 import { runDaemonCli } from './daemon.js';
@@ -211,7 +211,7 @@ async function main() {
     .command('auth')
     .description('manage provider credentials')
     .action(async () => {
-      await runAuthCli('status');
+      await AuthCliController.run('status');
     });
 
   authCommand
@@ -219,21 +219,21 @@ async function main() {
     .description('log in to a provider')
     .option('--no-browser', 'print the authorization URL without opening a browser')
     .action(async (provider: string, flags: { browser?: boolean }) => {
-      await runAuthCli('login', provider, { openBrowser: flags.browser });
+      await AuthCliController.run('login', provider, { openBrowser: flags.browser });
     });
 
   authCommand
     .command('status')
     .description('show stored provider credentials')
     .action(async () => {
-      await runAuthCli('status');
+      await AuthCliController.run('status');
     });
 
   authCommand
     .command('logout <provider>')
     .description('remove a stored provider credential')
     .action(async (provider: string) => {
-      await runAuthCli('logout', provider);
+      await AuthCliController.run('logout', provider);
     });
 
   program

--- a/src/core/auth/README.md
+++ b/src/core/auth/README.md
@@ -1,0 +1,17 @@
+# Auth
+
+`src/core/auth/` owns persisted provider credentials and OpenAI account sign-in.
+
+The boundary is intentionally small:
+
+- `ProviderCredentialRepository` owns `auth.json` path resolution, zod-backed
+  deserialization, writes, private file permissions, summaries, and redaction.
+- `OpenAiOAuthService` owns the OpenAI OAuth browser flow, token exchange,
+  refresh, account-id extraction, and platform-specific browser launching.
+- Runtime and LLM services may ask auth for credentials, but auth should not
+  own model policy, adapter selection, tool behavior, or UI formatting.
+
+When adding another persisted auth format, add schema fields in `schemas.ts` and
+repository methods on `ProviderCredentialRepository`. Avoid loose one-off
+exported functions; auth behavior should be reachable through a clear class
+boundary.

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -1,0 +1,13 @@
+export { ProviderCredentialRepository } from './provider-credentials.js';
+export { OpenAiOAuthService } from './openai-oauth.js';
+export type {
+  OpenAiIdTokenClaims,
+  OpenAiOAuthCredential,
+  OpenAiOAuthLoginOptions,
+  OpenAiOAuthRefreshOptions,
+  OpenAiOAuthTokenResponse,
+  PkceCodes,
+  ProviderCredentialStore,
+  ProviderCredentialSummary,
+  StoredProviderCredential,
+} from './types.js';

--- a/src/core/auth/openai-oauth.ts
+++ b/src/core/auth/openai-oauth.ts
@@ -1,8 +1,16 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { createServer, type Server } from 'node:http';
 import { spawn } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import type { StoredProviderCredential } from './provider-credentials.js';
+import type {
+  OpenAiIdTokenClaims,
+  OpenAiOAuthCallbackServer,
+  OpenAiOAuthCredential,
+  OpenAiOAuthLoginOptions,
+  OpenAiOAuthRefreshOptions,
+  OpenAiOAuthTokenResponse,
+  PkceCodes,
+} from './types.js';
 
 export const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 export const OPENAI_AUTH_ISSUER = 'https://auth.openai.com';
@@ -10,394 +18,354 @@ export const OPENAI_CODEX_RESPONSES_ENDPOINT = 'https://chatgpt.com/backend-api/
 export const OPENAI_OAUTH_CALLBACK_PATH = '/auth/callback';
 export const DEFAULT_OPENAI_OAUTH_PORT = 1455;
 
-export type PkceCodes = {
-  verifier: string;
-  challenge: string;
-};
-
-export type OpenAiOAuthTokenResponse = {
-  id_token?: string;
-  access_token: string;
-  refresh_token: string;
-  expires_in?: number;
-};
-
-export type OpenAiOAuthCredential = Extract<StoredProviderCredential, { type: 'oauth' }>;
-
-export type OpenAiOAuthLoginOptions = {
-  port?: number;
-  openBrowser?: boolean;
-  timeoutMs?: number;
-  fetchImpl?: typeof fetch;
-  openUrl?: (url: string) => Promise<void> | void;
-  onAuthorizeUrl?: (url: string) => void;
-};
-
-export type OpenAiOAuthRefreshOptions = {
-  refreshToken: string;
-  fetchImpl?: typeof fetch;
-};
-
-export type OpenAiIdTokenClaims = {
-  chatgpt_account_id?: string;
-  organizations?: Array<{ id?: string }>;
-  'https://api.openai.com/auth'?: {
-    chatgpt_account_id?: string;
-  };
-};
-
-export function generatePkceCodes(): PkceCodes {
-  const verifier = base64UrlEncode(randomBytes(32));
-  const challenge = base64UrlEncode(createHash('sha256').update(verifier).digest());
-  return { verifier, challenge };
-}
-
-export function generateOAuthState(): string {
-  return base64UrlEncode(randomBytes(32));
-}
-
-export function buildOpenAiAuthorizeUrl(args: {
-  redirectUri: string;
-  pkce: PkceCodes;
-  state: string;
-  originator?: string;
-}): string {
-  const params = new URLSearchParams({
-    response_type: 'code',
-    client_id: OPENAI_CODEX_CLIENT_ID,
-    redirect_uri: args.redirectUri,
-    scope: 'openid profile email offline_access',
-    code_challenge: args.pkce.challenge,
-    code_challenge_method: 'S256',
-    id_token_add_organizations: 'true',
-    codex_cli_simplified_flow: 'true',
-    state: args.state,
-    originator: args.originator ?? 'heddle',
-  });
-
-  return `${OPENAI_AUTH_ISSUER}/oauth/authorize?${params.toString()}`;
-}
-
-export async function runOpenAiBrowserOAuthLogin(
-  options: OpenAiOAuthLoginOptions = {},
-): Promise<OpenAiOAuthCredential> {
-  const port = options.port ?? DEFAULT_OPENAI_OAUTH_PORT;
-  const pkce = generatePkceCodes();
-  const state = generateOAuthState();
-  const callback = await startOpenAiOAuthCallbackServer({
-    port,
-    state,
-    pkce,
-    timeoutMs: options.timeoutMs,
-    fetchImpl: options.fetchImpl,
-  });
-  const authUrl = buildOpenAiAuthorizeUrl({
-    redirectUri: callback.redirectUri,
-    pkce,
-    state,
-  });
-
-  try {
-    options.onAuthorizeUrl?.(authUrl);
-    if (options.openBrowser !== false) {
-      await (options.openUrl ?? openUrlInBrowser)(authUrl);
-    }
-    const tokens = await callback.tokens;
-    return createOpenAiOAuthCredential(tokens);
-  } finally {
-    await callback.close();
+/**
+ * OpenAI account sign-in service. It owns OAuth URL construction, callback
+ * handling, token exchange/refresh, credential creation, and browser launch.
+ */
+export class OpenAiOAuthService {
+  static generatePkceCodes(): PkceCodes {
+    const verifier = OpenAiOAuthService.base64UrlEncode(randomBytes(32));
+    const challenge = OpenAiOAuthService.base64UrlEncode(createHash('sha256').update(verifier).digest());
+    return { verifier, challenge };
   }
-}
 
-export async function refreshOpenAiOAuthCredential(
-  credential: OpenAiOAuthCredential,
-  options: { fetchImpl?: typeof fetch } = {},
-): Promise<OpenAiOAuthCredential> {
-  const tokens = await refreshOpenAiOAuthToken({
-    refreshToken: credential.refreshToken,
-    fetchImpl: options.fetchImpl,
-  });
-  return {
-    ...createOpenAiOAuthCredential(tokens),
-    createdAt: credential.createdAt,
-    accountId: extractOpenAiAccountId(tokens) ?? credential.accountId,
-  };
-}
+  static generateState(): string {
+    return OpenAiOAuthService.base64UrlEncode(randomBytes(32));
+  }
 
-export async function exchangeOpenAiOAuthCode(args: {
-  code: string;
-  redirectUri: string;
-  codeVerifier: string;
-  fetchImpl?: typeof fetch;
-}): Promise<OpenAiOAuthTokenResponse> {
-  const fetcher = args.fetchImpl ?? fetch;
-  const response = await fetcher(`${OPENAI_AUTH_ISSUER}/oauth/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'authorization_code',
-      code: args.code,
+  static buildAuthorizeUrl(args: {
+    redirectUri: string;
+    pkce: PkceCodes;
+    state: string;
+    originator?: string;
+  }): string {
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: OPENAI_CODEX_CLIENT_ID,
       redirect_uri: args.redirectUri,
-      client_id: OPENAI_CODEX_CLIENT_ID,
-      code_verifier: args.codeVerifier,
-    }).toString(),
-  });
-
-  if (!response.ok) {
-    throw new Error(`OpenAI OAuth token exchange failed: ${response.status}`);
-  }
-
-  return normalizeTokenResponse(await response.json());
-}
-
-export async function refreshOpenAiOAuthToken(
-  options: OpenAiOAuthRefreshOptions,
-): Promise<OpenAiOAuthTokenResponse> {
-  const fetcher = options.fetchImpl ?? fetch;
-  const response = await fetcher(`${OPENAI_AUTH_ISSUER}/oauth/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: options.refreshToken,
-      client_id: OPENAI_CODEX_CLIENT_ID,
-    }).toString(),
-  });
-
-  if (!response.ok) {
-    throw new Error(`OpenAI OAuth token refresh failed: ${response.status}`);
-  }
-
-  return normalizeTokenResponse(await response.json());
-}
-
-export function createOpenAiOAuthCredential(
-  tokens: OpenAiOAuthTokenResponse,
-  now = Date.now(),
-): OpenAiOAuthCredential {
-  const timestamp = new Date(now).toISOString();
-  return {
-    type: 'oauth',
-    provider: 'openai',
-    accessToken: tokens.access_token,
-    refreshToken: tokens.refresh_token,
-    expiresAt: now + (tokens.expires_in ?? 3600) * 1000,
-    accountId: extractOpenAiAccountId(tokens),
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    label: 'ChatGPT/Codex OAuth',
-  };
-}
-
-export function parseJwtClaims(token: string): OpenAiIdTokenClaims | undefined {
-  const parts = token.split('.');
-  if (parts.length !== 3) {
-    return undefined;
-  }
-
-  try {
-    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as OpenAiIdTokenClaims;
-  } catch {
-    return undefined;
-  }
-}
-
-export function extractOpenAiAccountId(tokens: Pick<OpenAiOAuthTokenResponse, 'id_token' | 'access_token'>): string | undefined {
-  const idClaims = tokens.id_token ? parseJwtClaims(tokens.id_token) : undefined;
-  const idAccount = idClaims ? extractOpenAiAccountIdFromClaims(idClaims) : undefined;
-  if (idAccount) {
-    return idAccount;
-  }
-
-  const accessClaims = parseJwtClaims(tokens.access_token);
-  return accessClaims ? extractOpenAiAccountIdFromClaims(accessClaims) : undefined;
-}
-
-export function extractOpenAiAccountIdFromClaims(claims: OpenAiIdTokenClaims): string | undefined {
-  return (
-    claims.chatgpt_account_id
-    ?? claims['https://api.openai.com/auth']?.chatgpt_account_id
-    ?? claims.organizations?.find((organization) => organization.id)?.id
-  );
-}
-
-type CallbackServer = {
-  redirectUri: string;
-  tokens: Promise<OpenAiOAuthTokenResponse>;
-  close: () => Promise<void>;
-};
-
-async function startOpenAiOAuthCallbackServer(args: {
-  port: number;
-  state: string;
-  pkce: PkceCodes;
-  timeoutMs?: number;
-  fetchImpl?: typeof fetch;
-}): Promise<CallbackServer> {
-  let settled = false;
-  let resolveTokens: (tokens: OpenAiOAuthTokenResponse) => void;
-  let rejectTokens: (error: Error) => void;
-  const tokens = new Promise<OpenAiOAuthTokenResponse>((resolve, reject) => {
-    resolveTokens = resolve;
-    rejectTokens = reject;
-  });
-  const timeout = setTimeout(() => {
-    if (!settled) {
-      settled = true;
-      rejectTokens(new Error('OpenAI OAuth callback timed out'));
-    }
-  }, args.timeoutMs ?? 5 * 60 * 1000);
-
-  const server = createServer((req, res) => {
-    const url = new URL(req.url ?? '/', `http://localhost:${args.port}`);
-    if (url.pathname !== OPENAI_OAUTH_CALLBACK_PATH) {
-      res.writeHead(404);
-      res.end('Not found');
-      return;
-    }
-
-    const error = url.searchParams.get('error');
-    if (error) {
-      settled = true;
-      const message = url.searchParams.get('error_description') ?? error;
-      rejectTokens(new Error(message));
-      res.writeHead(200, { 'Content-Type': 'text/html' });
-      res.end(renderCallbackHtml('Authorization failed', message));
-      return;
-    }
-
-    const code = url.searchParams.get('code');
-    const state = url.searchParams.get('state');
-    if (!code) {
-      settled = true;
-      rejectTokens(new Error('OpenAI OAuth callback did not include a code'));
-      res.writeHead(400, { 'Content-Type': 'text/html' });
-      res.end(renderCallbackHtml('Authorization failed', 'Missing authorization code.'));
-      return;
-    }
-    if (state !== args.state) {
-      settled = true;
-      rejectTokens(new Error('OpenAI OAuth callback state did not match'));
-      res.writeHead(400, { 'Content-Type': 'text/html' });
-      res.end(renderCallbackHtml('Authorization failed', 'Invalid OAuth state.'));
-      return;
-    }
-
-    settled = true;
-    const redirectUri = `http://localhost:${getServerPort(server) ?? args.port}${OPENAI_OAUTH_CALLBACK_PATH}`;
-    void exchangeOpenAiOAuthCode({
-      code,
-      redirectUri,
-      codeVerifier: args.pkce.verifier,
-      fetchImpl: args.fetchImpl,
-    }).then(resolveTokens, rejectTokens);
-
-    res.writeHead(200, { 'Content-Type': 'text/html' });
-    res.end(renderCallbackHtml('Authorization successful', 'You can close this window and return to Heddle.'));
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(args.port, '127.0.0.1', () => {
-      server.off('error', reject);
-      resolve();
+      scope: 'openid profile email offline_access',
+      code_challenge: args.pkce.challenge,
+      code_challenge_method: 'S256',
+      id_token_add_organizations: 'true',
+      codex_cli_simplified_flow: 'true',
+      state: args.state,
+      originator: args.originator ?? 'heddle',
     });
-  });
 
-  const actualPort = getServerPort(server) ?? args.port;
-  const redirectUri = `http://localhost:${actualPort}${OPENAI_OAUTH_CALLBACK_PATH}`;
-
-  return {
-    redirectUri,
-    tokens: tokens.finally(() => clearTimeout(timeout)),
-    close: async () => {
-      clearTimeout(timeout);
-      await new Promise<void>((resolve) => {
-        if (!server.listening) {
-          resolve();
-          return;
-        }
-        server.close(() => resolve());
-      });
-    },
-  };
-}
-
-function normalizeTokenResponse(input: unknown): OpenAiOAuthTokenResponse {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    throw new Error('OpenAI OAuth token response was not an object');
+    return `${OPENAI_AUTH_ISSUER}/oauth/authorize?${params.toString()}`;
   }
 
-  const candidate = input as Record<string, unknown>;
-  if (typeof candidate.access_token !== 'string' || typeof candidate.refresh_token !== 'string') {
-    throw new Error('OpenAI OAuth token response did not include access and refresh tokens');
+  static async runBrowserLogin(options: OpenAiOAuthLoginOptions = {}): Promise<OpenAiOAuthCredential> {
+    const port = options.port ?? DEFAULT_OPENAI_OAUTH_PORT;
+    const pkce = OpenAiOAuthService.generatePkceCodes();
+    const state = OpenAiOAuthService.generateState();
+    const callback = await OpenAiOAuthService.startCallbackServer({
+      port,
+      state,
+      pkce,
+      timeoutMs: options.timeoutMs,
+      fetchImpl: options.fetchImpl,
+    });
+    const authUrl = OpenAiOAuthService.buildAuthorizeUrl({
+      redirectUri: callback.redirectUri,
+      pkce,
+      state,
+    });
+
+    try {
+      options.onAuthorizeUrl?.(authUrl);
+      if (options.openBrowser !== false) {
+        await (options.openUrl ?? OpenAiOAuthService.openUrlInBrowser)(authUrl);
+      }
+      const tokens = await callback.tokens;
+      return OpenAiOAuthService.createCredential(tokens);
+    } finally {
+      await callback.close();
+    }
   }
 
-  return {
-    id_token: typeof candidate.id_token === 'string' ? candidate.id_token : undefined,
-    access_token: candidate.access_token,
-    refresh_token: candidate.refresh_token,
-    expires_in:
-      typeof candidate.expires_in === 'number' && Number.isFinite(candidate.expires_in) ?
-        candidate.expires_in
-      : undefined,
-  };
-}
-
-function base64UrlEncode(value: Buffer): string {
-  return value.toString('base64url');
-}
-
-function getServerPort(server: Server): number | undefined {
-  const address = server.address();
-  return typeof address === 'object' && address ? (address as AddressInfo).port : undefined;
-}
-
-async function openUrlInBrowser(url: string): Promise<void> {
-  const { command, args } = buildOpenUrlCommand(url, process.platform);
-  const child = spawn(command, args, {
-    detached: true,
-    stdio: 'ignore',
-  });
-  child.unref();
-}
-
-export function buildOpenUrlCommand(url: string, platform: NodeJS.Platform = process.platform): { command: string; args: string[] } {
-  if (platform === 'darwin') {
-    return { command: 'open', args: [url] };
-  }
-
-  if (platform === 'win32') {
-    const script = `Start-Process -FilePath '${escapePowerShellSingleQuotedString(url)}'`;
+  static async refreshCredential(
+    credential: OpenAiOAuthCredential,
+    options: { fetchImpl?: typeof fetch } = {},
+  ): Promise<OpenAiOAuthCredential> {
+    const tokens = await OpenAiOAuthService.refreshToken({
+      refreshToken: credential.refreshToken,
+      fetchImpl: options.fetchImpl,
+    });
     return {
-      command: 'powershell.exe',
-      args: ['-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')],
+      ...OpenAiOAuthService.createCredential(tokens),
+      createdAt: credential.createdAt,
+      accountId: OpenAiOAuthService.extractAccountId(tokens) ?? credential.accountId,
     };
   }
 
-  return { command: 'xdg-open', args: [url] };
-}
+  static async exchangeCode(args: {
+    code: string;
+    redirectUri: string;
+    codeVerifier: string;
+    fetchImpl?: typeof fetch;
+  }): Promise<OpenAiOAuthTokenResponse> {
+    const fetcher = args.fetchImpl ?? fetch;
+    const response = await fetcher(`${OPENAI_AUTH_ISSUER}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: args.code,
+        redirect_uri: args.redirectUri,
+        client_id: OPENAI_CODEX_CLIENT_ID,
+        code_verifier: args.codeVerifier,
+      }).toString(),
+    });
 
-function escapePowerShellSingleQuotedString(value: string): string {
-  return value.replaceAll("'", "''");
-}
+    if (!response.ok) {
+      throw new Error(`OpenAI OAuth token exchange failed: ${response.status}`);
+    }
 
-function renderCallbackHtml(title: string, message: string): string {
-  return `<!doctype html>
+    return OpenAiOAuthService.normalizeTokenResponse(await response.json());
+  }
+
+  static async refreshToken(options: OpenAiOAuthRefreshOptions): Promise<OpenAiOAuthTokenResponse> {
+    const fetcher = options.fetchImpl ?? fetch;
+    const response = await fetcher(`${OPENAI_AUTH_ISSUER}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: options.refreshToken,
+        client_id: OPENAI_CODEX_CLIENT_ID,
+      }).toString(),
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI OAuth token refresh failed: ${response.status}`);
+    }
+
+    return OpenAiOAuthService.normalizeTokenResponse(await response.json());
+  }
+
+  static createCredential(
+    tokens: OpenAiOAuthTokenResponse,
+    now = Date.now(),
+  ): OpenAiOAuthCredential {
+    const timestamp = new Date(now).toISOString();
+    return {
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: now + (tokens.expires_in ?? 3600) * 1000,
+      accountId: OpenAiOAuthService.extractAccountId(tokens),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      label: 'ChatGPT/Codex OAuth',
+    };
+  }
+
+  static parseJwtClaims(token: string): OpenAiIdTokenClaims | undefined {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as OpenAiIdTokenClaims;
+    } catch {
+      return undefined;
+    }
+  }
+
+  static extractAccountId(tokens: Pick<OpenAiOAuthTokenResponse, 'id_token' | 'access_token'>): string | undefined {
+    const idClaims = tokens.id_token ? OpenAiOAuthService.parseJwtClaims(tokens.id_token) : undefined;
+    const idAccount = idClaims ? OpenAiOAuthService.extractAccountIdFromClaims(idClaims) : undefined;
+    if (idAccount) {
+      return idAccount;
+    }
+
+    const accessClaims = OpenAiOAuthService.parseJwtClaims(tokens.access_token);
+    return accessClaims ? OpenAiOAuthService.extractAccountIdFromClaims(accessClaims) : undefined;
+  }
+
+  static extractAccountIdFromClaims(claims: OpenAiIdTokenClaims): string | undefined {
+    return (
+      claims.chatgpt_account_id
+      ?? claims['https://api.openai.com/auth']?.chatgpt_account_id
+      ?? claims.organizations?.find((organization) => organization.id)?.id
+    );
+  }
+
+  static buildOpenUrlCommand(url: string, platform: NodeJS.Platform = process.platform): { command: string; args: string[] } {
+    if (platform === 'darwin') {
+      return { command: 'open', args: [url] };
+    }
+
+    if (platform === 'win32') {
+      const script = `Start-Process -FilePath '${OpenAiOAuthService.escapePowerShellSingleQuotedString(url)}'`;
+      return {
+        command: 'powershell.exe',
+        args: ['-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')],
+      };
+    }
+
+    return { command: 'xdg-open', args: [url] };
+  }
+
+  private static async startCallbackServer(args: {
+    port: number;
+    state: string;
+    pkce: PkceCodes;
+    timeoutMs?: number;
+    fetchImpl?: typeof fetch;
+  }): Promise<OpenAiOAuthCallbackServer> {
+    let settled = false;
+    let resolveTokens: (tokens: OpenAiOAuthTokenResponse) => void;
+    let rejectTokens: (error: Error) => void;
+    const tokens = new Promise<OpenAiOAuthTokenResponse>((resolve, reject) => {
+      resolveTokens = resolve;
+      rejectTokens = reject;
+    });
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        rejectTokens(new Error('OpenAI OAuth callback timed out'));
+      }
+    }, args.timeoutMs ?? 5 * 60 * 1000);
+
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? '/', `http://localhost:${args.port}`);
+      if (url.pathname !== OPENAI_OAUTH_CALLBACK_PATH) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      const error = url.searchParams.get('error');
+      if (error) {
+        settled = true;
+        const message = url.searchParams.get('error_description') ?? error;
+        rejectTokens(new Error(message));
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(OpenAiOAuthService.renderCallbackHtml('Authorization failed', message));
+        return;
+      }
+
+      const code = url.searchParams.get('code');
+      const state = url.searchParams.get('state');
+      if (!code) {
+        settled = true;
+        rejectTokens(new Error('OpenAI OAuth callback did not include a code'));
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(OpenAiOAuthService.renderCallbackHtml('Authorization failed', 'Missing authorization code.'));
+        return;
+      }
+      if (state !== args.state) {
+        settled = true;
+        rejectTokens(new Error('OpenAI OAuth callback state did not match'));
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(OpenAiOAuthService.renderCallbackHtml('Authorization failed', 'Invalid OAuth state.'));
+        return;
+      }
+
+      settled = true;
+      const redirectUri = `http://localhost:${OpenAiOAuthService.getServerPort(server) ?? args.port}${OPENAI_OAUTH_CALLBACK_PATH}`;
+      void OpenAiOAuthService.exchangeCode({
+        code,
+        redirectUri,
+        codeVerifier: args.pkce.verifier,
+        fetchImpl: args.fetchImpl,
+      }).then(resolveTokens, rejectTokens);
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(OpenAiOAuthService.renderCallbackHtml('Authorization successful', 'You can close this window and return to Heddle.'));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(args.port, '127.0.0.1', () => {
+        server.off('error', reject);
+        resolve();
+      });
+    });
+
+    const actualPort = OpenAiOAuthService.getServerPort(server) ?? args.port;
+    const redirectUri = `http://localhost:${actualPort}${OPENAI_OAUTH_CALLBACK_PATH}`;
+
+    return {
+      redirectUri,
+      tokens: tokens.finally(() => clearTimeout(timeout)),
+      close: async () => {
+        clearTimeout(timeout);
+        await new Promise<void>((resolve) => {
+          if (!server.listening) {
+            resolve();
+            return;
+          }
+          server.close(() => resolve());
+        });
+      },
+    };
+  }
+
+  private static normalizeTokenResponse(input: unknown): OpenAiOAuthTokenResponse {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+      throw new Error('OpenAI OAuth token response was not an object');
+    }
+
+    const candidate = input as Record<string, unknown>;
+    if (typeof candidate.access_token !== 'string' || typeof candidate.refresh_token !== 'string') {
+      throw new Error('OpenAI OAuth token response did not include access and refresh tokens');
+    }
+
+    return {
+      id_token: typeof candidate.id_token === 'string' ? candidate.id_token : undefined,
+      access_token: candidate.access_token,
+      refresh_token: candidate.refresh_token,
+      expires_in:
+        typeof candidate.expires_in === 'number' && Number.isFinite(candidate.expires_in) ?
+          candidate.expires_in
+        : undefined,
+    };
+  }
+
+  private static base64UrlEncode(value: Buffer): string {
+    return value.toString('base64url');
+  }
+
+  private static getServerPort(server: Server): number | undefined {
+    const address = server.address();
+    return typeof address === 'object' && address ? (address as AddressInfo).port : undefined;
+  }
+
+  private static async openUrlInBrowser(url: string): Promise<void> {
+    const { command, args } = OpenAiOAuthService.buildOpenUrlCommand(url, process.platform);
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+  }
+
+  private static escapePowerShellSingleQuotedString(value: string): string {
+    return value.replaceAll("'", "''");
+  }
+
+  private static renderCallbackHtml(title: string, message: string): string {
+    return `<!doctype html>
 <html>
   <head><title>Heddle OpenAI OAuth</title></head>
   <body>
-    <h1>${escapeHtml(title)}</h1>
-    <p>${escapeHtml(message)}</p>
+    <h1>${OpenAiOAuthService.escapeHtml(title)}</h1>
+    <p>${OpenAiOAuthService.escapeHtml(message)}</p>
   </body>
 </html>`;
-}
+  }
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
+  private static escapeHtml(value: string): string {
+    return value
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
 }

--- a/src/core/auth/provider-credentials.ts
+++ b/src/core/auth/provider-credentials.ts
@@ -1,239 +1,105 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import type { LlmProvider } from '../llm/types.js';
+import type { LlmProvider } from '@/core/llm/types.js';
+import { ProviderCredentialSchemas } from './schemas.js';
+import type {
+  ProviderCredentialStore,
+  ProviderCredentialSummary,
+  StoredProviderCredential,
+} from './types.js';
 
-export type StoredProviderCredential =
-  | {
-      type: 'api-key';
-      provider: LlmProvider;
-      key: string;
-      createdAt: string;
-      updatedAt: string;
-      label?: string;
-    }
-  | {
-      type: 'bearer';
-      provider: LlmProvider;
-      token: string;
-      createdAt: string;
-      updatedAt: string;
-      label?: string;
-    }
-  | {
-      type: 'oauth';
-      provider: LlmProvider;
-      accessToken: string;
-      refreshToken: string;
-      expiresAt: number;
-      createdAt: string;
-      updatedAt: string;
-      accountId?: string;
-      label?: string;
+/**
+ * File-backed repository for provider credentials. It owns the auth.json path,
+ * zod-backed deserialization, private file permissions, and redacted views.
+ */
+export class ProviderCredentialRepository {
+  private readonly storePath: string;
+
+  constructor(input: { storePath?: string } = {}) {
+    this.storePath = input.storePath ?? ProviderCredentialRepository.resolveStorePath();
+  }
+
+  static resolveStorePath(baseDir = join(homedir(), '.heddle')): string {
+    return join(baseDir, 'auth.json');
+  }
+
+  static emptyStore(): ProviderCredentialStore {
+    return ProviderCredentialSchemas.emptyStore();
+  }
+
+  static summarize(credential: StoredProviderCredential): ProviderCredentialSummary {
+    return {
+      provider: credential.provider,
+      type: credential.type,
+      label: credential.label,
+      accountId: credential.type === 'oauth' ? credential.accountId : undefined,
+      expiresAt: credential.type === 'oauth' ? credential.expiresAt : undefined,
+      expired: credential.type === 'oauth' ? credential.expiresAt <= Date.now() : undefined,
+      createdAt: credential.createdAt,
+      updatedAt: credential.updatedAt,
     };
-
-export type ProviderCredentialStore = {
-  version: 1;
-  credentials: Partial<Record<LlmProvider, StoredProviderCredential>>;
-};
-
-export type ProviderCredentialSummary = {
-  provider: LlmProvider;
-  type: StoredProviderCredential['type'];
-  label?: string;
-  accountId?: string;
-  expiresAt?: number;
-  expired?: boolean;
-  createdAt: string;
-  updatedAt: string;
-};
-
-const SUPPORTED_PROVIDERS = new Set<LlmProvider>(['openai', 'anthropic', 'google']);
-const SUPPORTED_TYPES = new Set<StoredProviderCredential['type']>(['api-key', 'bearer', 'oauth']);
-
-export function resolveProviderCredentialStorePath(baseDir = join(homedir(), '.heddle')): string {
-  return join(baseDir, 'auth.json');
-}
-
-export function createEmptyProviderCredentialStore(): ProviderCredentialStore {
-  return {
-    version: 1,
-    credentials: {},
-  };
-}
-
-export function readProviderCredentialStore(path = resolveProviderCredentialStorePath()): ProviderCredentialStore {
-  if (!existsSync(path)) {
-    return createEmptyProviderCredentialStore();
   }
 
-  const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
-  return parseProviderCredentialStore(parsed);
-}
-
-export function writeProviderCredentialStore(store: ProviderCredentialStore, path = resolveProviderCredentialStorePath()) {
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(store, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
-  chmodSync(path, 0o600);
-}
-
-export function getStoredProviderCredential(
-  provider: LlmProvider,
-  path = resolveProviderCredentialStorePath(),
-): StoredProviderCredential | undefined {
-  return readProviderCredentialStore(path).credentials[provider];
-}
-
-export function setStoredProviderCredential(
-  credential: StoredProviderCredential,
-  path = resolveProviderCredentialStorePath(),
-) {
-  const store = readProviderCredentialStore(path);
-  store.credentials[credential.provider] = credential;
-  writeProviderCredentialStore(store, path);
-}
-
-export function removeStoredProviderCredential(
-  provider: LlmProvider,
-  path = resolveProviderCredentialStorePath(),
-): boolean {
-  const store = readProviderCredentialStore(path);
-  const existed = Boolean(store.credentials[provider]);
-  delete store.credentials[provider];
-  writeProviderCredentialStore(store, path);
-  return existed;
-}
-
-export function listStoredProviderCredentialSummaries(
-  path = resolveProviderCredentialStorePath(),
-): ProviderCredentialSummary[] {
-  const store = readProviderCredentialStore(path);
-  return Object.values(store.credentials)
-    .filter((credential): credential is StoredProviderCredential => Boolean(credential))
-    .map(summarizeProviderCredential)
-    .sort((a, b) => a.provider.localeCompare(b.provider));
-}
-
-export function summarizeProviderCredential(credential: StoredProviderCredential): ProviderCredentialSummary {
-  return {
-    provider: credential.provider,
-    type: credential.type,
-    label: credential.label,
-    accountId: credential.type === 'oauth' ? credential.accountId : undefined,
-    expiresAt: credential.type === 'oauth' ? credential.expiresAt : undefined,
-    expired: credential.type === 'oauth' ? credential.expiresAt <= Date.now() : undefined,
-    createdAt: credential.createdAt,
-    updatedAt: credential.updatedAt,
-  };
-}
-
-export function redactProviderCredential(credential: StoredProviderCredential): Record<string, unknown> {
-  const summary = summarizeProviderCredential(credential);
-  return {
-    ...summary,
-    key: credential.type === 'api-key' ? redactSecret(credential.key) : undefined,
-    token: credential.type === 'bearer' ? redactSecret(credential.token) : undefined,
-    accessToken: credential.type === 'oauth' ? redactSecret(credential.accessToken) : undefined,
-    refreshToken: credential.type === 'oauth' ? redactSecret(credential.refreshToken) : undefined,
-  };
-}
-
-export function redactSecret(secret: string): string {
-  if (secret.length <= 8) {
-    return '<redacted>';
+  static redact(credential: StoredProviderCredential): Record<string, unknown> {
+    const summary = ProviderCredentialRepository.summarize(credential);
+    return {
+      ...summary,
+      key: credential.type === 'api-key' ? ProviderCredentialRepository.redactSecret(credential.key) : undefined,
+      token: credential.type === 'bearer' ? ProviderCredentialRepository.redactSecret(credential.token) : undefined,
+      accessToken: credential.type === 'oauth' ? ProviderCredentialRepository.redactSecret(credential.accessToken) : undefined,
+      refreshToken: credential.type === 'oauth' ? ProviderCredentialRepository.redactSecret(credential.refreshToken) : undefined,
+    };
   }
 
-  return `${secret.slice(0, 4)}…${secret.slice(-4)}`;
-}
-
-function parseProviderCredentialStore(input: unknown): ProviderCredentialStore {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    return createEmptyProviderCredentialStore();
-  }
-
-  const candidate = input as { version?: unknown; credentials?: unknown };
-  if (candidate.version !== 1 || !candidate.credentials || typeof candidate.credentials !== 'object' || Array.isArray(candidate.credentials)) {
-    return createEmptyProviderCredentialStore();
-  }
-
-  const credentials: ProviderCredentialStore['credentials'] = {};
-  for (const [provider, rawCredential] of Object.entries(candidate.credentials)) {
-    if (!isLlmProvider(provider)) {
-      continue;
+  static redactSecret(secret: string): string {
+    if (secret.length <= 8) {
+      return '<redacted>';
     }
-    const credential = parseStoredProviderCredential(provider, rawCredential);
-    if (credential) {
-      credentials[provider] = credential;
+
+    return `${secret.slice(0, 4)}…${secret.slice(-4)}`;
+  }
+
+  read(): ProviderCredentialStore {
+    if (!existsSync(this.storePath)) {
+      return ProviderCredentialRepository.emptyStore();
+    }
+
+    try {
+      return ProviderCredentialSchemas.parseStore(JSON.parse(readFileSync(this.storePath, 'utf8')) as unknown);
+    } catch {
+      return ProviderCredentialRepository.emptyStore();
     }
   }
 
-  return {
-    version: 1,
-    credentials,
-  };
-}
-
-function parseStoredProviderCredential(
-  provider: LlmProvider,
-  input: unknown,
-): StoredProviderCredential | undefined {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    return undefined;
+  write(store: ProviderCredentialStore): void {
+    mkdirSync(dirname(this.storePath), { recursive: true });
+    writeFileSync(this.storePath, `${JSON.stringify(store, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+    chmodSync(this.storePath, 0o600);
   }
 
-  const candidate = input as Record<string, unknown>;
-  if (!isCredentialType(candidate.type)) {
-    return undefined;
+  get(provider: LlmProvider): StoredProviderCredential | undefined {
+    return this.read().credentials[provider];
   }
 
-  const createdAt = readString(candidate.createdAt);
-  const updatedAt = readString(candidate.updatedAt);
-  if (!createdAt || !updatedAt) {
-    return undefined;
+  set(credential: StoredProviderCredential): void {
+    const store = this.read();
+    store.credentials[credential.provider] = credential;
+    this.write(store);
   }
 
-  const base = {
-    provider,
-    createdAt,
-    updatedAt,
-    label: readString(candidate.label),
-  };
-
-  if (candidate.type === 'api-key') {
-    const key = readString(candidate.key);
-    return key ? { ...base, type: 'api-key', key } : undefined;
+  remove(provider: LlmProvider): boolean {
+    const store = this.read();
+    const existed = Boolean(store.credentials[provider]);
+    delete store.credentials[provider];
+    this.write(store);
+    return existed;
   }
 
-  if (candidate.type === 'bearer') {
-    const token = readString(candidate.token);
-    return token ? { ...base, type: 'bearer', token } : undefined;
+  listSummaries(): ProviderCredentialSummary[] {
+    return Object.values(this.read().credentials)
+      .filter((credential): credential is StoredProviderCredential => Boolean(credential))
+      .map(ProviderCredentialRepository.summarize)
+      .sort((a, b) => a.provider.localeCompare(b.provider));
   }
-
-  const accessToken = readString(candidate.accessToken);
-  const refreshToken = readString(candidate.refreshToken);
-  const expiresAt = typeof candidate.expiresAt === 'number' && Number.isFinite(candidate.expiresAt) ? candidate.expiresAt : undefined;
-  if (!accessToken || !refreshToken || !expiresAt) {
-    return undefined;
-  }
-
-  return {
-    ...base,
-    type: 'oauth',
-    accessToken,
-    refreshToken,
-    expiresAt,
-    accountId: readString(candidate.accountId),
-  };
-}
-
-function isLlmProvider(value: string): value is LlmProvider {
-  return SUPPORTED_PROVIDERS.has(value as LlmProvider);
-}
-
-function isCredentialType(value: unknown): value is StoredProviderCredential['type'] {
-  return typeof value === 'string' && SUPPORTED_TYPES.has(value as StoredProviderCredential['type']);
-}
-
-function readString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value : undefined;
 }

--- a/src/core/auth/schemas.ts
+++ b/src/core/auth/schemas.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import type { LlmProvider } from '@/core/llm/types.js';
+import type { ProviderCredentialStore, StoredProviderCredential } from './types.js';
+
+const providerSchema = z.enum(['openai', 'anthropic', 'google'])
+  .describe('LLM provider that owns this stored credential.');
+
+const credentialBaseSchema = z.object({
+  provider: providerSchema,
+  createdAt: z.string().min(1).describe('ISO timestamp for the first time this credential was stored.'),
+  updatedAt: z.string().min(1).describe('ISO timestamp for the last credential update.'),
+  label: z.string().min(1).optional().describe('Human-readable credential label for status output.'),
+});
+
+export const storedProviderCredentialSchema = z.discriminatedUnion('type', [
+  credentialBaseSchema.extend({
+    type: z.literal('api-key').describe('Static provider API-key credential.'),
+    key: z.string().min(1).describe('Provider API key secret.'),
+  }),
+  credentialBaseSchema.extend({
+    type: z.literal('bearer').describe('Static bearer token credential.'),
+    token: z.string().min(1).describe('Provider bearer token secret.'),
+  }),
+  credentialBaseSchema.extend({
+    type: z.literal('oauth').describe('OAuth account sign-in credential.'),
+    accessToken: z.string().min(1).describe('OAuth access token secret.'),
+    refreshToken: z.string().min(1).describe('OAuth refresh token secret.'),
+    expiresAt: z.number().finite().describe('Access token expiry as epoch milliseconds.'),
+    accountId: z.string().min(1).optional().describe('Provider account identifier, when available.'),
+  }),
+]) satisfies z.ZodType<StoredProviderCredential>;
+
+export const providerCredentialStoreSchema = z.object({
+  version: z.literal(1).describe('Credential store schema version.'),
+  credentials: z.record(providerSchema, z.unknown()).describe('Credentials keyed by provider.'),
+}).describe('Persisted Heddle provider credential store.');
+
+export class ProviderCredentialSchemas {
+  static parseStore(input: unknown): ProviderCredentialStore {
+    const parsed = providerCredentialStoreSchema.safeParse(input);
+    if (!parsed.success) {
+      return ProviderCredentialSchemas.emptyStore();
+    }
+
+    const credentials: ProviderCredentialStore['credentials'] = {};
+    for (const [provider, value] of Object.entries(parsed.data.credentials)) {
+      const credential = ProviderCredentialSchemas.parseCredential(provider as LlmProvider, value);
+      if (credential) {
+        credentials[provider as LlmProvider] = credential;
+      }
+    }
+
+    return {
+      version: 1,
+      credentials,
+    };
+  }
+
+  static parseCredential(provider: LlmProvider, input: unknown): StoredProviderCredential | undefined {
+    const parsed = storedProviderCredentialSchema.safeParse(input);
+    if (!parsed.success || parsed.data.provider !== provider) {
+      return undefined;
+    }
+    return parsed.data;
+  }
+
+  static emptyStore(): ProviderCredentialStore {
+    return {
+      version: 1,
+      credentials: {},
+    };
+  }
+}

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -1,0 +1,88 @@
+import type { LlmProvider } from '@/core/llm/types.js';
+
+export type StoredProviderCredential =
+  | {
+      type: 'api-key';
+      provider: LlmProvider;
+      key: string;
+      createdAt: string;
+      updatedAt: string;
+      label?: string;
+    }
+  | {
+      type: 'bearer';
+      provider: LlmProvider;
+      token: string;
+      createdAt: string;
+      updatedAt: string;
+      label?: string;
+    }
+  | {
+      type: 'oauth';
+      provider: LlmProvider;
+      accessToken: string;
+      refreshToken: string;
+      expiresAt: number;
+      createdAt: string;
+      updatedAt: string;
+      accountId?: string;
+      label?: string;
+    };
+
+export type ProviderCredentialStore = {
+  version: 1;
+  credentials: Partial<Record<LlmProvider, StoredProviderCredential>>;
+};
+
+export type ProviderCredentialSummary = {
+  provider: LlmProvider;
+  type: StoredProviderCredential['type'];
+  label?: string;
+  accountId?: string;
+  expiresAt?: number;
+  expired?: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PkceCodes = {
+  verifier: string;
+  challenge: string;
+};
+
+export type OpenAiOAuthTokenResponse = {
+  id_token?: string;
+  access_token: string;
+  refresh_token: string;
+  expires_in?: number;
+};
+
+export type OpenAiOAuthCredential = Extract<StoredProviderCredential, { type: 'oauth' }>;
+
+export type OpenAiOAuthLoginOptions = {
+  port?: number;
+  openBrowser?: boolean;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  openUrl?: (url: string) => Promise<void> | void;
+  onAuthorizeUrl?: (url: string) => void;
+};
+
+export type OpenAiOAuthRefreshOptions = {
+  refreshToken: string;
+  fetchImpl?: typeof fetch;
+};
+
+export type OpenAiIdTokenClaims = {
+  chatgpt_account_id?: string;
+  organizations?: Array<{ id?: string }>;
+  'https://api.openai.com/auth'?: {
+    chatgpt_account_id?: string;
+  };
+};
+
+export type OpenAiOAuthCallbackServer = {
+  redirectUri: string;
+  tokens: Promise<OpenAiOAuthTokenResponse>;
+  close: () => Promise<void>;
+};

--- a/src/core/llm/adapters/openai/openai-adapter.ts
+++ b/src/core/llm/adapters/openai/openai-adapter.ts
@@ -12,13 +12,13 @@ import type { ToolDefinition, ToolCall } from '@/core/types.js';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import {
   OPENAI_CODEX_RESPONSES_ENDPOINT,
-  refreshOpenAiOAuthCredential,
-  type OpenAiOAuthCredential,
+  OpenAiOAuthService,
 } from '@/core/auth/openai-oauth.js';
 import {
-  setStoredProviderCredential,
+  ProviderCredentialRepository,
+  type OpenAiOAuthCredential,
   type StoredProviderCredential,
-} from '@/core/auth/provider-credentials.js';
+} from '@/core/auth/index.js';
 import { ModelPolicyService } from '@/core/llm/models/index.js';
 import { OpenAiCodec } from './openai-codec.js';
 
@@ -225,8 +225,8 @@ export class OpenAiOAuthFetchService {
 
     const oauthFetch: CompatibleFetch = async (requestInput, init) => {
       if (credential.expiresAt <= Date.now() + refreshBeforeMs) {
-        credential = await refreshOpenAiOAuthCredential(credential, { fetchImpl: fetcher as typeof fetch });
-        setStoredProviderCredential(credential, options.storePath);
+        credential = await OpenAiOAuthService.refreshCredential(credential, { fetchImpl: fetcher as typeof fetch });
+        new ProviderCredentialRepository({ storePath: options.storePath }).set(credential);
       }
 
       const request = requestInput instanceof Request ? requestInput : undefined;

--- a/src/core/llm/service.ts
+++ b/src/core/llm/service.ts
@@ -1,7 +1,7 @@
 import {
-  getStoredProviderCredential,
+  ProviderCredentialRepository,
   type StoredProviderCredential,
-} from '@/core/auth/provider-credentials.js';
+} from '@/core/auth/index.js';
 import { BuiltinLlmProviderRegistry } from './registry/index.js';
 import type { LlmAdapter, LlmAdapterCreateInput, LlmProvider, LlmProviderResolutionInput } from './types.js';
 
@@ -51,7 +51,7 @@ export class LlmAdapterService {
     provider: LlmProvider,
     storePath?: string,
   ): Extract<StoredProviderCredential, { type: 'oauth' }> | undefined {
-    const credential = getStoredProviderCredential(provider, storePath);
+    const credential = new ProviderCredentialRepository({ storePath }).get(provider);
     return credential?.type === 'oauth' ? credential : undefined;
   }
 

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import type { AssistantDiagnostics, ToolCall, ToolDefinition } from '../types.js';
-import type { StoredProviderCredential } from '@/core/auth/provider-credentials.js';
+import type { StoredProviderCredential } from '@/core/auth/index.js';
 
 export type LlmStreamEvent =
   | { type: 'content.delta'; delta: string }

--- a/src/core/runtime/credentials/service.ts
+++ b/src/core/runtime/credentials/service.ts
@@ -1,7 +1,7 @@
 import {
-  getStoredProviderCredential,
+  ProviderCredentialRepository,
   type StoredProviderCredential,
-} from '@/core/auth/provider-credentials.js';
+} from '@/core/auth/index.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
 import type { LlmProvider } from '@/core/llm/types.js';
 import type { ApiKeyRuntime, ProviderCredentialSource } from './types.js';
@@ -44,7 +44,7 @@ export class RuntimeCredentialService {
     options: { storePath?: string } = {},
   ): Extract<StoredProviderCredential, { type: 'oauth' }> | undefined {
     const provider = LlmAdapterService.inferProvider(model);
-    const credential = getStoredProviderCredential(provider, options.storePath);
+    const credential = new ProviderCredentialRepository({ storePath: options.storePath }).get(provider);
     return credential?.type === 'oauth' ? credential : undefined;
   }
 

--- a/src/core/runtime/loop/service.ts
+++ b/src/core/runtime/loop/service.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { resolveProviderCredentialStorePath } from '@/core/auth/provider-credentials.js';
+import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import { AgentRunService } from '@/core/agent/index.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
@@ -163,7 +163,7 @@ export class AgentLoopRuntimeService {
     stateDir?: string;
   }): string | undefined {
     return args.stateDir
-      ? resolveProviderCredentialStorePath(resolve(args.workspaceRoot, args.stateDir))
+      ? ProviderCredentialRepository.resolveStorePath(resolve(args.workspaceRoot, args.stateDir))
       : undefined;
   }
 


### PR DESCRIPTION
## Summary
- Convert provider credential persistence into `ProviderCredentialRepository` with zod-backed auth store parsing.
- Convert OpenAI OAuth helpers into `OpenAiOAuthService` and move auth contracts into `types.ts`.
- Route CLI/runtime/LLM callers through the new auth classes and update tests.

## Why
Auth was still a function-heavy module with manual persisted JSON parsing. This aligns it with the class/types/schema service-boundary pattern used by the rest of the core refactors.

## Verification
- `yarn typecheck`
- `yarn test src/__tests__/integration/core/provider-credentials.test.ts src/__tests__/unit/core/openai-oauth.test.ts src/__tests__/unit/core/llm-factory.test.ts src/__tests__/integration/tui/auth-cli.test.ts src/__tests__/integration/chat/chat-runtime.test.ts src/__tests__/unit/core/chat-turn-runtime.test.ts`
- `yarn lint`
- `yarn build`
- `yarn verify:tui-behavior`
- `yarn -s cli:dev auth status`
- `yarn -s cli:dev --model gpt-5.4 --max-steps 2 ask "Reply with exactly OK and do not call tools."`
- `yarn -s cli:dev --prefer-api-key --model gpt-5.1-codex-mini --max-steps 1 ask "Reply with exactly OK."`
- `yarn -s cli:dev --model claude-haiku-4-5 --max-steps 1 ask "Reply with exactly OK."`
- `yarn test:browser-integration`