### PR TITLE
[codex] unify session auto titles

### DIFF
--- a/docs/architecture/live-events.md
+++ b/docs/architecture/live-events.md
@@ -83,7 +83,7 @@ flowchart TD
   Runtime --> Trace
   Activity --> Publisher["ControlPlaneChatSessionEventsController<br/>publishActivity / publishActivities"]
   Publisher --> Bus["EventEmitter keyed by sessionId"]
-  Bus --> Queue["ControlPlaneSessionEventQueue<br/>AsyncIterable adapter"]
+  Bus --> Queue["ControlPlaneEventQueue<br/>AsyncIterable adapter"]
   Queue --> TRPC["tRPC subscription<br/>controlPlane.sessionEvents"]
   Bus --> SSE["SSE endpoint<br/>/control-plane/sessions/:id/events"]
   TRPC --> WebV2["web-v2 hook<br/>useControlPlaneSessionEvents"]
@@ -143,6 +143,11 @@ The server sends `ControlPlaneSessionEventEnvelope` values to browser clients:
 durable persisted state. Do not replace streaming with repeated full-session
 refreshes; that tends to wipe transient UI state and makes the interface feel
 non-streaming.
+
+Session-list metadata changes use the separate `controlPlane.sessionsEvents`
+tRPC subscription. That stream emits `sessions.updated` when the session catalog
+changes, so clients can refresh sidebars without subscribing to every individual
+session.
 
 ## Event Examples
 
@@ -262,8 +267,8 @@ cannot be watched yet:
 The control-plane controller uses an in-process `EventEmitter` keyed by
 `sessionId`. This keeps a live run scoped to the session that produced it.
 
-For tRPC subscriptions, `ControlPlaneSessionEventQueue` adapts EventEmitter
-callbacks into an `AsyncIterable`. It is transport infrastructure only:
+For tRPC subscriptions, `ControlPlaneEventQueue` adapts callbacks into an
+`AsyncIterable`. It is transport infrastructure only:
 
 - buffer events when the browser is not awaiting the next item yet;
 - wake pending readers when an event arrives;

--- a/src/__tests__/unit/control-plane/session-list-events.test.ts
+++ b/src/__tests__/unit/control-plane/session-list-events.test.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ControlPlaneChatSessionsController } from '@/server/features/control-plane/controllers/chat-sessions-controller.js';
+import type { ControlPlaneSessionsEventEnvelope } from '@/server/features/control-plane/types.js';
+
+describe('ControlPlaneChatSessionsController session list events', () => {
+  it('emits a sessions.updated event when the session catalog changes', async () => {
+    const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-session-list-events-'));
+    mkdirSync(stateRoot, { recursive: true });
+    const catalogPath = join(stateRoot, 'chat-sessions.catalog.json');
+    writeFileSync(catalogPath, JSON.stringify({ version: 1, sessions: [] }));
+
+    const controller = new ControlPlaneChatSessionsController();
+    const abort = new AbortController();
+    const events = controller.subscribeSessionListEvents({
+      stateRoot,
+      signal: abort.signal,
+    });
+    const next = nextSessionListEvent(events);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    writeFileSync(catalogPath, JSON.stringify({
+      version: 1,
+      sessions: [{
+        id: 'session-1',
+        name: 'Renamed session',
+        updatedAt: new Date().toISOString(),
+      }],
+    }));
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: 'sessions.updated',
+      },
+    });
+
+    abort.abort();
+    await events.return(undefined);
+  });
+});
+
+async function nextSessionListEvent(
+  events: AsyncGenerator<ControlPlaneSessionsEventEnvelope>,
+): Promise<IteratorResult<ControlPlaneSessionsEventEnvelope>> {
+  return await Promise.race([
+    events.next(),
+    new Promise<IteratorResult<ControlPlaneSessionsEventEnvelope>>((_, reject) => {
+      setTimeout(() => reject(new Error('Timed out waiting for sessions.updated')), 1000);
+    }),
+  ]);
+}

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -9,6 +9,7 @@ import type { TraceEvent } from '../../../core/types.js';
 import { FileChatSessionRepository } from '../../../core/chat/engine/sessions/repository/index.js';
 import type { ChatSession } from '../../../core/chat/types.js';
 import { TraceSummaryService } from '@/core/observability/index.js';
+import type { LlmAdapter } from '@/core/llm/types.js';
 
 describe('createConversationEngine', () => {
   beforeEach(() => {
@@ -145,6 +146,112 @@ describe('createConversationEngine', () => {
     expect(() => engine.sessions.updateSettings('missing', { driftEnabled: false })).toThrow(
       'Chat session not found: missing',
     );
+  });
+
+  it('auto-renames generic sessions after the first user message', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      apiKeyPresent: true,
+    });
+    const session = engine.sessions.create({ id: 'session-1', name: 'Session 1' });
+    engine.sessions.update(session.id, (current) => ({
+      ...current,
+      history: [
+        { role: 'user', content: 'Inspect the architecture docs' },
+        { role: 'assistant', content: 'The architecture docs place shared chat policy in core.' },
+      ],
+    }));
+
+    const result = await engine.sessions.autoRenameAfterFirstUserMessage(session.id, {
+      llm: fakeTitleLlm('Architecture Docs Review!!!'),
+      prompt: 'Inspect the architecture docs',
+      responseText: 'Shared chat policy belongs in core.',
+    });
+
+    expect(result.renamed).toBe(true);
+    expect(engine.sessions.require(session.id).name).toBe('Architecture Docs Review!!!');
+  });
+
+  it('does not auto-rename custom sessions or later multi-message sessions', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      apiKeyPresent: true,
+    });
+    const custom = engine.sessions.create({ id: 'custom-session', name: 'Manual Investigation' });
+    const later = engine.sessions.create({ id: 'later-session', name: 'Session 42' });
+    engine.sessions.update(custom.id, (session) => ({
+      ...session,
+      history: [
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'done' },
+      ],
+    }));
+    engine.sessions.update(later.id, (session) => ({
+      ...session,
+      history: [
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'done' },
+        { role: 'user', content: 'second' },
+        { role: 'assistant', content: 'done again' },
+      ],
+    }));
+    const llm = fakeTitleLlm('Generated Title');
+
+    await expect(engine.sessions.autoRenameAfterFirstUserMessage(custom.id, {
+      llm,
+      prompt: 'first',
+      responseText: 'done',
+    })).resolves.toEqual({ renamed: false, session: expect.objectContaining({ name: 'Manual Investigation' }) });
+    await expect(engine.sessions.autoRenameAfterFirstUserMessage(later.id, {
+      llm,
+      prompt: 'second',
+      responseText: 'done again',
+    })).resolves.toEqual({ renamed: false, session: expect.objectContaining({ name: 'Session 42' }) });
+    expect(llm.chat).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite a manual rename while title generation is running', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      apiKeyPresent: true,
+    });
+    const session = engine.sessions.create({ id: 'session-1', name: 'Session 1' });
+    engine.sessions.update(session.id, (current) => ({
+      ...current,
+      history: [
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'done' },
+      ],
+    }));
+    let resolveTitle: (value: { content: string }) => void = () => undefined;
+    const llm: LlmAdapter = {
+      chat: vi.fn(() => new Promise((resolve) => {
+        resolveTitle = resolve;
+      })),
+    };
+
+    const pending = engine.sessions.autoRenameAfterFirstUserMessage(session.id, {
+      llm,
+      prompt: 'first',
+      responseText: 'done',
+    });
+    engine.sessions.rename(session.id, 'Manual Rename');
+    resolveTitle({ content: 'Generated Rename' });
+
+    await expect(pending).resolves.toEqual({ renamed: false, session: expect.objectContaining({ name: 'Manual Rename' }) });
+    expect(engine.sessions.require(session.id).name).toBe('Manual Rename');
   });
 
   it('owns persisted conversation message, reset, continue prompt, and drift mutations', () => {
@@ -500,3 +607,9 @@ describe('createConversationEngine', () => {
     expect(sessionRepository.read('session-1', true)?.lease).toBeUndefined();
   });
 });
+
+function fakeTitleLlm(title: string): LlmAdapter {
+  return {
+    chat: vi.fn(async () => ({ content: title })),
+  };
+}

--- a/src/cli/chat/hooks/controllers/useAgentRunController.ts
+++ b/src/cli/chat/hooks/controllers/useAgentRunController.ts
@@ -15,9 +15,7 @@ import {
   RuntimeCredentialService,
 } from '@/core/runtime/credentials/index.js';
 import { ToolApprovalService } from '@/core/approvals/index.js';
-import { ChatSessionRecords, ChatSessionTitles } from '@/core/chat/engine/sessions/records/index.js';
 import type { ConversationSessionService } from '@/core/chat/engine/types.js';
-import { normalizeSessionTitle } from '../../utils/format.js';
 import type { ApprovalChoice, ChatSession, LiveEvent, PendingApproval } from '../../state/types.js';
 import type { ChatRuntimeConfig } from '../../utils/runtime.js';
 import {
@@ -189,25 +187,18 @@ export function useAgentRunController(args: UseAgentRunArgs) {
   );
 
   const maybeAutoNameSession = (sessionId: string, prompt: string, responseText: string) => {
-    const session = sessions.find((candidate) => candidate.id === sessionId);
-    if (!session || !ChatSessionRecords.isGenericName(session.name) || titleCredentialSource.type === 'missing') {
+    if (!sessions.some((candidate) => candidate.id === sessionId) || titleCredentialSource.type === 'missing') {
       return;
     }
 
     void (async () => {
       try {
-        const title = await ChatSessionTitles.generate({
+        const result = await sessionService.autoRenameAfterFirstUserMessage(sessionId, {
           llm: titleLlm,
           prompt,
           responseText,
-          normalize: normalizeSessionTitle,
         });
-        if (!title) {
-          return;
-        }
-
-        if (ChatSessionRecords.isGenericName(sessionService.require(sessionId).name)) {
-          sessionService.rename(sessionId, title);
+        if (result.renamed) {
           refreshSessions();
         }
       } catch (titleError) {

--- a/src/cli/chat/utils/format.ts
+++ b/src/cli/chat/utils/format.ts
@@ -329,23 +329,6 @@ function buildApprovalEffects(options: {
   return effects;
 }
 
-export function normalizeSessionTitle(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  const normalized = value
-    .replace(/[\r\n]+/g, ' ')
-    .replace(/["'`]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (!normalized) {
-    return undefined;
-  }
-
-  return truncate(normalized, 48);
-}
-
 function describePathAwareToolEffect(tool: string, path: string): string {
   switch (tool) {
     case 'list_files':

--- a/src/core/chat/engine/sessions/README.md
+++ b/src/core/chat/engine/sessions/README.md
@@ -42,7 +42,8 @@ The intended structure is class-based by responsibility:
 - `archives/` owns file-backed archived transcript and rolling-summary
   persistence for compacted chat history.
 - session title prompting lives under `records/` as session metadata behavior;
-  host auto-rename timing stays in the host.
+  first-message auto-rename policy lives on the session service so TUI and
+  control-plane hosts share it.
 - `types.ts` at this folder root describes the main session service contract
   and config shape.
 - each meaningful subfolder exposes a `types.ts` contract so callers can see

--- a/src/core/chat/engine/sessions/records/records.ts
+++ b/src/core/chat/engine/sessions/records/records.ts
@@ -105,4 +105,9 @@ export class ChatSessionRecords {
   static isGenericName(name: string): boolean {
     return /^Session \d+$/.test(name.trim());
   }
+
+  static canAutoRenameAfterFirstUserMessage(session: ChatSession): boolean {
+    return ChatSessionRecords.isGenericName(session.name)
+      && session.history.filter((message) => message.role === 'user').length === 1;
+  }
 }

--- a/src/core/chat/engine/sessions/records/titles.ts
+++ b/src/core/chat/engine/sessions/records/titles.ts
@@ -2,10 +2,11 @@
  * Pure session-title generation behavior.
  *
  * Owns the prompt and LLM call used to suggest a short chat session title.
- * Storage and host auto-rename policy stay outside this class.
+ * Storage and auto-rename policy stay on the session service.
  */
 import type { ChatMessage, LlmAdapter } from '@/core/llm/types.js';
 import type { GenerateChatSessionTitleInput } from './types.js';
+import { truncate } from '@/core/utils/text.js';
 
 export class ChatSessionTitles {
   static buildPrompt(prompt: string, responseText: string): ChatMessage[] {
@@ -13,7 +14,7 @@ export class ChatSessionTitles {
       {
         role: 'system',
         content:
-          'You name terminal chat sessions. Return only a short 3 to 6 word title in plain text. No quotes, no punctuation, no prefix.',
+          'You name chat sessions. Return only a short 3 to 6 word title in plain text. No quotes, no punctuation, no prefix.',
       },
       {
         role: 'user',
@@ -24,6 +25,23 @@ export class ChatSessionTitles {
 
   static async generate(args: GenerateChatSessionTitleInput & { llm: LlmAdapter }): Promise<string | undefined> {
     const result = await args.llm.chat(ChatSessionTitles.buildPrompt(args.prompt, args.responseText), []);
-    return args.normalize(result.content);
+    return ChatSessionTitles.normalize(result.content);
+  }
+
+  static normalize(value: string | undefined): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const normalized = value
+      .replace(/[\r\n]+/g, ' ')
+      .replace(/["'`]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (!normalized) {
+      return undefined;
+    }
+
+    return truncate(normalized, 48);
   }
 }

--- a/src/core/chat/engine/sessions/records/types.ts
+++ b/src/core/chat/engine/sessions/records/types.ts
@@ -17,7 +17,6 @@ export type CreateChatSessionRecordOptions = {
 export type GenerateChatSessionTitleInput = {
   prompt: string;
   responseText: string;
-  normalize: (value: string | undefined) => string | undefined;
 };
 
 export type BuildChatTurnSummaryInput = {

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -19,11 +19,13 @@ import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repositor
 import type { ChatSessionRepository } from '@/core/chat/engine/sessions/repository/types.js';
 import { ChatSessionLeases, type ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
-import { ChatSessionRecords, ConversationLines } from '@/core/chat/engine/sessions/records/index.js';
+import { ChatSessionRecords, ChatSessionTitles, ConversationLines } from '@/core/chat/engine/sessions/records/index.js';
 import type { ChatSession } from '@/core/chat/types.js';
 import type { NormalizedConversationEngineConfig } from '../config.js';
 import type {
   AppendConversationMessageInput,
+  AutoRenameConversationSessionInput,
+  AutoRenameConversationSessionResult,
   ApplyConversationCompactionResultInput,
   ConversationSessionService,
   CreateConversationSessionInput,
@@ -215,6 +217,31 @@ export class FileConversationSessionService implements ConversationSessionServic
       ...session,
       name,
     }));
+  }
+
+  async autoRenameAfterFirstUserMessage(
+    id: string,
+    input: AutoRenameConversationSessionInput,
+  ): Promise<AutoRenameConversationSessionResult> {
+    const session = this.read(id);
+    if (!session || !ChatSessionRecords.canAutoRenameAfterFirstUserMessage(session)) {
+      return { renamed: false, session };
+    }
+
+    const title = await ChatSessionTitles.generate(input);
+    if (!title) {
+      return { renamed: false, session };
+    }
+
+    const latest = this.require(id);
+    if (!ChatSessionRecords.canAutoRenameAfterFirstUserMessage(latest)) {
+      return { renamed: false, session: latest };
+    }
+
+    return {
+      renamed: true,
+      session: this.rename(id, title),
+    };
   }
 
   delete(id: string): boolean {

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -7,7 +7,7 @@ import type {
   TraceSummaryService,
 } from '@/core/observability/index.js';
 import type { AgentLoopEvent, RunAgentLoopOptions } from '../../runtime/loop/index.js';
-import type { ChatMessage, ReasoningEffort } from '../../llm/types.js';
+import type { ChatMessage, LlmAdapter, ReasoningEffort } from '../../llm/types.js';
 import type { TraceEvent } from '../../types.js';
 import type { ChatSessionLeaseOwner } from './sessions/leases/index.js';
 import type { ChatSession, ChatSessionRetention } from '../types.js';
@@ -51,6 +51,7 @@ export type ConversationSessionService = {
   create(input?: CreateConversationSessionInput): ChatSession;
   createOneOff(input?: CreateConversationSessionInput): ChatSession;
   rename(id: string, name: string): ChatSession;
+  autoRenameAfterFirstUserMessage(id: string, input: AutoRenameConversationSessionInput): Promise<AutoRenameConversationSessionResult>;
   delete(id: string): boolean;
 
   // Generic mutation escape hatch
@@ -87,6 +88,17 @@ export type CreateConversationSessionInput = {
   workspaceId?: string;
   apiKeyPresent?: boolean;
   retention?: ChatSessionRetention;
+};
+
+export type AutoRenameConversationSessionInput = {
+  llm: LlmAdapter;
+  prompt: string;
+  responseText: string;
+};
+
+export type AutoRenameConversationSessionResult = {
+  renamed: boolean;
+  session?: ChatSession;
 };
 
 export type UpdateConversationSessionSettingsInput = {

--- a/src/server/features/control-plane/controllers/chat-sessions-controller.ts
+++ b/src/server/features/control-plane/controllers/chat-sessions-controller.ts
@@ -15,6 +15,7 @@
 import { EventEmitter } from 'node:events';
 import { watch } from 'node:fs';
 import { join } from 'node:path';
+import type { Logger } from 'pino';
 import {
   ToolApprovalPolicies,
   ToolApprovalService,
@@ -46,6 +47,7 @@ import type {
   ChatTurnReview,
   ControlPlaneSessionEventEnvelope,
   ControlPlaneSessionLiveEvent,
+  ControlPlaneSessionsEventEnvelope,
 } from '../types.js';
 
 type ControlPlaneSessionReadArgs = Omit<ConversationEngineConfig, 'model'> & {
@@ -70,6 +72,7 @@ type SubmitChatPromptArgs = ControlPlaneSessionReadArgs & {
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;
   leaseOwner: ChatSessionLeaseOwner;
+  logger?: Pick<Logger, 'debug'>;
 };
 
 type ContinueChatPromptArgs = Omit<SubmitChatPromptArgs, 'prompt'>;
@@ -120,7 +123,7 @@ export class ControlPlaneChatSessionsController {
       return await this.runFakeBrowserIntegrationSessionPrompt(args);
     }
 
-    return await this.runEngineTurn(args, async ({ engine, host, abortSignal }) => {
+    const result = await this.runEngineTurn(args, async ({ engine, host, abortSignal }) => {
       return await engine.turns.submit({
         sessionId: args.sessionId,
         prompt: args.prompt,
@@ -132,6 +135,11 @@ export class ControlPlaneChatSessionsController {
         leaseOwner: args.leaseOwner,
       });
     });
+    this.scheduleAutoRenameAfterFirstUserMessage(args, {
+      responseText: result.summary,
+      sessionModel: result.session?.model,
+    });
+    return result;
   }
 
   async continuePrompt(args: ContinueChatPromptArgs) {
@@ -172,7 +180,7 @@ export class ControlPlaneChatSessionsController {
     sessionId: string;
     signal?: AbortSignal;
   }): AsyncGenerator<ControlPlaneSessionEventEnvelope> {
-    const queue = new ControlPlaneSessionEventQueue();
+    const queue = new ControlPlaneEventQueue<ControlPlaneSessionEventEnvelope>();
 
     // Live LLM/tool/compaction updates arrive through the in-memory event bus.
     // This is the path that streams assistant text to the client during a run;
@@ -220,6 +228,40 @@ export class ControlPlaneChatSessionsController {
       }
     } finally {
       unsubscribe();
+      watcher?.close();
+      args.signal?.removeEventListener('abort', abort);
+      queue.close();
+    }
+  }
+
+  async *subscribeSessionListEvents(args: {
+    stateRoot: string;
+    signal?: AbortSignal;
+  }): AsyncGenerator<ControlPlaneSessionsEventEnvelope> {
+    const queue = new ControlPlaneEventQueue<ControlPlaneSessionsEventEnvelope>();
+    const abort = () => queue.close();
+    args.signal?.addEventListener('abort', abort, { once: true });
+
+    let watcher: ReturnType<typeof watch> | undefined;
+    try {
+      watcher = watch(join(args.stateRoot, 'chat-sessions.catalog.json'), { persistent: false }, () => {
+        queue.push({
+          type: 'sessions.updated',
+          timestamp: new Date().toISOString(),
+        });
+      });
+    } catch {
+      queue.push({
+        type: 'waiting',
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    try {
+      for await (const event of queue) {
+        yield event;
+      }
+    } finally {
       watcher?.close();
       args.signal?.removeEventListener('abort', abort);
       queue.close();
@@ -319,6 +361,55 @@ export class ControlPlaneChatSessionsController {
       this.pendingApprovals.delete(args.sessionId);
       this.inFlightRuns.delete(args.sessionId);
     }
+  }
+
+  private scheduleAutoRenameAfterFirstUserMessage(
+    args: SubmitChatPromptArgs,
+    input: { responseText: string; sessionModel?: string },
+  ): void {
+    const titleLlm = this.createSessionTitleLlm(args, input.sessionModel);
+    if (!titleLlm) {
+      return;
+    }
+
+    void this.createEngine(args).sessions.autoRenameAfterFirstUserMessage(args.sessionId, {
+      llm: titleLlm,
+      prompt: args.prompt,
+      responseText: input.responseText,
+    }).catch((error: unknown) => {
+      args.logger?.debug(
+        { error: error instanceof Error ? error.message : String(error), sessionId: args.sessionId },
+        'Session auto-title failed',
+      );
+    });
+  }
+
+  private createSessionTitleLlm(
+    args: Pick<ControlPlaneSessionReadArgs, 'preferApiKey' | 'credentialStorePath' | 'model'>,
+    sessionModel: string | undefined,
+  ) {
+    const activeModel = sessionModel ?? args.model ?? DEFAULT_OPENAI_MODEL;
+    const credentialMode = ModelPolicyService.credentialModeFromSource(
+      RuntimeCredentialService.resolveCredentialSourceForModel(activeModel, args),
+    );
+    const titleModel = ModelPolicyService.resolveSystemSelectedModel({
+      purpose: 'session-title',
+      provider: 'openai',
+      activeModel,
+      credentialMode,
+    });
+    const titleCredentialSource = RuntimeCredentialService.resolveCredentialSourceForModel(titleModel, args);
+    if (titleCredentialSource.type === 'missing') {
+      return undefined;
+    }
+
+    return LlmAdapterService.create({
+      model: titleModel,
+      credentials: {
+        apiKey: RuntimeCredentialService.resolveApiKeyForModel(titleModel, args),
+        credentialStorePath: args.credentialStorePath,
+      },
+    });
   }
 
   private createEngine(args: ControlPlaneSessionReadArgs): ConversationEngine {
@@ -475,24 +566,21 @@ export class ControlPlaneChatSessionsController {
 export const controlPlaneChatSessionsController = new ControlPlaneChatSessionsController();
 
 /**
- * Per-subscription delivery queue for control-plane session events.
+ * Per-subscription delivery queue for control-plane events.
  *
- * The controller uses EventEmitter for in-process fanout, while tRPC
- * subscriptions consume an AsyncIterable. This queue is the transport adapter
- * between those two shapes: it buffers events when the browser is not awaiting
- * the next item yet, wakes pending readers when an event arrives, and closes
- * cleanly when the subscription is aborted.
+ * Some controller sources use EventEmitter and others use file watchers, while
+ * tRPC subscriptions consume an AsyncIterable. This queue is the transport
+ * adapter between push callbacks and subscription iteration.
  *
  * Boundary: this class must stay transport/infrastructure-only. It should not
- * inspect or transform conversation activities; event vocabulary belongs to the
- * conversation engine and control-plane event publisher.
+ * inspect or transform event payloads.
  */
-class ControlPlaneSessionEventQueue implements AsyncIterable<ControlPlaneSessionEventEnvelope> {
-  private readonly events: ControlPlaneSessionEventEnvelope[] = [];
-  private readonly waiters: Array<(event: ControlPlaneSessionEventEnvelope | undefined) => void> = [];
+class ControlPlaneEventQueue<Event> implements AsyncIterable<Event> {
+  private readonly events: Event[] = [];
+  private readonly waiters: Array<(event: Event | undefined) => void> = [];
   private closed = false;
 
-  push(event: ControlPlaneSessionEventEnvelope): void {
+  push(event: Event): void {
     if (this.closed) {
       return;
     }
@@ -515,9 +603,9 @@ class ControlPlaneSessionEventQueue implements AsyncIterable<ControlPlaneSession
     this.waiters.splice(0).forEach((waiter) => waiter(undefined));
   }
 
-  async *[Symbol.asyncIterator](): AsyncIterator<ControlPlaneSessionEventEnvelope> {
+  async *[Symbol.asyncIterator](): AsyncIterator<Event> {
     while (!this.closed || this.events.length > 0) {
-      const event = this.events.shift() ?? await new Promise<ControlPlaneSessionEventEnvelope | undefined>((resolve) => {
+      const event = this.events.shift() ?? await new Promise<Event | undefined>((resolve) => {
         this.waiters.push(resolve);
       });
       if (!event) {

--- a/src/server/features/control-plane/router.ts
+++ b/src/server/features/control-plane/router.ts
@@ -200,6 +200,12 @@ export const controlPlaneRouter = router({
       sessions: controlPlaneChatSessionsController.readViews(controlPlaneSessionEngineArgs(ctx)),
     };
   }),
+  sessionsEvents: procedure.subscription(({ ctx, signal }) => {
+    return controlPlaneChatSessionsController.subscribeSessionListEvents({
+      stateRoot: ctx.activeWorkspace.stateRoot,
+      signal,
+    });
+  }),
   sessionCreate: procedure.input(createSessionInputSchema).mutation(({ ctx, input }) => {
     return controlPlaneChatSessionsController.createSession({
       ...controlPlaneSessionEngineArgs(ctx),
@@ -279,6 +285,7 @@ export const controlPlaneRouter = router({
       includePlanTool: input.includePlanTool,
       apiKey: input.apiKey,
       preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
+      logger: ctx.logger,
       systemContext: input.systemContext,
       memoryMaintenanceMode: input.memoryMaintenanceMode,
       leaseOwner: {

--- a/src/server/features/control-plane/types.ts
+++ b/src/server/features/control-plane/types.ts
@@ -163,6 +163,11 @@ export type ControlPlaneSessionEventEnvelope =
     timestamp: string;
   };
 
+export type ControlPlaneSessionsEventEnvelope = {
+  type: 'sessions.updated' | 'waiting';
+  timestamp: string;
+};
+
 export type ControlPlaneHeartbeatAgentEvent = {
   type: string;
   timestamp?: string;

--- a/src/web-v2/api/client.ts
+++ b/src/web-v2/api/client.ts
@@ -33,6 +33,7 @@ type AsyncIterableValue<T> = T extends AsyncIterable<infer Value> ? Value : T;
 export type ControlPlaneState = RouterOutputs['controlPlane']['state'];
 export type ControlPlaneSessionDetail = RouterOutputs['controlPlane']['session'];
 export type ControlPlaneSessionEventEnvelope = AsyncIterableValue<RouterOutputs['controlPlane']['sessionEvents']>;
+export type ControlPlaneSessionsEventEnvelope = AsyncIterableValue<RouterOutputs['controlPlane']['sessionsEvents']>;
 export type ControlPlaneHeartbeatEventEnvelope = AsyncIterableValue<RouterOutputs['controlPlane']['heartbeatEvents']>;
 export type ControlPlaneSessionMessage = NonNullable<ControlPlaneSessionDetail>['messages'][number];
 export type ControlPlanePendingApproval = RouterOutputs['controlPlane']['sessionPendingApproval'];

--- a/src/web-v2/hooks/shell/useControlPlaneSidebarData.ts
+++ b/src/web-v2/hooks/shell/useControlPlaneSidebarData.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { trpcReact } from '@web/api/client';
+import { trpcReact, type ControlPlaneSessionsEventEnvelope } from '@web/api/client';
 import type { useWorkbenchNavigation } from '../useWorkbenchNavigation';
 import { applyLiveTaskState } from '../tasks/useControlPlaneTaskLiveState';
 import type { useControlPlaneHeartbeatEvents } from '../tasks/useControlPlaneHeartbeatEvents';
@@ -15,11 +15,12 @@ export function useControlPlaneSidebarData({
   taskEvents: HeartbeatEvents;
 }) {
   const stateQuery = trpcReact.controlPlane.state.useQuery();
+  const sessionsQuery = trpcReact.controlPlane.sessions.useQuery();
   const tasksQuery = trpcReact.controlPlane.heartbeatTasks.useQuery();
 
   const sessions = useMemo(
-    () => stateQuery.data?.sessions ?? [],
-    [stateQuery.data?.sessions],
+    () => sessionsQuery.data?.sessions ?? stateQuery.data?.sessions ?? [],
+    [sessionsQuery.data?.sessions, stateQuery.data?.sessions],
   );
   const tasks = useMemo(
     () => (tasksQuery.data?.tasks ?? []).map((task) => applyLiveTaskState(task, taskEvents.liveTasks[task.taskId])),
@@ -42,8 +43,19 @@ export function useControlPlaneSidebarData({
     navigation.selectTask(tasks[0]!.taskId, { replace: true });
   }, [navigation, tasks]);
 
+  trpcReact.controlPlane.sessionsEvents.useSubscription(undefined, {
+    onData: (event: ControlPlaneSessionsEventEnvelope) => {
+      if (event.type !== 'sessions.updated') {
+        return;
+      }
+
+      void sessionsQuery.refetch();
+    },
+  });
+
   return {
     stateQuery,
+    sessionsQuery,
     tasksQuery,
     sessions,
     tasks,

--- a/src/web-v2/hooks/useControlPlaneAppState.ts
+++ b/src/web-v2/hooks/useControlPlaneAppState.ts
@@ -42,7 +42,10 @@ export function useControlPlaneAppState() {
   async function createSession() {
     const session = await createSessionMutation.mutateAsync();
     navigation.selectSession(session.id);
-    await utils.controlPlane.state.invalidate();
+    await Promise.all([
+      utils.controlPlane.state.invalidate(),
+      utils.controlPlane.sessions.invalidate(),
+    ]);
   }
 
   return {


### PR DESCRIPTION
## Summary

- Move first-message session auto-title policy into the core conversation session service.
- Reuse the shared auto-title service from TUI and web/control-plane prompt submission.
- Add a `controlPlane.sessionsEvents` subscription so web-v2 sidebars refresh when session metadata changes.
- Update live-event docs and add focused regression coverage for auto-title and session-list events.

## Why

TUI already renamed generic sessions after the first response, but web-v2 did not. The title prompt lived in core while the rename policy lived in the TUI host, which made parity drift likely. This PR keeps the policy at the session service boundary and lets hosts only provide runtime dependencies.

## Validation

- `yarn install` completed and ran package prepare/build successfully.
- `yarn test:unit src/__tests__/unit/core/conversation-engine.test.ts src/__tests__/unit/control-plane/session-list-events.test.ts` passed. The script runs the full unit suite: 48 files, 309 tests.
- `yarn typecheck`
- `yarn client:v2:build`
- `yarn lint`
- `git diff --check`