### PR TITLE
Build web v2 session workbench slice

### DIFF
--- a/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
+++ b/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
@@ -6,7 +6,8 @@ test('loads the web v2 shell sections', async ({ page }) => {
   await expect(page.getByRole('complementary', { name: 'Primary navigation' })).toBeVisible();
   await expect(page.getByRole('main')).toBeVisible();
   await expect(page.getByRole('complementary', { name: 'Context inspector' })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Sessions' })).toBeVisible();
+  await expect(page.getByTestId('web-v2-surface-sessions')).toBeVisible();
+  await expect(page.getByTestId('web-v2-workbench-title')).toBeVisible();
   await expect(page.getByRole('link', { name: 'Sessions' })).toHaveAttribute('aria-current', 'page');
 });
 
@@ -31,19 +32,22 @@ test('navigates primary and settings routes without hash routing', async ({ page
   await page.getByRole('link', { name: 'Tasks' }).click();
   await expect(page).toHaveURL(/\/tasks$/);
   await expect(page).not.toHaveURL(/#/);
-  await expect(page.getByRole('heading', { name: 'Tasks' })).toBeVisible();
+  await expect(page.getByTestId('web-v2-surface-tasks')).toBeVisible();
+  await expect(page.getByTestId('web-v2-workbench-title')).toHaveText('Tasks');
   await expect(page.getByRole('link', { name: 'Tasks' })).toHaveAttribute('aria-current', 'page');
 
   await page.getByRole('button', { name: 'Settings' }).click();
   await page.getByRole('button', { name: 'Open settings' }).click();
   await expect(page).toHaveURL(/\/settings\/general$/);
-  await expect(page.getByRole('heading', { name: 'General' })).toBeVisible();
+  await expect(page.getByTestId('web-v2-settings-general')).toBeVisible();
+  await expect(page.getByTestId('web-v2-workbench-title')).toHaveText('General');
 
   await page.getByRole('link', { name: 'Memory Status' }).click();
   await expect(page).toHaveURL(/\/settings\/memory$/);
-  await expect(page.getByRole('heading', { name: 'Memory Status' })).toBeVisible();
+  await expect(page.getByTestId('web-v2-settings-memory')).toBeVisible();
+  await expect(page.getByTestId('web-v2-workbench-title')).toHaveText('Memory Status');
 
   await page.getByRole('button', { name: 'Back to App' }).click();
   await expect(page).toHaveURL(/\/sessions$/);
-  await expect(page.getByRole('heading', { name: 'Sessions' })).toBeVisible();
+  await expect(page.getByTestId('web-v2-surface-sessions')).toBeVisible();
 });

--- a/src/web-v2/App.tsx
+++ b/src/web-v2/App.tsx
@@ -1,3 +1,6 @@
+import { useEffect, useState } from 'react';
+import { useControlPlaneSidebarData } from '@web/hooks/useControlPlaneSidebarData';
+import { useControlPlaneSessionDetail } from '@web/hooks/useControlPlaneSessionDetail';
 import { useWorkbenchNavigation } from '@web/hooks/useWorkbenchNavigation';
 import { AppFrame } from '@web/layout/AppFrame';
 import { AppRoutes } from '@web/layout/AppRoutes';
@@ -5,6 +8,17 @@ import { APP_ROUTES, SETTINGS_ROUTES } from '@web/layout/routes';
 
 export function App() {
   const navigation = useWorkbenchNavigation();
+  const sidebarData = useControlPlaneSidebarData();
+  const [selectedSessionId, setSelectedSessionId] = useState<string | undefined>();
+  const selectedSession = useControlPlaneSessionDetail(selectedSessionId);
+
+  useEffect(() => {
+    if (selectedSessionId || sidebarData.sessions.length === 0) {
+      return;
+    }
+
+    setSelectedSessionId(sidebarData.sessions[0]?.id);
+  }, [selectedSessionId, sidebarData.sessions]);
 
   return (
     <AppFrame
@@ -13,12 +27,18 @@ export function App() {
       appNavigationItems={APP_ROUTES}
       settingsNavigationItems={SETTINGS_ROUTES}
       settingsOpen={navigation.settingsOpen}
+      selectedSessionId={selectedSessionId}
+      sessions={sidebarData.sessions}
+      tasks={sidebarData.tasks}
       onOpenSettings={navigation.openSettings}
       onCloseSettings={navigation.closeSettings}
+      onSelectSession={setSelectedSessionId}
     >
       <AppRoutes
         activeSurfaceId={navigation.activeSurfaceId}
         activeSettingsSectionId={navigation.activeSettingsSectionId}
+        selectedSession={selectedSession.session}
+        selectedSessionLoading={selectedSession.loading}
       />
     </AppFrame>
   );

--- a/src/web-v2/components/conversation/AssistantMarkdown.tsx
+++ b/src/web-v2/components/conversation/AssistantMarkdown.tsx
@@ -1,0 +1,23 @@
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
+import remarkGfm from 'remark-gfm';
+
+const markdownComponents: Components = {
+  a: ({ node: _node, ...props }) => (
+    <a {...props} target="_blank" rel="noreferrer noopener" />
+  ),
+};
+
+export function AssistantMarkdown({ markdown }: { markdown: string }) {
+  return (
+    <div className="v2-assistant-markdown">
+      <ReactMarkdown
+        components={markdownComponents}
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        skipHtml
+      >
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/src/web-v2/components/conversation/ConversationComposer.tsx
+++ b/src/web-v2/components/conversation/ConversationComposer.tsx
@@ -1,0 +1,143 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { ArrowUp, Plus } from 'lucide-react';
+import { Button } from '@web/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@web/components/ui/select';
+import { Textarea } from '@web/components/ui/textarea';
+import { useI18n } from '@web/i18n';
+
+const mockModels = [
+  { value: 'gpt-5.5', label: 'GPT-5.5' },
+  { value: 'codex-5.3', label: 'Codex 5.3' },
+  { value: 'gpt-5.4', label: 'GPT-5.4' },
+  { value: 'sonnet-4.6', label: 'Sonnet 4.6' },
+  { value: 'opus-4.7', label: 'Opus 4.7' },
+] as const;
+
+const mockReasoningEfforts = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'extra-high', label: 'Extra High' },
+] as const;
+
+type MockModelValue = (typeof mockModels)[number]['value'];
+type MockReasoningEffortValue = (typeof mockReasoningEfforts)[number]['value'];
+
+const composerTextareaMinHeight = 50;
+const composerTextareaMaxHeight = 176;
+
+// ConversationComposer is visual-only for this slice. Model and reasoning
+// options are local mocks until the v2 composer is wired to control-plane APIs.
+export function ConversationComposer() {
+  const { t } = useI18n();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [draft, setDraft] = useState('');
+  const [model, setModel] = useState<MockModelValue>('gpt-5.5');
+  const [reasoningEffort, setReasoningEffort] = useState<MockReasoningEffortValue>('medium');
+
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    textarea.style.height = `${composerTextareaMinHeight}px`;
+    const nextHeight = Math.min(textarea.scrollHeight, composerTextareaMaxHeight);
+    textarea.style.height = `${Math.max(nextHeight, composerTextareaMinHeight)}px`;
+    textarea.style.overflowY = textarea.scrollHeight > composerTextareaMaxHeight ? 'auto' : 'hidden';
+  }, [draft]);
+
+  return (
+    <form className="v2-composer-shell" onSubmit={(event) => event.preventDefault()}>
+      <Textarea
+        ref={textareaRef}
+        aria-label={t('composer.promptAriaLabel')}
+        className="v2-composer-textarea"
+        placeholder={t('composer.placeholder')}
+        rows={2}
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+      />
+      <div className="v2-composer-toolbar">
+        <Button
+          type="button"
+          variant="ghost"
+          size="none"
+          className="v2-composer-icon-button"
+          aria-label={t('composer.addContext')}
+        >
+          <Plus aria-hidden="true" />
+        </Button>
+        <div className="ml-auto flex min-w-0 items-center gap-1.5">
+          <ModelSelect value={model} onValueChange={setModel} ariaLabel={t('composer.model')} />
+          <ReasoningEffortSelect
+            value={reasoningEffort}
+            onValueChange={setReasoningEffort}
+            ariaLabel={t('composer.reasoningEffort')}
+          />
+          <Button
+            type="submit"
+            size="none"
+            className="v2-composer-send-button"
+            aria-label={t('composer.send')}
+            disabled={!draft.trim()}
+          >
+            <ArrowUp aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+interface ModelSelectProps {
+  value: MockModelValue;
+  onValueChange: (value: MockModelValue) => void;
+  ariaLabel: string;
+}
+
+function ModelSelect({ value, onValueChange, ariaLabel }: ModelSelectProps) {
+  return (
+    <Select value={value} onValueChange={(nextValue) => onValueChange(nextValue as MockModelValue)}>
+      <SelectTrigger className="v2-composer-select w-[7.5rem]" aria-label={ariaLabel}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align="end" className="w-56">
+        {mockModels.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+interface ReasoningEffortSelectProps {
+  value: MockReasoningEffortValue;
+  onValueChange: (value: MockReasoningEffortValue) => void;
+  ariaLabel: string;
+}
+
+function ReasoningEffortSelect({ value, onValueChange, ariaLabel }: ReasoningEffortSelectProps) {
+  return (
+    <Select value={value} onValueChange={(nextValue) => onValueChange(nextValue as MockReasoningEffortValue)}>
+      <SelectTrigger className="v2-composer-select w-[7rem]" aria-label={ariaLabel}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align="end" className="w-44">
+        {mockReasoningEfforts.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/web-v2/components/conversation/ConversationMessage.tsx
+++ b/src/web-v2/components/conversation/ConversationMessage.tsx
@@ -1,0 +1,25 @@
+import { memo } from 'react';
+import type { ControlPlaneSessionDetail } from '@web/hooks/useControlPlaneSessionDetail';
+import { AssistantMarkdown } from './AssistantMarkdown';
+
+type ConversationMessageView = NonNullable<ControlPlaneSessionDetail>['messages'][number];
+
+export const ConversationMessage = memo(function ConversationMessage({ message }: { message: ConversationMessageView }) {
+  if (message.role === 'user') {
+    return (
+      <article className="v2-message-row v2-message-row-user" data-message-role="user">
+        <div className="v2-user-message-card">
+          {message.text}
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className="v2-message-row v2-message-row-assistant" data-message-role="assistant">
+      <div className="v2-assistant-article-shell">
+        <AssistantMarkdown markdown={message.text} />
+      </div>
+    </article>
+  );
+});

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -1,0 +1,54 @@
+import type { ControlPlaneSessionDetail } from '@web/hooks/useControlPlaneSessionDetail';
+import { ConversationComposer } from './ConversationComposer';
+import { ConversationMessage } from './ConversationMessage';
+
+interface ConversationThreadProps {
+  session: ControlPlaneSessionDetail;
+  loading: boolean;
+  emptyTitle: string;
+}
+
+// ConversationThread renders the selected session in the central work area.
+// It stays read-only until the composer and turn-running flow are introduced.
+export function ConversationThread({ session, loading, emptyTitle }: ConversationThreadProps) {
+  if (loading && !session) {
+    return (
+      <div className="flex h-full min-w-0 flex-col">
+        <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-muted-foreground">
+          {emptyTitle}
+        </div>
+        <div className="v2-composer-region">
+          <ConversationComposer />
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="flex h-full min-w-0 flex-col">
+        <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-muted-foreground">
+          {emptyTitle}
+        </div>
+        <div className="v2-composer-region">
+          <ConversationComposer />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-w-0 flex-col">
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-6 py-8">
+          {session.messages.map((message) => (
+            <ConversationMessage key={message.id} message={message} />
+          ))}
+        </div>
+      </div>
+      <div className="v2-composer-region">
+        <ConversationComposer />
+      </div>
+    </div>
+  );
+}

--- a/src/web-v2/components/conversation/index.ts
+++ b/src/web-v2/components/conversation/index.ts
@@ -1,0 +1,4 @@
+export { AssistantMarkdown } from './AssistantMarkdown';
+export { ConversationComposer } from './ConversationComposer';
+export { ConversationMessage } from './ConversationMessage';
+export { ConversationThread } from './ConversationThread';

--- a/src/web-v2/components/navigation/AppNavigation.tsx
+++ b/src/web-v2/components/navigation/AppNavigation.tsx
@@ -5,6 +5,7 @@ import {
   SidebarMenu,
   SidebarMenuItem,
 } from '@web/components/ui/sidebar';
+import type { ControlPlaneState } from '@web/api/client';
 import { useI18n } from '@web/i18n';
 import type { AppRoute } from '@web/layout/routes';
 import type { AppSurfaceId } from '@web/layout/types';
@@ -15,12 +16,24 @@ import { SidebarSettingsEntry } from './SidebarSettingsEntry';
 interface AppNavigationProps {
   activeItemId: AppSurfaceId;
   items: readonly AppRoute[];
+  selectedSessionId?: string;
+  sessions: ControlPlaneState['sessions'];
+  tasks: ControlPlaneState['heartbeat']['tasks'];
   onOpenSettings: () => void;
+  onSelectSession: (sessionId: string) => void;
 }
 
 // AppNavigation owns the primary workbench sidebar mode: app surfaces, the
 // future session list region, and the bottom settings entry point.
-export function AppNavigation({ activeItemId, items, onOpenSettings }: AppNavigationProps) {
+export function AppNavigation({
+  activeItemId,
+  items,
+  selectedSessionId,
+  sessions,
+  tasks,
+  onOpenSettings,
+  onSelectSession,
+}: AppNavigationProps) {
   const { t } = useI18n();
 
   return (
@@ -32,7 +45,16 @@ export function AppNavigation({ activeItemId, items, onOpenSettings }: AppNaviga
       </SidebarHeader>
       <MainNavigationSection activeItemId={activeItemId} items={items} />
       <SidebarContent>
-        <SidebarContentRegion ariaLabel={t('navigation.sessionListAriaLabel')} />
+        <SidebarContentRegion
+          ariaLabel={activeItemId === 'tasks' ? t('navigation.taskListAriaLabel') : t('navigation.sessionListAriaLabel')}
+          activeSurfaceId={activeItemId}
+          selectedSessionId={selectedSessionId}
+          sessionListTitle={t('navigation.sessionListTitle')}
+          taskListTitle={t('navigation.taskListTitle')}
+          sessions={sessions}
+          tasks={tasks}
+          onSelectSession={onSelectSession}
+        />
       </SidebarContent>
       <SidebarFooter className="v2-panel-divider border-t p-1.5">
         <SidebarMenu>

--- a/src/web-v2/components/navigation/SessionListSection.tsx
+++ b/src/web-v2/components/navigation/SessionListSection.tsx
@@ -1,0 +1,40 @@
+import type { ControlPlaneState } from '@web/api/client';
+
+interface SessionListSectionProps {
+  selectedSessionId?: string;
+  sessions: ControlPlaneState['sessions'];
+  title: string;
+  onSelectSession: (sessionId: string) => void;
+}
+
+// SessionListSection renders the left-rail session list using the same view
+// shape returned by the control-plane tRPC sessions endpoint.
+export function SessionListSection({ selectedSessionId, sessions, title, onSelectSession }: SessionListSectionProps) {
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-1 px-2 py-2" aria-label={title}>
+      <div
+        className="px-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-normal text-muted-foreground"
+      >
+        {title}
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-auto">
+        {sessions.map((session) => (
+          <button
+            key={session.id}
+            type="button"
+            aria-current={selectedSessionId === session.id ? 'page' : undefined}
+            className="group flex w-full min-w-0 flex-col rounded-md px-2 py-1.5 text-left outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring aria-current-page:bg-sidebar-accent aria-current-page:text-sidebar-accent-foreground"
+            onClick={() => onSelectSession(session.id)}
+          >
+            <span className="w-full truncate text-sm font-medium leading-5 text-sidebar-foreground group-hover:text-sidebar-accent-foreground">
+              {session.name}
+            </span>
+            <span className="w-full truncate text-xs leading-4 text-muted-foreground">
+              {session.lastSummary ?? session.lastPrompt ?? session.model ?? session.id}
+            </span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/web-v2/components/navigation/SidebarContentRegion.tsx
+++ b/src/web-v2/components/navigation/SidebarContentRegion.tsx
@@ -1,14 +1,46 @@
+import type { ControlPlaneState } from '@web/api/client';
+import type { AppSurfaceId } from '@web/layout/types';
+import { SessionListSection } from './SessionListSection';
+import { TaskListSection } from './TaskListSection';
+
 interface SidebarContentRegionProps {
   ariaLabel: string;
+  activeSurfaceId: AppSurfaceId;
+  selectedSessionId?: string;
+  sessionListTitle: string;
+  taskListTitle: string;
+  sessions: ControlPlaneState['sessions'];
+  tasks: ControlPlaneState['heartbeat']['tasks'];
+  onSelectSession: (sessionId: string) => void;
 }
 
-// SidebarContentRegion reserves the future session-list area without inventing
-// sample sessions or extra product surfaces.
-export function SidebarContentRegion({ ariaLabel }: SidebarContentRegionProps) {
+// SidebarContentRegion owns the scrollable content area below primary
+// navigation. Lists use the same shapes as their tRPC-backed views.
+export function SidebarContentRegion({
+  ariaLabel,
+  activeSurfaceId,
+  selectedSessionId,
+  sessionListTitle,
+  taskListTitle,
+  sessions,
+  tasks,
+  onSelectSession,
+}: SidebarContentRegionProps) {
   return (
     <div
-      className="v2-panel-divider v2-panel-surface min-h-0 flex-1 border-t"
+      className="v2-panel-divider v2-panel-surface flex min-h-0 flex-1 flex-col border-t"
       aria-label={ariaLabel}
-    />
+    >
+      {activeSurfaceId === 'tasks' ? (
+        <TaskListSection tasks={tasks} title={taskListTitle} />
+      ) : (
+        <SessionListSection
+          selectedSessionId={selectedSessionId}
+          sessions={sessions}
+          title={sessionListTitle}
+          onSelectSession={onSelectSession}
+        />
+      )}
+    </div>
   );
 }

--- a/src/web-v2/components/navigation/TaskListSection.tsx
+++ b/src/web-v2/components/navigation/TaskListSection.tsx
@@ -1,0 +1,41 @@
+import type { ControlPlaneState } from '@web/api/client';
+
+interface TaskListSectionProps {
+  tasks: ControlPlaneState['heartbeat']['tasks'];
+  title: string;
+}
+
+// TaskListSection renders heartbeat task views using the same shape exposed by
+// the control-plane state tRPC endpoint.
+export function TaskListSection({ tasks, title }: TaskListSectionProps) {
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-1 px-2 py-2" aria-label={title}>
+      <div
+        className="px-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-normal text-muted-foreground"
+      >
+        {title}
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-auto">
+        {tasks.map((task) => (
+          <button
+            key={task.taskId}
+            type="button"
+            className="group flex w-full min-w-0 flex-col rounded-md px-2 py-1.5 text-left outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+          >
+            <span className="flex w-full min-w-0 items-center gap-2">
+              <span className="truncate text-sm font-medium leading-5 text-sidebar-foreground group-hover:text-sidebar-accent-foreground">
+                {task.name ?? task.task}
+              </span>
+              <span className="ml-auto shrink-0 text-[0.6875rem] leading-4 text-muted-foreground">
+                {task.status}
+              </span>
+            </span>
+            <span className="w-full truncate text-xs leading-4 text-muted-foreground">
+              {task.summary ?? task.progress ?? task.task}
+            </span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/web-v2/components/navigation/index.ts
+++ b/src/web-v2/components/navigation/index.ts
@@ -1,7 +1,9 @@
 export { AppNavigation } from './AppNavigation';
 export { LanguageSelect } from './LanguageSelect';
 export { MainNavigationSection } from './MainNavigationSection';
+export { SessionListSection } from './SessionListSection';
 export { SettingsMenu } from './SettingsMenu';
 export { SettingsNavigation } from './SettingsNavigation';
 export { SidebarContentRegion } from './SidebarContentRegion';
 export { SidebarSettingsEntry } from './SidebarSettingsEntry';
+export { TaskListSection } from './TaskListSection';

--- a/src/web-v2/components/panels/SessionSidebar.tsx
+++ b/src/web-v2/components/panels/SessionSidebar.tsx
@@ -1,4 +1,5 @@
 import { AppNavigation, SettingsNavigation } from '@web/components/navigation';
+import type { ControlPlaneState } from '@web/api/client';
 import type { AppRoute, SettingsRoute } from '@web/layout/routes';
 import type { AppSurfaceId, SettingsSectionId } from '@web/layout/types';
 
@@ -8,8 +9,12 @@ interface SessionSidebarProps {
   appNavigationItems: readonly AppRoute[];
   settingsNavigationItems: readonly SettingsRoute[];
   settingsOpen: boolean;
+  selectedSessionId?: string;
+  sessions: ControlPlaneState['sessions'];
+  tasks: ControlPlaneState['heartbeat']['tasks'];
   onOpenSettings: () => void;
   onCloseSettings: () => void;
+  onSelectSession: (sessionId: string) => void;
 }
 
 // SessionSidebar owns the primary agent workbench rail: app navigation,
@@ -20,8 +25,12 @@ export function SessionSidebar({
   appNavigationItems,
   settingsNavigationItems,
   settingsOpen,
+  selectedSessionId,
+  sessions,
+  tasks,
   onOpenSettings,
   onCloseSettings,
+  onSelectSession,
 }: SessionSidebarProps) {
   return (
     <div className="flex h-full min-w-0 flex-col text-sm">
@@ -35,7 +44,11 @@ export function SessionSidebar({
         <AppNavigation
           activeItemId={activeSurfaceId}
           items={appNavigationItems}
+          selectedSessionId={selectedSessionId}
+          sessions={sessions}
+          tasks={tasks}
           onOpenSettings={onOpenSettings}
+          onSelectSession={onSelectSession}
         />
       )}
     </div>

--- a/src/web-v2/components/ui/button.tsx
+++ b/src/web-v2/components/ui/button.tsx
@@ -16,6 +16,7 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
+        none: '',
         default: 'h-9 px-4 py-2',
         sm: 'h-8 rounded-md px-3 text-xs',
         lg: 'h-10 rounded-md px-8',

--- a/src/web-v2/components/ui/textarea.tsx
+++ b/src/web-v2/components/ui/textarea.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { cn } from '@web/lib/utils';
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      'w-full resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+      className,
+    )}
+    {...props}
+  />
+));
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/src/web-v2/hooks/useControlPlaneSessionDetail.ts
+++ b/src/web-v2/hooks/useControlPlaneSessionDetail.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { trpc, type RouterOutputs } from '@web/api/client';
+
+export type ControlPlaneSessionDetail = RouterOutputs['controlPlane']['session'];
+
+type ControlPlaneSessionDetailState = {
+  session: ControlPlaneSessionDetail;
+  loading: boolean;
+};
+
+// useControlPlaneSessionDetail loads the selected conversation detail from the
+// same control-plane endpoint that web-v1 uses.
+export function useControlPlaneSessionDetail(sessionId: string | undefined): ControlPlaneSessionDetailState {
+  const [state, setState] = useState<ControlPlaneSessionDetailState>({
+    session: null,
+    loading: false,
+  });
+
+  useEffect(() => {
+    if (!sessionId) {
+      setState({ session: null, loading: false });
+      return;
+    }
+
+    let cancelled = false;
+    const id = sessionId;
+    setState((current) => ({ ...current, loading: true }));
+
+    async function load() {
+      const session = await trpc.controlPlane.session.query({ id });
+      if (cancelled) {
+        return;
+      }
+
+      setState({ session, loading: false });
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  return state;
+}

--- a/src/web-v2/hooks/useControlPlaneSidebarData.ts
+++ b/src/web-v2/hooks/useControlPlaneSidebarData.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { trpc, type ControlPlaneState } from '@web/api/client';
+
+type ControlPlaneSidebarData = {
+  sessions: ControlPlaneState['sessions'];
+  tasks: ControlPlaneState['heartbeat']['tasks'];
+};
+
+// useControlPlaneSidebarData keeps the v2 sidebar wired to the server-owned
+// control-plane view shape. Mock data should not live below this boundary.
+export function useControlPlaneSidebarData(): ControlPlaneSidebarData {
+  const [data, setData] = useState<ControlPlaneSidebarData>({
+    sessions: [],
+    tasks: [],
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      const state = await trpc.controlPlane.state.query();
+      if (cancelled) {
+        return;
+      }
+
+      setData({
+        sessions: state.sessions,
+        tasks: state.heartbeat.tasks,
+      });
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return data;
+}

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -2,6 +2,14 @@
   "app": {
     "name": "Heddle"
   },
+  "composer": {
+    "addContext": "Add context",
+    "model": "Model",
+    "placeholder": "Send follow-up",
+    "promptAriaLabel": "Message",
+    "reasoningEffort": "Reasoning effort",
+    "send": "Send"
+  },
   "inspector": {
     "contextAriaLabel": "Context inspector"
   },
@@ -19,10 +27,13 @@
     "openSettings": "Open settings",
     "primaryAriaLabel": "Primary navigation",
     "sessionListAriaLabel": "Session list",
+    "sessionListTitle": "Recent sessions",
     "settings": "Settings",
     "settingsAriaLabel": "Settings navigation",
     "settingsMenuAriaLabel": "Settings menu",
-    "skipToMain": "Skip to Main Content"
+    "skipToMain": "Skip to Main Content",
+    "taskListAriaLabel": "Task list",
+    "taskListTitle": "Tasks"
   },
   "settings": {
     "general": "General",
@@ -34,6 +45,7 @@
     "tasks": "Tasks"
   },
   "workbench": {
+    "emptyConversation": "Select a session to view the conversation.",
     "workspaceAriaLabel": "workspace"
   }
 }

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -2,6 +2,14 @@
   "app": {
     "name": "Heddle"
   },
+  "composer": {
+    "addContext": "添加上下文",
+    "model": "模型",
+    "placeholder": "发送后续消息",
+    "promptAriaLabel": "消息",
+    "reasoningEffort": "推理强度",
+    "send": "发送"
+  },
   "inspector": {
     "contextAriaLabel": "上下文检查器"
   },
@@ -19,10 +27,13 @@
     "openSettings": "打开设置",
     "primaryAriaLabel": "主导航",
     "sessionListAriaLabel": "会话列表",
+    "sessionListTitle": "最近会话",
     "settings": "设置",
     "settingsAriaLabel": "设置导航",
     "settingsMenuAriaLabel": "设置菜单",
-    "skipToMain": "跳到主要内容"
+    "skipToMain": "跳到主要内容",
+    "taskListAriaLabel": "任务列表",
+    "taskListTitle": "任务"
   },
   "settings": {
     "general": "通用",
@@ -34,6 +45,7 @@
     "tasks": "任务"
   },
   "workbench": {
+    "emptyConversation": "选择一个会话以查看对话内容。",
     "workspaceAriaLabel": "工作区"
   }
 }

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -2,6 +2,14 @@
   "app": {
     "name": "Heddle"
   },
+  "composer": {
+    "addContext": "加入脈絡",
+    "model": "模型",
+    "placeholder": "送出後續訊息",
+    "promptAriaLabel": "訊息",
+    "reasoningEffort": "推理強度",
+    "send": "送出"
+  },
   "inspector": {
     "contextAriaLabel": "脈絡檢視器"
   },
@@ -19,10 +27,13 @@
     "openSettings": "開啟設定",
     "primaryAriaLabel": "主要導覽",
     "sessionListAriaLabel": "對話清單",
+    "sessionListTitle": "最近對話",
     "settings": "設定",
     "settingsAriaLabel": "設定導覽",
     "settingsMenuAriaLabel": "設定選單",
-    "skipToMain": "跳到主要內容"
+    "skipToMain": "跳到主要內容",
+    "taskListAriaLabel": "任務清單",
+    "taskListTitle": "任務"
   },
   "settings": {
     "general": "一般",
@@ -34,6 +45,7 @@
     "tasks": "任務"
   },
   "workbench": {
+    "emptyConversation": "選擇一個對話以查看內容。",
     "workspaceAriaLabel": "工作區"
   }
 }

--- a/src/web-v2/layout/AppFrame.tsx
+++ b/src/web-v2/layout/AppFrame.tsx
@@ -10,6 +10,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '@web/components/ui/sidebar';
+import type { ControlPlaneState } from '@web/api/client';
 import { ContextInspector, ConversationWorkspace, SessionSidebar } from '@web/components/panels';
 import { useI18n } from '@web/i18n';
 import type { AppRoute, SettingsRoute } from '@web/layout/routes';
@@ -21,8 +22,12 @@ interface AppFrameProps {
   appNavigationItems: readonly AppRoute[];
   settingsNavigationItems: readonly SettingsRoute[];
   settingsOpen: boolean;
+  selectedSessionId?: string;
+  sessions: ControlPlaneState['sessions'];
+  tasks: ControlPlaneState['heartbeat']['tasks'];
   onOpenSettings: () => void;
   onCloseSettings: () => void;
+  onSelectSession: (sessionId: string) => void;
 }
 
 // AppFrame owns only shell placement. Workflow state should stay in feature
@@ -33,8 +38,12 @@ export function AppFrame({
   appNavigationItems,
   settingsNavigationItems,
   settingsOpen,
+  selectedSessionId,
+  sessions,
+  tasks,
   onOpenSettings,
   onCloseSettings,
+  onSelectSession,
   children,
 }: PropsWithChildren<AppFrameProps>) {
   const { t } = useI18n();
@@ -53,8 +62,12 @@ export function AppFrame({
           appNavigationItems={appNavigationItems}
           settingsNavigationItems={settingsNavigationItems}
           settingsOpen={settingsOpen}
+          selectedSessionId={selectedSessionId}
+          sessions={sessions}
+          tasks={tasks}
           onOpenSettings={onOpenSettings}
           onCloseSettings={onCloseSettings}
+          onSelectSession={onSelectSession}
         />
       </Sidebar>
 

--- a/src/web-v2/layout/AppRoutes.tsx
+++ b/src/web-v2/layout/AppRoutes.tsx
@@ -4,17 +4,25 @@ import {
   DEFAULT_APP_ROUTE,
   SETTINGS_ROUTES,
 } from '@web/layout/routes';
+import type { ControlPlaneSessionDetail } from '@web/hooks/useControlPlaneSessionDetail';
 import type { AppSurfaceId, SettingsSectionId } from '@web/layout/types';
 import { WorkbenchView } from '@web/views/WorkbenchView';
 
 interface AppRoutesProps {
   activeSurfaceId: AppSurfaceId;
   activeSettingsSectionId: SettingsSectionId;
+  selectedSession: ControlPlaneSessionDetail;
+  selectedSessionLoading: boolean;
 }
 
 // AppRoutes renders route config into v2 workbench views. Keep route inventory
 // and route rendering here so App remains only shell composition.
-export function AppRoutes({ activeSurfaceId, activeSettingsSectionId }: AppRoutesProps) {
+export function AppRoutes({
+  activeSurfaceId,
+  activeSettingsSectionId,
+  selectedSession,
+  selectedSessionLoading,
+}: AppRoutesProps) {
   return (
     <Routes>
       <Route path="/" element={<Navigate to={DEFAULT_APP_ROUTE} replace />} />
@@ -26,6 +34,8 @@ export function AppRoutes({ activeSurfaceId, activeSettingsSectionId }: AppRoute
             <WorkbenchView
               activeSurfaceId={route.id}
               activeSettingsSectionId={activeSettingsSectionId}
+              selectedSession={selectedSession}
+              selectedSessionLoading={selectedSessionLoading}
               settingsOpen={false}
             />
           )}
@@ -39,6 +49,8 @@ export function AppRoutes({ activeSurfaceId, activeSettingsSectionId }: AppRoute
             <WorkbenchView
               activeSurfaceId={activeSurfaceId}
               activeSettingsSectionId={route.id}
+              selectedSession={selectedSession}
+              selectedSessionLoading={selectedSessionLoading}
               settingsOpen
             />
           )}

--- a/src/web-v2/tailwind.css
+++ b/src/web-v2/tailwind.css
@@ -141,4 +141,226 @@
   .v2-resize-handle:hover {
     background: color-mix(in oklab, var(--color-border) 90%, transparent);
   }
+
+  .v2-message-row {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .v2-message-row-user {
+    justify-content: flex-end;
+  }
+
+  .v2-message-row-assistant {
+    justify-content: flex-start;
+  }
+
+  .v2-user-message-card {
+    max-width: min(42rem, 78%);
+    white-space: pre-wrap;
+    border-radius: var(--radius-xl);
+    background: color-mix(in oklab, var(--color-accent) 82%, var(--color-background));
+    padding: 0.75rem 0.875rem;
+    color: var(--color-foreground);
+    font-size: 0.9375rem;
+    line-height: 1.55;
+  }
+
+  .v2-assistant-article-shell {
+    width: 100%;
+    min-width: 0;
+    color: color-mix(in oklab, var(--color-foreground) 94%, transparent);
+  }
+
+  .v2-assistant-markdown {
+    max-width: 100%;
+    font-size: 0.9375rem;
+    line-height: 1.7;
+  }
+
+  .v2-assistant-markdown > :last-child {
+    margin-bottom: 0;
+  }
+
+  .v2-assistant-markdown p,
+  .v2-assistant-markdown ul,
+  .v2-assistant-markdown ol,
+  .v2-assistant-markdown pre,
+  .v2-assistant-markdown blockquote,
+  .v2-assistant-markdown table {
+    margin-bottom: 0.9rem;
+  }
+
+  .v2-assistant-markdown h1,
+  .v2-assistant-markdown h2,
+  .v2-assistant-markdown h3,
+  .v2-assistant-markdown h4 {
+    margin-top: 1.45rem;
+    margin-bottom: 0.55rem;
+    font-weight: 650;
+    line-height: 1.25;
+    color: var(--color-foreground);
+  }
+
+  .v2-assistant-markdown h1:first-child,
+  .v2-assistant-markdown h2:first-child,
+  .v2-assistant-markdown h3:first-child,
+  .v2-assistant-markdown h4:first-child {
+    margin-top: 0;
+  }
+
+  .v2-assistant-markdown h1 {
+    font-size: 1.35rem;
+  }
+
+  .v2-assistant-markdown h2 {
+    font-size: 1.15rem;
+  }
+
+  .v2-assistant-markdown h3 {
+    font-size: 1rem;
+  }
+
+  .v2-assistant-markdown ul,
+  .v2-assistant-markdown ol {
+    padding-left: 1.25rem;
+  }
+
+  .v2-assistant-markdown li + li {
+    margin-top: 0.25rem;
+  }
+
+  .v2-assistant-markdown a {
+    color: color-mix(in oklab, var(--color-foreground) 88%, hsl(210 100% 70%));
+    text-decoration-line: underline;
+    text-underline-offset: 0.18em;
+  }
+
+  .v2-assistant-markdown code {
+    border-radius: var(--radius-sm);
+    background: color-mix(in oklab, var(--color-muted) 88%, var(--color-background));
+    padding: 0.1rem 0.28rem;
+    font-family: var(--font-mono);
+    font-size: 0.86em;
+  }
+
+  .v2-assistant-markdown pre {
+    overflow: auto;
+    border-radius: var(--radius-lg);
+    border: 1px solid color-mix(in oklab, var(--color-border) 62%, transparent);
+    background: color-mix(in oklab, var(--color-background) 92%, black);
+    padding: 0.85rem;
+  }
+
+  .v2-assistant-markdown pre code {
+    border-radius: 0;
+    background: transparent;
+    padding: 0;
+    font-size: 0.8125rem;
+  }
+
+  .v2-assistant-markdown blockquote {
+    border-left: 2px solid color-mix(in oklab, var(--color-border) 86%, transparent);
+    color: var(--color-muted-foreground);
+    padding-left: 0.85rem;
+  }
+
+  .v2-assistant-markdown table {
+    display: block;
+    width: 100%;
+    overflow: auto;
+    border-collapse: collapse;
+  }
+
+  .v2-assistant-markdown th,
+  .v2-assistant-markdown td {
+    border: 1px solid color-mix(in oklab, var(--color-border) 70%, transparent);
+    padding: 0.4rem 0.55rem;
+    text-align: left;
+  }
+
+  .v2-assistant-markdown th {
+    background: color-mix(in oklab, var(--color-muted) 78%, transparent);
+  }
+
+  .v2-composer-region {
+    padding: 0 1.5rem 1.25rem;
+  }
+
+  .v2-composer-shell {
+    margin-inline: auto;
+    display: flex;
+    width: min(100%, 48rem);
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.375rem;
+    border-radius: 1.375rem;
+    border: 1px solid color-mix(in oklab, var(--color-border) 76%, transparent);
+    background: color-mix(in oklab, var(--color-card) 82%, var(--color-background));
+    padding: 0.625rem;
+    box-shadow: 0 18px 42px hsl(235 18% 3% / 0.26);
+  }
+
+  .v2-composer-textarea {
+    min-height: 3.125rem;
+    max-height: 11rem;
+    padding: 0.15rem 0.25rem;
+    font-size: 0.9375rem;
+    line-height: 1.55;
+  }
+
+  .v2-composer-toolbar {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .v2-composer-icon-button {
+    height: 2rem;
+    width: 2rem;
+    border-radius: 999px;
+    color: var(--color-muted-foreground);
+  }
+
+  .v2-composer-icon-button:hover {
+    background: color-mix(in oklab, var(--color-accent) 70%, transparent);
+    color: var(--color-foreground);
+  }
+
+  .v2-composer-select {
+    height: 2rem;
+    border-color: transparent;
+    background: transparent;
+    color: var(--color-muted-foreground);
+    box-shadow: none;
+  }
+
+  .v2-composer-select:hover {
+    border-color: transparent;
+    background: color-mix(in oklab, var(--color-accent) 58%, transparent);
+    color: var(--color-foreground);
+  }
+
+  .v2-composer-send-button {
+    height: 2rem;
+    width: 2rem;
+    min-width: 2rem;
+    border-radius: 999px;
+    padding: 0;
+    background: var(--color-primary);
+    color: var(--color-primary-foreground);
+    box-shadow: none;
+  }
+
+  .v2-composer-send-button:hover {
+    background: color-mix(in oklab, var(--color-primary) 92%, white);
+  }
+
+  .v2-composer-send-button:disabled {
+    background: color-mix(in oklab, var(--color-muted) 86%, var(--color-background));
+    color: var(--color-muted-foreground);
+    opacity: 1;
+  }
 }

--- a/src/web-v2/views/WorkbenchView.tsx
+++ b/src/web-v2/views/WorkbenchView.tsx
@@ -1,3 +1,5 @@
+import { ConversationThread } from '@web/components/conversation';
+import type { ControlPlaneSessionDetail } from '@web/hooks/useControlPlaneSessionDetail';
 import type { I18nMessageKey } from '@web/i18n';
 import { useI18n } from '@web/i18n';
 import type { AppSurfaceId, SettingsSectionId } from '@web/layout/types';
@@ -5,6 +7,8 @@ import type { AppSurfaceId, SettingsSectionId } from '@web/layout/types';
 interface WorkbenchViewProps {
   activeSurfaceId: AppSurfaceId;
   activeSettingsSectionId: SettingsSectionId;
+  selectedSession: ControlPlaneSessionDetail;
+  selectedSessionLoading: boolean;
   settingsOpen: boolean;
 }
 
@@ -19,18 +23,42 @@ const settingsSectionLabelKeys = {
   memory: 'settings.memory',
 } satisfies Record<SettingsSectionId, I18nMessageKey>;
 
-// WorkbenchView keeps the first v2 pass structural. It names the selected
-// surface while leaving workflow content and data loading to later slices.
-export function WorkbenchView({ activeSurfaceId, activeSettingsSectionId, settingsOpen }: WorkbenchViewProps) {
+// WorkbenchView renders the selected v2 surface while keeping data loading in
+// shell-level hooks so route views stay presentational.
+export function WorkbenchView({
+  activeSurfaceId,
+  activeSettingsSectionId,
+  selectedSession,
+  selectedSessionLoading,
+  settingsOpen,
+}: WorkbenchViewProps) {
   const { t } = useI18n();
-  const title = t(settingsOpen ? settingsSectionLabelKeys[activeSettingsSectionId] : appSurfaceLabelKeys[activeSurfaceId]);
+  const title =
+    !settingsOpen && activeSurfaceId === 'sessions' && selectedSession ?
+      selectedSession.name
+    : t(settingsOpen ? settingsSectionLabelKeys[activeSettingsSectionId] : appSurfaceLabelKeys[activeSurfaceId]);
+
+  const testId =
+    settingsOpen ? `web-v2-settings-${activeSettingsSectionId}` : `web-v2-surface-${activeSurfaceId}`;
 
   return (
-    <section className="flex h-full min-w-0 flex-col bg-background">
+    <section className="flex h-full min-w-0 flex-col bg-background" data-testid={testId}>
       <header className="v2-panel-header">
-        <h1 className="text-balance text-sm font-medium">{title}</h1>
+        <h1 className="text-balance text-sm font-medium" data-testid="web-v2-workbench-title">{title}</h1>
       </header>
-      <div className="min-h-0 flex-1 bg-background" aria-label={`${title} ${t('workbench.workspaceAriaLabel')}`} />
+      <div
+        className="min-h-0 flex-1 bg-background"
+        aria-label={`${title} ${t('workbench.workspaceAriaLabel')}`}
+        data-testid="web-v2-workbench-body"
+      >
+        {!settingsOpen && activeSurfaceId === 'sessions' ? (
+          <ConversationThread
+            emptyTitle={t('workbench.emptyConversation')}
+            loading={selectedSessionLoading}
+            session={selectedSession}
+          />
+        ) : null}
+      </div>
     </section>
   );
 }

--- a/src/web-v2/vite.config.ts
+++ b/src/web-v2/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
     port: 5174,
     allowedHosts: ['.ts.net'],
     proxy: {
+      '/trpc': {
+        target: process.env.HEDDLE_SERVER_URL ?? 'http://127.0.0.1:8765',
+        changeOrigin: true,
+      },
       '/control-plane': {
         target: process.env.HEDDLE_SERVER_URL ?? 'http://127.0.0.1:8765',
         changeOrigin: true,


### PR DESCRIPTION
## Summary
- wire web-v2 sidebar lists to control-plane sessions and heartbeat tasks
- render selected session conversations with v2-owned markdown/message components
- add the first visual-only composer with model and reasoning selectors
- add the missing web-v2 /trpc dev proxy

## Verification
- yarn client:v2:build