### PR TITLE
[codex] Add web-v2 tool approval UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "client:dev": "vite --config src/web/vite.config.ts",
     "client:v2:build": "tsc -p src/web-v2/tsconfig.json --noEmit && vite build --config src/web-v2/vite.config.ts",
     "client:v2:dev": "vite --config src/web-v2/vite.config.ts",
-    "server:dev": "tsx --no-cache src/server/dev.ts",
+    "server:dev": "tsx watch --clear-screen=false --no-cache src/server/dev.ts",
     "daemon:dev": "tsx --no-cache src/cli/main.ts daemon --assets-dir dist/src/web",
     "verify:tui-behavior": "node --import tsx/esm scripts/verify-tui-behavior.tsx",
     "verify:tui-session-boundary": "yarn verify:tui-behavior",

--- a/src/server/features/control-plane/controllers/chat-sessions-controller.ts
+++ b/src/server/features/control-plane/controllers/chat-sessions-controller.ts
@@ -247,7 +247,7 @@ export class ControlPlaneChatSessionsController {
 
   resolvePendingApproval(
     sessionId: string,
-    decision: { approved: boolean; reason?: string },
+    decision: ToolApprovalUserDecision,
   ): boolean {
     const pending = this.pendingApprovals.get(sessionId);
     if (!pending) {
@@ -257,9 +257,7 @@ export class ControlPlaneChatSessionsController {
     this.pendingApprovals.delete(sessionId);
     // This resolves the promise created by ToolApprovalService.requestHumanApproval.
     // The paused agent turn resumes immediately after this call returns.
-    pending.resolve(decision.approved
-      ? { type: 'approve', reason: decision.reason }
-      : { type: 'deny', reason: decision.reason });
+    pending.resolve(decision);
     return true;
   }
 

--- a/src/server/features/control-plane/router.ts
+++ b/src/server/features/control-plane/router.ts
@@ -62,8 +62,20 @@ const turnReviewInputSchema = z.object({
 
 const sessionApprovalDecisionSchema = z.object({
   sessionId: z.string().min(1),
-  approved: z.boolean(),
-  reason: z.string().optional(),
+  decision: z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('approve'),
+      reason: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal('deny'),
+      reason: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal('approve_and_remember_project'),
+      reason: z.string().optional(),
+    }),
+  ]),
 });
 
 const sessionSettingsInputSchema = z.object({
@@ -201,10 +213,7 @@ export const controlPlaneRouter = router({
   }),
   sessionResolveApproval: procedure.input(sessionApprovalDecisionSchema).mutation(({ input }) => {
     return {
-      resolved: controlPlaneChatSessionsController.resolvePendingApproval(input.sessionId, {
-        approved: input.approved,
-        reason: input.reason,
-      }),
+      resolved: controlPlaneChatSessionsController.resolvePendingApproval(input.sessionId, input.decision),
     };
   }),
   sessionCancel: procedure.input(sessionInputSchema).mutation(({ input }) => {

--- a/src/web-v2/App.tsx
+++ b/src/web-v2/App.tsx
@@ -9,7 +9,9 @@ import { APP_ROUTES, SETTINGS_ROUTES } from '@web/layout/routes';
 
 export function App() {
   const navigation = useWorkbenchNavigation();
+  const utils = trpcReact.useUtils();
   const stateQuery = trpcReact.controlPlane.state.useQuery();
+  const createSessionMutation = trpcReact.controlPlane.sessionCreate.useMutation();
   const sidebarSessions = useMemo(
     () => stateQuery.data?.sessions ?? [],
     [stateQuery.data?.sessions],
@@ -33,6 +35,12 @@ export function App() {
     setSelectedSessionId(sidebarSessions[0]?.id);
   }, [selectedSessionId, sidebarSessions]);
 
+  async function createSession() {
+    const session = await createSessionMutation.mutateAsync();
+    setSelectedSessionId(session.id);
+    await utils.controlPlane.state.invalidate();
+  }
+
   return (
     <AppFrame
       activeSurfaceId={navigation.activeSurfaceId}
@@ -45,6 +53,7 @@ export function App() {
       tasks={sidebarTasks}
       onOpenSettings={navigation.openSettings}
       onCloseSettings={navigation.closeSettings}
+      onCreateSession={createSession}
       onSelectSession={setSelectedSessionId}
     >
       <AppRoutes
@@ -54,7 +63,11 @@ export function App() {
         selectedSessionLoading={selectedSession.loading}
         selectedSessionSubmitting={selectedSession.submitting}
         selectedSessionLiveStatus={selectedSession.liveStatus}
+        selectedSessionPendingApproval={selectedSession.pendingApproval}
+        selectedSessionApprovalResolving={selectedSession.approvalResolving}
+        selectedSessionApprovalError={selectedSession.approvalError}
         onSubmitSessionPrompt={selectedSession.submitPrompt}
+        onResolveSessionApproval={selectedSession.resolvePendingApproval}
       />
     </AppFrame>
   );

--- a/src/web-v2/api/client.ts
+++ b/src/web-v2/api/client.ts
@@ -34,4 +34,6 @@ export type ControlPlaneState = RouterOutputs['controlPlane']['state'];
 export type ControlPlaneSessionDetail = RouterOutputs['controlPlane']['session'];
 export type ControlPlaneSessionEventEnvelope = AsyncIterableValue<RouterOutputs['controlPlane']['sessionEvents']>;
 export type ControlPlaneSessionMessage = NonNullable<ControlPlaneSessionDetail>['messages'][number];
+export type ControlPlanePendingApproval = RouterOutputs['controlPlane']['sessionPendingApproval'];
+export type ControlPlaneApprovalDecision = RouterInputs['controlPlane']['sessionResolveApproval']['decision'];
 export type ControlPlaneSessionSendPromptResult = RouterOutputs['controlPlane']['sessionSendPrompt'];

--- a/src/web-v2/components/conversation/ApprovalPanel.tsx
+++ b/src/web-v2/components/conversation/ApprovalPanel.tsx
@@ -1,0 +1,137 @@
+import { BookmarkCheck, Check, ShieldAlert, XCircle } from 'lucide-react';
+import type { ControlPlaneApprovalDecision, ControlPlanePendingApproval } from '@web/hooks/useControlPlaneSessionDetail';
+import { Button } from '@web/components/ui/button';
+import { useI18n } from '@web/i18n';
+
+type PendingApproval = NonNullable<ControlPlanePendingApproval>;
+
+type ApprovalPanelProps = {
+  approval: PendingApproval;
+  resolving: boolean;
+  error?: string;
+  onResolve: (decision: ControlPlaneApprovalDecision) => Promise<void>;
+};
+
+export function ApprovalPanel({ approval, resolving, error, onResolve }: ApprovalPanelProps) {
+  const { t } = useI18n();
+  const detail = resolveApprovalDetail(approval.input, {
+    command: t('approval.command'),
+    path: t('approval.path'),
+  });
+  const rawPayload = detail ? undefined : formatRawPayload(approval.input);
+  const rememberLabel = approval.rememberProjectApproval?.label;
+
+  return (
+    <section className="v2-approval-panel" aria-label={t('approval.ariaLabel')}>
+      <div className="v2-approval-main">
+        <div className="v2-approval-header">
+          <ShieldAlert aria-hidden="true" className="size-4" />
+          <div className="min-w-0">
+            <h2 className="text-balance text-sm font-semibold text-foreground">{t('approval.title')}</h2>
+            <p className="truncate text-xs text-muted-foreground">{approval.summary}</p>
+          </div>
+        </div>
+
+        <dl className="v2-approval-details">
+          <ApprovalMeta label={t('approval.tool')} value={approval.tool} />
+          {detail ? <ApprovalMeta label={detail.label} value={detail.value} monospace /> : null}
+          {approval.reason ? <ApprovalMeta label={t('approval.reason')} value={approval.reason} /> : null}
+        </dl>
+      </div>
+
+      <div className="v2-approval-actions">
+        <Button
+          type="button"
+          size="sm"
+          disabled={resolving}
+          onClick={() => void onResolve({ type: 'approve', reason: 'Approved in web-v2' })}
+        >
+          <Check aria-hidden="true" />
+          {t('approval.approveOnce')}
+        </Button>
+        {rememberLabel ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            disabled={resolving}
+            onClick={() => void onResolve({
+              type: 'approve_and_remember_project',
+              reason: 'Approved and remembered for this project in web-v2',
+            })}
+          >
+            <BookmarkCheck aria-hidden="true" />
+            {rememberLabel}
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          size="sm"
+          variant="destructive"
+          disabled={resolving}
+          onClick={() => void onResolve({ type: 'deny', reason: 'Denied in web-v2' })}
+        >
+          <XCircle aria-hidden="true" />
+          {t('approval.deny')}
+        </Button>
+      </div>
+
+      {approval.editPreview ? (
+        <details className="v2-approval-disclosure">
+          <summary>
+            {approval.editPreview.action}: {approval.editPreview.path}
+            {approval.editPreview.truncated ? ` (${t('approval.truncated')})` : ''}
+          </summary>
+          <pre className="v2-approval-code">{approval.editPreview.diff}</pre>
+        </details>
+      ) : null}
+
+      {rawPayload ? (
+        <details className="v2-approval-disclosure">
+          <summary>{t('approval.payload')}</summary>
+          <pre className="v2-approval-code">{rawPayload}</pre>
+        </details>
+      ) : null}
+
+      {error ? <p className="v2-approval-error" role="alert">{error}</p> : null}
+    </section>
+  );
+}
+
+function ApprovalMeta({ label, value, monospace }: { label: string; value: string; monospace?: boolean }) {
+  return (
+    <div className="v2-approval-meta-row">
+      <dt>{label}</dt>
+      <dd className={monospace ? 'font-mono' : undefined}>{value}</dd>
+    </div>
+  );
+}
+
+function resolveApprovalDetail(
+  input: unknown,
+  labels: { command: string; path: string },
+): { label: string; value: string } | undefined {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return undefined;
+  }
+
+  const record = input as Record<string, unknown>;
+  if (typeof record.command === 'string' && record.command.trim()) {
+    return { label: labels.command, value: record.command };
+  }
+
+  if (typeof record.path === 'string' && record.path.trim()) {
+    return { label: labels.path, value: record.path };
+  }
+
+  return undefined;
+}
+
+function formatRawPayload(input: unknown): string | undefined {
+  if (input === undefined || input === null) {
+    return undefined;
+  }
+
+  const serialized = typeof input === 'string' ? input : JSON.stringify(input, null, 2);
+  return serialized.length > 1600 ? `${serialized.slice(0, 1600)}...` : serialized;
+}

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -1,4 +1,9 @@
-import type { ControlPlaneSessionDetail } from '@web/hooks/useControlPlaneSessionDetail';
+import type {
+  ControlPlaneApprovalDecision,
+  ControlPlanePendingApproval,
+  ControlPlaneSessionDetail,
+} from '@web/hooks/useControlPlaneSessionDetail';
+import { ApprovalPanel } from './ApprovalPanel';
 import { ConversationComposer } from './ConversationComposer';
 import { ConversationMessage } from './ConversationMessage';
 import { Loader2 } from 'lucide-react';
@@ -8,8 +13,12 @@ interface ConversationThreadProps {
   loading: boolean;
   submitting: boolean;
   liveStatus?: string;
+  pendingApproval: ControlPlanePendingApproval;
+  approvalResolving: boolean;
+  approvalError?: string;
   emptyTitle: string;
   onSubmitPrompt: (prompt: string) => Promise<void>;
+  onResolveApproval: (decision: ControlPlaneApprovalDecision) => Promise<void>;
 }
 
 // ConversationThread renders the selected session in the central work area.
@@ -18,8 +27,12 @@ export function ConversationThread({
   loading,
   submitting,
   liveStatus,
+  pendingApproval,
+  approvalResolving,
+  approvalError,
   emptyTitle,
   onSubmitPrompt,
+  onResolveApproval,
 }: ConversationThreadProps) {
   if (loading && !session) {
     return (
@@ -66,8 +79,19 @@ export function ConversationThread({
           {liveStatus ? <p className="v2-live-status-line" data-testid="web-v2-live-status">{liveStatus}</p> : null}
         </div>
       </div>
+      {pendingApproval ? (
+        <div className="v2-approval-region">
+          <ApprovalPanel
+            approval={pendingApproval}
+            error={approvalError}
+            resolving={approvalResolving}
+            onResolve={onResolveApproval}
+          />
+        </div>
+      ) : null}
       <div className="v2-composer-region">
         <ConversationComposer
+          disabled={Boolean(pendingApproval)}
           submitting={submitting}
           onSubmitPrompt={onSubmitPrompt}
         />

--- a/src/web-v2/components/conversation/index.ts
+++ b/src/web-v2/components/conversation/index.ts
@@ -1,4 +1,5 @@
 export { AssistantMarkdown } from './AssistantMarkdown';
+export { ApprovalPanel } from './ApprovalPanel';
 export { ConversationComposer } from './ConversationComposer';
 export { ConversationMessage } from './ConversationMessage';
 export { ConversationThread } from './ConversationThread';

--- a/src/web-v2/components/navigation/AppNavigation.tsx
+++ b/src/web-v2/components/navigation/AppNavigation.tsx
@@ -20,6 +20,7 @@ interface AppNavigationProps {
   sessions: ControlPlaneState['sessions'];
   tasks: ControlPlaneState['heartbeat']['tasks'];
   onOpenSettings: () => void;
+  onCreateSession: () => Promise<void>;
   onSelectSession: (sessionId: string) => void;
 }
 
@@ -32,6 +33,7 @@ export function AppNavigation({
   sessions,
   tasks,
   onOpenSettings,
+  onCreateSession,
   onSelectSession,
 }: AppNavigationProps) {
   const { t } = useI18n();
@@ -53,6 +55,7 @@ export function AppNavigation({
           taskListTitle={t('navigation.taskListTitle')}
           sessions={sessions}
           tasks={tasks}
+          onCreateSession={onCreateSession}
           onSelectSession={onSelectSession}
         />
       </SidebarContent>

--- a/src/web-v2/components/navigation/SessionListSection.tsx
+++ b/src/web-v2/components/navigation/SessionListSection.tsx
@@ -1,20 +1,42 @@
 import type { ControlPlaneState } from '@web/api/client';
+import { Button } from '@web/components/ui/button';
+import { useI18n } from '@web/i18n';
 import { cn } from '@web/lib/utils';
+import { Plus } from 'lucide-react';
 
 interface SessionListSectionProps {
   selectedSessionId?: string;
   sessions: ControlPlaneState['sessions'];
   title: string;
+  onCreateSession: () => Promise<void>;
   onSelectSession: (sessionId: string) => void;
 }
 
 // SessionListSection renders the left-rail session list using the same view
 // shape returned by the control-plane tRPC sessions endpoint.
-export function SessionListSection({ selectedSessionId, sessions, title, onSelectSession }: SessionListSectionProps) {
+export function SessionListSection({
+  selectedSessionId,
+  sessions,
+  title,
+  onCreateSession,
+  onSelectSession,
+}: SessionListSectionProps) {
+  const { t } = useI18n();
+
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-1 px-2 py-2" aria-label={title}>
+      <Button
+        type="button"
+        variant="ghost"
+        size="none"
+        className="v2-sidebar-action"
+        onClick={() => void onCreateSession()}
+      >
+        <Plus aria-hidden="true" />
+        <span>{t('navigation.newChat')}</span>
+      </Button>
       <div
-        className="px-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-normal text-muted-foreground"
+        className="px-2 pt-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-normal text-muted-foreground"
       >
         {title}
       </div>

--- a/src/web-v2/components/navigation/SidebarContentRegion.tsx
+++ b/src/web-v2/components/navigation/SidebarContentRegion.tsx
@@ -11,6 +11,7 @@ interface SidebarContentRegionProps {
   taskListTitle: string;
   sessions: ControlPlaneState['sessions'];
   tasks: ControlPlaneState['heartbeat']['tasks'];
+  onCreateSession: () => Promise<void>;
   onSelectSession: (sessionId: string) => void;
 }
 
@@ -24,6 +25,7 @@ export function SidebarContentRegion({
   taskListTitle,
   sessions,
   tasks,
+  onCreateSession,
   onSelectSession,
 }: SidebarContentRegionProps) {
   return (
@@ -38,6 +40,7 @@ export function SidebarContentRegion({
           selectedSessionId={selectedSessionId}
           sessions={sessions}
           title={sessionListTitle}
+          onCreateSession={onCreateSession}
           onSelectSession={onSelectSession}
         />
       )}

--- a/src/web-v2/components/panels/SessionSidebar.tsx
+++ b/src/web-v2/components/panels/SessionSidebar.tsx
@@ -14,6 +14,7 @@ interface SessionSidebarProps {
   tasks: ControlPlaneState['heartbeat']['tasks'];
   onOpenSettings: () => void;
   onCloseSettings: () => void;
+  onCreateSession: () => Promise<void>;
   onSelectSession: (sessionId: string) => void;
 }
 
@@ -30,6 +31,7 @@ export function SessionSidebar({
   tasks,
   onOpenSettings,
   onCloseSettings,
+  onCreateSession,
   onSelectSession,
 }: SessionSidebarProps) {
   return (
@@ -48,6 +50,7 @@ export function SessionSidebar({
           sessions={sessions}
           tasks={tasks}
           onOpenSettings={onOpenSettings}
+          onCreateSession={onCreateSession}
           onSelectSession={onSelectSession}
         />
       )}

--- a/src/web-v2/hooks/useControlPlanePendingApproval.ts
+++ b/src/web-v2/hooks/useControlPlanePendingApproval.ts
@@ -1,0 +1,64 @@
+import { skipToken } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  trpcReact,
+  type ControlPlaneApprovalDecision,
+  type ControlPlanePendingApproval,
+} from '@web/api/client';
+
+export type ControlPlanePendingApprovalState = {
+  pendingApproval: ControlPlanePendingApproval;
+  approvalResolving: boolean;
+  approvalError?: string;
+  refreshPendingApproval: (sessionId: string) => void;
+  resolvePendingApproval: (decision: ControlPlaneApprovalDecision) => Promise<void>;
+};
+
+export function useControlPlanePendingApproval(sessionId: string | undefined): ControlPlanePendingApprovalState {
+  const utils = trpcReact.useUtils();
+  const [approvalError, setApprovalError] = useState<string | undefined>();
+  const pendingApprovalQuery = trpcReact.controlPlane.sessionPendingApproval.useQuery(
+    sessionId ? { id: sessionId } : skipToken,
+    {
+      enabled: Boolean(sessionId),
+      refetchOnWindowFocus: false,
+    },
+  );
+  const resolveApprovalMutation = trpcReact.controlPlane.sessionResolveApproval.useMutation();
+
+  useEffect(() => {
+    setApprovalError(undefined);
+  }, [sessionId]);
+
+  const refreshPendingApproval = useCallback((targetSessionId: string) => {
+    void utils.controlPlane.sessionPendingApproval.invalidate({ id: targetSessionId });
+  }, [utils]);
+
+  const resolvePendingApproval = useCallback(async (decision: ControlPlaneApprovalDecision) => {
+    if (!sessionId) {
+      return;
+    }
+
+    setApprovalError(undefined);
+    try {
+      const result = await resolveApprovalMutation.mutateAsync({
+        sessionId,
+        decision,
+      });
+      if (!result.resolved) {
+        throw new Error('No pending approval found for this session.');
+      }
+      await utils.controlPlane.sessionPendingApproval.invalidate({ id: sessionId });
+    } catch (error) {
+      setApprovalError(error instanceof Error ? error.message : String(error));
+    }
+  }, [resolveApprovalMutation, sessionId, utils]);
+
+  return {
+    pendingApproval: pendingApprovalQuery.data ?? null,
+    approvalResolving: resolveApprovalMutation.isPending,
+    approvalError,
+    refreshPendingApproval,
+    resolvePendingApproval,
+  };
+}

--- a/src/web-v2/hooks/useControlPlanePendingApproval.ts
+++ b/src/web-v2/hooks/useControlPlanePendingApproval.ts
@@ -14,13 +14,24 @@ export type ControlPlanePendingApprovalState = {
   resolvePendingApproval: (decision: ControlPlaneApprovalDecision) => Promise<void>;
 };
 
-export function useControlPlanePendingApproval(sessionId: string | undefined): ControlPlanePendingApprovalState {
+type UseControlPlanePendingApprovalOptions = {
+  pollingEnabled?: boolean;
+};
+
+export function useControlPlanePendingApproval(
+  sessionId: string | undefined,
+  options: UseControlPlanePendingApprovalOptions = {},
+): ControlPlanePendingApprovalState {
   const utils = trpcReact.useUtils();
   const [approvalError, setApprovalError] = useState<string | undefined>();
   const pendingApprovalQuery = trpcReact.controlPlane.sessionPendingApproval.useQuery(
     sessionId ? { id: sessionId } : skipToken,
     {
       enabled: Boolean(sessionId),
+      // The live stream is only a notification channel. Poll while a run is
+      // active so a prompt submitted during subscription setup still discovers
+      // server-held approval requests.
+      refetchInterval: options.pollingEnabled ? 750 : false,
       refetchOnWindowFocus: false,
     },
   );

--- a/src/web-v2/hooks/useControlPlaneSessionDetail.ts
+++ b/src/web-v2/hooks/useControlPlaneSessionDetail.ts
@@ -2,9 +2,10 @@ import { useMemo, useState } from 'react';
 import type { ControlPlaneSessionDetail } from '@web/api/client';
 import { useControlPlaneSessionEvents } from './useControlPlaneSessionEvents';
 import { useControlPlaneSessionLoader } from './useControlPlaneSessionLoader';
+import { useControlPlanePendingApproval } from './useControlPlanePendingApproval';
 import { useControlPlaneSessionPromptSubmit } from './useControlPlaneSessionPromptSubmit';
 
-export type { ControlPlaneSessionDetail } from '@web/api/client';
+export type { ControlPlaneApprovalDecision, ControlPlanePendingApproval, ControlPlaneSessionDetail } from '@web/api/client';
 
 type ControlPlaneSessionDetailState = {
   session: ControlPlaneSessionDetail;
@@ -13,7 +14,11 @@ type ControlPlaneSessionDetailState = {
   running: boolean;
   error?: string;
   liveStatus?: string;
+  pendingApproval: ReturnType<typeof useControlPlanePendingApproval>['pendingApproval'];
+  approvalResolving: boolean;
+  approvalError?: string;
   submitPrompt: (prompt: string) => Promise<void>;
+  resolvePendingApproval: ReturnType<typeof useControlPlanePendingApproval>['resolvePendingApproval'];
 };
 
 // Composes the web-v2 session detail workflow from focused hooks: persisted
@@ -22,9 +27,11 @@ export function useControlPlaneSessionDetail(sessionId: string | undefined): Con
   const [running, setRunning] = useState(false);
   const [liveStatus, setLiveStatus] = useState<string | undefined>();
   const loader = useControlPlaneSessionLoader(sessionId);
+  const approval = useControlPlanePendingApproval(sessionId);
   const events = useControlPlaneSessionEvents({
     sessionId,
     refresh: loader.refresh,
+    refreshPendingApproval: approval.refreshPendingApproval,
     setSession: loader.setSession,
     setRunning,
     setLiveStatus,
@@ -45,8 +52,16 @@ export function useControlPlaneSessionDetail(sessionId: string | undefined): Con
     running,
     error: loader.error,
     liveStatus,
+    pendingApproval: approval.pendingApproval,
+    approvalResolving: approval.approvalResolving,
+    approvalError: approval.approvalError,
     submitPrompt: promptSubmit.submitPrompt,
+    resolvePendingApproval: approval.resolvePendingApproval,
   }), [
+    approval.approvalError,
+    approval.approvalResolving,
+    approval.pendingApproval,
+    approval.resolvePendingApproval,
     liveStatus,
     loader.error,
     loader.loading,

--- a/src/web-v2/hooks/useControlPlaneSessionDetail.ts
+++ b/src/web-v2/hooks/useControlPlaneSessionDetail.ts
@@ -27,7 +27,9 @@ export function useControlPlaneSessionDetail(sessionId: string | undefined): Con
   const [running, setRunning] = useState(false);
   const [liveStatus, setLiveStatus] = useState<string | undefined>();
   const loader = useControlPlaneSessionLoader(sessionId);
-  const approval = useControlPlanePendingApproval(sessionId);
+  const approval = useControlPlanePendingApproval(sessionId, {
+    pollingEnabled: running,
+  });
   const events = useControlPlaneSessionEvents({
     sessionId,
     refresh: loader.refresh,

--- a/src/web-v2/hooks/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/useControlPlaneSessionEvents.ts
@@ -11,6 +11,7 @@ import type { RefreshControlPlaneSession } from './useControlPlaneSessionLoader'
 type UseControlPlaneSessionEventsArgs = {
   sessionId?: string;
   refresh: RefreshControlPlaneSession;
+  refreshPendingApproval: (sessionId: string) => void;
   setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
   setRunning: Dispatch<SetStateAction<boolean>>;
   setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
@@ -25,6 +26,7 @@ export type ControlPlaneSessionEventsState = {
 export function useControlPlaneSessionEvents({
   sessionId,
   refresh,
+  refreshPendingApproval,
   setSession,
   setRunning,
   setLiveStatus,
@@ -48,11 +50,12 @@ export function useControlPlaneSessionEvents({
     event.activities?.forEach((activity) => applySessionActivity(activity, {
       sessionId: event.sessionId,
       refresh,
+      refreshPendingApproval,
       setLiveStatus,
       setRunning,
       setSession,
     }));
-  }, [refresh, setLiveStatus, setRunning, setSession]);
+  }, [refresh, refreshPendingApproval, setLiveStatus, setRunning, setSession]);
 
   const subscription = trpcReact.controlPlane.sessionEvents.useSubscription(
     sessionId ? { sessionId } : skipToken,
@@ -93,6 +96,7 @@ export function useControlPlaneSessionEvents({
 type SessionActivityContext = {
   sessionId: string;
   refresh: RefreshControlPlaneSession;
+  refreshPendingApproval: (sessionId: string) => void;
   setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
   setRunning: Dispatch<SetStateAction<boolean>>;
   setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
@@ -132,13 +136,13 @@ const sessionActivityHandlers: SessionActivityHandlerMap = {
   'tool.completed': (activity, { setLiveStatus }) => {
     setLiveStatus(`${activity.tool} finished in ${Math.round(activity.durationMs)}ms`);
   },
-  'tool.approval_requested': (activity, { setLiveStatus }) => {
+  'tool.approval_requested': (activity, { sessionId, refreshPendingApproval, setLiveStatus }) => {
+    refreshPendingApproval(sessionId);
     setLiveStatus(`Approval requested for ${activity.derived?.kind === 'tool-summary' ? activity.derived.summary : activity.call.tool}`);
   },
-  'run.finished': (_activity, { sessionId, refresh, setRunning, setLiveStatus }) => {
-    setRunning(false);
-    setLiveStatus(undefined);
-    void refresh(sessionId, { silent: true });
+  'tool.approval_resolved': (_activity, { sessionId, refreshPendingApproval, setLiveStatus }) => {
+    refreshPendingApproval(sessionId);
+    setLiveStatus('Approval resolved. Resuming...');
   },
   'compaction.running': (activity, { setLiveStatus }) => {
     setLiveStatus(activity.archivePath ? `Compacting earlier history... ${activity.archivePath}` : 'Compacting earlier history...');

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -2,6 +2,19 @@
   "app": {
     "name": "Heddle"
   },
+  "approval": {
+    "approveOnce": "Approve once",
+    "ariaLabel": "Pending tool approval",
+    "command": "Command",
+    "deny": "Deny",
+    "path": "Path",
+    "payload": "Payload",
+    "reason": "Reason",
+    "requestedAt": "Requested",
+    "title": "Approval required",
+    "tool": "Tool",
+    "truncated": "truncated"
+  },
   "composer": {
     "addContext": "Add context",
     "model": "Model",
@@ -24,6 +37,7 @@
     "collapseSidebar": "Collapse sidebar",
     "expandSidebar": "Expand sidebar",
     "mainAriaLabel": "Main app navigation",
+    "newChat": "New chat",
     "openSettings": "Open settings",
     "primaryAriaLabel": "Primary navigation",
     "sessionListAriaLabel": "Session list",

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -2,6 +2,19 @@
   "app": {
     "name": "Heddle"
   },
+  "approval": {
+    "approveOnce": "批准一次",
+    "ariaLabel": "待批准工具请求",
+    "command": "命令",
+    "deny": "拒绝",
+    "path": "路径",
+    "payload": "载荷",
+    "reason": "原因",
+    "requestedAt": "请求时间",
+    "title": "需要批准",
+    "tool": "工具",
+    "truncated": "已截断"
+  },
   "composer": {
     "addContext": "添加上下文",
     "model": "模型",
@@ -24,6 +37,7 @@
     "collapseSidebar": "收起侧边栏",
     "expandSidebar": "展开侧边栏",
     "mainAriaLabel": "主应用导航",
+    "newChat": "新建会话",
     "openSettings": "打开设置",
     "primaryAriaLabel": "主导航",
     "sessionListAriaLabel": "会话列表",

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -2,6 +2,19 @@
   "app": {
     "name": "Heddle"
   },
+  "approval": {
+    "approveOnce": "核准一次",
+    "ariaLabel": "待核准工具請求",
+    "command": "指令",
+    "deny": "拒絕",
+    "path": "路徑",
+    "payload": "承載資料",
+    "reason": "原因",
+    "requestedAt": "請求時間",
+    "title": "需要核准",
+    "tool": "工具",
+    "truncated": "已截斷"
+  },
   "composer": {
     "addContext": "加入脈絡",
     "model": "模型",
@@ -24,6 +37,7 @@
     "collapseSidebar": "收合側邊欄",
     "expandSidebar": "展開側邊欄",
     "mainAriaLabel": "主要應用導覽",
+    "newChat": "新增對話",
     "openSettings": "開啟設定",
     "primaryAriaLabel": "主要導覽",
     "sessionListAriaLabel": "對話清單",

--- a/src/web-v2/layout/AppFrame.tsx
+++ b/src/web-v2/layout/AppFrame.tsx
@@ -27,6 +27,7 @@ interface AppFrameProps {
   tasks: ControlPlaneState['heartbeat']['tasks'];
   onOpenSettings: () => void;
   onCloseSettings: () => void;
+  onCreateSession: () => Promise<void>;
   onSelectSession: (sessionId: string) => void;
 }
 
@@ -43,6 +44,7 @@ export function AppFrame({
   tasks,
   onOpenSettings,
   onCloseSettings,
+  onCreateSession,
   onSelectSession,
   children,
 }: PropsWithChildren<AppFrameProps>) {
@@ -67,6 +69,7 @@ export function AppFrame({
           tasks={tasks}
           onOpenSettings={onOpenSettings}
           onCloseSettings={onCloseSettings}
+          onCreateSession={onCreateSession}
           onSelectSession={onSelectSession}
         />
       </Sidebar>

--- a/src/web-v2/layout/AppRoutes.tsx
+++ b/src/web-v2/layout/AppRoutes.tsx
@@ -4,7 +4,11 @@ import {
   DEFAULT_APP_ROUTE,
   SETTINGS_ROUTES,
 } from '@web/layout/routes';
-import type { ControlPlaneSessionDetail } from '@web/hooks/useControlPlaneSessionDetail';
+import type {
+  ControlPlaneApprovalDecision,
+  ControlPlanePendingApproval,
+  ControlPlaneSessionDetail,
+} from '@web/hooks/useControlPlaneSessionDetail';
 import type { AppSurfaceId, SettingsSectionId } from '@web/layout/types';
 import { WorkbenchView } from '@web/views/WorkbenchView';
 
@@ -15,7 +19,11 @@ interface AppRoutesProps {
   selectedSessionLoading: boolean;
   selectedSessionSubmitting: boolean;
   selectedSessionLiveStatus?: string;
+  selectedSessionPendingApproval: ControlPlanePendingApproval;
+  selectedSessionApprovalResolving: boolean;
+  selectedSessionApprovalError?: string;
   onSubmitSessionPrompt: (prompt: string) => Promise<void>;
+  onResolveSessionApproval: (decision: ControlPlaneApprovalDecision) => Promise<void>;
 }
 
 // AppRoutes renders route config into v2 workbench views. Keep route inventory
@@ -27,7 +35,11 @@ export function AppRoutes({
   selectedSessionLoading,
   selectedSessionSubmitting,
   selectedSessionLiveStatus,
+  selectedSessionPendingApproval,
+  selectedSessionApprovalResolving,
+  selectedSessionApprovalError,
   onSubmitSessionPrompt,
+  onResolveSessionApproval,
 }: AppRoutesProps) {
   return (
     <Routes>
@@ -44,8 +56,12 @@ export function AppRoutes({
               selectedSessionLoading={selectedSessionLoading}
               selectedSessionSubmitting={selectedSessionSubmitting}
               selectedSessionLiveStatus={selectedSessionLiveStatus}
+              selectedSessionPendingApproval={selectedSessionPendingApproval}
+              selectedSessionApprovalResolving={selectedSessionApprovalResolving}
+              selectedSessionApprovalError={selectedSessionApprovalError}
               settingsOpen={false}
               onSubmitSessionPrompt={onSubmitSessionPrompt}
+              onResolveSessionApproval={onResolveSessionApproval}
             />
           )}
         />
@@ -62,8 +78,12 @@ export function AppRoutes({
               selectedSessionLoading={selectedSessionLoading}
               selectedSessionSubmitting={selectedSessionSubmitting}
               selectedSessionLiveStatus={selectedSessionLiveStatus}
+              selectedSessionPendingApproval={selectedSessionPendingApproval}
+              selectedSessionApprovalResolving={selectedSessionApprovalResolving}
+              selectedSessionApprovalError={selectedSessionApprovalError}
               settingsOpen
               onSubmitSessionPrompt={onSubmitSessionPrompt}
+              onResolveSessionApproval={onResolveSessionApproval}
             />
           )}
         />

--- a/src/web-v2/tailwind.css
+++ b/src/web-v2/tailwind.css
@@ -127,6 +127,24 @@
     transition: flex-basis 160ms ease, width 160ms ease;
   }
 
+  .v2-sidebar-action {
+    display: inline-flex;
+    width: 100%;
+    height: 1.875rem;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.5rem;
+    border-radius: var(--radius-md);
+    padding-inline: 0.5rem;
+    color: var(--color-sidebar-foreground);
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .v2-sidebar-action:hover {
+    background: color-mix(in oklab, var(--color-accent) 70%, transparent);
+  }
+
   .v2-popover-surface {
     border-radius: var(--radius-xl);
     border: 1px solid color-mix(in oklab, var(--color-border) 76%, transparent);
@@ -293,6 +311,109 @@
 
   .v2-live-error-line {
     color: color-mix(in oklab, var(--color-destructive) 82%, var(--color-foreground));
+  }
+
+  .v2-approval-region {
+    padding: 0 1.5rem 0.5rem;
+  }
+
+  .v2-approval-panel {
+    margin-inline: auto;
+    display: grid;
+    width: min(100%, 48rem);
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.625rem 0.875rem;
+    align-items: center;
+    border-radius: var(--radius-lg);
+    border: 1px solid color-mix(in oklab, var(--color-border) 80%, transparent);
+    background: color-mix(in oklab, var(--color-card) 72%, var(--color-background));
+    padding: 0.625rem 0.75rem;
+  }
+
+  .v2-approval-main {
+    display: grid;
+    min-width: 0;
+    gap: 0.375rem;
+  }
+
+  .v2-approval-header {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--color-foreground);
+  }
+
+  .v2-approval-details {
+    display: flex;
+    min-width: 0;
+    flex-wrap: wrap;
+    gap: 0.375rem 0.875rem;
+    margin: 0;
+  }
+
+  .v2-approval-meta-row {
+    display: inline-flex;
+    min-width: 0;
+    max-width: 100%;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    line-height: 1.45;
+  }
+
+  .v2-approval-meta-row dt {
+    color: var(--color-muted-foreground);
+  }
+
+  .v2-approval-meta-row dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--color-foreground);
+  }
+
+  .v2-approval-disclosure {
+    grid-column: 1 / -1;
+    border-radius: var(--radius-md);
+    border: 1px solid color-mix(in oklab, var(--color-border) 70%, transparent);
+    background: color-mix(in oklab, var(--color-background) 72%, var(--color-card));
+    padding: 0.5rem 0.625rem;
+  }
+
+  .v2-approval-disclosure summary {
+    cursor: pointer;
+    color: var(--color-muted-foreground);
+    font-size: 0.75rem;
+    line-height: 1.4;
+  }
+
+  .v2-approval-code {
+    max-height: 11rem;
+    margin-top: 0.5rem;
+    overflow: auto;
+    border-radius: var(--radius-sm);
+    background: var(--color-background);
+    padding: 0.625rem;
+    color: color-mix(in oklab, var(--color-foreground) 90%, transparent);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.55;
+  }
+
+  .v2-approval-error {
+    grid-column: 1 / -1;
+    margin: 0;
+    color: color-mix(in oklab, var(--color-destructive) 86%, var(--color-foreground));
+    font-size: 0.8125rem;
+    line-height: 1.45;
+  }
+
+  .v2-approval-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.5rem;
   }
 
   .v2-composer-region {

--- a/src/web-v2/views/WorkbenchView.tsx
+++ b/src/web-v2/views/WorkbenchView.tsx
@@ -1,5 +1,9 @@
 import { ConversationThread } from '@web/components/conversation';
-import type { ControlPlaneSessionDetail } from '@web/hooks/useControlPlaneSessionDetail';
+import type {
+  ControlPlaneApprovalDecision,
+  ControlPlanePendingApproval,
+  ControlPlaneSessionDetail,
+} from '@web/hooks/useControlPlaneSessionDetail';
 import type { I18nMessageKey } from '@web/i18n';
 import { useI18n } from '@web/i18n';
 import type { AppSurfaceId, SettingsSectionId } from '@web/layout/types';
@@ -11,8 +15,12 @@ interface WorkbenchViewProps {
   selectedSessionLoading: boolean;
   selectedSessionSubmitting: boolean;
   selectedSessionLiveStatus?: string;
+  selectedSessionPendingApproval: ControlPlanePendingApproval;
+  selectedSessionApprovalResolving: boolean;
+  selectedSessionApprovalError?: string;
   settingsOpen: boolean;
   onSubmitSessionPrompt: (prompt: string) => Promise<void>;
+  onResolveSessionApproval: (decision: ControlPlaneApprovalDecision) => Promise<void>;
 }
 
 const appSurfaceLabelKeys = {
@@ -35,8 +43,12 @@ export function WorkbenchView({
   selectedSessionLoading,
   selectedSessionSubmitting,
   selectedSessionLiveStatus,
+  selectedSessionPendingApproval,
+  selectedSessionApprovalResolving,
+  selectedSessionApprovalError,
   settingsOpen,
   onSubmitSessionPrompt,
+  onResolveSessionApproval,
 }: WorkbenchViewProps) {
   const { t } = useI18n();
   const title =
@@ -62,9 +74,13 @@ export function WorkbenchView({
             emptyTitle={t('workbench.emptyConversation')}
             liveStatus={selectedSessionLiveStatus}
             loading={selectedSessionLoading}
+            pendingApproval={selectedSessionPendingApproval}
+            approvalResolving={selectedSessionApprovalResolving}
+            approvalError={selectedSessionApprovalError}
             session={selectedSession}
             submitting={selectedSessionSubmitting}
             onSubmitPrompt={onSubmitSessionPrompt}
+            onResolveApproval={onResolveSessionApproval}
           />
         ) : null}
       </div>

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -106,7 +106,13 @@ export async function resolvePendingSessionApproval(
   approved: boolean,
   reason?: string,
 ): Promise<{ resolved: boolean }> {
-  return await trpc.controlPlane.sessionResolveApproval.mutate({ sessionId, approved, reason });
+  return await trpc.controlPlane.sessionResolveApproval.mutate({
+    sessionId,
+    decision: {
+      type: approved ? 'approve' : 'deny',
+      reason,
+    },
+  });
 }
 
 export async function fetchWorkspaceFileSuggestions(query: string): Promise<WorkspaceFileSuggestion[]> {


### PR DESCRIPTION
## Summary

- add web-v2 pending tool approval API wiring and compact approval panel
- resolve approvals using the core `ToolApprovalUserDecision` shape instead of the old boolean payload
- add a `New chat` button above recent sessions for fresh test sessions
- make `yarn server:dev` run `tsx watch` so the dev server reloads after server code changes

## Validation

- `git diff --check`
- `yarn typecheck`
- `yarn client:v2:build`
- `yarn test:unit src/__tests__/unit/core/approval-policy-chain.test.ts src/__tests__/unit/tui/approval-flow.test.tsx`

Note: `yarn client:v2:build` still emits the existing Vite chunk-size warning, but the build succeeds.
