### PR TITLE
[codex] Add resizable web-v2 side panels

### DIFF
--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -65,7 +65,7 @@ export function ConversationThread({
 
   return (
     <div className="flex h-full min-w-0 flex-col">
-      <div className="min-h-0 flex-1 overflow-auto">
+      <div className="v2-scrollbar-hidden min-h-0 flex-1 overflow-auto">
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-6 py-8">
           {loading ? (
             <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">

--- a/src/web-v2/components/navigation/SessionListSection.tsx
+++ b/src/web-v2/components/navigation/SessionListSection.tsx
@@ -40,7 +40,7 @@ export function SessionListSection({
       >
         {title}
       </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-auto">
+      <div className="v2-scrollbar-hidden flex min-h-0 flex-1 flex-col gap-0.5 overflow-auto">
         {sessions.map((session) => {
           const selected = selectedSessionId === session.id;
 

--- a/src/web-v2/components/navigation/TaskListSection.tsx
+++ b/src/web-v2/components/navigation/TaskListSection.tsx
@@ -15,7 +15,7 @@ export function TaskListSection({ tasks, title }: TaskListSectionProps) {
       >
         {title}
       </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-auto">
+      <div className="v2-scrollbar-hidden flex min-h-0 flex-1 flex-col gap-0.5 overflow-auto">
         {tasks.map((task) => (
           <button
             key={task.taskId}

--- a/src/web-v2/components/panels/ConversationWorkspace.tsx
+++ b/src/web-v2/components/panels/ConversationWorkspace.tsx
@@ -4,7 +4,7 @@ import type { PropsWithChildren } from 'react';
 // Feature views render inside it and should stay API-backed.
 export function ConversationWorkspace({ children }: PropsWithChildren) {
   return (
-    <main id="main-content" className="h-full min-w-0">
+    <main id="main-content" className="h-full min-h-0 min-w-0 overflow-hidden">
       {children}
     </main>
   );

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -24,7 +24,9 @@
     "send": "Send"
   },
   "inspector": {
-    "contextAriaLabel": "Context inspector"
+    "collapsePanel": "Collapse context inspector",
+    "contextAriaLabel": "Context inspector",
+    "expandPanel": "Expand context inspector"
   },
   "language": {
     "enUs": "English (US)",

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -24,7 +24,9 @@
     "send": "发送"
   },
   "inspector": {
-    "contextAriaLabel": "上下文检查器"
+    "collapsePanel": "收起上下文检查器",
+    "contextAriaLabel": "上下文检查器",
+    "expandPanel": "展开上下文检查器"
   },
   "language": {
     "enUs": "英文（美国）",

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -24,7 +24,9 @@
     "send": "送出"
   },
   "inspector": {
-    "contextAriaLabel": "脈絡檢視器"
+    "collapsePanel": "收合脈絡檢視器",
+    "contextAriaLabel": "脈絡檢視器",
+    "expandPanel": "展開脈絡檢視器"
   },
   "language": {
     "enUs": "英文（美國）",

--- a/src/web-v2/layout/AppFrame.tsx
+++ b/src/web-v2/layout/AppFrame.tsx
@@ -1,4 +1,6 @@
-import type { PropsWithChildren } from 'react';
+import { useRef, useState, type PropsWithChildren } from 'react';
+import { PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen } from 'lucide-react';
+import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels';
 import {
   ResizableHandle,
   ResizablePanel,
@@ -8,9 +10,10 @@ import {
   Sidebar,
   SidebarInset,
   SidebarProvider,
-  SidebarTrigger,
+  useSidebar,
 } from '@web/components/ui/sidebar';
 import type { ControlPlaneState } from '@web/api/client';
+import { Button } from '@web/components/ui/button';
 import { ContextInspector, ConversationWorkspace, SessionSidebar } from '@web/components/panels';
 import { useI18n } from '@web/i18n';
 import type { AppRoute, SettingsRoute } from '@web/layout/routes';
@@ -48,47 +51,172 @@ export function AppFrame({
   onSelectSession,
   children,
 }: PropsWithChildren<AppFrameProps>) {
+  return (
+    <SidebarProvider className="v2-shell h-dvh overflow-hidden bg-background font-sans text-foreground">
+      <AppFramePanels
+        activeSurfaceId={activeSurfaceId}
+        activeSettingsSectionId={activeSettingsSectionId}
+        appNavigationItems={appNavigationItems}
+        settingsNavigationItems={settingsNavigationItems}
+        settingsOpen={settingsOpen}
+        selectedSessionId={selectedSessionId}
+        sessions={sessions}
+        tasks={tasks}
+        onOpenSettings={onOpenSettings}
+        onCloseSettings={onCloseSettings}
+        onCreateSession={onCreateSession}
+        onSelectSession={onSelectSession}
+      >
+        {children}
+      </AppFramePanels>
+    </SidebarProvider>
+  );
+}
+
+function AppFramePanels({
+  activeSurfaceId,
+  activeSettingsSectionId,
+  appNavigationItems,
+  settingsNavigationItems,
+  settingsOpen,
+  selectedSessionId,
+  sessions,
+  tasks,
+  onOpenSettings,
+  onCloseSettings,
+  onCreateSession,
+  onSelectSession,
+  children,
+}: PropsWithChildren<AppFrameProps>) {
   const { t } = useI18n();
+  const { setOpen: setSidebarOpen } = useSidebar();
+  const sidebarPanelRef = useRef<PanelImperativeHandle | null>(null);
+  const inspectorPanelRef = useRef<PanelImperativeHandle | null>(null);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
+
+  function toggleSidebarPanel() {
+    if (sidebarCollapsed) {
+      sidebarPanelRef.current?.expand();
+      setSidebarOpen(true);
+      setSidebarCollapsed(false);
+      return;
+    }
+
+    sidebarPanelRef.current?.collapse();
+    setSidebarOpen(false);
+    setSidebarCollapsed(true);
+  }
+
+  function toggleInspectorPanel() {
+    if (inspectorCollapsed) {
+      inspectorPanelRef.current?.expand();
+      setInspectorCollapsed(false);
+      return;
+    }
+
+    inspectorPanelRef.current?.collapse();
+    setInspectorCollapsed(true);
+  }
+
+  function syncSidebarCollapsed(panelSize: PanelSize) {
+    const collapsed = panelSize.asPercentage <= 1;
+    setSidebarCollapsed((previous) => {
+      if (previous !== collapsed) {
+        setSidebarOpen(!collapsed);
+      }
+
+      return collapsed;
+    });
+  }
+
+  function syncInspectorCollapsed(panelSize: PanelSize) {
+    setInspectorCollapsed(panelSize.asPercentage <= 1);
+  }
 
   return (
-    <SidebarProvider className="v2-shell h-dvh bg-background font-sans text-foreground">
+    <>
       <a className="sr-only focus:not-sr-only" href="#main-content">{t('navigation.skipToMain')}</a>
-      <Sidebar
-        aria-label={t('navigation.primaryAriaLabel')}
-        className="v2-sidebar-panel v2-panel-divider"
-        collapsible="offcanvas"
-      >
-        <SessionSidebar
-          activeSurfaceId={activeSurfaceId}
-          activeSettingsSectionId={activeSettingsSectionId}
-          appNavigationItems={appNavigationItems}
-          settingsNavigationItems={settingsNavigationItems}
-          settingsOpen={settingsOpen}
-          selectedSessionId={selectedSessionId}
-          sessions={sessions}
-          tasks={tasks}
-          onOpenSettings={onOpenSettings}
-          onCloseSettings={onCloseSettings}
-          onCreateSession={onCreateSession}
-          onSelectSession={onSelectSession}
-        />
-      </Sidebar>
+      <ResizablePanelGroup className="min-h-0 overflow-hidden" direction="horizontal">
+        <ResizablePanel
+          collapsible
+          className="h-full min-h-0 overflow-hidden"
+          collapsedSize={0}
+          defaultSize="17rem"
+          minSize="14rem"
+          maxSize="24rem"
+          panelRef={sidebarPanelRef}
+          onResize={syncSidebarCollapsed}
+        >
+          <Sidebar
+            aria-label={t('navigation.primaryAriaLabel')}
+            className="v2-sidebar-panel v2-panel-divider w-full"
+            collapsible="none"
+          >
+            <SessionSidebar
+              activeSurfaceId={activeSurfaceId}
+              activeSettingsSectionId={activeSettingsSectionId}
+              appNavigationItems={appNavigationItems}
+              settingsNavigationItems={settingsNavigationItems}
+              settingsOpen={settingsOpen}
+              selectedSessionId={selectedSessionId}
+              sessions={sessions}
+              tasks={tasks}
+              onOpenSettings={onOpenSettings}
+              onCloseSettings={onCloseSettings}
+              onCreateSession={onCreateSession}
+              onSelectSession={onSelectSession}
+            />
+          </Sidebar>
+        </ResizablePanel>
 
-      <SidebarInset>
-        <SidebarTrigger
-          className="absolute left-2 top-2 z-20"
-        />
-        <ResizablePanelGroup direction="horizontal">
-          <ResizablePanel defaultSize="74%" minSize="32rem">
+        <ResizableHandle />
+
+        <ResizablePanel className="h-full min-h-0 overflow-hidden" defaultSize="58%" minSize="32rem">
+          <SidebarInset className="h-full min-h-0 overflow-hidden">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-expanded={!sidebarCollapsed}
+              aria-label={t(sidebarCollapsed ? 'navigation.expandSidebar' : 'navigation.collapseSidebar')}
+              className="v2-icon-button absolute left-2 top-2 z-20 size-7"
+              onClick={toggleSidebarPanel}
+            >
+              {sidebarCollapsed ? <PanelLeftOpen aria-hidden="true" /> : <PanelLeftClose aria-hidden="true" />}
+              <span className="sr-only">{t(sidebarCollapsed ? 'navigation.expandSidebar' : 'navigation.collapseSidebar')}</span>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-expanded={!inspectorCollapsed}
+              aria-label={t(inspectorCollapsed ? 'inspector.expandPanel' : 'inspector.collapsePanel')}
+              className="v2-icon-button absolute right-2 top-2 z-20 size-7"
+              onClick={toggleInspectorPanel}
+            >
+              {inspectorCollapsed ? <PanelRightOpen aria-hidden="true" /> : <PanelRightClose aria-hidden="true" />}
+              <span className="sr-only">{t(inspectorCollapsed ? 'inspector.expandPanel' : 'inspector.collapsePanel')}</span>
+            </Button>
             <ConversationWorkspace>{children}</ConversationWorkspace>
-          </ResizablePanel>
+          </SidebarInset>
+        </ResizablePanel>
 
-          <ResizableHandle />
-          <ResizablePanel defaultSize="26%" minSize="14rem" maxSize="36rem">
-            <ContextInspector />
-          </ResizablePanel>
-        </ResizablePanelGroup>
-      </SidebarInset>
-    </SidebarProvider>
+        <ResizableHandle />
+
+        <ResizablePanel
+          collapsible
+          className="h-full min-h-0 overflow-hidden"
+          collapsedSize={0}
+          defaultSize="22rem"
+          minSize="14rem"
+          maxSize="36rem"
+          panelRef={inspectorPanelRef}
+          onResize={syncInspectorCollapsed}
+        >
+          <ContextInspector />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </>
   );
 }

--- a/src/web-v2/tailwind.css
+++ b/src/web-v2/tailwind.css
@@ -152,6 +152,15 @@
     box-shadow: 0 12px 28px hsl(235 18% 3% / 0.32);
   }
 
+  .v2-scrollbar-hidden {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .v2-scrollbar-hidden::-webkit-scrollbar {
+    display: none;
+  }
+
   .v2-resize-handle {
     background: color-mix(in oklab, var(--color-border) 74%, transparent);
   }


### PR DESCRIPTION
## Summary

- make both web-v2 side regions resizable with the existing resizable panel primitive
- keep the left side using the existing shadcn sidebar structure while wiring collapse to the panel state
- add a collapsible right context inspector control
- preserve fixed header/composer layout and hide scrollbars in scrollable v2 lists/transcript

## Validation

- `yarn typecheck`
- `yarn client:v2:build`
- `yarn test:browser-integration:v2`

Note: `yarn client:v2:build` still emits the existing Vite chunk-size warning, but the build succeeds.
