### PR TITLE
Refactor memory service boundary

### DIFF
--- a/src/__tests__/integration/memory/memory-catalog.test.ts
+++ b/src/__tests__/integration/memory/memory-catalog.test.ts
@@ -3,11 +3,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
-  appendMemoryCatalogSystemContext,
-  bootstrapMemoryWorkspace,
   DEFAULT_MEMORY_CATEGORIES,
-  loadMemoryRootCatalog,
-  validateMemoryCatalogShape,
+  MemoryCatalogService,
 } from '../../../core/memory/catalog.js';
 
 describe('memory catalog', () => {
@@ -15,7 +12,8 @@ describe('memory catalog', () => {
     const memoryRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-catalog-'));
     writeFileSync(join(memoryRoot, 'README.md'), '# Existing Memory\n', 'utf8');
 
-    const result = bootstrapMemoryWorkspace({ memoryRoot });
+    const catalog = new MemoryCatalogService(memoryRoot);
+    const result = catalog.bootstrap();
 
     expect(readFileSync(join(memoryRoot, 'README.md'), 'utf8')).toBe('# Existing Memory\n');
     expect(result.createdPaths).toEqual(expect.arrayContaining([
@@ -31,7 +29,7 @@ describe('memory catalog', () => {
     for (const category of DEFAULT_MEMORY_CATEGORIES) {
       expect(existsSync(join(memoryRoot, category.path, 'README.md'))).toBe(true);
     }
-    expect(validateMemoryCatalogShape({ memoryRoot })).toEqual({
+    expect(catalog.validateShape()).toEqual({
       ok: true,
       memoryRoot,
       missing: [],
@@ -41,7 +39,7 @@ describe('memory catalog', () => {
   it('returns bounded missing-catalog guidance when no root catalog exists', () => {
     const memoryRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-missing-'));
 
-    const result = loadMemoryRootCatalog({ memoryRoot, maxBytes: 200 });
+    const result = new MemoryCatalogService(memoryRoot).loadRootCatalog(200);
 
     expect(result.exists).toBe(false);
     expect(result.truncated).toBe(false);
@@ -53,7 +51,7 @@ describe('memory catalog', () => {
     const memoryRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-truncate-'));
     writeFileSync(join(memoryRoot, 'README.md'), `# Memory\n\n${'A'.repeat(200)}`, 'utf8');
 
-    const result = loadMemoryRootCatalog({ memoryRoot, maxBytes: 32 });
+    const result = new MemoryCatalogService(memoryRoot).loadRootCatalog(32);
 
     expect(result.exists).toBe(true);
     expect(result.truncated).toBe(true);
@@ -63,11 +61,11 @@ describe('memory catalog', () => {
 
   it('appends the memory domain model and root catalog to existing system context only', () => {
     const memoryRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-context-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    const catalog = new MemoryCatalogService(memoryRoot);
+    catalog.bootstrap();
 
-    const context = appendMemoryCatalogSystemContext({
+    const context = catalog.appendCatalogSystemContext({
       systemContext: 'Source: AGENTS.md\nRead docs first.',
-      memoryRoot,
     });
 
     expect(context).toContain('Source: AGENTS.md');
@@ -94,7 +92,7 @@ describe('memory catalog', () => {
     const memoryRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-invalid-'));
     writeFileSync(join(memoryRoot, 'README.md'), '# Memory\n', 'utf8');
 
-    const result = validateMemoryCatalogShape({ memoryRoot });
+    const result = new MemoryCatalogService(memoryRoot).validateShape();
 
     expect(result.ok).toBe(false);
     expect(result.missing).toContain('current-state/README.md');

--- a/src/__tests__/integration/memory/memory-integration.test.ts
+++ b/src/__tests__/integration/memory/memory-integration.test.ts
@@ -3,8 +3,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { LlmAdapter, LlmResponse } from '../../../core/llm/types.js';
-import { bootstrapMemoryWorkspace } from '../../../core/memory/catalog.js';
-import { runMaintenanceForRecordedCandidates } from '../../../core/memory/maintenance-integration.js';
+import { MemoryCatalogService } from '../../../core/memory/catalog.js';
+import { MemoryMaintenanceIntegrationService } from '../../../core/memory/maintenance-integration.js';
 import type { TraceEvent } from '../../../core/types.js';
 
 const fakeInfo = {
@@ -21,7 +21,7 @@ const fakeInfo = {
 describe('memory maintenance integration', () => {
   it('maintains candidates recorded in a trace and emits lifecycle events', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-memory-integration-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     await mkdir(join(memoryRoot, '_maintenance'), { recursive: true });
     await writeFile(join(memoryRoot, '_maintenance', 'candidates.jsonl'), `${JSON.stringify({
       id: 'candidate-integration',
@@ -63,8 +63,7 @@ describe('memory maintenance integration', () => {
       () => ({ content: 'Maintained verification memory.' }),
     ]);
 
-    const result = await runMaintenanceForRecordedCandidates({
-      memoryRoot,
+    const result = await new MemoryMaintenanceIntegrationService(memoryRoot).runForRecordedCandidates({
       llm,
       source: 'test integration',
       trace: [{
@@ -86,7 +85,7 @@ describe('memory maintenance integration', () => {
 
   it('emits maintenance failure without throwing', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-memory-integration-fail-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     await mkdir(join(memoryRoot, '_maintenance'), { recursive: true });
     await writeFile(join(memoryRoot, '_maintenance', 'candidates.jsonl'), `${JSON.stringify({
       id: 'candidate-fail',
@@ -102,8 +101,7 @@ describe('memory maintenance integration', () => {
       },
     };
 
-    const result = await runMaintenanceForRecordedCandidates({
-      memoryRoot,
+    const result = await new MemoryMaintenanceIntegrationService(memoryRoot).runForRecordedCandidates({
       llm,
       source: 'test integration',
       trace: [{
@@ -124,7 +122,7 @@ describe('memory maintenance integration', () => {
 
   it('serializes maintenance runs per memory root', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-memory-integration-queue-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     await mkdir(join(memoryRoot, '_maintenance'), { recursive: true });
     await writeFile(join(memoryRoot, '_maintenance', 'candidates.jsonl'), [
       JSON.stringify({
@@ -163,15 +161,13 @@ describe('memory maintenance integration', () => {
       },
     };
 
-    const firstRun = runMaintenanceForRecordedCandidates({
-      memoryRoot,
+    const firstRun = new MemoryMaintenanceIntegrationService(memoryRoot).runForRecordedCandidates({
       llm: firstLlm,
       source: 'first',
       trace: [candidateRecordedTrace('candidate-one')],
     });
     await firstEntered.promise;
-    const secondRun = runMaintenanceForRecordedCandidates({
-      memoryRoot,
+    const secondRun = new MemoryMaintenanceIntegrationService(memoryRoot).runForRecordedCandidates({
       llm: secondLlm,
       source: 'second',
       trace: [candidateRecordedTrace('candidate-two')],
@@ -186,7 +182,7 @@ describe('memory maintenance integration', () => {
 
   it('fails gracefully when another process holds the maintenance lock', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-memory-integration-lock-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     await mkdir(join(memoryRoot, '_maintenance'), { recursive: true });
     await writeFile(join(memoryRoot, '_maintenance', 'maintenance.lock'), `${JSON.stringify({
       id: 'other-process',
@@ -209,8 +205,7 @@ describe('memory maintenance integration', () => {
       },
     };
 
-    const result = await runMaintenanceForRecordedCandidates({
-      memoryRoot,
+    const result = await new MemoryMaintenanceIntegrationService(memoryRoot).runForRecordedCandidates({
       llm,
       source: 'locked',
       trace: [candidateRecordedTrace('candidate-locked')],
@@ -228,7 +223,7 @@ describe('memory maintenance integration', () => {
 
   it('recovers stale maintenance locks', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-memory-integration-stale-lock-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     await mkdir(join(memoryRoot, '_maintenance'), { recursive: true });
     await writeFile(join(memoryRoot, '_maintenance', 'maintenance.lock'), `${JSON.stringify({
       id: 'stale-process',
@@ -246,8 +241,7 @@ describe('memory maintenance integration', () => {
       () => ({ content: 'Processed after stale lock recovery.' }),
     ]);
 
-    const result = await runMaintenanceForRecordedCandidates({
-      memoryRoot,
+    const result = await new MemoryMaintenanceIntegrationService(memoryRoot).runForRecordedCandidates({
       llm,
       source: 'stale lock',
       trace: [candidateRecordedTrace('candidate-stale-lock')],

--- a/src/__tests__/integration/memory/memory-maintainer.test.ts
+++ b/src/__tests__/integration/memory/memory-maintainer.test.ts
@@ -4,13 +4,10 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { ChatMessage, LlmAdapter, LlmResponse } from '../../../core/llm/types.js';
 import type { ToolDefinition } from '../../../core/types.js';
-import { bootstrapMemoryWorkspace } from '../../../core/memory/catalog.js';
+import { MemoryCatalogService } from '../../../core/memory/catalog.js';
 import { createMemoryMaintainerTools } from '../../../core/memory/maintainer-tools.js';
-import {
-  readPendingKnowledgeCandidates,
-  runKnowledgeMaintenance,
-  type KnowledgeCandidate,
-} from '../../../core/memory/maintainer.js';
+import { MemoryMaintenanceService } from '../../../core/memory/maintainer.js';
+import type { KnowledgeCandidate } from '../../../core/memory/types.js';
 
 const fakeInfo = {
   provider: 'openai' as const,
@@ -26,7 +23,7 @@ const fakeInfo = {
 describe('memory maintainer', () => {
   it('creates a new cataloged note from a candidate and records the run', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-maintainer-create-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     const seenTools: string[][] = [];
     const llm = scriptedMaintainer([
       (_messages, tools) => {
@@ -60,8 +57,7 @@ describe('memory maintainer', () => {
       () => ({ content: 'Created operations/verification.md and updated operations/README.md.' }),
     ]);
 
-    const result = await runKnowledgeMaintenance({
-      memoryRoot,
+    const result = await new MemoryMaintenanceService(memoryRoot).run({
       observations: [candidate('candidate-1', 'The canonical verification command is yarn build.')],
       llm,
       source: 'test',
@@ -89,7 +85,7 @@ describe('memory maintainer', () => {
 
   it('updates an existing note instead of creating a duplicate', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-maintainer-update-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     await writeFile(join(memoryRoot, 'operations', 'verification.md'), '# Verification\n\nRun tests with `yarn test`.\n', 'utf8');
     const llm = scriptedMaintainer([
       () => ({
@@ -111,8 +107,7 @@ describe('memory maintainer', () => {
       () => ({ content: 'Updated operations/verification.md.' }),
     ]);
 
-    await runKnowledgeMaintenance({
-      memoryRoot,
+    await new MemoryMaintenanceService(memoryRoot).run({
       observations: [candidate('candidate-2', 'The canonical build check is yarn build.')],
       llm,
       source: 'test',
@@ -124,7 +119,7 @@ describe('memory maintainer', () => {
 
   it('lets the maintainer judge low-importance candidates but prefilters secret-like candidates', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-maintainer-skip-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     let calls = 0;
     const llm = scriptedMaintainer([
       () => {
@@ -133,8 +128,7 @@ describe('memory maintainer', () => {
       },
     ]);
 
-    const result = await runKnowledgeMaintenance({
-      memoryRoot,
+    const result = await new MemoryMaintenanceService(memoryRoot).run({
       observations: [
         { ...candidate('candidate-low', 'Temporary scratch note.'), importance: 'low' },
         candidate('candidate-secret', 'The API key is sk-test-secret-value-123456'),
@@ -159,7 +153,7 @@ describe('memory maintainer', () => {
       '',
     ].join('\n'), 'utf8');
 
-    const pending = await readPendingKnowledgeCandidates({ memoryRoot });
+    const pending = await new MemoryMaintenanceService(memoryRoot).readPendingCandidates();
 
     expect(pending.map((item) => item.id)).toEqual(['candidate-pending']);
   });

--- a/src/__tests__/integration/memory/memory-visibility.test.ts
+++ b/src/__tests__/integration/memory/memory-visibility.test.ts
@@ -3,24 +3,17 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import pino from 'pino';
 import { describe, expect, it } from 'vitest';
-import { bootstrapMemoryWorkspace } from '../../../core/memory/catalog.js';
-import {
-  listMemoryNotePaths,
-  loadMemoryStatus,
-  readMemoryNote,
-  searchMemoryNotes,
-} from '../../../core/memory/visibility.js';
-import {
-  repairMissingMemoryCatalogs,
-  validateMemoryWorkspace,
-} from '../../../core/memory/validation.js';
+import { MemoryCatalogService } from '../../../core/memory/catalog.js';
+import { MemoryValidationService } from '../../../core/memory/validation.js';
+import { MemoryVisibilityService } from '../../../core/memory/visibility.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 import { controlPlaneRouter } from '../../../server/features/control-plane/router.js';
 
 describe('memory visibility', () => {
   it('loads memory status, lists notes, reads notes, and searches notes', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-memory-visibility-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
+    const visibility = new MemoryVisibilityService(memoryRoot);
     await mkdir(join(memoryRoot, '_maintenance'), { recursive: true });
     await writeFile(join(memoryRoot, 'operations', 'verification.md'), '# Verification\n\nRun `yarn build`.\n', 'utf8');
     await writeFile(join(memoryRoot, '_maintenance', 'candidates.jsonl'), `${JSON.stringify({
@@ -43,12 +36,12 @@ describe('memory visibility', () => {
       catalogMissing: [],
     })}\n`, 'utf8');
 
-    await expect(listMemoryNotePaths({ memoryRoot })).resolves.toContain('operations/verification.md');
-    await expect(readMemoryNote({ memoryRoot, path: 'operations/verification.md' })).resolves.toContain('yarn build');
-    await expect(searchMemoryNotes({ memoryRoot, query: 'yarn build' })).resolves.toContain('operations/verification.md');
-    await expect(readMemoryNote({ memoryRoot, path: '../outside.md' })).rejects.toThrow(/must stay inside/);
+    await expect(visibility.listNotePaths()).resolves.toContain('operations/verification.md');
+    await expect(visibility.readNote({ path: 'operations/verification.md' })).resolves.toContain('yarn build');
+    await expect(visibility.searchNotes({ query: 'yarn build' })).resolves.toContain('operations/verification.md');
+    await expect(visibility.readNote({ path: '../outside.md' })).rejects.toThrow(/must stay inside/);
 
-    const status = await loadMemoryStatus({ memoryRoot });
+    const status = await visibility.loadStatus();
     expect(status).toMatchObject({
       catalog: { ok: true },
       candidates: { pending: 1 },
@@ -60,7 +53,7 @@ describe('memory visibility', () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'heddle-memory-visibility-workspace-'));
     const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-memory-visibility-state-'));
     const memoryRoot = join(stateRoot, 'memory');
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     await writeFile(join(memoryRoot, 'operations', 'verification.md'), '# Verification\n\nRun `yarn build`.\n', 'utf8');
     const catalog = RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
     const activeWorkspace = catalog.workspaces[0];
@@ -86,7 +79,7 @@ describe('memory visibility', () => {
 
   it('validates memory quality issues and safely repairs missing catalogs', async () => {
     const memoryRoot = await mkdtemp(join(tmpdir(), 'heddle-memory-validation-'));
-    bootstrapMemoryWorkspace({ memoryRoot });
+    new MemoryCatalogService(memoryRoot).bootstrap();
     await rm(join(memoryRoot, 'operations', 'README.md'));
     await writeFile(join(memoryRoot, 'operations', 'orphan.md'), '# Orphan\n\nNo catalog link yet.\n', 'utf8');
     await writeFile(join(memoryRoot, 'README.md'), `# Workspace Memory\n\n${'A'.repeat(13 * 1024)}\n`, 'utf8');
@@ -98,7 +91,8 @@ describe('memory visibility', () => {
       summary: 'Pending memory.',
     })}\n`, 'utf8');
 
-    const validation = await validateMemoryWorkspace({ memoryRoot });
+    const validationService = new MemoryValidationService(memoryRoot);
+    const validation = await validationService.validate();
     expect(validation.issues).toEqual(expect.arrayContaining([
       expect.objectContaining({ type: 'missing_catalog', path: 'operations/README.md' }),
       expect.objectContaining({ type: 'oversized_catalog', path: 'README.md' }),
@@ -107,10 +101,10 @@ describe('memory visibility', () => {
     ]));
     expect(validation.ok).toBe(false);
 
-    const repair = await repairMissingMemoryCatalogs({ memoryRoot });
+    const repair = validationService.repairMissingCatalogs();
     expect(repair.createdPaths).toContain('operations/README.md');
 
-    const repaired = await validateMemoryWorkspace({ memoryRoot });
+    const repaired = await validationService.validate();
     expect(repaired.issues).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ type: 'missing_catalog', path: 'operations/README.md' }),
     ]));

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -13,7 +13,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
-  appendMemoryCatalogSystemContext,
   DEFAULT_OPENAI_MODEL,
   type ToolCall,
   type ToolDefinition,
@@ -23,6 +22,7 @@ import {
   createLogger,
   RuntimeCredentialService,
 } from '../index.js';
+import { MemoryCatalogService } from '@/core/memory/catalog.js';
 import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
 import { createConversationEngine } from '../core/chat/engine/index.js';
 import type { ConversationEngine } from '../core/chat/engine/index.js';
@@ -69,9 +69,8 @@ export class AskCliHost {
     const maxSteps = options.maxSteps ?? AskCliHost.parsePositiveInt(process.env.HEDDLE_MAX_STEPS) ?? 100;
     const workspaceRoot = options.workspaceRoot ?? process.cwd();
     const stateRoot = join(workspaceRoot, options.stateDir ?? '.heddle');
-    const systemContext = appendMemoryCatalogSystemContext({
+    const systemContext = new MemoryCatalogService(join(stateRoot, 'memory')).appendCatalogSystemContext({
       systemContext: options.systemContext,
-      memoryRoot: join(stateRoot, 'memory'),
     });
     const logger = createLogger({ pretty: true, level: 'debug' });
     const provider = LlmAdapterService.inferProvider(model);

--- a/src/cli/chat/utils/runtime.ts
+++ b/src/cli/chat/utils/runtime.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from 'node:path';
-import { appendMemoryCatalogSystemContext, DEFAULT_OPENAI_MODEL, LlmAdapterService } from '../../../index.js';
+import { DEFAULT_OPENAI_MODEL, LlmAdapterService } from '../../../index.js';
 import type { LlmProvider } from '../../../index.js';
+import { MemoryCatalogService } from '@/core/memory/catalog.js';
 import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
 import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import {
@@ -96,9 +97,8 @@ export function resolveChatRuntimeConfig(options: ChatCliOptions): ChatRuntimeCo
     memoryDir,
     directShellApproval: options.directShellApproval ?? 'never',
     searchIgnoreDirs: options.searchIgnoreDirs ?? [],
-    systemContext: appendMemoryCatalogSystemContext({
+    systemContext: new MemoryCatalogService(memoryDir).appendCatalogSystemContext({
       systemContext: options.systemContext,
-      memoryRoot: memoryDir,
     }),
     runtimeHost: options.runtimeHost,
   };

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5,21 +5,11 @@ import { dirname, resolve } from 'node:path';
 import { chdir } from 'node:process';
 import { Command } from 'commander';
 import { DEFAULT_OPENAI_MODEL, LlmAdapterService } from '../index.js';
-import { bootstrapMemoryWorkspace } from '../core/memory/catalog.js';
-import {
-  readPendingKnowledgeCandidates,
-  runKnowledgeMaintenanceForBacklog,
-} from '../core/memory/maintainer.js';
-import {
-  listMemoryNotePaths,
-  loadMemoryStatus,
-  readMemoryNote,
-  searchMemoryNotes,
-} from '../core/memory/visibility.js';
-import {
-  repairMissingMemoryCatalogs,
-  validateMemoryWorkspace,
-} from '../core/memory/validation.js';
+import { MemoryCatalogService } from '../core/memory/catalog.js';
+import { MemoryMaintenanceService } from '../core/memory/maintainer.js';
+import { MemoryValidationService } from '../core/memory/validation.js';
+import { MemoryVisibilityService } from '../core/memory/visibility.js';
+import type { MemoryValidationResult } from '../core/memory/types.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import { AuthCliController } from './auth.js';
 import { AskCliHost } from './ask.js';
@@ -321,9 +311,11 @@ async function runMemoryCli(
   } = {},
 ) {
   const memoryRoot = resolve(options.workspaceRoot, options.stateDir, 'memory');
+  const catalog = new MemoryCatalogService(memoryRoot);
+  const visibility = new MemoryVisibilityService(memoryRoot);
 
   if (command === 'init') {
-    const result = bootstrapMemoryWorkspace({ memoryRoot });
+    const result = catalog.bootstrap();
     process.stdout.write(`Memory root: ${result.memoryRoot}\n`);
     process.stdout.write(
       result.createdPaths.length > 0 ?
@@ -334,7 +326,7 @@ async function runMemoryCli(
   }
 
   if (command === 'status') {
-    const result = await loadMemoryStatus({ memoryRoot });
+    const result = await visibility.loadStatus();
     process.stdout.write(`Memory root: ${result.memoryRoot}\n`);
     process.stdout.write(`Catalog shape: ${result.catalog.ok ? 'ok' : 'missing required catalogs'}\n`);
     process.stdout.write(`Notes: ${result.notes.count}\n`);
@@ -352,7 +344,7 @@ async function runMemoryCli(
   }
 
   if (command === 'list') {
-    const notes = await listMemoryNotePaths({ memoryRoot, path: flags.path });
+    const notes = await visibility.listNotePaths(flags.path);
     process.stdout.write(`Memory root: ${memoryRoot}\n`);
     process.stdout.write(notes.length > 0 ? `${notes.join('\n')}\n` : 'No memory notes found.\n');
     return;
@@ -362,8 +354,7 @@ async function runMemoryCli(
     if (!flags.path) {
       throw new Error('Usage: heddle memory read <path>');
     }
-    process.stdout.write(await readMemoryNote({
-      memoryRoot,
+    process.stdout.write(await visibility.readNote({
       path: flags.path,
       offset: flags.offset,
       maxLines: flags.maxLines,
@@ -376,8 +367,7 @@ async function runMemoryCli(
     if (!flags.query) {
       throw new Error('Usage: heddle memory search <query>');
     }
-    process.stdout.write(await searchMemoryNotes({
-      memoryRoot,
+    process.stdout.write(await visibility.searchNotes({
       query: flags.query,
       path: flags.path,
       maxResults: flags.maxResults,
@@ -392,8 +382,9 @@ async function runMemoryCli(
 
 async function runMemoryValidateCli(options: ResolvedCliOptions, flags: { repair: boolean }) {
   const memoryRoot = resolve(options.workspaceRoot, options.stateDir, 'memory');
+  const validationService = new MemoryValidationService(memoryRoot);
   if (flags.repair) {
-    const repair = await repairMissingMemoryCatalogs({ memoryRoot });
+    const repair = validationService.repairMissingCatalogs();
     process.stdout.write(`Memory root: ${repair.memoryRoot}\n`);
     process.stdout.write(
       repair.createdPaths.length > 0 ?
@@ -402,19 +393,21 @@ async function runMemoryValidateCli(options: ResolvedCliOptions, flags: { repair
     );
   }
 
-  const validation = await validateMemoryWorkspace({ memoryRoot });
+  const validation = await validationService.validate();
   writeMemoryValidation(validation);
 }
 
 async function runMemoryMaintainCli(options: ResolvedCliOptions, flags: { dryRun: boolean; reconcile: boolean }) {
   const memoryRoot = resolve(options.workspaceRoot, options.stateDir, 'memory');
+  const validationService = new MemoryValidationService(memoryRoot);
+  const maintenance = new MemoryMaintenanceService(memoryRoot);
   if (flags.reconcile) {
-    const repair = await repairMissingMemoryCatalogs({ memoryRoot });
+    const repair = validationService.repairMissingCatalogs();
     if (repair.createdPaths.length > 0) {
       process.stdout.write(`Repaired missing catalogs:\n${repair.createdPaths.map((path) => `- ${path}`).join('\n')}\n`);
     }
   }
-  const pending = await readPendingKnowledgeCandidates({ memoryRoot });
+  const pending = await maintenance.readPendingCandidates();
 
   if (flags.dryRun) {
     process.stdout.write(`Memory root: ${memoryRoot}\n`);
@@ -423,7 +416,7 @@ async function runMemoryMaintainCli(options: ResolvedCliOptions, flags: { dryRun
       process.stdout.write(`- ${candidate.id}: ${candidate.summary}\n`);
     }
     if (flags.reconcile) {
-      writeMemoryValidation(await validateMemoryWorkspace({ memoryRoot }));
+      writeMemoryValidation(await validationService.validate());
     }
     return;
   }
@@ -432,7 +425,7 @@ async function runMemoryMaintainCli(options: ResolvedCliOptions, flags: { dryRun
     process.stdout.write(`Memory root: ${memoryRoot}\n`);
     process.stdout.write('No pending memory candidates.\n');
     if (flags.reconcile) {
-      writeMemoryValidation(await validateMemoryWorkspace({ memoryRoot }));
+      writeMemoryValidation(await validationService.validate());
     }
     return;
   }
@@ -443,8 +436,7 @@ async function runMemoryMaintainCli(options: ResolvedCliOptions, flags: { dryRun
     throw new Error(`Missing provider API key for memory maintainer model: ${model}`);
   }
 
-  const result = await runKnowledgeMaintenanceForBacklog({
-    memoryRoot,
+  const result = await maintenance.runBacklog({
     llm: LlmAdapterService.create({
       model,
       credentials: { apiKey },
@@ -462,11 +454,11 @@ async function runMemoryMaintainCli(options: ResolvedCliOptions, flags: { dryRun
     process.stdout.write(`Missing:\n${result.run.catalogMissing.map((path) => `- ${path}`).join('\n')}\n`);
   }
   if (flags.reconcile) {
-    writeMemoryValidation(await validateMemoryWorkspace({ memoryRoot }));
+    writeMemoryValidation(await validationService.validate());
   }
 }
 
-function writeMemoryValidation(result: Awaited<ReturnType<typeof validateMemoryWorkspace>>) {
+function writeMemoryValidation(result: MemoryValidationResult) {
   const hasErrors = result.issues.some((issue) => issue.severity === 'error');
   const hasWarnings = result.issues.some((issue) => issue.severity === 'warning');
   const label =

--- a/src/core/chat/engine/turns/memory/turn-memory-maintenance.ts
+++ b/src/core/chat/engine/turns/memory/turn-memory-maintenance.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import type { AgentLoopResult } from '@/core/runtime/loop/index.js';
 import type { TraceEvent } from '@/core/types.js';
-import { runMaintenanceForRecordedCandidates } from '@/core/memory/maintenance-integration.js';
+import { MemoryMaintenanceIntegrationService } from '@/core/memory/maintenance-integration.js';
 import { TraceSummaryService } from '@/core/observability/index.js';
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
 import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
@@ -23,8 +23,10 @@ export class ConversationTurnMemoryMaintenance {
       source: args.source,
       trace: args.result.trace,
     };
-    const maintenance = await runMaintenanceForRecordedCandidates({
-      ...maintenanceInput,
+    const maintenance = await new MemoryMaintenanceIntegrationService(maintenanceInput.memoryRoot).runForRecordedCandidates({
+      llm: maintenanceInput.llm,
+      source: maintenanceInput.source,
+      trace: maintenanceInput.trace,
       maxSteps: 20,
       onTraceEvent: (event) =>
         args.onEvent?.({
@@ -54,8 +56,10 @@ export class ConversationTurnMemoryMaintenance {
 
   static async runBackground(args: ScheduleBackgroundTurnMemoryMaintenanceArgs) {
     const maintenanceInput: RunMemoryMaintenanceCoreArgs = args;
-    const maintenance = await runMaintenanceForRecordedCandidates({
-      ...maintenanceInput,
+    const maintenance = await new MemoryMaintenanceIntegrationService(maintenanceInput.memoryRoot).runForRecordedCandidates({
+      llm: maintenanceInput.llm,
+      source: maintenanceInput.source,
+      trace: maintenanceInput.trace,
       maxSteps: 20,
       onTraceEvent: (event) =>
         args.onEvent?.({

--- a/src/core/chat/engine/turns/runtime/runtime-resolver.ts
+++ b/src/core/chat/engine/turns/runtime/runtime-resolver.ts
@@ -5,7 +5,7 @@ import {
   RuntimeCredentialService,
 } from '@/core/runtime/credentials/index.js';
 import { appendAwarenessDomainSystemContext } from '@/core/awareness/domain-prompt.js';
-import { appendMemoryCatalogSystemContext } from '@/core/memory/catalog.js';
+import { MemoryCatalogService } from '@/core/memory/catalog.js';
 import type { ApiKeyRuntime } from '@/core/runtime/credentials/index.js';
 import type { ChatTurnRuntime, ResolveConversationTurnRuntimeArgs } from './types.js';
 
@@ -48,9 +48,8 @@ export class ConversationTurnRuntimeResolver {
       apiKey,
       providerCredentialSource,
       memoryDir,
-      systemContext: appendAwarenessDomainSystemContext(appendMemoryCatalogSystemContext({
+      systemContext: appendAwarenessDomainSystemContext(new MemoryCatalogService(memoryDir).appendCatalogSystemContext({
         systemContext: config.systemContext,
-        memoryRoot: memoryDir,
       })),
       reasoningEffort: session.reasoningEffort,
       llm: LlmAdapterService.create({

--- a/src/core/heartbeat/wake/service.ts
+++ b/src/core/heartbeat/wake/service.ts
@@ -6,7 +6,7 @@
  * delegates model/tool stepping to `AgentLoopRuntimeService`.
  */
 import { resolve } from 'node:path';
-import { appendMemoryCatalogSystemContext } from '@/core/memory/catalog.js';
+import { MemoryCatalogService } from '@/core/memory/catalog.js';
 import { AgentLoopCheckpointService, AgentLoopRuntimeService } from '@/core/runtime/loop/index.js';
 import type { RunAgentLoopOptions } from '@/core/runtime/loop/index.js';
 import { HeartbeatDecisionPolicy } from './decision.js';
@@ -74,9 +74,8 @@ export class HeartbeatWakeService {
       ...runtimeOptions
     } = options;
     const memoryDir = providedMemoryDir ?? resolve(workspaceRoot ?? process.cwd(), stateDir ?? '.heddle', 'memory');
-    const systemContext = HeartbeatWakePrompt.appendSystemContext(appendMemoryCatalogSystemContext({
+    const systemContext = HeartbeatWakePrompt.appendSystemContext(new MemoryCatalogService(memoryDir).appendCatalogSystemContext({
       systemContext: providedSystemContext,
-      memoryRoot: memoryDir,
     }));
 
     return {

--- a/src/core/memory/README.md
+++ b/src/core/memory/README.md
@@ -24,14 +24,29 @@ guidance.
 
 ## Public Entry Points
 
-- `catalog.ts`: catalog bootstrap, load, append system context, and validation.
+- `types.ts`: memory-domain contracts for catalogs, candidates, runs, visibility,
+  validation, and note operations.
+- `schemas.ts`: zod validation for persisted memory JSONL records and locks.
+- `catalog.ts`: `MemoryCatalogService` owns catalog bootstrap, root catalog
+  loading, startup system-context assembly, and required catalog shape.
 - `domain-prompt.ts`: memory-specific system context.
-- `maintainer.ts`: pending candidate reading and maintenance execution.
-- `maintenance-integration.ts`: run maintenance for candidates recorded in a
-  trace.
+- `maintenance-repository.ts`: `MemoryMaintenanceRepository` owns candidate,
+  run, status, and lock file persistence.
+- `maintainer.ts`: `MemoryMaintenanceService` owns pending candidate reads and
+  agent-backed maintenance execution.
+- `maintainer-prompt.ts`: `MemoryMaintainerPrompt` owns static maintainer
+  instructions and dynamic candidate/catalog prompt assembly. Keep static text
+  before dynamic memory content for provider token caching.
+- `maintenance-integration.ts`: `MemoryMaintenanceIntegrationService` owns
+  trace-triggered maintenance scheduling, locking, and lifecycle events.
+- `note-service.ts`: `MemoryNoteService` owns note list/read/search/edit
+  behavior. Tool adapters should call this service, not duplicate file logic.
 - `maintainer-tools.ts`: tools used by maintainer mode.
-- `visibility.ts`: memory status, list, read, and search views for hosts.
-- `templates.ts`: memory note templates.
+- `visibility.ts`: `MemoryVisibilityService` owns host-facing status and note
+  visibility views.
+- `validation.ts`: `MemoryValidationService` owns workspace health checks and
+  safe missing-catalog repair.
+- `templates.ts`: pure memory note template helpers.
 
 ## Extension Points
 
@@ -41,6 +56,8 @@ guidance.
   domain.
 - Add new memory trace summaries through the observability/trace summarizer path
   once it exists.
+- Add persisted memory records by updating `types.ts`, `schemas.ts`, and the
+  owning repository together.
 
 ## Common Changes
 
@@ -50,6 +67,8 @@ guidance.
   maintainer tests.
 - To change maintenance concurrency or locking, update
   `maintenance-integration.ts` and integration coverage.
+- To change note access, update `MemoryNoteService`; keep knowledge tools as
+  adapters over that service.
 
 ## Tests
 
@@ -64,4 +83,7 @@ guidance.
 - Memory is a durable knowledge domain, not scratch context.
 - Live workspace evidence wins over memory for implementation facts.
 - Do not store secrets, speculative guesses, or one-turn command output.
-
+- Keep domain behavior inside the memory service/repository classes. Pure prompt
+  text, templates, and tool composition can remain small helper modules.
+- Do not make memory visibility call memory tools. The dependency direction is
+  tools and hosts -> memory services.

--- a/src/core/memory/catalog.ts
+++ b/src/core/memory/catalog.ts
@@ -1,39 +1,17 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { buildMemoryDomainSystemContext } from './domain-prompt.js';
+import type {
+  BootstrapMemoryWorkspaceResult,
+  MemoryCatalogLoadResult,
+  MemoryCatalogShapeValidation,
+  MemoryCategory,
+} from './types.js';
 
 export const DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES = 12 * 1024;
 export const DEFAULT_MEMORY_ROOT_CATALOG_TARGET_BYTES = 8 * 1024;
 export const DEFAULT_MEMORY_FOLDER_CATALOG_MAX_BYTES = 8 * 1024;
 export const DEFAULT_MEMORY_FOLDER_CATALOG_TARGET_BYTES = 5 * 1024;
-
-export type MemoryCategory = {
-  path: string;
-  title: string;
-  purpose: string;
-  readWhen: string;
-};
-
-export type BootstrapMemoryWorkspaceResult = {
-  memoryRoot: string;
-  createdPaths: string[];
-};
-
-export type MemoryCatalogLoadResult = {
-  memoryRoot: string;
-  catalogPath: string;
-  exists: boolean;
-  content: string;
-  truncated: boolean;
-  originalBytes: number;
-  maxBytes: number;
-};
-
-export type MemoryCatalogShapeValidation = {
-  ok: boolean;
-  memoryRoot: string;
-  missing: string[];
-};
 
 export const DEFAULT_MEMORY_CATEGORIES: MemoryCategory[] = [
   {
@@ -80,34 +58,103 @@ export const DEFAULT_MEMORY_CATEGORIES: MemoryCategory[] = [
   },
 ];
 
-export function bootstrapMemoryWorkspace(options: { memoryRoot: string }): BootstrapMemoryWorkspaceResult {
-  const memoryRoot = resolve(options.memoryRoot);
-  const createdPaths: string[] = [];
+/**
+ * Owns the cataloged memory workspace shape and the startup memory context.
+ */
+export class MemoryCatalogService {
+  constructor(private readonly memoryRoot: string) {}
 
-  mkdirSync(memoryRoot, { recursive: true });
-  writeIfMissing(join(memoryRoot, 'README.md'), createRootCatalogTemplate(), createdPaths, memoryRoot);
+  bootstrap(): BootstrapMemoryWorkspaceResult {
+    const memoryRoot = this.resolveRoot();
+    const createdPaths: string[] = [];
 
-  for (const category of DEFAULT_MEMORY_CATEGORIES) {
-    const categoryRoot = join(memoryRoot, category.path);
-    mkdirSync(categoryRoot, { recursive: true });
-    writeIfMissing(join(categoryRoot, 'README.md'), createFolderCatalogTemplate(category), createdPaths, memoryRoot);
+    mkdirSync(memoryRoot, { recursive: true });
+    MemoryCatalogService.writeIfMissing(join(memoryRoot, 'README.md'), MemoryCatalogService.createRootCatalogTemplate(), createdPaths, memoryRoot);
+
+    for (const category of DEFAULT_MEMORY_CATEGORIES) {
+      const categoryRoot = join(memoryRoot, category.path);
+      mkdirSync(categoryRoot, { recursive: true });
+      MemoryCatalogService.writeIfMissing(join(categoryRoot, 'README.md'), MemoryCatalogService.createFolderCatalogTemplate(category), createdPaths, memoryRoot);
+    }
+
+    mkdirSync(join(memoryRoot, '_maintenance'), { recursive: true });
+    MemoryCatalogService.writeIfMissing(join(memoryRoot, '_maintenance', 'runs.jsonl'), '', createdPaths, memoryRoot);
+
+    return { memoryRoot, createdPaths };
   }
 
-  mkdirSync(join(memoryRoot, '_maintenance'), { recursive: true });
-  writeIfMissing(join(memoryRoot, '_maintenance', 'runs.jsonl'), '', createdPaths, memoryRoot);
+  loadRootCatalog(maxBytes = DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES): MemoryCatalogLoadResult {
+    const memoryRoot = this.resolveRoot();
+    const catalogPath = join(memoryRoot, 'README.md');
 
-  return { memoryRoot, createdPaths };
-}
+    if (!existsSync(catalogPath)) {
+      return MemoryCatalogService.missingRootCatalog(memoryRoot, catalogPath, maxBytes);
+    }
 
-export function loadMemoryRootCatalog(options: {
-  memoryRoot: string;
-  maxBytes?: number;
-}): MemoryCatalogLoadResult {
-  const memoryRoot = resolve(options.memoryRoot);
-  const maxBytes = options.maxBytes ?? DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES;
-  const catalogPath = join(memoryRoot, 'README.md');
+    const original = readFileSync(catalogPath, 'utf8').trim();
+    const originalBytes = Buffer.byteLength(original, 'utf8');
+    const truncatedContent = MemoryCatalogService.truncateUtf8(original, maxBytes);
+    const truncated = originalBytes > Buffer.byteLength(truncatedContent, 'utf8');
+    const content =
+      truncated ?
+        [
+          truncatedContent,
+          '',
+          `[Memory catalog truncated to ${maxBytes} bytes from ${originalBytes} bytes. Use read_memory_note on README.md for the full catalog.]`,
+        ].join('\n')
+      : original;
 
-  if (!existsSync(catalogPath)) {
+    return {
+      memoryRoot,
+      catalogPath,
+      exists: true,
+      content,
+      truncated,
+      originalBytes,
+      maxBytes,
+    };
+  }
+
+  formatCatalogSystemContext(catalog: MemoryCatalogLoadResult): string {
+    const header = catalog.exists ? '## Workspace Memory Catalog' : '## Workspace Memory Catalog Missing';
+    return [
+      header,
+      '',
+      `Source: ${catalog.catalogPath}`,
+      '',
+      catalog.content,
+      '',
+      'Startup memory policy: this is the only memory document loaded automatically. Use memory tools to read relevant folder catalogs or notes before relying on deeper memory.',
+    ].join('\n');
+  }
+
+  appendCatalogSystemContext(options: { systemContext?: string; maxBytes?: number }): string {
+    const catalog = this.loadRootCatalog(options.maxBytes);
+    const memoryContext = this.formatCatalogSystemContext(catalog);
+    const domainContext = buildMemoryDomainSystemContext();
+    const context = `${domainContext}\n\n${memoryContext}`;
+    return options.systemContext ? `${context}\n\n${options.systemContext}` : context;
+  }
+
+  validateShape(): MemoryCatalogShapeValidation {
+    const memoryRoot = this.resolveRoot();
+    const requiredPaths = [
+      'README.md',
+      ...DEFAULT_MEMORY_CATEGORIES.map((category) => join(category.path, 'README.md')),
+    ];
+    const missing = requiredPaths.filter((relativePath) => !existsSync(join(memoryRoot, relativePath)));
+    return {
+      ok: missing.length === 0,
+      memoryRoot,
+      missing,
+    };
+  }
+
+  private resolveRoot(): string {
+    return resolve(this.memoryRoot);
+  }
+
+  private static missingRootCatalog(memoryRoot: string, catalogPath: string, maxBytes: number): MemoryCatalogLoadResult {
     const content = [
       'No workspace memory catalog exists yet.',
       '',
@@ -128,161 +175,95 @@ export function loadMemoryRootCatalog(options: {
     };
   }
 
-  const original = readFileSync(catalogPath, 'utf8').trim();
-  const originalBytes = Buffer.byteLength(original, 'utf8');
-  const truncatedContent = truncateUtf8(original, maxBytes);
-  const truncated = originalBytes > Buffer.byteLength(truncatedContent, 'utf8');
-  const content =
-    truncated ?
-      [
-        truncatedContent,
-        '',
-        `[Memory catalog truncated to ${maxBytes} bytes from ${originalBytes} bytes. Use read_memory_note on README.md for the full catalog.]`,
-      ].join('\n')
-    : original;
+  private static writeIfMissing(path: string, content: string, createdPaths: string[], memoryRoot: string) {
+    if (existsSync(path)) {
+      return;
+    }
 
-  return {
-    memoryRoot,
-    catalogPath,
-    exists: true,
-    content,
-    truncated,
-    originalBytes,
-    maxBytes,
-  };
-}
-
-export function formatMemoryCatalogSystemContext(catalog: MemoryCatalogLoadResult): string {
-  const header = catalog.exists ? '## Workspace Memory Catalog' : '## Workspace Memory Catalog Missing';
-  return [
-    header,
-    '',
-    `Source: ${catalog.catalogPath}`,
-    '',
-    catalog.content,
-    '',
-    'Startup memory policy: this is the only memory document loaded automatically. Use memory tools to read relevant folder catalogs or notes before relying on deeper memory.',
-  ].join('\n');
-}
-
-export function appendMemoryCatalogSystemContext(options: {
-  systemContext?: string;
-  memoryRoot: string;
-  maxBytes?: number;
-}): string {
-  const catalog = loadMemoryRootCatalog({ memoryRoot: options.memoryRoot, maxBytes: options.maxBytes });
-  const memoryContext = formatMemoryCatalogSystemContext(catalog);
-  const domainContext = buildMemoryDomainSystemContext();
-  const context = `${domainContext}\n\n${memoryContext}`;
-  return options.systemContext ? `${context}\n\n${options.systemContext}` : context;
-}
-
-export function validateMemoryCatalogShape(options: { memoryRoot: string }): MemoryCatalogShapeValidation {
-  const memoryRoot = resolve(options.memoryRoot);
-  const requiredPaths = [
-    'README.md',
-    ...DEFAULT_MEMORY_CATEGORIES.map((category) => join(category.path, 'README.md')),
-  ];
-  const missing = requiredPaths.filter((relativePath) => !existsSync(join(memoryRoot, relativePath)));
-  return {
-    ok: missing.length === 0,
-    memoryRoot,
-    missing,
-  };
-}
-
-function writeIfMissing(path: string, content: string, createdPaths: string[], memoryRoot: string) {
-  if (existsSync(path)) {
-    return;
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, 'utf8');
+    createdPaths.push(path.slice(memoryRoot.length).replace(/^\/+/, '') || '.');
   }
 
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, content, 'utf8');
-  createdPaths.push(toMemoryRelativePath(memoryRoot, path));
-}
-
-function createRootCatalogTemplate(): string {
-  return [
-    '# Workspace Memory',
-    '',
-    'Purpose: durable workspace knowledge that helps future agents become operational quickly.',
-    '',
-    '## Authority And Freshness',
-    '',
-    '- Live workspace evidence wins over memory when they disagree.',
-    '- Current-state notes with recent verification are stronger than older focused notes.',
-    '- Historical notes explain decisions and incidents but may be stale.',
-    '- Important stale, disputed, or superseded facts should be marked rather than silently removed.',
-    '',
-    '## Fast Reading Path',
-    '',
-    '- New non-trivial task: read `current-state/README.md`, then the category that matches the task.',
-    '- Coding or architecture task: read `domain/README.md`, `operations/README.md`, and relevant preferences.',
-    '- Workflow, release, PR, or incident task: read `workflows/README.md`, `operations/README.md`, and relevant history.',
-    '- Coordination-heavy task: read `relationships/README.md`.',
-    '',
-    '## Category Index',
-    '',
-    ...DEFAULT_MEMORY_CATEGORIES.map((category) => `- [${category.title}](${category.path}/README.md): ${category.purpose}`),
-    '',
-    '## High-Value Notes',
-    '',
-    '- Add links here when notes become important enough for every fresh agent to notice.',
-    '',
-    '## Stale Or Disputed Notes',
-    '',
-    '- Add links here when a note should be treated with caution.',
-    '',
-    '## Maintenance Instructions',
-    '',
-    '- Keep this catalog short and navigable.',
-    '- Every folder that contains memory notes needs its own `README.md` catalog.',
-    '- Every durable note should be discoverable through this catalog or a folder catalog.',
-    '- Prefer updating existing notes over scattering small one-off notes.',
-    '- Do not store secrets.',
-    '',
-  ].join('\n');
-}
-
-function createFolderCatalogTemplate(category: MemoryCategory): string {
-  return [
-    `# ${category.title}`,
-    '',
-    `Purpose: ${category.purpose}`,
-    '',
-    `When to read: ${category.readWhen}`,
-    '',
-    '## Notes Index',
-    '',
-    '- Add note links here as this folder grows.',
-    '',
-    '## Related Folders',
-    '',
-    '- `../README.md`: root memory catalog.',
-    '',
-    '## Maintenance Rules',
-    '',
-    '- Keep this catalog short enough to scan quickly.',
-    '- Add notes only when they preserve durable context for future work.',
-    '- Update this catalog whenever adding, renaming, or retiring notes in this folder.',
-    '- Mark stale, disputed, or superseded knowledge explicitly.',
-    '',
-  ].join('\n');
-}
-
-function truncateUtf8(value: string, maxBytes: number): string {
-  if (maxBytes <= 0) {
-    return '';
+  private static createRootCatalogTemplate(): string {
+    return [
+      '# Workspace Memory',
+      '',
+      'Purpose: durable workspace knowledge that helps future agents become operational quickly.',
+      '',
+      '## Authority And Freshness',
+      '',
+      '- Live workspace evidence wins over memory when they disagree.',
+      '- Current-state notes with recent verification are stronger than older focused notes.',
+      '- Historical notes explain decisions and incidents but may be stale.',
+      '- Important stale, disputed, or superseded facts should be marked rather than silently removed.',
+      '',
+      '## Fast Reading Path',
+      '',
+      '- New non-trivial task: read `current-state/README.md`, then the category that matches the task.',
+      '- Coding or architecture task: read `domain/README.md`, `operations/README.md`, and relevant preferences.',
+      '- Workflow, release, PR, or incident task: read `workflows/README.md`, `operations/README.md`, and relevant history.',
+      '- Coordination-heavy task: read `relationships/README.md`.',
+      '',
+      '## Category Index',
+      '',
+      ...DEFAULT_MEMORY_CATEGORIES.map((category) => `- [${category.title}](${category.path}/README.md): ${category.purpose}`),
+      '',
+      '## High-Value Notes',
+      '',
+      '- Add links here when notes become important enough for every fresh agent to notice.',
+      '',
+      '## Stale Or Disputed Notes',
+      '',
+      '- Add links here when a note should be treated with caution.',
+      '',
+      '## Maintenance Instructions',
+      '',
+      '- Keep this catalog short and navigable.',
+      '- Every folder that contains memory notes needs its own `README.md` catalog.',
+      '- Every durable note should be discoverable through this catalog or a folder catalog.',
+      '- Prefer updating existing notes over scattering small one-off notes.',
+      '- Do not store secrets.',
+      '',
+    ].join('\n');
   }
 
-  const bytes = Buffer.from(value, 'utf8');
-  if (bytes.length <= maxBytes) {
-    return value;
+  private static createFolderCatalogTemplate(category: MemoryCategory): string {
+    return [
+      `# ${category.title}`,
+      '',
+      `Purpose: ${category.purpose}`,
+      '',
+      `When to read: ${category.readWhen}`,
+      '',
+      '## Notes Index',
+      '',
+      '- Add note links here as this folder grows.',
+      '',
+      '## Related Folders',
+      '',
+      '- `../README.md`: root memory catalog.',
+      '',
+      '## Maintenance Rules',
+      '',
+      '- Keep this catalog short enough to scan quickly.',
+      '- Add notes only when they preserve durable context for future work.',
+      '- Update this catalog whenever adding, renaming, or retiring a note in this folder.',
+      '- Mark stale, disputed, or superseded knowledge explicitly.',
+      '',
+    ].join('\n');
   }
 
-  return bytes.subarray(0, maxBytes).toString('utf8').replace(/\uFFFD+$/u, '').trimEnd();
-}
+  private static truncateUtf8(value: string, maxBytes: number): string {
+    if (maxBytes <= 0) {
+      return '';
+    }
 
-function toMemoryRelativePath(memoryRoot: string, path: string): string {
-  return path.slice(memoryRoot.length).replace(/^\/+/, '') || '.';
+    const bytes = Buffer.from(value, 'utf8');
+    if (bytes.length <= maxBytes) {
+      return value;
+    }
+
+    return bytes.subarray(0, maxBytes).toString('utf8').replace(/\uFFFD+$/u, '').trimEnd();
+  }
 }

--- a/src/core/memory/index.ts
+++ b/src/core/memory/index.ts
@@ -1,0 +1,39 @@
+export {
+  DEFAULT_MEMORY_CATEGORIES,
+  DEFAULT_MEMORY_FOLDER_CATALOG_MAX_BYTES,
+  DEFAULT_MEMORY_FOLDER_CATALOG_TARGET_BYTES,
+  DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES,
+  DEFAULT_MEMORY_ROOT_CATALOG_TARGET_BYTES,
+  MemoryCatalogService,
+} from './catalog.js';
+export { buildMemoryDomainSystemContext } from './domain-prompt.js';
+export { MemoryMaintenanceRepository } from './maintenance-repository.js';
+export { MemoryMaintainerPrompt } from './maintainer-prompt.js';
+export { MemoryMaintenanceService } from './maintainer.js';
+export { MemoryMaintenanceIntegrationService } from './maintenance-integration.js';
+export { createMemoryMaintainerTools } from './maintainer-tools.js';
+export { MemoryNoteService } from './note-service.js';
+export { MemorySchemas } from './schemas.js';
+export { createMemoryNoteTemplate, slugifyMemoryTitle } from './templates.js';
+export { MemoryValidationService } from './validation.js';
+export { MemoryVisibilityService } from './visibility.js';
+export type {
+  BootstrapMemoryWorkspaceResult,
+  KnowledgeCandidate,
+  KnowledgeCandidateStatusRecord,
+  KnowledgeMaintenanceRunRecord,
+  ListMemoryNotesInput,
+  MemoryCatalogLoadResult,
+  MemoryCatalogShapeValidation,
+  MemoryCategory,
+  MemoryMaintenanceLockRecord,
+  MemoryStatusView,
+  MemoryValidationIssue,
+  MemoryValidationResult,
+  ReadMemoryNoteInput,
+  RunKnowledgeMaintenanceOptions,
+  RunKnowledgeMaintenanceResult,
+  RunMaintenanceForRecordedCandidatesOptions,
+  RunMaintenanceForRecordedCandidatesResult,
+  SearchMemoryNotesInput,
+} from './types.js';

--- a/src/core/memory/maintainer-prompt.ts
+++ b/src/core/memory/maintainer-prompt.ts
@@ -1,0 +1,63 @@
+import type { KnowledgeCandidate } from './types.js';
+
+/**
+ * Owns the memory maintainer prompt text.
+ *
+ * Keep static instructions before dynamic catalog/candidate content so model
+ * providers can reuse token cache across maintenance runs.
+ */
+export class MemoryMaintainerPrompt {
+  private static readonly staticSystemContext = `## Memory Maintainer Mode
+
+You maintain Heddle workspace memory. You are not doing general coding work.
+Use only memory tools. Do not ask for shell, code edit, web, or external tools.
+
+### Hard Invariants
+
+- Every durable note must be discoverable through the root catalog or a folder catalog.
+- Read the root catalog first, then read the relevant folder catalog before writing.
+- Search existing notes before creating a new note.
+- Prefer updating existing notes over creating duplicates.
+- Update folder catalogs whenever you create, rename, or retire a note.
+- Update the root catalog only when a new high-value note or discovery path matters globally.
+- Do not store secrets, credentials, private keys, tokens, or passwords.
+- Skip low-value, duplicate, speculative, or one-turn scratch observations.`;
+
+  static buildSystemContext(rootCatalog: string): string {
+    return `${MemoryMaintainerPrompt.staticSystemContext}
+
+## Loaded Root Catalog
+
+${rootCatalog}`;
+  }
+
+  static buildMaintenanceGoal(observations: KnowledgeCandidate[]): string {
+    return `# Memory Maintenance Task
+
+Process these pending memory candidates into maintained cataloged memory.
+
+${MemoryMaintainerPrompt.formatCandidates(observations)}
+
+End with a concise summary of what memory notes or catalogs changed, or why candidates were skipped.`;
+  }
+
+  private static formatCandidates(observations: KnowledgeCandidate[]): string {
+    return observations
+      .map((candidate, index) => {
+        const evidence = candidate.evidence?.length
+          ? `\n\n### Evidence\n\n${candidate.evidence.map((item) => `- ${item}`).join('\n')}`
+          : '';
+        const sourceRefs = candidate.sourceRefs?.length
+          ? `\n\n### Source Refs\n\n${candidate.sourceRefs.map((ref) => `- ${ref}`).join('\n')}`
+          : '';
+        const categoryHint = candidate.categoryHint ? `\n- Category hint: ${candidate.categoryHint}` : '';
+        const importance = candidate.importance ? `\n- Importance: ${candidate.importance}` : '';
+        const confidence = candidate.confidence ? `\n- Confidence: ${candidate.confidence}` : '';
+
+        return `## Candidate ${index + 1}: ${candidate.id}
+
+- Summary: ${candidate.summary}${categoryHint}${importance}${confidence}${evidence}${sourceRefs}`;
+      })
+      .join('\n\n');
+  }
+}

--- a/src/core/memory/maintainer.ts
+++ b/src/core/memory/maintainer.ts
@@ -1,270 +1,175 @@
-import { appendFile, mkdir, readFile } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
-import type { LlmAdapter } from '../llm/types.js';
-import type { RunResult } from '../types.js';
-import { AgentRunService } from '../agent/index.js';
-import { createLogger } from '../utils/logger.js';
-import { bootstrapMemoryWorkspace, loadMemoryRootCatalog, validateMemoryCatalogShape } from './catalog.js';
+import { isAbsolute, relative, resolve } from 'node:path';
+import { AgentRunService } from '@/core/agent/index.js';
+import { createLogger } from '@/core/utils/logger.js';
+import { MemoryCatalogService } from './catalog.js';
+import { MemoryMaintenanceRepository } from './maintenance-repository.js';
+import { MemoryMaintainerPrompt } from './maintainer-prompt.js';
 import { createMemoryMaintainerTools } from './maintainer-tools.js';
+import type {
+  KnowledgeCandidate,
+  KnowledgeMaintenanceRunRecord,
+  RunKnowledgeMaintenanceOptions,
+  RunKnowledgeMaintenanceResult,
+} from './types.js';
 
-export type KnowledgeCandidate = {
-  id: string;
-  recordedAt: string;
-  status: 'pending';
-  summary: string;
-  evidence?: string[];
-  categoryHint?: string;
-  importance?: 'low' | 'medium' | 'high';
-  confidence?: 'user-stated' | 'tool-verified' | 'inferred' | 'historical';
-  sourceRefs?: string[];
-};
+/**
+ * Owns the agent-backed memory maintenance workflow over pending candidates.
+ */
+export class MemoryMaintenanceService {
+  constructor(
+    private readonly memoryRoot: string,
+    private readonly repository = new MemoryMaintenanceRepository(memoryRoot),
+    private readonly catalog = new MemoryCatalogService(memoryRoot),
+  ) {}
 
-export type KnowledgeMaintenanceRunRecord = {
-  id: string;
-  startedAt: string;
-  finishedAt: string;
-  source: string;
-  outcome: RunResult['outcome'] | 'skipped';
-  summary: string;
-  candidateIds: string[];
-  processedCandidateIds: string[];
-  failedCandidateIds: string[];
-  catalogValid: boolean;
-  catalogMissing: string[];
-};
-
-export type RunKnowledgeMaintenanceOptions = {
-  memoryRoot: string;
-  observations: KnowledgeCandidate[];
-  llm: LlmAdapter;
-  source: string;
-  maxSteps?: number;
-  now?: () => Date;
-  nextRunId?: () => string;
-};
-
-export type RunKnowledgeMaintenanceResult = {
-  run: KnowledgeMaintenanceRunRecord;
-  result?: RunResult;
-};
-
-export async function readPendingKnowledgeCandidates(options: { memoryRoot: string }): Promise<KnowledgeCandidate[]> {
-  const memoryRoot = resolve(options.memoryRoot);
-  const candidatesPath = join(memoryRoot, '_maintenance', 'candidates.jsonl');
-  const lines = await readJsonlLines(candidatesPath);
-  const processed = new Set<string>();
-  const pending: KnowledgeCandidate[] = [];
-
-  for (const line of lines) {
-    const parsed = parseJsonObject(line);
-    if (!parsed) {
-      continue;
-    }
-
-    if (parsed.kind === 'candidate_status' && typeof parsed.candidateId === 'string' && parsed.status === 'processed') {
-      processed.add(parsed.candidateId);
-      continue;
-    }
-
-    if (isKnowledgeCandidate(parsed)) {
-      pending.push(parsed);
-    }
+  async readPendingCandidates(): Promise<KnowledgeCandidate[]> {
+    return await this.repository.readPendingCandidates();
   }
 
-  return pending.filter((candidate) => !processed.has(candidate.id));
-}
+  async run(options: Omit<RunKnowledgeMaintenanceOptions, 'memoryRoot'>): Promise<RunKnowledgeMaintenanceResult> {
+    const memoryRoot = resolve(this.memoryRoot);
+    this.catalog.bootstrap();
 
-export async function runKnowledgeMaintenance(options: RunKnowledgeMaintenanceOptions): Promise<RunKnowledgeMaintenanceResult> {
-  const memoryRoot = resolve(options.memoryRoot);
-  bootstrapMemoryWorkspace({ memoryRoot });
-  const now = options.now ?? (() => new Date());
-  const startedAt = now();
-  const runId = options.nextRunId?.() ?? `memory-run-${startedAt.getTime()}`;
-  const candidateIds = options.observations.map((candidate) => candidate.id);
-  const skippedCandidateIds = options.observations
-    .filter((candidate) => !isMaintainerCandidateAllowed(candidate))
-    .map((candidate) => candidate.id);
-  const observations = options.observations.filter(isMaintainerCandidateAllowed);
+    const now = options.now ?? (() => new Date());
+    const startedAt = now();
+    const runId = options.nextRunId?.() ?? `memory-run-${startedAt.getTime()}`;
+    const candidateIds = options.observations.map((candidate) => candidate.id);
+    const skippedCandidateIds = options.observations
+      .filter((candidate) => !MemoryMaintenanceService.isMaintainerCandidateAllowed(candidate))
+      .map((candidate) => candidate.id);
+    const observations = options.observations.filter(MemoryMaintenanceService.isMaintainerCandidateAllowed);
 
-  if (observations.length === 0) {
-    const validation = validateMemoryCatalogShape({ memoryRoot });
-    const summary =
-      candidateIds.length === 0 ? 'No pending knowledge candidates.'
-      : `Skipped ${candidateIds.length} low-value, duplicate, or secret-like memory candidate(s).`;
-    const run = {
+    if (observations.length === 0) {
+      const validation = this.catalog.validateShape();
+      const run = MemoryMaintenanceService.skippedRun({
+        runId,
+        startedAt,
+        finishedAt: now(),
+        source: options.source,
+        candidateIds,
+        skippedCandidateIds,
+        catalogValid: validation.ok,
+        catalogMissing: validation.missing,
+      });
+      await this.repository.appendMaintenanceRun(run);
+      return { run };
+    }
+
+    const rootCatalog = this.catalog.loadRootCatalog().content;
+    const result = await AgentRunService.run({
+      goal: MemoryMaintainerPrompt.buildMaintenanceGoal(observations),
+      llm: options.llm,
+      tools: createMemoryMaintainerTools({ memoryRoot }),
+      maxSteps: options.maxSteps ?? 40,
+      logger: createLogger({ console: false, level: 'silent' }),
+      systemContext: MemoryMaintainerPrompt.buildSystemContext(rootCatalog),
+    });
+    const validation = this.catalog.validateShape();
+    const processedCandidateIds = result.outcome === 'done' ? observations.map((candidate) => candidate.id) : [];
+    const failedCandidateIds = result.outcome === 'done' ? skippedCandidateIds : candidateIds;
+    const run: KnowledgeMaintenanceRunRecord = {
       id: runId,
       startedAt: startedAt.toISOString(),
       finishedAt: now().toISOString(),
       source: options.source,
-      outcome: 'skipped' as const,
-      summary,
+      outcome: result.outcome,
+      summary: result.summary,
       candidateIds,
-      processedCandidateIds: [],
-      failedCandidateIds: skippedCandidateIds,
+      processedCandidateIds,
+      failedCandidateIds,
       catalogValid: validation.ok,
       catalogMissing: validation.missing,
     };
-    await appendMaintenanceRun(memoryRoot, run);
-    return { run };
-  }
 
-  const rootCatalog = loadMemoryRootCatalog({ memoryRoot }).content;
-  const goal = buildMaintenanceGoal(observations);
-  const systemContext = buildMaintainerSystemContext(rootCatalog);
-  const result = await AgentRunService.run({
-    goal,
-    llm: options.llm,
-    tools: createMemoryMaintainerTools({ memoryRoot }),
-    maxSteps: options.maxSteps ?? 40,
-    logger: createLogger({ console: false, level: 'silent' }),
-    systemContext,
-  });
-  const validation = validateMemoryCatalogShape({ memoryRoot });
-  const processedCandidateIds = result.outcome === 'done' ? observations.map((candidate) => candidate.id) : [];
-  const failedCandidateIds = result.outcome === 'done' ? skippedCandidateIds : candidateIds;
-  const run = {
-    id: runId,
-    startedAt: startedAt.toISOString(),
-    finishedAt: now().toISOString(),
-    source: options.source,
-    outcome: result.outcome,
-    summary: result.summary,
-    candidateIds,
-    processedCandidateIds,
-    failedCandidateIds,
-    catalogValid: validation.ok,
-    catalogMissing: validation.missing,
-  };
-
-  await appendMaintenanceRun(memoryRoot, run);
-  if (processedCandidateIds.length > 0) {
-    await appendCandidateStatusEvents(memoryRoot, processedCandidateIds, run.id, now);
-  }
-
-  return { run, result };
-}
-
-function isMaintainerCandidateAllowed(candidate: KnowledgeCandidate): boolean {
-  const text = [
-    candidate.summary,
-    ...(candidate.evidence ?? []),
-    ...(candidate.sourceRefs ?? []),
-  ].join('\n');
-  return !containsSecretLikeText(text);
-}
-
-export async function runKnowledgeMaintenanceForBacklog(options: Omit<RunKnowledgeMaintenanceOptions, 'observations'>): Promise<RunKnowledgeMaintenanceResult> {
-  const observations = await readPendingKnowledgeCandidates({ memoryRoot: options.memoryRoot });
-  return await runKnowledgeMaintenance({ ...options, observations });
-}
-
-function buildMaintainerSystemContext(rootCatalog: string): string {
-  return [
-    '## Memory Maintainer Mode',
-    '',
-    'You maintain Heddle workspace memory. You are not doing general coding work.',
-    'Use only memory tools. Do not ask for shell, code edit, web, or external tools.',
-    '',
-    'Hard invariants:',
-    '- Every durable note must be discoverable through the root catalog or a folder catalog.',
-    '- Read the root catalog first, then read the relevant folder catalog before writing.',
-    '- Search existing notes before creating a new note.',
-    '- Prefer updating existing notes over creating duplicates.',
-    '- Update folder catalogs whenever you create, rename, or retire a note.',
-    '- Update the root catalog only when a new high-value note or discovery path matters globally.',
-    '- Do not store secrets, credentials, private keys, tokens, or passwords.',
-    '- Skip low-value, duplicate, speculative, or one-turn scratch observations.',
-    '',
-    'Loaded root catalog:',
-    '',
-    rootCatalog,
-  ].join('\n');
-}
-
-function buildMaintenanceGoal(observations: KnowledgeCandidate[]): string {
-  return [
-    'Process these pending memory candidates into maintained cataloged memory.',
-    '',
-    ...observations.map((candidate, index) => [
-      `Candidate ${index + 1}: ${candidate.id}`,
-      `Summary: ${candidate.summary}`,
-      candidate.categoryHint ? `Category hint: ${candidate.categoryHint}` : undefined,
-      candidate.importance ? `Importance: ${candidate.importance}` : undefined,
-      candidate.confidence ? `Confidence: ${candidate.confidence}` : undefined,
-      candidate.evidence?.length ? `Evidence:\n${candidate.evidence.map((item) => `- ${item}`).join('\n')}` : undefined,
-      candidate.sourceRefs?.length ? `Source refs: ${candidate.sourceRefs.join(', ')}` : undefined,
-    ].filter((line): line is string => Boolean(line)).join('\n')),
-    '',
-    'End with a concise summary of what memory notes or catalogs changed, or why candidates were skipped.',
-  ].join('\n\n');
-}
-
-async function appendMaintenanceRun(memoryRoot: string, run: KnowledgeMaintenanceRunRecord) {
-  const path = join(memoryRoot, '_maintenance', 'runs.jsonl');
-  await mkdir(dirname(path), { recursive: true });
-  await appendFile(path, `${JSON.stringify(run)}\n`, 'utf8');
-}
-
-async function appendCandidateStatusEvents(memoryRoot: string, candidateIds: string[], runId: string, now: () => Date) {
-  const path = join(memoryRoot, '_maintenance', 'candidates.jsonl');
-  await mkdir(dirname(path), { recursive: true });
-  const recordedAt = now().toISOString();
-  await appendFile(
-    path,
-    candidateIds.map((candidateId) => JSON.stringify({
-      kind: 'candidate_status',
-      candidateId,
-      status: 'processed',
-      runId,
-      recordedAt,
-    })).join('\n') + '\n',
-    'utf8',
-  );
-}
-
-async function readJsonlLines(path: string): Promise<string[]> {
-  try {
-    const raw = await readFile(path, 'utf8');
-    return raw.split(/\r?\n/u).filter((line) => line.trim());
-  } catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-      return [];
+    await this.repository.appendMaintenanceRun(run);
+    if (processedCandidateIds.length > 0) {
+      await this.repository.appendCandidateStatusEvents(processedCandidateIds, run.id, now);
     }
-    throw error;
+
+    return { run, result };
   }
-}
 
-function parseJsonObject(line: string): Record<string, unknown> | undefined {
-  try {
-    const parsed = JSON.parse(line) as unknown;
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as Record<string, unknown> : undefined;
-  } catch {
-    return undefined;
+  async runBacklog(options: Omit<RunKnowledgeMaintenanceOptions, 'memoryRoot' | 'observations'>): Promise<RunKnowledgeMaintenanceResult> {
+    return await this.run({
+      ...options,
+      observations: await this.readPendingCandidates(),
+    });
   }
-}
 
-function isKnowledgeCandidate(value: Record<string, unknown>): value is KnowledgeCandidate {
-  return typeof value.id === 'string'
-    && typeof value.recordedAt === 'string'
-    && value.status === 'pending'
-    && typeof value.summary === 'string'
-    && (value.evidence === undefined || isStringArray(value.evidence))
-    && (value.categoryHint === undefined || typeof value.categoryHint === 'string')
-    && (value.importance === undefined || value.importance === 'low' || value.importance === 'medium' || value.importance === 'high')
-    && (value.confidence === undefined || value.confidence === 'user-stated' || value.confidence === 'tool-verified' || value.confidence === 'inferred' || value.confidence === 'historical')
-    && (value.sourceRefs === undefined || isStringArray(value.sourceRefs));
-}
+  static isRecordableCandidateText(value: string): boolean {
+    return !MemoryMaintenanceService.containsSecretLikeText(value);
+  }
 
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === 'string');
-}
+  static isSafeSourceRef(value: string, memoryRoot: string): boolean {
+    if (value.includes('\0')) {
+      return false;
+    }
 
-function containsSecretLikeText(value: string): boolean {
-  const normalized = value.toLowerCase();
-  return /\b(api[_ -]?key|password|passwd|private[_ -]?key|access[_ -]?token|refresh[_ -]?token|bearer\s+[a-z0-9._~+/=-]{12,})\b/i.test(value)
-    || /\bsecret\s*[:=]\s*\S{8,}/i.test(value)
-    || /\bsk-[a-z0-9_-]{12,}\b/i.test(value)
-    || normalized.includes('-----begin private key-----')
-    || normalized.includes('-----begin rsa private key-----')
-    || normalized.includes('-----begin openssh private key-----');
+    if (value.startsWith('trace-') || value.startsWith('session-') || value.startsWith('command:')) {
+      return true;
+    }
+
+    if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
+      return false;
+    }
+
+    if (isAbsolute(value)) {
+      return false;
+    }
+
+    const normalizedSegments = value.replace(/\\/g, '/').split('/');
+    if (normalizedSegments.includes('..')) {
+      return false;
+    }
+
+    const workspaceRoot = resolve(memoryRoot, '..', '..');
+    const resolved = resolve(workspaceRoot, value);
+    const rel = relative(workspaceRoot, resolved);
+    return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+  }
+
+  private static skippedRun(args: {
+    runId: string;
+    startedAt: Date;
+    finishedAt: Date;
+    source: string;
+    candidateIds: string[];
+    skippedCandidateIds: string[];
+    catalogValid: boolean;
+    catalogMissing: string[];
+  }): KnowledgeMaintenanceRunRecord {
+    return {
+      id: args.runId,
+      startedAt: args.startedAt.toISOString(),
+      finishedAt: args.finishedAt.toISOString(),
+      source: args.source,
+      outcome: 'skipped',
+      summary:
+        args.candidateIds.length === 0 ? 'No pending knowledge candidates.'
+        : `Skipped ${args.candidateIds.length} low-value, duplicate, or secret-like memory candidate(s).`,
+      candidateIds: args.candidateIds,
+      processedCandidateIds: [],
+      failedCandidateIds: args.skippedCandidateIds,
+      catalogValid: args.catalogValid,
+      catalogMissing: args.catalogMissing,
+    };
+  }
+
+  private static isMaintainerCandidateAllowed(candidate: KnowledgeCandidate): boolean {
+    return MemoryMaintenanceService.isRecordableCandidateText([
+      candidate.summary,
+      ...(candidate.evidence ?? []),
+      ...(candidate.sourceRefs ?? []),
+    ].join('\n'));
+  }
+
+  private static containsSecretLikeText(value: string): boolean {
+    const normalized = value.toLowerCase();
+    return /\b(api[_ -]?key|password|passwd|private[_ -]?key|access[_ -]?token|refresh[_ -]?token|bearer\s+[a-z0-9._~+/=-]{12,})\b/i.test(value)
+      || /\bsecret\s*[:=]\s*\S{8,}/i.test(value)
+      || /\bsk-[a-z0-9_-]{12,}\b/i.test(value)
+      || normalized.includes('-----begin private key-----')
+      || normalized.includes('-----begin rsa private key-----')
+      || normalized.includes('-----begin openssh private key-----');
+  }
 }

--- a/src/core/memory/maintenance-integration.ts
+++ b/src/core/memory/maintenance-integration.ts
@@ -1,237 +1,211 @@
-import { mkdir, open, readFile, rm } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
-import type { LlmAdapter } from '../llm/types.js';
-import type { TraceEvent } from '../types.js';
-import {
-  readPendingKnowledgeCandidates,
-  runKnowledgeMaintenance,
-  type RunKnowledgeMaintenanceResult,
-} from './maintainer.js';
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import type { TraceEvent } from '@/core/types.js';
+import { MemoryMaintenanceRepository } from './maintenance-repository.js';
+import { MemoryMaintenanceService } from './maintainer.js';
+import type {
+  RunMaintenanceForRecordedCandidatesOptions,
+  RunMaintenanceForRecordedCandidatesResult,
+} from './types.js';
 
 const DEFAULT_LOCK_STALE_AFTER_MS = 10 * 60 * 1000;
 const DEFAULT_LOCK_POLL_MS = 250;
 const DEFAULT_LOCK_TIMEOUT_MS = 30 * 1000;
 const maintenanceQueues = new Map<string, Promise<void>>();
 
-export type RunMaintenanceForRecordedCandidatesOptions = {
-  memoryRoot: string;
-  llm: LlmAdapter;
-  source: string;
-  trace: TraceEvent[];
-  maxSteps?: number;
-  lockTimeoutMs?: number;
-  lockStaleAfterMs?: number;
-  onTraceEvent?: (event: TraceEvent) => void;
-};
+/**
+ * Bridges turn traces into serialized memory maintenance runs.
+ */
+export class MemoryMaintenanceIntegrationService {
+  constructor(
+    private readonly memoryRoot: string,
+    private readonly repository = new MemoryMaintenanceRepository(memoryRoot),
+    private readonly maintenance = new MemoryMaintenanceService(memoryRoot, repository),
+  ) {}
 
-export type RunMaintenanceForRecordedCandidatesResult = {
-  candidateIds: string[];
-  maintenance?: RunKnowledgeMaintenanceResult;
-  events: TraceEvent[];
-};
-
-export async function runMaintenanceForRecordedCandidates(
-  options: RunMaintenanceForRecordedCandidatesOptions,
-): Promise<RunMaintenanceForRecordedCandidatesResult> {
-  return await enqueueMaintenance(options.memoryRoot, () => runMaintenanceForRecordedCandidatesNow(options));
-}
-
-async function runMaintenanceForRecordedCandidatesNow(
-  options: RunMaintenanceForRecordedCandidatesOptions,
-): Promise<RunMaintenanceForRecordedCandidatesResult> {
-  const candidateIds = [...new Set(options.trace
-    .filter((event): event is Extract<TraceEvent, { type: 'memory.candidate_recorded' }> => event.type === 'memory.candidate_recorded')
-    .map((event) => event.candidateId))];
-
-  if (candidateIds.length === 0) {
-    return { candidateIds, events: [] };
+  async runForRecordedCandidates(
+    options: Omit<RunMaintenanceForRecordedCandidatesOptions, 'memoryRoot'>,
+  ): Promise<RunMaintenanceForRecordedCandidatesResult> {
+    return await this.enqueue(() => this.runNow(options));
   }
 
-  const pending = await readPendingKnowledgeCandidates({ memoryRoot: options.memoryRoot });
-  const observations = pending.filter((candidate) => candidateIds.includes(candidate.id));
-  if (observations.length === 0) {
-    return { candidateIds, events: [] };
-  }
+  private async runNow(
+    options: Omit<RunMaintenanceForRecordedCandidatesOptions, 'memoryRoot'>,
+  ): Promise<RunMaintenanceForRecordedCandidatesResult> {
+    const candidateIds = MemoryMaintenanceIntegrationService.candidateIdsFromTrace(options.trace);
+    if (candidateIds.length === 0) {
+      return { candidateIds, events: [] };
+    }
 
-  const runId = `memory-run-${Date.now()}`;
-  const started = createEvent({
-    type: 'memory.maintenance_started',
-    runId,
-    candidateIds: observations.map((candidate) => candidate.id),
-    step: nextMemoryStep(options.trace),
-  });
-  options.onTraceEvent?.(started);
+    const pending = await this.repository.readPendingCandidates();
+    const observations = pending.filter((candidate) => candidateIds.includes(candidate.id));
+    if (observations.length === 0) {
+      return { candidateIds, events: [] };
+    }
 
-  let lock: { release: () => Promise<void> } | undefined;
-  try {
-    lock = await acquireMemoryMaintenanceLock({
-      memoryRoot: options.memoryRoot,
-      staleAfterMs: options.lockStaleAfterMs,
-      timeoutMs: options.lockTimeoutMs,
+    const runId = `memory-run-${Date.now()}`;
+    const started = MemoryMaintenanceIntegrationService.createEvent({
+      type: 'memory.maintenance_started',
+      runId,
+      candidateIds: observations.map((candidate) => candidate.id),
+      step: MemoryMaintenanceIntegrationService.nextMemoryStep(options.trace),
     });
-    const maintenance = await runKnowledgeMaintenance({
-      memoryRoot: options.memoryRoot,
-      observations,
-      llm: options.llm,
-      source: options.source,
-      maxSteps: options.maxSteps,
-      nextRunId: () => runId,
-    });
-    if (maintenance.run.outcome === 'error' || maintenance.run.outcome === 'max_steps' || maintenance.run.outcome === 'interrupted') {
-      const failed = createEvent({
-        type: 'memory.maintenance_failed',
+    options.onTraceEvent?.(started);
+
+    let lock: { release: () => Promise<void> } | undefined;
+    try {
+      lock = await this.acquireLock({
+        staleAfterMs: options.lockStaleAfterMs,
+        timeoutMs: options.lockTimeoutMs,
+      });
+      const maintenance = await this.maintenance.run({
+        observations,
+        llm: options.llm,
+        source: options.source,
+        maxSteps: options.maxSteps,
+        nextRunId: () => runId,
+      });
+      if (maintenance.run.outcome === 'error' || maintenance.run.outcome === 'max_steps' || maintenance.run.outcome === 'interrupted') {
+        const failed = MemoryMaintenanceIntegrationService.createEvent({
+          type: 'memory.maintenance_failed',
+          runId: maintenance.run.id,
+          error: maintenance.run.summary,
+          candidateIds: observations.map((candidate) => candidate.id),
+          step: MemoryMaintenanceIntegrationService.nextMemoryStep(options.trace),
+        });
+        options.onTraceEvent?.(failed);
+        return { candidateIds, maintenance, events: [started, failed] };
+      }
+
+      const finished = MemoryMaintenanceIntegrationService.createEvent({
+        type: 'memory.maintenance_finished',
         runId: maintenance.run.id,
-        error: maintenance.run.summary,
+        outcome: maintenance.run.outcome,
+        summary: maintenance.run.summary,
+        processedCandidateIds: maintenance.run.processedCandidateIds,
+        failedCandidateIds: maintenance.run.failedCandidateIds,
+        step: MemoryMaintenanceIntegrationService.nextMemoryStep(options.trace),
+      });
+      options.onTraceEvent?.(finished);
+      return { candidateIds, maintenance, events: [started, finished] };
+    } catch (error) {
+      const failed = MemoryMaintenanceIntegrationService.createEvent({
+        type: 'memory.maintenance_failed',
+        runId,
+        error: error instanceof Error ? error.message : String(error),
         candidateIds: observations.map((candidate) => candidate.id),
-        step: nextMemoryStep(options.trace),
+        step: MemoryMaintenanceIntegrationService.nextMemoryStep(options.trace),
       });
       options.onTraceEvent?.(failed);
-      return { candidateIds, maintenance, events: [started, failed] };
+      return { candidateIds, events: [started, failed] };
+    } finally {
+      await lock?.release();
+    }
+  }
+
+  private async acquireLock(options: {
+    staleAfterMs?: number;
+    timeoutMs?: number;
+  }): Promise<{ release: () => Promise<void> }> {
+    const lockPath = this.repository.maintenanceLockPath();
+    const lockId = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const startedAt = Date.now();
+    const timeoutMs = options.timeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+    const staleAfterMs = options.staleAfterMs ?? DEFAULT_LOCK_STALE_AFTER_MS;
+    await mkdir(dirname(lockPath), { recursive: true });
+
+    while (true) {
+      try {
+        await this.repository.writeLock(lockPath, {
+          id: lockId,
+          pid: process.pid,
+          acquiredAt: new Date().toISOString(),
+        });
+
+        return {
+          release: async () => {
+            await this.releaseLock(lockPath, lockId);
+          },
+        };
+      } catch (error) {
+        if (!(error instanceof Error) || !('code' in error) || error.code !== 'EEXIST') {
+          throw error;
+        }
+
+        if (await this.removeStaleLock(lockPath, staleAfterMs)) {
+          continue;
+        }
+
+        if (Date.now() - startedAt >= timeoutMs) {
+          throw new Error(`Memory maintenance lock is busy: ${lockPath}`, { cause: error });
+        }
+        await MemoryMaintenanceIntegrationService.sleep(DEFAULT_LOCK_POLL_MS);
+      }
+    }
+  }
+
+  private async releaseLock(lockPath: string, lockId: string) {
+    const current = await this.repository.readLock(lockPath);
+    if (current?.id !== lockId) {
+      return;
+    }
+    await this.repository.removeLock(lockPath);
+  }
+
+  private async removeStaleLock(lockPath: string, staleAfterMs: number): Promise<boolean> {
+    const current = await this.repository.readLock(lockPath);
+    if (!current) {
+      return false;
     }
 
-    const finished = createEvent({
-      type: 'memory.maintenance_finished',
-      runId: maintenance.run.id,
-      outcome: maintenance.run.outcome,
-      summary: maintenance.run.summary,
-      processedCandidateIds: maintenance.run.processedCandidateIds,
-      failedCandidateIds: maintenance.run.failedCandidateIds,
-      step: nextMemoryStep(options.trace),
-    });
-    options.onTraceEvent?.(finished);
-    return { candidateIds, maintenance, events: [started, finished] };
-  } catch (error) {
-    const failed = createEvent({
-      type: 'memory.maintenance_failed',
-      runId,
-      error: error instanceof Error ? error.message : String(error),
-      candidateIds: observations.map((candidate) => candidate.id),
-      step: nextMemoryStep(options.trace),
-    });
-    options.onTraceEvent?.(failed);
-    return { candidateIds, events: [started, failed] };
-  } finally {
-    await lock?.release();
+    const acquiredAt = Date.parse(current.acquiredAt);
+    if (!Number.isFinite(acquiredAt) || Date.now() - acquiredAt < staleAfterMs) {
+      return false;
+    }
+
+    await this.repository.removeLock(lockPath);
+    return true;
   }
-}
 
-async function acquireMemoryMaintenanceLock(options: {
-  memoryRoot: string;
-  staleAfterMs?: number;
-  timeoutMs?: number;
-}): Promise<{ release: () => Promise<void> }> {
-  const memoryRoot = resolve(options.memoryRoot);
-  const lockPath = join(memoryRoot, '_maintenance', 'maintenance.lock');
-  const lockId = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const startedAt = Date.now();
-  const timeoutMs = options.timeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
-  const staleAfterMs = options.staleAfterMs ?? DEFAULT_LOCK_STALE_AFTER_MS;
-  await mkdir(dirname(lockPath), { recursive: true });
+  private async enqueue<T>(run: () => Promise<T>): Promise<T> {
+    const memoryRoot = resolve(this.memoryRoot);
+    const previous = maintenanceQueues.get(memoryRoot) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolvePromise) => {
+      release = resolvePromise;
+    });
+    const queued = previous.then(() => current, () => current);
+    maintenanceQueues.set(memoryRoot, queued);
 
-  while (true) {
+    await previous.catch(() => undefined);
     try {
-      const handle = await open(lockPath, 'wx');
-      await handle.writeFile(JSON.stringify({
-        id: lockId,
-        pid: process.pid,
-        acquiredAt: new Date().toISOString(),
-      }) + '\n', 'utf8');
-      await handle.close();
-
-      return {
-        async release() {
-          await releaseMemoryMaintenanceLock(lockPath, lockId);
-        },
-      };
-    } catch (error) {
-      if (!(error instanceof Error) || !('code' in error) || error.code !== 'EEXIST') {
-        throw error;
+      return await run();
+    } finally {
+      release();
+      if (maintenanceQueues.get(memoryRoot) === queued) {
+        maintenanceQueues.delete(memoryRoot);
       }
-
-      if (await removeStaleMemoryMaintenanceLock(lockPath, staleAfterMs)) {
-        continue;
-      }
-
-      if (Date.now() - startedAt >= timeoutMs) {
-        throw new Error(`Memory maintenance lock is busy: ${lockPath}`, { cause: error });
-      }
-      await sleep(DEFAULT_LOCK_POLL_MS);
     }
   }
-}
 
-async function releaseMemoryMaintenanceLock(lockPath: string, lockId: string) {
-  const current = await readMemoryMaintenanceLock(lockPath);
-  if (current?.id !== lockId) {
-    return;
-  }
-  await rm(lockPath, { force: true });
-}
-
-async function removeStaleMemoryMaintenanceLock(lockPath: string, staleAfterMs: number): Promise<boolean> {
-  const current = await readMemoryMaintenanceLock(lockPath);
-  if (!current) {
-    return false;
+  private static candidateIdsFromTrace(trace: TraceEvent[]): string[] {
+    return [...new Set(trace
+      .filter((event): event is Extract<TraceEvent, { type: 'memory.candidate_recorded' }> => event.type === 'memory.candidate_recorded')
+      .map((event) => event.candidateId))];
   }
 
-  const acquiredAt = Date.parse(current.acquiredAt);
-  if (!Number.isFinite(acquiredAt) || Date.now() - acquiredAt < staleAfterMs) {
-    return false;
+  private static createEvent<T extends Omit<TraceEvent, 'timestamp'> & { type: TraceEvent['type'] }>(event: T): T & { timestamp: string } {
+    return {
+      ...event,
+      timestamp: new Date().toISOString(),
+    };
   }
 
-  await rm(lockPath, { force: true });
-  return true;
-}
-
-async function readMemoryMaintenanceLock(lockPath: string): Promise<{ id: string; acquiredAt: string } | undefined> {
-  try {
-    const parsed = JSON.parse(await readFile(lockPath, 'utf8')) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return undefined;
-    }
-    const candidate = parsed as Record<string, unknown>;
-    return typeof candidate.id === 'string' && typeof candidate.acquiredAt === 'string' ?
-      { id: candidate.id, acquiredAt: candidate.acquiredAt }
-    : undefined;
-  } catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-      return undefined;
-    }
-    return undefined;
+  private static nextMemoryStep(trace: TraceEvent[]): number {
+    return trace.reduce((max, event) => 'step' in event ? Math.max(max, event.step) : max, 0) + 1;
   }
-}
 
-async function sleep(ms: number): Promise<void> {
-  await new Promise<void>((resolve) => setTimeout(resolve, ms));
-}
-
-async function enqueueMaintenance<T>(memoryRoot: string, run: () => Promise<T>): Promise<T> {
-  const previous = maintenanceQueues.get(memoryRoot) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queued = previous.then(() => current, () => current);
-  maintenanceQueues.set(memoryRoot, queued);
-
-  await previous.catch(() => undefined);
-  try {
-    return await run();
-  } finally {
-    release();
-    if (maintenanceQueues.get(memoryRoot) === queued) {
-      maintenanceQueues.delete(memoryRoot);
-    }
+  private static async sleep(ms: number): Promise<void> {
+    await new Promise<void>((resolvePromise) => setTimeout(resolvePromise, ms));
   }
-}
-
-function createEvent<T extends Omit<TraceEvent, 'timestamp'> & { type: TraceEvent['type'] }>(event: T): T & { timestamp: string } {
-  return {
-    ...event,
-    timestamp: new Date().toISOString(),
-  };
-}
-
-function nextMemoryStep(trace: TraceEvent[]): number {
-  return trace.reduce((max, event) => 'step' in event ? Math.max(max, event.step) : max, 0) + 1;
 }

--- a/src/core/memory/maintenance-repository.ts
+++ b/src/core/memory/maintenance-repository.ts
@@ -1,0 +1,153 @@
+import { appendFile, mkdir, open, readFile, rm } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { MemorySchemas } from './schemas.js';
+import type {
+  KnowledgeCandidate,
+  KnowledgeCandidateStatusRecord,
+  KnowledgeMaintenanceRunRecord,
+  MemoryMaintenanceLockRecord,
+} from './types.js';
+
+/**
+ * Owns memory maintenance JSONL files and lock-file persistence.
+ */
+export class MemoryMaintenanceRepository {
+  constructor(private readonly memoryRoot: string) {}
+
+  async readPendingCandidates(): Promise<KnowledgeCandidate[]> {
+    const entries = await this.readCandidateLogEntries();
+    const processed = new Set<string>();
+    const pending: KnowledgeCandidate[] = [];
+
+    for (const entry of entries) {
+      if ('kind' in entry) {
+        processed.add(entry.candidateId);
+        continue;
+      }
+      pending.push(entry);
+    }
+
+    return pending.filter((candidate) => !processed.has(candidate.id));
+  }
+
+  async appendCandidate(candidate: KnowledgeCandidate): Promise<void> {
+    await this.appendJsonLine(this.candidatesPath(), candidate);
+  }
+
+  async appendCandidateStatusEvents(candidateIds: string[], runId: string, now: () => Date): Promise<void> {
+    const recordedAt = now().toISOString();
+    const records: KnowledgeCandidateStatusRecord[] = candidateIds.map((candidateId) => ({
+      kind: 'candidate_status',
+      candidateId,
+      status: 'processed',
+      runId,
+      recordedAt,
+    }));
+
+    await this.appendJsonLines(this.candidatesPath(), records);
+  }
+
+  async appendMaintenanceRun(run: KnowledgeMaintenanceRunRecord): Promise<void> {
+    await this.appendJsonLine(this.runsPath(), run);
+  }
+
+  async readRecentMaintenanceRuns(limit = 5): Promise<KnowledgeMaintenanceRunRecord[]> {
+    const lines = await this.readJsonlLines(this.runsPath());
+    return lines
+      .map((line) => this.parseMaintenanceRun(line))
+      .filter((run): run is KnowledgeMaintenanceRunRecord => Boolean(run))
+      .slice(-limit)
+      .reverse();
+  }
+
+  async writeLock(lockPath: string, record: MemoryMaintenanceLockRecord): Promise<void> {
+    await mkdir(dirname(lockPath), { recursive: true });
+    const handle = await open(lockPath, 'wx');
+    try {
+      await handle.writeFile(`${JSON.stringify(record)}\n`, 'utf8');
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async readLock(lockPath: string): Promise<MemoryMaintenanceLockRecord | undefined> {
+    try {
+      const parsed = JSON.parse(await readFile(lockPath, 'utf8')) as unknown;
+      const result = MemorySchemas.parseMaintenanceLock(parsed);
+      return result.success ? result.data : undefined;
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        return undefined;
+      }
+      return undefined;
+    }
+  }
+
+  async removeLock(lockPath: string): Promise<void> {
+    await rm(lockPath, { force: true });
+  }
+
+  maintenanceLockPath(): string {
+    return join(this.resolveRoot(), '_maintenance', 'maintenance.lock');
+  }
+
+  private async readCandidateLogEntries(): Promise<Array<KnowledgeCandidate | KnowledgeCandidateStatusRecord>> {
+    const lines = await this.readJsonlLines(this.candidatesPath());
+    return lines
+      .map((line) => this.parseCandidateLogEntry(line))
+      .filter((entry): entry is KnowledgeCandidate | KnowledgeCandidateStatusRecord => Boolean(entry));
+  }
+
+  private candidatesPath(): string {
+    return join(this.resolveRoot(), '_maintenance', 'candidates.jsonl');
+  }
+
+  private runsPath(): string {
+    return join(this.resolveRoot(), '_maintenance', 'runs.jsonl');
+  }
+
+  private async appendJsonLine(path: string, record: unknown): Promise<void> {
+    await this.appendJsonLines(path, [record]);
+  }
+
+  private async appendJsonLines(path: string, records: unknown[]): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`, 'utf8');
+  }
+
+  private async readJsonlLines(path: string): Promise<string[]> {
+    try {
+      const raw = await readFile(path, 'utf8');
+      return raw.split(/\r?\n/u).filter((line) => line.trim());
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  private parseCandidateLogEntry(line: string): KnowledgeCandidate | KnowledgeCandidateStatusRecord | undefined {
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      const result = MemorySchemas.parseCandidateLogEntry(parsed);
+      return result.success ? result.data : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private parseMaintenanceRun(line: string): KnowledgeMaintenanceRunRecord | undefined {
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      const result = MemorySchemas.parseMaintenanceRun(parsed);
+      return result.success ? result.data : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private resolveRoot(): string {
+    return resolve(this.memoryRoot);
+  }
+}

--- a/src/core/memory/note-service.ts
+++ b/src/core/memory/note-service.ts
@@ -1,0 +1,204 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+import { executeScopedEdit } from '@/core/tools/toolkits/coding-files/file-edit-core.js';
+import type { ToolResult } from '@/core/types.js';
+import { MemoryPathUtils } from './path-utils.js';
+import type { ListMemoryNotesInput, ReadMemoryNoteInput, SearchMemoryNotesInput } from './types.js';
+
+const DEFAULT_MAX_SEARCH_RESULTS = 100;
+
+/**
+ * Owns note-level memory reads, search, listing, and scoped note edits.
+ */
+export class MemoryNoteService {
+  constructor(private readonly memoryRoot: string) {}
+
+  async list(input: ListMemoryNotesInput = {}): Promise<string[]> {
+    const targetPath = this.resolvePath(input.path ?? '.');
+    if (!await MemoryPathUtils.pathExists(targetPath)) {
+      return [];
+    }
+
+    const info = await stat(targetPath);
+    if (info.isFile()) {
+      return [MemoryPathUtils.toMemoryRelativePath(this.resolveRoot(), targetPath)];
+    }
+
+    const notes = await this.listMarkdownNotes(targetPath);
+    return notes.map((path) => MemoryPathUtils.toMemoryRelativePath(this.resolveRoot(), path)).sort();
+  }
+
+  async read(input: ReadMemoryNoteInput): Promise<string> {
+    const targetPath = this.resolvePath(input.path);
+    try {
+      return MemoryNoteService.pageText(await readFile(targetPath, 'utf8'), input.offset, input.maxLines);
+    } catch (error) {
+      if (MemoryPathUtils.isErrorWithCode(error, 'EISDIR')) {
+        throw new Error(`Failed to read ${targetPath}: path is a directory, not a file. Use list_memory_notes to inspect memory directories.`, { cause: error });
+      }
+      throw new Error(`Failed to read ${targetPath}: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+    }
+  }
+
+  async search(input: SearchMemoryNotesInput): Promise<string> {
+    const targetPath = this.resolvePath(input.path ?? '.');
+    if (!await MemoryPathUtils.pathExists(targetPath)) {
+      return 'No matches found.';
+    }
+
+    return await this.searchWithCli(targetPath, input.query, MemoryNoteService.sanitizeMaxResults(input.maxResults));
+  }
+
+  async edit(raw: unknown): Promise<ToolResult> {
+    return await executeScopedEdit(raw, {
+      toolName: 'edit_memory_note',
+      rootPath: this.resolveRoot(),
+      rootLabel: 'memory root',
+      subjectLabel: 'memory note',
+      creationHint: 'Set createIfMissing to true if you want edit_memory_note to create it.',
+      enforceRoot: true,
+    });
+  }
+
+  private resolvePath(path: string): string {
+    const result = MemoryPathUtils.resolveMemoryPath(this.resolveRoot(), path);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    return result.path;
+  }
+
+  private async listMarkdownNotes(root: string): Promise<string[]> {
+    const results: string[] = [];
+    const entries = await readdir(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === '_maintenance') {
+        continue;
+      }
+
+      const nextPath = resolve(root, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...await this.listMarkdownNotes(nextPath));
+        continue;
+      }
+
+      if (entry.isFile() && MemoryNoteService.isMarkdownPath(nextPath)) {
+        results.push(nextPath);
+      }
+    }
+
+    return results.sort();
+  }
+
+  private async searchWithCli(targetPath: string, query: string, maxResults: number): Promise<string> {
+    const memoryRoot = this.resolveRoot();
+    const relativeTarget = MemoryPathUtils.toMemoryRelativePath(memoryRoot, targetPath);
+    const normalizedTarget = relativeTarget === '.' ? '.' : relativeTarget;
+
+    const rgResult = await MemoryNoteService.runSearchCommand('rg', ['-n', '--no-heading', '--glob', '*.md', query, normalizedTarget], memoryRoot);
+    if (rgResult.kind === 'ok') {
+      return MemoryNoteService.trimSearchOutput(rgResult.stdout, maxResults);
+    }
+
+    if (rgResult.kind === 'nonzero_no_match') {
+      return 'No matches found.';
+    }
+
+    if (rgResult.kind !== 'missing_binary') {
+      throw new Error(`Failed to search memory notes in ${targetPath}: ${rgResult.error}`);
+    }
+
+    const grepResult = await MemoryNoteService.runSearchCommand('grep', ['-R', '-n', '--include=*.md', query, normalizedTarget], memoryRoot);
+    if (grepResult.kind === 'ok') {
+      return MemoryNoteService.trimSearchOutput(grepResult.stdout, maxResults);
+    }
+
+    if (grepResult.kind === 'nonzero_no_match') {
+      return 'No matches found.';
+    }
+
+    throw new Error(`Failed to search memory notes in ${targetPath}: ${grepResult.error}`);
+  }
+
+  private resolveRoot(): string {
+    return resolve(this.memoryRoot);
+  }
+
+  private static pageText(content: string, offset?: number, maxLines?: number): string {
+    const lines = content.split('\n');
+    const start = offset && offset > 0 ? Math.floor(offset) : 0;
+    const end = maxLines && maxLines > 0 ? start + Math.floor(maxLines) : undefined;
+    return start > 0 || end !== undefined ? lines.slice(start, end).join('\n') : content;
+  }
+
+  private static sanitizeMaxResults(value: number | undefined): number {
+    if (!value || !Number.isFinite(value) || value <= 0) {
+      return DEFAULT_MAX_SEARCH_RESULTS;
+    }
+
+    return Math.min(Math.floor(value), DEFAULT_MAX_SEARCH_RESULTS);
+  }
+
+  private static isMarkdownPath(path: string): boolean {
+    return /\.md$/i.test(path);
+  }
+
+  private static trimSearchOutput(stdout: string, maxResults: number): string {
+    const lines = stdout
+      .split('\n')
+      .map((line) => line.trimEnd().replace(/^\.\//, ''))
+      .filter((line) => line.length > 0)
+      .slice(0, maxResults);
+    return lines.length > 0 ? lines.join('\n') : 'No matches found.';
+  }
+
+  private static async runSearchCommand(
+    binary: string,
+    args: string[],
+    cwd: string,
+  ): Promise<
+    | { kind: 'ok'; stdout: string }
+    | { kind: 'missing_binary'; error: string }
+    | { kind: 'nonzero_no_match'; error: string }
+    | { kind: 'error'; error: string }
+  > {
+    return await new Promise((resolvePromise) => {
+      const child = spawn(binary, args, {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (chunk: Buffer | string) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        stderr += chunk.toString();
+      });
+      child.on('error', (error) => {
+        if ('code' in error && error.code === 'ENOENT') {
+          resolvePromise({ kind: 'missing_binary', error: `${binary} is not available in the environment.` });
+          return;
+        }
+
+        resolvePromise({ kind: 'error', error: error.message });
+      });
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolvePromise({ kind: 'ok', stdout });
+          return;
+        }
+
+        if (code === 1) {
+          resolvePromise({ kind: 'nonzero_no_match', error: stderr.trim() || `${binary} returned exit code 1` });
+          return;
+        }
+
+        resolvePromise({ kind: 'error', error: stderr.trim() || `${binary} returned exit code ${code ?? 'unknown'}` });
+      });
+    });
+  }
+}

--- a/src/core/memory/path-utils.ts
+++ b/src/core/memory/path-utils.ts
@@ -1,0 +1,35 @@
+import { access } from 'node:fs/promises';
+import { isAbsolute, relative, resolve } from 'node:path';
+
+export class MemoryPathUtils {
+  static resolveMemoryPath(memoryRoot: string, requestedPath: string): { ok: true; path: string } | { ok: false; error: string } {
+    if (!requestedPath.trim()) {
+      return { ok: false, error: `Memory note paths must be non-empty and stay inside ${memoryRoot}.` };
+    }
+
+    const targetPath = resolve(memoryRoot, requestedPath);
+    const rel = relative(memoryRoot, targetPath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      return { ok: false, error: `Memory note paths must stay inside ${memoryRoot}. Refusing to access ${targetPath}.` };
+    }
+
+    return { ok: true, path: targetPath };
+  }
+
+  static toMemoryRelativePath(memoryRoot: string, filePath: string): string {
+    return relative(memoryRoot, filePath) || '.';
+  }
+
+  static async pathExists(path: string): Promise<boolean> {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  static isErrorWithCode(error: unknown, code: string): error is Error & { code: string } {
+    return error instanceof Error && 'code' in error && error.code === code;
+  }
+}

--- a/src/core/memory/schemas.ts
+++ b/src/core/memory/schemas.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+
+export class MemorySchemas {
+  static readonly candidate = z.object({
+    id: z.string().describe('Stable id for a pending durable knowledge candidate.'),
+    recordedAt: z.string().describe('ISO timestamp when the candidate was recorded.'),
+    status: z.literal('pending').describe('Candidates in the JSONL log are pending until a status event marks them processed.'),
+    summary: z.string().describe('Concise durable fact or preference to preserve.'),
+    evidence: z.array(z.string()).optional().describe('Short supporting observations.'),
+    categoryHint: z.string().optional().describe('Suggested memory category.'),
+    importance: z.enum(['low', 'medium', 'high']).optional().describe('Expected future value.'),
+    confidence: z.enum(['user-stated', 'tool-verified', 'inferred', 'historical']).optional().describe('Why the candidate should be trusted.'),
+    sourceRefs: z.array(z.string()).optional().describe('Workspace-relative paths, commands, trace ids, or note references.'),
+  });
+
+  static readonly candidateStatus = z.object({
+    kind: z.literal('candidate_status').describe('Discriminator for candidate status events in the candidate JSONL log.'),
+    candidateId: z.string().describe('Candidate id whose status changed.'),
+    status: z.literal('processed').describe('Processed candidates are hidden from pending reads.'),
+    runId: z.string().describe('Maintenance run that processed the candidate.'),
+    recordedAt: z.string().describe('ISO timestamp when the status event was recorded.'),
+  });
+
+  static readonly candidateLogEntry = z.union([
+    MemorySchemas.candidate,
+    MemorySchemas.candidateStatus,
+  ]);
+
+  static readonly maintenanceRun = z.object({
+    id: z.string().describe('Stable id for a memory maintenance run.'),
+    startedAt: z.string().describe('ISO timestamp when the run started.'),
+    finishedAt: z.string().describe('ISO timestamp when the run finished.'),
+    source: z.string().describe('Caller or workflow that triggered the run.'),
+    outcome: z.enum(['done', 'max_steps', 'error', 'interrupted', 'skipped']).describe('Agent-loop or maintenance outcome.'),
+    summary: z.string().describe('Human-readable run result summary.'),
+    candidateIds: z.array(z.string()).describe('All candidate ids considered by the run.'),
+    processedCandidateIds: z.array(z.string()).describe('Candidate ids successfully processed.'),
+    failedCandidateIds: z.array(z.string()).describe('Candidate ids skipped or not processed.'),
+    catalogValid: z.boolean().describe('Whether required memory catalogs existed after the run.'),
+    catalogMissing: z.array(z.string()).describe('Missing required catalog paths.'),
+  });
+
+  static readonly maintenanceLock = z.object({
+    id: z.string().describe('Opaque lock owner id.'),
+    pid: z.number().optional().describe('Process id that acquired the lock.'),
+    acquiredAt: z.string().describe('ISO timestamp when the lock was acquired.'),
+  });
+
+  static parseCandidateLogEntry(value: unknown) {
+    return MemorySchemas.candidateLogEntry.safeParse(value);
+  }
+
+  static parseMaintenanceRun(value: unknown) {
+    return MemorySchemas.maintenanceRun.safeParse(value);
+  }
+
+  static parseMaintenanceLock(value: unknown) {
+    return MemorySchemas.maintenanceLock.safeParse(value);
+  }
+}

--- a/src/core/memory/types.ts
+++ b/src/core/memory/types.ts
@@ -1,0 +1,170 @@
+import type { LlmAdapter } from '@/core/llm/types.js';
+import type { RunResult, TraceEvent } from '@/core/types.js';
+
+export type MemoryCategory = {
+  path: string;
+  title: string;
+  purpose: string;
+  readWhen: string;
+};
+
+export type BootstrapMemoryWorkspaceResult = {
+  memoryRoot: string;
+  createdPaths: string[];
+};
+
+export type MemoryCatalogLoadResult = {
+  memoryRoot: string;
+  catalogPath: string;
+  exists: boolean;
+  content: string;
+  truncated: boolean;
+  originalBytes: number;
+  maxBytes: number;
+};
+
+export type MemoryCatalogShapeValidation = {
+  ok: boolean;
+  memoryRoot: string;
+  missing: string[];
+};
+
+export type KnowledgeCandidate = {
+  id: string;
+  recordedAt: string;
+  status: 'pending';
+  summary: string;
+  evidence?: string[];
+  categoryHint?: string;
+  importance?: 'low' | 'medium' | 'high';
+  confidence?: 'user-stated' | 'tool-verified' | 'inferred' | 'historical';
+  sourceRefs?: string[];
+};
+
+export type KnowledgeCandidateStatusRecord = {
+  kind: 'candidate_status';
+  candidateId: string;
+  status: 'processed';
+  runId: string;
+  recordedAt: string;
+};
+
+export type KnowledgeMaintenanceRunRecord = {
+  id: string;
+  startedAt: string;
+  finishedAt: string;
+  source: string;
+  outcome: RunResult['outcome'] | 'skipped';
+  summary: string;
+  candidateIds: string[];
+  processedCandidateIds: string[];
+  failedCandidateIds: string[];
+  catalogValid: boolean;
+  catalogMissing: string[];
+};
+
+export type RunKnowledgeMaintenanceOptions = {
+  memoryRoot: string;
+  observations: KnowledgeCandidate[];
+  llm: LlmAdapter;
+  source: string;
+  maxSteps?: number;
+  now?: () => Date;
+  nextRunId?: () => string;
+};
+
+export type RunKnowledgeMaintenanceResult = {
+  run: KnowledgeMaintenanceRunRecord;
+  result?: RunResult;
+};
+
+export type RunMaintenanceForRecordedCandidatesOptions = {
+  memoryRoot: string;
+  llm: LlmAdapter;
+  source: string;
+  trace: TraceEvent[];
+  maxSteps?: number;
+  lockTimeoutMs?: number;
+  lockStaleAfterMs?: number;
+  onTraceEvent?: (event: TraceEvent) => void;
+};
+
+export type RunMaintenanceForRecordedCandidatesResult = {
+  candidateIds: string[];
+  maintenance?: RunKnowledgeMaintenanceResult;
+  events: TraceEvent[];
+};
+
+export type MemoryStatusView = {
+  memoryRoot: string;
+  catalog: {
+    ok: boolean;
+    missing: string[];
+  };
+  notes: {
+    count: number;
+  };
+  candidates: {
+    pending: number;
+  };
+  runs: {
+    latest: KnowledgeMaintenanceRunRecord[];
+  };
+};
+
+export type MemoryValidationIssue =
+  | {
+    type: 'missing_catalog';
+    severity: 'error';
+    path: string;
+    message: string;
+  }
+  | {
+    type: 'oversized_catalog';
+    severity: 'warning';
+    path: string;
+    sizeBytes: number;
+    maxBytes: number;
+    message: string;
+  }
+  | {
+    type: 'orphan_note';
+    severity: 'warning';
+    path: string;
+    message: string;
+  }
+  | {
+    type: 'pending_candidates';
+    severity: 'info';
+    count: number;
+    message: string;
+  };
+
+export type MemoryValidationResult = {
+  memoryRoot: string;
+  ok: boolean;
+  issueCount: number;
+  issues: MemoryValidationIssue[];
+};
+
+export type ListMemoryNotesInput = {
+  path?: string;
+};
+
+export type ReadMemoryNoteInput = {
+  path: string;
+  maxLines?: number;
+  offset?: number;
+};
+
+export type SearchMemoryNotesInput = {
+  query: string;
+  path?: string;
+  maxResults?: number;
+};
+
+export type MemoryMaintenanceLockRecord = {
+  id: string;
+  pid?: number;
+  acquiredAt: string;
+};

--- a/src/core/memory/validation.ts
+++ b/src/core/memory/validation.ts
@@ -3,144 +3,121 @@ import { basename, dirname, join, resolve } from 'node:path';
 import {
   DEFAULT_MEMORY_FOLDER_CATALOG_MAX_BYTES,
   DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES,
-  bootstrapMemoryWorkspace,
-  validateMemoryCatalogShape,
+  MemoryCatalogService,
 } from './catalog.js';
-import { readPendingKnowledgeCandidates } from './maintainer.js';
-import { listMemoryNotePaths } from './visibility.js';
+import { MemoryMaintenanceRepository } from './maintenance-repository.js';
+import { MemoryVisibilityService } from './visibility.js';
+import type { MemoryValidationIssue, MemoryValidationResult } from './types.js';
 
-export type MemoryValidationIssue =
-  | {
-    type: 'missing_catalog';
-    severity: 'error';
-    path: string;
-    message: string;
-  }
-  | {
-    type: 'oversized_catalog';
-    severity: 'warning';
-    path: string;
-    sizeBytes: number;
-    maxBytes: number;
-    message: string;
-  }
-  | {
-    type: 'orphan_note';
-    severity: 'warning';
-    path: string;
-    message: string;
-  }
-  | {
-    type: 'pending_candidates';
-    severity: 'info';
-    count: number;
-    message: string;
-  };
+/**
+ * Owns memory workspace health checks and lightweight repair actions.
+ */
+export class MemoryValidationService {
+  constructor(
+    private readonly memoryRoot: string,
+    private readonly catalog = new MemoryCatalogService(memoryRoot),
+    private readonly visibility = new MemoryVisibilityService(memoryRoot),
+    private readonly maintenance = new MemoryMaintenanceRepository(memoryRoot),
+  ) {}
 
-export type MemoryValidationResult = {
-  memoryRoot: string;
-  ok: boolean;
-  issueCount: number;
-  issues: MemoryValidationIssue[];
-};
-
-export async function validateMemoryWorkspace(options: { memoryRoot: string }): Promise<MemoryValidationResult> {
-  const memoryRoot = resolve(options.memoryRoot);
-  const issues: MemoryValidationIssue[] = [];
-  const shape = validateMemoryCatalogShape({ memoryRoot });
-  for (const path of shape.missing) {
-    issues.push({
-      type: 'missing_catalog',
-      severity: 'error',
-      path,
-      message: `Missing required memory catalog: ${path}`,
-    });
-  }
-
-  const notes = await listMemoryNotePaths({ memoryRoot });
-  await appendOversizedCatalogIssues(memoryRoot, notes, issues);
-  await appendOrphanNoteIssues(memoryRoot, notes, issues);
-
-  const pending = await readPendingKnowledgeCandidates({ memoryRoot });
-  if (pending.length > 0) {
-    issues.push({
-      type: 'pending_candidates',
-      severity: 'info',
-      count: pending.length,
-      message: `${pending.length} pending memory candidate${pending.length === 1 ? '' : 's'} waiting for maintenance.`,
-    });
-  }
-
-  return {
-    memoryRoot,
-    ok: issues.every((issue) => issue.severity !== 'error'),
-    issueCount: issues.length,
-    issues,
-  };
-}
-
-export async function repairMissingMemoryCatalogs(options: { memoryRoot: string }): Promise<{ memoryRoot: string; createdPaths: string[] }> {
-  return bootstrapMemoryWorkspace({ memoryRoot: options.memoryRoot });
-}
-
-async function appendOversizedCatalogIssues(memoryRoot: string, notes: string[], issues: MemoryValidationIssue[]) {
-  for (const path of notes.filter((note) => basename(note).toLowerCase() === 'readme.md')) {
-    const fullPath = join(memoryRoot, path);
-    const info = await stat(fullPath);
-    const maxBytes = path === 'README.md' ? DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES : DEFAULT_MEMORY_FOLDER_CATALOG_MAX_BYTES;
-    if (info.size <= maxBytes) {
-      continue;
+  async validate(): Promise<MemoryValidationResult> {
+    const memoryRoot = resolve(this.memoryRoot);
+    const issues: MemoryValidationIssue[] = [];
+    const shape = this.catalog.validateShape();
+    for (const path of shape.missing) {
+      issues.push({
+        type: 'missing_catalog',
+        severity: 'error',
+        path,
+        message: `Missing required memory catalog: ${path}`,
+      });
     }
 
-    issues.push({
-      type: 'oversized_catalog',
-      severity: 'warning',
-      path,
-      sizeBytes: info.size,
-      maxBytes,
-      message: `Memory catalog ${path} is ${info.size} bytes, above the ${maxBytes} byte cap.`,
-    });
-  }
-}
+    const notes = await this.visibility.listNotePaths();
+    await this.appendOversizedCatalogIssues(memoryRoot, notes, issues);
+    await this.appendOrphanNoteIssues(memoryRoot, notes, issues);
 
-async function appendOrphanNoteIssues(memoryRoot: string, notes: string[], issues: MemoryValidationIssue[]) {
-  const catalogPaths = notes.filter((note) => basename(note).toLowerCase() === 'readme.md');
-  const catalogTextByPath = new Map<string, string>();
-  for (const catalogPath of catalogPaths) {
-    catalogTextByPath.set(catalogPath, await readFile(join(memoryRoot, catalogPath), 'utf8'));
-  }
-
-  for (const note of notes) {
-    if (basename(note).toLowerCase() === 'readme.md') {
-      continue;
+    const pending = await this.maintenance.readPendingCandidates();
+    if (pending.length > 0) {
+      issues.push({
+        type: 'pending_candidates',
+        severity: 'info',
+        count: pending.length,
+        message: `${pending.length} pending memory candidate${pending.length === 1 ? '' : 's'} waiting for maintenance.`,
+      });
     }
 
-    const folderCatalog = catalogPathForNote(note);
-    const folderCatalogText = catalogTextByPath.get(folderCatalog) ?? '';
-    const rootCatalogText = catalogTextByPath.get('README.md') ?? '';
-    const localName = basename(note);
-    const linkedFromFolder = folderCatalogText.includes(localName) || folderCatalogText.includes(note);
-    const linkedFromRoot = rootCatalogText.includes(note);
-    if (linkedFromFolder || linkedFromRoot) {
-      continue;
+    return {
+      memoryRoot,
+      ok: issues.every((issue) => issue.severity !== 'error'),
+      issueCount: issues.length,
+      issues,
+    };
+  }
+
+  repairMissingCatalogs() {
+    return this.catalog.bootstrap();
+  }
+
+  private async appendOversizedCatalogIssues(memoryRoot: string, notes: string[], issues: MemoryValidationIssue[]) {
+    for (const path of notes.filter((note) => basename(note).toLowerCase() === 'readme.md')) {
+      const fullPath = join(memoryRoot, path);
+      const info = await stat(fullPath);
+      const maxBytes = path === 'README.md' ? DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES : DEFAULT_MEMORY_FOLDER_CATALOG_MAX_BYTES;
+      if (info.size <= maxBytes) {
+        continue;
+      }
+
+      issues.push({
+        type: 'oversized_catalog',
+        severity: 'warning',
+        path,
+        sizeBytes: info.size,
+        maxBytes,
+        message: `Memory catalog ${path} is ${info.size} bytes, above the ${maxBytes} byte cap.`,
+      });
+    }
+  }
+
+  private async appendOrphanNoteIssues(memoryRoot: string, notes: string[], issues: MemoryValidationIssue[]) {
+    const catalogPaths = notes.filter((note) => basename(note).toLowerCase() === 'readme.md');
+    const catalogTextByPath = new Map<string, string>();
+    for (const catalogPath of catalogPaths) {
+      catalogTextByPath.set(catalogPath, await readFile(join(memoryRoot, catalogPath), 'utf8'));
     }
 
-    issues.push({
-      type: 'orphan_note',
-      severity: 'warning',
-      path: note,
-      message: orphanNoteMessage(note, folderCatalog),
-    });
+    for (const note of notes) {
+      if (basename(note).toLowerCase() === 'readme.md') {
+        continue;
+      }
+
+      const folderCatalog = MemoryValidationService.catalogPathForNote(note);
+      const folderCatalogText = catalogTextByPath.get(folderCatalog) ?? '';
+      const rootCatalogText = catalogTextByPath.get('README.md') ?? '';
+      const localName = basename(note);
+      const linkedFromFolder = folderCatalogText.includes(localName) || folderCatalogText.includes(note);
+      const linkedFromRoot = rootCatalogText.includes(note);
+      if (linkedFromFolder || linkedFromRoot) {
+        continue;
+      }
+
+      issues.push({
+        type: 'orphan_note',
+        severity: 'warning',
+        path: note,
+        message: MemoryValidationService.orphanNoteMessage(note, folderCatalog),
+      });
+    }
   }
-}
 
-function catalogPathForNote(path: string): string {
-  const folder = dirname(path);
-  return folder === '.' ? 'README.md' : join(folder, 'README.md');
-}
+  private static catalogPathForNote(path: string): string {
+    const folder = dirname(path);
+    return folder === '.' ? 'README.md' : join(folder, 'README.md');
+  }
 
-function orphanNoteMessage(note: string, folderCatalog: string): string {
-  return folderCatalog === 'README.md' ?
-    `Memory note ${note} is not linked from README.md.`
-  : `Memory note ${note} is not linked from ${folderCatalog} or README.md.`;
+  private static orphanNoteMessage(note: string, folderCatalog: string): string {
+    return folderCatalog === 'README.md' ?
+      `Memory note ${note} is not linked from README.md.`
+    : `Memory note ${note} is not linked from ${folderCatalog} or README.md.`;
+  }
 }

--- a/src/core/memory/visibility.ts
+++ b/src/core/memory/visibility.ts
@@ -1,204 +1,59 @@
-import { access, readdir, readFile } from 'node:fs/promises';
-import { isAbsolute, relative, resolve } from 'node:path';
-import { createReadMemoryNoteTool, createSearchMemoryNotesTool } from '../tools/toolkits/knowledge/memory-notes.js';
-import { validateMemoryCatalogShape } from './catalog.js';
-import { readPendingKnowledgeCandidates, type KnowledgeMaintenanceRunRecord } from './maintainer.js';
+import { resolve } from 'node:path';
+import { MemoryCatalogService } from './catalog.js';
+import { MemoryMaintenanceRepository } from './maintenance-repository.js';
+import { MemoryNoteService } from './note-service.js';
+import type { MemoryStatusView, ReadMemoryNoteInput, SearchMemoryNotesInput } from './types.js';
 
-export type MemoryStatusView = {
-  memoryRoot: string;
-  catalog: {
-    ok: boolean;
-    missing: string[];
-  };
-  notes: {
-    count: number;
-  };
-  candidates: {
-    pending: number;
-  };
-  runs: {
-    latest: KnowledgeMaintenanceRunRecord[];
-  };
-};
+/**
+ * Owns host-facing memory status and note visibility reads.
+ */
+export class MemoryVisibilityService {
+  constructor(
+    private readonly memoryRoot: string,
+    private readonly notes = new MemoryNoteService(memoryRoot),
+    private readonly maintenance = new MemoryMaintenanceRepository(memoryRoot),
+    private readonly catalog = new MemoryCatalogService(memoryRoot),
+  ) {}
 
-export async function loadMemoryStatus(options: {
-  memoryRoot: string;
-  recentRunLimit?: number;
-}): Promise<MemoryStatusView> {
-  const memoryRoot = resolve(options.memoryRoot);
-  const [notes, pending, latestRuns] = await Promise.all([
-    listMemoryNotePaths({ memoryRoot }),
-    readPendingKnowledgeCandidates({ memoryRoot }),
-    readRecentMemoryMaintenanceRuns({ memoryRoot, limit: options.recentRunLimit ?? 5 }),
-  ]);
-  const catalog = validateMemoryCatalogShape({ memoryRoot });
+  async loadStatus(recentRunLimit = 5): Promise<MemoryStatusView> {
+    const [notes, pending, latestRuns] = await Promise.all([
+      this.notes.list(),
+      this.maintenance.readPendingCandidates(),
+      this.maintenance.readRecentMaintenanceRuns(recentRunLimit),
+    ]);
+    const catalog = this.catalog.validateShape();
 
-  return {
-    memoryRoot,
-    catalog: {
-      ok: catalog.ok,
-      missing: catalog.missing,
-    },
-    notes: {
-      count: notes.length,
-    },
-    candidates: {
-      pending: pending.length,
-    },
-    runs: {
-      latest: latestRuns,
-    },
-  };
-}
-
-export async function listMemoryNotePaths(options: { memoryRoot: string; path?: string }): Promise<string[]> {
-  const memoryRoot = resolve(options.memoryRoot);
-  const target = resolveMemoryPath(memoryRoot, options.path ?? '.');
-  if (!target.ok) {
-    throw new Error(target.error);
+    return {
+      memoryRoot: resolve(this.memoryRoot),
+      catalog: {
+        ok: catalog.ok,
+        missing: catalog.missing,
+      },
+      notes: {
+        count: notes.length,
+      },
+      candidates: {
+        pending: pending.length,
+      },
+      runs: {
+        latest: latestRuns,
+      },
+    };
   }
 
-  if (!await pathExists(target.path)) {
-    return [];
+  async listNotePaths(path?: string): Promise<string[]> {
+    return await this.notes.list({ path });
   }
 
-  const notes = await listMarkdownNotes(target.path);
-  return notes.map((path) => toMemoryRelativePath(memoryRoot, path)).sort();
-}
-
-export async function readMemoryNote(options: {
-  memoryRoot: string;
-  path: string;
-  offset?: number;
-  maxLines?: number;
-}): Promise<string> {
-  const result = await createReadMemoryNoteTool({ memoryRoot: options.memoryRoot }).execute({
-    path: options.path,
-    offset: options.offset,
-    maxLines: options.maxLines,
-  });
-  if (!result.ok) {
-    throw new Error(result.error);
-  }
-  return typeof result.output === 'string' ? result.output : JSON.stringify(result.output, null, 2);
-}
-
-export async function searchMemoryNotes(options: {
-  memoryRoot: string;
-  query: string;
-  path?: string;
-  maxResults?: number;
-}): Promise<string> {
-  const result = await createSearchMemoryNotesTool({ memoryRoot: options.memoryRoot }).execute({
-    query: options.query,
-    path: options.path,
-    maxResults: options.maxResults,
-  });
-  if (!result.ok) {
-    throw new Error(result.error);
-  }
-  return typeof result.output === 'string' ? result.output : JSON.stringify(result.output, null, 2);
-}
-
-export async function readRecentMemoryMaintenanceRuns(options: {
-  memoryRoot: string;
-  limit?: number;
-}): Promise<KnowledgeMaintenanceRunRecord[]> {
-  const memoryRoot = resolve(options.memoryRoot);
-  const raw = await readTextIfExists(resolve(memoryRoot, '_maintenance', 'runs.jsonl'));
-  if (!raw) {
-    return [];
+  async readNote(input: ReadMemoryNoteInput): Promise<string> {
+    return await this.notes.read(input);
   }
 
-  return raw
-    .split(/\r?\n/u)
-    .filter((line) => line.trim())
-    .map(parseRunRecord)
-    .filter((run): run is KnowledgeMaintenanceRunRecord => Boolean(run))
-    .slice(-(options.limit ?? 5))
-    .reverse();
-}
-
-function resolveMemoryPath(memoryRoot: string, requestedPath: string): { ok: true; path: string } | { ok: false; error: string } {
-  if (!requestedPath.trim()) {
-    return { ok: false, error: `Memory note paths must be non-empty and stay inside ${memoryRoot}.` };
+  async searchNotes(input: SearchMemoryNotesInput): Promise<string> {
+    return await this.notes.search(input);
   }
 
-  const targetPath = resolve(memoryRoot, requestedPath);
-  const rel = relative(memoryRoot, targetPath);
-  if (rel.startsWith('..') || isAbsolute(rel)) {
-    return { ok: false, error: `Memory note paths must stay inside ${memoryRoot}. Refusing to access ${targetPath}.` };
+  async readRecentMaintenanceRuns(limit = 5) {
+    return await this.maintenance.readRecentMaintenanceRuns(limit);
   }
-
-  return { ok: true, path: targetPath };
-}
-
-async function listMarkdownNotes(root: string): Promise<string[]> {
-  const entries = await readdir(root, { withFileTypes: true });
-  const results: string[] = [];
-  for (const entry of entries) {
-    if (entry.name === '_maintenance') {
-      continue;
-    }
-
-    const nextPath = resolve(root, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...await listMarkdownNotes(nextPath));
-      continue;
-    }
-
-    if (entry.isFile() && /\.md$/iu.test(entry.name)) {
-      results.push(nextPath);
-    }
-  }
-  return results;
-}
-
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function readTextIfExists(path: string): Promise<string | undefined> {
-  try {
-    return await readFile(path, 'utf8');
-  } catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-function parseRunRecord(line: string): KnowledgeMaintenanceRunRecord | undefined {
-  try {
-    const parsed = JSON.parse(line) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return undefined;
-    }
-    const record = parsed as Record<string, unknown>;
-    return typeof record.id === 'string'
-      && typeof record.startedAt === 'string'
-      && typeof record.finishedAt === 'string'
-      && typeof record.source === 'string'
-      && typeof record.outcome === 'string'
-      && typeof record.summary === 'string'
-      && Array.isArray(record.candidateIds)
-      && Array.isArray(record.processedCandidateIds)
-      && Array.isArray(record.failedCandidateIds)
-      && typeof record.catalogValid === 'boolean'
-      && Array.isArray(record.catalogMissing) ?
-        record as KnowledgeMaintenanceRunRecord
-    : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function toMemoryRelativePath(memoryRoot: string, filePath: string): string {
-  return relative(memoryRoot, filePath) || '.';
 }

--- a/src/core/tools/toolkits/knowledge/memory-notes.ts
+++ b/src/core/tools/toolkits/knowledge/memory-notes.ts
@@ -1,31 +1,13 @@
-import { access, readdir, readFile, stat } from 'node:fs/promises';
-import { isAbsolute, relative, resolve } from 'node:path';
-import { spawn } from 'node:child_process';
-import type { ToolDefinition, ToolResult } from '../../../types.js';
-import { executeScopedEdit } from '../coding-files/file-edit-core.js';
+import { resolve } from 'node:path';
+import { MemoryNoteService } from '@/core/memory/note-service.js';
+import type { ListMemoryNotesInput, ReadMemoryNoteInput, SearchMemoryNotesInput } from '@/core/memory/types.js';
+import type { ToolDefinition, ToolResult } from '@/core/types.js';
 
 export type MemoryNotesToolOptions = {
   memoryRoot?: string;
 };
 
-type ListMemoryNotesInput = {
-  path?: string;
-};
-
-type ReadMemoryNoteInput = {
-  path: string;
-  maxLines?: number;
-  offset?: number;
-};
-
-type SearchMemoryNotesInput = {
-  query: string;
-  path?: string;
-  maxResults?: number;
-};
-
 const DEFAULT_MEMORY_ROOT = resolve(process.cwd(), '.heddle', 'memory');
-const DEFAULT_MAX_SEARCH_RESULTS = 100;
 
 export function createListMemoryNotesTool(options: MemoryNotesToolOptions = {}): ToolDefinition {
   return {
@@ -43,40 +25,17 @@ export function createListMemoryNotesTool(options: MemoryNotesToolOptions = {}):
       },
     },
     async execute(raw: unknown): Promise<ToolResult> {
-      if (!isListMemoryNotesInput(raw)) {
+      if (!MemoryNotesToolInput.isList(raw)) {
         return { ok: false, error: 'Invalid input for list_memory_notes. Optional field: path.' };
       }
 
-      const memoryRoot = resolveMemoryRoot(options);
-      const targetPath = resolveMemoryPath(memoryRoot, raw.path ?? '.');
-      if (!targetPath.ok) {
-        return { ok: false, error: targetPath.error };
-      }
-
-      const exists = await pathExists(targetPath.path);
-      if (!exists) {
-        return { ok: true, output: '' };
-      }
-
       try {
-        const info = await stat(targetPath.path);
-        if (info.isFile()) {
-          return {
-            ok: true,
-            output: toMemoryRelativePath(memoryRoot, targetPath.path),
-          };
-        }
-
-        const entries = await listMarkdownNotes(targetPath.path);
         return {
           ok: true,
-          output: entries.map((entry) => toMemoryRelativePath(memoryRoot, entry)).join('\n'),
+          output: (await memoryNotes(options).list(raw)).join('\n'),
         };
       } catch (error) {
-        return {
-          ok: false,
-          error: `Failed to list memory notes in ${targetPath.path}: ${error instanceof Error ? error.message : String(error)}`,
-        };
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
       }
     },
   };
@@ -107,34 +66,17 @@ export function createReadMemoryNoteTool(options: MemoryNotesToolOptions = {}): 
       required: ['path'],
     },
     async execute(raw: unknown): Promise<ToolResult> {
-      if (!isReadMemoryNoteInput(raw)) {
+      if (!MemoryNotesToolInput.isRead(raw)) {
         return { ok: false, error: 'Invalid input for read_memory_note. Required field: path. Optional fields: maxLines, offset.' };
       }
 
-      const memoryRoot = resolveMemoryRoot(options);
-      const targetPath = resolveMemoryPath(memoryRoot, raw.path);
-      if (!targetPath.ok) {
-        return { ok: false, error: targetPath.error };
-      }
-
       try {
-        const content = await readFile(targetPath.path, 'utf8');
         return {
           ok: true,
-          output: pageText(content, raw.offset, raw.maxLines),
+          output: await memoryNotes(options).read(raw),
         };
       } catch (error) {
-        if (isErrorWithCode(error, 'EISDIR')) {
-          return {
-            ok: false,
-            error: `Failed to read ${targetPath.path}: path is a directory, not a file. Use list_memory_notes to inspect memory directories.`,
-          };
-        }
-
-        return {
-          ok: false,
-          error: `Failed to read ${targetPath.path}: ${error instanceof Error ? error.message : String(error)}`,
-        };
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
       }
     },
   };
@@ -165,23 +107,18 @@ export function createSearchMemoryNotesTool(options: MemoryNotesToolOptions = {}
       required: ['query'],
     },
     async execute(raw: unknown): Promise<ToolResult> {
-      if (!isSearchMemoryNotesInput(raw)) {
+      if (!MemoryNotesToolInput.isSearch(raw)) {
         return { ok: false, error: 'Invalid input for search_memory_notes. Required field: query. Optional fields: path, maxResults.' };
       }
 
-      const memoryRoot = resolveMemoryRoot(options);
-      const targetPath = resolveMemoryPath(memoryRoot, raw.path ?? '.');
-      if (!targetPath.ok) {
-        return { ok: false, error: targetPath.error };
+      try {
+        return {
+          ok: true,
+          output: await memoryNotes(options).search(raw),
+        };
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
       }
-
-      const exists = await pathExists(targetPath.path);
-      if (!exists) {
-        return { ok: true, output: 'No matches found.' };
-      }
-
-      const searchResult = await searchWithCli(memoryRoot, targetPath.path, raw.query, sanitizeMaxResults(raw.maxResults));
-      return searchResult;
     },
   };
 }
@@ -223,14 +160,7 @@ export function createEditMemoryNoteTool(options: MemoryNotesToolOptions = {}): 
       required: ['path'],
     },
     async execute(raw: unknown): Promise<ToolResult> {
-      return executeScopedEdit(raw, {
-        toolName: 'edit_memory_note',
-        rootPath: resolveMemoryRoot(options),
-        rootLabel: 'memory root',
-        subjectLabel: 'memory note',
-        creationHint: 'Set createIfMissing to true if you want edit_memory_note to create it.',
-        enforceRoot: true,
-      });
+      return await memoryNotes(options).edit(raw);
     },
   };
 }
@@ -240,233 +170,47 @@ export const readMemoryNoteTool = createReadMemoryNoteTool();
 export const searchMemoryNotesTool = createSearchMemoryNotesTool();
 export const editMemoryNoteTool = createEditMemoryNoteTool();
 
-function resolveMemoryRoot(options: MemoryNotesToolOptions): string {
-  return resolve(options.memoryRoot ?? DEFAULT_MEMORY_ROOT);
-}
-
-function resolveMemoryPath(memoryRoot: string, requestedPath: string): { ok: true; path: string } | { ok: false; error: string } {
-  if (!requestedPath.trim()) {
-    return { ok: false, error: `Memory note paths must be non-empty and stay inside ${memoryRoot}.` };
-  }
-
-  const targetPath = resolve(memoryRoot, requestedPath);
-  const rel = relative(memoryRoot, targetPath);
-  if (rel.startsWith('..') || isAbsolute(rel)) {
-    return { ok: false, error: `Memory note paths must stay inside ${memoryRoot}. Refusing to access ${targetPath}.` };
-  }
-
-  return { ok: true, path: targetPath };
-}
-
-async function listMarkdownNotes(root: string): Promise<string[]> {
-  const results: string[] = [];
-  const entries = await readdir(root, { withFileTypes: true });
-  for (const entry of entries) {
-    const nextPath = resolve(root, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...await listMarkdownNotes(nextPath));
-      continue;
+class MemoryNotesToolInput {
+  static isList(raw: unknown): raw is ListMemoryNotesInput {
+    if (raw === undefined) {
+      return true;
     }
 
-    if (entry.isFile() && isMarkdownPath(nextPath)) {
-      results.push(nextPath);
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return false;
     }
+
+    const input = raw as Record<string, unknown>;
+    return Object.keys(input).every((key) => key === 'path')
+      && (input.path === undefined || typeof input.path === 'string');
   }
 
-  return results.sort();
-}
+  static isRead(raw: unknown): raw is ReadMemoryNoteInput {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return false;
+    }
 
-function pageText(content: string, offset?: number, maxLines?: number): string {
-  const lines = content.split('\n');
-  const start = offset && offset > 0 ? Math.floor(offset) : 0;
-  const end = maxLines && maxLines > 0 ? start + Math.floor(maxLines) : undefined;
-  if (start > 0 || end !== undefined) {
-    return lines.slice(start, end).join('\n');
+    const input = raw as Record<string, unknown>;
+    return Object.keys(input).every((key) => key === 'path' || key === 'maxLines' || key === 'offset')
+      && typeof input.path === 'string'
+      && (input.maxLines === undefined || typeof input.maxLines === 'number')
+      && (input.offset === undefined || typeof input.offset === 'number');
   }
 
-  return content;
-}
+  static isSearch(raw: unknown): raw is SearchMemoryNotesInput {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return false;
+    }
 
-function sanitizeMaxResults(value: number | undefined): number {
-  if (!value || !Number.isFinite(value) || value <= 0) {
-    return DEFAULT_MAX_SEARCH_RESULTS;
-  }
-
-  return Math.min(Math.floor(value), DEFAULT_MAX_SEARCH_RESULTS);
-}
-
-function toMemoryRelativePath(memoryRoot: string, filePath: string): string {
-  const rel = relative(memoryRoot, filePath);
-  return rel || '.';
-}
-
-function isMarkdownPath(path: string): boolean {
-  return /\.md$/i.test(path);
-}
-
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
+    const input = raw as Record<string, unknown>;
+    return Object.keys(input).every((key) => key === 'query' || key === 'path' || key === 'maxResults')
+      && typeof input.query === 'string'
+      && input.query.trim().length > 0
+      && (input.path === undefined || typeof input.path === 'string')
+      && (input.maxResults === undefined || typeof input.maxResults === 'number');
   }
 }
 
-function isListMemoryNotesInput(raw: unknown): raw is ListMemoryNotesInput {
-  if (raw === undefined) {
-    return true;
-  }
-
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return false;
-  }
-
-  const input = raw as Record<string, unknown>;
-  const keys = Object.keys(input);
-  if (keys.some((key) => key !== 'path')) {
-    return false;
-  }
-
-  return input.path === undefined || typeof input.path === 'string';
-}
-
-function isReadMemoryNoteInput(raw: unknown): raw is ReadMemoryNoteInput {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return false;
-  }
-
-  const input = raw as Record<string, unknown>;
-  const keys = Object.keys(input);
-  if (keys.some((key) => key !== 'path' && key !== 'maxLines' && key !== 'offset')) {
-    return false;
-  }
-
-  return (
-    typeof input.path === 'string' &&
-    (input.maxLines === undefined || typeof input.maxLines === 'number') &&
-    (input.offset === undefined || typeof input.offset === 'number')
-  );
-}
-
-function isSearchMemoryNotesInput(raw: unknown): raw is SearchMemoryNotesInput {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return false;
-  }
-
-  const input = raw as Record<string, unknown>;
-  const keys = Object.keys(input);
-  if (keys.some((key) => key !== 'query' && key !== 'path' && key !== 'maxResults')) {
-    return false;
-  }
-
-  return (
-    typeof input.query === 'string' &&
-    input.query.trim().length > 0 &&
-    (input.path === undefined || typeof input.path === 'string') &&
-    (input.maxResults === undefined || typeof input.maxResults === 'number')
-  );
-}
-
-function isErrorWithCode(error: unknown, code: string): error is Error & { code: string } {
-  return error instanceof Error && 'code' in error && error.code === code;
-}
-
-async function searchWithCli(memoryRoot: string, targetPath: string, query: string, maxResults: number): Promise<ToolResult> {
-  const relativeTarget = toMemoryRelativePath(memoryRoot, targetPath);
-  const normalizedTarget = relativeTarget === '.' ? '.' : relativeTarget;
-
-  const rgResult = await runSearchCommand('rg', ['-n', '--no-heading', '--glob', '*.md', query, normalizedTarget], memoryRoot);
-  if (rgResult.kind === 'ok') {
-    return {
-      ok: true,
-      output: trimSearchOutput(rgResult.stdout, maxResults),
-    };
-  }
-
-  if (rgResult.kind === 'nonzero_no_match') {
-    return { ok: true, output: 'No matches found.' };
-  }
-
-  if (rgResult.kind !== 'missing_binary') {
-    return {
-      ok: false,
-      error: `Failed to search memory notes in ${targetPath}: ${rgResult.error}`,
-    };
-  }
-
-  const grepResult = await runSearchCommand('grep', ['-R', '-n', '--include=*.md', query, normalizedTarget], memoryRoot);
-  if (grepResult.kind === 'ok') {
-    return {
-      ok: true,
-      output: trimSearchOutput(grepResult.stdout, maxResults),
-    };
-  }
-
-  if (grepResult.kind === 'nonzero_no_match') {
-    return { ok: true, output: 'No matches found.' };
-  }
-
-  return {
-    ok: false,
-    error: `Failed to search memory notes in ${targetPath}: ${grepResult.error}`,
-  };
-}
-
-function trimSearchOutput(stdout: string, maxResults: number): string {
-  const lines = stdout
-    .split('\n')
-    .map((line) => line.trimEnd().replace(/^\.\//, ''))
-    .filter((line) => line.length > 0)
-    .slice(0, maxResults);
-  return lines.length > 0 ? lines.join('\n') : 'No matches found.';
-}
-
-async function runSearchCommand(
-  binary: string,
-  args: string[],
-  cwd: string,
-): Promise<
-  | { kind: 'ok'; stdout: string }
-  | { kind: 'missing_binary'; error: string }
-  | { kind: 'nonzero_no_match'; error: string }
-  | { kind: 'error'; error: string }
-> {
-  return new Promise((resolvePromise) => {
-    const child = spawn(binary, args, {
-      cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    let stdout = '';
-    let stderr = '';
-
-    child.stdout.on('data', (chunk: Buffer | string) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on('data', (chunk: Buffer | string) => {
-      stderr += chunk.toString();
-    });
-    child.on('error', (error) => {
-      if ('code' in error && error.code === 'ENOENT') {
-        resolvePromise({ kind: 'missing_binary', error: `${binary} is not available in the environment.` });
-        return;
-      }
-
-      resolvePromise({ kind: 'error', error: error.message });
-    });
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolvePromise({ kind: 'ok', stdout });
-        return;
-      }
-
-      if (code === 1) {
-        resolvePromise({ kind: 'nonzero_no_match', error: stderr.trim() || `${binary} returned exit code 1` });
-        return;
-      }
-
-      resolvePromise({ kind: 'error', error: stderr.trim() || `${binary} returned exit code ${code ?? 'unknown'}` });
-    });
-  });
+function memoryNotes(options: MemoryNotesToolOptions): MemoryNoteService {
+  return new MemoryNoteService(resolve(options.memoryRoot ?? DEFAULT_MEMORY_ROOT));
 }

--- a/src/core/tools/toolkits/knowledge/record-knowledge.ts
+++ b/src/core/tools/toolkits/knowledge/record-knowledge.ts
@@ -1,5 +1,7 @@
-import { mkdir, appendFile } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { resolve } from 'node:path';
+import { MemoryMaintenanceRepository } from '@/core/memory/maintenance-repository.js';
+import { MemoryMaintenanceService } from '@/core/memory/maintainer.js';
+import type { KnowledgeCandidate } from '@/core/memory/types.js';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
 
 export type RecordKnowledgeToolOptions = {
@@ -8,7 +10,9 @@ export type RecordKnowledgeToolOptions = {
   nextId?: () => string;
 };
 
-type RecordKnowledgeInput = {
+type RecordKnowledgeInput = Omit<KnowledgeCandidate, 'id' | 'recordedAt' | 'status'>;
+
+type RecordKnowledgeCandidate = {
   summary: string;
   evidence?: string[];
   categoryHint?: string;
@@ -64,23 +68,21 @@ export function createRecordKnowledgeTool(options: RecordKnowledgeToolOptions = 
       required: ['summary'],
     },
     async execute(raw: unknown): Promise<ToolResult> {
-      const parsed = validateRecordKnowledgeInput(raw, resolveMemoryRoot(options));
+      const memoryRoot = resolveMemoryRoot(options);
+      const parsed = RecordKnowledgeToolInput.validate(raw, memoryRoot);
       if (!parsed.ok) {
         return { ok: false, error: parsed.error };
       }
 
-      const memoryRoot = resolveMemoryRoot(options);
-      const candidatePath = resolve(memoryRoot, '_maintenance', 'candidates.jsonl');
       const now = options.now?.() ?? new Date();
       const record = {
         id: options.nextId?.() ?? `candidate-${now.getTime()}`,
         recordedAt: now.toISOString(),
         status: 'pending',
         ...parsed.input,
-      };
+      } satisfies KnowledgeCandidate;
 
-      await mkdir(dirname(candidatePath), { recursive: true });
-      await appendFile(candidatePath, `${JSON.stringify(record)}\n`, 'utf8');
+      await new MemoryMaintenanceRepository(memoryRoot).appendCandidate(record);
 
       return {
         ok: true,
@@ -97,136 +99,100 @@ export function createRecordKnowledgeTool(options: RecordKnowledgeToolOptions = 
 
 export const recordKnowledgeTool = createRecordKnowledgeTool();
 
-function validateRecordKnowledgeInput(
-  raw: unknown,
-  memoryRoot: string,
-): { ok: true; input: RecordKnowledgeInput } | { ok: false; error: string } {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return { ok: false, error: invalidInputMessage() };
+class RecordKnowledgeToolInput {
+  static validate(
+    raw: unknown,
+    memoryRoot: string,
+  ): { ok: true; input: RecordKnowledgeInput } | { ok: false; error: string } {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return { ok: false, error: RecordKnowledgeToolInput.invalidInputMessage() };
+    }
+
+    const input = raw as Record<string, unknown>;
+    const allowedKeys = new Set(['summary', 'evidence', 'categoryHint', 'importance', 'confidence', 'sourceRefs']);
+    if (Object.keys(input).some((key) => !allowedKeys.has(key))) {
+      return { ok: false, error: RecordKnowledgeToolInput.invalidInputMessage() };
+    }
+
+    if (typeof input.summary !== 'string' || !input.summary.trim() || input.summary.length > MAX_SUMMARY_LENGTH) {
+      return { ok: false, error: `Invalid input for record_knowledge. Required field summary must be a non-empty string up to ${MAX_SUMMARY_LENGTH} characters.` };
+    }
+
+    const summary = input.summary.trim();
+    if (!MemoryMaintenanceService.isRecordableCandidateText(summary)) {
+      return { ok: false, error: 'record_knowledge refused secret-like content in summary. Do not store credentials, tokens, private keys, or passwords in memory.' };
+    }
+
+    const evidence = RecordKnowledgeToolInput.validateOptionalStringArray(input.evidence, 'evidence', MAX_EVIDENCE_ITEMS);
+    if (!evidence.ok) {
+      return { ok: false, error: evidence.error };
+    }
+    if (evidence.values.some((value) => !MemoryMaintenanceService.isRecordableCandidateText(value))) {
+      return { ok: false, error: 'record_knowledge refused secret-like content in evidence. Do not store credentials, tokens, private keys, or passwords in memory.' };
+    }
+
+    const sourceRefs = RecordKnowledgeToolInput.validateOptionalStringArray(input.sourceRefs, 'sourceRefs', MAX_SOURCE_REFS);
+    if (!sourceRefs.ok) {
+      return { ok: false, error: sourceRefs.error };
+    }
+    const invalidSourceRef = sourceRefs.values.find((sourceRef) => !MemoryMaintenanceService.isSafeSourceRef(sourceRef, memoryRoot));
+    if (invalidSourceRef) {
+      return { ok: false, error: `record_knowledge sourceRefs must be workspace-relative paths or non-path references. Refusing unsafe sourceRef: ${invalidSourceRef}` };
+    }
+    if (sourceRefs.values.some((value) => !MemoryMaintenanceService.isRecordableCandidateText(value))) {
+      return { ok: false, error: 'record_knowledge refused secret-like content in sourceRefs. Do not store credentials, tokens, private keys, or passwords in memory.' };
+    }
+
+    if (input.categoryHint !== undefined && (typeof input.categoryHint !== 'string' || !input.categoryHint.trim() || input.categoryHint.length > 80)) {
+      return { ok: false, error: 'Invalid input for record_knowledge. Optional field categoryHint must be a non-empty string up to 80 characters.' };
+    }
+
+    if (input.importance !== undefined && input.importance !== 'low' && input.importance !== 'medium' && input.importance !== 'high') {
+      return { ok: false, error: 'Invalid input for record_knowledge. Optional field importance must be one of: low, medium, high.' };
+    }
+
+    if (
+      input.confidence !== undefined
+      && input.confidence !== 'user-stated'
+      && input.confidence !== 'tool-verified'
+      && input.confidence !== 'inferred'
+      && input.confidence !== 'historical'
+    ) {
+      return { ok: false, error: 'Invalid input for record_knowledge. Optional field confidence must be one of: user-stated, tool-verified, inferred, historical.' };
+    }
+
+    return {
+      ok: true,
+      input: {
+        summary,
+        evidence: evidence.values.length > 0 ? evidence.values : undefined,
+        categoryHint: typeof input.categoryHint === 'string' ? input.categoryHint.trim() : undefined,
+        importance: input.importance as RecordKnowledgeCandidate['importance'] | undefined,
+        confidence: input.confidence as RecordKnowledgeCandidate['confidence'] | undefined,
+        sourceRefs: sourceRefs.values.length > 0 ? sourceRefs.values : undefined,
+      },
+    };
   }
 
-  const input = raw as Record<string, unknown>;
-  const allowedKeys = new Set(['summary', 'evidence', 'categoryHint', 'importance', 'confidence', 'sourceRefs']);
-  if (Object.keys(input).some((key) => !allowedKeys.has(key))) {
-    return { ok: false, error: invalidInputMessage() };
+  private static validateOptionalStringArray(
+    raw: unknown,
+    field: string,
+    maxItems: number,
+  ): { ok: true; values: string[] } | { ok: false; error: string } {
+    if (raw === undefined) {
+      return { ok: true, values: [] };
+    }
+    if (!Array.isArray(raw) || raw.length > maxItems || raw.some((value) => typeof value !== 'string' || !value.trim() || value.length > MAX_TEXT_FIELD_LENGTH)) {
+      return { ok: false, error: `Invalid input for record_knowledge. Optional field ${field} must be an array of up to ${maxItems} non-empty strings, each up to ${MAX_TEXT_FIELD_LENGTH} characters.` };
+    }
+    return { ok: true, values: raw.map((value) => value.trim()) };
   }
 
-  if (typeof input.summary !== 'string' || !input.summary.trim() || input.summary.length > MAX_SUMMARY_LENGTH) {
-    return { ok: false, error: `Invalid input for record_knowledge. Required field summary must be a non-empty string up to ${MAX_SUMMARY_LENGTH} characters.` };
+  private static invalidInputMessage(): string {
+    return 'Invalid input for record_knowledge. Required field: summary. Optional fields: evidence, categoryHint, importance, confidence, sourceRefs.';
   }
-
-  const summary = input.summary.trim();
-  if (containsSecretLikeText(summary)) {
-    return { ok: false, error: 'record_knowledge refused secret-like content in summary. Do not store credentials, tokens, private keys, or passwords in memory.' };
-  }
-
-  const evidence = validateOptionalStringArray(input.evidence, 'evidence', MAX_EVIDENCE_ITEMS);
-  if (!evidence.ok) {
-    return { ok: false, error: evidence.error };
-  }
-  if (evidence.values.some(containsSecretLikeText)) {
-    return { ok: false, error: 'record_knowledge refused secret-like content in evidence. Do not store credentials, tokens, private keys, or passwords in memory.' };
-  }
-
-  const sourceRefs = validateOptionalStringArray(input.sourceRefs, 'sourceRefs', MAX_SOURCE_REFS);
-  if (!sourceRefs.ok) {
-    return { ok: false, error: sourceRefs.error };
-  }
-  const invalidSourceRef = sourceRefs.values.find((sourceRef) => !isSafeSourceRef(sourceRef, memoryRoot));
-  if (invalidSourceRef) {
-    return { ok: false, error: `record_knowledge sourceRefs must be workspace-relative paths or non-path references. Refusing unsafe sourceRef: ${invalidSourceRef}` };
-  }
-  if (sourceRefs.values.some(containsSecretLikeText)) {
-    return { ok: false, error: 'record_knowledge refused secret-like content in sourceRefs. Do not store credentials, tokens, private keys, or passwords in memory.' };
-  }
-
-  if (input.categoryHint !== undefined && (typeof input.categoryHint !== 'string' || !input.categoryHint.trim() || input.categoryHint.length > 80)) {
-    return { ok: false, error: 'Invalid input for record_knowledge. Optional field categoryHint must be a non-empty string up to 80 characters.' };
-  }
-
-  if (input.importance !== undefined && input.importance !== 'low' && input.importance !== 'medium' && input.importance !== 'high') {
-    return { ok: false, error: 'Invalid input for record_knowledge. Optional field importance must be one of: low, medium, high.' };
-  }
-
-  if (
-    input.confidence !== undefined
-    && input.confidence !== 'user-stated'
-    && input.confidence !== 'tool-verified'
-    && input.confidence !== 'inferred'
-    && input.confidence !== 'historical'
-  ) {
-    return { ok: false, error: 'Invalid input for record_knowledge. Optional field confidence must be one of: user-stated, tool-verified, inferred, historical.' };
-  }
-
-  return {
-    ok: true,
-    input: {
-      summary,
-      evidence: evidence.values.length > 0 ? evidence.values : undefined,
-      categoryHint: typeof input.categoryHint === 'string' ? input.categoryHint.trim() : undefined,
-      importance: input.importance as RecordKnowledgeInput['importance'] | undefined,
-      confidence: input.confidence as RecordKnowledgeInput['confidence'] | undefined,
-      sourceRefs: sourceRefs.values.length > 0 ? sourceRefs.values : undefined,
-    },
-  };
-}
-
-function validateOptionalStringArray(
-  raw: unknown,
-  field: string,
-  maxItems: number,
-): { ok: true; values: string[] } | { ok: false; error: string } {
-  if (raw === undefined) {
-    return { ok: true, values: [] };
-  }
-  if (!Array.isArray(raw) || raw.length > maxItems || raw.some((value) => typeof value !== 'string' || !value.trim() || value.length > MAX_TEXT_FIELD_LENGTH)) {
-    return { ok: false, error: `Invalid input for record_knowledge. Optional field ${field} must be an array of up to ${maxItems} non-empty strings, each up to ${MAX_TEXT_FIELD_LENGTH} characters.` };
-  }
-  return { ok: true, values: raw.map((value) => value.trim()) };
-}
-
-function containsSecretLikeText(value: string): boolean {
-  const normalized = value.toLowerCase();
-  return /\b(api[_ -]?key|password|passwd|private[_ -]?key|access[_ -]?token|refresh[_ -]?token|bearer\s+[a-z0-9._~+/=-]{12,})\b/i.test(value)
-    || /\bsecret\s*[:=]\s*\S{8,}/i.test(value)
-    || /\bsk-[a-z0-9_-]{12,}\b/i.test(value)
-    || normalized.includes('-----begin private key-----')
-    || normalized.includes('-----begin rsa private key-----')
-    || normalized.includes('-----begin openSSH private key-----'.toLowerCase());
-}
-
-function isSafeSourceRef(value: string, memoryRoot: string): boolean {
-  if (value.includes('\0')) {
-    return false;
-  }
-
-  if (value.startsWith('trace-') || value.startsWith('session-') || value.startsWith('command:')) {
-    return true;
-  }
-
-  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
-    return false;
-  }
-
-  if (isAbsolute(value)) {
-    return false;
-  }
-
-  const normalizedSegments = value.replace(/\\/g, '/').split('/');
-  if (normalizedSegments.includes('..')) {
-    return false;
-  }
-
-  const workspaceRoot = resolve(memoryRoot, '..', '..');
-  const resolved = resolve(workspaceRoot, value);
-  const rel = relative(workspaceRoot, resolved);
-  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
 }
 
 function resolveMemoryRoot(options: RecordKnowledgeToolOptions): string {
   return resolve(options.memoryRoot ?? DEFAULT_MEMORY_ROOT);
-}
-
-function invalidInputMessage(): string {
-  return 'Invalid input for record_knowledge. Required field: summary. Optional fields: evidence, categoryHint, importance, confidence, sourceRefs.';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,36 +100,35 @@ export {
   DEFAULT_MEMORY_FOLDER_CATALOG_TARGET_BYTES,
   DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES,
   DEFAULT_MEMORY_ROOT_CATALOG_TARGET_BYTES,
-  appendMemoryCatalogSystemContext,
-  bootstrapMemoryWorkspace,
-  formatMemoryCatalogSystemContext,
-  loadMemoryRootCatalog,
-  validateMemoryCatalogShape,
+  MemoryCatalogService,
 } from './core/memory/catalog.js';
+export { MemoryMaintenanceRepository } from './core/memory/maintenance-repository.js';
+export { MemoryMaintenanceService } from './core/memory/maintainer.js';
+export { MemoryMaintenanceIntegrationService } from './core/memory/maintenance-integration.js';
+export { MemoryNoteService } from './core/memory/note-service.js';
+export { MemoryValidationService } from './core/memory/validation.js';
+export { MemoryVisibilityService } from './core/memory/visibility.js';
 export type {
   BootstrapMemoryWorkspaceResult,
+  KnowledgeCandidate,
+  KnowledgeCandidateStatusRecord,
+  KnowledgeMaintenanceRunRecord,
+  ListMemoryNotesInput,
   MemoryCatalogLoadResult,
   MemoryCatalogShapeValidation,
   MemoryCategory,
-} from './core/memory/catalog.js';
-export {
-  readPendingKnowledgeCandidates,
-  runKnowledgeMaintenance,
-  runKnowledgeMaintenanceForBacklog,
-} from './core/memory/maintainer.js';
-export type {
-  KnowledgeCandidate,
-  KnowledgeMaintenanceRunRecord,
-  RunKnowledgeMaintenanceOptions,
-  RunKnowledgeMaintenanceResult,
-} from './core/memory/maintainer.js';
-export { createMemoryMaintainerTools } from './core/memory/maintainer-tools.js';
-export { createMemoryNoteTemplate, slugifyMemoryTitle } from './core/memory/templates.js';
-export { runMaintenanceForRecordedCandidates } from './core/memory/maintenance-integration.js';
-export type {
+  MemoryStatusView,
+  MemoryValidationIssue,
+  MemoryValidationResult,
+  ReadMemoryNoteInput,
   RunMaintenanceForRecordedCandidatesOptions,
   RunMaintenanceForRecordedCandidatesResult,
-} from './core/memory/maintenance-integration.js';
+  RunKnowledgeMaintenanceOptions,
+  RunKnowledgeMaintenanceResult,
+  SearchMemoryNotesInput,
+} from './core/memory/types.js';
+export { createMemoryMaintainerTools } from './core/memory/maintainer-tools.js';
+export { createMemoryNoteTemplate, slugifyMemoryTitle } from './core/memory/templates.js';
 
 // Integrations
 export {

--- a/src/server/features/control-plane/controllers/ask.ts
+++ b/src/server/features/control-plane/controllers/ask.ts
@@ -1,7 +1,6 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
-  appendMemoryCatalogSystemContext,
   DEFAULT_OPENAI_MODEL,
   LlmAdapterService,
   createLogger,
@@ -10,7 +9,8 @@ import {
   RuntimeCredentialService,
   type RunResult,
 } from '../../../../index.js';
-import { runMaintenanceForRecordedCandidates } from '../../../../core/memory/maintenance-integration.js';
+import { MemoryCatalogService } from '../../../../core/memory/catalog.js';
+import { MemoryMaintenanceIntegrationService } from '../../../../core/memory/maintenance-integration.js';
 
 // Legacy control-plane one-shot ask path. New ask callers should create a
 // `retention: "one_off"` chat session and submit through the session turn API
@@ -58,15 +58,13 @@ export class ControlPlaneAskController {
       stateDir: ControlPlaneAskController.relativeStateDir(args.workspaceRoot, args.stateRoot),
       searchIgnoreDirs: args.searchIgnoreDirs,
       memoryDir,
-      systemContext: appendMemoryCatalogSystemContext({
+      systemContext: new MemoryCatalogService(memoryDir).appendCatalogSystemContext({
         systemContext: args.systemContext,
-        memoryRoot: memoryDir,
       }),
       includePlanTool: false,
       llm,
     });
-    const maintenance = await runMaintenanceForRecordedCandidates({
-      memoryRoot: memoryDir,
+    const maintenance = await new MemoryMaintenanceIntegrationService(memoryDir).runForRecordedCandidates({
       llm,
       source: 'control plane ask',
       trace: result.trace,

--- a/src/server/features/control-plane/controllers/memory.ts
+++ b/src/server/features/control-plane/controllers/memory.ts
@@ -1,21 +1,16 @@
 import { resolve } from 'node:path';
-import {
-  listMemoryNotePaths,
-  loadMemoryStatus,
-  readMemoryNote,
-  searchMemoryNotes,
-} from '../../../../core/memory/visibility.js';
+import { MemoryVisibilityService } from '../../../../core/memory/visibility.js';
 
 export class ControlPlaneMemoryController {
   static async readStatus(stateRoot: string) {
-    return await loadMemoryStatus({ memoryRoot: ControlPlaneMemoryController.memoryRoot(stateRoot) });
+    return await ControlPlaneMemoryController.memory(stateRoot).loadStatus();
   }
 
   static async listNotes(stateRoot: string, path?: string) {
     const memoryRoot = ControlPlaneMemoryController.memoryRoot(stateRoot);
     return {
       memoryRoot,
-      notes: await listMemoryNotePaths({ memoryRoot, path }),
+      notes: await new MemoryVisibilityService(memoryRoot).listNotePaths(path),
     };
   }
 
@@ -24,8 +19,7 @@ export class ControlPlaneMemoryController {
     return {
       memoryRoot,
       path,
-      content: await readMemoryNote({
-        memoryRoot,
+      content: await new MemoryVisibilityService(memoryRoot).readNote({
         path,
         offset: options?.offset,
         maxLines: options?.maxLines,
@@ -38,8 +32,7 @@ export class ControlPlaneMemoryController {
     return {
       memoryRoot,
       query,
-      matches: await searchMemoryNotes({
-        memoryRoot,
+      matches: await new MemoryVisibilityService(memoryRoot).searchNotes({
         query,
         path: options?.path,
         maxResults: options?.maxResults,
@@ -49,5 +42,9 @@ export class ControlPlaneMemoryController {
 
   private static memoryRoot(stateRoot: string): string {
     return resolve(stateRoot, 'memory');
+  }
+
+  private static memory(stateRoot: string): MemoryVisibilityService {
+    return new MemoryVisibilityService(ControlPlaneMemoryController.memoryRoot(stateRoot));
   }
 }

--- a/src/server/features/control-plane/types.ts
+++ b/src/server/features/control-plane/types.ts
@@ -2,7 +2,7 @@ import type { AgentLoopEvent } from '@/core/runtime/loop/index.js';
 import type { DaemonOwnerRecord } from '@/core/runtime/daemon/index.js';
 import type { HeartbeatRunView, HeartbeatTaskView } from '@/core/heartbeat/index.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
-import type { MemoryStatusView } from '../../../core/memory/visibility.js';
+import type { MemoryStatusView } from '../../../core/memory/types.js';
 import type { ReviewDiffFile } from '../../../core/review/diff-domain.js';
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { ReasoningEffort } from '../../../core/llm/types.js';


### PR DESCRIPTION
## Summary
- Convert memory catalog, notes, maintenance, visibility, and validation flows to class-based service and repository boundaries.
- Add `types.ts`, zod-backed memory schemas, repository-owned JSONL parsing, and a domain `index.ts`.
- Move maintainer prompt construction into `MemoryMaintainerPrompt`, with static instructions before dynamic catalog/candidate content for token-cache friendliness.
- Invert memory/tool dependency so knowledge tools delegate to memory services instead of memory visibility calling tool implementations.

## Verification
- `yarn typecheck`
- `yarn lint`
- `yarn test src/__tests__/integration/memory src/__tests__/integration/tools/tools.test.ts`
- `yarn -s cli:dev memory status`
- `yarn -s cli:dev memory list operations`