### PR TITLE
[codex] Fix web-v2 session highlight

### DIFF
--- a/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
+++ b/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
@@ -71,7 +71,10 @@ test('submits a prompt and renders the mocked session response', async ({ page }
   const session = await trpc.controlPlane.sessionCreate.mutate({ name: 'Web v2 submit smoke' });
 
   await page.goto('/sessions');
-  await page.getByRole('button', { name: /Web v2 submit smoke/ }).click();
+  const sessionListItem = page.getByRole('button', { name: /Web v2 submit smoke/ });
+  await sessionListItem.click();
+  await expect(sessionListItem).toHaveAttribute('aria-current', 'true');
+  await expect(sessionListItem).toHaveClass(/bg-sidebar-accent/);
   await page.getByRole('textbox', { name: 'Message' }).fill('Run the web v2 submit smoke');
   await page.getByRole('button', { name: 'Send' }).click();
 

--- a/src/web-v2/components/navigation/SessionListSection.tsx
+++ b/src/web-v2/components/navigation/SessionListSection.tsx
@@ -1,4 +1,5 @@
 import type { ControlPlaneState } from '@web/api/client';
+import { cn } from '@web/lib/utils';
 
 interface SessionListSectionProps {
   selectedSessionId?: string;
@@ -18,22 +19,46 @@ export function SessionListSection({ selectedSessionId, sessions, title, onSelec
         {title}
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-auto">
-        {sessions.map((session) => (
-          <button
-            key={session.id}
-            type="button"
-            aria-current={selectedSessionId === session.id ? 'page' : undefined}
-            className="group flex w-full min-w-0 flex-col rounded-md px-2 py-1.5 text-left outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring aria-current-page:bg-sidebar-accent aria-current-page:text-sidebar-accent-foreground"
-            onClick={() => onSelectSession(session.id)}
-          >
-            <span className="w-full truncate text-sm font-medium leading-5 text-sidebar-foreground group-hover:text-sidebar-accent-foreground">
-              {session.name}
-            </span>
-            <span className="w-full truncate text-xs leading-4 text-muted-foreground">
-              {session.lastSummary ?? session.lastPrompt ?? session.model ?? session.id}
-            </span>
-          </button>
-        ))}
+        {sessions.map((session) => {
+          const selected = selectedSessionId === session.id;
+
+          return (
+            <button
+              key={session.id}
+              type="button"
+              aria-current={selected ? 'true' : undefined}
+              className={cn(
+                'group relative flex w-full min-w-0 flex-col rounded-md py-1.5 pl-4 pr-2 text-left outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring',
+                selected && 'bg-sidebar-accent text-sidebar-accent-foreground',
+              )}
+              onClick={() => onSelectSession(session.id)}
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'absolute bottom-1.5 left-1 top-1.5 w-0.5 rounded-full bg-transparent',
+                  selected && 'bg-sidebar-accent-foreground',
+                )}
+              />
+              <span
+                className={cn(
+                  'w-full truncate text-sm font-medium leading-5 text-sidebar-foreground group-hover:text-sidebar-accent-foreground',
+                  selected && 'text-sidebar-accent-foreground',
+                )}
+              >
+                {session.name}
+              </span>
+              <span
+                className={cn(
+                  'w-full truncate text-xs leading-4 text-muted-foreground',
+                  selected && 'text-sidebar-accent-foreground/75',
+                )}
+              >
+                {session.lastSummary ?? session.lastPrompt ?? session.model ?? session.id}
+              </span>
+            </button>
+          );
+        })}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- make the selected web-v2 session row render an explicit active state
- add a left active indicator and selected text colors
- assert the selected row state in the web-v2 browser integration smoke

## Why
Selecting a session updated the workbench, but the left sidebar did not clearly show which session was active. The previous styling depended on an aria-current utility that did not provide a reliable visible affordance.

## Validation
- yarn test:browser-integration:v2

## Notes
- yarn client:v2:build is currently blocked by an unrelated TypeScript error in src/web-v2/hooks/useControlPlaneSessionEvents.ts around the run.finished activity handler type.