### PR TITLE
[codex] Refine workspace-scoped session routing

### DIFF
--- a/docs/architecture/live-events.md
+++ b/docs/architecture/live-events.md
@@ -82,7 +82,7 @@ flowchart TD
   Agent --> Trace["TraceEvent<br/>durable observability"]
   Runtime --> Trace
   Activity --> Publisher["ControlPlaneChatSessionEventsController<br/>publishActivity / publishActivities"]
-  Publisher --> Bus["EventEmitter keyed by sessionId"]
+  Publisher --> Bus["EventEmitter keyed by workspaceId + sessionId"]
   Bus --> Queue["RuntimeSubscriptionStream<br/>AsyncIterable adapter"]
   Queue --> TRPC["tRPC subscription<br/>controlPlane.sessionEvents"]
   Bus --> SSE["SSE endpoint<br/>/control-plane/sessions/:id/events"]
@@ -265,7 +265,9 @@ cannot be watched yet:
 ## Delivery Mechanics
 
 The control-plane controller uses an in-process `EventEmitter` keyed by
-`sessionId`. This keeps a live run scoped to the session that produced it.
+`workspaceId` and `sessionId`. This keeps a live run scoped to the session and
+workspace state root that produced it, even when different workspaces contain
+the same session id.
 
 For tRPC subscriptions, `RuntimeSubscriptionStream` in
 `src/core/runtime/subscriptions` adapts callbacks into an `AsyncIterable`. It is

--- a/docs/architecture/workspaces.md
+++ b/docs/architecture/workspaces.md
@@ -1,0 +1,106 @@
+# Workspaces
+
+This document defines the workspace contract for the daemon, server control
+plane, and web-v2.
+
+## Goal
+
+A workspace is the project root whose `.heddle` directory owns all project
+state. The workspace's state root is the source of truth for sessions, memory,
+traces, logs, uploads, heartbeat tasks, and any other persisted side effect.
+
+The daemon can serve multiple workspaces, but a workspace-scoped operation must
+never infer its target from the daemon process current directory after the
+request has reached the server boundary.
+
+## Vocabulary
+
+- **Workspace root**: the project directory shown to the user.
+- **Workspace state root**: the `.heddle` directory under the workspace root.
+- **Heddle global registry**: the user-level registry under `~/.heddle` that
+  records daemon ownership and known workspaces across local state roots.
+- **Request workspace**: the workspace selected by one frontend request,
+  resolved once from the request `workspaceId`.
+
+`stateRoot` is derived from the workspace root as `<workspaceRoot>/.heddle`.
+Avoid reintroducing older root names such as `anchorRoot`.
+
+## Runtime Model
+
+The daemon has a startup workspace for bootstrap, asset serving, registry
+ownership, and default fallback behavior. That startup workspace is not the
+same thing as the workspace currently visible in web-v2.
+
+Web-v2 carries the selected `workspaceId` in workspace-owned tRPC calls and
+upload requests. The server resolves that id to a `RequestWorkspace` once at
+the API boundary:
+
+```text
+web-v2 selected workspaceId
+  -> tRPC workspace middleware or upload service
+  -> RequestWorkspace { workspaceRoot, stateRoot, workspaceId }
+  -> controller
+  -> core service
+  -> persisted state under stateRoot
+```
+
+Controllers and core services should receive concrete roots. They should not
+look at process cwd, daemon cwd, or the active workspace catalog again for a
+request that already resolved a request workspace.
+
+## Frontend Rule
+
+Everything visible in web-v2 should be keyed by the selected workspace:
+
+- the session list;
+- selected session detail;
+- live session event subscription;
+- file mention autocomplete;
+- diff preview;
+- memory settings/status;
+- heartbeat tasks and runs;
+- image uploads.
+
+When the user switches workspace, the UI may leave runs active in the old
+workspace. Late responses from the old workspace must refresh that old
+workspace's cache, but must not overwrite the currently viewed workspace or
+session state.
+
+## Backend Side Effects
+
+Workspace-scoped control-plane procedures use the request workspace resolved by
+`controlPlaneWorkspaceProcedure`. The concrete roots must flow into the domain
+owner:
+
+- session catalog and session JSON: `stateRoot/chat-sessions.catalog.json` and
+  `stateRoot/chat-sessions/`;
+- traces: `stateRoot/traces/`;
+- memory: `stateRoot/memory/`;
+- uploaded images: `stateRoot/uploads/sessions/<sessionId>/`;
+- heartbeat tasks and runs: `stateRoot/heartbeat/`;
+- diff and file search: `workspaceRoot`;
+- operation logs: `stateRoot/logs/server.log`.
+
+The daemon may still write process lifecycle and transport-level logs to the
+startup state root. Workspace operations should additionally write to the
+request workspace log so debugging evidence follows the same state root as the
+session, trace, and memory artifacts.
+
+## Extension Rules
+
+When adding a new web-v2 feature that reads or mutates workspace-owned data:
+
+1. Carry `workspaceId` from the selected route or shell state into the API call.
+2. Use the workspace-scoped tRPC procedure unless the operation is genuinely
+   global, such as browsing local directories or creating a workspace.
+3. Resolve the workspace once at the server boundary.
+4. Pass `workspaceRoot`, `stateRoot`, and `workspaceId` downstream as concrete
+   values.
+5. Include `workspaceId` in React Query inputs and invalidate the specific
+   workspace cache after mutations.
+6. Add a regression test proving the operation uses the requested workspace
+   without switching the daemon active workspace.
+
+Do not add compatibility shims that silently fall back to the daemon workspace
+for workspace-owned data. If a temporary compatibility path is unavoidable,
+mark it with an inline comment so it is easy to remove before v2 release.

--- a/docs/architecture/workspaces.md
+++ b/docs/architecture/workspaces.md
@@ -38,7 +38,7 @@ the API boundary:
 ```text
 web-v2 selected workspaceId
   -> tRPC workspace middleware or upload service
-  -> RequestWorkspace { workspaceRoot, stateRoot, workspaceId }
+  -> RequestWorkspace { workspaceRoot, stateRoot, workspaceId, logger }
   -> controller
   -> core service
   -> persisted state under stateRoot
@@ -85,6 +85,10 @@ The daemon may still write process lifecycle and transport-level logs to the
 startup state root. Workspace operations should additionally write to the
 request workspace log so debugging evidence follows the same state root as the
 session, trace, and memory artifacts.
+
+Workspace loggers are cached per resolved workspace state root. Workspace-owned
+controllers should use the logger on the resolved request workspace instead of
+the daemon startup logger.
 
 ## Extension Rules
 

--- a/src/__tests__/integration/control-plane/session-image-uploads.test.ts
+++ b/src/__tests__/integration/control-plane/session-image-uploads.test.ts
@@ -1,10 +1,11 @@
-import { existsSync, mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
 import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
 import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
+import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 import { createHeddleServerApp } from '@/server/app.js';
 
 describe('control-plane session image uploads', () => {
@@ -50,6 +51,8 @@ describe('control-plane session image uploads', () => {
       expect(body.uploads?.map((upload) => upload.mediaType)).toEqual(['image/png', 'image/webp', 'image/png']);
       expect(body.uploads?.every((upload) => upload.path.includes(join('.heddle', 'uploads', 'sessions', sessionId)))).toBe(true);
       expect(body.uploads?.every((upload) => existsSync(upload.path))).toBe(true);
+      const log = await readLogUntil(join(stateRoot, 'logs', 'server.log'), 'Control-plane session images uploaded');
+      expect(log).toContain(sessionId);
     } finally {
       await closeServer(server);
     }
@@ -89,6 +92,65 @@ describe('control-plane session image uploads', () => {
       await closeServer(server);
     }
   });
+
+  it('stores uploads and upload logs under the requested workspace state root', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-session-image-upload-workspaces-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
+    const resolved = RuntimeWorkspaceService.createDescriptor({
+      workspaceRoot,
+      stateRoot,
+      name: 'Second workspace',
+      newWorkspaceRoot: join(workspaceRoot, 'second'),
+      setActive: false,
+      nextId: 'workspace-2',
+    });
+    const secondWorkspace = resolved.workspaces.find((workspace) => workspace.id === 'workspace-2');
+    if (!secondWorkspace) {
+      throw new Error('expected second workspace');
+    }
+
+    const sessionId = 'session-images';
+    new FileChatSessionRepository({
+      sessionStoragePath: join(secondWorkspace.stateRoot, 'chat-sessions.catalog.json'),
+    }).save([
+      ChatSessionRecords.create({
+        id: sessionId,
+        name: 'Image session',
+        apiKeyPresent: true,
+        workspaceId: secondWorkspace.id,
+      }),
+    ]);
+
+    const server = createHeddleServerApp({ workspaceRoot, stateRoot }).listen(0, '127.0.0.1');
+    await onceListening(server);
+    const address = server.address() as AddressInfo;
+
+    try {
+      const formData = new FormData();
+      formData.append('images', new Blob(['fake-png'], { type: 'image/png' }), 'screen.png');
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/control-plane/sessions/${sessionId}/uploads?workspaceId=${secondWorkspace.id}`, {
+        method: 'POST',
+        body: formData,
+      });
+      const body = await response.json() as {
+        uploads?: Array<{ path: string; originalName: string; mediaType: string; sizeBytes: number }>;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.uploads).toHaveLength(1);
+      expect(body.uploads?.[0]?.path).toContain(join(secondWorkspace.stateRoot, 'uploads', 'sessions', sessionId));
+      expect(body.uploads?.[0]?.path).not.toContain(join(stateRoot, 'uploads', 'sessions', sessionId));
+      const secondLog = await readLogUntil(join(secondWorkspace.stateRoot, 'logs', 'server.log'), 'Control-plane session images uploaded');
+      expect(secondLog).toContain(secondWorkspace.id);
+      const defaultLogPath = join(stateRoot, 'logs', 'server.log');
+      const defaultLog = existsSync(defaultLogPath) ? readFileSync(defaultLogPath, 'utf8') : '';
+      expect(defaultLog).not.toContain('Control-plane session images uploaded');
+    } finally {
+      await closeServer(server);
+    }
+  });
 });
 
 async function onceListening(server: { once: (event: 'listening', listener: () => void) => void; listening?: boolean }) {
@@ -112,4 +174,20 @@ async function closeServer(server: { close: (listener: (error?: Error) => void) 
       resolve();
     });
   });
+}
+
+async function readLogUntil(path: string, expectedText: string): Promise<string> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) {
+      const text = readFileSync(path, 'utf8');
+      if (text.includes(expectedText)) {
+        return text;
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  return existsSync(path) ? readFileSync(path, 'utf8') : '';
 }

--- a/src/__tests__/integration/control-plane/workspace-catalog.test.ts
+++ b/src/__tests__/integration/control-plane/workspace-catalog.test.ts
@@ -233,6 +233,21 @@ describe('workspace catalog', () => {
     const secondSessions = await caller.sessions({ workspaceId: secondWorkspace.id });
     expect(defaultSessions.sessions.map((session) => session.name)).toEqual(['Default workspace session']);
     expect(secondSessions.sessions.map((session) => session.name)).toEqual(['Second workspace session']);
+    await expect(caller.state({ workspaceId: secondWorkspace.id })).resolves.toMatchObject({
+      activeWorkspaceId: secondWorkspace.id,
+      workspace: {
+        id: secondWorkspace.id,
+        workspaceRoot: secondWorkspace.workspaceRoot,
+        stateRoot: secondWorkspace.stateRoot,
+      },
+      sessions: [
+        expect.objectContaining({
+          id: 'session-1',
+          name: 'Second workspace session',
+          workspaceId: secondWorkspace.id,
+        }),
+      ],
+    });
 
     await caller.sessionSettingsUpdate({
       workspaceId: secondWorkspace.id,
@@ -293,6 +308,10 @@ describe('workspace catalog', () => {
     })).resolves.toMatchObject({
       files: [{ path: 'second-only.md' }],
     });
+
+    const secondWorkspaceLog = await readLogUntil(join(secondWorkspace.stateRoot, 'logs', 'server.log'), 'workspaceFileSearch');
+    expect(secondWorkspaceLog).toContain(secondWorkspace.stateRoot);
+    expect(existsSync(join(activeWorkspace.stateRoot, 'logs', 'server.log'))).toBe(false);
   });
 
   it('repairs legacy workspace roots before routing file search', async () => {
@@ -441,3 +460,19 @@ describe('workspace catalog', () => {
     expect(listingWithHidden.entries.map((entry) => entry.name)).toContain('.hidden');
   });
 });
+
+async function readLogUntil(path: string, expectedText: string): Promise<string> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) {
+      const text = readFileSync(path, 'utf8');
+      if (text.includes(expectedText)) {
+        return text;
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  return existsSync(path) ? readFileSync(path, 'utf8') : '';
+}

--- a/src/__tests__/integration/control-plane/workspace-catalog.test.ts
+++ b/src/__tests__/integration/control-plane/workspace-catalog.test.ts
@@ -9,6 +9,7 @@ import {
   RuntimeWorkspaceService,
 } from '@/core/runtime/workspaces/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
+import { createConversationEngine } from '@/core/chat/engine/conversation-engine.js';
 import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
 
 describe('workspace catalog', () => {
@@ -27,14 +28,14 @@ describe('workspace catalog', () => {
     expect(catalog.workspaces).toHaveLength(1);
     expect(catalog.workspaces[0]).toMatchObject({
       id: DEFAULT_WORKSPACE_ID,
-      anchorRoot: workspaceRoot,
+      workspaceRoot,
       repoRoots: [workspaceRoot],
       stateRoot,
     });
 
     const saved = JSON.parse(readFileSync(catalogPath, 'utf8')) as typeof catalog;
     expect(saved.activeWorkspaceId).toBe(DEFAULT_WORKSPACE_ID);
-    expect(saved.workspaces[0]?.anchorRoot).toBe(workspaceRoot);
+    expect(saved.workspaces[0]?.workspaceRoot).toBe(workspaceRoot);
   });
 
   it('exposes the active workspace in control-plane state', async () => {
@@ -68,7 +69,7 @@ describe('workspace catalog', () => {
     expect(state.activeWorkspaceId).toBe(DEFAULT_WORKSPACE_ID);
     expect(state.workspace).toMatchObject({
       id: DEFAULT_WORKSPACE_ID,
-      anchorRoot: workspaceRoot,
+      workspaceRoot,
       stateRoot,
     });
     expect(state.workspaces).toHaveLength(1);
@@ -95,7 +96,7 @@ describe('workspace catalog', () => {
       workspaceRoot,
       stateRoot,
       name: 'Second workspace',
-      anchorRoot: join(workspaceRoot, 'nested'),
+      newWorkspaceRoot: join(workspaceRoot, 'nested'),
       setActive: false,
       nextId: 'workspace-2',
     });
@@ -113,7 +114,7 @@ describe('workspace catalog', () => {
     expect(switched.activeWorkspace).toMatchObject({
       id: 'workspace-2',
       name: 'Second workspace',
-      anchorRoot: join(workspaceRoot, 'nested'),
+      workspaceRoot: join(workspaceRoot, 'nested'),
       stateRoot: join(workspaceRoot, 'nested', '.heddle'),
     });
   });
@@ -163,13 +164,13 @@ describe('workspace catalog', () => {
 
     const created = await caller.workspaceCreate({
       name: 'Second workspace',
-      anchorRoot: join(workspaceRoot, 'second'),
+      workspaceRoot: join(workspaceRoot, 'second'),
       setActive: true,
     });
     expect(created.activeWorkspaceId).not.toBe(DEFAULT_WORKSPACE_ID);
     expect(created.workspace).toMatchObject({
       name: 'Second workspace',
-      anchorRoot: join(workspaceRoot, 'second'),
+      workspaceRoot: join(workspaceRoot, 'second'),
       stateRoot: join(workspaceRoot, 'second', '.heddle'),
     });
 
@@ -183,6 +184,186 @@ describe('workspace catalog', () => {
     const registeredStateRoots = RuntimeDaemonRegistryService.read(registryPath).workspaces.map((record) => record.workspace.stateRoot);
     expect(registeredStateRoots).toContain(stateRoot);
     expect(registeredStateRoots).toContain(join(workspaceRoot, 'second', '.heddle'));
+  });
+
+  it('routes session APIs through the requested workspace state root without switching active workspace', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-workspace-session-routing-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
+    const resolved = RuntimeWorkspaceService.createDescriptor({
+      workspaceRoot,
+      stateRoot,
+      name: 'Second workspace',
+      newWorkspaceRoot: join(workspaceRoot, 'second'),
+      setActive: false,
+      nextId: 'workspace-2',
+    });
+    const activeWorkspace = resolved.workspaces.find((workspace) => workspace.id === DEFAULT_WORKSPACE_ID);
+    const secondWorkspace = resolved.workspaces.find((workspace) => workspace.id === 'workspace-2');
+    if (!activeWorkspace || !secondWorkspace) {
+      throw new Error('expected both workspaces');
+    }
+
+    createConversationEngine({
+      workspaceRoot: activeWorkspace.workspaceRoot,
+      stateRoot: activeWorkspace.stateRoot,
+      model: 'gpt-5.4',
+      workspaceId: activeWorkspace.id,
+      apiKeyPresent: true,
+    }).sessions.create({ id: 'session-1', name: 'Default workspace session' });
+    createConversationEngine({
+      workspaceRoot: secondWorkspace.workspaceRoot,
+      stateRoot: secondWorkspace.stateRoot,
+      model: 'gpt-5.4',
+      workspaceId: secondWorkspace.id,
+      apiKeyPresent: true,
+    }).sessions.create({ id: 'session-1', name: 'Second workspace session' });
+
+    const caller = controlPlaneRouter.createCaller({
+      workspaceRoot,
+      stateRoot,
+      activeWorkspaceId: activeWorkspace.id,
+      activeWorkspace,
+      workspaces: resolved.workspaces,
+      runtimeHost: null,
+      logger: pino({ level: 'silent' }),
+    });
+
+    const defaultSessions = await caller.sessions({ workspaceId: activeWorkspace.id });
+    const secondSessions = await caller.sessions({ workspaceId: secondWorkspace.id });
+    expect(defaultSessions.sessions.map((session) => session.name)).toEqual(['Default workspace session']);
+    expect(secondSessions.sessions.map((session) => session.name)).toEqual(['Second workspace session']);
+
+    await caller.sessionSettingsUpdate({
+      workspaceId: secondWorkspace.id,
+      id: 'session-1',
+      model: 'gpt-5.5',
+    });
+
+    await expect(caller.session({ workspaceId: activeWorkspace.id, id: 'session-1' })).resolves.toMatchObject({
+      id: 'session-1',
+      name: 'Default workspace session',
+      model: 'gpt-5.4',
+      workspaceId: activeWorkspace.id,
+    });
+    await expect(caller.session({ workspaceId: secondWorkspace.id, id: 'session-1' })).resolves.toMatchObject({
+      id: 'session-1',
+      name: 'Second workspace session',
+      model: 'gpt-5.5',
+      workspaceId: secondWorkspace.id,
+    });
+  });
+
+  it('routes workspace file search through the requested workspace root', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-workspace-file-routing-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
+    const resolved = RuntimeWorkspaceService.createDescriptor({
+      workspaceRoot,
+      stateRoot,
+      name: 'Second workspace',
+      newWorkspaceRoot: join(workspaceRoot, 'second'),
+      setActive: false,
+      nextId: 'workspace-2',
+    });
+    const activeWorkspace = resolved.workspaces.find((workspace) => workspace.id === DEFAULT_WORKSPACE_ID);
+    const secondWorkspace = resolved.workspaces.find((workspace) => workspace.id === 'workspace-2');
+    if (!activeWorkspace || !secondWorkspace) {
+      throw new Error('expected both workspaces');
+    }
+
+    mkdirSync(activeWorkspace.workspaceRoot, { recursive: true });
+    mkdirSync(secondWorkspace.workspaceRoot, { recursive: true });
+    writeFileSync(join(activeWorkspace.workspaceRoot, 'active-only.md'), 'active\n');
+    writeFileSync(join(secondWorkspace.workspaceRoot, 'second-only.md'), 'second\n');
+
+    const caller = controlPlaneRouter.createCaller({
+      workspaceRoot,
+      stateRoot,
+      activeWorkspaceId: activeWorkspace.id,
+      activeWorkspace,
+      workspaces: resolved.workspaces,
+      runtimeHost: null,
+      logger: pino({ level: 'silent' }),
+    });
+
+    await expect(caller.workspaceFileSearch({
+      workspaceId: secondWorkspace.id,
+      query: 'only',
+    })).resolves.toMatchObject({
+      files: [{ path: 'second-only.md' }],
+    });
+  });
+
+  it('repairs legacy workspace roots before routing file search', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-workspace-repair-default-'));
+    const secondRoot = mkdtempSync(join(tmpdir(), 'heddle-workspace-repair-second-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const secondStateRoot = join(secondRoot, '.heddle');
+    mkdirSync(stateRoot, { recursive: true });
+    mkdirSync(secondRoot, { recursive: true });
+    writeFileSync(join(workspaceRoot, 'default-only.md'), 'default\n');
+    writeFileSync(join(secondRoot, 'second-only.md'), 'second\n');
+    const timestamp = '2026-05-25T00:00:00.000Z';
+    writeFileSync(FileWorkspaceRepository.resolveCatalogPath(stateRoot), JSON.stringify({
+      version: 1,
+      activeWorkspaceId: 'workspace-2',
+      workspaces: [
+        {
+          id: DEFAULT_WORKSPACE_ID,
+          name: 'Default workspace',
+          workspaceRoot,
+          repoRoots: [workspaceRoot],
+          stateRoot,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        {
+          id: 'workspace-2',
+          name: 'Second workspace',
+          workspaceRoot,
+          repoRoots: [workspaceRoot],
+          stateRoot: secondStateRoot,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+    }, null, 2));
+
+    const resolved = RuntimeWorkspaceService.resolveContext({ workspaceRoot, stateRoot });
+    const secondWorkspace = resolved.workspaces.find((workspace) => workspace.id === 'workspace-2');
+    if (!secondWorkspace) {
+      throw new Error('expected repaired second workspace');
+    }
+    expect(secondWorkspace).toMatchObject({
+      workspaceRoot: secondRoot,
+      repoRoots: [secondRoot],
+      stateRoot: secondStateRoot,
+    });
+
+    const saved = JSON.parse(readFileSync(FileWorkspaceRepository.resolveCatalogPath(stateRoot), 'utf8')) as typeof resolved.catalog;
+    expect(saved.workspaces.find((workspace) => workspace.id === 'workspace-2')).toMatchObject({
+      workspaceRoot: secondRoot,
+      repoRoots: [secondRoot],
+      stateRoot: secondStateRoot,
+    });
+
+    const caller = controlPlaneRouter.createCaller({
+      workspaceRoot,
+      stateRoot,
+      activeWorkspaceId: resolved.activeWorkspaceId,
+      activeWorkspace: resolved.activeWorkspace,
+      workspaces: resolved.workspaces,
+      runtimeHost: null,
+      logger: pino({ level: 'silent' }),
+    });
+
+    await expect(caller.workspaceFileSearch({
+      workspaceId: secondWorkspace.id,
+      query: 'only',
+    })).resolves.toMatchObject({
+      files: [{ path: 'second-only.md' }],
+    });
   });
 
   it('exposes known workspaces from the user-level registry', async () => {
@@ -217,7 +398,7 @@ describe('workspace catalog', () => {
     });
 
     const state = await caller.state();
-    expect(state.knownWorkspaces.map((workspace) => workspace.anchorRoot)).toEqual([otherRoot]);
+    expect(state.knownWorkspaces.map((workspace) => workspace.workspaceRoot)).toEqual([otherRoot]);
   });
 
   it('can browse local directories for workspace selection', async () => {

--- a/src/__tests__/integration/server/daemon-registry.test.ts
+++ b/src/__tests__/integration/server/daemon-registry.test.ts
@@ -31,7 +31,7 @@ describe('daemon registry', () => {
     expect(registry.workspaces[0]).toMatchObject({
       workspace: {
         id: 'default',
-        anchorRoot: workspaceRoot,
+        workspaceRoot,
       },
       owner: {
         ownerId: 'daemon-1',
@@ -92,7 +92,7 @@ describe('daemon registry', () => {
     const registry = RuntimeDaemonRegistryService.registerKnownWorkspaces({ registryPath, workspaces: secondCatalog.workspaces });
 
     expect(registry.workspaces).toHaveLength(2);
-    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, 'default', join(firstRoot, '.heddle'))?.workspace.anchorRoot).toBe(firstRoot);
-    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, 'default', join(secondRoot, '.heddle'))?.workspace.anchorRoot).toBe(secondRoot);
+    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, 'default', join(firstRoot, '.heddle'))?.workspace.workspaceRoot).toBe(firstRoot);
+    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, 'default', join(secondRoot, '.heddle'))?.workspace.workspaceRoot).toBe(secondRoot);
   });
 });

--- a/src/__tests__/integration/web/control-plane-screens.test.tsx
+++ b/src/__tests__/integration/web/control-plane-screens.test.tsx
@@ -129,7 +129,7 @@ describe('control-plane screens', () => {
     await waitFor(() => {
       expect(onCreateWorkspace).toHaveBeenCalledWith({
         name: 'Fresh',
-        anchorRoot: '/Users/example/fresh',
+        workspaceRoot: '/Users/example/fresh',
         setActive: true,
       });
     });
@@ -137,7 +137,7 @@ describe('control-plane screens', () => {
     fireEvent.click(screen.getByRole('button', { name: /Archived/ }));
     expect(onCreateWorkspace).toHaveBeenLastCalledWith({
       name: 'Archived',
-      anchorRoot: '/Users/example/archived',
+      workspaceRoot: '/Users/example/archived',
       setActive: true,
     });
 
@@ -170,7 +170,7 @@ function createControlPlaneState(): ControlPlaneState {
     workspace: {
       id: 'primary',
       name: 'Primary',
-      anchorRoot: '/Users/example/primary',
+      workspaceRoot: '/Users/example/primary',
       repoRoots: ['/Users/example/primary'],
       stateRoot: '/Users/example/primary/.heddle',
       createdAt: '2026-04-01T00:00:00.000Z',
@@ -180,7 +180,7 @@ function createControlPlaneState(): ControlPlaneState {
       {
         id: 'primary',
         name: 'Primary',
-        anchorRoot: '/Users/example/primary',
+        workspaceRoot: '/Users/example/primary',
         repoRoots: ['/Users/example/primary'],
         stateRoot: '/Users/example/primary/.heddle',
         createdAt: '2026-04-01T00:00:00.000Z',
@@ -189,7 +189,7 @@ function createControlPlaneState(): ControlPlaneState {
       {
         id: 'secondary',
         name: 'Secondary',
-        anchorRoot: '/Users/example/secondary',
+        workspaceRoot: '/Users/example/secondary',
         repoRoots: ['/Users/example/secondary'],
         stateRoot: '/Users/example/secondary/.heddle',
         createdAt: '2026-04-01T00:00:00.000Z',
@@ -200,7 +200,7 @@ function createControlPlaneState(): ControlPlaneState {
       {
         id: 'archived',
         name: 'Archived',
-        anchorRoot: '/Users/example/archived',
+        workspaceRoot: '/Users/example/archived',
         repoRoots: ['/Users/example/archived'],
         stateRoot: '/Users/example/archived/.heddle',
         createdAt: '2026-03-01T00:00:00.000Z',

--- a/src/__tests__/unit/control-plane/control-plane-host-surface.test.ts
+++ b/src/__tests__/unit/control-plane/control-plane-host-surface.test.ts
@@ -85,7 +85,7 @@ function baseState(overrides: Partial<ControlPlaneState> = {}): ControlPlaneStat
     workspace: {
       id: 'default',
       name: 'workspace',
-      anchorRoot: '/workspace',
+      workspaceRoot: '/workspace',
       stateRoot: '/workspace/.heddle',
       repoRoots: ['/workspace'],
       createdAt: '2026-04-21T00:00:00.000Z',

--- a/src/__tests__/unit/control-plane/session-cancel.test.ts
+++ b/src/__tests__/unit/control-plane/session-cancel.test.ts
@@ -34,19 +34,21 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
     const internals = controller as unknown as ControllerInternals;
     const abortController = new AbortController();
     const decisions: ToolApprovalUserDecision[] = [];
+    const workspaceId = 'workspace-cancel';
     const sessionId = 'session-cancel-approval';
+    const sessionKey = `${workspaceId}:${sessionId}`;
 
-    internals.inFlightRuns.set(sessionId, { controller: abortController });
-    internals.pendingApprovals.set(sessionId, {
+    internals.inFlightRuns.set(sessionKey, { controller: abortController });
+    internals.pendingApprovals.set(sessionKey, {
       approval: createApprovalRequest(),
       resolve: (decision) => {
         decisions.push(decision);
       },
     });
 
-    expect(controller.cancelRun(sessionId)).toBe(true);
+    expect(controller.cancelRun({ workspaceId, sessionId })).toBe(true);
     expect(abortController.signal.aborted).toBe(true);
-    expect(internals.pendingApprovals.has(sessionId)).toBe(false);
+    expect(internals.pendingApprovals.has(sessionKey)).toBe(false);
     expect(decisions).toEqual([{
       type: 'deny',
       reason: 'Cancelled by user',
@@ -56,12 +58,13 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
   it('returns false when no run is active', () => {
     const controller = new ControlPlaneChatSessionsController();
 
-    expect(controller.cancelRun('missing-session')).toBe(false);
+    expect(controller.cancelRun({ workspaceId: 'workspace-missing', sessionId: 'missing-session' })).toBe(false);
   });
 
   it('passes shouldStop from the active abort controller into the engine turn', async () => {
     const controller = new ControlPlaneChatSessionsController();
     const internals = controller as unknown as ControllerInternals;
+    const workspaceId = 'workspace-should-stop';
     const sessionId = 'session-cancel-should-stop';
     const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-control-plane-cancel-'));
     const session = ChatSessionRecords.create({
@@ -73,6 +76,7 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
     const observedShouldStop: boolean[] = [];
 
     await internals.runEngineTurn({
+      workspaceId,
       workspaceRoot: stateRoot,
       stateRoot,
       sessionStoragePath: join(stateRoot, 'chat-sessions.catalog.json'),
@@ -85,7 +89,7 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
       },
     }, async ({ shouldStop }) => {
       observedShouldStop.push(shouldStop());
-      expect(controller.cancelRun(sessionId)).toBe(true);
+      expect(controller.cancelRun({ workspaceId, sessionId })).toBe(true);
       observedShouldStop.push(shouldStop());
       return {
         outcome: 'interrupted',
@@ -95,7 +99,7 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
     });
 
     expect(observedShouldStop).toEqual([false, true]);
-    expect(controller.isRunning(sessionId)).toBe(false);
+    expect(controller.isRunning({ workspaceId, sessionId })).toBe(false);
   });
 });
 

--- a/src/__tests__/unit/control-plane/session-message-controller.test.ts
+++ b/src/__tests__/unit/control-plane/session-message-controller.test.ts
@@ -32,12 +32,29 @@ describe('SessionMessageController', () => {
       { id: 'persisted-assistant', role: 'assistant', text: 'Heddle is a coding agent runtime.' },
     ]);
   });
+
+  it('does not preserve transient messages across workspaces with colliding session ids', () => {
+    const current = sessionWithMessages([
+      { id: 'live-user', role: 'user', text: 'Old workspace prompt' },
+    ], 'workspace-1');
+    const next = sessionWithMessages([
+      { id: 'persisted-assistant', role: 'assistant', text: 'Different workspace.' },
+    ], 'workspace-2');
+
+    expect(SessionMessageController.mergeTransientMessages(current, next)?.messages).toEqual([
+      { id: 'persisted-assistant', role: 'assistant', text: 'Different workspace.' },
+    ]);
+  });
 });
 
-function sessionWithMessages(messages: NonNullable<ControlPlaneSessionDetail>['messages']): ControlPlaneSessionDetail {
+function sessionWithMessages(
+  messages: NonNullable<ControlPlaneSessionDetail>['messages'],
+  workspaceId?: string,
+): ControlPlaneSessionDetail {
   return {
     id: 'session-1',
     name: 'Session 1',
+    workspaceId,
     messageCount: messages.length,
     turnCount: 0,
     messages,

--- a/src/__tests__/unit/control-plane/web-v2-routes.test.ts
+++ b/src/__tests__/unit/control-plane/web-v2-routes.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSettingsRoute,
+  resolveAppSurface,
+  resolveRouteSessionId,
+  resolveRouteTaskSelection,
+  resolveRouteWorkspaceId,
+  routeForAppSurface,
+  routeForSession,
+  routeForSettingsSection,
+  routeForTaskRun,
+} from '../../../web-v2/layout/routes.js';
+
+describe('web-v2 workspace routes', () => {
+  it('builds workspace-scoped routes while preserving legacy fallbacks', () => {
+    expect(routeForAppSurface('sessions')).toBe('/sessions');
+    expect(routeForAppSurface('sessions', 'default')).toBe('/workspaces/default/sessions');
+    expect(routeForSession('workspace/one', 'session 1')).toBe('/workspaces/workspace%2Fone/sessions/session%201');
+    expect(routeForTaskRun('default', 'task-a', 'run-b')).toBe('/workspaces/default/tasks/task-a/runs/run-b');
+    expect(routeForSettingsSection('memory', 'default')).toBe('/workspaces/default/settings/memory');
+  });
+
+  it('parses workspace-scoped session, task, and settings routes', () => {
+    expect(resolveRouteWorkspaceId('/workspaces/default/sessions/session-1')).toBe('default');
+    expect(resolveAppSurface('/workspaces/default/sessions/session-1')).toBe('sessions');
+    expect(resolveRouteSessionId('/workspaces/default/sessions/session-1')).toBe('session-1');
+    expect(resolveRouteTaskSelection('/workspaces/default/tasks/task-a/runs/run-b')).toEqual({
+      taskId: 'task-a',
+      runId: 'run-b',
+    });
+    expect(isSettingsRoute('/workspaces/default/settings/general')).toBe(true);
+  });
+});

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -150,7 +150,9 @@ export class HeartbeatTaskRunnerService {
       },
       model,
       apiKey: RuntimeCredentialService.resolveApiKeyForModel(model, credentialOptions),
-      stateDir: args.task.runtime?.stateDir ?? args.runtime?.stateDir,
+      workspaceRoot: args.runtime?.workspaceRoot ?? args.task.runtime?.workspaceRoot,
+      stateDir: args.runtime?.stateDir ?? args.task.runtime?.stateDir,
+      memoryDir: args.runtime?.memoryDir ?? args.task.runtime?.memoryDir,
       approvalPolicies: [
         ToolApprovalPolicies.unattendedLocalAutomation(),
         ...(args.runtime?.approvalPolicies ?? []),

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -44,6 +44,7 @@ export type HeartbeatTaskRunner = (
 export type HeartbeatTaskRunnerRuntimeOptions = {
   workspaceRoot?: string;
   stateDir?: string;
+  memoryDir?: string;
   apiKey?: string;
   apiKeyProvider?: 'explicit' | 'openai' | 'anthropic';
   preferApiKey?: boolean;

--- a/src/core/runtime/workspaces/schemas.ts
+++ b/src/core/runtime/workspaces/schemas.ts
@@ -8,11 +8,17 @@ import { z } from 'zod';
 export const WorkspaceDescriptorSchema = z.object({
   id: z.string().describe('Stable workspace identifier used by host surfaces and daemon registration.'),
   name: z.string().describe('Human-facing workspace name shown in control-plane workspace lists.'),
-  anchorRoot: z.string().describe('Primary filesystem root represented by this workspace.'),
+  workspaceRoot: z.string().describe('Filesystem root where this workspace stores its .heddle state directory.'),
   repoRoots: z.array(z.string()).describe('Repository roots grouped into this workspace.'),
   stateRoot: z.string().describe('Heddle state directory for this workspace.'),
   createdAt: z.string().describe('Timestamp when this workspace descriptor was created.'),
   updatedAt: z.string().describe('Timestamp when this workspace descriptor was last changed.'),
+});
+
+const WorkspaceDescriptorReadSchema = WorkspaceDescriptorSchema.partial().extend({
+  // Legacy catalog field retained only so existing v1 catalogs normalize into
+  // the workspaceRoot vocabulary on the next save.
+  anchorRoot: z.string().optional().catch(undefined),
 });
 
 export const WorkspaceCatalogSchema = z.object({
@@ -24,5 +30,5 @@ export const WorkspaceCatalogSchema = z.object({
 export const WorkspaceCatalogReadSchema = z.object({
   version: z.literal(1).optional().catch(1),
   activeWorkspaceId: z.string().optional().catch(undefined),
-  workspaces: z.array(WorkspaceDescriptorSchema.partial()).optional().catch(undefined),
+  workspaces: z.array(WorkspaceDescriptorReadSchema).optional().catch(undefined),
 });

--- a/src/core/runtime/workspaces/service.ts
+++ b/src/core/runtime/workspaces/service.ts
@@ -5,7 +5,7 @@
  * normalization, active workspace selection, creation, and renaming. Host code
  * should call this service instead of touching workspace catalog files.
  */
-import { basename, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { FileWorkspaceRepository } from './repository.js';
 import { WorkspaceCatalogReadSchema } from './schemas.js';
 import {
@@ -93,10 +93,10 @@ export class RuntimeWorkspaceService {
   static createDescriptor(input: CreateWorkspaceDescriptorInput): ResolvedWorkspaceContext {
     const resolved = RuntimeWorkspaceService.resolveContext(input);
     const now = new Date().toISOString();
-    const anchorRoot = resolve(input.anchorRoot);
-    const workspaceStateRoot = resolve(input.workspaceStateRoot ?? join(anchorRoot, basename(input.stateRoot)));
+    const workspaceRoot = resolve(input.newWorkspaceRoot);
+    const workspaceStateRoot = resolve(input.workspaceStateRoot ?? join(workspaceRoot, basename(input.stateRoot)));
     const existing = resolved.workspaces.find((workspace) => (
-      resolve(workspace.stateRoot) === workspaceStateRoot || resolve(workspace.anchorRoot) === anchorRoot
+      resolve(workspace.stateRoot) === workspaceStateRoot || resolve(workspace.workspaceRoot) === workspaceRoot
     ));
 
     if (existing) {
@@ -111,11 +111,11 @@ export class RuntimeWorkspaceService {
     const repoRoots =
       input.repoRoots && input.repoRoots.length > 0 ?
         input.repoRoots.map((root) => resolve(root))
-      : [anchorRoot];
+      : [workspaceRoot];
     const nextWorkspace: WorkspaceDescriptor = {
       id: input.nextId ?? `workspace-${Date.now()}`,
-      name: input.name.trim() || RuntimeWorkspaceService.deriveDefaultWorkspaceName(anchorRoot),
-      anchorRoot,
+      name: input.name.trim() || RuntimeWorkspaceService.deriveDefaultWorkspaceName(workspaceRoot),
+      workspaceRoot,
       repoRoots,
       stateRoot: workspaceStateRoot,
       createdAt: now,
@@ -151,7 +151,7 @@ export class RuntimeWorkspaceService {
         {
           id: DEFAULT_WORKSPACE_ID,
           name: RuntimeWorkspaceService.deriveDefaultWorkspaceName(config.workspaceRoot),
-          anchorRoot: config.workspaceRoot,
+          workspaceRoot: config.workspaceRoot,
           repoRoots: [config.workspaceRoot],
           stateRoot: config.stateRoot,
           createdAt: now,
@@ -202,17 +202,24 @@ export class RuntimeWorkspaceService {
     options: { fallbackId: string; workspaceRoot: string; stateRoot: string },
   ): WorkspaceDescriptor {
     const now = new Date().toISOString();
-    const anchorRoot = resolve(workspace.anchorRoot ?? options.workspaceRoot);
-    const stateRoot = resolve(workspace.stateRoot ?? join(anchorRoot, basename(options.stateRoot)));
+    const rawWorkspaceRoot = workspace.workspaceRoot
+      // Legacy catalog compatibility: anchorRoot is normalized away when the
+      // catalog is next saved.
+      ?? (workspace as { anchorRoot?: string }).anchorRoot;
+    const stateDirName = basename(options.stateRoot);
+    const fallbackWorkspaceRoot = resolve(rawWorkspaceRoot ?? options.workspaceRoot);
+    const stateRoot = resolve(workspace.stateRoot ?? join(fallbackWorkspaceRoot, stateDirName));
+    const workspaceRoot = basename(stateRoot) === stateDirName ? dirname(stateRoot) : fallbackWorkspaceRoot;
+    const savedRepoRoots = workspace.repoRoots?.map((root) => resolve(root)) ?? [];
     const repoRoots =
-      workspace.repoRoots && workspace.repoRoots.length > 0 ?
-        workspace.repoRoots.map((root) => resolve(root))
-      : [anchorRoot];
+      savedRepoRoots.length > 0 ?
+        savedRepoRoots.map((root) => (root === fallbackWorkspaceRoot ? workspaceRoot : root))
+      : [workspaceRoot];
 
     return {
       id: workspace.id?.trim() || options.fallbackId,
-      name: workspace.name?.trim() || RuntimeWorkspaceService.deriveDefaultWorkspaceName(anchorRoot),
-      anchorRoot,
+      name: workspace.name?.trim() || RuntimeWorkspaceService.deriveDefaultWorkspaceName(workspaceRoot),
+      workspaceRoot,
       repoRoots,
       stateRoot,
       createdAt: workspace.createdAt ?? now,

--- a/src/core/runtime/workspaces/types.ts
+++ b/src/core/runtime/workspaces/types.ts
@@ -3,7 +3,7 @@ export const DEFAULT_WORKSPACE_ID = 'default';
 export type WorkspaceDescriptor = {
   id: string;
   name: string;
-  anchorRoot: string;
+  workspaceRoot: string;
   repoRoots: string[];
   stateRoot: string;
   createdAt: string;
@@ -31,7 +31,7 @@ export type WorkspaceRootConfig = {
 
 export type CreateWorkspaceDescriptorInput = WorkspaceRootConfig & {
   name: string;
-  anchorRoot: string;
+  newWorkspaceRoot: string;
   repoRoots?: string[];
   nextId?: string;
   setActive?: boolean;

--- a/src/server/controllers/restful/control-plane/chat-session-events.ts
+++ b/src/server/controllers/restful/control-plane/chat-session-events.ts
@@ -22,8 +22,17 @@ export class ChatSessionEventsRestController {
       workspaceRoot: this.options.workspaceRoot,
       stateRoot: this.options.stateRoot,
     });
+    const workspaceId = this.readWorkspaceId(request);
+    const workspace = workspaceId
+      ? workspaceContext.workspaces.find((candidate) => candidate.id === workspaceId)
+      : workspaceContext.activeWorkspace;
+    if (!workspace) {
+      response.status(404).json({ error: `Workspace not found: ${workspaceId}` });
+      return;
+    }
+
     const sessionFilePath = controlPlaneChatSessionsController.resolveFilePath(
-      workspaceContext.activeWorkspace.stateRoot,
+      workspace.stateRoot,
       sessionId,
     );
     response.setHeader('Content-Type', 'text/event-stream');
@@ -38,13 +47,13 @@ export class ChatSessionEventsRestController {
       (response as typeof response & { flush?: () => void }).flush?.();
     };
 
-    send('ready', { sessionId });
+    send('ready', { sessionId, workspaceId: workspace.id });
     const heartbeat = setInterval(() => {
-      send('heartbeat', { sessionId, timestamp: new Date().toISOString() });
+      send('heartbeat', { sessionId, workspaceId: workspace.id, timestamp: new Date().toISOString() });
     }, 15000);
 
     const unsubscribe = controlPlaneChatSessionsController.subscribeToEvents({
-      workspaceId: workspaceContext.activeWorkspace.id,
+      workspaceId: workspace.id,
       sessionId,
     }, (payload) => {
       send('session.event', payload);
@@ -53,10 +62,10 @@ export class ChatSessionEventsRestController {
     let watcher: ReturnType<typeof watch> | undefined;
     try {
       watcher = watch(sessionFilePath, { persistent: false }, () => {
-        send('session.updated', { sessionId, timestamp: new Date().toISOString() });
+        send('session.updated', { sessionId, workspaceId: workspace.id, timestamp: new Date().toISOString() });
       });
     } catch {
-      send('waiting', { sessionId, timestamp: new Date().toISOString() });
+      send('waiting', { sessionId, workspaceId: workspace.id, timestamp: new Date().toISOString() });
     }
 
     request.on('close', () => {
@@ -66,4 +75,10 @@ export class ChatSessionEventsRestController {
       response.end();
     });
   };
+
+  private readWorkspaceId(request: Request): string | undefined {
+    const rawWorkspaceId = request.query.workspaceId;
+    const workspaceId = typeof rawWorkspaceId === 'string' ? rawWorkspaceId.trim() : '';
+    return workspaceId || undefined;
+  }
 }

--- a/src/server/controllers/restful/control-plane/chat-session-events.ts
+++ b/src/server/controllers/restful/control-plane/chat-session-events.ts
@@ -43,7 +43,10 @@ export class ChatSessionEventsRestController {
       send('heartbeat', { sessionId, timestamp: new Date().toISOString() });
     }, 15000);
 
-    const unsubscribe = controlPlaneChatSessionsController.subscribeToEvents(sessionId, (payload) => {
+    const unsubscribe = controlPlaneChatSessionsController.subscribeToEvents({
+      workspaceId: workspaceContext.activeWorkspace.id,
+      sessionId,
+    }, (payload) => {
       send('session.event', payload);
     });
 

--- a/src/server/controllers/trpc/control-plane/chat-session-events.ts
+++ b/src/server/controllers/trpc/control-plane/chat-session-events.ts
@@ -5,6 +5,7 @@ import type { ControlPlaneSessionLiveEvent } from '@/server/control-plane-types.
 export class ControlPlaneChatSessionEventsController {
   static emitSessionActivities(args: {
     eventBus: EventEmitter;
+    workspaceId: string;
     sessionId: string;
     activities: ConversationActivity[];
   }) {
@@ -12,7 +13,7 @@ export class ControlPlaneChatSessionEventsController {
       return;
     }
 
-    args.eventBus.emit(args.sessionId, {
+    args.eventBus.emit(ControlPlaneChatSessionEventsController.sessionAddressKey(args), {
       sessionId: args.sessionId,
       timestamp: new Date().toISOString(),
       activities: args.activities,
@@ -21,11 +22,13 @@ export class ControlPlaneChatSessionEventsController {
 
   static createSessionEventPublisher(args: {
     eventBus: EventEmitter;
+    workspaceId: string;
     sessionId: string;
   }) {
     const publishActivities = (activities: ConversationActivity[]) => {
       ControlPlaneChatSessionEventsController.emitSessionActivities({
         eventBus: args.eventBus,
+        workspaceId: args.workspaceId,
         sessionId: args.sessionId,
         activities,
       });
@@ -40,5 +43,9 @@ export class ControlPlaneChatSessionEventsController {
     };
 
     return publisher;
+  }
+
+  private static sessionAddressKey(address: { workspaceId: string; sessionId: string }): string {
+    return `${address.workspaceId}:${address.sessionId}`;
   }
 }

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -51,9 +51,10 @@ import type {
   ControlPlaneSessionsEventEnvelope,
 } from '@/server/control-plane-types.js';
 
-type ControlPlaneSessionReadArgs = Omit<ConversationEngineConfig, 'model'> & {
+type ControlPlaneSessionReadArgs = Omit<ConversationEngineConfig, 'model' | 'workspaceId'> & {
   model?: string;
   sessionStoragePath: string;
+  workspaceId: string;
 };
 
 type CreateControlPlaneChatSessionArgs = ControlPlaneSessionReadArgs & {
@@ -175,16 +176,18 @@ export class ControlPlaneChatSessionsController {
   }
 
   subscribeToEvents(
-    sessionId: string,
+    sessionAddress: ControlPlaneSessionAddress,
     listener: (event: ControlPlaneSessionLiveEvent) => void,
   ): () => void {
-    this.sessionEventBus.on(sessionId, listener);
+    const key = ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress);
+    this.sessionEventBus.on(key, listener);
     return () => {
-      this.sessionEventBus.off(sessionId, listener);
+      this.sessionEventBus.off(key, listener);
     };
   }
 
   async *subscribeLiveEvents(args: {
+    workspaceId: string;
     stateRoot: string;
     sessionId: string;
     signal?: AbortSignal;
@@ -195,7 +198,7 @@ export class ControlPlaneChatSessionsController {
         // Live LLM/tool/compaction updates arrive through the in-memory event
         // bus. This path streams assistant text without touching the session
         // file for each model delta.
-        (sink) => this.subscribeToEvents(args.sessionId, (event) => {
+        (sink) => this.subscribeToEvents(args, (event) => {
           sink.push({
             ...event,
             type: 'session.event',
@@ -259,24 +262,25 @@ export class ControlPlaneChatSessionsController {
     yield* stream;
   }
 
-  getPendingApproval(sessionId: string): ToolApprovalRequest | undefined {
-    return this.pendingApprovals.get(sessionId)?.approval;
+  getPendingApproval(sessionAddress: ControlPlaneSessionAddress): ToolApprovalRequest | undefined {
+    return this.pendingApprovals.get(ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress))?.approval;
   }
 
-  isRunning(sessionId: string): boolean {
-    return this.inFlightRuns.has(sessionId);
+  isRunning(sessionAddress: ControlPlaneSessionAddress): boolean {
+    return this.inFlightRuns.has(ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress));
   }
 
-  cancelRun(sessionId: string): boolean {
-    const run = this.inFlightRuns.get(sessionId);
+  cancelRun(sessionAddress: ControlPlaneSessionAddress): boolean {
+    const key = ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress);
+    const run = this.inFlightRuns.get(key);
     if (!run) {
       return false;
     }
 
     run.controller.abort();
-    const pending = this.pendingApprovals.get(sessionId);
+    const pending = this.pendingApprovals.get(key);
     if (pending) {
-      this.pendingApprovals.delete(sessionId);
+      this.pendingApprovals.delete(key);
       pending.resolve({
         type: 'deny',
         reason: 'Cancelled by user',
@@ -286,15 +290,16 @@ export class ControlPlaneChatSessionsController {
   }
 
   resolvePendingApproval(
-    sessionId: string,
+    sessionAddress: ControlPlaneSessionAddress,
     decision: ToolApprovalUserDecision,
   ): boolean {
-    const pending = this.pendingApprovals.get(sessionId);
+    const key = ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress);
+    const pending = this.pendingApprovals.get(key);
     if (!pending) {
       return false;
     }
 
-    this.pendingApprovals.delete(sessionId);
+    this.pendingApprovals.delete(key);
     // This resolves the promise created by ToolApprovalService.requestHumanApproval.
     // The paused agent turn resumes immediately after this call returns.
     pending.resolve(decision);
@@ -335,14 +340,16 @@ export class ControlPlaneChatSessionsController {
       shouldStop: () => boolean;
     }) => ReturnType<ConversationEngine['turns']['submit']>,
   ) {
-    if (this.inFlightRuns.has(args.sessionId)) {
+    const sessionKey = ControlPlaneChatSessionsController.sessionAddressKey(args);
+    if (this.inFlightRuns.has(sessionKey)) {
       throw new Error('A run is already in progress for this session.');
     }
 
     const controller = new AbortController();
-    this.inFlightRuns.set(args.sessionId, { controller });
+    this.inFlightRuns.set(sessionKey, { controller });
     const publisher = ControlPlaneChatSessionEventsController.createSessionEventPublisher({
       eventBus: this.sessionEventBus,
+      workspaceId: args.workspaceId,
       sessionId: args.sessionId,
     });
 
@@ -358,8 +365,8 @@ export class ControlPlaneChatSessionsController {
         session: ControlPlaneChatSessionPresenter.projectDetail(result.session)[0] ?? null,
       };
     } finally {
-      this.pendingApprovals.delete(args.sessionId);
-      this.inFlightRuns.delete(args.sessionId);
+      this.pendingApprovals.delete(sessionKey);
+      this.inFlightRuns.delete(sessionKey);
     }
   }
 
@@ -426,8 +433,8 @@ export class ControlPlaneChatSessionsController {
     });
   }
 
-  private createEngineHost(args: ControlPlaneSessionReadArgs & { sessionId: string }, publisher: ControlPlaneTurnPublisher): ConversationEngineHost {
-    const sessionId = args.sessionId;
+  private createEngineHost(args: ControlPlaneSessionReadArgs & ControlPlaneSessionAddress, publisher: ControlPlaneTurnPublisher): ConversationEngineHost {
+    const sessionKey = ControlPlaneChatSessionsController.sessionAddressKey(args);
     const approvalService = this.createApprovalService(args);
 
     return {
@@ -443,13 +450,13 @@ export class ControlPlaneChatSessionsController {
             storePending: ({ request, resolve }) => {
               // Keep the resolver in memory while the browser renders the
               // request. sessionResolveApproval later calls this resolver.
-              this.pendingApprovals.set(sessionId, {
+              this.pendingApprovals.set(sessionKey, {
                 approval: request,
                 resolve,
               });
             },
           });
-          this.pendingApprovals.delete(sessionId);
+          this.pendingApprovals.delete(sessionKey);
           return decision;
         },
       },
@@ -475,7 +482,7 @@ export class ControlPlaneChatSessionsController {
 
     const timestamp = new Date().toISOString();
     const assistantText = `Mocked browser integration agent response: ${args.prompt}`;
-    await this.emitBrowserIntegrationStreamPreview(args.sessionId, assistantText);
+    await this.emitBrowserIntegrationStreamPreview(args, assistantText);
     const nextHistory = [
       ...session.history,
       { role: 'user' as const, content: args.prompt },
@@ -514,12 +521,13 @@ export class ControlPlaneChatSessionsController {
     };
   }
 
-  private async emitBrowserIntegrationStreamPreview(sessionId: string, assistantText: string): Promise<void> {
+  private async emitBrowserIntegrationStreamPreview(sessionAddress: ControlPlaneSessionAddress, assistantText: string): Promise<void> {
     // The browser-integration fake has to emit a real live activity before its
     // final mutation result so web-v2 can regression-test incremental streaming.
     const publisher = ControlPlaneChatSessionEventsController.createSessionEventPublisher({
       eventBus: this.sessionEventBus,
-      sessionId,
+      workspaceId: sessionAddress.workspaceId,
+      sessionId: sessionAddress.sessionId,
     });
     const runId = `browser-integration-run-${Date.now()}`;
     const timestamp = new Date().toISOString();
@@ -561,6 +569,15 @@ export class ControlPlaneChatSessionsController {
   private firstNonEmpty(...values: Array<string | undefined>): string | undefined {
     return values.find((value) => typeof value === 'string' && value.trim().length > 0);
   }
+
+  static sessionAddressKey(address: ControlPlaneSessionAddress): string {
+    return `${address.workspaceId}:${address.sessionId}`;
+  }
 }
+
+type ControlPlaneSessionAddress = {
+  workspaceId: string;
+  sessionId: string;
+};
 
 export const controlPlaneChatSessionsController = new ControlPlaneChatSessionsController();

--- a/src/server/controllers/trpc/control-plane/control-plane-state.ts
+++ b/src/server/controllers/trpc/control-plane/control-plane-state.ts
@@ -2,15 +2,19 @@ import { resolve } from 'node:path';
 import type { HeddleServerContext } from '@/server/types.js';
 import type { ControlPlaneState } from '@/server/control-plane-types.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
+import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import { controlPlaneChatSessionsController } from './chat-sessions-controller.js';
 import { ControlPlaneHeartbeatController } from './heartbeat.js';
 import { ControlPlaneMemoryController } from './memory.js';
 
 export class ControlPlaneStateController {
-  static async load(context: HeddleServerContext): Promise<ControlPlaneState> {
-    const workspaceRoot = context.activeWorkspace.workspaceRoot;
-    const stateRoot = context.activeWorkspace.stateRoot;
+  static async load(
+    context: HeddleServerContext,
+    workspace: WorkspaceDescriptor = context.activeWorkspace,
+  ): Promise<ControlPlaneState> {
+    const workspaceRoot = workspace.workspaceRoot;
+    const stateRoot = workspace.stateRoot;
     const [tasks, memory] = await Promise.all([
       ControlPlaneHeartbeatController.listTasks(stateRoot),
       ControlPlaneMemoryController.readStatus(stateRoot),
@@ -24,8 +28,8 @@ export class ControlPlaneStateController {
         openai: RuntimeCredentialService.resolveCredentialSourceForModel('gpt-5.4', { preferApiKey: context.preferApiKey }),
         anthropic: RuntimeCredentialService.resolveCredentialSourceForModel('claude-sonnet-4-6', { preferApiKey: context.preferApiKey }),
       },
-      activeWorkspaceId: context.activeWorkspaceId,
-      workspace: context.activeWorkspace,
+      activeWorkspaceId: workspace.id,
+      workspace,
       workspaces: context.workspaces,
       knownWorkspaces: ControlPlaneStateController.readKnownWorkspaces(context),
       runtimeHost: context.runtimeHost,
@@ -34,7 +38,7 @@ export class ControlPlaneStateController {
         stateRoot,
         sessionStoragePath: resolve(stateRoot, 'chat-sessions.catalog.json'),
         preferApiKey: context.preferApiKey,
-        workspaceId: context.activeWorkspace.id,
+        workspaceId: workspace.id,
       }),
       heartbeat: {
         tasks,

--- a/src/server/controllers/trpc/control-plane/control-plane-state.ts
+++ b/src/server/controllers/trpc/control-plane/control-plane-state.ts
@@ -9,7 +9,7 @@ import { ControlPlaneMemoryController } from './memory.js';
 
 export class ControlPlaneStateController {
   static async load(context: HeddleServerContext): Promise<ControlPlaneState> {
-    const workspaceRoot = context.activeWorkspace.anchorRoot;
+    const workspaceRoot = context.activeWorkspace.workspaceRoot;
     const stateRoot = context.activeWorkspace.stateRoot;
     const [tasks, memory] = await Promise.all([
       ControlPlaneHeartbeatController.listTasks(stateRoot),

--- a/src/server/heartbeat-scheduler-host.ts
+++ b/src/server/heartbeat-scheduler-host.ts
@@ -67,7 +67,7 @@ export class HeddleHeartbeatSchedulerHost {
 
   private startWorkspaceScheduler(workspace: WorkspaceDescriptor): HeartbeatSchedulerHandle {
     return HeartbeatSchedulerService.start({
-      workspaceRoot: workspace.anchorRoot,
+      workspaceRoot: workspace.workspaceRoot,
       stateRoot: workspace.stateRoot,
       preferApiKey: this.options.preferApiKey,
       pollIntervalMs: this.options.pollIntervalMs,

--- a/src/server/routes/trpc/control-plane-workspace.ts
+++ b/src/server/routes/trpc/control-plane-workspace.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import type { Logger } from 'pino';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import type { HeddleServerContext } from '@/server/types.js';
 import { procedure } from '@/server/trpc.js';
@@ -11,6 +12,7 @@ type WorkspaceScopedInput = {
 
 export type ControlPlaneRequestWorkspace = {
   workspace: WorkspaceDescriptor;
+  logger: Logger;
   sessionEngineArgs: {
     workspaceRoot: string;
     stateRoot: string;
@@ -35,7 +37,7 @@ export const controlPlaneWorkspaceProcedure = procedure
       },
     });
 
-    getWorkspaceOperationLogger(requestWorkspace.workspace.stateRoot).info({
+    requestWorkspace.logger.info({
       durationMs: Date.now() - startedAt,
       ok: result.ok,
       path,
@@ -64,8 +66,10 @@ export function resolveControlPlaneRequestWorkspace(
   input?: WorkspaceScopedInput,
 ): ControlPlaneRequestWorkspace {
   const workspace = resolveWorkspaceDescriptor(ctx, input?.workspaceId);
+  const logger = getWorkspaceOperationLogger(workspace.stateRoot);
   return {
     workspace,
+    logger,
     sessionEngineArgs: {
       workspaceRoot: workspace.workspaceRoot,
       stateRoot: workspace.stateRoot,

--- a/src/server/routes/trpc/control-plane-workspace.ts
+++ b/src/server/routes/trpc/control-plane-workspace.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import type { HeddleServerContext } from '@/server/types.js';
 import { procedure } from '@/server/trpc.js';
+import { getWorkspaceOperationLogger } from '@/server/workspace-operation-logger.js';
 import { workspaceScopedInputSchema } from './schema.js';
 
 type WorkspaceScopedInput = {
@@ -25,11 +26,31 @@ export type ControlPlaneWorkspaceContext = HeddleServerContext & {
 
 export const controlPlaneWorkspaceProcedure = procedure
   .input(workspaceScopedInputSchema)
-  .use(({ ctx, input, next }) => next({
-    ctx: {
-      requestWorkspace: resolveControlPlaneRequestWorkspace(ctx, input),
-    },
-  }));
+  .use(async ({ ctx, input, next, path, type }) => {
+    const requestWorkspace = resolveControlPlaneRequestWorkspace(ctx, input);
+    const startedAt = Date.now();
+    const result = await next({
+      ctx: {
+        requestWorkspace,
+      },
+    });
+
+    getWorkspaceOperationLogger(requestWorkspace.workspace.stateRoot).info({
+      durationMs: Date.now() - startedAt,
+      ok: result.ok,
+      path,
+      type,
+      workspaceId: requestWorkspace.workspace.id,
+      workspaceRoot: requestWorkspace.workspace.workspaceRoot,
+      stateRoot: requestWorkspace.workspace.stateRoot,
+      error: result.ok ? undefined : {
+        code: result.error.code,
+        message: result.error.message,
+      },
+    }, 'Control-plane workspace request');
+
+    return result;
+  });
 
 /**
  * Resolves the workspace for one control-plane request.

--- a/src/server/routes/trpc/control-plane-workspace.ts
+++ b/src/server/routes/trpc/control-plane-workspace.ts
@@ -1,0 +1,68 @@
+import { resolve } from 'node:path';
+import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
+import type { HeddleServerContext } from '@/server/types.js';
+import { procedure } from '@/server/trpc.js';
+import { workspaceScopedInputSchema } from './schema.js';
+
+type WorkspaceScopedInput = {
+  workspaceId?: string;
+} | null | undefined;
+
+export type ControlPlaneRequestWorkspace = {
+  workspace: WorkspaceDescriptor;
+  sessionEngineArgs: {
+    workspaceRoot: string;
+    stateRoot: string;
+    sessionStoragePath: string;
+    preferApiKey: boolean;
+    workspaceId: string;
+  };
+};
+
+export type ControlPlaneWorkspaceContext = HeddleServerContext & {
+  requestWorkspace: ControlPlaneRequestWorkspace;
+};
+
+export const controlPlaneWorkspaceProcedure = procedure
+  .input(workspaceScopedInputSchema)
+  .use(({ ctx, input, next }) => next({
+    ctx: {
+      requestWorkspace: resolveControlPlaneRequestWorkspace(ctx, input),
+    },
+  }));
+
+/**
+ * Resolves the workspace for one control-plane request.
+ *
+ * Web v2 routes carry the workspace being viewed. Every workspace-owned
+ * tRPC procedure should resolve through this helper so reads, mutations,
+ * subscriptions, traces, logs, memory, and task state use the same state root.
+ */
+export function resolveControlPlaneRequestWorkspace(
+  ctx: HeddleServerContext,
+  input?: WorkspaceScopedInput,
+): ControlPlaneRequestWorkspace {
+  const workspace = resolveWorkspaceDescriptor(ctx, input?.workspaceId);
+  return {
+    workspace,
+    sessionEngineArgs: {
+      workspaceRoot: workspace.workspaceRoot,
+      stateRoot: workspace.stateRoot,
+      sessionStoragePath: resolve(workspace.stateRoot, 'chat-sessions.catalog.json'),
+      preferApiKey: ctx.preferApiKey,
+      workspaceId: workspace.id,
+    },
+  };
+}
+
+function resolveWorkspaceDescriptor(ctx: HeddleServerContext, workspaceId: string | undefined): WorkspaceDescriptor {
+  if (!workspaceId) {
+    return ctx.activeWorkspace;
+  }
+
+  const workspace = ctx.workspaces.find((candidate) => candidate.id === workspaceId);
+  if (!workspace) {
+    throw new Error(`Workspace not found: ${workspaceId}`);
+  }
+  return workspace;
+}

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -47,8 +47,8 @@ import {
 } from './schema.js';
 
 export const controlPlaneRouter = router({
-  state: procedure.query(async ({ ctx }) => {
-    return await ControlPlaneStateController.load(ctx);
+  state: controlPlaneWorkspaceProcedure.query(async ({ ctx }) => {
+    return await ControlPlaneStateController.load(ctx, ctx.requestWorkspace.workspace);
   }),
   sessions: controlPlaneWorkspaceProcedure.input(sessionsInputSchema).query(({ ctx }) => {
     const requestWorkspace = ctx.requestWorkspace;

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -156,7 +156,7 @@ export const controlPlaneRouter = router({
     };
   }),
   sessionSendPrompt: controlPlaneWorkspaceProcedure.input(sessionMessageInputSchema).mutation(async ({ ctx, input }) => {
-    const { sessionEngineArgs } = ctx.requestWorkspace;
+    const { logger, sessionEngineArgs } = ctx.requestWorkspace;
     return await controlPlaneChatSessionsController.submitPrompt({
       ...sessionEngineArgs,
       sessionId: input.sessionId,
@@ -166,7 +166,7 @@ export const controlPlaneRouter = router({
       includePlanTool: input.includePlanTool,
       apiKey: input.apiKey,
       preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
-      logger: ctx.logger,
+      logger,
       systemContext: input.systemContext,
       memoryMaintenanceMode: input.memoryMaintenanceMode,
       leaseOwner: {
@@ -318,7 +318,7 @@ export const controlPlaneRouter = router({
     };
   }),
   heartbeatTaskRunNow: controlPlaneWorkspaceProcedure.input(heartbeatTaskRunNowInputSchema).mutation(async ({ ctx, input }) => {
-    const { workspace } = ctx.requestWorkspace;
+    const { logger, workspace } = ctx.requestWorkspace;
     const { workspaceId: _workspaceId, ...runInput } = input;
     const task = await ControlPlaneHeartbeatController.triggerTaskRun(workspace.stateRoot, input.taskId);
     controlPlaneHeartbeatEventsController.publish({
@@ -340,7 +340,7 @@ export const controlPlaneRouter = router({
         event,
       }),
     }).catch((error: unknown) => {
-      ctx.logger.error({ error, taskId: input.taskId }, 'Failed to run heartbeat task from control plane');
+      logger.error({ error, taskId: input.taskId }, 'Failed to run heartbeat task from control plane');
     });
 
     return {

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -1,4 +1,3 @@
-import { resolve } from 'node:path';
 import dayjs from 'dayjs';
 import { BUILT_IN_MODEL_GROUPS, ModelPolicyService } from '@/core/llm/models/index.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
@@ -16,6 +15,7 @@ import { ControlPlaneWorkspaceFilesController } from '@/server/controllers/trpc/
 import { ControlPlaneWorkspaceDiffController } from '@/server/controllers/trpc/control-plane/workspace-diff.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
+import { controlPlaneWorkspaceProcedure } from './control-plane-workspace.js';
 import {
   agentAskInputSchema,
   createSessionInputSchema,
@@ -35,6 +35,8 @@ import {
   sessionEventsInputSchema,
   sessionInputSchema,
   sessionMessageInputSchema,
+  sessionsEventsInputSchema,
+  sessionsInputSchema,
   sessionSettingsInputSchema,
   turnReviewInputSchema,
   workspaceBrowseInputSchema,
@@ -48,34 +50,41 @@ export const controlPlaneRouter = router({
   state: procedure.query(async ({ ctx }) => {
     return await ControlPlaneStateController.load(ctx);
   }),
-  sessions: procedure.query(({ ctx }) => {
+  sessions: controlPlaneWorkspaceProcedure.input(sessionsInputSchema).query(({ ctx }) => {
+    const requestWorkspace = ctx.requestWorkspace;
     return {
-      sessions: controlPlaneChatSessionsController.readViews(controlPlaneSessionEngineArgs(ctx)),
+      workspaceId: requestWorkspace.workspace.id,
+      sessions: controlPlaneChatSessionsController.readViews(requestWorkspace.sessionEngineArgs),
     };
   }),
-  sessionsEvents: procedure.subscription(({ ctx, signal }) => {
+  sessionsEvents: controlPlaneWorkspaceProcedure.input(sessionsEventsInputSchema).subscription(({ ctx, signal }) => {
+    const { workspace } = ctx.requestWorkspace;
     return controlPlaneChatSessionsController.subscribeSessionListEvents({
-      stateRoot: ctx.activeWorkspace.stateRoot,
+      stateRoot: workspace.stateRoot,
       signal,
     });
   }),
-  sessionCreate: procedure.input(createSessionInputSchema).mutation(({ ctx, input }) => {
+  sessionCreate: controlPlaneWorkspaceProcedure.input(createSessionInputSchema).mutation(({ ctx, input }) => {
+    const { workspace, sessionEngineArgs } = ctx.requestWorkspace;
     return controlPlaneChatSessionsController.createSession({
-      ...controlPlaneSessionEngineArgs(ctx),
+      ...sessionEngineArgs,
       suggestedName: input?.name,
-      workspaceId: ctx.activeWorkspace.id,
+      workspaceId: workspace.id,
       model: input?.model,
       retention: input?.retention,
       apiKeyPresent: input?.apiKeyPresent,
       preferApiKey: ctx.preferApiKey,
     });
   }),
-  session: procedure.input(sessionInputSchema).query(({ ctx, input }) => {
-    return controlPlaneChatSessionsController.readDetail(controlPlaneSessionEngineArgs(ctx), input.id) ?? null;
+  session: controlPlaneWorkspaceProcedure.input(sessionInputSchema).query(({ ctx, input }) => {
+    const { sessionEngineArgs } = ctx.requestWorkspace;
+    return controlPlaneChatSessionsController.readDetail(sessionEngineArgs, input.id) ?? null;
   }),
-  sessionEvents: procedure.input(sessionEventsInputSchema).subscription(({ ctx, input, signal }) => {
+  sessionEvents: controlPlaneWorkspaceProcedure.input(sessionEventsInputSchema).subscription(({ ctx, input, signal }) => {
+    const { workspace } = ctx.requestWorkspace;
     return controlPlaneChatSessionsController.subscribeLiveEvents({
-      stateRoot: ctx.activeWorkspace.stateRoot,
+      workspaceId: workspace.id,
+      stateRoot: workspace.stateRoot,
       sessionId: input.sessionId,
       signal,
     });
@@ -96,9 +105,10 @@ export const controlPlaneRouter = router({
       })),
     };
   }),
-  sessionSettingsUpdate: procedure.input(sessionSettingsInputSchema).mutation(({ ctx, input }) => {
+  sessionSettingsUpdate: controlPlaneWorkspaceProcedure.input(sessionSettingsInputSchema).mutation(({ ctx, input }) => {
+    const { sessionEngineArgs } = ctx.requestWorkspace;
     return controlPlaneChatSessionsController.updateSettings({
-      ...controlPlaneSessionEngineArgs(ctx),
+      ...sessionEngineArgs,
       sessionId: input.id,
       settings: {
         model: input.model,
@@ -107,30 +117,48 @@ export const controlPlaneRouter = router({
       },
     });
   }),
-  sessionTurnReview: procedure.input(turnReviewInputSchema).query(({ ctx, input }) => {
-    return controlPlaneChatSessionsController.readTurnReview(controlPlaneSessionEngineArgs(ctx), input.sessionId, input.turnId) ?? null;
+  sessionTurnReview: controlPlaneWorkspaceProcedure.input(turnReviewInputSchema).query(({ ctx, input }) => {
+    const { sessionEngineArgs } = ctx.requestWorkspace;
+    return controlPlaneChatSessionsController.readTurnReview(sessionEngineArgs, input.sessionId, input.turnId) ?? null;
   }),
-  sessionPendingApproval: procedure.input(sessionInputSchema).query(({ input }) => {
-    return controlPlaneChatSessionsController.getPendingApproval(input.id) ?? null;
+  sessionPendingApproval: controlPlaneWorkspaceProcedure.input(sessionInputSchema).query(({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return controlPlaneChatSessionsController.getPendingApproval({
+      workspaceId: workspace.id,
+      sessionId: input.id,
+    }) ?? null;
   }),
-  sessionRunning: procedure.input(sessionInputSchema).query(({ input }) => {
-    return { running: controlPlaneChatSessionsController.isRunning(input.id) };
-  }),
-  sessionResolveApproval: procedure.input(sessionApprovalDecisionSchema).mutation(({ input }) => {
+  sessionRunning: controlPlaneWorkspaceProcedure.input(sessionInputSchema).query(({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
-      resolved: controlPlaneChatSessionsController.resolvePendingApproval(input.sessionId, input.decision),
+      running: controlPlaneChatSessionsController.isRunning({
+        workspaceId: workspace.id,
+        sessionId: input.id,
+      }),
     };
   }),
-  sessionCancel: procedure.input(sessionInputSchema).mutation(({ input }) => {
+  sessionResolveApproval: controlPlaneWorkspaceProcedure.input(sessionApprovalDecisionSchema).mutation(({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
-      cancelled: controlPlaneChatSessionsController.cancelRun(input.id),
+      resolved: controlPlaneChatSessionsController.resolvePendingApproval({
+        workspaceId: workspace.id,
+        sessionId: input.sessionId,
+      }, input.decision),
     };
   }),
-  sessionSendPrompt: procedure.input(sessionMessageInputSchema).mutation(async ({ ctx, input }) => {
+  sessionCancel: controlPlaneWorkspaceProcedure.input(sessionInputSchema).mutation(({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return {
+      cancelled: controlPlaneChatSessionsController.cancelRun({
+        workspaceId: workspace.id,
+        sessionId: input.id,
+      }),
+    };
+  }),
+  sessionSendPrompt: controlPlaneWorkspaceProcedure.input(sessionMessageInputSchema).mutation(async ({ ctx, input }) => {
+    const { sessionEngineArgs } = ctx.requestWorkspace;
     return await controlPlaneChatSessionsController.submitPrompt({
-      workspaceRoot: ctx.activeWorkspace.anchorRoot,
-      stateRoot: ctx.activeWorkspace.stateRoot,
-      sessionStoragePath: resolve(ctx.activeWorkspace.stateRoot, 'chat-sessions.catalog.json'),
+      ...sessionEngineArgs,
       sessionId: input.sessionId,
       prompt: input.prompt,
       maxSteps: input.maxSteps,
@@ -148,11 +176,10 @@ export const controlPlaneRouter = router({
       },
     });
   }),
-  sessionContinue: procedure.input(sessionInputSchema).mutation(async ({ ctx, input }) => {
+  sessionContinue: controlPlaneWorkspaceProcedure.input(sessionInputSchema).mutation(async ({ ctx, input }) => {
+    const { sessionEngineArgs } = ctx.requestWorkspace;
     return await controlPlaneChatSessionsController.continuePrompt({
-      workspaceRoot: ctx.activeWorkspace.anchorRoot,
-      stateRoot: ctx.activeWorkspace.stateRoot,
-      sessionStoragePath: resolve(ctx.activeWorkspace.stateRoot, 'chat-sessions.catalog.json'),
+      ...sessionEngineArgs,
       sessionId: input.id,
       apiKey: input.apiKey,
       preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
@@ -163,11 +190,12 @@ export const controlPlaneRouter = router({
       },
     });
   }),
-  agentAsk: procedure.input(agentAskInputSchema).mutation(async ({ ctx, input }) => {
+  agentAsk: controlPlaneWorkspaceProcedure.input(agentAskInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return await ControlPlaneAskController.run({
       goal: input.goal,
-      workspaceRoot: ctx.activeWorkspace.anchorRoot,
-      stateRoot: ctx.activeWorkspace.stateRoot,
+      workspaceRoot: workspace.workspaceRoot,
+      stateRoot: workspace.stateRoot,
       model: input.model,
       maxSteps: input.maxSteps,
       apiKey: input.apiKey,
@@ -176,87 +204,105 @@ export const controlPlaneRouter = router({
       systemContext: input.systemContext,
     });
   }),
-  heartbeatTasks: procedure.query(async ({ ctx }) => {
+  heartbeatTasks: controlPlaneWorkspaceProcedure.query(async ({ ctx }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
-      tasks: await ControlPlaneHeartbeatController.listTasks(ctx.activeWorkspace.stateRoot),
+      workspaceId: workspace.id,
+      tasks: await ControlPlaneHeartbeatController.listTasks(workspace.stateRoot),
     };
   }),
-  heartbeatTaskCreate: procedure.input(heartbeatTaskCreateInputSchema).mutation(async ({ ctx, input }) => {
+  heartbeatTaskCreate: controlPlaneWorkspaceProcedure.input(heartbeatTaskCreateInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    const { workspaceId: _workspaceId, ...taskInput } = input;
     return {
-      task: await ControlPlaneHeartbeatController.createTask(ctx.activeWorkspace.stateRoot, {
-        ...input,
-        workspaceId: ctx.activeWorkspace.id,
-        workspaceRoot: ctx.activeWorkspace.anchorRoot,
-        stateDir: ctx.activeWorkspace.stateRoot,
+      task: await ControlPlaneHeartbeatController.createTask(workspace.stateRoot, {
+        ...taskInput,
+        workspaceId: workspace.id,
+        workspaceRoot: workspace.workspaceRoot,
+        stateDir: workspace.stateRoot,
       }),
     };
   }),
-  heartbeatTaskUpdate: procedure.input(heartbeatTaskUpdateInputSchema).mutation(async ({ ctx, input }) => {
+  heartbeatTaskUpdate: controlPlaneWorkspaceProcedure.input(heartbeatTaskUpdateInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    const { workspaceId: _workspaceId, taskId: _taskId, ...taskInput } = input;
     return {
-      task: await ControlPlaneHeartbeatController.updateTask(ctx.activeWorkspace.stateRoot, input.taskId, input),
+      task: await ControlPlaneHeartbeatController.updateTask(workspace.stateRoot, input.taskId, taskInput),
     };
   }),
-  heartbeatTaskDelete: procedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
+  heartbeatTaskDelete: controlPlaneWorkspaceProcedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
-      task: await ControlPlaneHeartbeatController.deleteTask(ctx.activeWorkspace.stateRoot, input.taskId),
+      task: await ControlPlaneHeartbeatController.deleteTask(workspace.stateRoot, input.taskId),
     };
   }),
-  heartbeatTask: procedure.input(heartbeatTaskDetailInputSchema).query(async ({ ctx, input }) => {
-    return await ControlPlaneHeartbeatController.readTask(ctx.activeWorkspace.stateRoot, input.taskId, {
+  heartbeatTask: controlPlaneWorkspaceProcedure.input(heartbeatTaskDetailInputSchema).query(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return await ControlPlaneHeartbeatController.readTask(workspace.stateRoot, input.taskId, {
       runLimit: input.runLimit,
     });
   }),
-  heartbeatEvents: procedure.subscription(({ ctx, signal }) => {
+  heartbeatEvents: controlPlaneWorkspaceProcedure.subscription(({ ctx, signal }) => {
+    const { workspace } = ctx.requestWorkspace;
     return controlPlaneHeartbeatEventsController.subscribe({
-      workspaceId: ctx.activeWorkspace.id,
+      workspaceId: workspace.id,
       signal,
     });
   }),
-  heartbeatRuns: procedure.input(heartbeatRunsInputSchema).query(async ({ ctx, input }) => {
+  heartbeatRuns: controlPlaneWorkspaceProcedure.input(heartbeatRunsInputSchema).query(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
-      runs: await ControlPlaneHeartbeatController.listRuns(ctx.activeWorkspace.stateRoot, {
+      runs: await ControlPlaneHeartbeatController.listRuns(workspace.stateRoot, {
         taskId: input?.taskId,
         limit: input?.limit ?? 20,
       }),
     };
   }),
-  heartbeatRun: procedure.input(heartbeatRunInputSchema).query(async ({ ctx, input }) => {
+  heartbeatRun: controlPlaneWorkspaceProcedure.input(heartbeatRunInputSchema).query(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
-      run: await ControlPlaneHeartbeatController.readRun(ctx.activeWorkspace.stateRoot, input.taskId, input.runId) ?? null,
+      run: await ControlPlaneHeartbeatController.readRun(workspace.stateRoot, input.taskId, input.runId) ?? null,
     };
   }),
-  memoryStatus: procedure.query(async ({ ctx }) => {
-    return await ControlPlaneMemoryController.readStatus(ctx.activeWorkspace.stateRoot);
+  memoryStatus: controlPlaneWorkspaceProcedure.query(async ({ ctx }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return await ControlPlaneMemoryController.readStatus(workspace.stateRoot);
   }),
-  memoryList: procedure.input(memoryListInputSchema).query(async ({ ctx, input }) => {
-    return await ControlPlaneMemoryController.listNotes(ctx.activeWorkspace.stateRoot, input?.path);
+  memoryList: controlPlaneWorkspaceProcedure.input(memoryListInputSchema).query(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return await ControlPlaneMemoryController.listNotes(workspace.stateRoot, input?.path);
   }),
-  memoryRead: procedure.input(memoryReadInputSchema).query(async ({ ctx, input }) => {
-    return await ControlPlaneMemoryController.readNote(ctx.activeWorkspace.stateRoot, input.path, {
+  memoryRead: controlPlaneWorkspaceProcedure.input(memoryReadInputSchema).query(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return await ControlPlaneMemoryController.readNote(workspace.stateRoot, input.path, {
       offset: input.offset,
       maxLines: input.maxLines,
     });
   }),
-  memorySearch: procedure.input(memorySearchInputSchema).query(async ({ ctx, input }) => {
-    return await ControlPlaneMemoryController.searchNotes(ctx.activeWorkspace.stateRoot, input.query, {
+  memorySearch: controlPlaneWorkspaceProcedure.input(memorySearchInputSchema).query(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return await ControlPlaneMemoryController.searchNotes(workspace.stateRoot, input.query, {
       path: input.path,
       maxResults: input.maxResults,
     });
   }),
-  heartbeatTaskEnable: procedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
+  heartbeatTaskEnable: controlPlaneWorkspaceProcedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
-      task: await ControlPlaneHeartbeatController.setTaskEnabled(ctx.activeWorkspace.stateRoot, input.taskId, true),
+      task: await ControlPlaneHeartbeatController.setTaskEnabled(workspace.stateRoot, input.taskId, true),
     };
   }),
-  heartbeatTaskDisable: procedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
+  heartbeatTaskDisable: controlPlaneWorkspaceProcedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
-      task: await ControlPlaneHeartbeatController.setTaskEnabled(ctx.activeWorkspace.stateRoot, input.taskId, false),
+      task: await ControlPlaneHeartbeatController.setTaskEnabled(workspace.stateRoot, input.taskId, false),
     };
   }),
-  heartbeatTaskResume: procedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
-    const task = await ControlPlaneHeartbeatController.resumeTask(ctx.activeWorkspace.stateRoot, input.taskId);
+  heartbeatTaskResume: controlPlaneWorkspaceProcedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    const task = await ControlPlaneHeartbeatController.resumeTask(workspace.stateRoot, input.taskId);
     controlPlaneHeartbeatEventsController.publish({
-      workspaceId: ctx.activeWorkspace.id,
+      workspaceId: workspace.id,
       event: {
         type: 'heartbeat.task.due',
         taskId: input.taskId,
@@ -265,15 +311,18 @@ export const controlPlaneRouter = router({
     });
     return { task };
   }),
-  heartbeatTaskTrigger: procedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
+  heartbeatTaskTrigger: controlPlaneWorkspaceProcedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
-      task: await ControlPlaneHeartbeatController.triggerTaskRun(ctx.activeWorkspace.stateRoot, input.taskId),
+      task: await ControlPlaneHeartbeatController.triggerTaskRun(workspace.stateRoot, input.taskId),
     };
   }),
-  heartbeatTaskRunNow: procedure.input(heartbeatTaskRunNowInputSchema).mutation(async ({ ctx, input }) => {
-    const task = await ControlPlaneHeartbeatController.triggerTaskRun(ctx.activeWorkspace.stateRoot, input.taskId);
+  heartbeatTaskRunNow: controlPlaneWorkspaceProcedure.input(heartbeatTaskRunNowInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    const { workspaceId: _workspaceId, ...runInput } = input;
+    const task = await ControlPlaneHeartbeatController.triggerTaskRun(workspace.stateRoot, input.taskId);
     controlPlaneHeartbeatEventsController.publish({
-      workspaceId: ctx.activeWorkspace.id,
+      workspaceId: workspace.id,
       event: {
         type: 'heartbeat.task.due',
         taskId: input.taskId,
@@ -281,13 +330,13 @@ export const controlPlaneRouter = router({
       },
     });
 
-    void ControlPlaneHeartbeatController.runTaskNow(ctx.activeWorkspace.stateRoot, {
-      ...input,
-      workspaceRoot: ctx.activeWorkspace.anchorRoot,
-      stateDir: ctx.activeWorkspace.stateRoot,
+    void ControlPlaneHeartbeatController.runTaskNow(workspace.stateRoot, {
+      ...runInput,
+      workspaceRoot: workspace.workspaceRoot,
+      stateDir: workspace.stateRoot,
       preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
       onEvent: (event) => controlPlaneHeartbeatEventsController.publish({
-        workspaceId: ctx.activeWorkspace.id,
+        workspaceId: workspace.id,
         event,
       }),
     }).catch((error: unknown) => {
@@ -300,10 +349,12 @@ export const controlPlaneRouter = router({
       run: null,
     };
   }),
-  workspaceFileSearch: procedure.input(fileSearchInputSchema).query(async ({ ctx, input }) => {
+  workspaceFileSearch: controlPlaneWorkspaceProcedure.input(fileSearchInputSchema).query(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
     return {
+      workspaceId: workspace.id,
       files: await ControlPlaneWorkspaceFilesController.searchFiles({
-        workspaceRoot: ctx.activeWorkspace.anchorRoot,
+        workspaceRoot: workspace.workspaceRoot,
         query: input?.query ?? '',
         limit: input?.limit ?? 20,
       }),
@@ -316,11 +367,19 @@ export const controlPlaneRouter = router({
       includeHidden: input?.includeHidden ?? false,
     });
   }),
-  workspaceChanges: procedure.query(async ({ ctx }) => {
-    return await ControlPlaneWorkspaceDiffController.readChanges(ctx.activeWorkspace.anchorRoot);
+  workspaceChanges: controlPlaneWorkspaceProcedure.query(async ({ ctx }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return {
+      workspaceId: workspace.id,
+      ...await ControlPlaneWorkspaceDiffController.readChanges(workspace.workspaceRoot),
+    };
   }),
-  workspaceFileDiff: procedure.input(workspaceFileDiffInputSchema).query(async ({ ctx, input }) => {
-    return await ControlPlaneWorkspaceDiffController.readFileDiff(ctx.activeWorkspace.anchorRoot, input.path);
+  workspaceFileDiff: controlPlaneWorkspaceProcedure.input(workspaceFileDiffInputSchema).query(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return {
+      workspaceId: workspace.id,
+      ...await ControlPlaneWorkspaceDiffController.readFileDiff(workspace.workspaceRoot, input.path),
+    };
   }),
   workspaceSetActive: procedure.input(workspaceSetActiveInputSchema).mutation(({ ctx, input }) => {
     const resolved = RuntimeWorkspaceService.setActive({
@@ -340,7 +399,7 @@ export const controlPlaneRouter = router({
       workspaceRoot: ctx.workspaceRoot,
       stateRoot: ctx.stateRoot,
       name: input.name,
-      anchorRoot: input.anchorRoot,
+      newWorkspaceRoot: input.workspaceRoot,
       repoRoots: input.repoRoots,
       setActive: input.setActive,
     });
@@ -365,20 +424,11 @@ export const controlPlaneRouter = router({
       workspaces: resolved.workspaces,
     };
   }),
-  layoutSnapshotSave: procedure.input(layoutSnapshotInputSchema).mutation(async ({ ctx, input }) => {
-    return await ControlPlaneLayoutSnapshotsController.save(ctx.activeWorkspace.stateRoot, input.snapshot);
+  layoutSnapshotSave: controlPlaneWorkspaceProcedure.input(layoutSnapshotInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return await ControlPlaneLayoutSnapshotsController.save(workspace.stateRoot, input.snapshot);
   }),
 });
-
-function controlPlaneSessionEngineArgs(ctx: HeddleServerContext) {
-  return {
-    workspaceRoot: ctx.activeWorkspace.anchorRoot,
-    stateRoot: ctx.activeWorkspace.stateRoot,
-    sessionStoragePath: resolve(ctx.activeWorkspace.stateRoot, 'chat-sessions.catalog.json'),
-    preferApiKey: ctx.preferApiKey,
-    workspaceId: ctx.activeWorkspace.id,
-  };
-}
 
 function registerControlPlaneWorkspaces(
   ctx: HeddleServerContext,

--- a/src/server/routes/trpc/schema.ts
+++ b/src/server/routes/trpc/schema.ts
@@ -2,11 +2,21 @@ import { z } from 'zod';
 
 export const sessionInputSchema = z.object({
   id: z.string().min(1),
+  workspaceId: z.string().min(1).optional(),
   apiKey: z.string().min(1).optional(),
   preferApiKey: z.boolean().optional(),
 });
 
+export const sessionsInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
+}).optional();
+
+export const sessionsEventsInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
+}).optional();
+
 export const createSessionInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   name: z.string().min(1).optional(),
   model: z.string().min(1).optional(),
   retention: z.enum(['reusable', 'one_off']).optional(),
@@ -14,6 +24,7 @@ export const createSessionInputSchema = z.object({
 }).optional();
 
 export const sessionMessageInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   sessionId: z.string().min(1),
   prompt: z.string().min(1),
   maxSteps: z.number().int().min(1).max(500).optional(),
@@ -26,10 +37,12 @@ export const sessionMessageInputSchema = z.object({
 });
 
 export const sessionEventsInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   sessionId: z.string().min(1),
 });
 
 export const agentAskInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   goal: z.string().min(1),
   model: z.string().min(1).optional(),
   maxSteps: z.number().int().min(1).max(500).optional(),
@@ -40,11 +53,13 @@ export const agentAskInputSchema = z.object({
 });
 
 export const turnReviewInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   sessionId: z.string().min(1),
   turnId: z.string().min(1),
 });
 
 export const sessionApprovalDecisionSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   sessionId: z.string().min(1),
   decision: z.discriminatedUnion('type', [
     z.object({
@@ -64,21 +79,25 @@ export const sessionApprovalDecisionSchema = z.object({
 
 export const sessionSettingsInputSchema = z.object({
   id: z.string().min(1),
+  workspaceId: z.string().min(1).optional(),
   model: z.string().min(1).optional(),
   reasoningEffort: z.enum(['low', 'medium', 'high', 'ultrahigh']).optional().nullable(),
   driftEnabled: z.boolean().optional(),
 });
 
 export const heartbeatRunsInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   taskId: z.string().min(1).optional(),
   limit: z.number().int().min(1).max(100).optional(),
 }).optional();
 
 export const heartbeatTaskInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   taskId: z.string().min(1),
 });
 
 export const heartbeatTaskCreateInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   id: z.string().min(1).regex(/^[a-zA-Z0-9._-]+$/).optional(),
   name: z.string().min(1).optional(),
   task: z.string().min(1),
@@ -103,11 +122,13 @@ export const heartbeatTaskUpdateInputSchema = heartbeatTaskCreateInputSchema
   });
 
 export const heartbeatTaskDetailInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   taskId: z.string().min(1),
   runLimit: z.number().int().min(1).max(100).optional(),
 });
 
 export const heartbeatTaskRunNowInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   taskId: z.string().min(1),
   model: z.string().min(1).optional(),
   maxSteps: z.number().int().min(1).max(500).optional(),
@@ -118,11 +139,13 @@ export const heartbeatTaskRunNowInputSchema = z.object({
 });
 
 export const heartbeatRunInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   taskId: z.string().min(1),
   runId: z.string().min(1),
 });
 
 export const fileSearchInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   query: z.string().max(200).optional(),
   limit: z.number().int().min(1).max(50).optional(),
 }).optional();
@@ -134,26 +157,35 @@ export const workspaceBrowseInputSchema = z.object({
 }).optional();
 
 export const workspaceFileDiffInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   path: z.string().min(1),
 });
 
+export const workspaceScopedInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
+}).optional();
+
 export const memoryListInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   path: z.string().min(1).optional(),
 }).optional();
 
 export const memoryReadInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   path: z.string().min(1),
   offset: z.number().int().min(0).optional(),
   maxLines: z.number().int().min(1).max(1000).optional(),
 });
 
 export const memorySearchInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   query: z.string().min(1).max(200),
   path: z.string().min(1).optional(),
   maxResults: z.number().int().min(1).max(200).optional(),
 });
 
 export const layoutSnapshotInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
   snapshot: z.unknown(),
 });
 
@@ -163,7 +195,7 @@ export const workspaceSetActiveInputSchema = z.object({
 
 export const workspaceCreateInputSchema = z.object({
   name: z.string().min(1),
-  anchorRoot: z.string().min(1),
+  workspaceRoot: z.string().min(1),
   repoRoots: z.array(z.string().min(1)).optional(),
   setActive: z.boolean().optional(),
 });

--- a/src/server/services/control-plane/chat-session-image-uploads.ts
+++ b/src/server/services/control-plane/chat-session-image-uploads.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto';
 import type { Request } from 'express';
 import { RuntimeWorkspaceService, type WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { controlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
+import { getWorkspaceOperationLogger } from '@/server/workspace-operation-logger.js';
 
 export const CHAT_SESSION_IMAGE_UPLOAD_LIMITS = {
   maxFiles: 10,
@@ -94,8 +95,17 @@ export class ChatSessionImageUploadService {
     }
 
     const uploadRoot = resolve(workspace.stateRoot, 'uploads', 'sessions', sessionId);
+    const uploads = files.map((file) => this.projectUploadedFile(uploadRoot, file));
+    getWorkspaceOperationLogger(workspace.stateRoot).info({
+      sessionId,
+      uploadCount: uploads.length,
+      workspaceId: workspace.id,
+      workspaceRoot: workspace.workspaceRoot,
+      stateRoot: workspace.stateRoot,
+    }, 'Control-plane session images uploaded');
+
     return {
-      uploads: files.map((file) => this.projectUploadedFile(uploadRoot, file)),
+      uploads,
     };
   }
 

--- a/src/server/services/control-plane/chat-session-image-uploads.ts
+++ b/src/server/services/control-plane/chat-session-image-uploads.ts
@@ -39,24 +39,34 @@ const SUPPORTED_IMAGE_TYPES = {
 /**
  * Owns browser-uploaded session image storage for the local control plane.
  *
- * Images are persisted under the active workspace state root so the runtime can
+ * Images are persisted under the selected workspace state root so the runtime can
  * later inspect them through the existing filesystem-backed view_image tool.
  */
 export class ChatSessionImageUploadService {
   constructor(private readonly options: ChatSessionImageUploadServiceOptions) {}
 
-  resolveActiveWorkspace(): WorkspaceDescriptor {
-    return RuntimeWorkspaceService.resolveContext({
+  resolveWorkspace(request: Request): WorkspaceDescriptor {
+    const workspaceContext = RuntimeWorkspaceService.resolveContext({
       workspaceRoot: this.options.workspaceRoot,
       stateRoot: this.options.stateRoot,
-    }).activeWorkspace;
+    });
+    const workspaceId = this.readWorkspaceId(request);
+    if (!workspaceId) {
+      return workspaceContext.activeWorkspace;
+    }
+
+    const workspace = workspaceContext.workspaces.find((candidate) => candidate.id === workspaceId);
+    if (!workspace) {
+      throw new ChatSessionUploadError(404, `Workspace not found: ${workspaceId}`);
+    }
+    return workspace;
   }
 
   async resolveUploadDirectory(request: Request): Promise<string> {
     const sessionId = this.readSessionId(request);
-    const activeWorkspace = this.resolveActiveWorkspace();
-    this.requireSession(activeWorkspace, sessionId);
-    const uploadDirectory = join(activeWorkspace.stateRoot, 'uploads', 'sessions', sessionId);
+    const workspace = this.resolveWorkspace(request);
+    this.requireSession(workspace, sessionId);
+    const uploadDirectory = join(workspace.stateRoot, 'uploads', 'sessions', sessionId);
     await mkdir(uploadDirectory, { recursive: true });
     return uploadDirectory;
   }
@@ -71,8 +81,8 @@ export class ChatSessionImageUploadService {
 
   completeUploads(request: Request): ChatSessionImageUploadResult {
     const sessionId = this.readSessionId(request);
-    const activeWorkspace = this.resolveActiveWorkspace();
-    this.requireSession(activeWorkspace, sessionId);
+    const workspace = this.resolveWorkspace(request);
+    this.requireSession(workspace, sessionId);
 
     const files = this.readUploadedFiles(request.files);
     if (!files.length) {
@@ -83,17 +93,18 @@ export class ChatSessionImageUploadService {
       throw new ChatSessionUploadError(400, `Upload at most ${CHAT_SESSION_IMAGE_UPLOAD_LIMITS.maxFiles} images at a time.`);
     }
 
-    const uploadRoot = resolve(activeWorkspace.stateRoot, 'uploads', 'sessions', sessionId);
+    const uploadRoot = resolve(workspace.stateRoot, 'uploads', 'sessions', sessionId);
     return {
       uploads: files.map((file) => this.projectUploadedFile(uploadRoot, file)),
     };
   }
 
-  private requireSession(activeWorkspace: WorkspaceDescriptor, sessionId: string): void {
+  private requireSession(workspace: WorkspaceDescriptor, sessionId: string): void {
     const session = controlPlaneChatSessionsController.readDetail({
-      workspaceRoot: activeWorkspace.anchorRoot,
-      stateRoot: activeWorkspace.stateRoot,
-      sessionStoragePath: resolve(activeWorkspace.stateRoot, 'chat-sessions.catalog.json'),
+      workspaceRoot: workspace.workspaceRoot,
+      stateRoot: workspace.stateRoot,
+      sessionStoragePath: resolve(workspace.stateRoot, 'chat-sessions.catalog.json'),
+      workspaceId: workspace.id,
     }, sessionId);
     if (!session) {
       throw new ChatSessionUploadError(404, `Chat session not found: ${sessionId}`);
@@ -144,6 +155,12 @@ export class ChatSessionImageUploadService {
     }
 
     return sessionId;
+  }
+
+  private readWorkspaceId(request: Request): string | undefined {
+    const rawWorkspaceId = request.query.workspaceId;
+    const workspaceId = typeof rawWorkspaceId === 'string' ? rawWorkspaceId.trim() : '';
+    return workspaceId || undefined;
   }
 
   private decodeOriginalFilename(originalName: string): string {

--- a/src/server/workspace-operation-logger.ts
+++ b/src/server/workspace-operation-logger.ts
@@ -1,0 +1,20 @@
+import type { Logger } from 'pino';
+import { resolve } from 'node:path';
+import { createServerLogger } from './logger.js';
+
+const workspaceLoggers = new Map<string, Logger>();
+
+export function getWorkspaceOperationLogger(stateRoot: string): Logger {
+  const resolvedStateRoot = resolve(stateRoot);
+  const cached = workspaceLoggers.get(resolvedStateRoot);
+  if (cached) {
+    return cached;
+  }
+
+  const logger = createServerLogger({
+    stateRoot: resolvedStateRoot,
+    console: false,
+  });
+  workspaceLoggers.set(resolvedStateRoot, logger);
+  return logger;
+}

--- a/src/web-v2/api/uploads.ts
+++ b/src/web-v2/api/uploads.ts
@@ -9,19 +9,25 @@ export type ControlPlaneSessionImageUpload = {
 };
 
 export type UploadControlPlaneSessionImagesInput = {
+  workspaceId?: string;
   sessionId: string;
   files: File[];
 };
 
 export async function uploadControlPlaneSessionImages(
-  { sessionId, files }: UploadControlPlaneSessionImagesInput,
+  { workspaceId, sessionId, files }: UploadControlPlaneSessionImagesInput,
 ): Promise<ControlPlaneSessionImageUpload[]> {
   const formData = new FormData();
   files.forEach((file) => {
     formData.append('images', file, file.name);
   });
 
-  const response = await fetch(`/control-plane/sessions/${encodeURIComponent(sessionId)}/uploads`, {
+  const searchParams = new URLSearchParams();
+  if (workspaceId) {
+    searchParams.set('workspaceId', workspaceId);
+  }
+  const queryString = searchParams.toString();
+  const response = await fetch(`/control-plane/sessions/${encodeURIComponent(sessionId)}/uploads${queryString ? `?${queryString}` : ''}`, {
     method: 'POST',
     body: formData,
   });

--- a/src/web-v2/components/conversation/ConversationComposer.tsx
+++ b/src/web-v2/components/conversation/ConversationComposer.tsx
@@ -27,6 +27,7 @@ import type { SessionDriftLevel } from './SessionDriftControl';
 // execution settings, file mentions, and textarea sizing live in focused peers.
 export function ConversationComposer({
   sessionId,
+  workspaceId,
   disabled,
   driftEnabled,
   driftLevel,
@@ -45,6 +46,7 @@ export function ConversationComposer({
   onUpdateReasoningEffort,
 }: {
   sessionId?: string;
+  workspaceId?: string;
   disabled?: boolean;
   driftEnabled?: boolean;
   driftLevel?: SessionDriftLevel;
@@ -74,7 +76,7 @@ export function ConversationComposer({
     removeAttachment: removeImageAttachment,
     uploadedPaths: uploadedImagePaths,
     uploadImages,
-  } = useComposerImageAttachments({ sessionId });
+  } = useComposerImageAttachments({ workspaceId, sessionId });
   const turnActive = Boolean(submitting || running || cancelling);
   const controlsDisabled = disabled || turnActive;
   const sendDisabled = disabled
@@ -84,7 +86,7 @@ export function ConversationComposer({
   const effectiveDriftEnabled = driftEnabled ?? false;
   const effectiveDriftLevel = driftLevel ?? 'unknown';
   const effectiveReasoningEffort = reasoningEffort ?? 'medium';
-  const imageUploadDisabled = controlsDisabled || imageUploading || !sessionId;
+  const imageUploadDisabled = controlsDisabled || imageUploading || !workspaceId || !sessionId;
   const handleUploadImages = useCallback((files: FileList | File[]) => {
     void uploadImages(files);
   }, [uploadImages]);
@@ -105,6 +107,7 @@ export function ConversationComposer({
     await onSubmitPrompt(prompt);
   }, [clearUploadedAttachments, draft, onSubmitPrompt, sendDisabled, uploadedImagePaths]);
   const fileMentions = useFileMentionAutocomplete({
+    workspaceId,
     value: draft,
     onValueChange: setDraft,
     textareaRef,

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -125,6 +125,7 @@ export function ConversationThread({
       ) : null}
       <div className="v2-composer-region">
         <ConversationComposer
+          key={`${workspaceId ?? 'workspace'}:${session.id}`}
           sessionId={session.id}
           workspaceId={workspaceId}
           disabled={Boolean(pendingApproval)}

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -12,6 +12,7 @@ import { ConversationMessage } from './ConversationMessage';
 import { Loader2 } from 'lucide-react';
 
 interface ConversationThreadProps {
+  workspaceId?: string;
   session: ControlPlaneSessionDetail;
   loading: boolean;
   submitting: boolean;
@@ -35,6 +36,7 @@ interface ConversationThreadProps {
 
 // ConversationThread renders the selected session in the central work area.
 export function ConversationThread({
+  workspaceId,
   session,
   loading,
   submitting,
@@ -72,7 +74,7 @@ export function ConversationThread({
           </div>
         </div>
         <div className="v2-composer-region">
-          <ConversationComposer disabled onSubmitPrompt={onSubmitPrompt} />
+          <ConversationComposer disabled workspaceId={workspaceId} onSubmitPrompt={onSubmitPrompt} />
         </div>
       </div>
     );
@@ -85,7 +87,7 @@ export function ConversationThread({
           {emptyTitle}
         </div>
         <div className="v2-composer-region">
-          <ConversationComposer disabled onSubmitPrompt={onSubmitPrompt} />
+          <ConversationComposer disabled workspaceId={workspaceId} onSubmitPrompt={onSubmitPrompt} />
         </div>
       </div>
     );
@@ -124,6 +126,7 @@ export function ConversationThread({
       <div className="v2-composer-region">
         <ConversationComposer
           sessionId={session.id}
+          workspaceId={workspaceId}
           disabled={Boolean(pendingApproval)}
           driftEnabled={session.driftEnabled ?? false}
           driftLevel={session.driftLevel}

--- a/src/web-v2/components/diff/DiffPreview.tsx
+++ b/src/web-v2/components/diff/DiffPreview.tsx
@@ -10,20 +10,22 @@ import { MonacoDiffViewer } from '@web/components/diff/MonacoDiffViewer';
 import { useI18n } from '@web/i18n';
 import { cn } from '@web/lib/utils';
 
-export function DiffPreview() {
+export function DiffPreview({ workspaceId }: { workspaceId?: string }) {
   const { t } = useI18n();
-  const changesQuery = trpcReact.controlPlane.workspaceChanges.useQuery(undefined, {
+  const changesQuery = trpcReact.controlPlane.workspaceChanges.useQuery(workspaceId ? { workspaceId } : undefined, {
+    enabled: Boolean(workspaceId),
     refetchOnWindowFocus: true,
   });
   const [expandedPaths, setExpandedPaths] = useState<string[]>([]);
-  const files = useMemo(() => changesQuery.data?.files ?? [], [changesQuery.data?.files]);
+  const changes = changesQuery.data?.workspaceId === workspaceId ? changesQuery.data : undefined;
+  const files = useMemo(() => changes?.files ?? [], [changes?.files]);
 
   useEffect(() => {
-    if (!changesQuery.data) {
+    if (!changes) {
       return;
     }
     setExpandedPaths(files.map((file) => file.path));
-  }, [changesQuery.data, files]);
+  }, [changes, files]);
 
   function togglePath(path: string) {
     setExpandedPaths((current) => (
@@ -41,12 +43,12 @@ export function DiffPreview() {
       </header>
 
       <div className="v2-scrollbar-hidden min-h-0 flex-1 overflow-y-auto">
-        {changesQuery.isLoading ?
+        {!changes && changesQuery.isFetching ?
           <DiffPreviewEmpty title={t('diffPreview.loadingTitle')} body={t('diffPreview.loadingBody')} />
         : changesQuery.error ?
           <DiffPreviewEmpty title={t('diffPreview.failedTitle')} body={changesQuery.error.message} tone="danger" />
-        : changesQuery.data?.vcs === 'none' ?
-          <DiffPreviewEmpty title={t('diffPreview.noGitTitle')} body={changesQuery.data.error ?? t('diffPreview.noGitBody')} />
+        : changes?.vcs === 'none' ?
+          <DiffPreviewEmpty title={t('diffPreview.noGitTitle')} body={changes.error ?? t('diffPreview.noGitBody')} />
         : files.length ?
           <div className="grid">
             {files.map((file) => (
@@ -54,6 +56,7 @@ export function DiffPreview() {
                 key={file.path}
                 expanded={expandedPaths.includes(file.path)}
                 file={file}
+                workspaceId={workspaceId}
                 onToggle={() => togglePath(file.path)}
               />
             ))}
@@ -67,19 +70,22 @@ export function DiffPreview() {
 function DiffPreviewFile({
   expanded,
   file,
+  workspaceId,
   onToggle,
 }: {
   expanded: boolean;
   file: ControlPlaneWorkspaceChangedFile;
+  workspaceId?: string;
   onToggle: () => void;
 }) {
   const { t } = useI18n();
   const fileDiffQuery = trpcReact.controlPlane.workspaceFileDiff.useQuery(
-    expanded ? { path: file.path } : skipToken,
+    expanded && workspaceId ? { workspaceId, path: file.path } : skipToken,
     {
-      enabled: expanded,
+      enabled: expanded && Boolean(workspaceId),
     },
   );
+  const fileDiff = fileDiffQuery.data?.workspaceId === workspaceId ? fileDiffQuery.data : undefined;
 
   return (
     <article className={cn('v2-diff-file', expanded && 'v2-diff-file-expanded')}>
@@ -112,9 +118,9 @@ function DiffPreviewFile({
             <DiffPreviewEmpty title={t('diffPreview.loadingFileTitle')} body={t('diffPreview.loadingFileBody')} compact />
           : fileDiffQuery.error ?
             <DiffPreviewEmpty title={t('diffPreview.fileFailedTitle')} body={fileDiffQuery.error.message} tone="danger" compact />
-          : fileDiffQuery.data?.error ?
-            <DiffPreviewEmpty title={t('diffPreview.fileUnavailableTitle')} body={fileDiffQuery.data.error} compact />
-          : <FileDiffContent fileDiff={fileDiffQuery.data} />}
+          : fileDiff?.error ?
+            <DiffPreviewEmpty title={t('diffPreview.fileUnavailableTitle')} body={fileDiff.error} compact />
+          : <FileDiffContent fileDiff={fileDiff} />}
         </div>
       : null}
     </article>

--- a/src/web-v2/components/navigation/AppNavigation.tsx
+++ b/src/web-v2/components/navigation/AppNavigation.tsx
@@ -12,17 +12,22 @@ import type { AppSurfaceId } from '@web/layout/types';
 import { MainNavigationSection } from './MainNavigationSection';
 import { SidebarContentRegion } from './SidebarContentRegion';
 import { SidebarSettingsEntry } from './SidebarSettingsEntry';
+import { WorkspaceSwitcher } from './WorkspaceSwitcher';
 
 interface AppNavigationProps {
   activeItemId: AppSurfaceId;
   items: readonly AppRoute[];
+  selectedWorkspaceId?: string;
   selectedSessionId?: string;
   selectedTaskId?: string;
   sessions: ControlPlaneState['sessions'];
   tasks: ControlPlaneState['heartbeat']['tasks'];
+  workspaces: ControlPlaneState['workspaces'];
   onOpenSettings: () => void;
+  onOpenWorkspaceSettings: () => void;
   onCreateSession: () => Promise<void>;
   onCreateTask: () => void;
+  onSelectWorkspace: (workspaceId: string) => void;
   onSelectSession: (sessionId: string) => void;
   onSelectTask: (taskId: string) => void;
 }
@@ -32,13 +37,17 @@ interface AppNavigationProps {
 export function AppNavigation({
   activeItemId,
   items,
+  selectedWorkspaceId,
   selectedSessionId,
   selectedTaskId,
   sessions,
   tasks,
+  workspaces,
   onOpenSettings,
+  onOpenWorkspaceSettings,
   onCreateSession,
   onCreateTask,
+  onSelectWorkspace,
   onSelectSession,
   onSelectTask,
 }: AppNavigationProps) {
@@ -46,12 +55,18 @@ export function AppNavigation({
 
   return (
     <>
-      <SidebarHeader className="v2-panel-divider h-12 justify-center border-b px-2 py-0">
-        <div className="flex items-center gap-2">
+      <SidebarHeader className="v2-panel-divider border-b px-2 py-2">
+        <div className="mb-1 flex h-6 items-center gap-2 px-1.5">
           <span className="v2-type-app-title text-foreground">Heddle</span>
         </div>
+        <WorkspaceSwitcher
+          selectedWorkspaceId={selectedWorkspaceId}
+          workspaces={workspaces}
+          onOpenWorkspaceSettings={onOpenWorkspaceSettings}
+          onSelectWorkspace={onSelectWorkspace}
+        />
       </SidebarHeader>
-      <MainNavigationSection activeItemId={activeItemId} items={items} />
+      <MainNavigationSection activeItemId={activeItemId} items={items} workspaceId={selectedWorkspaceId} />
       <SidebarContent>
         <SidebarContentRegion
           ariaLabel={activeItemId === 'tasks' ? t('navigation.taskListAriaLabel') : t('navigation.sessionListAriaLabel')}

--- a/src/web-v2/components/navigation/MainNavigationSection.tsx
+++ b/src/web-v2/components/navigation/MainNavigationSection.tsx
@@ -7,11 +7,12 @@ import { SidebarLink } from './SidebarLink';
 interface MainNavigationSectionProps {
   activeItemId: AppSurfaceId;
   items: readonly AppRoute[];
+  workspaceId?: string;
 }
 
 // MainNavigationSection owns the current top-level web-v2 routes. Do not add
 // placeholder features here until the matching route and behavior exist.
-export function MainNavigationSection({ activeItemId, items }: MainNavigationSectionProps) {
+export function MainNavigationSection({ activeItemId, items, workspaceId }: MainNavigationSectionProps) {
   const { t } = useI18n();
 
   return (
@@ -23,7 +24,7 @@ export function MainNavigationSection({ activeItemId, items }: MainNavigationSec
               <SidebarMenuItem key={item.id}>
                 <SidebarLink
                   active={item.id === activeItemId}
-                  href={item.href}
+                  href={workspaceId ? `/workspaces/${encodeURIComponent(workspaceId)}${item.href}` : item.href}
                   label={t(item.labelKey)}
                   surfaceId={item.id}
                 />

--- a/src/web-v2/components/navigation/WorkspaceSwitcher.tsx
+++ b/src/web-v2/components/navigation/WorkspaceSwitcher.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { Check, ChevronDown, Folder, Settings } from 'lucide-react';
+import type { ControlPlaneState } from '@web/api/client';
+import { Button } from '@web/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@web/components/ui/popover';
+import { useI18n } from '@web/i18n';
+import { cn } from '@web/lib/utils';
+
+interface WorkspaceSwitcherProps {
+  selectedWorkspaceId?: string;
+  workspaces: ControlPlaneState['workspaces'];
+  onOpenWorkspaceSettings: () => void;
+  onSelectWorkspace: (workspaceId: string) => void;
+}
+
+export function WorkspaceSwitcher({
+  selectedWorkspaceId,
+  workspaces,
+  onOpenWorkspaceSettings,
+  onSelectWorkspace,
+}: WorkspaceSwitcherProps) {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const selectedWorkspace = workspaces.find((workspace) => workspace.id === selectedWorkspaceId);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="group flex h-7 w-full min-w-0 items-center gap-2 rounded-md px-1.5 text-left text-sidebar-foreground outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+          aria-label={t('navigation.workspaceSwitcher')}
+        >
+          <Folder className="size-4 shrink-0 text-muted-foreground group-hover:text-sidebar-accent-foreground" aria-hidden="true" />
+          <span className="v2-type-nav-primary min-w-0 flex-1 truncate">
+            {selectedWorkspace?.name ?? selectedWorkspaceId ?? t('navigation.workspaceSwitcher')}
+          </span>
+          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground group-hover:text-sidebar-accent-foreground" aria-hidden="true" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="w-72 p-1.5"
+      >
+        <div className="px-2 py-1.5">
+          <p className="v2-type-section-label text-muted-foreground">{t('navigation.switchWorkspace')}</p>
+        </div>
+        <div className="max-h-72 overflow-auto">
+          {workspaces.length ? workspaces.map((workspace) => {
+            const selected = workspace.id === selectedWorkspaceId;
+
+            return (
+              <button
+                key={workspace.id}
+                type="button"
+                className={cn(
+                  'group flex w-full min-w-0 items-start gap-2 rounded-md px-2 py-1.5 text-left outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-1 focus-visible:ring-ring',
+                  selected && 'bg-accent text-accent-foreground',
+                )}
+                onClick={() => {
+                  setOpen(false);
+                  onSelectWorkspace(workspace.id);
+                }}
+              >
+                <Check
+                  className={cn(
+                    'mt-0.5 size-3.5 shrink-0 text-transparent',
+                    selected && 'text-accent-foreground',
+                  )}
+                  aria-hidden="true"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="v2-type-nav-primary block truncate">{workspace.name}</span>
+                  <span className="v2-type-caption block truncate text-muted-foreground group-hover:text-accent-foreground/75">
+                    {workspace.workspaceRoot}
+                  </span>
+                </span>
+              </button>
+            );
+          }) : (
+            <p className="v2-type-caption px-2 py-3 text-muted-foreground">{t('navigation.noWorkspaces')}</p>
+          )}
+        </div>
+        <div className="mt-1 border-t border-border pt-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="none"
+            className="h-8 w-full justify-start px-2"
+            onClick={() => {
+              setOpen(false);
+              onOpenWorkspaceSettings();
+            }}
+          >
+            <Settings aria-hidden="true" />
+            <span>{t('navigation.manageWorkspaces')}</span>
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/web-v2/components/navigation/index.ts
+++ b/src/web-v2/components/navigation/index.ts
@@ -6,3 +6,4 @@ export { SettingsNavigation } from './SettingsNavigation';
 export { SidebarContentRegion } from './SidebarContentRegion';
 export { SidebarSettingsEntry } from './SidebarSettingsEntry';
 export { TaskListSection } from './TaskListSection';
+export { WorkspaceSwitcher } from './WorkspaceSwitcher';

--- a/src/web-v2/components/panels/ContextInspector.tsx
+++ b/src/web-v2/components/panels/ContextInspector.tsx
@@ -1,5 +1,5 @@
 import { DiffPreview } from '@web/components/diff/DiffPreview';
 
-export function ContextInspector() {
-  return <DiffPreview />;
+export function ContextInspector({ workspaceId }: { workspaceId?: string }) {
+  return <DiffPreview workspaceId={workspaceId} />;
 }

--- a/src/web-v2/components/panels/SessionSidebar.tsx
+++ b/src/web-v2/components/panels/SessionSidebar.tsx
@@ -9,14 +9,18 @@ interface SessionSidebarProps {
   appNavigationItems: readonly AppRoute[];
   settingsNavigationItems: readonly SettingsRoute[];
   settingsOpen: boolean;
+  selectedWorkspaceId?: string;
   selectedSessionId?: string;
   selectedTaskId?: string;
   sessions: ControlPlaneState['sessions'];
   tasks: ControlPlaneState['heartbeat']['tasks'];
+  workspaces: ControlPlaneState['workspaces'];
   onOpenSettings: () => void;
+  onOpenWorkspaceSettings: () => void;
   onCloseSettings: () => void;
   onCreateSession: () => Promise<void>;
   onCreateTask: () => void;
+  onSelectWorkspace: (workspaceId: string) => void;
   onSelectSession: (sessionId: string) => void;
   onSelectTask: (taskId: string) => void;
 }
@@ -29,14 +33,18 @@ export function SessionSidebar({
   appNavigationItems,
   settingsNavigationItems,
   settingsOpen,
+  selectedWorkspaceId,
   selectedSessionId,
   selectedTaskId,
   sessions,
   tasks,
+  workspaces,
   onOpenSettings,
+  onOpenWorkspaceSettings,
   onCloseSettings,
   onCreateSession,
   onCreateTask,
+  onSelectWorkspace,
   onSelectSession,
   onSelectTask,
 }: SessionSidebarProps) {
@@ -52,13 +60,17 @@ export function SessionSidebar({
         <AppNavigation
           activeItemId={activeSurfaceId}
           items={appNavigationItems}
+          selectedWorkspaceId={selectedWorkspaceId}
           selectedSessionId={selectedSessionId}
           selectedTaskId={selectedTaskId}
           sessions={sessions}
           tasks={tasks}
+          workspaces={workspaces}
           onOpenSettings={onOpenSettings}
+          onOpenWorkspaceSettings={onOpenWorkspaceSettings}
           onCreateSession={onCreateSession}
           onCreateTask={onCreateTask}
+          onSelectWorkspace={onSelectWorkspace}
           onSelectSession={onSelectSession}
           onSelectTask={onSelectTask}
         />

--- a/src/web-v2/controllers/session-messages/session-message-controller.ts
+++ b/src/web-v2/controllers/session-messages/session-message-controller.ts
@@ -56,7 +56,7 @@ export class SessionMessageController {
     current: ControlPlaneSessionDetail,
     next: ControlPlaneSessionDetail,
   ): ControlPlaneSessionDetail {
-    if (!current || !next || current.id !== next.id) {
+    if (!current || !next || current.id !== next.id || current.workspaceId !== next.workspaceId) {
       return next;
     }
 

--- a/src/web-v2/hooks/conversation/useComposerImageAttachments.ts
+++ b/src/web-v2/hooks/conversation/useComposerImageAttachments.ts
@@ -18,12 +18,13 @@ export type ComposerImageAttachment = {
 };
 
 type UseComposerImageAttachmentsArgs = {
+  workspaceId?: string;
   sessionId?: string;
 };
 
 const imageMediaTypePrefix = 'image/';
 
-export function useComposerImageAttachments({ sessionId }: UseComposerImageAttachmentsArgs) {
+export function useComposerImageAttachments({ workspaceId, sessionId }: UseComposerImageAttachmentsArgs) {
   const [attachments, setAttachments] = useState<ComposerImageAttachment[]>([]);
   const [validationError, setValidationError] = useState<I18nMessageKey | undefined>();
   const attachmentsRef = useRef<ComposerImageAttachment[]>([]);
@@ -61,7 +62,7 @@ export function useComposerImageAttachments({ sessionId }: UseComposerImageAttac
   }, []);
 
   const uploadImages = useCallback(async (fileList: FileList | File[]) => {
-    if (!sessionId || uploadPending) {
+    if (!workspaceId || !sessionId || uploadPending) {
       return;
     }
 
@@ -86,7 +87,7 @@ export function useComposerImageAttachments({ sessionId }: UseComposerImageAttac
     setAttachments((current) => [...current, ...pendingAttachments]);
 
     try {
-      const uploads = await uploadImageFiles({ sessionId, files: imageFiles });
+      const uploads = await uploadImageFiles({ workspaceId, sessionId, files: imageFiles });
       const uploadsById = new Map(
         pendingAttachments.map((attachment, index) => [attachment.localId, uploads[index]]),
       );
@@ -116,7 +117,7 @@ export function useComposerImageAttachments({ sessionId }: UseComposerImageAttac
         ? { ...attachment, status: 'error' as const, error: message }
         : attachment));
     }
-  }, [sessionId, uploadImageFiles, uploadPending, resetUploadImages]);
+  }, [sessionId, uploadImageFiles, uploadPending, resetUploadImages, workspaceId]);
 
   const uploadedPaths = useMemo(() => attachments
     .map((attachment) => attachment.upload?.path)

--- a/src/web-v2/hooks/conversation/useFileMentionAutocomplete.ts
+++ b/src/web-v2/hooks/conversation/useFileMentionAutocomplete.ts
@@ -104,8 +104,15 @@ export function useFileMentionAutocomplete({
   );
 
   const suggestions = useMemo(
-    () => queryIsCurrent && !fileSearchQuery.isFetching ? fileSearchQuery.data?.files ?? [] : [],
-    [fileSearchQuery.data?.files, fileSearchQuery.isFetching, queryIsCurrent],
+    () => {
+      const data = fileSearchQuery.data;
+      if (!queryIsCurrent || fileSearchQuery.isFetching || !data || data.workspaceId !== workspaceId) {
+        return [];
+      }
+
+      return data.files;
+    },
+    [fileSearchQuery.data, fileSearchQuery.isFetching, queryIsCurrent, workspaceId],
   );
   const activeOptionId = mentionToken && suggestions[activeIndex] ? `${optionIdPrefix}-${activeIndex}` : undefined;
   const loading = Boolean(mentionToken) && (!queryIsCurrent || fileSearchQuery.isFetching);

--- a/src/web-v2/hooks/conversation/useFileMentionAutocomplete.ts
+++ b/src/web-v2/hooks/conversation/useFileMentionAutocomplete.ts
@@ -26,6 +26,7 @@ type FileMentionToken = {
 type TextareaRef = RefObject<HTMLTextAreaElement | null>;
 
 export type UseFileMentionAutocompleteOptions = {
+  workspaceId?: string;
   value: string;
   onValueChange: (value: string) => void;
   textareaRef?: TextareaRef;
@@ -36,6 +37,7 @@ export type UseFileMentionAutocompleteOptions = {
 };
 
 export function useFileMentionAutocomplete({
+  workspaceId,
   value,
   onValueChange,
   textareaRef,
@@ -82,12 +84,14 @@ export function useFileMentionAutocomplete({
     return () => window.clearTimeout(timeout);
   }, [debounceMs, disabled, mentionToken]);
 
-  const queryInput = debouncedMentionToken ? {
+  const queryInput = debouncedMentionToken && workspaceId ? {
+    workspaceId,
     query: debouncedMentionToken.query,
     limit,
   } : skipToken;
 
   const fileSearchQuery = trpcReact.controlPlane.workspaceFileSearch.useQuery(queryInput, {
+    enabled: Boolean(workspaceId && debouncedMentionToken),
     staleTime: 10_000,
   });
 
@@ -100,8 +104,8 @@ export function useFileMentionAutocomplete({
   );
 
   const suggestions = useMemo(
-    () => queryIsCurrent ? fileSearchQuery.data?.files ?? [] : [],
-    [fileSearchQuery.data?.files, queryIsCurrent],
+    () => queryIsCurrent && !fileSearchQuery.isFetching ? fileSearchQuery.data?.files ?? [] : [],
+    [fileSearchQuery.data?.files, fileSearchQuery.isFetching, queryIsCurrent],
   );
   const activeOptionId = mentionToken && suggestions[activeIndex] ? `${optionIdPrefix}-${activeIndex}` : undefined;
   const loading = Boolean(mentionToken) && (!queryIsCurrent || fileSearchQuery.isFetching);
@@ -120,6 +124,10 @@ export function useFileMentionAutocomplete({
     setDebouncedMentionToken(null);
     setActiveIndex(0);
   }, []);
+
+  useEffect(() => {
+    close();
+  }, [close, workspaceId]);
 
   const insertMention = useCallback((suggestion: FileMentionSuggestion) => {
     if (!mentionToken || disabled) {

--- a/src/web-v2/hooks/sessions/useControlPlanePendingApproval.ts
+++ b/src/web-v2/hooks/sessions/useControlPlanePendingApproval.ts
@@ -14,20 +14,25 @@ export type ControlPlanePendingApprovalState = {
   resolvePendingApproval: (decision: ControlPlaneApprovalDecision) => Promise<void>;
 };
 
+type SessionAddress = {
+  workspaceId?: string;
+  sessionId?: string;
+};
+
 type UseControlPlanePendingApprovalOptions = {
   pollingEnabled?: boolean;
 };
 
 export function useControlPlanePendingApproval(
-  sessionId: string | undefined,
+  { workspaceId, sessionId }: SessionAddress,
   options: UseControlPlanePendingApprovalOptions = {},
 ): ControlPlanePendingApprovalState {
   const utils = trpcReact.useUtils();
   const [approvalError, setApprovalError] = useState<string | undefined>();
   const pendingApprovalQuery = trpcReact.controlPlane.sessionPendingApproval.useQuery(
-    sessionId ? { id: sessionId } : skipToken,
+    sessionId && workspaceId ? { id: sessionId, workspaceId } : skipToken,
     {
-      enabled: Boolean(sessionId),
+      enabled: Boolean(sessionId && workspaceId),
       // The live stream is only a notification channel. Poll while a run is
       // active so a prompt submitted during subscription setup still discovers
       // server-held approval requests.
@@ -42,28 +47,33 @@ export function useControlPlanePendingApproval(
   }, [sessionId]);
 
   const refreshPendingApproval = useCallback((targetSessionId: string) => {
-    void utils.controlPlane.sessionPendingApproval.invalidate({ id: targetSessionId });
-  }, [utils]);
+    if (!workspaceId) {
+      return;
+    }
+
+    void utils.controlPlane.sessionPendingApproval.invalidate({ id: targetSessionId, workspaceId });
+  }, [utils, workspaceId]);
 
   const resolvePendingApproval = useCallback(async (decision: ControlPlaneApprovalDecision) => {
-    if (!sessionId) {
+    if (!sessionId || !workspaceId) {
       return;
     }
 
     setApprovalError(undefined);
     try {
       const result = await resolveApprovalMutation.mutateAsync({
+        workspaceId,
         sessionId,
         decision,
       });
       if (!result.resolved) {
         throw new Error('No pending approval found for this session.');
       }
-      await utils.controlPlane.sessionPendingApproval.invalidate({ id: sessionId });
+      await utils.controlPlane.sessionPendingApproval.invalidate({ id: sessionId, workspaceId });
     } catch (error) {
       setApprovalError(error instanceof Error ? error.message : String(error));
     }
-  }, [resolveApprovalMutation, sessionId, utils]);
+  }, [resolveApprovalMutation, sessionId, utils, workspaceId]);
 
   return {
     pendingApproval: pendingApprovalQuery.data ?? null,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
@@ -33,20 +33,30 @@ type ControlPlaneSessionDetailState = {
   resolvePendingApproval: ReturnType<typeof useControlPlanePendingApproval>['resolvePendingApproval'];
 };
 
+type UseControlPlaneSessionDetailArgs = {
+  workspaceId?: string;
+  sessionId?: string;
+};
+
 // Composes the web-v2 session detail workflow from focused hooks: persisted
 // detail loading, live event subscription, and prompt submission.
-export function useControlPlaneSessionDetail(sessionId: string | undefined): ControlPlaneSessionDetailState {
+export function useControlPlaneSessionDetail({
+  workspaceId,
+  sessionId,
+}: UseControlPlaneSessionDetailArgs): ControlPlaneSessionDetailState {
   const [liveStatus, setLiveStatus] = useState<string | undefined>();
-  const loader = useControlPlaneSessionLoader(sessionId);
+  const loader = useControlPlaneSessionLoader({ workspaceId, sessionId });
   const runControl = useControlPlaneSessionRunControl({
+    workspaceId,
     sessionId,
     setLiveStatus,
     setError: loader.setError,
   });
-  const approval = useControlPlanePendingApproval(sessionId, {
+  const approval = useControlPlanePendingApproval({ workspaceId, sessionId }, {
     pollingEnabled: runControl.running,
   });
   const events = useControlPlaneSessionEvents({
+    workspaceId,
     sessionId,
     refresh: loader.refresh,
     refreshPendingApproval: approval.refreshPendingApproval,
@@ -55,6 +65,7 @@ export function useControlPlaneSessionDetail(sessionId: string | undefined): Con
     setLiveStatus,
   });
   const promptSubmit = useControlPlaneSessionPromptSubmit({
+    workspaceId,
     sessionId,
     streamConnected: events.streamConnected,
     setSession: loader.setSession,
@@ -63,6 +74,7 @@ export function useControlPlaneSessionDetail(sessionId: string | undefined): Con
     setLiveStatus,
   });
   const settings = useControlPlaneSessionSettings({
+    workspaceId,
     sessionId,
     setSession: loader.setSession,
     setError: loader.setError,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { skipToken } from '@tanstack/react-query';
 import {
   trpcReact,
@@ -35,11 +35,16 @@ export function useControlPlaneSessionEvents({
 }: UseControlPlaneSessionEventsArgs): ControlPlaneSessionEventsState {
   const utils = trpcReact.useUtils();
   const [streamConnected, setStreamConnected] = useState(false);
+  const activeAddressRef = useRef<SessionAddress>({ workspaceId, sessionId });
   const invalidateWorkspaceDiff = useCallback(() => {
     void utils.controlPlane.workspaceChanges.invalidate(workspaceId ? { workspaceId } : undefined);
     void utils.controlPlane.workspaceFileDiff.invalidate();
   }, [utils, workspaceId]);
   const applySessionEvent = useCallback((event: ControlPlaneSessionEventEnvelope) => {
+    if (!isActiveSessionAddress(activeAddressRef.current, { workspaceId, sessionId: event.sessionId })) {
+      return;
+    }
+
     if (event.type === 'waiting') {
       setLiveStatus('Waiting for the session event stream...');
       return;
@@ -63,7 +68,7 @@ export function useControlPlaneSessionEvents({
       setRunning,
       setSession,
     }));
-  }, [invalidateWorkspaceDiff, refresh, refreshPendingApproval, setLiveStatus, setRunning, setSession]);
+  }, [invalidateWorkspaceDiff, refresh, refreshPendingApproval, setLiveStatus, setRunning, setSession, workspaceId]);
 
   const subscription = trpcReact.controlPlane.sessionEvents.useSubscription(
     sessionId && workspaceId ? { sessionId, workspaceId } : skipToken,
@@ -83,6 +88,7 @@ export function useControlPlaneSessionEvents({
   );
 
   useEffect(() => {
+    activeAddressRef.current = { workspaceId, sessionId };
     if (!sessionId || !workspaceId) {
       setRunning(false);
       setLiveStatus(undefined);
@@ -99,6 +105,20 @@ export function useControlPlaneSessionEvents({
   }, [subscription.status]);
 
   return { streamConnected };
+}
+
+type SessionAddress = {
+  workspaceId?: string;
+  sessionId?: string;
+};
+
+function isActiveSessionAddress(active: SessionAddress, event: SessionAddress): boolean {
+  return Boolean(
+    active.workspaceId
+    && active.sessionId
+    && active.workspaceId === event.workspaceId
+    && active.sessionId === event.sessionId,
+  );
 }
 
 type SessionActivityContext = {

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
@@ -64,11 +64,19 @@ export function useControlPlaneSessionEvents({
       refresh,
       refreshPendingApproval,
       invalidateWorkspaceDiff,
+      updateSession: (updater) => {
+        setSession(updater);
+        if (workspaceId) {
+          utils.controlPlane.session.setData(
+            { id: event.sessionId, workspaceId },
+            (current) => applySessionUpdate(current ?? null, updater),
+          );
+        }
+      },
       setLiveStatus,
       setRunning,
-      setSession,
     }));
-  }, [invalidateWorkspaceDiff, refresh, refreshPendingApproval, setLiveStatus, setRunning, setSession, workspaceId]);
+  }, [invalidateWorkspaceDiff, refresh, refreshPendingApproval, setLiveStatus, setRunning, setSession, utils.controlPlane.session, workspaceId]);
 
   const subscription = trpcReact.controlPlane.sessionEvents.useSubscription(
     sessionId && workspaceId ? { sessionId, workspaceId } : skipToken,
@@ -121,12 +129,19 @@ function isActiveSessionAddress(active: SessionAddress, event: SessionAddress): 
   );
 }
 
+function applySessionUpdate(
+  current: ControlPlaneSessionDetail,
+  updater: SetStateAction<ControlPlaneSessionDetail>,
+): ControlPlaneSessionDetail {
+  return typeof updater === 'function' ? updater(current) : updater;
+}
+
 type SessionActivityContext = {
   sessionId: string;
   refresh: RefreshControlPlaneSession;
   refreshPendingApproval: (sessionId: string) => void;
   invalidateWorkspaceDiff: () => void;
-  setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
+  updateSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
   setRunning: Dispatch<SetStateAction<boolean>>;
   setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
 };
@@ -140,8 +155,8 @@ type SessionActivityHandlerMap = {
 };
 
 const sessionActivityHandlers: SessionActivityHandlerMap = {
-  'assistant.stream': (activity, { setSession, setLiveStatus }) => {
-    setSession((current) => (
+  'assistant.stream': (activity, { updateSession, setLiveStatus }) => {
+    updateSession((current) => (
       SessionMessageController.upsertLiveAssistantMessage(
         current,
         activity.text,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
@@ -9,6 +9,7 @@ import { SessionMessageController } from '@web/controllers/session-messages';
 import type { RefreshControlPlaneSession } from './useControlPlaneSessionLoader';
 
 type UseControlPlaneSessionEventsArgs = {
+  workspaceId?: string;
   sessionId?: string;
   refresh: RefreshControlPlaneSession;
   refreshPendingApproval: (sessionId: string) => void;
@@ -24,6 +25,7 @@ export type ControlPlaneSessionEventsState = {
 // Subscribes to the selected session's live event stream and applies only the
 // web-v2 conversation state transitions that this interface currently renders.
 export function useControlPlaneSessionEvents({
+  workspaceId,
   sessionId,
   refresh,
   refreshPendingApproval,
@@ -34,9 +36,9 @@ export function useControlPlaneSessionEvents({
   const utils = trpcReact.useUtils();
   const [streamConnected, setStreamConnected] = useState(false);
   const invalidateWorkspaceDiff = useCallback(() => {
-    void utils.controlPlane.workspaceChanges.invalidate();
+    void utils.controlPlane.workspaceChanges.invalidate(workspaceId ? { workspaceId } : undefined);
     void utils.controlPlane.workspaceFileDiff.invalidate();
-  }, [utils]);
+  }, [utils, workspaceId]);
   const applySessionEvent = useCallback((event: ControlPlaneSessionEventEnvelope) => {
     if (event.type === 'waiting') {
       setLiveStatus('Waiting for the session event stream...');
@@ -64,7 +66,7 @@ export function useControlPlaneSessionEvents({
   }, [invalidateWorkspaceDiff, refresh, refreshPendingApproval, setLiveStatus, setRunning, setSession]);
 
   const subscription = trpcReact.controlPlane.sessionEvents.useSubscription(
-    sessionId ? { sessionId } : skipToken,
+    sessionId && workspaceId ? { sessionId, workspaceId } : skipToken,
     {
       onStarted: () => {
         setStreamConnected(true);
@@ -81,7 +83,7 @@ export function useControlPlaneSessionEvents({
   );
 
   useEffect(() => {
-    if (!sessionId) {
+    if (!sessionId || !workspaceId) {
       setRunning(false);
       setLiveStatus(undefined);
       setStreamConnected(false);
@@ -90,7 +92,7 @@ export function useControlPlaneSessionEvents({
 
     setRunning(false);
     setLiveStatus(undefined);
-  }, [sessionId, setLiveStatus, setRunning]);
+  }, [sessionId, setLiveStatus, setRunning, workspaceId]);
 
   useEffect(() => {
     setStreamConnected(subscription.status === 'pending');

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionLoader.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionLoader.ts
@@ -40,6 +40,13 @@ export function useControlPlaneSessionLoader({
     },
   );
 
+  useEffect(() => {
+    latestRefreshMode.current = null;
+    setSession(null);
+    setManualLoading(false);
+    setError(undefined);
+  }, [sessionId, workspaceId]);
+
   const refresh = useCallback<RefreshControlPlaneSession>(async (id, options = {}) => {
     if (!id || id !== sessionId) {
       return;
@@ -58,7 +65,9 @@ export function useControlPlaneSessionLoader({
       }
 
       setSession((current) => (
-        options.silent ? SessionMessageController.mergeTransientMessages(current, next) : next
+        options.silent && isSameSessionAddress(current, next)
+          ? SessionMessageController.mergeTransientMessages(current, next)
+          : next
       ));
       setError(undefined);
     } catch (loadError) {
@@ -84,11 +93,11 @@ export function useControlPlaneSessionLoader({
 
     const querySession = sessionQuery.data;
     setSession((current) => {
-      if (latestRefreshMode.current === 'silent' && current?.id === querySession.id) {
+      if (latestRefreshMode.current === 'silent' && isSameSessionAddress(current, querySession)) {
         return SessionMessageController.mergeTransientMessages(current, querySession);
       }
 
-      if (current?.id === querySession.id) {
+      if (isSameSessionAddress(current, querySession)) {
         return SessionMessageController.mergeTransientMessages(current, querySession);
       }
 
@@ -111,4 +120,11 @@ export function useControlPlaneSessionLoader({
     setError,
     refresh,
   };
+}
+
+function isSameSessionAddress(
+  current: ControlPlaneSessionDetail,
+  next: NonNullable<ControlPlaneSessionDetail>,
+): boolean {
+  return current?.id === next.id && current.workspaceId === next.workspaceId;
 }

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionLoader.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionLoader.ts
@@ -17,18 +17,26 @@ export type ControlPlaneSessionLoaderState = {
   refresh: RefreshControlPlaneSession;
 };
 
+type UseControlPlaneSessionLoaderArgs = {
+  workspaceId?: string;
+  sessionId?: string;
+};
+
 // Loads persisted session detail through React Query and preserves browser-only
 // transient messages during silent refreshes.
-export function useControlPlaneSessionLoader(sessionId: string | undefined): ControlPlaneSessionLoaderState {
+export function useControlPlaneSessionLoader({
+  workspaceId,
+  sessionId,
+}: UseControlPlaneSessionLoaderArgs): ControlPlaneSessionLoaderState {
   const [session, setSession] = useState<ControlPlaneSessionDetail>(null);
   const [manualLoading, setManualLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
   const latestRefreshMode = useRef<'normal' | 'silent' | null>(null);
 
   const sessionQuery = trpcReact.controlPlane.session.useQuery(
-    sessionId ? { id: sessionId } : skipToken,
+    sessionId && workspaceId ? { id: sessionId, workspaceId } : skipToken,
     {
-      enabled: Boolean(sessionId),
+      enabled: Boolean(sessionId && workspaceId),
     },
   );
 
@@ -63,7 +71,7 @@ export function useControlPlaneSessionLoader(sessionId: string | undefined): Con
   }, [sessionId, sessionQuery]);
 
   useEffect(() => {
-    if (!sessionId) {
+    if (!sessionId || !workspaceId) {
       setSession(null);
       setManualLoading(false);
       setError(undefined);
@@ -87,7 +95,7 @@ export function useControlPlaneSessionLoader(sessionId: string | undefined): Con
       return querySession;
     });
     latestRefreshMode.current = null;
-  }, [sessionId, sessionQuery.data]);
+  }, [sessionId, sessionQuery.data, workspaceId]);
 
   useEffect(() => {
     if (sessionQuery.error) {

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
@@ -72,10 +72,18 @@ export function useControlPlaneSessionPromptSubmit({
     setRunning(true);
     setError(undefined);
     setLiveStatus(streamConnected ? 'Heddle is working...' : 'Heddle is working... reconnecting live stream if needed.');
+    utils.controlPlane.session.setData(
+      { id: sessionId, workspaceId },
+      (current) => SessionMessageController.appendOptimisticUserTurn(current ?? null, trimmed),
+    );
     setSession((current) => SessionMessageController.appendOptimisticUserTurn(current, trimmed));
 
     try {
       const result = await sessionSendPromptMutation.mutateAsync({ workspaceId, sessionId, prompt: trimmed });
+      utils.controlPlane.session.setData(
+        { id: submission.sessionId, workspaceId: submission.workspaceId },
+        result.session,
+      );
       if (isCurrentSubmission()) {
         setSession(result.session);
         setRunning(false);

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { trpcReact, type ControlPlaneSessionDetail } from '@web/api/client';
 import { SessionMessageController } from '@web/controllers/session-messages';
 
@@ -17,6 +17,12 @@ export type ControlPlaneSessionPromptSubmitState = {
   submitPrompt: (prompt: string) => Promise<void>;
 };
 
+type PromptSubmission = {
+  id: number;
+  workspaceId: string;
+  sessionId: string;
+};
+
 // Owns prompt mutation state and optimistic conversation updates for web-v2.
 export function useControlPlaneSessionPromptSubmit({
   workspaceId,
@@ -28,17 +34,39 @@ export function useControlPlaneSessionPromptSubmit({
   setLiveStatus,
 }: UseControlPlaneSessionPromptSubmitArgs): ControlPlaneSessionPromptSubmitState {
   const [submitting, setSubmitting] = useState(false);
+  const activeSubmissionRef = useRef<PromptSubmission | null>(null);
+  const submissionSequenceRef = useRef(0);
+  const utils = trpcReact.useUtils();
   const sessionSendPromptMutation = trpcReact.controlPlane.sessionSendPrompt.useMutation();
 
   useEffect(() => {
+    activeSubmissionRef.current = null;
     setSubmitting(false);
-  }, [sessionId]);
+  }, [sessionId, workspaceId]);
 
   const submitPrompt = useCallback(async (prompt: string) => {
     const trimmed = prompt.trim();
     if (!workspaceId || !sessionId || !trimmed || submitting) {
       return;
     }
+
+    const submission = {
+      id: submissionSequenceRef.current + 1,
+      workspaceId,
+      sessionId,
+    };
+    submissionSequenceRef.current = submission.id;
+    activeSubmissionRef.current = submission;
+
+    const isCurrentSubmission = () => {
+      const current = activeSubmissionRef.current;
+      return Boolean(
+        current
+        && current.id === submission.id
+        && current.workspaceId === submission.workspaceId
+        && current.sessionId === submission.sessionId,
+      );
+    };
 
     setSubmitting(true);
     setRunning(true);
@@ -48,15 +76,28 @@ export function useControlPlaneSessionPromptSubmit({
 
     try {
       const result = await sessionSendPromptMutation.mutateAsync({ workspaceId, sessionId, prompt: trimmed });
-      setSession(result.session);
-      setRunning(false);
-      setLiveStatus(undefined);
+      if (isCurrentSubmission()) {
+        setSession(result.session);
+        setRunning(false);
+        setLiveStatus(undefined);
+      }
     } catch (submitError) {
-      setError(submitError instanceof Error ? submitError.message : String(submitError));
-      setRunning(false);
-      setLiveStatus(undefined);
+      if (isCurrentSubmission()) {
+        setError(submitError instanceof Error ? submitError.message : String(submitError));
+        setRunning(false);
+        setLiveStatus(undefined);
+      }
     } finally {
-      setSubmitting(false);
+      void Promise.all([
+        utils.controlPlane.sessions.invalidate({ workspaceId: submission.workspaceId }),
+        utils.controlPlane.session.invalidate({ id: submission.sessionId, workspaceId: submission.workspaceId }),
+        utils.controlPlane.sessionRunning.invalidate({ id: submission.sessionId, workspaceId: submission.workspaceId }),
+      ]).catch(() => undefined);
+
+      if (isCurrentSubmission()) {
+        activeSubmissionRef.current = null;
+        setSubmitting(false);
+      }
     }
   }, [
     sessionId,
@@ -68,6 +109,9 @@ export function useControlPlaneSessionPromptSubmit({
     streamConnected,
     submitting,
     sessionSendPromptMutation,
+    utils.controlPlane.session,
+    utils.controlPlane.sessionRunning,
+    utils.controlPlane.sessions,
   ]);
 
   return {

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
@@ -3,6 +3,7 @@ import { trpcReact, type ControlPlaneSessionDetail } from '@web/api/client';
 import { SessionMessageController } from '@web/controllers/session-messages';
 
 type UseControlPlaneSessionPromptSubmitArgs = {
+  workspaceId?: string;
   sessionId?: string;
   streamConnected: boolean;
   setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
@@ -18,6 +19,7 @@ export type ControlPlaneSessionPromptSubmitState = {
 
 // Owns prompt mutation state and optimistic conversation updates for web-v2.
 export function useControlPlaneSessionPromptSubmit({
+  workspaceId,
   sessionId,
   streamConnected,
   setSession,
@@ -34,7 +36,7 @@ export function useControlPlaneSessionPromptSubmit({
 
   const submitPrompt = useCallback(async (prompt: string) => {
     const trimmed = prompt.trim();
-    if (!sessionId || !trimmed || submitting) {
+    if (!workspaceId || !sessionId || !trimmed || submitting) {
       return;
     }
 
@@ -45,7 +47,7 @@ export function useControlPlaneSessionPromptSubmit({
     setSession((current) => SessionMessageController.appendOptimisticUserTurn(current, trimmed));
 
     try {
-      const result = await sessionSendPromptMutation.mutateAsync({ sessionId, prompt: trimmed });
+      const result = await sessionSendPromptMutation.mutateAsync({ workspaceId, sessionId, prompt: trimmed });
       setSession(result.session);
       setRunning(false);
       setLiveStatus(undefined);
@@ -58,6 +60,7 @@ export function useControlPlaneSessionPromptSubmit({
     }
   }, [
     sessionId,
+    workspaceId,
     setError,
     setLiveStatus,
     setRunning,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionRunControl.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionRunControl.ts
@@ -11,6 +11,7 @@ export type ControlPlaneSessionRunControlState = {
 };
 
 type UseControlPlaneSessionRunControlArgs = {
+  workspaceId?: string;
   sessionId?: string;
   setLiveStatus: (status: string | undefined) => void;
   setError: (error: string | undefined) => void;
@@ -19,6 +20,7 @@ type UseControlPlaneSessionRunControlArgs = {
 // Owns web-v2 run-control state that has to reconcile optimistic local turn
 // state, server-held in-flight runs, and user-requested cancellation.
 export function useControlPlaneSessionRunControl({
+  workspaceId,
   sessionId,
   setLiveStatus,
   setError,
@@ -29,9 +31,9 @@ export function useControlPlaneSessionRunControl({
   const [cancelError, setCancelError] = useState<string | undefined>();
   const serverConfirmedRunningRef = useRef(false);
   const sessionRunningQuery = trpcReact.controlPlane.sessionRunning.useQuery(
-    sessionId ? { id: sessionId } : skipToken,
+    sessionId && workspaceId ? { id: sessionId, workspaceId } : skipToken,
     {
-      enabled: Boolean(sessionId),
+      enabled: Boolean(sessionId && workspaceId),
       refetchInterval: running || cancelling ? 1000 : false,
       refetchOnWindowFocus: false,
     },
@@ -43,7 +45,7 @@ export function useControlPlaneSessionRunControl({
     setCancelling(false);
     setCancelError(undefined);
     serverConfirmedRunningRef.current = false;
-  }, [sessionId]);
+  }, [sessionId, workspaceId]);
 
   useEffect(() => {
     const serverRunning = sessionRunningQuery.data?.running;
@@ -53,13 +55,13 @@ export function useControlPlaneSessionRunControl({
       return;
     }
 
-    if (serverRunning === false && (cancelling || serverConfirmedRunningRef.current)) {
+    if (serverRunning === false && (running || cancelling || serverConfirmedRunningRef.current)) {
       serverConfirmedRunningRef.current = false;
       setRunningState(false);
       setCancelling(false);
       setLiveStatus(undefined);
     }
-  }, [cancelling, sessionRunningQuery.data?.running, setLiveStatus]);
+  }, [cancelling, running, sessionRunningQuery.data?.running, setLiveStatus]);
 
   const setRunning = useCallback<Dispatch<SetStateAction<boolean>>>((nextRunning) => {
     setRunningState((current) => (
@@ -73,7 +75,7 @@ export function useControlPlaneSessionRunControl({
   }, []);
 
   const cancelRun = useCallback(async () => {
-    if (!sessionId || cancelMutation.isPending) {
+    if (!sessionId || !workspaceId || cancelMutation.isPending) {
       return;
     }
 
@@ -82,9 +84,9 @@ export function useControlPlaneSessionRunControl({
     setLiveStatus('Stop requested. Waiting for the current step to settle...');
 
     try {
-      const result = await cancelMutation.mutateAsync({ id: sessionId });
-      await utils.controlPlane.sessionPendingApproval.invalidate({ id: sessionId });
-      await utils.controlPlane.sessionRunning.invalidate({ id: sessionId });
+      const result = await cancelMutation.mutateAsync({ id: sessionId, workspaceId });
+      await utils.controlPlane.sessionPendingApproval.invalidate({ id: sessionId, workspaceId });
+      await utils.controlPlane.sessionRunning.invalidate({ id: sessionId, workspaceId });
       if (!result.cancelled) {
         setRunningState(false);
         setCancelling(false);
@@ -97,7 +99,7 @@ export function useControlPlaneSessionRunControl({
       setCancelling(false);
       setLiveStatus(undefined);
     }
-  }, [cancelMutation, sessionId, setError, setLiveStatus, utils]);
+  }, [cancelMutation, sessionId, setError, setLiveStatus, utils, workspaceId]);
 
   return {
     running,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionSettings.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionSettings.ts
@@ -10,6 +10,7 @@ export type ControlPlaneReasoningEffort = NonNullable<Exclude<ControlPlaneSessio
 export type ControlPlaneReasoningEffortSelection = ControlPlaneReasoningEffort | 'default';
 
 type UseControlPlaneSessionSettingsArgs = {
+  workspaceId?: string;
   sessionId?: string;
   setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
   setError: Dispatch<SetStateAction<string | undefined>>;
@@ -27,6 +28,7 @@ export type ControlPlaneSessionSettingsState = {
 // Owns web-v2 session setting mutations. The composer renders controls, while
 // this hook keeps API writes and cache invalidation at the session workflow layer.
 export function useControlPlaneSessionSettings({
+  workspaceId,
   sessionId,
   setSession,
   setError,
@@ -35,21 +37,23 @@ export function useControlPlaneSessionSettings({
   const modelOptionsQuery = trpcReact.controlPlane.modelOptions.useQuery();
   const updateSettingsMutation = trpcReact.controlPlane.sessionSettingsUpdate.useMutation();
 
-  const updateSettings = useCallback(async (settings: Omit<ControlPlaneSessionSettingsInput, 'id'>) => {
-    if (!sessionId) {
+  const updateSettings = useCallback(async (settings: Omit<ControlPlaneSessionSettingsInput, 'id' | 'workspaceId'>) => {
+    if (!sessionId || !workspaceId) {
       return;
     }
 
     try {
       const updated = await updateSettingsMutation.mutateAsync({
         id: sessionId,
+        workspaceId,
         ...settings,
       });
       setSession(updated);
       setError(undefined);
       await Promise.all([
         utils.controlPlane.state.invalidate(),
-        utils.controlPlane.session.invalidate({ id: sessionId }),
+        utils.controlPlane.sessions.invalidate({ workspaceId }),
+        utils.controlPlane.session.invalidate({ id: sessionId, workspaceId }),
       ]);
     } catch (settingsError) {
       setError(settingsError instanceof Error ? settingsError.message : String(settingsError));
@@ -60,7 +64,9 @@ export function useControlPlaneSessionSettings({
     setSession,
     updateSettingsMutation,
     utils.controlPlane.session,
+    utils.controlPlane.sessions,
     utils.controlPlane.state,
+    workspaceId,
   ]);
 
   return useMemo(() => ({

--- a/src/web-v2/hooks/shell/useControlPlaneSidebarData.ts
+++ b/src/web-v2/hooks/shell/useControlPlaneSidebarData.ts
@@ -17,7 +17,9 @@ export function useControlPlaneSidebarData({
   navigation: WorkbenchNavigation;
   taskEvents: HeartbeatEvents;
 }) {
-  const stateQuery = trpcReact.controlPlane.state.useQuery();
+  const stateQuery = trpcReact.controlPlane.state.useQuery(
+    navigation.selectedWorkspaceId ? { workspaceId: navigation.selectedWorkspaceId } : undefined,
+  );
   const workspaceId = navigation.selectedWorkspaceId ?? stateQuery.data?.activeWorkspaceId;
   const workspaceKnown = Boolean(workspaceId && stateQuery.data?.workspaces.some((workspace) => workspace.id === workspaceId));
   const [loadedSessions, setLoadedSessions] = useState<{

--- a/src/web-v2/hooks/shell/useControlPlaneSidebarData.ts
+++ b/src/web-v2/hooks/shell/useControlPlaneSidebarData.ts
@@ -1,11 +1,14 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { skipToken } from '@tanstack/react-query';
 import { trpcReact, type ControlPlaneSessionsEventEnvelope } from '@web/api/client';
+import type { ControlPlaneState } from '@web/api/client';
 import type { useWorkbenchNavigation } from '../useWorkbenchNavigation';
 import { applyLiveTaskState } from '../tasks/useControlPlaneTaskLiveState';
 import type { useControlPlaneHeartbeatEvents } from '../tasks/useControlPlaneHeartbeatEvents';
 
 type WorkbenchNavigation = ReturnType<typeof useWorkbenchNavigation>;
 type HeartbeatEvents = ReturnType<typeof useControlPlaneHeartbeatEvents>;
+type SidebarSession = ControlPlaneState['sessions'][number];
 
 export function useControlPlaneSidebarData({
   navigation,
@@ -15,16 +18,51 @@ export function useControlPlaneSidebarData({
   taskEvents: HeartbeatEvents;
 }) {
   const stateQuery = trpcReact.controlPlane.state.useQuery();
-  const sessionsQuery = trpcReact.controlPlane.sessions.useQuery();
-  const tasksQuery = trpcReact.controlPlane.heartbeatTasks.useQuery();
+  const workspaceId = navigation.selectedWorkspaceId ?? stateQuery.data?.activeWorkspaceId;
+  const workspaceKnown = Boolean(workspaceId && stateQuery.data?.workspaces.some((workspace) => workspace.id === workspaceId));
+  const [loadedSessions, setLoadedSessions] = useState<{
+    workspaceId?: string;
+    sessions: SidebarSession[];
+  }>({ sessions: [] });
+  const sessionsQuery = trpcReact.controlPlane.sessions.useQuery(
+    workspaceKnown && workspaceId ? { workspaceId } : undefined,
+    {
+      enabled: workspaceKnown,
+    },
+  );
+  const tasksQuery = trpcReact.controlPlane.heartbeatTasks.useQuery(
+    workspaceKnown && workspaceId ? { workspaceId } : undefined,
+    {
+      enabled: workspaceKnown,
+    },
+  );
+
+  useEffect(() => {
+    if (!workspaceId || !sessionsQuery.data || sessionsQuery.data.workspaceId !== workspaceId) {
+      setLoadedSessions({ sessions: [] });
+      return;
+    }
+
+    setLoadedSessions({
+      workspaceId,
+      sessions: sessionsQuery.data.sessions,
+    });
+  }, [sessionsQuery.data, workspaceId]);
 
   const sessions = useMemo(
-    () => sessionsQuery.data?.sessions ?? stateQuery.data?.sessions ?? [],
-    [sessionsQuery.data?.sessions, stateQuery.data?.sessions],
+    () => loadedSessions.workspaceId === workspaceId ? loadedSessions.sessions : [],
+    [loadedSessions, workspaceId],
   );
   const tasks = useMemo(
-    () => (tasksQuery.data?.tasks ?? []).map((task) => applyLiveTaskState(task, taskEvents.liveTasks[task.taskId])),
-    [taskEvents.liveTasks, tasksQuery.data?.tasks],
+    () => {
+      const taskData = tasksQuery.data;
+      if (!taskData || taskData.workspaceId !== workspaceId) {
+        return [];
+      }
+
+      return taskData.tasks.map((task) => applyLiveTaskState(task, taskEvents.liveTasks[task.taskId]));
+    },
+    [taskEvents.liveTasks, tasksQuery.data, workspaceId],
   );
 
   useEffect(() => {
@@ -32,8 +70,8 @@ export function useControlPlaneSidebarData({
       return;
     }
 
-    navigation.selectSession(sessions[0]!.id, { replace: true });
-  }, [navigation, sessions]);
+    navigation.selectSession(sessions[0]!.id, { workspaceId, replace: true });
+  }, [navigation, sessions, workspaceId]);
 
   useEffect(() => {
     if (navigation.selectedTaskId || navigation.settingsOpen || navigation.activeSurfaceId !== 'tasks' || tasks.length === 0) {
@@ -43,7 +81,7 @@ export function useControlPlaneSidebarData({
     navigation.selectTask(tasks[0]!.taskId, { replace: true });
   }, [navigation, tasks]);
 
-  trpcReact.controlPlane.sessionsEvents.useSubscription(undefined, {
+  trpcReact.controlPlane.sessionsEvents.useSubscription(workspaceId ? { workspaceId } : skipToken, {
     onData: (event: ControlPlaneSessionsEventEnvelope) => {
       if (event.type !== 'sessions.updated') {
         return;
@@ -57,6 +95,7 @@ export function useControlPlaneSidebarData({
     stateQuery,
     sessionsQuery,
     tasksQuery,
+    workspaceId,
     sessions,
     tasks,
   };

--- a/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
@@ -15,7 +15,7 @@ export type ControlPlaneLiveTaskState = {
   updatedAt: string;
 };
 
-export function useControlPlaneHeartbeatEvents() {
+export function useControlPlaneHeartbeatEvents(workspaceId?: string) {
   const utils = trpcReact.useUtils();
   const [liveTasks, setLiveTasks] = useState<Record<string, ControlPlaneLiveTaskState>>({});
 
@@ -32,23 +32,24 @@ export function useControlPlaneHeartbeatEvents() {
     setLiveTasks((current) => applyHeartbeatEvent(current, event));
 
     if (event.type === 'heartbeat.task.finished') {
-      void utils.controlPlane.heartbeatTasks.invalidate();
-      void utils.controlPlane.heartbeatTask.invalidate({ taskId: event.taskId });
+      void utils.controlPlane.heartbeatTasks.invalidate(workspaceId ? { workspaceId } : undefined);
+      void utils.controlPlane.heartbeatTask.invalidate(workspaceId ? { workspaceId, taskId: event.taskId } : { taskId: event.taskId });
       void utils.controlPlane.state.invalidate();
       void utils.controlPlane.heartbeatRun.invalidate({
+        workspaceId,
         taskId: event.taskId,
         runId: event.record.runId,
       });
     }
 
     if (event.type === 'heartbeat.task.failed') {
-      void utils.controlPlane.heartbeatTasks.invalidate();
-      void utils.controlPlane.heartbeatTask.invalidate({ taskId: event.taskId });
+      void utils.controlPlane.heartbeatTasks.invalidate(workspaceId ? { workspaceId } : undefined);
+      void utils.controlPlane.heartbeatTask.invalidate(workspaceId ? { workspaceId, taskId: event.taskId } : { taskId: event.taskId });
       void utils.controlPlane.state.invalidate();
     }
-  }, [utils]);
+  }, [utils, workspaceId]);
 
-  trpcReact.controlPlane.heartbeatEvents.useSubscription(undefined, {
+  trpcReact.controlPlane.heartbeatEvents.useSubscription(workspaceId ? { workspaceId } : undefined, {
     onData: applyHeartbeatEnvelope,
   });
 

--- a/src/web-v2/hooks/tasks/useControlPlaneTaskActions.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneTaskActions.ts
@@ -12,11 +12,13 @@ export function useControlPlaneTaskActions({
   selectedTask,
   sidebarTasks,
   taskEvents,
+  workspaceId,
 }: {
   navigation: WorkbenchNavigation;
   selectedTask: ControlPlaneHeartbeatTaskView | undefined;
   sidebarTasks: ControlPlaneHeartbeatTaskView[];
   taskEvents: HeartbeatEvents;
+  workspaceId?: string;
 }) {
   const utils = trpcReact.useUtils();
   const modelOptionsQuery = trpcReact.controlPlane.modelOptions.useQuery();
@@ -35,14 +37,18 @@ export function useControlPlaneTaskActions({
   const [deleteError, setDeleteError] = useState<string | undefined>();
 
   async function createTask(input: TaskCreateInput, options: { runNow: boolean }) {
+    if (!workspaceId) {
+      return;
+    }
+
     setCreateError(undefined);
     try {
-      const created = await createTaskMutation.mutateAsync(input);
-      navigation.selectTask(created.task.taskId);
+      const created = await createTaskMutation.mutateAsync({ ...input, workspaceId });
+      navigation.selectTask(created.task.taskId, { workspaceId });
       await invalidateTaskViews(created.task.taskId);
       if (options.runNow) {
         taskEvents.markTaskRunQueued(created.task.taskId);
-        await runTaskNowMutation.mutateAsync({ taskId: created.task.taskId });
+        await runTaskNowMutation.mutateAsync({ workspaceId, taskId: created.task.taskId });
       }
       setCreateOpen(false);
     } catch (error) {
@@ -52,13 +58,14 @@ export function useControlPlaneTaskActions({
   }
 
   async function updateSelectedTask(input: TaskCreateInput) {
-    if (!navigation.selectedTaskId) {
+    if (!navigation.selectedTaskId || !workspaceId) {
       return;
     }
 
     setEditError(undefined);
     try {
       const updated = await updateTaskMutation.mutateAsync({
+        workspaceId,
         taskId: navigation.selectedTaskId,
         ...input,
         model: input.model ?? null,
@@ -73,18 +80,18 @@ export function useControlPlaneTaskActions({
   }
 
   async function deleteSelectedTask() {
-    if (!navigation.selectedTaskId) {
+    if (!navigation.selectedTaskId || !workspaceId) {
       return;
     }
 
     const taskId = navigation.selectedTaskId;
     setDeleteError(undefined);
     try {
-      await deleteTaskMutation.mutateAsync({ taskId });
+      await deleteTaskMutation.mutateAsync({ workspaceId, taskId });
       setDeleteOpen(false);
       const nextTask = sidebarTasks.find((task) => task.taskId !== taskId);
       if (nextTask) {
-        navigation.selectTask(nextTask.taskId, { replace: true });
+        navigation.selectTask(nextTask.taskId, { workspaceId, replace: true });
       } else {
         navigation.selectSurface('tasks', { replace: true });
       }
@@ -96,46 +103,46 @@ export function useControlPlaneTaskActions({
   }
 
   async function runSelectedTaskNow() {
-    if (!navigation.selectedTaskId) {
+    if (!navigation.selectedTaskId || !workspaceId) {
       return;
     }
 
     const taskId = navigation.selectedTaskId;
     taskEvents.markTaskRunQueued(taskId);
-    navigation.selectTaskRun(taskId, LIVE_TASK_RUN_ID, { replace: true });
-    await runTaskNowMutation.mutateAsync({ taskId });
+    navigation.selectTaskRun(taskId, LIVE_TASK_RUN_ID, { workspaceId, replace: true });
+    await runTaskNowMutation.mutateAsync({ workspaceId, taskId });
   }
 
   async function resumeSelectedTask() {
-    if (!navigation.selectedTaskId) {
+    if (!navigation.selectedTaskId || !workspaceId) {
       return;
     }
 
     const taskId = navigation.selectedTaskId;
     taskEvents.markTaskRunQueued(taskId);
-    navigation.selectTaskRun(taskId, LIVE_TASK_RUN_ID, { replace: true });
-    await resumeTaskMutation.mutateAsync({ taskId });
+    navigation.selectTaskRun(taskId, LIVE_TASK_RUN_ID, { workspaceId, replace: true });
+    await resumeTaskMutation.mutateAsync({ workspaceId, taskId });
     await invalidateTaskViews(taskId);
   }
 
   async function setSelectedTaskEnabled(enabled: boolean) {
-    if (!navigation.selectedTaskId) {
+    if (!navigation.selectedTaskId || !workspaceId) {
       return;
     }
 
     const taskId = navigation.selectedTaskId;
     if (enabled) {
-      await enableTaskMutation.mutateAsync({ taskId });
+      await enableTaskMutation.mutateAsync({ workspaceId, taskId });
     } else {
-      await disableTaskMutation.mutateAsync({ taskId });
+      await disableTaskMutation.mutateAsync({ workspaceId, taskId });
     }
     await invalidateTaskViews(taskId);
   }
 
   async function invalidateTaskViews(taskId: string) {
     await Promise.all([
-      utils.controlPlane.heartbeatTasks.invalidate(),
-      utils.controlPlane.heartbeatTask.invalidate({ taskId }),
+      utils.controlPlane.heartbeatTasks.invalidate(workspaceId ? { workspaceId } : undefined),
+      utils.controlPlane.heartbeatTask.invalidate(workspaceId ? { workspaceId, taskId } : { taskId }),
       utils.controlPlane.state.invalidate(),
     ]);
   }

--- a/src/web-v2/hooks/tasks/useControlPlaneTaskDetail.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneTaskDetail.ts
@@ -11,13 +11,14 @@ type ControlPlaneTaskDetailState = {
 };
 
 export function useControlPlaneTaskDetail(
+  workspaceId: string | undefined,
   taskId: string | undefined,
   selectedRunId: string | undefined,
 ): ControlPlaneTaskDetailState {
   const taskQuery = trpcReact.controlPlane.heartbeatTask.useQuery(
-    taskId ? { taskId, runLimit: 50 } : skipToken,
+    taskId && workspaceId ? { workspaceId, taskId, runLimit: 50 } : skipToken,
     {
-      enabled: Boolean(taskId),
+      enabled: Boolean(taskId && workspaceId),
     },
   );
 

--- a/src/web-v2/hooks/tasks/useControlPlaneTaskRunDetail.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneTaskRunDetail.ts
@@ -2,6 +2,7 @@ import { skipToken } from '@tanstack/react-query';
 import { trpcReact, type ControlPlaneHeartbeatRun } from '@web/api/client';
 
 export function useControlPlaneTaskRunDetail(
+  workspaceId: string | undefined,
   taskId: string | undefined,
   runId: string | undefined,
 ): {
@@ -10,9 +11,9 @@ export function useControlPlaneTaskRunDetail(
   error?: string;
 } {
   const runQuery = trpcReact.controlPlane.heartbeatRun.useQuery(
-    taskId && runId ? { taskId, runId } : skipToken,
+    workspaceId && taskId && runId ? { workspaceId, taskId, runId } : skipToken,
     {
-      enabled: Boolean(taskId && runId),
+      enabled: Boolean(workspaceId && taskId && runId),
     },
   );
 

--- a/src/web-v2/hooks/tasks/useControlPlaneTaskSelection.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneTaskSelection.ts
@@ -11,14 +11,17 @@ type HeartbeatEvents = ReturnType<typeof useControlPlaneHeartbeatEvents>;
 export function useControlPlaneTaskSelection({
   navigation,
   taskEvents,
+  workspaceId,
 }: {
   navigation: WorkbenchNavigation;
   taskEvents: HeartbeatEvents;
+  workspaceId?: string;
 }) {
-  const detail = useControlPlaneTaskDetail(navigation.selectedTaskId, navigation.selectedTaskRunId);
+  const detail = useControlPlaneTaskDetail(workspaceId, navigation.selectedTaskId, navigation.selectedTaskRunId);
   const task = detail.task ? applyLiveTaskState(detail.task, taskEvents.liveTasks[detail.task.taskId]) : undefined;
   const selectedRunId = navigation.selectedTaskRunId ?? detail.selectedRun?.runId;
   const runDetail = useControlPlaneTaskRunDetail(
+    workspaceId,
     navigation.selectedTaskId,
     selectedRunId === LIVE_TASK_RUN_ID ? undefined : selectedRunId,
   );

--- a/src/web-v2/hooks/useControlPlaneAppState.ts
+++ b/src/web-v2/hooks/useControlPlaneAppState.ts
@@ -10,6 +10,7 @@ import { useWorkbenchNavigation } from './useWorkbenchNavigation';
 
 export type ControlPlaneRightPanelProps = {
   activeRouteMode: ReturnType<typeof useWorkbenchNavigation>['activeRouteMode'];
+  workspaceId?: string;
   taskRun: {
     error?: string;
     liveTask?: ControlPlaneHeartbeatTaskView;
@@ -23,19 +24,29 @@ export function useControlPlaneAppState() {
   const navigation = useWorkbenchNavigation();
   const utils = trpcReact.useUtils();
   const createSessionMutation = trpcReact.controlPlane.sessionCreate.useMutation();
-  const taskEvents = useControlPlaneHeartbeatEvents();
+  const taskEvents = useControlPlaneHeartbeatEvents(navigation.selectedWorkspaceId);
   const sidebar = useControlPlaneSidebarData({ navigation, taskEvents });
-  const memoryStatusQuery = trpcReact.controlPlane.memoryStatus.useQuery(undefined, {
+  const memoryStatusQuery = trpcReact.controlPlane.memoryStatus.useQuery(sidebar.workspaceId ? { workspaceId: sidebar.workspaceId } : undefined, {
     enabled: navigation.settingsOpen && navigation.activeSettingsSectionId === 'memory',
   });
-  const selectedSession = useControlPlaneSessionDetail(navigation.selectedSessionId);
-  const taskSelection = useControlPlaneTaskSelection({ navigation, taskEvents });
+  const selectedSession = useControlPlaneSessionDetail({
+    workspaceId: sidebar.workspaceId,
+    sessionId: navigation.selectedSessionId,
+  });
+  const taskSelection = useControlPlaneTaskSelection({
+    navigation,
+    taskEvents,
+    workspaceId: sidebar.workspaceId,
+  });
   const taskActions = useControlPlaneTaskActions({
     navigation,
     selectedTask: taskSelection.task,
     sidebarTasks: sidebar.tasks,
     taskEvents,
+    workspaceId: sidebar.workspaceId,
   });
+  const state = sidebar.stateQuery.data;
+  const stateMemoryStatus = state && state.activeWorkspaceId === sidebar.workspaceId ? state.memory : undefined;
 
   useControlPlaneErrorToasts({
     stateError: sidebar.stateQuery.error,
@@ -43,12 +54,14 @@ export function useControlPlaneAppState() {
   });
 
   async function createSession() {
-    const session = await createSessionMutation.mutateAsync();
-    navigation.selectSession(session.id);
-    await Promise.all([
-      utils.controlPlane.state.invalidate(),
-      utils.controlPlane.sessions.invalidate(),
-    ]);
+    const session = await createSessionMutation.mutateAsync(
+      sidebar.workspaceId ? { workspaceId: sidebar.workspaceId } : undefined,
+    );
+    navigation.selectSession(session.id, { workspaceId: sidebar.workspaceId });
+    await utils.controlPlane.state.invalidate();
+    await utils.controlPlane.sessions.invalidate(
+      sidebar.workspaceId ? { workspaceId: sidebar.workspaceId } : undefined,
+    );
   }
 
   return {
@@ -56,14 +69,18 @@ export function useControlPlaneAppState() {
       activeSurfaceId: navigation.activeSurfaceId,
       activeSettingsSectionId: navigation.activeSettingsSectionId,
       settingsOpen: navigation.settingsOpen,
+      selectedWorkspaceId: sidebar.workspaceId,
       selectedSessionId: navigation.selectedSessionId,
       selectedTaskId: navigation.selectedTaskId,
+      workspaces: sidebar.stateQuery.data?.workspaces ?? [],
       sessions: sidebar.sessions,
       tasks: sidebar.tasks,
       onOpenSettings: navigation.openSettings,
+      onOpenWorkspaceSettings: () => navigation.openSettings('workspaces'),
       onCloseSettings: navigation.closeSettings,
       onCreateSession: createSession,
       onCreateTask: taskActions.openCreateDialog,
+      onSelectWorkspace: navigation.selectWorkspace,
       onSelectSession: navigation.selectSession,
       onSelectTask: navigation.selectTask,
     },
@@ -71,11 +88,12 @@ export function useControlPlaneAppState() {
       activeSurfaceId: navigation.activeSurfaceId,
       activeSettingsSectionId: navigation.activeSettingsSectionId,
       memorySettingsView: {
-        status: memoryStatusQuery.data ?? sidebar.stateQuery.data?.memory,
+        status: memoryStatusQuery.data ?? stateMemoryStatus,
         loading: memoryStatusQuery.isLoading || sidebar.stateQuery.isLoading,
         error: memoryStatusQuery.error instanceof Error ? memoryStatusQuery.error.message : undefined,
       },
       sessionView: {
+        workspaceId: sidebar.workspaceId,
         session: selectedSession.session,
         loading: selectedSession.loading,
         submitting: selectedSession.submitting,
@@ -112,6 +130,7 @@ export function useControlPlaneAppState() {
     },
     rightPanelProps: {
       activeRouteMode: navigation.activeRouteMode,
+      workspaceId: sidebar.workspaceId,
       taskRun: {
         error: taskSelection.runDetail.error,
         liveTask: taskSelection.task,

--- a/src/web-v2/hooks/useWorkbenchNavigation.ts
+++ b/src/web-v2/hooks/useWorkbenchNavigation.ts
@@ -1,8 +1,10 @@
 import { useLocation, useNavigate } from 'react-router';
 import {
   resolveAppSurface,
+  isSettingsRoute,
   resolveRouteSessionId,
   resolveRouteTaskSelection,
+  resolveRouteWorkspaceId,
   resolveSettingsSection,
   routeForAppSurface,
   routeForSettingsSection,
@@ -10,7 +12,7 @@ import {
   routeForTask,
   routeForTaskRun,
 } from '@web/layout/routes';
-import type { AppSurfaceId } from '@web/layout/types';
+import type { AppSurfaceId, SettingsSectionId } from '@web/layout/types';
 
 export type WorkbenchRouteMode = AppSurfaceId | 'settings';
 
@@ -19,7 +21,8 @@ export type WorkbenchRouteMode = AppSurfaceId | 'settings';
 export function useWorkbenchNavigation() {
   const location = useLocation();
   const navigate = useNavigate();
-  const settingsOpen = location.pathname.startsWith('/settings');
+  const selectedWorkspaceId = resolveRouteWorkspaceId(location.pathname);
+  const settingsOpen = isSettingsRoute(location.pathname);
   const activeSurfaceId = resolveAppSurface(location.pathname);
   const activeSettingsSectionId = resolveSettingsSection(location.pathname);
   const selectedSessionId = resolveRouteSessionId(location.pathname);
@@ -30,27 +33,31 @@ export function useWorkbenchNavigation() {
     activeRouteMode,
     activeSurfaceId,
     activeSettingsSectionId,
+    selectedWorkspaceId,
     selectedSessionId,
     selectedTaskId: taskSelection.taskId,
     selectedTaskRunId: taskSelection.runId,
     settingsOpen,
     closeSettings() {
-      navigate(routeForAppSurface(activeSurfaceId));
+      navigate(routeForAppSurface(activeSurfaceId, selectedWorkspaceId));
     },
-    openSettings() {
-      navigate(routeForSettingsSection(activeSettingsSectionId));
+    openSettings(sectionId: SettingsSectionId = activeSettingsSectionId) {
+      navigate(routeForSettingsSection(sectionId, selectedWorkspaceId));
     },
     selectSurface(surfaceId: AppSurfaceId, options?: { replace?: boolean }) {
-      navigate(routeForAppSurface(surfaceId), { replace: options?.replace ?? false });
+      navigate(routeForAppSurface(surfaceId, selectedWorkspaceId), { replace: options?.replace ?? false });
     },
-    selectSession(sessionId: string, options?: { replace?: boolean }) {
-      navigate(routeForSession(sessionId), { replace: options?.replace ?? false });
+    selectWorkspace(workspaceId: string, options?: { replace?: boolean }) {
+      navigate(routeForAppSurface(activeSurfaceId, workspaceId), { replace: options?.replace ?? false });
     },
-    selectTask(taskId: string, options?: { replace?: boolean }) {
-      navigate(routeForTask(taskId), { replace: options?.replace ?? false });
+    selectSession(sessionId: string, options?: { workspaceId?: string; replace?: boolean }) {
+      navigate(routeForSession(options?.workspaceId ?? selectedWorkspaceId, sessionId), { replace: options?.replace ?? false });
     },
-    selectTaskRun(taskId: string, runId: string, options?: { replace?: boolean }) {
-      navigate(routeForTaskRun(taskId, runId), { replace: options?.replace ?? false });
+    selectTask(taskId: string, options?: { workspaceId?: string; replace?: boolean }) {
+      navigate(routeForTask(options?.workspaceId ?? selectedWorkspaceId, taskId), { replace: options?.replace ?? false });
+    },
+    selectTaskRun(taskId: string, runId: string, options?: { workspaceId?: string; replace?: boolean }) {
+      navigate(routeForTaskRun(options?.workspaceId ?? selectedWorkspaceId, taskId, runId), { replace: options?.replace ?? false });
     },
   };
 }

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -132,8 +132,10 @@
     "collapseSidebar": "Collapse sidebar",
     "expandSidebar": "Expand sidebar",
     "mainAriaLabel": "Main app navigation",
+    "manageWorkspaces": "Manage workspaces",
     "newChat": "New chat",
     "newTask": "New task",
+    "noWorkspaces": "No workspaces found",
     "openSettings": "Open settings",
     "primaryAriaLabel": "Primary navigation",
     "sessionListAriaLabel": "Session list",
@@ -142,8 +144,10 @@
     "settingsAriaLabel": "Settings navigation",
     "settingsMenuAriaLabel": "Settings menu",
     "skipToMain": "Skip to Main Content",
+    "switchWorkspace": "Switch workspace",
     "taskListAriaLabel": "Task list",
-    "taskListTitle": "Tasks"
+    "taskListTitle": "Tasks",
+    "workspaceSwitcher": "Workspace"
   },
   "settings": {
     "general": "General",

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -132,8 +132,10 @@
     "collapseSidebar": "收起侧边栏",
     "expandSidebar": "展开侧边栏",
     "mainAriaLabel": "主应用导航",
+    "manageWorkspaces": "管理工作区",
     "newChat": "新建会话",
     "newTask": "新建任务",
+    "noWorkspaces": "未找到工作区",
     "openSettings": "打开设置",
     "primaryAriaLabel": "主导航",
     "sessionListAriaLabel": "会话列表",
@@ -142,8 +144,10 @@
     "settingsAriaLabel": "设置导航",
     "settingsMenuAriaLabel": "设置菜单",
     "skipToMain": "跳到主要内容",
+    "switchWorkspace": "切换工作区",
     "taskListAriaLabel": "任务列表",
-    "taskListTitle": "任务"
+    "taskListTitle": "任务",
+    "workspaceSwitcher": "工作区"
   },
   "settings": {
     "general": "通用",

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -132,8 +132,10 @@
     "collapseSidebar": "收合側邊欄",
     "expandSidebar": "展開側邊欄",
     "mainAriaLabel": "主要應用導覽",
+    "manageWorkspaces": "管理工作區",
     "newChat": "新增對話",
     "newTask": "新增任務",
+    "noWorkspaces": "找不到工作區",
     "openSettings": "開啟設定",
     "primaryAriaLabel": "主要導覽",
     "sessionListAriaLabel": "對話清單",
@@ -142,8 +144,10 @@
     "settingsAriaLabel": "設定導覽",
     "settingsMenuAriaLabel": "設定選單",
     "skipToMain": "跳到主要內容",
+    "switchWorkspace": "切換工作區",
     "taskListAriaLabel": "任務清單",
-    "taskListTitle": "任務"
+    "taskListTitle": "任務",
+    "workspaceSwitcher": "工作區"
   },
   "settings": {
     "general": "一般",

--- a/src/web-v2/layout/AppFrameShared.tsx
+++ b/src/web-v2/layout/AppFrameShared.tsx
@@ -14,16 +14,20 @@ export interface AppFrameProps {
   appNavigationItems: readonly AppRoute[];
   settingsNavigationItems: readonly SettingsRoute[];
   settingsOpen: boolean;
+  selectedWorkspaceId?: string;
   selectedSessionId?: string;
   selectedTaskId?: string;
   sessions: ControlPlaneState['sessions'];
   tasks: ControlPlaneState['heartbeat']['tasks'];
+  workspaces: ControlPlaneState['workspaces'];
   rightPanel?: ReactNode;
   rightPanelAriaLabel?: string;
   onOpenSettings: () => void;
+  onOpenWorkspaceSettings: () => void;
   onCloseSettings: () => void;
   onCreateSession: () => Promise<void>;
   onCreateTask: () => void;
+  onSelectWorkspace: (workspaceId: string) => void;
   onSelectSession: (sessionId: string) => void;
   onSelectTask: (taskId: string) => void;
 }
@@ -46,14 +50,18 @@ export function AppFrameSidebar({
   appNavigationItems,
   settingsNavigationItems,
   settingsOpen,
+  selectedWorkspaceId,
   selectedSessionId,
   selectedTaskId,
   sessions,
   tasks,
+  workspaces,
   onOpenSettings,
+  onOpenWorkspaceSettings,
   onCloseSettings,
   onCreateSession,
   onCreateTask,
+  onSelectWorkspace,
   onSelectSession,
   onSelectTask,
 }: AppFrameProps) {
@@ -64,14 +72,18 @@ export function AppFrameSidebar({
       appNavigationItems={appNavigationItems}
       settingsNavigationItems={settingsNavigationItems}
       settingsOpen={settingsOpen}
+      selectedWorkspaceId={selectedWorkspaceId}
       selectedSessionId={selectedSessionId}
       selectedTaskId={selectedTaskId}
       sessions={sessions}
       tasks={tasks}
+      workspaces={workspaces}
       onOpenSettings={onOpenSettings}
+      onOpenWorkspaceSettings={onOpenWorkspaceSettings}
       onCloseSettings={onCloseSettings}
       onCreateSession={onCreateSession}
       onCreateTask={onCreateTask}
+      onSelectWorkspace={onSelectWorkspace}
       onSelectSession={onSelectSession}
       onSelectTask={onSelectTask}
     />

--- a/src/web-v2/layout/AppRoutes.tsx
+++ b/src/web-v2/layout/AppRoutes.tsx
@@ -21,8 +21,8 @@ interface AppRoutesProps {
 }
 
 const routePathBySurface = {
-  sessions: (href: string) => [`${href}/:sessionId?`],
-  tasks: (href: string) => [href, `${href}/:taskId`, `${href}/:taskId/runs/:runId`],
+  sessions: (href: string) => [`${href}/:sessionId?`, `/workspaces/:workspaceId${href}/:sessionId?`],
+  tasks: (href: string) => [href, `${href}/:taskId`, `${href}/:taskId/runs/:runId`, `/workspaces/:workspaceId${href}`, `/workspaces/:workspaceId${href}/:taskId`, `/workspaces/:workspaceId${href}/:taskId/runs/:runId`],
 } satisfies Record<AppSurfaceId, (href: string) => string[]>;
 
 const appRoutePaths = APP_ROUTES.flatMap((route) => (
@@ -65,18 +65,20 @@ export function AppRoutes({
         />
       ))}
       {SETTINGS_ROUTES.map((route) => (
-        <Route
-          key={route.id}
-          path={route.href}
-          element={(
-            <WorkbenchView
-              {...sharedWorkbenchProps}
-              activeSurfaceId={activeSurfaceId}
-              activeSettingsSectionId={route.id}
-              settingsOpen
-            />
-          )}
-        />
+        [route.href, `/workspaces/:workspaceId${route.href}`].map((path) => (
+          <Route
+            key={path}
+            path={path}
+            element={(
+              <WorkbenchView
+                {...sharedWorkbenchProps}
+                activeSurfaceId={activeSurfaceId}
+                activeSettingsSectionId={route.id}
+                settingsOpen
+              />
+            )}
+          />
+        ))
       ))}
       <Route path="*" element={<Navigate to={DEFAULT_APP_ROUTE} replace />} />
     </Routes>

--- a/src/web-v2/layout/ControlPlaneRightPanel.tsx
+++ b/src/web-v2/layout/ControlPlaneRightPanel.tsx
@@ -9,11 +9,12 @@ export function getControlPlaneRightPanel({
   activeRouteMode,
   t,
   taskRun,
+  workspaceId,
 }: ControlPlaneRightPanelProps & { t: (key: I18nMessageKey) => string }) {
   const panels = {
     sessions: {
       ariaLabel: t('inspector.contextAriaLabel'),
-      content: <ContextInspector />,
+      content: <ContextInspector workspaceId={workspaceId} />,
     },
     tasks: {
       ariaLabel: t('tasks.runDetailsAriaLabel'),

--- a/src/web-v2/layout/routes.ts
+++ b/src/web-v2/layout/routes.ts
@@ -30,41 +30,68 @@ export const DEFAULT_APP_ROUTE = APP_ROUTES[0].href;
 export const DEFAULT_SETTINGS_ROUTE = SETTINGS_ROUTES[0].href;
 const SESSION_ROUTE_PREFIX = '/sessions/';
 const TASK_ROUTE_PREFIX = '/tasks/';
+const WORKSPACE_ROUTE_PREFIX = '/workspaces/';
 
 export function resolveAppSurface(pathname: string): AppSurfaceId {
-  return APP_ROUTES.find((route) => pathname.startsWith(route.href))?.id ?? APP_ROUTES[0].id;
+  const routePath = workspaceScopedPath(pathname);
+  return APP_ROUTES.find((route) => routePath.startsWith(route.href))?.id ?? APP_ROUTES[0].id;
 }
 
 export function resolveSettingsSection(pathname: string): SettingsSectionId {
-  return SETTINGS_ROUTES.find((route) => pathname.startsWith(route.href))?.id ?? SETTINGS_ROUTES[0].id;
+  const routePath = workspaceScopedPath(pathname);
+  return SETTINGS_ROUTES.find((route) => routePath.startsWith(route.href))?.id ?? SETTINGS_ROUTES[0].id;
 }
 
-export function routeForAppSurface(id: AppSurfaceId): string {
-  return APP_ROUTES.find((route) => route.id === id)?.href ?? DEFAULT_APP_ROUTE;
+export function isSettingsRoute(pathname: string): boolean {
+  return workspaceScopedPath(pathname).startsWith('/settings');
 }
 
-export function routeForSettingsSection(id: SettingsSectionId): string {
-  return SETTINGS_ROUTES.find((route) => route.id === id)?.href ?? DEFAULT_SETTINGS_ROUTE;
+export function routeForAppSurface(id: AppSurfaceId, workspaceId?: string): string {
+  const legacyHref = APP_ROUTES.find((route) => route.id === id)?.href ?? DEFAULT_APP_ROUTE;
+  if (!workspaceId) {
+    return legacyHref;
+  }
+
+  return `/workspaces/${encodeURIComponent(workspaceId)}${legacyHref}`;
 }
 
-export function routeForSession(sessionId: string): string {
-  return `${DEFAULT_APP_ROUTE}/${encodeURIComponent(sessionId)}`;
+export function routeForSettingsSection(id: SettingsSectionId, workspaceId?: string): string {
+  const legacyHref = SETTINGS_ROUTES.find((route) => route.id === id)?.href ?? DEFAULT_SETTINGS_ROUTE;
+  if (!workspaceId) {
+    return legacyHref;
+  }
+
+  return `/workspaces/${encodeURIComponent(workspaceId)}${legacyHref}`;
 }
 
-export function routeForTask(taskId: string): string {
-  return `/tasks/${encodeURIComponent(taskId)}`;
+export function routeForSession(workspaceId: string | undefined, sessionId: string): string {
+  return `${routeForAppSurface('sessions', workspaceId)}/${encodeURIComponent(sessionId)}`;
 }
 
-export function routeForTaskRun(taskId: string, runId: string): string {
-  return `${routeForTask(taskId)}/runs/${encodeURIComponent(runId)}`;
+export function routeForTask(workspaceId: string | undefined, taskId: string): string {
+  return `${routeForAppSurface('tasks', workspaceId)}/${encodeURIComponent(taskId)}`;
 }
 
-export function resolveRouteSessionId(pathname: string): string | undefined {
-  if (!pathname.startsWith(SESSION_ROUTE_PREFIX)) {
+export function routeForTaskRun(workspaceId: string | undefined, taskId: string, runId: string): string {
+  return `${routeForTask(workspaceId, taskId)}/runs/${encodeURIComponent(runId)}`;
+}
+
+export function resolveRouteWorkspaceId(pathname: string): string | undefined {
+  if (!pathname.startsWith(WORKSPACE_ROUTE_PREFIX)) {
     return undefined;
   }
 
-  const [encodedSessionId] = pathname.slice(SESSION_ROUTE_PREFIX.length).split('/');
+  const [encodedWorkspaceId] = pathname.slice(WORKSPACE_ROUTE_PREFIX.length).split('/');
+  return decodePathSegment(encodedWorkspaceId);
+}
+
+export function resolveRouteSessionId(pathname: string): string | undefined {
+  const sessionPath = workspaceScopedPath(pathname);
+  if (!sessionPath.startsWith(SESSION_ROUTE_PREFIX)) {
+    return undefined;
+  }
+
+  const [encodedSessionId] = sessionPath.slice(SESSION_ROUTE_PREFIX.length).split('/');
   if (!encodedSessionId) {
     return undefined;
   }
@@ -77,11 +104,12 @@ export function resolveRouteSessionId(pathname: string): string | undefined {
 }
 
 export function resolveRouteTaskSelection(pathname: string): { taskId?: string; runId?: string } {
-  if (!pathname.startsWith(TASK_ROUTE_PREFIX)) {
+  const taskPath = workspaceScopedPath(pathname);
+  if (!taskPath.startsWith(TASK_ROUTE_PREFIX)) {
     return {};
   }
 
-  const [encodedTaskId, runSegment, encodedRunId] = pathname.slice(TASK_ROUTE_PREFIX.length).split('/');
+  const [encodedTaskId, runSegment, encodedRunId] = taskPath.slice(TASK_ROUTE_PREFIX.length).split('/');
   const taskId = decodePathSegment(encodedTaskId);
   if (!taskId) {
     return {};
@@ -91,6 +119,15 @@ export function resolveRouteTaskSelection(pathname: string): { taskId?: string; 
     taskId,
     runId: runSegment === 'runs' ? decodePathSegment(encodedRunId) : undefined,
   };
+}
+
+function workspaceScopedPath(pathname: string): string {
+  if (!pathname.startsWith(WORKSPACE_ROUTE_PREFIX)) {
+    return pathname;
+  }
+
+  const [, surfacePath = ''] = pathname.slice(WORKSPACE_ROUTE_PREFIX.length).split(/\/(.+)/);
+  return `/${surfacePath}`;
 }
 
 function decodePathSegment(value: string | undefined): string | undefined {

--- a/src/web/features/control-plane/components/common.tsx
+++ b/src/web/features/control-plane/components/common.tsx
@@ -151,7 +151,7 @@ export function WorkspacePathLabel({ state }: { state?: ControlPlaneState }) {
   return (
     <span className="workspace-path-label">
       {state.workspace.name}
-      <span className="muted"> · {shortPath(state.workspace.anchorRoot)}</span>
+      <span className="muted"> · {shortPath(state.workspace.workspaceRoot)}</span>
     </span>
   );
 }

--- a/src/web/features/control-plane/components/workspaces-screen/AddWorkspaceCard.tsx
+++ b/src/web/features/control-plane/components/workspaces-screen/AddWorkspaceCard.tsx
@@ -15,7 +15,7 @@ export function AddWorkspaceCard({
   recentWorkspaces?: WorkspaceListItem[];
 }) {
   const [name, setName] = useState('');
-  const [anchorRoot, setAnchorRoot] = useState('');
+  const [workspaceRoot, setWorkspaceRoot] = useState('');
   const [setActive, setSetActive] = useState(true);
   const [pickerOpen, setPickerOpen] = useState(false);
 
@@ -32,17 +32,17 @@ export function AddWorkspaceCard({
         className="mt-4 space-y-4"
         onSubmit={(event) => {
           event.preventDefault();
-          if (!onCreateWorkspace || !name.trim() || !anchorRoot.trim()) {
+          if (!onCreateWorkspace || !name.trim() || !workspaceRoot.trim()) {
             return;
           }
 
           void onCreateWorkspace({
             name: name.trim(),
-            anchorRoot: anchorRoot.trim(),
+            workspaceRoot: workspaceRoot.trim(),
             setActive,
           }).then(() => {
             setName('');
-            setAnchorRoot('');
+            setWorkspaceRoot('');
             setSetActive(true);
           });
         }}
@@ -64,8 +64,8 @@ export function AddWorkspaceCard({
           <div className="flex gap-2">
             <input
               className="h-11 min-w-0 flex-1 rounded-md border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground"
-              value={anchorRoot}
-              onChange={(event) => setAnchorRoot(event.target.value)}
+              value={workspaceRoot}
+              onChange={(event) => setWorkspaceRoot(event.target.value)}
               placeholder="/absolute/path/to/workspace"
               disabled={creatingWorkspace}
               data-testid="workspace-create-path"
@@ -96,7 +96,7 @@ export function AddWorkspaceCard({
           type="submit"
           variant="secondary"
           className="w-full"
-          disabled={creatingWorkspace || !name.trim() || !anchorRoot.trim()}
+          disabled={creatingWorkspace || !name.trim() || !workspaceRoot.trim()}
           data-testid="workspace-create-submit"
         >
           {creatingWorkspace ? 'Creating…' : 'Create workspace'}
@@ -104,11 +104,11 @@ export function AddWorkspaceCard({
       </form>
       <WorkspacePickerDialog
         open={pickerOpen}
-        selectedPath={anchorRoot}
+        selectedPath={workspaceRoot}
         recentWorkspaces={recentWorkspaces}
         onOpenChange={setPickerOpen}
         onSelectPath={(path) => {
-          setAnchorRoot(path);
+          setWorkspaceRoot(path);
           if (!name.trim()) {
             setName(workspaceNameFromPath(path));
           }

--- a/src/web/features/control-plane/components/workspaces-screen/AttachedWorkspacesCard.tsx
+++ b/src/web/features/control-plane/components/workspaces-screen/AttachedWorkspacesCard.tsx
@@ -43,7 +43,7 @@ export function AttachedWorkspacesCard({
                   <Badge variant="outline">{workspace.id}</Badge>
                 </div>
                 <dl className="mt-3 grid gap-2 text-sm">
-                  <WorkspaceMeta label="Workspace path">{workspace.anchorRoot}</WorkspaceMeta>
+                  <WorkspaceMeta label="Workspace path">{workspace.workspaceRoot}</WorkspaceMeta>
                   <WorkspaceMeta label="State path">{workspace.stateRoot}</WorkspaceMeta>
                   <WorkspaceMeta label="Repo roots">{workspace.repoRoots.join(', ')}</WorkspaceMeta>
                 </dl>

--- a/src/web/features/control-plane/components/workspaces-screen/RecentWorkspacesCard.tsx
+++ b/src/web/features/control-plane/components/workspaces-screen/RecentWorkspacesCard.tsx
@@ -42,7 +42,7 @@ export function RecentWorkspacesCard({
                   } else {
                     void onCreateWorkspace?.({
                       name: workspace.name,
-                      anchorRoot: workspace.anchorRoot,
+                      workspaceRoot: workspace.workspaceRoot,
                       setActive: true,
                     });
                   }
@@ -53,7 +53,7 @@ export function RecentWorkspacesCard({
                   {active ? <Badge variant="secondary">active</Badge> : null}
                   <Badge variant="outline">{attached ? 'attached' : 'known'}</Badge>
                 </span>
-                <span className="mt-1 block truncate text-xs text-muted-foreground">{workspace.anchorRoot}</span>
+                <span className="mt-1 block truncate text-xs text-muted-foreground">{workspace.workspaceRoot}</span>
                 <span className="mt-2 block text-[11px] text-muted-foreground">{shortPath(workspace.stateRoot)}</span>
               </button>
             );

--- a/src/web/features/control-plane/components/workspaces-screen/WorkspacePickerDialog.tsx
+++ b/src/web/features/control-plane/components/workspaces-screen/WorkspacePickerDialog.tsx
@@ -100,7 +100,7 @@ export function WorkspacePickerDialog({
                     type="button"
                     className="rounded-lg border border-border bg-card px-3 py-2 text-left hover:border-primary"
                     onClick={() => {
-                      onSelectPath(workspace.anchorRoot);
+                      onSelectPath(workspace.workspaceRoot);
                       onOpenChange(false);
                     }}
                   >
@@ -108,7 +108,7 @@ export function WorkspacePickerDialog({
                       <span className="block truncate text-sm font-semibold text-foreground">{workspace.name}</span>
                       <Badge variant="outline">{workspace.relation}</Badge>
                     </span>
-                    <span className="mt-1 block truncate text-xs text-muted-foreground">{workspace.anchorRoot}</span>
+                    <span className="mt-1 block truncate text-xs text-muted-foreground">{workspace.workspaceRoot}</span>
                   </button>
                 ))}
               </div>

--- a/src/web/features/control-plane/components/workspaces-screen/types.ts
+++ b/src/web/features/control-plane/components/workspaces-screen/types.ts
@@ -1,6 +1,6 @@
 import type { ControlPlaneState } from '../../../../lib/api';
 
-export type WorkspaceCreateInput = { name: string; anchorRoot: string; setActive: boolean };
+export type WorkspaceCreateInput = { name: string; workspaceRoot: string; setActive: boolean };
 
 export type WorkspaceListItem = ControlPlaneState['workspaces'][number] & {
   relation: 'attached' | 'known';

--- a/src/web/features/control-plane/hooks/useControlPlaneState.ts
+++ b/src/web/features/control-plane/hooks/useControlPlaneState.ts
@@ -44,7 +44,7 @@ export function useControlPlaneState() {
 
   const createWorkspace = useCallback(async (input: {
     name: string;
-    anchorRoot: string;
+    workspaceRoot: string;
     repoRoots?: string[];
     setActive?: boolean;
   }) => {

--- a/src/web/features/control-plane/hooks/useWorkspaceMutations.ts
+++ b/src/web/features/control-plane/hooks/useWorkspaceMutations.ts
@@ -11,7 +11,7 @@ export function useWorkspaceMutations({
 }: {
   state?: ControlPlaneState;
   setActiveWorkspace: (workspaceId: string) => Promise<void>;
-  createWorkspace: (input: { name: string; anchorRoot: string; setActive?: boolean }) => Promise<void>;
+  createWorkspace: (input: { name: string; workspaceRoot: string; setActive?: boolean }) => Promise<void>;
   renameWorkspace: (workspaceId: string, name: string) => Promise<void>;
   notify: (toast: ToastInput) => void;
 }) {
@@ -37,7 +37,7 @@ export function useWorkspaceMutations({
 
   const handleCreateWorkspace = useCallback(async (input: {
     name: string;
-    anchorRoot: string;
+    workspaceRoot: string;
     setActive: boolean;
   }) => {
     setCreatingWorkspace(true);

--- a/src/web/features/control-plane/screens/OverviewScreen.tsx
+++ b/src/web/features/control-plane/screens/OverviewScreen.tsx
@@ -31,7 +31,7 @@ export function OverviewScreen({
             <div className="space-y-1">
               <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">Active workspace</p>
               <h2 className="text-xl font-semibold text-foreground">{state.workspace.name}</h2>
-              <p className="text-sm text-muted-foreground">{shortPath(state.workspace.anchorRoot)}</p>
+              <p className="text-sm text-muted-foreground">{shortPath(state.workspace.workspaceRoot)}</p>
             </div>
             <Badge variant="secondary" className="w-fit max-w-full truncate">{state.workspace.id}</Badge>
           </div>
@@ -43,7 +43,7 @@ export function OverviewScreen({
           </div>
 
           <dl className="mt-4 grid gap-3 text-sm">
-            <MetaRow label="Workspace path">{state.workspace.anchorRoot}</MetaRow>
+            <MetaRow label="Workspace path">{state.workspace.workspaceRoot}</MetaRow>
             <MetaRow label="State path">{state.workspace.stateRoot}</MetaRow>
           </dl>
         </OverviewCard>

--- a/src/web/features/control-plane/shell/MobileControlPlaneShell.tsx
+++ b/src/web/features/control-plane/shell/MobileControlPlaneShell.tsx
@@ -53,7 +53,7 @@ export function MobileControlPlaneShell({
               <span className="text-xs font-semibold tracking-normal text-foreground">Heddle</span>
             </div>
             <p className="m-0 truncate text-xs leading-5 text-muted-foreground">
-              {state ? `${state.workspace.name} · ${shortPath(state.workspace.anchorRoot)}` : 'Reading workspace state'}
+              {state ? `${state.workspace.name} · ${shortPath(state.workspace.workspaceRoot)}` : 'Reading workspace state'}
             </p>
             {state && state.workspaces.length > 1 && onSetActiveWorkspace ?
               <label className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -159,7 +159,7 @@ export async function setActiveWorkspace(workspaceId: string): Promise<Workspace
 
 export async function createWorkspace(input: {
   name: string;
-  anchorRoot: string;
+  workspaceRoot: string;
   repoRoots?: string[];
   setActive?: boolean;
 }): Promise<WorkspaceMutationResult> {


### PR DESCRIPTION
## Summary
- add optional workspaceId inputs to control-plane session APIs and resolve session operations against the requested workspace
- scope live session events, pending approvals, cancellation, and running state by workspaceId plus sessionId
- add a minimal web-v2 workspace switcher and workspace-scoped routes such as /workspaces/:workspaceId/sessions/:sessionId
- pass workspaceId through web-v2 session detail, submit, settings, approval, live events, file mentions, and diff reads
- rename the descriptor vocabulary from anchorRoot to workspaceRoot across persisted catalogs, APIs, v1 UI surfaces, and v2 workspace selection
- keep read-only legacy anchorRoot catalog compatibility with inline cleanup comments so old catalogs normalize to workspaceRoot on save
- add regression coverage for duplicate session ids across workspaces, workspace-scoped file search, and web-v2 route helpers
- update live-events docs for the workspace-addressed event bus invariant

## Validation
- yarn typecheck
- yarn client:build
- yarn client:v2:build
- yarn test:unit
- yarn test:integration
- git diff --check
- Playwright smoke check against http://127.0.0.1:5175/workspaces/default/sessions with this worktree backend on port 8775

Note: the browser smoke still reports existing Monaco worker method warnings from the diff viewer path; the workspace route loaded and selected Session 1 correctly.
