### PR TITLE
[codex] refactor web v2 subscription transport

### DIFF
--- a/docs/architecture/live-events.md
+++ b/docs/architecture/live-events.md
@@ -83,7 +83,7 @@ flowchart TD
   Runtime --> Trace
   Activity --> Publisher["ControlPlaneChatSessionEventsController<br/>publishActivity / publishActivities"]
   Publisher --> Bus["EventEmitter keyed by sessionId"]
-  Bus --> Queue["ControlPlaneEventQueue<br/>AsyncIterable adapter"]
+  Bus --> Queue["RuntimeSubscriptionStream<br/>AsyncIterable adapter"]
   Queue --> TRPC["tRPC subscription<br/>controlPlane.sessionEvents"]
   Bus --> SSE["SSE endpoint<br/>/control-plane/sessions/:id/events"]
   TRPC --> WebV2["web-v2 hook<br/>useControlPlaneSessionEvents"]
@@ -267,12 +267,13 @@ cannot be watched yet:
 The control-plane controller uses an in-process `EventEmitter` keyed by
 `sessionId`. This keeps a live run scoped to the session that produced it.
 
-For tRPC subscriptions, `ControlPlaneEventQueue` adapts callbacks into an
-`AsyncIterable`. It is transport infrastructure only:
+For tRPC subscriptions, `RuntimeSubscriptionStream` in
+`src/core/runtime/subscriptions` adapts callbacks into an `AsyncIterable`. It is
+transport infrastructure only:
 
 - buffer events when the browser is not awaiting the next item yet;
 - wake pending readers when an event arrives;
-- close cleanly when the subscription aborts.
+- run source cleanup and close cleanly when the subscription aborts.
 
 It must not inspect or transform conversation activities. Event vocabulary
 belongs to the conversation engine and the session event publisher.

--- a/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
+++ b/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from '@playwright/test';
-import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import { createTRPCProxyClient, httpLink } from '@trpc/client';
 import type { AppRouter } from '../../../server/router';
 
 const serverPort = process.env.HEDDLE_BROWSER_INTEGRATION_SERVER_PORT ?? '19876';
 const trpc = createTRPCProxyClient<AppRouter>({
   links: [
-    httpBatchLink({
+    httpLink({
       url: `http://127.0.0.1:${serverPort}/trpc`,
     }),
   ],

--- a/src/__tests__/unit/core/runtime-subscription-stream.test.ts
+++ b/src/__tests__/unit/core/runtime-subscription-stream.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RuntimeSubscriptionStream } from '@/core/runtime/subscriptions/index.js';
+
+describe('RuntimeSubscriptionStream', () => {
+  it('buffers source events until a subscription reader asks for them', async () => {
+    const stream = RuntimeSubscriptionStream.fromSources<string>({
+      sources: [
+        (sink) => {
+          sink.push('ready');
+          sink.push('updated');
+        },
+      ],
+    });
+    const iterator = stream[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: 'ready' });
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: 'updated' });
+
+    stream.close();
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it('wakes pending readers and runs source cleanup when aborted', async () => {
+    const abort = new AbortController();
+    const cleanup = vi.fn();
+    const stream = RuntimeSubscriptionStream.fromSources<string>({
+      signal: abort.signal,
+      sources: [
+        () => cleanup,
+      ],
+    });
+    const iterator = stream[Symbol.asyncIterator]();
+    const waiting = iterator.next();
+
+    abort.abort();
+
+    await expect(waiting).resolves.toEqual({ done: true, value: undefined });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs cleanups once when the consumer stops iterating', async () => {
+    const cleanup = vi.fn();
+    const stream = RuntimeSubscriptionStream.fromSources<string>({
+      sources: [
+        (sink) => {
+          sink.push('ready');
+          return cleanup;
+        },
+      ],
+    });
+    const iterator = stream[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: 'ready' });
+    await iterator.return?.();
+    stream.close();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/runtime/subscriptions/README.md
+++ b/src/core/runtime/subscriptions/README.md
@@ -1,0 +1,55 @@
+# Runtime Subscriptions
+
+`src/core/runtime/subscriptions` owns the host-facing push-to-`AsyncIterable`
+transport primitive used by control-plane subscriptions.
+
+The service intentionally does not know about tRPC, SSE, conversation activity,
+heartbeat task records, or session metadata. Callers provide event sources such
+as an `EventEmitter` listener, a file watcher, or an interval; the stream owns
+buffering, waiter wakeups, abort handling, and cleanup.
+
+Use this when a host needs to bridge callback-style runtime/server events into
+a subscription transport. Keep domain vocabulary and event projection in the
+calling controller or domain service.
+
+## How It Works
+
+Each client subscription gets its own `RuntimeSubscriptionStream` instance. The
+stream starts one or more source callbacks and gives each source a `sink`.
+
+`sink` means "the writable end of this subscription." A source calls
+`sink.push(event)` when it receives an event, `sink.addCleanup(cleanup)` when it
+registers a listener/timer/watcher that must be released, and `sink.close()`
+when that source knows the subscription should stop.
+
+The stream itself is the readable end. tRPC consumes it as an `AsyncIterable`:
+
+```text
+event source callback -> sink.push(event) -> stream buffer/waiter -> for await
+```
+
+If the client is already waiting for the next event, `push` wakes that reader.
+If the client is busy, `push` buffers the event until the reader asks again.
+When the browser aborts the request or the consumer stops iterating, the stream
+runs registered cleanups and wakes any pending reader so the subscription can
+finish without leaking listeners.
+
+## Fanout
+
+Fanout belongs to the event source, not this primitive. For example,
+`ControlPlaneChatSessionsController` publishes live session events to an
+`EventEmitter` keyed by session id. If web-v2 and a future TUI both subscribe to
+the same session through tRPC, each interface creates its own tRPC subscription,
+each subscription creates its own `RuntimeSubscriptionStream`, and each stream
+registers its own listener on the same event bus key.
+
+```text
+publisher.emit(sessionId, event)
+  -> web stream listener -> web tRPC subscription
+  -> TUI stream listener -> TUI tRPC subscription
+```
+
+No change is needed in this primitive for that fanout model. Change it only if
+we later need shared delivery guarantees across subscribers, durable replay, or
+cross-process distribution; those would be event-source responsibilities rather
+than per-subscription buffer mechanics.

--- a/src/core/runtime/subscriptions/index.ts
+++ b/src/core/runtime/subscriptions/index.ts
@@ -1,0 +1,9 @@
+export {
+  RuntimeSubscriptionStream,
+} from './stream.js';
+export type {
+  RuntimeSubscriptionCleanup,
+  RuntimeSubscriptionSink,
+  RuntimeSubscriptionSource,
+  RuntimeSubscriptionStreamArgs,
+} from './types.js';

--- a/src/core/runtime/subscriptions/stream.ts
+++ b/src/core/runtime/subscriptions/stream.ts
@@ -1,0 +1,138 @@
+import type {
+  RuntimeSubscriptionCleanup,
+  RuntimeSubscriptionSink,
+  RuntimeSubscriptionSource,
+  RuntimeSubscriptionStreamArgs,
+} from './types.js';
+
+const CLOSED = Symbol('runtime-subscription-closed');
+
+/**
+ * Push-to-AsyncIterable bridge for host subscription transports.
+ *
+ * Event sources push payloads through the sink while the stream owns buffering,
+ * waiter wakeups, abort propagation, and source cleanup. It deliberately does
+ * not inspect event payloads.
+ */
+export class RuntimeSubscriptionStream<Event> implements AsyncIterable<Event> {
+  private readonly events: Event[] = [];
+  private readonly waiters: Array<(event: Event | typeof CLOSED) => void> = [];
+  private readonly cleanups: RuntimeSubscriptionCleanup[] = [];
+  private readonly abortSignal?: AbortSignal;
+  private readonly abort = () => this.close();
+  private closed = false;
+
+  // Convenience constructor for controllers that create a stream from several
+  // callback-style sources in one expression.
+  static fromSources<Event>(args: RuntimeSubscriptionStreamArgs<Event> = {}): RuntimeSubscriptionStream<Event> {
+    return new RuntimeSubscriptionStream(args);
+  }
+
+  // Starts the stream and attaches abort handling. Sources are registered
+  // immediately so callers can return the stream directly to tRPC.
+  constructor(args: RuntimeSubscriptionStreamArgs<Event> = {}) {
+    this.abortSignal = args.signal;
+    this.abortSignal?.addEventListener('abort', this.abort, { once: true });
+    if (this.abortSignal?.aborted) {
+      this.close();
+      return;
+    }
+
+    args.sources?.forEach((source) => this.addSource(source));
+  }
+
+  // The sink is the writable side passed to sources. Sources push events and
+  // register cleanup without seeing the stream's internal buffers or waiters.
+  get sink(): RuntimeSubscriptionSink<Event> {
+    return {
+      push: (event) => this.push(event),
+      close: () => this.close(),
+      addCleanup: (cleanup) => this.addCleanup(cleanup),
+    };
+  }
+
+  // Registers one event source for this client subscription. If the source
+  // returns a cleanup function, the stream will run it on close.
+  addSource(source: RuntimeSubscriptionSource<Event>): void {
+    if (this.closed) {
+      return;
+    }
+
+    const cleanup = source(this.sink);
+    if (cleanup) {
+      this.addCleanup(cleanup);
+    }
+  }
+
+  // Adds cleanup for resources opened after source registration, such as a
+  // lazily-created watcher or listener.
+  addCleanup(cleanup: RuntimeSubscriptionCleanup): void {
+    if (this.closed) {
+      this.runCleanup(cleanup);
+      return;
+    }
+
+    this.cleanups.push(cleanup);
+  }
+
+  // Delivers an event to the next waiting reader, or buffers it if the reader
+  // has not asked for the next item yet.
+  push(event: Event): void {
+    if (this.closed) {
+      return;
+    }
+
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(event);
+      return;
+    }
+
+    this.events.push(event);
+  }
+
+  // Stops accepting new events, removes abort handling, runs source cleanups,
+  // and wakes pending readers so the AsyncIterator can finish.
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    this.abortSignal?.removeEventListener('abort', this.abort);
+    this.cleanups.splice(0).reverse().forEach((cleanup) => this.runCleanup(cleanup));
+    this.waiters.splice(0).forEach((waiter) => waiter(CLOSED));
+  }
+
+  // Lets tRPC consume the stream with `for await`. The iterator drains buffered
+  // events first, then waits for future pushes until the stream closes.
+  async *[Symbol.asyncIterator](): AsyncIterator<Event> {
+    try {
+      while (!this.closed || this.events.length > 0) {
+        const event = this.events.length > 0
+          ? this.events.shift() as Event
+          : await new Promise<Event | typeof CLOSED>((resolve) => {
+            this.waiters.push(resolve);
+          });
+        if (event === CLOSED) {
+          break;
+        }
+
+        yield event;
+      }
+    } finally {
+      this.close();
+    }
+  }
+
+  // Runs one cleanup defensively so a failed listener/timer cleanup does not
+  // prevent the rest of the subscription from closing.
+  private runCleanup(cleanup: RuntimeSubscriptionCleanup): void {
+    try {
+      cleanup();
+    } catch {
+      // Cleanup runs during subscription shutdown. Continue closing the stream
+      // so one failed source cleanup cannot leave readers hanging.
+    }
+  }
+}

--- a/src/core/runtime/subscriptions/types.ts
+++ b/src/core/runtime/subscriptions/types.ts
@@ -1,0 +1,19 @@
+export type RuntimeSubscriptionCleanup = () => void;
+
+// The writable side given to a source callback for one client subscription.
+export type RuntimeSubscriptionSink<Event> = {
+  push(event: Event): void;
+  close(): void;
+  addCleanup(cleanup: RuntimeSubscriptionCleanup): void;
+};
+
+// A callback-style producer such as an EventEmitter listener, watcher, or timer.
+export type RuntimeSubscriptionSource<Event> = (
+  sink: RuntimeSubscriptionSink<Event>
+) => RuntimeSubscriptionCleanup | void;
+
+// Construction options for one per-client subscription stream.
+export type RuntimeSubscriptionStreamArgs<Event> = {
+  signal?: AbortSignal;
+  sources?: Array<RuntimeSubscriptionSource<Event>>;
+};

--- a/src/server/features/control-plane/controllers/chat-sessions-controller.ts
+++ b/src/server/features/control-plane/controllers/chat-sessions-controller.ts
@@ -37,6 +37,7 @@ import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import { ModelPolicyService } from '@/core/llm/models/index.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
+import { RuntimeSubscriptionStream } from '@/core/runtime/subscriptions/index.js';
 import type { ToolCall, ToolDefinition } from '@/core/types.js';
 import { ControlPlaneChatSessionEventsController } from './chat-session-events.js';
 import { ControlPlaneChatSessionPresenter } from './chat-session-presenter.js';
@@ -180,92 +181,74 @@ export class ControlPlaneChatSessionsController {
     sessionId: string;
     signal?: AbortSignal;
   }): AsyncGenerator<ControlPlaneSessionEventEnvelope> {
-    const queue = new ControlPlaneEventQueue<ControlPlaneSessionEventEnvelope>();
-
-    // Live LLM/tool/compaction updates arrive through the in-memory event bus.
-    // This is the path that streams assistant text to the client during a run;
-    // it does not touch the session file for each model delta.
-    const unsubscribe = this.subscribeToEvents(args.sessionId, (event) => {
-      queue.push({
-        ...event,
-        type: 'session.event',
-      });
+    const stream = RuntimeSubscriptionStream.fromSources<ControlPlaneSessionEventEnvelope>({
+      signal: args.signal,
+      sources: [
+        // Live LLM/tool/compaction updates arrive through the in-memory event
+        // bus. This path streams assistant text without touching the session
+        // file for each model delta.
+        (sink) => this.subscribeToEvents(args.sessionId, (event) => {
+          sink.push({
+            ...event,
+            type: 'session.event',
+          });
+        }),
+        (sink) => {
+          try {
+            // File changes represent durable session persistence, usually
+            // after a turn finishes or settings/session metadata are saved.
+            const watcher = watch(this.resolveFilePath(args.stateRoot, args.sessionId), { persistent: false }, () => {
+              sink.push({
+                type: 'session.updated',
+                sessionId: args.sessionId,
+                timestamp: new Date().toISOString(),
+              });
+            });
+            return () => watcher.close();
+          } catch {
+            // A newly selected or newly created session may not have a
+            // watchable file yet. Keep the subscription alive so later live
+            // events can still flow.
+            sink.push({
+              type: 'waiting',
+              sessionId: args.sessionId,
+              timestamp: new Date().toISOString(),
+            });
+          }
+        },
+      ],
     });
 
-    // Closing the browser subscription closes the queue, which lets the async
-    // iterator below exit and release the EventEmitter listener/file watcher.
-    const abort = () => queue.close();
-    args.signal?.addEventListener('abort', abort, { once: true });
-
-    let watcher: ReturnType<typeof watch> | undefined;
-    try {
-      // File changes represent durable session persistence, usually after a
-      // turn finishes or settings/session metadata are saved. They are not the
-      // source of token streaming; they only tell the client to refetch the
-      // persisted session snapshot.
-      watcher = watch(this.resolveFilePath(args.stateRoot, args.sessionId), { persistent: false }, () => {
-        queue.push({
-          type: 'session.updated',
-          sessionId: args.sessionId,
-          timestamp: new Date().toISOString(),
-        });
-      });
-    } catch {
-      // A newly selected or newly created session may not have a watchable file
-      // yet. Keep the subscription alive so later live events can still flow.
-      queue.push({
-        type: 'waiting',
-        sessionId: args.sessionId,
-        timestamp: new Date().toISOString(),
-      });
-    }
-
-    try {
-      // tRPC consumes this AsyncGenerator and forwards each envelope to the
-      // browser as a subscription payload.
-      for await (const event of queue) {
-        yield event;
-      }
-    } finally {
-      unsubscribe();
-      watcher?.close();
-      args.signal?.removeEventListener('abort', abort);
-      queue.close();
-    }
+    yield* stream;
   }
 
   async *subscribeSessionListEvents(args: {
     stateRoot: string;
     signal?: AbortSignal;
   }): AsyncGenerator<ControlPlaneSessionsEventEnvelope> {
-    const queue = new ControlPlaneEventQueue<ControlPlaneSessionsEventEnvelope>();
-    const abort = () => queue.close();
-    args.signal?.addEventListener('abort', abort, { once: true });
+    const stream = RuntimeSubscriptionStream.fromSources<ControlPlaneSessionsEventEnvelope>({
+      signal: args.signal,
+      sources: [
+        (sink) => {
+          try {
+            const watcher = watch(join(args.stateRoot, 'chat-sessions.catalog.json'), { persistent: false }, () => {
+              sink.push({
+                type: 'sessions.updated',
+                timestamp: new Date().toISOString(),
+              });
+            });
+            return () => watcher.close();
+          } catch {
+            sink.push({
+              type: 'waiting',
+              timestamp: new Date().toISOString(),
+            });
+          }
+        },
+      ],
+    });
 
-    let watcher: ReturnType<typeof watch> | undefined;
-    try {
-      watcher = watch(join(args.stateRoot, 'chat-sessions.catalog.json'), { persistent: false }, () => {
-        queue.push({
-          type: 'sessions.updated',
-          timestamp: new Date().toISOString(),
-        });
-      });
-    } catch {
-      queue.push({
-        type: 'waiting',
-        timestamp: new Date().toISOString(),
-      });
-    }
-
-    try {
-      for await (const event of queue) {
-        yield event;
-      }
-    } finally {
-      watcher?.close();
-      args.signal?.removeEventListener('abort', abort);
-      queue.close();
-    }
+    yield* stream;
   }
 
   getPendingApproval(sessionId: string): ToolApprovalRequest | undefined {
@@ -564,55 +547,3 @@ export class ControlPlaneChatSessionsController {
 }
 
 export const controlPlaneChatSessionsController = new ControlPlaneChatSessionsController();
-
-/**
- * Per-subscription delivery queue for control-plane events.
- *
- * Some controller sources use EventEmitter and others use file watchers, while
- * tRPC subscriptions consume an AsyncIterable. This queue is the transport
- * adapter between push callbacks and subscription iteration.
- *
- * Boundary: this class must stay transport/infrastructure-only. It should not
- * inspect or transform event payloads.
- */
-class ControlPlaneEventQueue<Event> implements AsyncIterable<Event> {
-  private readonly events: Event[] = [];
-  private readonly waiters: Array<(event: Event | undefined) => void> = [];
-  private closed = false;
-
-  push(event: Event): void {
-    if (this.closed) {
-      return;
-    }
-
-    const waiter = this.waiters.shift();
-    if (waiter) {
-      waiter(event);
-      return;
-    }
-
-    this.events.push(event);
-  }
-
-  close(): void {
-    if (this.closed) {
-      return;
-    }
-
-    this.closed = true;
-    this.waiters.splice(0).forEach((waiter) => waiter(undefined));
-  }
-
-  async *[Symbol.asyncIterator](): AsyncIterator<Event> {
-    while (!this.closed || this.events.length > 0) {
-      const event = this.events.shift() ?? await new Promise<Event | undefined>((resolve) => {
-        this.waiters.push(resolve);
-      });
-      if (!event) {
-        break;
-      }
-
-      yield event;
-    }
-  }
-}

--- a/src/server/features/control-plane/controllers/heartbeat-events.ts
+++ b/src/server/features/control-plane/controllers/heartbeat-events.ts
@@ -8,6 +8,7 @@
 import { EventEmitter } from 'node:events';
 import dayjs from 'dayjs';
 import { FileHeartbeatTaskService, type AgentHeartbeatEvent, type HeartbeatSchedulerEvent } from '@/core/heartbeat/index.js';
+import { RuntimeSubscriptionStream } from '@/core/runtime/subscriptions/index.js';
 import type { ControlPlaneHeartbeatAgentEvent, ControlPlaneHeartbeatEvent, ControlPlaneHeartbeatEventEnvelope } from '../types.js';
 
 export class ControlPlaneHeartbeatEventsController {
@@ -30,38 +31,36 @@ export class ControlPlaneHeartbeatEventsController {
     workspaceId: string;
     signal?: AbortSignal;
   }): AsyncGenerator<ControlPlaneHeartbeatEventEnvelope> {
-    const queue = new ControlPlaneHeartbeatEventQueue();
-    const listener = (event: ControlPlaneHeartbeatEventEnvelope) => queue.push(event);
-    this.eventBus.on(args.workspaceId, listener);
+    const stream = RuntimeSubscriptionStream.fromSources<ControlPlaneHeartbeatEventEnvelope>({
+      signal: args.signal,
+      sources: [
+        (sink) => {
+          const listener = (event: ControlPlaneHeartbeatEventEnvelope) => sink.push(event);
+          this.eventBus.on(args.workspaceId, listener);
+          return () => this.eventBus.off(args.workspaceId, listener);
+        },
+        (sink) => {
+          const heartbeat = setInterval(() => {
+            sink.push({
+              type: 'heartbeat',
+              workspaceId: args.workspaceId,
+              timestamp: dayjs().toISOString(),
+            });
+          }, 15000);
+          heartbeat.unref?.();
 
-    const heartbeat = setInterval(() => {
-      queue.push({
-        type: 'heartbeat',
-        workspaceId: args.workspaceId,
-        timestamp: dayjs().toISOString(),
-      });
-    }, 15000);
-    heartbeat.unref?.();
+          sink.push({
+            type: 'ready',
+            workspaceId: args.workspaceId,
+            timestamp: dayjs().toISOString(),
+          });
 
-    const abort = () => queue.close();
-    args.signal?.addEventListener('abort', abort, { once: true });
-
-    queue.push({
-      type: 'ready',
-      workspaceId: args.workspaceId,
-      timestamp: dayjs().toISOString(),
+          return () => clearInterval(heartbeat);
+        },
+      ],
     });
 
-    try {
-      for await (const event of queue) {
-        yield event;
-      }
-    } finally {
-      clearInterval(heartbeat);
-      this.eventBus.off(args.workspaceId, listener);
-      args.signal?.removeEventListener('abort', abort);
-      queue.close();
-    }
+    yield* stream;
   }
 
   private static projectEvent(event: HeartbeatSchedulerEvent): ControlPlaneHeartbeatEvent {
@@ -123,48 +122,6 @@ export class ControlPlaneHeartbeatEventsController {
 
   private static resolveEventTimestamp(event: ControlPlaneHeartbeatEvent): string {
     return 'timestamp' in event && typeof event.timestamp === 'string' ? event.timestamp : dayjs().toISOString();
-  }
-}
-
-class ControlPlaneHeartbeatEventQueue implements AsyncIterable<ControlPlaneHeartbeatEventEnvelope> {
-  private readonly events: ControlPlaneHeartbeatEventEnvelope[] = [];
-  private readonly waiters: Array<(event: ControlPlaneHeartbeatEventEnvelope | undefined) => void> = [];
-  private closed = false;
-
-  push(event: ControlPlaneHeartbeatEventEnvelope): void {
-    if (this.closed) {
-      return;
-    }
-
-    const waiter = this.waiters.shift();
-    if (waiter) {
-      waiter(event);
-      return;
-    }
-
-    this.events.push(event);
-  }
-
-  close(): void {
-    if (this.closed) {
-      return;
-    }
-
-    this.closed = true;
-    this.waiters.splice(0).forEach((waiter) => waiter(undefined));
-  }
-
-  async *[Symbol.asyncIterator](): AsyncIterator<ControlPlaneHeartbeatEventEnvelope> {
-    while (!this.closed || this.events.length > 0) {
-      const event = this.events.shift() ?? await new Promise<ControlPlaneHeartbeatEventEnvelope | undefined>((resolve) => {
-        this.waiters.push(resolve);
-      });
-      if (!event) {
-        break;
-      }
-
-      yield event;
-    }
   }
 }
 

--- a/src/web-v2/api/client.ts
+++ b/src/web-v2/api/client.ts
@@ -1,5 +1,5 @@
 import {
-  httpBatchLink,
+  httpLink,
   httpSubscriptionLink,
   splitLink,
 } from '@trpc/client';
@@ -13,7 +13,7 @@ const trpcLinks = [
     true: httpSubscriptionLink({
       url: '/trpc',
     }),
-    false: httpBatchLink({
+    false: httpLink({
       url: '/trpc',
     }),
   }),


### PR DESCRIPTION
## Summary
- Added a core runtime subscription stream that owns callback-to-AsyncIterable buffering, waiter wakeups, abort handling, and cleanup.
- Refactored web-v2 tRPC subscription producers for session events, session-list events, and heartbeat events to reuse that stream.
- Disabled HTTP batching for the web-v2 tRPC client and matching web-v2 browser-integration helper so network requests are individually identifiable.

## Validation
- yarn test:unit src/__tests__/unit/core/runtime-subscription-stream.test.ts src/__tests__/unit/control-plane/session-list-events.test.ts
- yarn typecheck
- yarn client:v2:build
- yarn lint