### PR TITLE
[codex] Add web-v2 diff preview

### DIFF
--- a/src/web-v2/api/client.ts
+++ b/src/web-v2/api/client.ts
@@ -37,3 +37,6 @@ export type ControlPlaneSessionMessage = NonNullable<ControlPlaneSessionDetail>[
 export type ControlPlanePendingApproval = RouterOutputs['controlPlane']['sessionPendingApproval'];
 export type ControlPlaneApprovalDecision = RouterInputs['controlPlane']['sessionResolveApproval']['decision'];
 export type ControlPlaneSessionSendPromptResult = RouterOutputs['controlPlane']['sessionSendPrompt'];
+export type ControlPlaneWorkspaceChanges = RouterOutputs['controlPlane']['workspaceChanges'];
+export type ControlPlaneWorkspaceChangedFile = ControlPlaneWorkspaceChanges['files'][number];
+export type ControlPlaneWorkspaceFileDiff = RouterOutputs['controlPlane']['workspaceFileDiff'];

--- a/src/web-v2/components/diff/DiffPreview.tsx
+++ b/src/web-v2/components/diff/DiffPreview.tsx
@@ -1,0 +1,178 @@
+import { skipToken } from '@tanstack/react-query';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useEffect, useState, type ReactNode } from 'react';
+import {
+  trpcReact,
+  type ControlPlaneWorkspaceChangedFile,
+  type ControlPlaneWorkspaceFileDiff,
+} from '@web/api/client';
+import { MonacoDiffViewer } from '@web/components/diff/MonacoDiffViewer';
+import { useI18n } from '@web/i18n';
+import { cn } from '@web/lib/utils';
+
+export function DiffPreview() {
+  const { t } = useI18n();
+  const changesQuery = trpcReact.controlPlane.workspaceChanges.useQuery(undefined, {
+    refetchOnWindowFocus: true,
+  });
+  const [expandedPaths, setExpandedPaths] = useState<string[]>([]);
+  const files = changesQuery.data?.files ?? [];
+
+  useEffect(() => {
+    if (!changesQuery.data) {
+      return;
+    }
+    setExpandedPaths(files.map((file) => file.path));
+  }, [changesQuery.data, files]);
+
+  function togglePath(path: string) {
+    setExpandedPaths((current) => (
+      current.includes(path)
+        ? current.filter((currentPath) => currentPath !== path)
+        : [...current, path]
+    ));
+  }
+
+  return (
+    <section className="flex h-full min-h-0 min-w-0 flex-col" aria-label={t('diffPreview.title')}>
+      <header className="shrink-0 border-b border-border/70 px-3 py-2">
+        <p className="text-sm font-semibold text-foreground">{t('diffPreview.title')}</p>
+        <p className="text-xs text-muted-foreground">{t('diffPreview.subtitle')}</p>
+      </header>
+
+      <div className="v2-scrollbar-hidden min-h-0 flex-1 overflow-y-auto">
+        {changesQuery.isLoading ?
+          <DiffPreviewEmpty title={t('diffPreview.loadingTitle')} body={t('diffPreview.loadingBody')} />
+        : changesQuery.error ?
+          <DiffPreviewEmpty title={t('diffPreview.failedTitle')} body={changesQuery.error.message} tone="danger" />
+        : changesQuery.data?.vcs === 'none' ?
+          <DiffPreviewEmpty title={t('diffPreview.noGitTitle')} body={changesQuery.data.error ?? t('diffPreview.noGitBody')} />
+        : files.length ?
+          <div className="grid">
+            {files.map((file) => (
+              <DiffPreviewFile
+                key={file.path}
+                expanded={expandedPaths.includes(file.path)}
+                file={file}
+                onToggle={() => togglePath(file.path)}
+              />
+            ))}
+          </div>
+        : <DiffPreviewEmpty title={t('diffPreview.cleanTitle')} body={t('diffPreview.cleanBody')} />}
+      </div>
+    </section>
+  );
+}
+
+function DiffPreviewFile({
+  expanded,
+  file,
+  onToggle,
+}: {
+  expanded: boolean;
+  file: ControlPlaneWorkspaceChangedFile;
+  onToggle: () => void;
+}) {
+  const { t } = useI18n();
+  const fileDiffQuery = trpcReact.controlPlane.workspaceFileDiff.useQuery(
+    expanded ? { path: file.path } : skipToken,
+    {
+      enabled: expanded,
+    },
+  );
+
+  return (
+    <article className={cn('v2-diff-file', expanded && 'v2-diff-file-expanded')}>
+      <button
+        type="button"
+        className="flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left"
+        aria-expanded={expanded}
+        onClick={onToggle}
+      >
+        {expanded ?
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        : <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />}
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium text-foreground">{file.path}</span>
+          {file.oldPath ? <span className="block truncate text-xs text-muted-foreground">{t('diffPreview.from')} {file.oldPath}</span> : null}
+        </span>
+        <DiffPreviewBadge>{file.status}</DiffPreviewBadge>
+        {file.additions !== undefined || file.deletions !== undefined ?
+          <DiffPreviewBadge tone="good">+{file.additions ?? 0} / -{file.deletions ?? 0}</DiffPreviewBadge>
+        : null}
+        {file.binary ? <DiffPreviewBadge tone="warn">{t('diffPreview.binary')}</DiffPreviewBadge> : null}
+      </button>
+
+      {expanded ?
+        <div>
+          {fileDiffQuery.isLoading ?
+            <DiffPreviewEmpty title={t('diffPreview.loadingFileTitle')} body={t('diffPreview.loadingFileBody')} compact />
+          : fileDiffQuery.error ?
+            <DiffPreviewEmpty title={t('diffPreview.fileFailedTitle')} body={fileDiffQuery.error.message} tone="danger" compact />
+          : fileDiffQuery.data?.error ?
+            <DiffPreviewEmpty title={t('diffPreview.fileUnavailableTitle')} body={fileDiffQuery.data.error} compact />
+          : <FileDiffContent fileDiff={fileDiffQuery.data} />}
+        </div>
+      : null}
+    </article>
+  );
+}
+
+function FileDiffContent({ fileDiff }: { fileDiff?: ControlPlaneWorkspaceFileDiff }) {
+  const { t } = useI18n();
+
+  if (!fileDiff) {
+    return <DiffPreviewEmpty title={t('diffPreview.noPatchTitle')} body={t('diffPreview.noPatchBody')} compact />;
+  }
+  if (fileDiff.binary) {
+    return <DiffPreviewEmpty title={t('diffPreview.binaryTitle')} body={t('diffPreview.binaryBody')} compact />;
+  }
+  if (fileDiff.diff?.hunks.length) {
+    return <MonacoDiffViewer diff={fileDiff.diff} />;
+  }
+  if (fileDiff.patch) {
+    return (
+      <pre className="v2-diff-patch v2-scrollbar-hidden" data-testid="web-v2-raw-diff">
+        {fileDiff.patch}
+      </pre>
+    );
+  }
+
+  return <DiffPreviewEmpty title={t('diffPreview.noPatchTitle')} body={t('diffPreview.noPatchBody')} compact />;
+}
+
+function DiffPreviewBadge({ children, tone }: { children: ReactNode; tone?: 'good' | 'warn' }) {
+  return (
+    <span className={cn(
+      'shrink-0 rounded-sm border px-1.5 py-0.5 text-[11px] leading-4',
+      tone === 'good' && 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200',
+      tone === 'warn' && 'border-amber-300/30 bg-amber-300/10 text-amber-100',
+      !tone && 'border-border/80 bg-muted/70 text-muted-foreground',
+    )}>
+      {children}
+    </span>
+  );
+}
+
+function DiffPreviewEmpty({
+  title,
+  body,
+  compact,
+  tone,
+}: {
+  title: string;
+  body: string;
+  compact?: boolean;
+  tone?: 'danger';
+}) {
+  return (
+    <div className={cn(
+      'rounded-md border border-border/70 bg-background/50',
+      compact ? 'px-3 py-2' : 'px-3 py-4',
+      tone === 'danger' && 'border-destructive/50 text-destructive',
+    )}>
+      <p className={cn('font-medium', compact ? 'text-xs' : 'text-sm')}>{title}</p>
+      <p className={cn('mt-1 text-muted-foreground', compact ? 'text-xs' : 'text-sm')}>{body}</p>
+    </div>
+  );
+}

--- a/src/web-v2/components/diff/MonacoDiffViewer.tsx
+++ b/src/web-v2/components/diff/MonacoDiffViewer.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useMemo, useRef } from 'react';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
+import 'monaco-editor/esm/vs/basic-languages/css/css.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/go/go.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/html/html.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/java/java.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/python/python.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/rust/rust.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/scss/scss.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/shell/shell.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js';
+import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import type { ControlPlaneWorkspaceFileDiff } from '@web/api/client';
+
+type ReviewDiffFile = NonNullable<ControlPlaneWorkspaceFileDiff['diff']>;
+
+type MonacoGlobal = typeof globalThis & {
+  MonacoEnvironment?: {
+    getWorker?: (_workerId: string, label: string) => Worker;
+  };
+  __heddleMonacoCancelHandlerInstalled?: boolean;
+  __heddleV2DiffThemeDefined?: boolean;
+};
+
+type DiffLineView = {
+  content: string;
+  lineNumber: string;
+  type: 'added' | 'deleted' | 'context' | 'separator';
+};
+
+const monacoGlobal = globalThis as MonacoGlobal;
+if (!monacoGlobal.MonacoEnvironment?.getWorker) {
+  monacoGlobal.MonacoEnvironment = {
+    getWorker() {
+      return new EditorWorker();
+    },
+  };
+}
+
+if (typeof window !== 'undefined' && !monacoGlobal.__heddleMonacoCancelHandlerInstalled) {
+  monacoGlobal.__heddleMonacoCancelHandlerInstalled = true;
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason as { name?: unknown; message?: unknown } | undefined;
+    if (reason?.name === 'Canceled' || reason?.message === 'Canceled') {
+      event.preventDefault();
+    }
+  }, { capture: true });
+}
+
+export function MonacoDiffViewer({ diff }: { diff: ReviewDiffFile }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const modelRef = useRef<monaco.editor.ITextModel | null>(null);
+  const decorationsRef = useRef<monaco.editor.IEditorDecorationsCollection | null>(null);
+  const model = useMemo(() => buildDiffModel(diff), [diff]);
+  const height = Math.min(520, Math.max(160, model.lines.length * 20 + 24));
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) {
+      return;
+    }
+
+    defineDiffTheme();
+
+    if (!editorRef.current) {
+      editorRef.current = monaco.editor.create(node, {
+        automaticLayout: true,
+        contextmenu: false,
+        fixedOverflowWidgets: true,
+        folding: false,
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+        fontSize: 12,
+        glyphMargin: false,
+        lineDecorationsWidth: 8,
+        lineNumbers: (lineNumber) => model.lines[lineNumber - 1]?.lineNumber ?? '',
+        lineNumbersMinChars: 4,
+        minimap: {
+          enabled: false,
+        },
+        overviewRulerLanes: 0,
+        padding: {
+          top: 0,
+          bottom: 0,
+        },
+        readOnly: true,
+        renderLineHighlight: 'none',
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+          horizontal: 'auto',
+          vertical: 'hidden',
+          verticalScrollbarSize: 0,
+        },
+        scrollBeyondLastLine: false,
+        theme: 'heddle-v2-diff',
+        wordWrap: 'off',
+      });
+    }
+  }, [model.lines]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+
+    modelRef.current?.dispose();
+    const nextModel = monaco.editor.createModel(model.text, model.language);
+    modelRef.current = nextModel;
+    editor.setModel(nextModel);
+    editor.updateOptions({
+      lineNumbers: (lineNumber) => model.lines[lineNumber - 1]?.lineNumber ?? '',
+    });
+    decorationsRef.current?.clear();
+    decorationsRef.current = editor.createDecorationsCollection(buildLineDecorations(model.lines));
+
+    return () => {
+      if (editorRef.current?.getModel() === nextModel) {
+        editorRef.current.setModel(null);
+      }
+      decorationsRef.current?.clear();
+      decorationsRef.current = null;
+      nextModel.dispose();
+      if (modelRef.current === nextModel) {
+        modelRef.current = null;
+      }
+    };
+  }, [model]);
+
+  useEffect(() => () => {
+    decorationsRef.current?.clear();
+    editorRef.current?.setModel(null);
+    editorRef.current?.dispose();
+    editorRef.current = null;
+    modelRef.current?.dispose();
+    modelRef.current = null;
+  }, []);
+
+  return (
+    <div className="v2-monaco-diff-viewer" data-testid="web-v2-monaco-diff-viewer">
+      <div ref={containerRef} className="v2-monaco-diff-viewer-editor" style={{ height }} />
+    </div>
+  );
+}
+
+function defineDiffTheme() {
+  if (monacoGlobal.__heddleV2DiffThemeDefined) {
+    return;
+  }
+
+  monacoGlobal.__heddleV2DiffThemeDefined = true;
+  monaco.editor.defineTheme('heddle-v2-diff', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [],
+    colors: {
+      'editor.background': '#181922',
+      'editor.foreground': '#d9dbe7',
+      'editorLineNumber.foreground': '#9ca0b4',
+      'editorLineNumber.activeForeground': '#d9dbe7',
+      'editor.selectionBackground': '#3a3d4f',
+    },
+  });
+}
+
+function buildLineDecorations(lines: DiffLineView[]): monaco.editor.IModelDeltaDecoration[] {
+  return lines.flatMap((line, index) => {
+    const lineNumber = index + 1;
+    const range = new monaco.Range(lineNumber, 1, lineNumber, 1);
+    const classNames = {
+      added: ['v2-monaco-diff-line-added', 'v2-monaco-diff-gutter-added'],
+      deleted: ['v2-monaco-diff-line-deleted', 'v2-monaco-diff-gutter-deleted'],
+      context: ['', ''],
+      separator: ['v2-monaco-diff-line-separator', 'v2-monaco-diff-gutter-separator'],
+    }[line.type];
+
+    if (!classNames[0] && !classNames[1]) {
+      return [];
+    }
+
+    return [{
+      range,
+      options: {
+        className: classNames[0],
+        isWholeLine: true,
+        lineNumberClassName: classNames[1],
+      },
+    }];
+  });
+}
+
+function buildDiffModel(diff: ReviewDiffFile): {
+  text: string;
+  language: string;
+  lines: DiffLineView[];
+} {
+  let previousNewLine = 0;
+  const lines = diff.hunks.flatMap((hunk): DiffLineView[] => {
+    const separator = buildHunkSeparator(hunk.header, previousNewLine);
+    previousNewLine = hunk.lines.reduce((lineNumber, line) => (
+      Math.max(lineNumber, line.newLineNumber ?? line.oldLineNumber ?? lineNumber)
+    ), previousNewLine);
+
+    return [
+      ...(separator ? [separator] : []),
+      ...hunk.lines.map((line): DiffLineView => ({
+        content: stripUnifiedDiffPrefix(line.content, line.type),
+        lineNumber: formatDiffLineNumber(line),
+        type: line.type === 'unknown' ? 'context' : line.type,
+      })),
+    ];
+  });
+
+  return {
+    text: lines.map((line) => line.content).join('\n'),
+    language: languageForPath(diff.path),
+    lines,
+  };
+}
+
+function buildHunkSeparator(header: string, previousNewLine: number): DiffLineView | undefined {
+  const match = /^@@ -(?<oldStart>\d+)(?:,\d+)? \+(?<newStart>\d+)(?:,\d+)? @@/.exec(header);
+  const lineNumber = Number(match?.groups?.newStart ?? match?.groups?.oldStart);
+  const hiddenLineCount = lineNumber - previousNewLine - 1;
+  if (!Number.isFinite(lineNumber) || hiddenLineCount <= 0) {
+    return undefined;
+  }
+
+  return {
+    content: `${hiddenLineCount} unmodified lines`,
+    lineNumber: '',
+    type: 'separator',
+  };
+}
+
+function formatDiffLineNumber(line: ReviewDiffFile['hunks'][number]['lines'][number]): string {
+  const lineNumber = line.type === 'deleted'
+    ? line.oldLineNumber
+    : line.newLineNumber ?? line.oldLineNumber;
+  return typeof lineNumber === 'number' ? String(lineNumber) : '';
+}
+
+function stripUnifiedDiffPrefix(content: string, type: 'context' | 'added' | 'deleted' | 'unknown'): string {
+  if ((type === 'added' && content.startsWith('+')) || (type === 'deleted' && content.startsWith('-'))) {
+    return content.slice(1);
+  }
+  if (type === 'context' && content.startsWith(' ')) {
+    return content.slice(1);
+  }
+  return content;
+}
+
+const LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  bash: 'shell',
+  cjs: 'javascript',
+  css: 'css',
+  cts: 'typescript',
+  go: 'go',
+  htm: 'html',
+  html: 'html',
+  java: 'java',
+  js: 'javascript',
+  json: 'json',
+  jsonc: 'json',
+  jsx: 'javascript',
+  md: 'markdown',
+  mdx: 'markdown',
+  mjs: 'javascript',
+  mts: 'typescript',
+  py: 'python',
+  rs: 'rust',
+  sass: 'scss',
+  scss: 'scss',
+  sh: 'shell',
+  svelte: 'html',
+  ts: 'typescript',
+  tsx: 'typescript',
+  vue: 'html',
+  yaml: 'yaml',
+  yml: 'yaml',
+  zsh: 'shell',
+};
+
+function languageForPath(path: string): string {
+  const lower = path.toLowerCase();
+  const extension = lower.includes('.') ? lower.slice(lower.lastIndexOf('.') + 1) : lower;
+  return LANGUAGE_BY_EXTENSION[extension] ?? 'plaintext';
+}

--- a/src/web-v2/components/panels/ContextInspector.tsx
+++ b/src/web-v2/components/panels/ContextInspector.tsx
@@ -1,11 +1,12 @@
+import { DiffPreview } from '@web/components/diff/DiffPreview';
 import { useI18n } from '@web/i18n';
 
-// ContextInspector owns the right-hand inspectable context region for selected
-// sessions, tasks, diffs, evidence, and tool/runtime details.
 export function ContextInspector() {
   const { t } = useI18n();
 
   return (
-    <aside className="v2-panel-surface h-full min-w-0" aria-label={t('inspector.contextAriaLabel')} />
+    <aside className="v2-panel-surface h-full min-w-0 overflow-hidden" aria-label={t('inspector.contextAriaLabel')}>
+      <DiffPreview />
+    </aside>
   );
 }

--- a/src/web-v2/hooks/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/useControlPlaneSessionEvents.ts
@@ -31,7 +31,12 @@ export function useControlPlaneSessionEvents({
   setRunning,
   setLiveStatus,
 }: UseControlPlaneSessionEventsArgs): ControlPlaneSessionEventsState {
+  const utils = trpcReact.useUtils();
   const [streamConnected, setStreamConnected] = useState(false);
+  const invalidateWorkspaceDiff = useCallback(() => {
+    void utils.controlPlane.workspaceChanges.invalidate();
+    void utils.controlPlane.workspaceFileDiff.invalidate();
+  }, [utils]);
   const applySessionEvent = useCallback((event: ControlPlaneSessionEventEnvelope) => {
     if (event.type === 'waiting') {
       setLiveStatus('Waiting for the session event stream...');
@@ -51,11 +56,12 @@ export function useControlPlaneSessionEvents({
       sessionId: event.sessionId,
       refresh,
       refreshPendingApproval,
+      invalidateWorkspaceDiff,
       setLiveStatus,
       setRunning,
       setSession,
     }));
-  }, [refresh, refreshPendingApproval, setLiveStatus, setRunning, setSession]);
+  }, [invalidateWorkspaceDiff, refresh, refreshPendingApproval, setLiveStatus, setRunning, setSession]);
 
   const subscription = trpcReact.controlPlane.sessionEvents.useSubscription(
     sessionId ? { sessionId } : skipToken,
@@ -97,6 +103,7 @@ type SessionActivityContext = {
   sessionId: string;
   refresh: RefreshControlPlaneSession;
   refreshPendingApproval: (sessionId: string) => void;
+  invalidateWorkspaceDiff: () => void;
   setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
   setRunning: Dispatch<SetStateAction<boolean>>;
   setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
@@ -125,16 +132,18 @@ const sessionActivityHandlers: SessionActivityHandlerMap = {
     setRunning(true);
     setLiveStatus('Run started...');
   },
-  'loop.finished': (_activity, { sessionId, refresh, setRunning, setLiveStatus }) => {
+  'loop.finished': (_activity, { sessionId, refresh, invalidateWorkspaceDiff, setRunning, setLiveStatus }) => {
     setRunning(false);
     setLiveStatus(undefined);
     void refresh(sessionId, { silent: true });
+    invalidateWorkspaceDiff();
   },
   'tool.calling': (activity, { setLiveStatus }) => {
     setLiveStatus(`Working... running ${activity.derived?.kind === 'tool-summary' ? activity.derived.summary : activity.tool}${formatStep(activity.step)}`);
   },
-  'tool.completed': (activity, { setLiveStatus }) => {
+  'tool.completed': (activity, { invalidateWorkspaceDiff, setLiveStatus }) => {
     setLiveStatus(`${activity.tool} finished in ${Math.round(activity.durationMs)}ms`);
+    invalidateWorkspaceDiff();
   },
   'tool.approval_requested': (activity, { sessionId, refreshPendingApproval, setLiveStatus }) => {
     refreshPendingApproval(sessionId);

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -23,6 +23,27 @@
     "reasoningEffort": "Reasoning effort",
     "send": "Send"
   },
+  "diffPreview": {
+    "binary": "binary",
+    "binaryBody": "Git reports this as a binary diff, so Heddle cannot render line-level changes.",
+    "binaryTitle": "Binary file",
+    "cleanBody": "Git does not report current workspace changes.",
+    "cleanTitle": "Clean workspace",
+    "failedTitle": "Workspace diff failed",
+    "fileFailedTitle": "File diff failed",
+    "fileUnavailableTitle": "File diff unavailable",
+    "from": "from",
+    "loadingBody": "Reading current Git changes from the active workspace.",
+    "loadingFileBody": "Reading the selected file patch.",
+    "loadingFileTitle": "Loading file diff",
+    "loadingTitle": "Loading workspace diff",
+    "noGitBody": "Current workspace changes require a Git-backed workspace.",
+    "noGitTitle": "Not a git workspace",
+    "noPatchBody": "Git reports this file as changed, but no patch text is available for it.",
+    "noPatchTitle": "No patch available",
+    "subtitle": "Current workspace changes",
+    "title": "Diff preview"
+  },
   "inspector": {
     "collapsePanel": "Collapse context inspector",
     "contextAriaLabel": "Context inspector",

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -23,6 +23,27 @@
     "reasoningEffort": "推理强度",
     "send": "发送"
   },
+  "diffPreview": {
+    "binary": "二进制",
+    "binaryBody": "Git 报告这是二进制差异，因此 Heddle 无法呈现逐行变更。",
+    "binaryTitle": "二进制文件",
+    "cleanBody": "Git 未报告当前工作区有变更。",
+    "cleanTitle": "工作区没有变更",
+    "failedTitle": "工作区差异读取失败",
+    "fileFailedTitle": "文件差异读取失败",
+    "fileUnavailableTitle": "文件差异不可用",
+    "from": "来自",
+    "loadingBody": "正在读取当前启用工作区的 Git 变更。",
+    "loadingFileBody": "正在读取所选文件的 patch。",
+    "loadingFileTitle": "正在加载文件差异",
+    "loadingTitle": "正在加载工作区差异",
+    "noGitBody": "当前工作区变更需要 Git 工作区。",
+    "noGitTitle": "不是 Git 工作区",
+    "noPatchBody": "Git 报告此文件已变更，但没有可用的 patch 文本。",
+    "noPatchTitle": "没有可用 patch",
+    "subtitle": "当前工作区变更",
+    "title": "差异预览"
+  },
   "inspector": {
     "collapsePanel": "收起上下文检查器",
     "contextAriaLabel": "上下文检查器",

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -23,6 +23,27 @@
     "reasoningEffort": "推理強度",
     "send": "送出"
   },
+  "diffPreview": {
+    "binary": "二進位",
+    "binaryBody": "Git 回報這是二進位差異，因此 Heddle 無法呈現逐行變更。",
+    "binaryTitle": "二進位檔案",
+    "cleanBody": "Git 未回報目前工作區有變更。",
+    "cleanTitle": "工作區沒有變更",
+    "failedTitle": "工作區差異讀取失敗",
+    "fileFailedTitle": "檔案差異讀取失敗",
+    "fileUnavailableTitle": "檔案差異無法使用",
+    "from": "來自",
+    "loadingBody": "正在讀取目前啟用工作區的 Git 變更。",
+    "loadingFileBody": "正在讀取選取檔案的 patch。",
+    "loadingFileTitle": "正在載入檔案差異",
+    "loadingTitle": "正在載入工作區差異",
+    "noGitBody": "目前工作區變更需要 Git 工作區。",
+    "noGitTitle": "不是 Git 工作區",
+    "noPatchBody": "Git 回報此檔案已變更，但沒有可用的 patch 文字。",
+    "noPatchTitle": "沒有可用 patch",
+    "subtitle": "目前工作區變更",
+    "title": "差異預覽"
+  },
   "inspector": {
     "collapsePanel": "收合脈絡檢視器",
     "contextAriaLabel": "脈絡檢視器",

--- a/src/web-v2/tailwind.css
+++ b/src/web-v2/tailwind.css
@@ -169,6 +169,63 @@
     background: color-mix(in oklab, var(--color-border) 90%, transparent);
   }
 
+  .v2-diff-file {
+    overflow: hidden;
+    border-bottom: 1px solid color-mix(in oklab, var(--color-border) 64%, transparent);
+    background: var(--color-card);
+  }
+
+  .v2-diff-file-expanded {
+    background: var(--color-card);
+  }
+
+  .v2-diff-patch {
+    max-height: 20rem;
+    overflow: auto;
+    border-radius: var(--radius-md);
+    border: 1px solid color-mix(in oklab, var(--color-border) 70%, transparent);
+    background: var(--color-background);
+    padding: 0.75rem;
+    color: var(--color-foreground);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.55;
+  }
+
+  .v2-monaco-diff-viewer {
+    overflow: hidden;
+    background: var(--color-card);
+  }
+
+  .v2-monaco-diff-viewer-editor {
+    min-height: 10rem;
+  }
+
+  .v2-monaco-diff-line-added {
+    background: color-mix(in oklab, hsl(140 45% 42%) 22%, transparent);
+  }
+
+  .v2-monaco-diff-line-deleted {
+    background: color-mix(in oklab, hsl(350 72% 58%) 22%, transparent);
+  }
+
+  .v2-monaco-diff-line-separator {
+    background: color-mix(in oklab, var(--color-muted) 80%, transparent);
+    color: var(--color-muted-foreground);
+  }
+
+  .v2-monaco-diff-gutter-added {
+    color: hsl(135 78% 80%) !important;
+  }
+
+  .v2-monaco-diff-gutter-deleted {
+    color: hsl(350 88% 78%) !important;
+  }
+
+  .v2-monaco-diff-gutter-separator {
+    color: var(--color-muted-foreground) !important;
+  }
+
   .v2-message-row {
     display: flex;
     width: 100%;


### PR DESCRIPTION
## Summary
- add a compact right-panel workspace diff preview for web-v2
- render each changed file as a collapsible Monaco-backed inline diff
- reuse existing control-plane workspace diff APIs and refresh diff queries from session tool events

## Validation
- yarn typecheck
- yarn client:v2:build
- yarn test:browser-integration:v2