### PR TITLE
[codex] Add task continuation controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.2.2",

--- a/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
+++ b/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
@@ -116,6 +116,20 @@ test('shows task run workbench and run details', async ({ page }) => {
   await page.getByRole('button', { name: 'Delete task' }).click();
   await expect(page.getByRole('dialog', { name: 'Delete task' })).toBeVisible();
   await expect(page.getByText('Delete this task, its checkpoint, and recorded runs. This cannot be undone.')).toBeVisible();
+
+  const toggleSmoke = await trpc.controlPlane.heartbeatTaskCreate.mutate({
+    id: `toggle-smoke-${Date.now()}`,
+    name: 'Toggle smoke task',
+    task: 'Task used to verify enable and continuation controls.',
+    intervalMs: 60_000,
+    defer: true,
+  });
+  await page.goto(`/tasks/${toggleSmoke.task.taskId}`);
+  await expect(page.getByText('Operator controlled')).toBeVisible();
+  await page.getByRole('switch', { name: 'Disable task' }).click();
+  await expect(page.getByText('paused').first()).toBeVisible();
+  await page.getByRole('switch', { name: 'Enable task' }).click();
+  await expect(page.getByText('enabled').first()).toBeVisible();
 });
 
 test('submits a prompt and renders the mocked session response', async ({ page }) => {

--- a/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
+++ b/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
@@ -48,6 +48,7 @@ describe('control-plane heartbeat mutations', () => {
       name: 'Recent repo changes',
       task: 'Show me recent repo changes.',
       enabled: true,
+      continuationMode: 'operator',
       schedule: {
         intervalMs: 60_000,
       },
@@ -57,6 +58,21 @@ describe('control-plane heartbeat mutations', () => {
       state: {
         status: 'waiting',
       },
+    });
+  });
+
+  it('updates heartbeat task continuation mode through the controller', async () => {
+    const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-cp-heartbeat-continuation-'));
+    const store = new FileHeartbeatTaskService({ dir: join(stateRoot, 'heartbeat') });
+    await store.saveTask(createTask());
+
+    const updated = await ControlPlaneHeartbeatController.updateTask(stateRoot, 'repo-check', {
+      continuationMode: 'agent',
+    });
+
+    expect(updated).toMatchObject({
+      taskId: 'repo-check',
+      continuationMode: 'agent',
     });
   });
 
@@ -117,6 +133,21 @@ describe('control-plane heartbeat mutations', () => {
 
     const views = await ControlPlaneHeartbeatController.listTasks(stateRoot);
     expect(views[0]).toMatchObject({ taskId: 'repo-check', enabled: true });
+  });
+
+  it('keeps blocked tasks behind explicit resume instead of enable', async () => {
+    const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-cp-heartbeat-blocked-enable-'));
+    const store = new FileHeartbeatTaskService({ dir: join(stateRoot, 'heartbeat') });
+    await store.saveTask(createTask({
+      enabled: false,
+      schedule: { intervalMs: 60_000, nextRunAt: undefined },
+      state: { status: 'blocked', resumable: true },
+    }));
+
+    await expect(ControlPlaneHeartbeatController.setTaskEnabled(stateRoot, 'repo-check', true)).rejects.toThrow(/blocked/i);
+
+    const resumed = await ControlPlaneHeartbeatController.resumeTask(stateRoot, 'repo-check');
+    expect(resumed).toMatchObject({ taskId: 'repo-check', enabled: true, state: { status: 'waiting' } });
   });
 
   it('queues run-now when enabled and rejects trigger while disabled', async () => {
@@ -207,9 +238,10 @@ describe('control-plane heartbeat mutations', () => {
       id: 'router-created',
       name: 'Router created',
       task: 'Run from router.',
+      continuationMode: 'agent',
       intervalMs: 60_000,
     });
-    expect(created.task).toMatchObject({ taskId: 'router-created', task: 'Run from router.', enabled: true });
+    expect(created.task).toMatchObject({ taskId: 'router-created', task: 'Run from router.', enabled: true, continuationMode: 'agent' });
   });
 
   it('exposes task detail and run detail through dedicated router procedures', async () => {

--- a/src/__tests__/integration/core/heartbeat-scheduler.test.ts
+++ b/src/__tests__/integration/core/heartbeat-scheduler.test.ts
@@ -79,11 +79,47 @@ describe('heartbeat scheduler', () => {
     ]);
   });
 
-  it('disables terminal complete and escalate tasks after the runner cycle', async () => {
+  it('keeps operator-controlled complete tasks scheduled after the runner cycle', async () => {
+    const task: HeartbeatTask = {
+      id: 'operator-task',
+      task: 'Review this task.',
+      enabled: true,
+      continuationMode: 'operator',
+      schedule: { intervalMs: 60_000 },
+    };
+    let savedTask: HeartbeatTask | undefined;
+
+    await HeartbeatSchedulerService.runDueTasks({
+      store: createMemoryTaskStore({
+        tasks: [task],
+        saveTask: (nextTask) => {
+          savedTask = nextTask;
+        },
+      }),
+      now: () => NOW,
+      runner: async () => createHeartbeatResult('complete'),
+    });
+
+    expect(savedTask).toMatchObject({
+      enabled: true,
+      continuationMode: 'operator',
+      schedule: { nextRunAt: '2026-04-13T00:01:00.000Z' },
+      state: {
+        status: 'waiting',
+        resumable: true,
+        result: {
+          decision: 'complete',
+        },
+      },
+    });
+  });
+
+  it('lets agent-controlled complete tasks stop after the runner cycle', async () => {
     const task: HeartbeatTask = {
       id: 'done-task',
       task: 'Finish this task.',
       enabled: true,
+      continuationMode: 'agent',
       schedule: { intervalMs: 60_000 },
     };
     let savedTask: HeartbeatTask | undefined;
@@ -195,6 +231,7 @@ describe('heartbeat scheduler', () => {
           id: 'summary-task',
           task: 'Summarize work.',
           enabled: true,
+          continuationMode: 'agent',
           schedule: { intervalMs: 60_000 },
         }],
       }),
@@ -240,7 +277,7 @@ describe('heartbeat scheduler', () => {
     await store.saveTask(task);
     await store.saveCheckpoint(task, checkpoint);
 
-    await expect(store.listTasks()).resolves.toEqual([task]);
+    await expect(store.listTasks()).resolves.toEqual([{ ...task, continuationMode: 'operator' }]);
     await expect(store.loadCheckpoint(task)).resolves.toMatchObject({
       version: 1,
       runId: checkpoint.runId,

--- a/src/core/heartbeat/agent/prompt.ts
+++ b/src/core/heartbeat/agent/prompt.ts
@@ -53,8 +53,15 @@ The required final decision line is: \`HEARTBEAT_DECISION: continue | pause | co
 
 - Current date time: ${context.currentDateTime}
 - Run interval: ${HeartbeatRunnerAgentPrompt.formatInterval(context.intervalMs)}
+- Continuation control: ${HeartbeatRunnerAgentPrompt.formatContinuationMode(context.continuationMode)}
 - Previous run: ${context.previousRunAt ?? 'none'}${context.previousRunId ? ` (${context.previousRunId})` : ''}
 - Next scheduled run: ${context.nextRunAt ?? 'not scheduled'}`;
+  }
+
+  private static formatContinuationMode(mode: HeartbeatRunnerAgentRunContext['continuationMode']): string {
+    return mode === 'agent' ?
+      'agent-controlled; your final decision can stop or delay future runs'
+    : 'operator-controlled; your final decision is recorded, but the operator schedule controls future runs';
   }
 
   private static formatInterval(intervalMs: number): string {

--- a/src/core/heartbeat/agent/types.ts
+++ b/src/core/heartbeat/agent/types.ts
@@ -27,6 +27,7 @@ export type AgentHeartbeatEvent = AgentLoopEvent | HeartbeatDecisionEvent | Hear
 export type HeartbeatRunnerAgentRunContext = {
   currentDateTime: string;
   intervalMs: number;
+  continuationMode?: 'operator' | 'agent';
   nextRunAt?: string;
   previousRunAt?: string;
   previousRunId?: string;

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -21,6 +21,7 @@ export type {
   CreateHeartbeatTaskInput,
   FileHeartbeatTaskServiceOptions,
   HeartbeatTask,
+  HeartbeatTaskContinuationMode,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
   HeartbeatTaskStatus,

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -143,6 +143,7 @@ export class HeartbeatTaskRunnerService {
       runContext: {
         currentDateTime: dayjs(args.runAt).toISOString(),
         intervalMs: args.task.schedule.intervalMs,
+        continuationMode: args.task.continuationMode ?? 'operator',
         nextRunAt: args.task.schedule.nextRunAt,
         previousRunAt: args.task.state?.runAt,
         previousRunId: args.task.state?.runId,

--- a/src/core/heartbeat/tasks/index.ts
+++ b/src/core/heartbeat/tasks/index.ts
@@ -7,6 +7,7 @@ export type {
 } from './service.js';
 export type {
   HeartbeatTask,
+  HeartbeatTaskContinuationMode,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
   HeartbeatTaskRuntime,

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 export const HeartbeatTaskStatusSchema = z.enum(['idle', 'running', 'waiting', 'blocked', 'complete', 'failed']);
 export const HeartbeatDecisionSchema = z.enum(['continue', 'pause', 'complete', 'escalate']);
+export const HeartbeatTaskContinuationModeSchema = z.enum(['operator', 'agent']);
 
 const LlmUsageSchema = z.object({
   inputTokens: z.number().describe('Prompt tokens reported for the heartbeat run.'),
@@ -25,6 +26,7 @@ export const HeartbeatTaskSchema = z.object({
   task: z.string().describe('Durable task instruction the heartbeat should pursue.'),
   name: z.string().optional().describe('Human-facing task label.'),
   enabled: z.boolean().describe('Whether the scheduler may run this task.'),
+  continuationMode: HeartbeatTaskContinuationModeSchema.default('operator').describe('Whether recurrence is controlled by the operator schedule or the agent decision.'),
   checkpointPath: z.string().optional().describe('Optional custom checkpoint file path.'),
   schedule: z.object({
     intervalMs: z.number().describe('Default interval between heartbeat runner cycles.'),

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -25,6 +25,7 @@ export type CreateHeartbeatTaskInput = {
   name?: string;
   task: string;
   enabled?: boolean;
+  continuationMode?: HeartbeatTask['continuationMode'];
   intervalMs?: number;
   defer?: boolean;
   model?: string;
@@ -39,6 +40,7 @@ export type UpdateHeartbeatTaskInput = {
   name?: string;
   task?: string;
   enabled?: boolean;
+  continuationMode?: HeartbeatTask['continuationMode'];
   intervalMs?: number;
   model?: string | null;
   maxSteps?: number | null;
@@ -118,6 +120,7 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
       name: input.name,
       task: input.task.trim(),
       enabled: input.enabled ?? true,
+      continuationMode: input.continuationMode ?? 'operator',
       schedule: {
         intervalMs,
         nextRunAt: (input.defer === false ? now.subtract(1, 'second') : now.add(intervalMs, 'millisecond')).toISOString(),
@@ -150,6 +153,7 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
       name: input.name ?? task.name,
       task: input.task?.trim() ?? task.task,
       enabled: input.enabled ?? task.enabled,
+      continuationMode: input.continuationMode ?? task.continuationMode ?? 'operator',
       schedule: {
         ...task.schedule,
         intervalMs,
@@ -239,7 +243,12 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
   async setTaskEnabled(taskId: string, enabled: boolean) {
     const task = await this.requireTask(taskId);
     const now = dayjs();
-    const status = enabled ? (task.state?.status ?? 'waiting') : (task.state?.status === 'running' ? 'running' : 'idle');
+    if (enabled && task.state?.status === 'blocked') {
+      throw new Error(`Heartbeat task ${taskId} is blocked. Use resume to unblock it.`);
+    }
+
+    const status = FileHeartbeatTaskService.resolveTaskEnabledStatus(task, enabled);
+    const progress = FileHeartbeatTaskService.resolveTaskEnabledProgress(task, enabled);
     const nextTask: HeartbeatTask = {
       ...task,
       enabled,
@@ -253,6 +262,8 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
       state: {
         ...task.state,
         status,
+        progress,
+        resumable: enabled ? true : task.state?.resumable,
         updatedAt: now.toISOString(),
       },
     };
@@ -356,6 +367,25 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
   private static taskLastRunTime(task: HeartbeatTaskView): number {
     const runAt = task.state.runAt ? dayjs(task.state.runAt) : undefined;
     return runAt?.isValid() ? runAt.valueOf() : 0;
+  }
+
+  private static resolveTaskEnabledStatus(task: HeartbeatTask, enabled: boolean): NonNullable<HeartbeatTaskState['status']> {
+    if (task.state?.status === 'running') {
+      return 'running';
+    }
+    if (!enabled && task.state?.status === 'blocked') {
+      return 'blocked';
+    }
+    return enabled ? 'waiting' : 'idle';
+  }
+
+  private static resolveTaskEnabledProgress(task: HeartbeatTask, enabled: boolean): string | undefined {
+    if (task.state?.status === 'running' || task.state?.status === 'blocked') {
+      return task.state.progress;
+    }
+    return enabled ?
+      'Heartbeat task enabled. Waiting for the next scheduled run.'
+    : 'Heartbeat task paused by operator.';
   }
 
   private static resolveHeartbeatRoot(options: FileHeartbeatTaskServiceOptions): string {

--- a/src/core/heartbeat/tasks/task-state.ts
+++ b/src/core/heartbeat/tasks/task-state.ts
@@ -9,7 +9,7 @@ import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration.js';
 import type { AgentHeartbeatResult } from '../agent/index.js';
 import { HeartbeatDecisionPolicy } from '../agent/index.js';
-import type { HeartbeatTask, HeartbeatTaskState, HeartbeatTaskStatus } from './types.js';
+import type { HeartbeatTask, HeartbeatTaskContinuationMode, HeartbeatTaskState, HeartbeatTaskStatus } from './types.js';
 
 dayjs.extend(duration);
 
@@ -17,6 +17,7 @@ export class HeartbeatTaskStateProjector {
   static normalize(task: HeartbeatTask): HeartbeatTask {
     return {
       ...task,
+      continuationMode: task.continuationMode ?? 'operator',
       schedule: {
         ...task.schedule,
         intervalMs: Math.max(1, Math.trunc(task.schedule.intervalMs)),
@@ -52,11 +53,14 @@ export class HeartbeatTaskStateProjector {
     now: Date;
     loadedCheckpoint: boolean;
   }): HeartbeatTask {
-    const terminal = args.result.decision === 'complete' || args.result.decision === 'escalate';
-    const delayMs =
-      terminal ? undefined
-      : args.result.decision === 'continue' ? args.task.schedule.intervalMs
-      : HeartbeatDecisionPolicy.suggestNextDelayMs(args.result.decision) ?? args.task.schedule.intervalMs;
+    const continuationMode = args.task.continuationMode ?? 'operator';
+    const terminal = HeartbeatTaskStateProjector.isTerminalDecision(args.result.decision, continuationMode);
+    const delayMs = HeartbeatTaskStateProjector.nextDelayMs({
+      decision: args.result.decision,
+      intervalMs: args.task.schedule.intervalMs,
+      continuationMode,
+      terminal,
+    });
     const projection = HeartbeatTaskStateProjector.projectResult(args.result, delayMs);
 
     return HeartbeatTaskStateProjector.normalize({
@@ -72,7 +76,7 @@ export class HeartbeatTaskStateProjector {
         runAt: dayjs(args.now).toISOString(),
         runId: args.result.state.runId,
         loadedCheckpoint: args.loadedCheckpoint,
-        resumable: args.result.decision !== 'complete',
+        resumable: args.result.decision !== 'complete' || continuationMode === 'operator',
         result: args.result,
         error: undefined,
         updatedAt: dayjs(args.now).toISOString(),
@@ -133,6 +137,13 @@ export class HeartbeatTaskStateProjector {
             : `Heartbeat paused. Waiting ${HeartbeatTaskStateProjector.formatDelay(delayMs)} before the next run.`,
         };
       case 'complete':
+        if (delayMs !== undefined) {
+          return {
+            status: 'waiting',
+            progress: `Heartbeat runner reported completion. Waiting until the next scheduled run in ${HeartbeatTaskStateProjector.formatDelay(delayMs)}.`,
+          };
+        }
+
         return {
           status: 'complete',
           progress: 'Heartbeat task completed and will not run again.',
@@ -143,6 +154,32 @@ export class HeartbeatTaskStateProjector {
           progress: 'Heartbeat escalated for user input and is waiting for follow-up.',
         };
     }
+  }
+
+  private static isTerminalDecision(
+    decision: AgentHeartbeatResult['decision'],
+    continuationMode: HeartbeatTaskContinuationMode,
+  ): boolean {
+    return decision === 'escalate' || (continuationMode === 'agent' && decision === 'complete');
+  }
+
+  private static nextDelayMs(args: {
+    decision: AgentHeartbeatResult['decision'];
+    intervalMs: number;
+    continuationMode: HeartbeatTaskContinuationMode;
+    terminal: boolean;
+  }): number | undefined {
+    if (args.terminal) {
+      return undefined;
+    }
+
+    if (args.continuationMode === 'operator') {
+      return args.intervalMs;
+    }
+
+    return args.decision === 'continue' ?
+      args.intervalMs
+    : HeartbeatDecisionPolicy.suggestNextDelayMs(args.decision) ?? args.intervalMs;
   }
 
   private static formatDelay(ms: number): string {

--- a/src/core/heartbeat/tasks/types.ts
+++ b/src/core/heartbeat/tasks/types.ts
@@ -14,6 +14,8 @@ export type HeartbeatTaskSchedule = {
   nextRunAt?: string;
 };
 
+export type HeartbeatTaskContinuationMode = 'operator' | 'agent';
+
 export type HeartbeatTaskRuntime = Pick<
   RunAgentHeartbeatOptions,
   | 'model'
@@ -43,6 +45,7 @@ export type HeartbeatTask = {
   task: string;
   name?: string;
   enabled: boolean;
+  continuationMode?: HeartbeatTaskContinuationMode;
   checkpointPath?: string;
   schedule: HeartbeatTaskSchedule;
   runtime?: HeartbeatTaskRuntime;

--- a/src/server/features/control-plane/controllers/heartbeat.ts
+++ b/src/server/features/control-plane/controllers/heartbeat.ts
@@ -11,6 +11,7 @@ type CreateHeartbeatTaskArgs = {
   name?: string;
   task: string;
   enabled?: boolean;
+  continuationMode?: 'operator' | 'agent';
   intervalMs?: number;
   defer?: boolean;
   model?: string;
@@ -25,6 +26,7 @@ type UpdateHeartbeatTaskArgs = {
   name?: string;
   task?: string;
   enabled?: boolean;
+  continuationMode?: 'operator' | 'agent';
   intervalMs?: number;
   model?: string | null;
   maxSteps?: number | null;

--- a/src/server/features/control-plane/router.ts
+++ b/src/server/features/control-plane/router.ts
@@ -101,6 +101,7 @@ const heartbeatTaskCreateInputSchema = z.object({
   name: z.string().min(1).optional(),
   task: z.string().min(1),
   enabled: z.boolean().optional(),
+  continuationMode: z.enum(['operator', 'agent']).optional(),
   intervalMs: z.number().int().min(1_000).max(365 * 24 * 60 * 60_000).optional(),
   defer: z.boolean().optional(),
   model: z.string().min(1).optional(),

--- a/src/web-v2/components/navigation/TaskListSection.tsx
+++ b/src/web-v2/components/navigation/TaskListSection.tsx
@@ -57,7 +57,7 @@ export function TaskListSection({
                 {task.name ?? task.task}
               </span>
               <span className="v2-type-caption ml-auto shrink-0 text-muted-foreground">
-                {task.state.status}
+                {task.state.status === 'blocked' || task.enabled ? task.state.status : t('tasks.paused')}
               </span>
             </span>
             <span className="v2-type-nav-secondary w-full truncate text-muted-foreground">

--- a/src/web-v2/components/tasks/TaskCreateDialog.tsx
+++ b/src/web-v2/components/tasks/TaskCreateDialog.tsx
@@ -36,6 +36,7 @@ const DEFAULT_MODEL_VALUE = '__default__';
 const taskCreateSchema = z.object({
   name: z.string().trim().min(1, 'Task name is required.'),
   task: z.string().trim().min(1, 'Task instruction is required.'),
+  continuationMode: z.enum(['operator', 'agent']),
   intervalMs: z.string().min(1, 'Schedule is required.'),
   model: z.string().optional(),
   maxSteps: z.string().trim().optional().refine((value) => {
@@ -90,12 +91,14 @@ export function TaskCreateDialog({
     defaultValues: {
       name: '',
       task: '',
+      continuationMode: 'operator',
       intervalMs: '3600000',
       model: DEFAULT_MODEL_VALUE,
       maxSteps: '',
     },
   });
   const intervalMs = useWatch({ control: form.control, name: 'intervalMs' });
+  const continuationMode = useWatch({ control: form.control, name: 'continuationMode' });
   const model = useWatch({ control: form.control, name: 'model' });
   const editing = mode === 'edit';
 
@@ -157,6 +160,23 @@ export function TaskCreateDialog({
             </Field>
 
             <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
+              <Field data-invalid={Boolean(form.formState.errors.continuationMode)}>
+                <FieldLabel>{t('tasks.create.continuation')}</FieldLabel>
+                <Select
+                  value={continuationMode}
+                  onValueChange={(value) => form.setValue('continuationMode', value as TaskCreateDialogValues['continuationMode'], { shouldDirty: true, shouldValidate: true })}
+                >
+                  <SelectTrigger aria-invalid={Boolean(form.formState.errors.continuationMode)}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="operator">{t('tasks.continuation.operator')}</SelectItem>
+                    <SelectItem value="agent">{t('tasks.continuation.agent')}</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FieldError>{form.formState.errors.continuationMode?.message}</FieldError>
+              </Field>
+
               <Field data-invalid={Boolean(form.formState.errors.intervalMs)}>
                 <FieldLabel>{t('tasks.create.schedule')}</FieldLabel>
                 <Select
@@ -246,6 +266,7 @@ function taskToDialogValues(task: ControlPlaneHeartbeatTaskView | undefined): Ta
   return {
     name: task?.name ?? '',
     task: task?.task ?? '',
+    continuationMode: task?.continuationMode ?? 'operator',
     intervalMs: String(task?.schedule.intervalMs ?? 3600000),
     model: task?.runtime?.model ?? DEFAULT_MODEL_VALUE,
     maxSteps: task?.runtime?.maxSteps ? String(task.runtime.maxSteps) : '',
@@ -258,6 +279,7 @@ function normalizeTaskCreateInput(values: TaskCreateDialogValues): TaskCreateInp
   return {
     name: values.name.trim(),
     task: values.task.trim(),
+    continuationMode: values.continuationMode,
     intervalMs: Number(values.intervalMs),
     model,
     maxSteps,

--- a/src/web-v2/components/tasks/TaskRunDetailsPanel.tsx
+++ b/src/web-v2/components/tasks/TaskRunDetailsPanel.tsx
@@ -17,7 +17,7 @@ export function TaskRunDetailsPanel({
   error,
   showingLiveRun = false,
 }: TaskRunDetailsPanelProps) {
-  const showLiveTask = liveTask?.state.status === 'running' || liveTask?.state.progress?.startsWith('Task queued');
+  const showLiveTask = Boolean(liveTask && (liveTask.state.status === 'running' || liveTask.state.progress?.startsWith('Task queued')));
   return (
     <div className="v2-task-inspector flex h-full min-w-0 flex-col">
       <header className="v2-panel-divider border-b px-4 py-3">
@@ -25,7 +25,7 @@ export function TaskRunDetailsPanel({
         <p className="v2-type-panel-subtitle text-muted-foreground">Selected task run</p>
       </header>
       <div className="v2-scrollbar-hidden min-h-0 flex-1 overflow-auto px-4 py-4">
-        {showLiveTask && !showingLiveRun ? (
+        {showLiveTask && liveTask && !showingLiveRun ? (
           <div className="mb-5">
             <TaskDetailBlock title={liveTask.state.status === 'running' ? 'Running now' : 'Latest task status'} body={liveTask.state.progress ?? liveTask.state.status} />
           </div>
@@ -64,7 +64,7 @@ export function TaskRunDetailsPanel({
             />
             <TaskMarkdownBlock title="Task result" body={run.result.summary} />
             {run.task.state.progress ? <TaskDetailBlock title="Progress" body={run.task.state.progress} /> : null}
-            {run.error ? <TaskDetailBlock title="Error" body={run.error} /> : null}
+            {run.task.state.error ? <TaskDetailBlock title="Error" body={run.task.state.error} /> : null}
           </div>
         ) : (
           <TaskInspectorEmpty title="No run selected" body="Select a run from the task workbench." />

--- a/src/web-v2/components/tasks/TaskRunList.tsx
+++ b/src/web-v2/components/tasks/TaskRunList.tsx
@@ -17,7 +17,7 @@ export function TaskRunList({
   selectedRunId,
   onSelectRun,
 }: TaskRunListProps) {
-  const showLiveRun = liveTask?.state.status === 'running' || liveTask?.state.progress?.startsWith('Task queued');
+  const showLiveRun = Boolean(liveTask && (liveTask.state.status === 'running' || liveTask.state.progress?.startsWith('Task queued')));
 
   if (runs.length === 0 && !showLiveRun) {
     return (
@@ -30,7 +30,7 @@ export function TaskRunList({
 
   return (
     <div className="flex min-w-0 flex-col gap-1">
-      {showLiveRun ? (
+      {showLiveRun && liveTask ? (
         <TaskLiveRunListItem
           task={liveTask}
           selected={selectedRunId === LIVE_TASK_RUN_ID}

--- a/src/web-v2/components/tasks/TaskWorkbenchHeader.tsx
+++ b/src/web-v2/components/tasks/TaskWorkbenchHeader.tsx
@@ -1,6 +1,9 @@
-import { Pencil, Play, RotateCcw, Trash2 } from 'lucide-react';
+import { Info, Pencil, Play, RotateCcw, Trash2 } from 'lucide-react';
 import type { ControlPlaneHeartbeatTaskView } from '@web/api/client';
 import { Button } from '@web/components/ui/button';
+import { Switch } from '@web/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@web/components/ui/tooltip';
+import type { I18nMessageKey } from '@web/i18n';
 import { useI18n } from '@web/i18n';
 import { formatTaskInterval, formatTaskTimestamp, taskDisplayName } from './task-format';
 import { TaskStatusPill } from './TaskStatusPill';
@@ -12,31 +15,71 @@ interface TaskWorkbenchHeaderProps {
   onDelete: () => void;
   onRunNow: () => Promise<void>;
   onResume: () => Promise<void>;
+  onSetEnabled: (enabled: boolean) => Promise<void>;
 }
 
-export function TaskWorkbenchHeader({ running, task, onEdit, onDelete, onRunNow, onResume }: TaskWorkbenchHeaderProps) {
+const continuationLabelKeys = {
+  operator: 'tasks.continuation.operator',
+  agent: 'tasks.continuation.agent',
+} satisfies Record<NonNullable<ControlPlaneHeartbeatTaskView['continuationMode']>, I18nMessageKey>;
+
+const continuationDescriptionKeys = {
+  operator: 'tasks.continuation.operatorDescription',
+  agent: 'tasks.continuation.agentDescription',
+} satisfies Record<NonNullable<ControlPlaneHeartbeatTaskView['continuationMode']>, I18nMessageKey>;
+
+export function TaskWorkbenchHeader({ running, task, onEdit, onDelete, onRunNow, onResume, onSetEnabled }: TaskWorkbenchHeaderProps) {
   const { t } = useI18n();
   const runDisabled = running || !task.enabled || task.state.status === 'running';
   const blocked = task.state.status === 'blocked';
+  const continuationMode = task.continuationMode ?? 'operator';
+  const toggleDisabled = running || task.state.status === 'running' || blocked;
 
   return (
     <section className="v2-task-header">
-      <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <h2 className="v2-type-body-strong min-w-0 truncate text-balance text-foreground">{taskDisplayName(task)}</h2>
             <TaskStatusPill status={task.state.status} />
-            <span className="v2-type-caption rounded-sm border border-border bg-muted/20 px-1.5 py-0.5 text-muted-foreground">
-              {task.enabled ? 'enabled' : 'paused'}
-            </span>
           </div>
-          <div className="v2-type-caption mt-2 flex min-w-0 flex-wrap gap-x-4 gap-y-1 text-muted-foreground">
+          <div className="v2-type-caption mt-3 flex min-w-0 flex-wrap items-center gap-x-4 gap-y-2 text-muted-foreground">
+            <label className="flex min-w-0 items-center gap-2">
+              <Switch
+                checked={task.enabled}
+                disabled={toggleDisabled}
+                aria-label={task.enabled ? t('tasks.disable') : t('tasks.enable')}
+                onCheckedChange={(enabled) => void onSetEnabled(enabled)}
+              />
+              <span>{task.enabled ? t('tasks.enabled') : t('tasks.paused')}</span>
+            </label>
+            <span className="inline-flex min-w-0 items-center gap-1 rounded-sm border border-border bg-muted/20 px-1.5 py-0.5 text-muted-foreground">
+              <span className="truncate">{t(continuationLabelKeys[continuationMode])}</span>
+              <TooltipProvider delayDuration={150}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="none"
+                      className="h-4 w-4 rounded-full p-0 text-muted-foreground hover:text-foreground"
+                      aria-label={t('tasks.continuation.tooltipLabel')}
+                    >
+                      <Info aria-hidden="true" className="size-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" align="start" className="max-w-64">
+                    {t(continuationDescriptionKeys[continuationMode])}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </span>
             <span>{formatTaskInterval(task.schedule.intervalMs)}</span>
             <span>last {formatTaskTimestamp(task.state.runAt)}</span>
             <span>next {formatTaskTimestamp(task.schedule.nextRunAt)}</span>
           </div>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
           <Button
             type="button"
             variant="ghost"

--- a/src/web-v2/components/ui/switch.tsx
+++ b/src/web-v2/components/ui/switch.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import { cn } from '@web/lib/utils';
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitive.Root
+    ref={ref}
+    className={cn(
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-input shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary',
+      className,
+    )}
+    {...props}
+  >
+    <SwitchPrimitive.Thumb
+      className={cn(
+        'pointer-events-none block size-4 rounded-full bg-background shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
+      )}
+    />
+  </SwitchPrimitive.Root>
+));
+Switch.displayName = SwitchPrimitive.Root.displayName;
+
+export { Switch };

--- a/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
@@ -2,6 +2,11 @@ import { useCallback, useState } from 'react';
 import dayjs from 'dayjs';
 import { trpcReact, type ControlPlaneHeartbeatEventEnvelope, type ControlPlaneHeartbeatTaskView } from '@web/api/client';
 
+type HeartbeatEventEnvelope = Extract<ControlPlaneHeartbeatEventEnvelope, { type: 'heartbeat.event' }>;
+type HeartbeatEvent = HeartbeatEventEnvelope['event'];
+type HeartbeatTaskEvent = Extract<HeartbeatEvent, { taskId: string }>;
+type HeartbeatAgentEvent = Extract<HeartbeatTaskEvent, { type: 'heartbeat.task.agent_event' }>['event'];
+
 export type ControlPlaneLiveTaskState = {
   taskId: string;
   status: ControlPlaneHeartbeatTaskView['state']['status'];
@@ -20,7 +25,7 @@ export function useControlPlaneHeartbeatEvents() {
     }
 
     const event = envelope.event;
-    if (!('taskId' in event)) {
+    if (!hasTaskId(event)) {
       return;
     }
 
@@ -68,7 +73,7 @@ export function useControlPlaneHeartbeatEvents() {
 
 function applyHeartbeatEvent(
   current: Record<string, ControlPlaneLiveTaskState>,
-  event: Extract<ControlPlaneHeartbeatEventEnvelope, { type: 'heartbeat.event' }>['event'],
+  event: HeartbeatTaskEvent,
 ): Record<string, ControlPlaneLiveTaskState> {
   const currentTask = current[event.taskId];
   const timestamp = 'timestamp' in event && typeof event.timestamp === 'string' ? event.timestamp : dayjs().toISOString();
@@ -80,43 +85,59 @@ function applyHeartbeatEvent(
     updatedAt: timestamp,
   } satisfies ControlPlaneLiveTaskState;
 
-  const eventViews = {
-    'heartbeat.task.due': () => ({
-      ...base,
-      status: 'waiting',
-      progress: 'Task is due. Waiting for the heartbeat runner...',
-    }),
-    'heartbeat.task.started': () => ({
-      ...base,
-      status: 'running',
-      progress: event.progress || 'Heartbeat runner started.',
-    }),
-    'heartbeat.task.agent_event': () => ({
-      ...base,
-      status: 'running',
-      progress: describeAgentEvent(event.event),
-      runId: 'runId' in event.event && typeof event.event.runId === 'string' ? event.event.runId : base.runId,
-    }),
-    'heartbeat.task.finished': () => ({
-      ...base,
-      status: event.record.task.state.status,
-      progress: event.record.task.state.progress ?? 'Heartbeat runner finished.',
-      runId: event.record.runId,
-    }),
-    'heartbeat.task.failed': () => ({
-      ...base,
-      status: 'failed',
-      progress: event.error,
-    }),
-  } satisfies Record<typeof event.type, () => ControlPlaneLiveTaskState>;
+  const next = projectHeartbeatTaskEvent(event, base);
 
   return {
     ...current,
-    [event.taskId]: eventViews[event.type](),
+    [event.taskId]: next,
   };
 }
 
-function describeAgentEvent(event: Extract<ControlPlaneHeartbeatEventEnvelope, { type: 'heartbeat.event' }>['event'] extends { event: infer AgentEvent } ? AgentEvent : never): string {
+function projectHeartbeatTaskEvent(
+  event: HeartbeatTaskEvent,
+  base: ControlPlaneLiveTaskState,
+): ControlPlaneLiveTaskState {
+  switch (event.type) {
+    case 'heartbeat.task.due':
+      return {
+        ...base,
+        status: 'waiting',
+        progress: 'Task is due. Waiting for the heartbeat runner...',
+      };
+    case 'heartbeat.task.started':
+      return {
+        ...base,
+        status: 'running',
+        progress: event.progress || 'Heartbeat runner started.',
+      };
+    case 'heartbeat.task.agent_event':
+      return {
+        ...base,
+        status: 'running',
+        progress: describeAgentEvent(event.event),
+        runId: 'runId' in event.event && typeof event.event.runId === 'string' ? event.event.runId : base.runId,
+      };
+    case 'heartbeat.task.finished':
+      return {
+        ...base,
+        status: event.record.task.state.status,
+        progress: event.record.task.state.progress ?? 'Heartbeat runner finished.',
+        runId: event.record.runId,
+      };
+    case 'heartbeat.task.failed':
+      return {
+        ...base,
+        status: 'failed',
+        progress: event.error,
+      };
+  }
+}
+
+function hasTaskId(event: HeartbeatEvent): event is HeartbeatTaskEvent {
+  return 'taskId' in event;
+}
+
+function describeAgentEvent(event: HeartbeatAgentEvent): string {
   if (!event || typeof event !== 'object' || !('type' in event)) {
     return 'Heartbeat runner is working...';
   }

--- a/src/web-v2/hooks/tasks/useControlPlaneTaskActions.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneTaskActions.ts
@@ -23,6 +23,8 @@ export function useControlPlaneTaskActions({
   const createTaskMutation = trpcReact.controlPlane.heartbeatTaskCreate.useMutation();
   const updateTaskMutation = trpcReact.controlPlane.heartbeatTaskUpdate.useMutation();
   const deleteTaskMutation = trpcReact.controlPlane.heartbeatTaskDelete.useMutation();
+  const enableTaskMutation = trpcReact.controlPlane.heartbeatTaskEnable.useMutation();
+  const disableTaskMutation = trpcReact.controlPlane.heartbeatTaskDisable.useMutation();
   const resumeTaskMutation = trpcReact.controlPlane.heartbeatTaskResume.useMutation();
   const runTaskNowMutation = trpcReact.controlPlane.heartbeatTaskRunNow.useMutation();
   const [createOpen, setCreateOpen] = useState(false);
@@ -116,6 +118,20 @@ export function useControlPlaneTaskActions({
     await invalidateTaskViews(taskId);
   }
 
+  async function setSelectedTaskEnabled(enabled: boolean) {
+    if (!navigation.selectedTaskId) {
+      return;
+    }
+
+    const taskId = navigation.selectedTaskId;
+    if (enabled) {
+      await enableTaskMutation.mutateAsync({ taskId });
+    } else {
+      await disableTaskMutation.mutateAsync({ taskId });
+    }
+    await invalidateTaskViews(taskId);
+  }
+
   async function invalidateTaskViews(taskId: string) {
     await Promise.all([
       utils.controlPlane.heartbeatTasks.invalidate(),
@@ -165,6 +181,12 @@ export function useControlPlaneTaskActions({
     },
     resumeSelectedTask,
     runSelectedTaskNow,
-    taskSubmitting: runTaskNowMutation.isPending || resumeTaskMutation.isPending || selectedTask?.state.status === 'running',
+    setSelectedTaskEnabled,
+    taskSubmitting:
+      runTaskNowMutation.isPending ||
+      resumeTaskMutation.isPending ||
+      enableTaskMutation.isPending ||
+      disableTaskMutation.isPending ||
+      selectedTask?.state.status === 'running',
   };
 }

--- a/src/web-v2/hooks/useControlPlaneAppState.ts
+++ b/src/web-v2/hooks/useControlPlaneAppState.ts
@@ -91,6 +91,7 @@ export function useControlPlaneAppState() {
         onDeleteTask: taskActions.openDeleteDialog,
         onRunNow: taskActions.runSelectedTaskNow,
         onResumeTask: taskActions.resumeSelectedTask,
+        onSetTaskEnabled: taskActions.setSelectedTaskEnabled,
         onSelectRun: taskSelection.selectRun,
       },
     },

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -90,8 +90,16 @@
     "tasks": "Tasks"
   },
   "tasks": {
+    "continuation": {
+      "agent": "Agent controlled",
+      "agentDescription": "The agent decision controls future runs. Complete stops the task until you enable or run it again.",
+      "operator": "Operator controlled",
+      "operatorDescription": "The schedule controls future runs. Agent decisions are recorded, but complete does not stop the task.",
+      "tooltipLabel": "Continuation mode details"
+    },
     "create": {
       "cancel": "Cancel",
+      "continuation": "Continuation",
       "create": "Create",
       "createAndRun": "Create and run",
       "defaultModel": "Default model",
@@ -112,6 +120,9 @@
       "taskPlaceholder": "Summarize recent repo changes and call out anything that needs review.",
       "title": "New task"
     },
+    "disable": "Disable task",
+    "enable": "Enable task",
+    "enabled": "enabled",
     "edit": {
       "description": "Update task instructions, schedule, and runtime settings.",
       "open": "Edit task",
@@ -125,6 +136,7 @@
       "open": "Delete task",
       "title": "Delete task"
     },
+    "paused": "paused",
     "resume": "Resume",
     "runNow": "Run now",
     "runDetailsAriaLabel": "Task run details"

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -90,8 +90,16 @@
     "tasks": "任务"
   },
   "tasks": {
+    "continuation": {
+      "agent": "Agent 控制",
+      "agentDescription": "Agent 决策会控制后续运行。complete 会停止任务，直到你再次启用或运行。",
+      "operator": "Operator 控制",
+      "operatorDescription": "计划会控制后续运行。Agent 决策会被记录，但 complete 不会停止任务。",
+      "tooltipLabel": "延续模式说明"
+    },
     "create": {
       "cancel": "取消",
+      "continuation": "延续方式",
       "create": "创建",
       "createAndRun": "创建并运行",
       "defaultModel": "默认模型",
@@ -112,6 +120,9 @@
       "taskPlaceholder": "总结最近仓库变更，并指出需要 review 的内容。",
       "title": "新建任务"
     },
+    "disable": "停用任务",
+    "enable": "启用任务",
+    "enabled": "已启用",
     "edit": {
       "description": "更新任务说明、计划和运行设置。",
       "open": "编辑任务",
@@ -125,6 +136,7 @@
       "open": "删除任务",
       "title": "删除任务"
     },
+    "paused": "已暂停",
     "resume": "恢复",
     "runNow": "立即运行",
     "runDetailsAriaLabel": "任务运行详情"

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -90,8 +90,16 @@
     "tasks": "任務"
   },
   "tasks": {
+    "continuation": {
+      "agent": "Agent 控制",
+      "agentDescription": "Agent 決策會控制後續執行。complete 會停止任務，直到你再次啟用或執行。",
+      "operator": "Operator 控制",
+      "operatorDescription": "排程會控制後續執行。Agent 決策會被記錄，但 complete 不會停止任務。",
+      "tooltipLabel": "延續模式說明"
+    },
     "create": {
       "cancel": "取消",
+      "continuation": "延續方式",
       "create": "建立",
       "createAndRun": "建立並執行",
       "defaultModel": "預設模型",
@@ -112,12 +120,24 @@
       "taskPlaceholder": "總結最近 repo 變更，並指出需要 review 的內容。",
       "title": "新增任務"
     },
+    "disable": "停用任務",
+    "enable": "啟用任務",
+    "enabled": "已啟用",
     "edit": {
       "description": "更新任務說明、排程和執行設定。",
       "open": "編輯任務",
       "save": "儲存變更",
       "title": "編輯任務"
     },
+    "delete": {
+      "cancel": "取消",
+      "confirm": "刪除任務",
+      "description": "刪除此任務、checkpoint 和已記錄的執行。此操作無法復原。",
+      "open": "刪除任務",
+      "title": "刪除任務"
+    },
+    "paused": "已暫停",
+    "resume": "恢復",
     "runNow": "立即執行",
     "runDetailsAriaLabel": "任務執行詳情"
   },

--- a/src/web-v2/views/TasksWorkbenchView.tsx
+++ b/src/web-v2/views/TasksWorkbenchView.tsx
@@ -12,6 +12,7 @@ interface TasksWorkbenchViewProps {
   onDeleteTask: () => void;
   onRunNow: () => Promise<void>;
   onResumeTask: () => Promise<void>;
+  onSetTaskEnabled: (enabled: boolean) => Promise<void>;
   onSelectRun: (runId: string) => void;
 }
 
@@ -26,6 +27,7 @@ export function TasksWorkbenchView({
   onDeleteTask,
   onRunNow,
   onResumeTask,
+  onSetTaskEnabled,
   onSelectRun,
 }: TasksWorkbenchViewProps) {
   if (loading) {
@@ -50,6 +52,7 @@ export function TasksWorkbenchView({
           onDelete={onDeleteTask}
           onRunNow={onRunNow}
           onResume={onResumeTask}
+          onSetEnabled={onSetTaskEnabled}
         />
         <section className="min-w-0">
           <h2 className="v2-type-section-label mb-2 text-muted-foreground">Runs</h2>

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,19 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
 
+"@radix-ui/react-switch@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-switch/-/react-switch-1.2.6.tgz#ff79acb831f0d5ea9216cfcc5b939912571358e3"
+  integrity sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
 "@radix-ui/react-toast@^1.2.15":
   version "1.2.15"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-toast/-/react-toast-1.2.15.tgz#746cf9a81297ddbfba214e5c81245ea3f706f876"


### PR DESCRIPTION
## Summary

- Add heartbeat task continuation mode with operator-controlled and agent-controlled behavior.
- Expose task enable/disable and continuation mode in the web-v2 task UI, including an info tooltip and mobile-safe wrapping.
- Add a Radix switch primitive for the scheduler enable toggle.
- Keep blocked tasks behind explicit Resume while allowing completed tasks to be enabled/rescheduled.
- Tighten nearby web-v2 task live-event/detail typing so the dedicated v2 build passes.

## Validation

- `yarn vitest run src/__tests__/integration/core/heartbeat-scheduler.test.ts src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts`
- `yarn typecheck`
- `yarn build`
- `yarn client:v2:build`
- `yarn lint`
- `yarn test:browser-integration:v2`
- Local Playwright visual check at desktop and 390x844 mobile widths: no horizontal overflow, continuation label visible, tooltip works, no console/page errors.
