### PR TITLE
[codex] Establish web v2 design foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ test-results/
 
 # IDE
 .claude/
+
+# Agents
+.agents/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['src/web/**/*.{ts,tsx}'],
+    files: ['src/web/**/*.{ts,tsx}', 'src/web-v2/**/*.{ts,tsx}'],
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "build": "yarn clean && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && yarn client:build",
     "client:build": "tsc -p src/web/tsconfig.json --noEmit && vite build --config src/web/vite.config.ts",
     "client:dev": "vite --config src/web/vite.config.ts",
+    "client:v2:build": "tsc -p src/web-v2/tsconfig.json --noEmit && vite build --config src/web-v2/vite.config.ts",
+    "client:v2:dev": "vite --config src/web-v2/vite.config.ts",
     "server:dev": "tsx --no-cache src/server/dev.ts",
     "daemon:dev": "tsx --no-cache src/cli/main.ts daemon --assets-dir dist/src/web",
     "verify:tui-behavior": "node --import tsx/esm scripts/verify-tui-behavior.tsx",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "skills": {
+    "baseline-ui": {
+      "source": "ibelick/ui-skills",
+      "sourceType": "github",
+      "skillPath": "skills/baseline-ui/SKILL.md",
+      "computedHash": "49817c981208de2f412719f7814d31eba2b2096462edc048a279d93f522cab0f"
+    },
+    "design-system-patterns": {
+      "source": "wshobson/agents",
+      "sourceType": "github",
+      "skillPath": "plugins/ui-design/skills/design-system-patterns/SKILL.md",
+      "computedHash": "5f8c9b187e77fcb31db78da2f7b55f905dcd2357454624cac93f00c766ace346"
+    },
+    "vercel-composition-patterns": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/composition-patterns/SKILL.md",
+      "computedHash": "575757e3e25761c8c562d6e395d29f0b76c98b1273c0bd72d88e6ab1bc9c7d42"
+    },
+    "web-design-guidelines": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/web-design-guidelines/SKILL.md",
+      "computedHash": "f3bc47f890f42a44db1007ab390709ec368e4b8c089baee6b0007182236ac474"
+    }
+  }
+}

--- a/src/web-v2/App.tsx
+++ b/src/web-v2/App.tsx
@@ -1,10 +1,38 @@
+import { useState } from 'react';
 import { AppFrame } from './layout/AppFrame';
-import { NAV_ITEMS } from './layout/navigation';
+import { APP_NAV_ITEMS, SETTINGS_NAV_ITEMS } from './layout/navigation';
+import type { AppSurfaceId, SettingsSectionId } from './layout/types';
+import { WorkbenchView } from './views/WorkbenchView';
 
 export function App() {
+  const [activeSurfaceId, setActiveSurfaceId] = useState<AppSurfaceId>('sessions');
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [activeSettingsSectionId, setActiveSettingsSectionId] = useState<SettingsSectionId>('general');
+
   return (
-    <AppFrame activeItemId="sessions" navigationItems={NAV_ITEMS}>
-      <div />
+    <AppFrame
+      activeSurfaceId={activeSurfaceId}
+      activeSettingsSectionId={activeSettingsSectionId}
+      appNavigationItems={APP_NAV_ITEMS}
+      settingsNavigationItems={SETTINGS_NAV_ITEMS}
+      settingsOpen={settingsOpen}
+      onAppNavigation={(id) => {
+        setActiveSurfaceId(id);
+        setSettingsOpen(false);
+      }}
+      onSettingsNavigation={setActiveSettingsSectionId}
+      onOpenSettings={() => {
+        setSettingsOpen(true);
+      }}
+      onCloseSettings={() => {
+        setSettingsOpen(false);
+      }}
+    >
+      <WorkbenchView
+        activeSurfaceId={activeSurfaceId}
+        activeSettingsSectionId={activeSettingsSectionId}
+        settingsOpen={settingsOpen}
+      />
     </AppFrame>
   );
 }

--- a/src/web-v2/App.tsx
+++ b/src/web-v2/App.tsx
@@ -1,0 +1,10 @@
+import { AppFrame } from './layout/AppFrame';
+import { NAV_ITEMS } from './layout/navigation';
+
+export function App() {
+  return (
+    <AppFrame activeItemId="sessions" navigationItems={NAV_ITEMS}>
+      <div />
+    </AppFrame>
+  );
+}

--- a/src/web-v2/README.md
+++ b/src/web-v2/README.md
@@ -18,6 +18,9 @@ current user-facing UI.
   global hooks until two real surfaces need the same behavior.
 - Start with navigation structure only, then build one complete workflow at a
   time.
+- Visual design follows [`design-language.md`](./design-language.md). Start with
+  shadcn/Tailwind semantic tokens and extend them only when a concrete product
+  need appears.
 
 ## Folder Shape
 

--- a/src/web-v2/README.md
+++ b/src/web-v2/README.md
@@ -1,0 +1,31 @@
+# Heddle Web V2
+
+`src/web-v2` is the parallel rebuild of the browser control plane. It exists so
+new frontend work can grow from a clean foundation while `src/web` remains the
+current user-facing UI.
+
+## Boundary
+
+- Browser code may talk to `api/` clients and local presentation/application
+  modules.
+- Browser code must not import `src/core` directly. Shared behavior belongs
+  behind server APIs or in browser-safe contracts.
+- Reuse tRPC-inferred server types from `AppRouter`. Do not redeclare DTOs in
+  the browser unless they are truly web-interface view models.
+- Start from shadcn/Tailwind tokens and primitives. Add custom CSS only when a
+  real product need cannot be expressed by the shared design system.
+- Keep workflow state close to the feature that owns it. Do not create broad
+  global hooks until two real surfaces need the same behavior.
+- Start with navigation structure only, then build one complete workflow at a
+  time.
+
+## Folder Shape
+
+- `api/`: tRPC clients and inferred server contracts.
+- `layout/`: app frame, navigation, and shell-level placement.
+- `views/`: route-level workflow surfaces.
+- `components/`: reusable v2-only presentation components when a second caller
+  exists.
+
+V2 should borrow from v1 only when the source module already respects the API
+boundary and does not carry legacy control-plane assumptions.

--- a/src/web-v2/api/client.ts
+++ b/src/web-v2/api/client.ts
@@ -1,0 +1,15 @@
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
+import type { AppRouter } from '@/server/router';
+
+export const trpc = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: '/trpc',
+    }),
+  ],
+});
+
+export type RouterInputs = inferRouterInputs<AppRouter>;
+export type RouterOutputs = inferRouterOutputs<AppRouter>;
+export type ControlPlaneState = RouterOutputs['controlPlane']['state'];

--- a/src/web-v2/design-language.md
+++ b/src/web-v2/design-language.md
@@ -1,0 +1,27 @@
+# Web V2 Design Language
+
+Heddle Web V2 is a dense, quiet developer workbench. It should feel closer to an editor or coding-agent control panel than a SaaS dashboard: text-first, pane-based, inspectable, and calm.
+
+## Token Policy
+
+Use Tailwind v4 `@theme` tokens in `src/web-v2/tailwind.css` as the visual source of truth. Components should use semantic classes such as `bg-background`, `bg-card`, `border-border`, `text-foreground`, `text-muted-foreground`, `bg-accent`, and `text-accent-foreground`.
+
+Do not use raw palette utilities like `bg-slate-900`, `text-blue-300`, or ad hoc hex values in v2 components unless the design language is intentionally extended first.
+
+## Visual Direction
+
+- Neutral dark palette with one restrained accent for selected, active, or focused state.
+- Borders and surface contrast define layout; shadows are rare.
+- No gradients, glow effects, decorative cards, or marketing-scale typography.
+- Radius stays compact: 4-8px for controls and surfaces.
+- Typography is compact product UI: 12px metadata, 13-14px navigation/body, 15-16px section headers.
+- Monospace is reserved for code, paths, IDs, commands, and numeric trace details.
+
+## Information Architecture
+
+- Left sidebar: main app navigation, session list, and bottom settings entry.
+- Center: active work surface.
+- Right: contextual inspector for the selected item or workflow.
+- Settings is a separate sidebar mode. Workspace management and memory status belong there, not in the main workbench.
+
+Every new surface should decide whether it belongs to the sidebar, center work surface, inspector, or settings before adding component code.

--- a/src/web-v2/index.html
+++ b/src/web-v2/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Heddle Control Plane V2</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/src/web-v2/layout/AppFrame.tsx
+++ b/src/web-v2/layout/AppFrame.tsx
@@ -1,37 +1,154 @@
 import type { PropsWithChildren } from 'react';
 import { Button } from '@/web/components/ui/button';
 import { cn } from '@/web/lib/utils';
-import type { NavigationItem } from './types';
+import type { AppSurfaceId, NavigationItem, SettingsSectionId } from './types';
 
 interface AppFrameProps {
-  activeItemId: string;
-  navigationItems: NavigationItem[];
+  activeSurfaceId: AppSurfaceId;
+  activeSettingsSectionId: SettingsSectionId;
+  appNavigationItems: NavigationItem[];
+  settingsNavigationItems: NavigationItem[];
+  settingsOpen: boolean;
+  onAppNavigation: (id: AppSurfaceId) => void;
+  onSettingsNavigation: (id: SettingsSectionId) => void;
+  onOpenSettings: () => void;
+  onCloseSettings: () => void;
 }
 
 // AppFrame owns only shell placement. Workflow state should stay in feature
 // views and server-backed API clients.
-export function AppFrame({ activeItemId, navigationItems, children }: PropsWithChildren<AppFrameProps>) {
+export function AppFrame({
+  activeSurfaceId,
+  activeSettingsSectionId,
+  appNavigationItems,
+  settingsNavigationItems,
+  settingsOpen,
+  onAppNavigation,
+  onSettingsNavigation,
+  onOpenSettings,
+  onCloseSettings,
+  children,
+}: PropsWithChildren<AppFrameProps>) {
   return (
-    <div className="grid min-h-screen grid-cols-[15rem_minmax(0,1fr)_20rem] bg-background text-foreground">
-      <aside className="border-r bg-card/40" aria-label="Primary navigation">
-        <div className="border-b px-4 py-3 text-sm font-medium">Heddle</div>
-        <nav className="grid gap-1 p-2">
-          {navigationItems.map((item) => (
-            <Button
-              key={item.id}
-              className={cn('justify-start', item.id === activeItemId && 'bg-accent text-accent-foreground')}
-              variant="ghost"
-              type="button"
-            >
-              {item.label}
-            </Button>
-          ))}
-        </nav>
+    <div className="flex h-dvh bg-background font-sans text-foreground">
+      <a className="sr-only focus:not-sr-only" href="#main-content">Skip to Main Content</a>
+      <aside className="flex w-60 shrink-0 flex-col border-r bg-card" aria-label="Primary navigation">
+        {settingsOpen ? (
+          <SettingsNavigation
+            activeItemId={activeSettingsSectionId}
+            items={settingsNavigationItems}
+            onBack={onCloseSettings}
+            onSelect={onSettingsNavigation}
+          />
+        ) : (
+          <AppNavigation
+            activeItemId={activeSurfaceId}
+            items={appNavigationItems}
+            onOpenSettings={onOpenSettings}
+            onSelect={onAppNavigation}
+          />
+        )}
       </aside>
 
-      <main className="min-w-0">{children}</main>
-
-      <aside className="border-l bg-card/30" aria-label="Context inspector" />
+      <main id="main-content" className="min-w-0 flex-1">{children}</main>
     </div>
+  );
+}
+
+function AppNavigation({
+  activeItemId,
+  items,
+  onOpenSettings,
+  onSelect,
+}: {
+  activeItemId: AppSurfaceId;
+  items: NavigationItem[];
+  onOpenSettings: () => void;
+  onSelect: (id: AppSurfaceId) => void;
+}) {
+  return (
+    <>
+      <div className="border-b px-3 py-2 text-sm font-medium text-foreground">Heddle</div>
+      <nav className="grid gap-1 p-2" aria-label="Main app navigation">
+        {items.map((item) => (
+          <SidebarLink
+            key={item.id}
+            active={item.id === activeItemId}
+            href={item.href}
+            label={item.label}
+            onClick={() => onSelect(item.id as AppSurfaceId)}
+          />
+        ))}
+      </nav>
+      <div className="min-h-0 flex-1 border-t bg-background" aria-label="Session list" />
+      <div className="border-t p-2">
+        <Button className="h-8 w-full justify-start px-2" onClick={onOpenSettings} type="button" variant="ghost">
+          Settings
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function SettingsNavigation({
+  activeItemId,
+  items,
+  onBack,
+  onSelect,
+}: {
+  activeItemId: SettingsSectionId;
+  items: NavigationItem[];
+  onBack: () => void;
+  onSelect: (id: SettingsSectionId) => void;
+}) {
+  return (
+    <>
+      <div className="border-b p-2">
+        <Button className="h-8 w-full justify-start px-2 text-muted-foreground" onClick={onBack} type="button" variant="ghost">
+          Back to App
+        </Button>
+      </div>
+      <nav className="grid gap-1 p-2" aria-label="Settings navigation">
+        {items.map((item) => (
+          <SidebarLink
+            key={item.id}
+            active={item.id === activeItemId}
+            href={item.href}
+            label={item.label}
+            onClick={() => onSelect(item.id as SettingsSectionId)}
+          />
+        ))}
+      </nav>
+    </>
+  );
+}
+
+function SidebarLink({
+  active,
+  href,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  href: string;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      className={cn('h-8 justify-start px-2 text-muted-foreground', active && 'bg-accent text-accent-foreground')}
+      asChild
+      variant="ghost"
+    >
+      <a
+        aria-current={active ? 'page' : undefined}
+        href={href}
+        onClick={() => {
+          onClick();
+        }}
+      >
+        {label}
+      </a>
+    </Button>
   );
 }

--- a/src/web-v2/layout/AppFrame.tsx
+++ b/src/web-v2/layout/AppFrame.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react';
-import { Button } from '@/web/components/ui/button';
-import { cn } from '@/web/lib/utils';
+import { AppNavigation } from './components/AppNavigation';
+import { SettingsNavigation } from './components/SettingsNavigation';
 import type { AppSurfaceId, NavigationItem, SettingsSectionId } from './types';
 
 interface AppFrameProps {
@@ -52,103 +52,5 @@ export function AppFrame({
 
       <main id="main-content" className="min-w-0 flex-1">{children}</main>
     </div>
-  );
-}
-
-function AppNavigation({
-  activeItemId,
-  items,
-  onOpenSettings,
-  onSelect,
-}: {
-  activeItemId: AppSurfaceId;
-  items: NavigationItem[];
-  onOpenSettings: () => void;
-  onSelect: (id: AppSurfaceId) => void;
-}) {
-  return (
-    <>
-      <div className="border-b px-3 py-2 text-sm font-medium text-foreground">Heddle</div>
-      <nav className="grid gap-1 p-2" aria-label="Main app navigation">
-        {items.map((item) => (
-          <SidebarLink
-            key={item.id}
-            active={item.id === activeItemId}
-            href={item.href}
-            label={item.label}
-            onClick={() => onSelect(item.id as AppSurfaceId)}
-          />
-        ))}
-      </nav>
-      <div className="min-h-0 flex-1 border-t bg-background" aria-label="Session list" />
-      <div className="border-t p-2">
-        <Button className="h-8 w-full justify-start px-2" onClick={onOpenSettings} type="button" variant="ghost">
-          Settings
-        </Button>
-      </div>
-    </>
-  );
-}
-
-function SettingsNavigation({
-  activeItemId,
-  items,
-  onBack,
-  onSelect,
-}: {
-  activeItemId: SettingsSectionId;
-  items: NavigationItem[];
-  onBack: () => void;
-  onSelect: (id: SettingsSectionId) => void;
-}) {
-  return (
-    <>
-      <div className="border-b p-2">
-        <Button className="h-8 w-full justify-start px-2 text-muted-foreground" onClick={onBack} type="button" variant="ghost">
-          Back to App
-        </Button>
-      </div>
-      <nav className="grid gap-1 p-2" aria-label="Settings navigation">
-        {items.map((item) => (
-          <SidebarLink
-            key={item.id}
-            active={item.id === activeItemId}
-            href={item.href}
-            label={item.label}
-            onClick={() => onSelect(item.id as SettingsSectionId)}
-          />
-        ))}
-      </nav>
-    </>
-  );
-}
-
-function SidebarLink({
-  active,
-  href,
-  label,
-  onClick,
-}: {
-  active: boolean;
-  href: string;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <Button
-      className={cn('h-8 justify-start px-2 text-muted-foreground', active && 'bg-accent text-accent-foreground')}
-      asChild
-      variant="ghost"
-    >
-      <a
-        aria-current={active ? 'page' : undefined}
-        href={href}
-        onClick={() => {
-          onClick();
-        }}
-      >
-        {label}
-      </a>
-    </Button>
   );
 }

--- a/src/web-v2/layout/AppFrame.tsx
+++ b/src/web-v2/layout/AppFrame.tsx
@@ -1,0 +1,37 @@
+import type { PropsWithChildren } from 'react';
+import { Button } from '@/web/components/ui/button';
+import { cn } from '@/web/lib/utils';
+import type { NavigationItem } from './types';
+
+interface AppFrameProps {
+  activeItemId: string;
+  navigationItems: NavigationItem[];
+}
+
+// AppFrame owns only shell placement. Workflow state should stay in feature
+// views and server-backed API clients.
+export function AppFrame({ activeItemId, navigationItems, children }: PropsWithChildren<AppFrameProps>) {
+  return (
+    <div className="grid min-h-screen grid-cols-[15rem_minmax(0,1fr)_20rem] bg-background text-foreground">
+      <aside className="border-r bg-card/40" aria-label="Primary navigation">
+        <div className="border-b px-4 py-3 text-sm font-medium">Heddle</div>
+        <nav className="grid gap-1 p-2">
+          {navigationItems.map((item) => (
+            <Button
+              key={item.id}
+              className={cn('justify-start', item.id === activeItemId && 'bg-accent text-accent-foreground')}
+              variant="ghost"
+              type="button"
+            >
+              {item.label}
+            </Button>
+          ))}
+        </nav>
+      </aside>
+
+      <main className="min-w-0">{children}</main>
+
+      <aside className="border-l bg-card/30" aria-label="Context inspector" />
+    </div>
+  );
+}

--- a/src/web-v2/layout/components/AppNavigation.tsx
+++ b/src/web-v2/layout/components/AppNavigation.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@/web/components/ui/button';
+import type { AppSurfaceId, NavigationItem } from '../types';
+import { SidebarLink } from './SidebarLink';
+
+interface AppNavigationProps {
+  activeItemId: AppSurfaceId;
+  items: NavigationItem[];
+  onOpenSettings: () => void;
+  onSelect: (id: AppSurfaceId) => void;
+}
+
+// AppNavigation owns the primary workbench sidebar mode: app surfaces, the
+// future session list region, and the bottom settings entry point.
+export function AppNavigation({ activeItemId, items, onOpenSettings, onSelect }: AppNavigationProps) {
+  return (
+    <>
+      <div className="border-b px-3 py-2 text-sm font-medium text-foreground">Heddle</div>
+      <nav className="grid gap-1 p-2" aria-label="Main app navigation">
+        {items.map((item) => (
+          <SidebarLink
+            key={item.id}
+            active={item.id === activeItemId}
+            href={item.href}
+            label={item.label}
+            onClick={() => onSelect(item.id as AppSurfaceId)}
+          />
+        ))}
+      </nav>
+      <div className="min-h-0 flex-1 border-t bg-background" aria-label="Session list" />
+      <div className="border-t p-2">
+        <Button className="h-8 w-full justify-start px-2" onClick={onOpenSettings} type="button" variant="ghost">
+          Settings
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/src/web-v2/layout/components/SettingsNavigation.tsx
+++ b/src/web-v2/layout/components/SettingsNavigation.tsx
@@ -1,0 +1,35 @@
+import { Button } from '@/web/components/ui/button';
+import type { NavigationItem, SettingsSectionId } from '../types';
+import { SidebarLink } from './SidebarLink';
+
+interface SettingsNavigationProps {
+  activeItemId: SettingsSectionId;
+  items: NavigationItem[];
+  onBack: () => void;
+  onSelect: (id: SettingsSectionId) => void;
+}
+
+// SettingsNavigation owns the alternate sidebar mode for configuration surfaces
+// that should not crowd the main agent workbench.
+export function SettingsNavigation({ activeItemId, items, onBack, onSelect }: SettingsNavigationProps) {
+  return (
+    <>
+      <div className="border-b p-2">
+        <Button className="h-8 w-full justify-start px-2 text-muted-foreground" onClick={onBack} type="button" variant="ghost">
+          Back to App
+        </Button>
+      </div>
+      <nav className="grid gap-1 p-2" aria-label="Settings navigation">
+        {items.map((item) => (
+          <SidebarLink
+            key={item.id}
+            active={item.id === activeItemId}
+            href={item.href}
+            label={item.label}
+            onClick={() => onSelect(item.id as SettingsSectionId)}
+          />
+        ))}
+      </nav>
+    </>
+  );
+}

--- a/src/web-v2/layout/components/SidebarLink.tsx
+++ b/src/web-v2/layout/components/SidebarLink.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@/web/components/ui/button';
+import { cn } from '@/web/lib/utils';
+
+interface SidebarLinkProps {
+  active: boolean;
+  href: string;
+  label: string;
+  onClick: () => void;
+}
+
+// SidebarLink is the shared nav row primitive for v2 sidebar modes.
+export function SidebarLink({ active, href, label, onClick }: SidebarLinkProps) {
+  return (
+    <Button
+      className={cn('h-8 justify-start px-2 text-muted-foreground', active && 'bg-accent text-accent-foreground')}
+      asChild
+      variant="ghost"
+    >
+      <a
+        aria-current={active ? 'page' : undefined}
+        href={href}
+        onClick={() => {
+          onClick();
+        }}
+      >
+        {label}
+      </a>
+    </Button>
+  );
+}

--- a/src/web-v2/layout/navigation.ts
+++ b/src/web-v2/layout/navigation.ts
@@ -1,9 +1,12 @@
 import type { NavigationItem } from './types';
 
-export const NAV_ITEMS: NavigationItem[] = [
-  { id: 'sessions', label: 'Sessions' },
-  { id: 'review', label: 'Review' },
-  { id: 'tasks', label: 'Tasks' },
-  { id: 'workspaces', label: 'Workspaces' },
-  { id: 'settings', label: 'Settings' },
+export const APP_NAV_ITEMS: NavigationItem[] = [
+  { id: 'sessions', label: 'Sessions', href: '#sessions' },
+  { id: 'tasks', label: 'Tasks', href: '#tasks' },
+];
+
+export const SETTINGS_NAV_ITEMS: NavigationItem[] = [
+  { id: 'general', label: 'General', href: '#settings-general' },
+  { id: 'workspaces', label: 'Workspace Management', href: '#settings-workspaces' },
+  { id: 'memory', label: 'Memory Status', href: '#settings-memory' },
 ];

--- a/src/web-v2/layout/navigation.ts
+++ b/src/web-v2/layout/navigation.ts
@@ -1,0 +1,9 @@
+import type { NavigationItem } from './types';
+
+export const NAV_ITEMS: NavigationItem[] = [
+  { id: 'sessions', label: 'Sessions' },
+  { id: 'review', label: 'Review' },
+  { id: 'tasks', label: 'Tasks' },
+  { id: 'workspaces', label: 'Workspaces' },
+  { id: 'settings', label: 'Settings' },
+];

--- a/src/web-v2/layout/types.ts
+++ b/src/web-v2/layout/types.ts
@@ -1,0 +1,4 @@
+export interface NavigationItem {
+  id: string;
+  label: string;
+}

--- a/src/web-v2/layout/types.ts
+++ b/src/web-v2/layout/types.ts
@@ -1,4 +1,8 @@
+export type AppSurfaceId = 'sessions' | 'tasks';
+export type SettingsSectionId = 'general' | 'workspaces' | 'memory';
+
 export interface NavigationItem {
-  id: string;
+  id: AppSurfaceId | SettingsSectionId;
   label: string;
+  href: string;
 }

--- a/src/web-v2/main.tsx
+++ b/src/web-v2/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
-import '../web/tailwind.css';
+import './tailwind.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/web-v2/main.tsx
+++ b/src/web-v2/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import '../web/tailwind.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/src/web-v2/tailwind.css
+++ b/src/web-v2/tailwind.css
@@ -1,0 +1,31 @@
+@import "tailwindcss";
+
+@theme {
+  --font-sans: ui-sans-serif, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+
+  --color-background: hsl(225 22% 6%);
+  --color-foreground: hsl(220 18% 92%);
+  --color-card: hsl(225 18% 9%);
+  --color-card-foreground: hsl(220 18% 92%);
+  --color-popover: hsl(225 18% 9%);
+  --color-popover-foreground: hsl(220 18% 92%);
+  --color-primary: hsl(220 14% 88%);
+  --color-primary-foreground: hsl(225 22% 6%);
+  --color-secondary: hsl(225 14% 15%);
+  --color-secondary-foreground: hsl(220 18% 90%);
+  --color-muted: hsl(225 13% 13%);
+  --color-muted-foreground: hsl(220 10% 62%);
+  --color-accent: hsl(225 12% 18%);
+  --color-accent-foreground: hsl(220 18% 94%);
+  --color-destructive: hsl(0 72% 63%);
+  --color-destructive-foreground: hsl(0 0% 98%);
+  --color-border: hsl(225 13% 18%);
+  --color-input: hsl(225 13% 18%);
+  --color-ring: hsl(220 11% 64%);
+
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 10px;
+}

--- a/src/web-v2/tsconfig.json
+++ b/src/web-v2/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "outDir": "../../dist/web-v2-types",
+    "rootDir": "../..",
+    "baseUrl": "../..",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["vite/client"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["../../node_modules", "../../dist"]
+}

--- a/src/web-v2/views/WorkbenchView.tsx
+++ b/src/web-v2/views/WorkbenchView.tsx
@@ -1,0 +1,37 @@
+import type { AppSurfaceId, SettingsSectionId } from '../layout/types';
+
+interface WorkbenchViewProps {
+  activeSurfaceId: AppSurfaceId;
+  activeSettingsSectionId: SettingsSectionId;
+  settingsOpen: boolean;
+}
+
+const appSurfaceLabels: Record<AppSurfaceId, string> = {
+  sessions: 'Sessions',
+  tasks: 'Tasks',
+};
+
+const settingsSectionLabels: Record<SettingsSectionId, string> = {
+  general: 'General',
+  workspaces: 'Workspace Management',
+  memory: 'Memory Status',
+};
+
+// WorkbenchView keeps the first v2 pass structural. It names the selected
+// surface while leaving workflow content and data loading to later slices.
+export function WorkbenchView({ activeSurfaceId, activeSettingsSectionId, settingsOpen }: WorkbenchViewProps) {
+  const title = settingsOpen ? settingsSectionLabels[activeSettingsSectionId] : appSurfaceLabels[activeSurfaceId];
+
+  return (
+    <section className="flex h-dvh min-w-0 bg-background">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="flex h-12 items-center border-b bg-card px-4">
+          <h1 className="text-balance text-sm font-medium">{title}</h1>
+        </header>
+        <div className="min-h-0 flex-1 bg-background" aria-label={`${title} workspace`} />
+      </div>
+
+      <aside className="w-80 shrink-0 border-l bg-card" aria-label="Context inspector" />
+    </section>
+  );
+}

--- a/src/web-v2/vite.config.ts
+++ b/src/web-v2/vite.config.ts
@@ -1,0 +1,29 @@
+import { resolve } from 'node:path';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '..'),
+    },
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 5174,
+    allowedHosts: ['.ts.net'],
+    proxy: {
+      '/control-plane': {
+        target: process.env.HEDDLE_SERVER_URL ?? 'http://127.0.0.1:8765',
+        changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    outDir: resolve(__dirname, '../../dist/src/web-v2'),
+    emptyOutDir: true,
+  },
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "src/__tests__/**/*", "src/web/**/*", "e2e/**/*", "scripts/**/*", "playwright.config.ts"]
+  "exclude": ["node_modules", "dist", "src/__tests__/**/*", "src/web/**/*", "src/web-v2/**/*", "e2e/**/*", "scripts/**/*", "playwright.config.ts"]
 }


### PR DESCRIPTION
## Summary

- Establish the first `web-v2` navigation shell with app navigation, settings navigation, and an empty workbench/inspector structure.
- Add a Tailwind v4 CSS-first design token file for the v2 surface.
- Document the v2 design language and boundary rules so future UI slices stay small, semantic, and API-backed.
- Track the agent design-system skills used for this slice while ignoring the installed `.agents/` folder.

## Validation

- `yarn client:v2:build`
- `yarn lint`
- `yarn typecheck`