### PR TITLE
[codex] Add session lifecycle API parity

### DIFF
--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -1,0 +1,262 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import pino from 'pino';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
+import { createConversationEngine } from '@/core/chat/engine/conversation-engine.js';
+import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
+import { DEFAULT_WORKSPACE_ID, RuntimeWorkspaceService, type WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
+import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
+import type { HeddleServerContext } from '@/server/types.js';
+
+const EXTERNAL_TUI_LEASE_OWNER: ChatSessionLeaseOwner = {
+  ownerKind: 'tui',
+  ownerId: 'external-tui-client',
+  clientLabel: 'terminal chat',
+};
+
+describe('control-plane session lifecycle API', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renames sessions through the workspace-scoped API', async () => {
+    const { caller } = createControlPlaneCaller();
+    const session = await caller.sessionCreate({ name: 'Original name' });
+
+    const renamed = await caller.sessionRename({
+      id: session.id,
+      name: 'Renamed from API',
+    });
+
+    expect(renamed.name).toBe('Renamed from API');
+    await expect(caller.session({ id: session.id })).resolves.toMatchObject({
+      id: session.id,
+      name: 'Renamed from API',
+    });
+  });
+
+  it('scopes lifecycle mutations to the requested workspace', async () => {
+    const { caller, secondaryWorkspace, createEngineForWorkspace } = createControlPlaneCaller();
+    const defaultEngine = createEngineForWorkspace(DEFAULT_WORKSPACE_ID);
+    const secondaryEngine = createEngineForWorkspace(secondaryWorkspace.id);
+    defaultEngine.sessions.create({
+      id: 'same-session-id',
+      name: 'Default workspace session',
+      apiKeyPresent: true,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+    });
+    secondaryEngine.sessions.create({
+      id: 'same-session-id',
+      name: 'Secondary workspace session',
+      apiKeyPresent: true,
+      workspaceId: secondaryWorkspace.id,
+    });
+
+    await caller.sessionRename({
+      workspaceId: secondaryWorkspace.id,
+      id: 'same-session-id',
+      name: 'Renamed secondary session',
+    });
+
+    await expect(caller.session({ workspaceId: DEFAULT_WORKSPACE_ID, id: 'same-session-id' })).resolves.toMatchObject({
+      id: 'same-session-id',
+      name: 'Default workspace session',
+    });
+    await expect(caller.session({ workspaceId: secondaryWorkspace.id, id: 'same-session-id' })).resolves.toMatchObject({
+      id: 'same-session-id',
+      name: 'Renamed secondary session',
+    });
+  });
+
+  it('deletes sessions and leaves the session catalog readable', async () => {
+    const { caller } = createControlPlaneCaller();
+    const deletedSession = await caller.sessionCreate({ name: 'Delete me' });
+    const keptSession = await caller.sessionCreate({ name: 'Keep me' });
+
+    await expect(caller.sessionDelete({ id: deletedSession.id })).resolves.toEqual({ deleted: true });
+
+    const sessions = await caller.sessions();
+    expect(sessions.sessions.map((session) => session.id)).toContain(keptSession.id);
+    expect(sessions.sessions.map((session) => session.id)).not.toContain(deletedSession.id);
+    await expect(caller.session({ id: deletedSession.id })).resolves.toBeNull();
+  });
+
+  it('resets session transcript state through the API', async () => {
+    const { caller, engine } = createControlPlaneCaller();
+    const session = engine.sessions.create({
+      id: 'session-reset-api',
+      name: 'Reset API session',
+      apiKeyPresent: true,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+    });
+    engine.sessions.appendMessage(session.id, {
+      id: 'local-user-message',
+      role: 'user',
+      text: 'old visible message',
+    });
+    engine.sessions.setLastContinuePrompt(session.id, 'continue old work');
+
+    const reset = await caller.sessionReset({ id: session.id });
+
+    expect(reset.messages.map((message) => message.text)).not.toContain('old visible message');
+    expect(reset.turns).toEqual([]);
+    expect(reset.lastContinuePrompt).toBeUndefined();
+    await expect(caller.session({ id: session.id })).resolves.toMatchObject({
+      id: session.id,
+      turns: [],
+    });
+  });
+
+  it('blocks destructive lifecycle mutations while another client owns the session lease', async () => {
+    const { caller, engine } = createControlPlaneCaller();
+    const session = engine.sessions.create({
+      id: 'leased-session-api',
+      name: 'Leased API session',
+      apiKeyPresent: true,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+    });
+    engine.sessions.acquireLease(session.id, EXTERNAL_TUI_LEASE_OWNER);
+
+    await expect(caller.sessionDelete({ id: session.id })).rejects.toThrow('already active');
+    await expect(caller.sessionReset({ id: session.id })).rejects.toThrow('already active');
+    await expect(caller.sessionCompact({ id: session.id, force: true })).rejects.toThrow('already active');
+    await expect(caller.sessionRunState({ id: session.id })).resolves.toEqual({
+      running: false,
+      pendingApproval: null,
+    });
+  });
+
+  it('compacts a session through the API without requiring clients to call compaction services', async () => {
+    const { caller, engine } = createControlPlaneCaller();
+    const session = engine.sessions.create({
+      id: 'session-compact-api',
+      name: 'Compact API session',
+      apiKeyPresent: true,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+    });
+    engine.sessions.update(session.id, (current) => ({
+      ...current,
+      history: [
+        { role: 'user', content: 'summarize this small transcript' },
+        { role: 'assistant', content: 'small transcript response' },
+      ],
+    }));
+
+    const compacted = await caller.sessionCompact({ id: session.id, force: true });
+
+    expect(compacted.id).toBe(session.id);
+    expect(compacted.context?.estimatedHistoryTokens).toEqual(expect.any(Number));
+    await expect(caller.session({ id: session.id })).resolves.toMatchObject({
+      id: session.id,
+      context: expect.objectContaining({
+        estimatedHistoryTokens: expect.any(Number),
+      }),
+    });
+  });
+
+  it('restores prior compaction state when manual compaction fails', async () => {
+    const { caller, engine } = createControlPlaneCaller();
+    const session = engine.sessions.create({
+      id: 'session-compact-failure-api',
+      name: 'Compact failure API session',
+      apiKeyPresent: true,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+    });
+    const priorContext = {
+      estimatedHistoryTokens: 42,
+      compaction: { status: 'idle' as const },
+      archive: { count: 1, currentSummaryPath: '.heddle/archive-summary.md' },
+    };
+    const priorArchives = [{
+      id: 'archive-1',
+      path: '.heddle/archive-1.jsonl',
+      summaryPath: '.heddle/archive-summary.md',
+      messageCount: 2,
+      createdAt: '2026-05-26T00:00:00.000Z',
+    }];
+    engine.sessions.update(session.id, (current) => ({
+      ...current,
+      history: [{ role: 'user', content: 'please compact then fail' }],
+      context: priorContext,
+      archives: priorArchives,
+    }));
+    vi.spyOn(ConversationCompactionService, 'compact').mockRejectedValueOnce(new Error('forced compaction failure'));
+
+    await expect(caller.sessionCompact({ id: session.id, force: true })).rejects.toThrow('forced compaction failure');
+    expect(engine.sessions.require(session.id).context).toEqual(priorContext);
+    expect(engine.sessions.require(session.id).archives).toEqual(priorArchives);
+  });
+
+  it('returns combined run state for a session', async () => {
+    const { caller } = createControlPlaneCaller();
+    const session = await caller.sessionCreate({ name: 'Run state session' });
+
+    await expect(caller.sessionRunState({ id: session.id })).resolves.toEqual({
+      running: false,
+      pendingApproval: null,
+    });
+  });
+});
+
+function createControlPlaneCaller() {
+  const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-session-lifecycle-'));
+  const stateRoot = join(workspaceRoot, '.heddle');
+  RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
+  const secondaryWorkspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-session-lifecycle-secondary-'));
+  const resolved = RuntimeWorkspaceService.createDescriptor({
+    workspaceRoot,
+    stateRoot,
+    newWorkspaceRoot: secondaryWorkspaceRoot,
+    workspaceStateRoot: join(secondaryWorkspaceRoot, '.heddle'),
+    nextId: 'workspace-secondary',
+    name: 'Secondary workspace',
+    setActive: false,
+  });
+  const activeWorkspace = resolved.workspaces.find((workspace) => workspace.id === DEFAULT_WORKSPACE_ID);
+  const secondaryWorkspace = resolved.workspaces.find((workspace) => workspace.id === 'workspace-secondary');
+  if (!activeWorkspace) {
+    throw new Error('expected default workspace');
+  }
+  if (!secondaryWorkspace) {
+    throw new Error('expected secondary workspace');
+  }
+
+  const context: HeddleServerContext = {
+    workspaceRoot,
+    stateRoot,
+    preferApiKey: false,
+    activeWorkspaceId: activeWorkspace.id,
+    activeWorkspace,
+    workspaces: resolved.workspaces,
+    runtimeHost: null,
+    logger: pino({ level: 'silent' }),
+  };
+  const createEngineForWorkspace = (workspaceId: string) => {
+    const workspace = resolved.workspaces.find((candidate) => candidate.id === workspaceId);
+    if (!workspace) {
+      throw new Error(`expected workspace: ${workspaceId}`);
+    }
+
+    return createWorkspaceEngine(workspace);
+  };
+
+  return {
+    caller: controlPlaneRouter.createCaller(context),
+    engine: createEngineForWorkspace(activeWorkspace.id),
+    secondaryWorkspace,
+    createEngineForWorkspace,
+  };
+}
+
+function createWorkspaceEngine(workspace: WorkspaceDescriptor) {
+  return createConversationEngine({
+    workspaceRoot: workspace.workspaceRoot,
+    stateRoot: workspace.stateRoot,
+    sessionStoragePath: resolve(workspace.stateRoot, 'chat-sessions.catalog.json'),
+    workspaceId: workspace.id,
+    model: 'gpt-5.4',
+    apiKeyPresent: true,
+  });
+}

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -23,6 +23,7 @@ import {
   type ToolApprovalUserDecision,
 } from '@/core/approvals/index.js';
 import { createConversationEngine } from '@/core/chat/engine/conversation-engine.js';
+import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
 import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
 import type {
   ConversationEngine,
@@ -65,6 +66,24 @@ type CreateControlPlaneChatSessionArgs = ControlPlaneSessionReadArgs & {
 type UpdateControlPlaneChatSessionSettingsArgs = ControlPlaneSessionReadArgs & {
   sessionId: string;
   settings: UpdateConversationSessionSettingsInput;
+};
+
+type RenameControlPlaneChatSessionArgs = ControlPlaneSessionReadArgs & {
+  sessionId: string;
+  name: string;
+};
+
+type DeleteControlPlaneChatSessionArgs = ControlPlaneSessionReadArgs & ControlPlaneSessionAddress & {
+  leaseOwner: ChatSessionLeaseOwner;
+};
+
+type ResetControlPlaneChatSessionArgs = ControlPlaneSessionReadArgs & ControlPlaneSessionAddress & {
+  leaseOwner: ChatSessionLeaseOwner;
+};
+
+type CompactControlPlaneChatSessionArgs = ControlPlaneSessionReadArgs & ControlPlaneSessionAddress & {
+  force?: boolean;
+  leaseOwner: ChatSessionLeaseOwner;
 };
 
 type SubmitChatPromptArgs = ControlPlaneSessionReadArgs & {
@@ -124,6 +143,105 @@ export class ControlPlaneChatSessionsController {
     const { sessionId, settings, ...engineInput } = args;
     const updated = this.createEngine(engineInput).sessions.updateSettings(sessionId, settings);
     return ControlPlaneChatSessionPresenter.projectDetail(updated)[0] as ChatSessionDetail;
+  }
+
+  renameSession(args: RenameControlPlaneChatSessionArgs): ChatSessionDetail {
+    const { sessionId, name, ...engineInput } = args;
+    const updated = this.createEngine(engineInput).sessions.rename(sessionId, name);
+    return ControlPlaneChatSessionPresenter.projectDetail(updated)[0] as ChatSessionDetail;
+  }
+
+  deleteSession(args: DeleteControlPlaneChatSessionArgs): { deleted: boolean } {
+    this.assertNoActiveRun(args);
+    const { sessionId, leaseOwner, ...engineInput } = args;
+    const sessions = this.createEngine(engineInput).sessions;
+    this.assertNoLeaseConflict(sessions, sessionId, leaseOwner);
+    return {
+      deleted: sessions.delete(sessionId),
+    };
+  }
+
+  resetSession(args: ResetControlPlaneChatSessionArgs): ChatSessionDetail {
+    this.assertNoActiveRun(args);
+    const { sessionId, leaseOwner, ...engineInput } = args;
+    const sessions = this.createEngine(engineInput).sessions;
+    this.assertNoLeaseConflict(sessions, sessionId, leaseOwner);
+    const session = sessions.require(sessionId);
+    const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
+    const updated = sessions.resetConversation(sessionId, {
+      apiKeyPresent: RuntimeCredentialService.hasCredentialForModel(model, {
+        apiKey: args.apiKey,
+        credentialStorePath: args.credentialStorePath,
+        preferApiKey: args.preferApiKey,
+      }),
+    });
+    return ControlPlaneChatSessionPresenter.projectDetail(updated)[0] as ChatSessionDetail;
+  }
+
+  async compactSession(args: CompactControlPlaneChatSessionArgs): Promise<ChatSessionDetail> {
+    this.assertNoActiveRun(args);
+    const sessionKey = ControlPlaneChatSessionsController.sessionAddressKey(args);
+    const controller = new AbortController();
+    this.inFlightRuns.set(sessionKey, { controller });
+    const { sessionId, force = true, leaseOwner, ...engineInput } = args;
+    const sessions = this.createEngine(engineInput).sessions;
+    let leaseAcquired = false;
+    let previousCompactionState: Pick<ChatSession, 'context' | 'archives'> | undefined;
+
+    try {
+      this.assertNoLeaseConflict(sessions, sessionId, leaseOwner);
+      const session = sessions.acquireLease(sessionId, leaseOwner);
+      leaseAcquired = true;
+      const publisher = ControlPlaneChatSessionEventsController.createSessionEventPublisher({
+        eventBus: this.sessionEventBus,
+        workspaceId: args.workspaceId,
+        sessionId,
+      });
+      previousCompactionState = {
+        context: session.context,
+        archives: session.archives,
+      };
+
+      sessions.markCompactionRunning(sessionId, { sourceHistory: session.history });
+      const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
+      const compacted = await ConversationCompactionService.compact({
+        history: session.history,
+        runtime: {
+          model,
+          stateRoot: args.stateRoot,
+          systemContext: args.systemContext,
+        },
+        session,
+        force,
+        summarizer: {
+          credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(model, {
+            apiKey: args.apiKey,
+            credentialStorePath: args.credentialStorePath,
+            preferApiKey: args.preferApiKey,
+          }),
+        },
+        onStatusChange: publisher.publishActivity,
+      });
+      const updated = sessions.applyCompactionResult(sessionId, compacted);
+      return ControlPlaneChatSessionPresenter.projectDetail(updated)[0] as ChatSessionDetail;
+    } catch (error) {
+      if (previousCompactionState) {
+        sessions.restoreCompactionState(sessionId, previousCompactionState);
+      }
+      throw error;
+    } finally {
+      if (leaseAcquired) {
+        sessions.releaseLease(sessionId, leaseOwner);
+      }
+      this.inFlightRuns.delete(sessionKey);
+    }
+  }
+
+  readRunState(sessionAddress: ControlPlaneSessionAddress) {
+    return {
+      running: this.isRunning(sessionAddress),
+      pendingApproval: this.getPendingApproval(sessionAddress) ?? null,
+    };
   }
 
   async submitPrompt(args: SubmitChatPromptArgs) {
@@ -468,6 +586,23 @@ export class ControlPlaneChatSessionsController {
       workspaceRoot: args.workspaceRoot,
       projectApprovalRulesFile: join(args.stateRoot, 'command-approvals.json'),
     });
+  }
+
+  private assertNoActiveRun(sessionAddress: ControlPlaneSessionAddress): void {
+    if (this.isRunning(sessionAddress)) {
+      throw new Error('A run is already in progress for this session.');
+    }
+  }
+
+  private assertNoLeaseConflict(
+    sessions: ConversationEngine['sessions'],
+    sessionId: string,
+    leaseOwner: ChatSessionLeaseOwner,
+  ): void {
+    const conflict = sessions.getLeaseConflict(sessionId, leaseOwner);
+    if (conflict) {
+      throw new Error(conflict);
+    }
   }
 
   private async runFakeBrowserIntegrationSessionPrompt(args: SubmitChatPromptArgs) {

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import { BUILT_IN_MODEL_GROUPS, ModelPolicyService } from '@/core/llm/models/index.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
@@ -32,9 +33,11 @@ import {
   memoryReadInputSchema,
   memorySearchInputSchema,
   sessionApprovalDecisionSchema,
+  sessionCompactInputSchema,
   sessionEventsInputSchema,
   sessionInputSchema,
   sessionMessageInputSchema,
+  sessionRenameInputSchema,
   sessionsEventsInputSchema,
   sessionsInputSchema,
   sessionSettingsInputSchema,
@@ -117,9 +120,57 @@ export const controlPlaneRouter = router({
       },
     });
   }),
+  sessionRename: controlPlaneWorkspaceProcedure.input(sessionRenameInputSchema).mutation(({ ctx, input }) => {
+    const { sessionEngineArgs } = ctx.requestWorkspace;
+    return controlPlaneChatSessionsController.renameSession({
+      ...sessionEngineArgs,
+      sessionId: input.id,
+      name: input.name,
+    });
+  }),
+  sessionDelete: controlPlaneWorkspaceProcedure.input(sessionInputSchema).mutation(({ ctx, input }) => {
+    const { workspace, sessionEngineArgs } = ctx.requestWorkspace;
+    return controlPlaneChatSessionsController.deleteSession({
+      ...sessionEngineArgs,
+      workspaceId: workspace.id,
+      sessionId: input.id,
+      leaseOwner: resolveControlPlaneLeaseOwner(ctx),
+    });
+  }),
+  sessionReset: controlPlaneWorkspaceProcedure.input(sessionInputSchema).mutation(({ ctx, input }) => {
+    const { workspace, sessionEngineArgs } = ctx.requestWorkspace;
+    return controlPlaneChatSessionsController.resetSession({
+      ...sessionEngineArgs,
+      workspaceId: workspace.id,
+      sessionId: input.id,
+      apiKey: input.apiKey,
+      preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
+      leaseOwner: resolveControlPlaneLeaseOwner(ctx),
+    });
+  }),
+  sessionCompact: controlPlaneWorkspaceProcedure.input(sessionCompactInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace, sessionEngineArgs } = ctx.requestWorkspace;
+    return await controlPlaneChatSessionsController.compactSession({
+      ...sessionEngineArgs,
+      workspaceId: workspace.id,
+      sessionId: input.id,
+      force: input.force,
+      apiKey: input.apiKey,
+      preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
+      systemContext: input.systemContext,
+      leaseOwner: resolveControlPlaneLeaseOwner(ctx),
+    });
+  }),
   sessionTurnReview: controlPlaneWorkspaceProcedure.input(turnReviewInputSchema).query(({ ctx, input }) => {
     const { sessionEngineArgs } = ctx.requestWorkspace;
     return controlPlaneChatSessionsController.readTurnReview(sessionEngineArgs, input.sessionId, input.turnId) ?? null;
+  }),
+  sessionRunState: controlPlaneWorkspaceProcedure.input(sessionInputSchema).query(({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return controlPlaneChatSessionsController.readRunState({
+      workspaceId: workspace.id,
+      sessionId: input.id,
+    });
   }),
   sessionPendingApproval: controlPlaneWorkspaceProcedure.input(sessionInputSchema).query(({ ctx, input }) => {
     const { workspace } = ctx.requestWorkspace;
@@ -169,11 +220,7 @@ export const controlPlaneRouter = router({
       logger,
       systemContext: input.systemContext,
       memoryMaintenanceMode: input.memoryMaintenanceMode,
-      leaseOwner: {
-        ownerKind: 'daemon',
-        ownerId: ctx.runtimeHost?.ownerId ?? `daemon-${process.pid}`,
-        clientLabel: 'control plane',
-      },
+      leaseOwner: resolveControlPlaneLeaseOwner(ctx),
     });
   }),
   sessionContinue: controlPlaneWorkspaceProcedure.input(sessionInputSchema).mutation(async ({ ctx, input }) => {
@@ -183,11 +230,7 @@ export const controlPlaneRouter = router({
       sessionId: input.id,
       apiKey: input.apiKey,
       preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
-      leaseOwner: {
-        ownerKind: 'daemon',
-        ownerId: ctx.runtimeHost?.ownerId ?? `daemon-${process.pid}`,
-        clientLabel: 'control plane',
-      },
+      leaseOwner: resolveControlPlaneLeaseOwner(ctx),
     });
   }),
   agentAsk: controlPlaneWorkspaceProcedure.input(agentAskInputSchema).mutation(async ({ ctx, input }) => {
@@ -429,6 +472,14 @@ export const controlPlaneRouter = router({
     return await ControlPlaneLayoutSnapshotsController.save(workspace.stateRoot, input.snapshot);
   }),
 });
+
+function resolveControlPlaneLeaseOwner(ctx: Pick<HeddleServerContext, 'runtimeHost'>): ChatSessionLeaseOwner {
+  return {
+    ownerKind: 'daemon',
+    ownerId: ctx.runtimeHost?.ownerId ?? `daemon-${process.pid}`,
+    clientLabel: 'control plane',
+  };
+}
 
 function registerControlPlaneWorkspaces(
   ctx: HeddleServerContext,

--- a/src/server/routes/trpc/schema.ts
+++ b/src/server/routes/trpc/schema.ts
@@ -7,6 +7,21 @@ export const sessionInputSchema = z.object({
   preferApiKey: z.boolean().optional(),
 });
 
+export const sessionRenameInputSchema = z.object({
+  id: z.string().min(1),
+  workspaceId: z.string().min(1).optional(),
+  name: z.string().min(1),
+});
+
+export const sessionCompactInputSchema = z.object({
+  id: z.string().min(1),
+  workspaceId: z.string().min(1).optional(),
+  force: z.boolean().optional(),
+  apiKey: z.string().min(1).optional(),
+  preferApiKey: z.boolean().optional(),
+  systemContext: z.string().min(1).optional(),
+});
+
 export const sessionsInputSchema = z.object({
   workspaceId: z.string().min(1).optional(),
 }).optional();


### PR DESCRIPTION
## Summary

Adds frontend-agnostic control-plane tRPC endpoints for session lifecycle operations that TUI and web-v2 can both consume:

- `sessionRename`
- `sessionDelete`
- `sessionReset`
- `sessionCompact`
- `sessionRunState`

The controller keeps lifecycle behavior behind the existing conversation engine/session service boundary. Destructive operations now respect durable session leases, and manual compaction holds the controller run slot plus session lease while it runs so a prompt cannot race the same session mid-compaction.

## Why

This is the next server-side parity slice for moving TUI away from direct core/session-service calls. The API names are client-agnostic and expose functionality rather than TUI-specific operations.

## Validation

- `yarn test:integration src/__tests__/integration/control-plane/session-lifecycle.test.ts`
- `yarn typecheck`
- `yarn build`
- `yarn lint`
- `git diff --check`

## Notes

This does not migrate TUI yet. The intended next slice is to point the TUI session lifecycle controller/hook paths at these shared tRPC-derived APIs, then remove the duplicated TUI direct session mutations once parity is proven.