### PR TITLE
Add web v2 prompt streaming

### DIFF
--- a/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
+++ b/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
@@ -1,4 +1,15 @@
 import { expect, test } from '@playwright/test';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import type { AppRouter } from '../../../server/router';
+
+const serverPort = process.env.HEDDLE_BROWSER_INTEGRATION_SERVER_PORT ?? '19876';
+const trpc = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: `http://127.0.0.1:${serverPort}/trpc`,
+    }),
+  ],
+});
 
 test('loads the web v2 shell sections', async ({ page }) => {
   await page.goto('/sessions');
@@ -50,4 +61,17 @@ test('navigates primary and settings routes without hash routing', async ({ page
   await page.getByRole('button', { name: 'Back to App' }).click();
   await expect(page).toHaveURL(/\/sessions$/);
   await expect(page.getByTestId('web-v2-surface-sessions')).toBeVisible();
+});
+
+test('submits a prompt and renders the mocked session response', async ({ page }) => {
+  const session = await trpc.controlPlane.sessionCreate.mutate({ name: 'Web v2 submit smoke' });
+
+  await page.goto('/sessions');
+  await page.getByRole('button', { name: /Web v2 submit smoke/ }).click();
+  await page.getByRole('textbox', { name: 'Message' }).fill('Run the web v2 submit smoke');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText('Run the web v2 submit smoke', { exact: true })).toBeVisible();
+  await expect(page.getByText('Mocked browser integration agent response: Run the web v2 submit smoke', { exact: true })).toBeVisible();
+  await expect(page.getByTestId('web-v2-workbench-title')).toHaveText(session.name);
 });

--- a/src/web-v2/App.tsx
+++ b/src/web-v2/App.tsx
@@ -39,6 +39,11 @@ export function App() {
         activeSettingsSectionId={navigation.activeSettingsSectionId}
         selectedSession={selectedSession.session}
         selectedSessionLoading={selectedSession.loading}
+        selectedSessionSubmitting={selectedSession.submitting}
+        selectedSessionRunning={selectedSession.running}
+        selectedSessionLiveStatus={selectedSession.liveStatus}
+        selectedSessionError={selectedSession.error}
+        onSubmitSessionPrompt={selectedSession.submitPrompt}
       />
     </AppFrame>
   );

--- a/src/web-v2/api/client.ts
+++ b/src/web-v2/api/client.ts
@@ -13,3 +13,13 @@ export const trpc = createTRPCProxyClient<AppRouter>({
 export type RouterInputs = inferRouterInputs<AppRouter>;
 export type RouterOutputs = inferRouterOutputs<AppRouter>;
 export type ControlPlaneState = RouterOutputs['controlPlane']['state'];
+export type ControlPlaneSessionDetail = RouterOutputs['controlPlane']['session'];
+export type ControlPlaneSessionMessage = NonNullable<ControlPlaneSessionDetail>['messages'][number];
+export type ControlPlaneSessionSendPromptResult = RouterOutputs['controlPlane']['sessionSendPrompt'];
+
+export async function sendControlPlaneSessionPrompt(
+  sessionId: string,
+  prompt: string,
+): Promise<ControlPlaneSessionSendPromptResult> {
+  return await trpc.controlPlane.sessionSendPrompt.mutate({ sessionId, prompt });
+}

--- a/src/web-v2/components/conversation/ConversationComposer.tsx
+++ b/src/web-v2/components/conversation/ConversationComposer.tsx
@@ -32,9 +32,17 @@ type MockReasoningEffortValue = (typeof mockReasoningEfforts)[number]['value'];
 const composerTextareaMinHeight = 50;
 const composerTextareaMaxHeight = 176;
 
-// ConversationComposer is visual-only for this slice. Model and reasoning
-// options are local mocks until the v2 composer is wired to control-plane APIs.
-export function ConversationComposer() {
+// ConversationComposer owns the prompt draft and visual controls. Model and
+// reasoning options stay local mocks until v2 wires them to control-plane APIs.
+export function ConversationComposer({
+  disabled,
+  submitting,
+  onSubmitPrompt,
+}: {
+  disabled?: boolean;
+  submitting?: boolean;
+  onSubmitPrompt: (prompt: string) => Promise<void>;
+}) {
   const { t } = useI18n();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [draft, setDraft] = useState('');
@@ -53,16 +61,41 @@ export function ConversationComposer() {
     textarea.style.overflowY = textarea.scrollHeight > composerTextareaMaxHeight ? 'auto' : 'hidden';
   }, [draft]);
 
+  const sendDisabled = disabled || submitting || !draft.trim();
+
+  async function handleSubmit() {
+    const prompt = draft.trim();
+    if (!prompt || sendDisabled) {
+      return;
+    }
+
+    setDraft('');
+    await onSubmitPrompt(prompt);
+  }
+
   return (
-    <form className="v2-composer-shell" onSubmit={(event) => event.preventDefault()}>
+    <form
+      className="v2-composer-shell"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleSubmit();
+      }}
+    >
       <Textarea
         ref={textareaRef}
         aria-label={t('composer.promptAriaLabel')}
         className="v2-composer-textarea"
+        disabled={disabled || submitting}
         placeholder={t('composer.placeholder')}
         rows={2}
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && !event.shiftKey && !event.altKey && !event.metaKey) {
+            event.preventDefault();
+            void handleSubmit();
+          }
+        }}
       />
       <div className="v2-composer-toolbar">
         <Button
@@ -86,7 +119,7 @@ export function ConversationComposer() {
             size="none"
             className="v2-composer-send-button"
             aria-label={t('composer.send')}
-            disabled={!draft.trim()}
+            disabled={sendDisabled}
           >
             <ArrowUp aria-hidden="true" />
           </Button>

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -5,12 +5,25 @@ import { ConversationMessage } from './ConversationMessage';
 interface ConversationThreadProps {
   session: ControlPlaneSessionDetail;
   loading: boolean;
+  submitting: boolean;
+  running: boolean;
+  liveStatus?: string;
+  error?: string;
   emptyTitle: string;
+  onSubmitPrompt: (prompt: string) => Promise<void>;
 }
 
 // ConversationThread renders the selected session in the central work area.
-// It stays read-only until the composer and turn-running flow are introduced.
-export function ConversationThread({ session, loading, emptyTitle }: ConversationThreadProps) {
+export function ConversationThread({
+  session,
+  loading,
+  submitting,
+  running,
+  liveStatus,
+  error,
+  emptyTitle,
+  onSubmitPrompt,
+}: ConversationThreadProps) {
   if (loading && !session) {
     return (
       <div className="flex h-full min-w-0 flex-col">
@@ -18,7 +31,7 @@ export function ConversationThread({ session, loading, emptyTitle }: Conversatio
           {emptyTitle}
         </div>
         <div className="v2-composer-region">
-          <ConversationComposer />
+          <ConversationComposer disabled onSubmitPrompt={onSubmitPrompt} />
         </div>
       </div>
     );
@@ -31,7 +44,7 @@ export function ConversationThread({ session, loading, emptyTitle }: Conversatio
           {emptyTitle}
         </div>
         <div className="v2-composer-region">
-          <ConversationComposer />
+          <ConversationComposer disabled onSubmitPrompt={onSubmitPrompt} />
         </div>
       </div>
     );
@@ -44,10 +57,16 @@ export function ConversationThread({ session, loading, emptyTitle }: Conversatio
           {session.messages.map((message) => (
             <ConversationMessage key={message.id} message={message} />
           ))}
+          {liveStatus ? <p className="v2-live-status-line" data-testid="web-v2-live-status">{liveStatus}</p> : null}
+          {error ? <p className="v2-live-error-line" data-testid="web-v2-session-error">{error}</p> : null}
         </div>
       </div>
       <div className="v2-composer-region">
-        <ConversationComposer />
+        <ConversationComposer
+          disabled={running}
+          submitting={submitting}
+          onSubmitPrompt={onSubmitPrompt}
+        />
       </div>
     </div>
   );

--- a/src/web-v2/controllers/session-events/index.ts
+++ b/src/web-v2/controllers/session-events/index.ts
@@ -1,0 +1,7 @@
+export { SessionLiveEventPresenter } from './session-live-event-presenter';
+export { SessionEventStreamController } from './session-event-stream-controller';
+export type {
+  ControlPlaneSessionEventEnvelope,
+  LiveSessionEvent,
+  SessionLiveEventViewUpdate,
+} from './types';

--- a/src/web-v2/controllers/session-events/session-event-stream-controller.ts
+++ b/src/web-v2/controllers/session-events/session-event-stream-controller.ts
@@ -1,0 +1,37 @@
+import type { ControlPlaneSessionEventEnvelope } from './types';
+
+/**
+ * Browser-side controller for the control-plane session SSE stream. It keeps
+ * EventSource parsing outside React hooks so hooks only handle state updates.
+ */
+export class SessionEventStreamController {
+  static subscribe(
+    sessionId: string,
+    onUpdate: (event: ControlPlaneSessionEventEnvelope) => void,
+  ): () => void {
+    const source = new EventSource(`/control-plane/sessions/${encodeURIComponent(sessionId)}/events`);
+    const handle = (type: string) => (event: MessageEvent<string>) => {
+      try {
+        const parsed = JSON.parse(event.data) as { sessionId?: string; timestamp?: string; event?: unknown };
+        onUpdate({
+          type,
+          sessionId: parsed.sessionId ?? sessionId,
+          timestamp: parsed.timestamp,
+          event: parsed.event,
+        });
+      } catch {
+        onUpdate({ type, sessionId });
+      }
+    };
+
+    source.addEventListener('ready', handle('ready'));
+    source.addEventListener('waiting', handle('waiting'));
+    source.addEventListener('heartbeat', handle('heartbeat'));
+    source.addEventListener('session.updated', handle('session.updated'));
+    source.addEventListener('session.event', handle('session.event'));
+
+    return () => {
+      source.close();
+    };
+  }
+}

--- a/src/web-v2/controllers/session-events/session-live-event-presenter.ts
+++ b/src/web-v2/controllers/session-events/session-live-event-presenter.ts
@@ -1,0 +1,71 @@
+import type { LiveSessionEvent, SessionLiveEventViewUpdate } from './types';
+
+type SessionLiveEventPresenterFn = (event: LiveSessionEvent) => SessionLiveEventViewUpdate;
+type EventTypePresenterMap = Record<string, SessionLiveEventPresenterFn | undefined>;
+type CompactionStatusPresenterMap = Record<NonNullable<LiveSessionEvent['status']>, SessionLiveEventPresenterFn>;
+
+/**
+ * Presents raw control-plane live events as the tiny web-v2 conversation view
+ * update shape. It is intentionally browser-facing and should stay independent
+ * from core runtime classes.
+ */
+export class SessionLiveEventPresenter {
+  private static readonly eventTypePresenters: EventTypePresenterMap = {
+    'assistant.stream': (event) => ({
+      assistantText: event.text ?? '',
+      assistantDone: event.done,
+      status: event.done ? null : 'Receiving assistant response...',
+    }),
+    'loop.started': () => ({ running: true, status: 'Run started...' }),
+    'tool.calling': (event) => ({
+      status: `Working... running ${event.tool ?? 'tool'}${SessionLiveEventPresenter.formatStep(event.step)}`,
+    }),
+    'tool.completed': (event) => ({
+      status: `${event.tool ?? 'Tool'} finished${SessionLiveEventPresenter.formatDuration(event.durationMs)}`,
+    }),
+    trace: (event) => SessionLiveEventPresenter.presentTraceEvent(event),
+    'loop.finished': () => ({ running: false, refresh: true }),
+  };
+
+  private static readonly compactionStatusPresenters: CompactionStatusPresenterMap = {
+    running: (event) => ({
+      status: event.archivePath ? `Compacting earlier history... ${event.archivePath}` : 'Compacting earlier history...',
+    }),
+    failed: (event) => ({
+      status: event.error ? `Compaction failed: ${event.error}` : 'Compaction failed.',
+    }),
+    finished: (event) => ({
+      status: event.summaryPath ? `Compaction finished. Summary: ${event.summaryPath}` : 'Compaction finished.',
+    }),
+  };
+
+  private static readonly traceEventPresenters: EventTypePresenterMap = {
+    'tool.approval_requested': (event) => ({
+      status: `Approval requested for ${event.event?.call?.tool ?? 'tool'}`,
+    }),
+    'run.finished': () => ({ running: false, refresh: true }),
+  };
+
+  static present(event: LiveSessionEvent): SessionLiveEventViewUpdate {
+    const eventTypePresenter = event.type ? SessionLiveEventPresenter.eventTypePresenters[event.type] : undefined;
+    if (eventTypePresenter) {
+      return eventTypePresenter(event);
+    }
+
+    const compactionStatusPresenter = event.status ? SessionLiveEventPresenter.compactionStatusPresenters[event.status] : undefined;
+    return compactionStatusPresenter?.(event) ?? {};
+  }
+
+  private static presentTraceEvent(event: LiveSessionEvent): SessionLiveEventViewUpdate {
+    const tracePresenter = event.event?.type ? SessionLiveEventPresenter.traceEventPresenters[event.event.type] : undefined;
+    return tracePresenter?.(event) ?? {};
+  }
+
+  private static formatStep(step: number | undefined): string {
+    return typeof step === 'number' ? ` (step ${step})` : '';
+  }
+
+  private static formatDuration(durationMs: number | undefined): string {
+    return typeof durationMs === 'number' ? ` in ${Math.round(durationMs)}ms` : '';
+  }
+}

--- a/src/web-v2/controllers/session-events/types.ts
+++ b/src/web-v2/controllers/session-events/types.ts
@@ -1,0 +1,35 @@
+export type ControlPlaneSessionEventEnvelope = {
+  type: string;
+  sessionId: string;
+  timestamp?: string;
+  event?: unknown;
+};
+
+export type LiveSessionEvent = {
+  type?: string;
+  text?: string;
+  done?: boolean;
+  tool?: string;
+  step?: number;
+  durationMs?: number;
+  event?: {
+    type?: string;
+    summary?: string;
+    outcome?: string;
+    call?: {
+      tool?: string;
+    };
+  };
+  status?: 'running' | 'finished' | 'failed';
+  archivePath?: string;
+  summaryPath?: string;
+  error?: string;
+};
+
+export type SessionLiveEventViewUpdate = {
+  assistantText?: string;
+  assistantDone?: boolean;
+  status?: string | null;
+  running?: boolean;
+  refresh?: boolean;
+};

--- a/src/web-v2/controllers/session-messages/index.ts
+++ b/src/web-v2/controllers/session-messages/index.ts
@@ -1,0 +1,1 @@
+export { SessionMessageController } from './session-message-controller';

--- a/src/web-v2/controllers/session-messages/session-message-controller.ts
+++ b/src/web-v2/controllers/session-messages/session-message-controller.ts
@@ -1,0 +1,86 @@
+import type { ControlPlaneSessionDetail, ControlPlaneSessionMessage } from '@web/api/client';
+
+/**
+ * Shapes transient browser-only session messages around persisted session
+ * detail from the control-plane API.
+ */
+export class SessionMessageController {
+  static appendOptimisticUserTurn(session: ControlPlaneSessionDetail, prompt: string): ControlPlaneSessionDetail {
+    if (!session) {
+      return session;
+    }
+
+    return {
+      ...session,
+      messages: [
+        ...session.messages.filter((message) => !message.id.startsWith('live-')),
+        {
+          id: 'live-user',
+          role: 'user',
+          text: prompt,
+        },
+      ],
+    };
+  }
+
+  static upsertLiveAssistantMessage(
+    session: ControlPlaneSessionDetail,
+    text: string,
+    done: boolean | undefined,
+  ): ControlPlaneSessionDetail {
+    if (!session) {
+      return session;
+    }
+
+    const messages = session.messages.filter((message) => message.id !== 'live-run-status');
+    const lastMessage = messages.at(-1);
+    if (lastMessage?.id === 'live-assistant' && lastMessage.role === 'assistant') {
+      const nextMessages = [...messages];
+      nextMessages[nextMessages.length - 1] = SessionMessageController.createLiveAssistantMessage(text, done);
+      return {
+        ...session,
+        messages: nextMessages,
+      };
+    }
+
+    return {
+      ...session,
+      messages: [
+        ...messages,
+        SessionMessageController.createLiveAssistantMessage(text, done),
+      ],
+    };
+  }
+
+  static mergeTransientMessages(
+    current: ControlPlaneSessionDetail,
+    next: ControlPlaneSessionDetail,
+  ): ControlPlaneSessionDetail {
+    if (!current || !next || current.id !== next.id) {
+      return next;
+    }
+
+    const nextMessageIds = new Set(next.messages.map((message) => message.id));
+    const transientMessages = current.messages.filter((message) => (
+      message.id.startsWith('live-') && !nextMessageIds.has(message.id)
+    ));
+
+    return transientMessages.length ? {
+      ...next,
+      messages: [
+        ...next.messages,
+        ...transientMessages,
+      ],
+    } : next;
+  }
+
+  private static createLiveAssistantMessage(text: string, done: boolean | undefined): ControlPlaneSessionMessage {
+    return {
+      id: 'live-assistant',
+      role: 'assistant',
+      text,
+      isStreaming: !done,
+      isPending: !done,
+    };
+  }
+}

--- a/src/web-v2/hooks/useControlPlaneSessionDetail.ts
+++ b/src/web-v2/hooks/useControlPlaneSessionDetail.ts
@@ -1,46 +1,58 @@
-import { useEffect, useState } from 'react';
-import { trpc, type RouterOutputs } from '@web/api/client';
+import { useMemo, useState } from 'react';
+import type { ControlPlaneSessionDetail } from '@web/api/client';
+import { useControlPlaneSessionEvents } from './useControlPlaneSessionEvents';
+import { useControlPlaneSessionLoader } from './useControlPlaneSessionLoader';
+import { useControlPlaneSessionPromptSubmit } from './useControlPlaneSessionPromptSubmit';
 
-export type ControlPlaneSessionDetail = RouterOutputs['controlPlane']['session'];
+export type { ControlPlaneSessionDetail } from '@web/api/client';
 
 type ControlPlaneSessionDetailState = {
   session: ControlPlaneSessionDetail;
   loading: boolean;
+  submitting: boolean;
+  running: boolean;
+  error?: string;
+  liveStatus?: string;
+  submitPrompt: (prompt: string) => Promise<void>;
 };
 
-// useControlPlaneSessionDetail loads the selected conversation detail from the
-// same control-plane endpoint that web-v1 uses.
+// Composes the web-v2 session detail workflow from focused hooks: persisted
+// detail loading, live event subscription, and prompt submission.
 export function useControlPlaneSessionDetail(sessionId: string | undefined): ControlPlaneSessionDetailState {
-  const [state, setState] = useState<ControlPlaneSessionDetailState>({
-    session: null,
-    loading: false,
+  const [running, setRunning] = useState(false);
+  const [liveStatus, setLiveStatus] = useState<string | undefined>();
+  const loader = useControlPlaneSessionLoader(sessionId);
+  const promptSubmit = useControlPlaneSessionPromptSubmit({
+    sessionId,
+    setSession: loader.setSession,
+    setRunning,
+    setError: loader.setError,
+    setLiveStatus,
   });
 
-  useEffect(() => {
-    if (!sessionId) {
-      setState({ session: null, loading: false });
-      return;
-    }
+  useControlPlaneSessionEvents({
+    sessionId,
+    refresh: loader.refresh,
+    setSession: loader.setSession,
+    setRunning,
+    setLiveStatus,
+  });
 
-    let cancelled = false;
-    const id = sessionId;
-    setState((current) => ({ ...current, loading: true }));
-
-    async function load() {
-      const session = await trpc.controlPlane.session.query({ id });
-      if (cancelled) {
-        return;
-      }
-
-      setState({ session, loading: false });
-    }
-
-    void load();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionId]);
-
-  return state;
+  return useMemo(() => ({
+    session: loader.session,
+    loading: loader.loading,
+    submitting: promptSubmit.submitting,
+    running,
+    error: loader.error,
+    liveStatus,
+    submitPrompt: promptSubmit.submitPrompt,
+  }), [
+    liveStatus,
+    loader.error,
+    loader.loading,
+    loader.session,
+    promptSubmit.submitting,
+    promptSubmit.submitPrompt,
+    running,
+  ]);
 }

--- a/src/web-v2/hooks/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/useControlPlaneSessionEvents.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, type Dispatch, type SetStateAction } from 'react';
+import type { ControlPlaneSessionDetail } from '@web/api/client';
+import {
+  SessionLiveEventPresenter,
+  SessionEventStreamController,
+  type ControlPlaneSessionEventEnvelope,
+  type LiveSessionEvent,
+} from '@web/controllers/session-events';
+import { SessionMessageController } from '@web/controllers/session-messages';
+import type { RefreshControlPlaneSession } from './useControlPlaneSessionLoader';
+
+type UseControlPlaneSessionEventsArgs = {
+  sessionId?: string;
+  refresh: RefreshControlPlaneSession;
+  setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
+  setRunning: Dispatch<SetStateAction<boolean>>;
+  setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
+};
+
+// Subscribes to the selected session's live event stream and applies only the
+// web-v2 conversation state transitions that this interface currently renders.
+export function useControlPlaneSessionEvents({
+  sessionId,
+  refresh,
+  setSession,
+  setRunning,
+  setLiveStatus,
+}: UseControlPlaneSessionEventsArgs) {
+  const applySessionEvent = useCallback((event: ControlPlaneSessionEventEnvelope) => {
+    if (event.type === 'waiting') {
+      setLiveStatus('Waiting for the session event stream...');
+      return;
+    }
+
+    if (event.type !== 'session.event' || !event.event || typeof event.event !== 'object') {
+      return;
+    }
+
+    const viewUpdate = SessionLiveEventPresenter.present(event.event as LiveSessionEvent);
+    if (viewUpdate.assistantText !== undefined) {
+      setSession((current) => (
+        SessionMessageController.upsertLiveAssistantMessage(
+          current,
+          viewUpdate.assistantText ?? '',
+          viewUpdate.assistantDone,
+        )
+      ));
+    }
+    if (viewUpdate.status !== undefined) {
+      setLiveStatus(viewUpdate.status ?? undefined);
+    }
+    if (viewUpdate.running !== undefined) {
+      setRunning(viewUpdate.running);
+    }
+    if (viewUpdate.refresh) {
+      setLiveStatus(undefined);
+      void refresh(event.sessionId, { silent: true });
+    }
+  }, [refresh, setLiveStatus, setRunning, setSession]);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setRunning(false);
+      setLiveStatus(undefined);
+      return;
+    }
+
+    return SessionEventStreamController.subscribe(sessionId, (event) => {
+      if (event.type === 'session.updated') {
+        void refresh(sessionId, { silent: true });
+        return;
+      }
+
+      applySessionEvent(event);
+    });
+  }, [applySessionEvent, refresh, sessionId, setLiveStatus, setRunning]);
+}

--- a/src/web-v2/hooks/useControlPlaneSessionLoader.ts
+++ b/src/web-v2/hooks/useControlPlaneSessionLoader.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { trpc, type ControlPlaneSessionDetail } from '@web/api/client';
+import { SessionMessageController } from '@web/controllers/session-messages';
+
+export type RefreshControlPlaneSession = (
+  sessionId: string,
+  options?: { silent?: boolean },
+) => Promise<void>;
+
+export type ControlPlaneSessionLoaderState = {
+  session: ControlPlaneSessionDetail;
+  loading: boolean;
+  error?: string;
+  setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
+  setError: Dispatch<SetStateAction<string | undefined>>;
+  refresh: RefreshControlPlaneSession;
+};
+
+// Loads persisted session detail and preserves browser-only transient messages
+// during silent refreshes triggered by session file or stream events.
+export function useControlPlaneSessionLoader(sessionId: string | undefined): ControlPlaneSessionLoaderState {
+  const [session, setSession] = useState<ControlPlaneSessionDetail>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  const refresh = useCallback<RefreshControlPlaneSession>(async (id, options = {}) => {
+    if (!options.silent) {
+      setLoading(true);
+    }
+
+    try {
+      const next = await trpc.controlPlane.session.query({ id });
+      setSession((current) => (
+        options.silent ? SessionMessageController.mergeTransientMessages(current, next) : next
+      ));
+      setError(undefined);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : String(loadError));
+    } finally {
+      if (!options.silent) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setSession(null);
+      setLoading(false);
+      setError(undefined);
+      return;
+    }
+
+    void refresh(sessionId);
+  }, [refresh, sessionId]);
+
+  return {
+    session,
+    loading,
+    error,
+    setSession,
+    setError,
+    refresh,
+  };
+}

--- a/src/web-v2/hooks/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/useControlPlaneSessionPromptSubmit.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { sendControlPlaneSessionPrompt, type ControlPlaneSessionDetail } from '@web/api/client';
+import { SessionMessageController } from '@web/controllers/session-messages';
+
+type UseControlPlaneSessionPromptSubmitArgs = {
+  sessionId?: string;
+  setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
+  setRunning: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<string | undefined>>;
+  setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
+};
+
+export type ControlPlaneSessionPromptSubmitState = {
+  submitting: boolean;
+  submitPrompt: (prompt: string) => Promise<void>;
+};
+
+// Owns prompt mutation state and optimistic conversation updates for web-v2.
+export function useControlPlaneSessionPromptSubmit({
+  sessionId,
+  setSession,
+  setRunning,
+  setError,
+  setLiveStatus,
+}: UseControlPlaneSessionPromptSubmitArgs): ControlPlaneSessionPromptSubmitState {
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setSubmitting(false);
+  }, [sessionId]);
+
+  const submitPrompt = useCallback(async (prompt: string) => {
+    const trimmed = prompt.trim();
+    if (!sessionId || !trimmed || submitting) {
+      return;
+    }
+
+    setSubmitting(true);
+    setRunning(true);
+    setError(undefined);
+    setLiveStatus('Heddle is working...');
+    setSession((current) => SessionMessageController.appendOptimisticUserTurn(current, trimmed));
+
+    try {
+      const result = await sendControlPlaneSessionPrompt(sessionId, trimmed);
+      setSession(result.session);
+      setRunning(false);
+      setLiveStatus(undefined);
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : String(submitError));
+      setRunning(false);
+      setLiveStatus(undefined);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [sessionId, setError, setLiveStatus, setRunning, setSession, submitting]);
+
+  return {
+    submitting,
+    submitPrompt,
+  };
+}

--- a/src/web-v2/layout/AppRoutes.tsx
+++ b/src/web-v2/layout/AppRoutes.tsx
@@ -13,6 +13,11 @@ interface AppRoutesProps {
   activeSettingsSectionId: SettingsSectionId;
   selectedSession: ControlPlaneSessionDetail;
   selectedSessionLoading: boolean;
+  selectedSessionSubmitting: boolean;
+  selectedSessionRunning: boolean;
+  selectedSessionLiveStatus?: string;
+  selectedSessionError?: string;
+  onSubmitSessionPrompt: (prompt: string) => Promise<void>;
 }
 
 // AppRoutes renders route config into v2 workbench views. Keep route inventory
@@ -22,6 +27,11 @@ export function AppRoutes({
   activeSettingsSectionId,
   selectedSession,
   selectedSessionLoading,
+  selectedSessionSubmitting,
+  selectedSessionRunning,
+  selectedSessionLiveStatus,
+  selectedSessionError,
+  onSubmitSessionPrompt,
 }: AppRoutesProps) {
   return (
     <Routes>
@@ -36,7 +46,12 @@ export function AppRoutes({
               activeSettingsSectionId={activeSettingsSectionId}
               selectedSession={selectedSession}
               selectedSessionLoading={selectedSessionLoading}
+              selectedSessionSubmitting={selectedSessionSubmitting}
+              selectedSessionRunning={selectedSessionRunning}
+              selectedSessionLiveStatus={selectedSessionLiveStatus}
+              selectedSessionError={selectedSessionError}
               settingsOpen={false}
+              onSubmitSessionPrompt={onSubmitSessionPrompt}
             />
           )}
         />
@@ -51,7 +66,12 @@ export function AppRoutes({
               activeSettingsSectionId={route.id}
               selectedSession={selectedSession}
               selectedSessionLoading={selectedSessionLoading}
+              selectedSessionSubmitting={selectedSessionSubmitting}
+              selectedSessionRunning={selectedSessionRunning}
+              selectedSessionLiveStatus={selectedSessionLiveStatus}
+              selectedSessionError={selectedSessionError}
               settingsOpen
+              onSubmitSessionPrompt={onSubmitSessionPrompt}
             />
           )}
         />

--- a/src/web-v2/tailwind.css
+++ b/src/web-v2/tailwind.css
@@ -284,6 +284,17 @@
     background: color-mix(in oklab, var(--color-muted) 78%, transparent);
   }
 
+  .v2-live-status-line,
+  .v2-live-error-line {
+    color: var(--color-muted-foreground);
+    font-size: 0.8125rem;
+    line-height: 1.45;
+  }
+
+  .v2-live-error-line {
+    color: color-mix(in oklab, var(--color-destructive) 82%, var(--color-foreground));
+  }
+
   .v2-composer-region {
     padding: 0 1.5rem 1.25rem;
   }

--- a/src/web-v2/views/WorkbenchView.tsx
+++ b/src/web-v2/views/WorkbenchView.tsx
@@ -9,7 +9,12 @@ interface WorkbenchViewProps {
   activeSettingsSectionId: SettingsSectionId;
   selectedSession: ControlPlaneSessionDetail;
   selectedSessionLoading: boolean;
+  selectedSessionSubmitting: boolean;
+  selectedSessionRunning: boolean;
+  selectedSessionLiveStatus?: string;
+  selectedSessionError?: string;
   settingsOpen: boolean;
+  onSubmitSessionPrompt: (prompt: string) => Promise<void>;
 }
 
 const appSurfaceLabelKeys = {
@@ -30,7 +35,12 @@ export function WorkbenchView({
   activeSettingsSectionId,
   selectedSession,
   selectedSessionLoading,
+  selectedSessionSubmitting,
+  selectedSessionRunning,
+  selectedSessionLiveStatus,
+  selectedSessionError,
   settingsOpen,
+  onSubmitSessionPrompt,
 }: WorkbenchViewProps) {
   const { t } = useI18n();
   const title =
@@ -54,8 +64,13 @@ export function WorkbenchView({
         {!settingsOpen && activeSurfaceId === 'sessions' ? (
           <ConversationThread
             emptyTitle={t('workbench.emptyConversation')}
+            error={selectedSessionError}
+            liveStatus={selectedSessionLiveStatus}
             loading={selectedSessionLoading}
+            running={selectedSessionRunning}
             session={selectedSession}
+            submitting={selectedSessionSubmitting}
+            onSubmitPrompt={onSubmitSessionPrompt}
           />
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- wire web v2 composer submit to the control-plane session prompt mutation
- subscribe to session SSE events for optimistic user turns, assistant stream text, and one-line live status updates
- add a web-v2 browser integration smoke test for prompt submit/rendering

## Verification
- yarn client:v2:build
- yarn build
- yarn lint
- env HEDDLE_BROWSER_INTEGRATION_CLIENT_PORT=25174 HEDDLE_BROWSER_INTEGRATION_CLIENT_V2_PORT=25175 HEDDLE_BROWSER_INTEGRATION_SERVER_PORT=29876 yarn test:browser-integration:v2