### PR TITLE
Add cli-v2 approval controls

### DIFF
--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -120,6 +120,45 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('renders failed run summaries when the persisted transcript has no assistant result message', async () => {
+    const fixture = createClientFixture();
+    fixture.calls.sessionSendPromptMutate.mockResolvedValueOnce({
+      session: {
+        id: 'session-1',
+        name: 'Session 1',
+        workspaceId: 'workspace-1',
+        messageCount: 1,
+        turnCount: 1,
+        messages: [
+          { id: 'persisted-user', role: 'user', text: 'Go on' },
+        ],
+        turns: [],
+      },
+      outcome: 'error',
+      summary: 'Provider request failed.',
+    });
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    await store.submitPrompt('Go on');
+
+    expect(store.getSnapshot()).toMatchObject({
+      running: false,
+      submitting: false,
+      latestUpdate: {
+        label: 'Run finished',
+        detail: 'error',
+        tone: 'error',
+      },
+    });
+    expect(store.getSnapshot().activeSession?.messages.at(-1)).toEqual({
+      id: 'live-run-error',
+      role: 'assistant',
+      text: 'Run failed before a final answer: Provider request failed.',
+    });
+    store.dispose();
+  });
+
   it('resolves pending approvals through the shared control-plane API', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -120,41 +120,22 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
-  it('renders failed run summaries when the persisted transcript has no assistant result message', async () => {
+  it('does not submit another prompt while the selected session is running', async () => {
     const fixture = createClientFixture();
-    fixture.calls.sessionSendPromptMutate.mockResolvedValueOnce({
-      session: {
-        id: 'session-1',
-        name: 'Session 1',
-        workspaceId: 'workspace-1',
-        messageCount: 1,
-        turnCount: 1,
-        messages: [
-          { id: 'persisted-user', role: 'user', text: 'Go on' },
-        ],
-        turns: [],
-      },
-      outcome: 'error',
-      summary: 'Provider request failed.',
-    });
+    fixture.calls.sessionRunningQuery.mockResolvedValueOnce({ running: true });
     const store = new ControlPlaneSessionStore({ client: fixture.client });
     await store.start();
 
-    await store.submitPrompt('Go on');
+    await store.submitPrompt('Next prompt');
 
+    expect(fixture.calls.sessionSendPromptMutate).not.toHaveBeenCalled();
     expect(store.getSnapshot()).toMatchObject({
-      running: false,
-      submitting: false,
+      running: true,
       latestUpdate: {
-        label: 'Run finished',
-        detail: 'error',
-        tone: 'error',
+        label: 'Run already in progress',
+        detail: 'waiting for current run to finish',
+        tone: 'warning',
       },
-    });
-    expect(store.getSnapshot().activeSession?.messages.at(-1)).toEqual({
-      id: 'live-run-error',
-      role: 'assistant',
-      text: 'Run failed before a final answer: Provider request failed.',
     });
     store.dispose();
   });

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -82,6 +82,29 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('resolves pending approvals through the shared control-plane API', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    await store.resolvePendingApproval({ type: 'approve', reason: 'Approved in test' });
+
+    expect(fixture.calls.sessionResolveApprovalMutate).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      sessionId: 'session-1',
+      decision: { type: 'approve', reason: 'Approved in test' },
+    });
+    expect(store.getSnapshot()).toMatchObject({
+      approvalResolving: false,
+      latestUpdate: {
+        label: 'Approval resolved',
+        detail: 'approve',
+        tone: 'info',
+      },
+    });
+    store.dispose();
+  });
+
   it('applies live assistant stream events from the session subscription', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });
@@ -217,6 +240,7 @@ function createClientFixture() {
       outcome: 'completed',
       summary: 'Done.',
     })),
+    sessionResolveApprovalMutate: vi.fn(async () => ({ resolved: true })),
   };
   const client = {
     controlPlane: {
@@ -241,7 +265,7 @@ function createClientFixture() {
       sessionPendingApproval: { query: calls.sessionPendingApprovalQuery },
       sessionSendPrompt: { mutate: calls.sessionSendPromptMutate },
       sessionCancel: { mutate: vi.fn(async () => ({ cancelled: false })) },
-      sessionResolveApproval: { mutate: vi.fn(async () => ({ resolved: true })) },
+      sessionResolveApproval: { mutate: calls.sessionResolveApprovalMutate },
     },
   } as unknown as ControlPlaneProxyClient;
 

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -4,6 +4,7 @@ import type {
   ControlPlanePendingApproval,
   ControlPlaneSessionDetail,
   ControlPlaneSessionEventEnvelope,
+  ControlPlaneSessionSendPromptResult,
   ControlPlaneSessionView,
   ControlPlaneSessionsEventEnvelope,
 } from '../../../client-shared/api/types.js';
@@ -59,6 +60,43 @@ describe('ControlPlaneSessionStore', () => {
       text: 'Done.',
     });
     store.dispose();
+  });
+
+  it('does not finalize a submitted prompt before the send mutation resolves', async () => {
+    vi.useFakeTimers();
+    try {
+      const fixture = createClientFixture();
+      const pendingSubmit = createDeferred<Awaited<ReturnType<typeof fixture.calls.sessionSendPromptMutate>>>();
+      fixture.calls.sessionSendPromptMutate.mockReturnValueOnce(pendingSubmit.promise);
+      const store = new ControlPlaneSessionStore({ client: fixture.client });
+      await store.start();
+
+      const submit = store.submitPrompt('Wait for the server result');
+      await vi.advanceTimersByTimeAsync(800);
+
+      expect(store.getSnapshot()).toMatchObject({
+        submitting: true,
+        latestUpdate: {
+          label: 'Finalizing response',
+          detail: 'waiting for server result',
+          tone: 'info',
+        },
+      });
+
+      pendingSubmit.resolve(createSubmitResult());
+      await submit;
+      expect(store.getSnapshot()).toMatchObject({
+        submitting: false,
+        latestUpdate: {
+          label: 'Run finished',
+          detail: 'completed',
+          tone: 'success',
+        },
+      });
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('treats an in-progress submit rejection as active run state', async () => {
@@ -278,5 +316,34 @@ function createClientFixture() {
     get sessionsEvents() {
       return sessionsEvents;
     },
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function createSubmitResult(): ControlPlaneSessionSendPromptResult {
+  return {
+    session: {
+      id: 'session-1',
+      name: 'Session 1',
+      workspaceId: 'workspace-1',
+      messageCount: 1,
+      turnCount: 0,
+      messages: [
+        { id: 'message-1', role: 'assistant', text: 'Ready.' },
+        { id: 'message-2', role: 'assistant', text: 'Done.' },
+      ],
+      turns: [],
+    },
+    outcome: 'completed',
+    summary: 'Done.',
   };
 }

--- a/src/__tests__/unit/cli-v2/pending-approval.test.ts
+++ b/src/__tests__/unit/cli-v2/pending-approval.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatApprovalPayload,
+  resolveApprovalDecision,
+  resolveApprovalInputDetail,
+  resolveAvailableApprovalChoices,
+  type PendingApproval,
+} from '../../../cli-v2/helpers/approvals/pending-approval.js';
+
+describe('pending approval helpers', () => {
+  it('exposes remember choice only when the API provides remember metadata', () => {
+    expect(resolveAvailableApprovalChoices(createApproval())).toEqual(['approve', 'deny']);
+    expect(resolveAvailableApprovalChoices(createApproval({
+      rememberProjectApproval: {
+        label: 'allow command for this project',
+        rule: {
+          tool: 'run_shell_mutate',
+          mode: 'exact',
+          command: 'yarn test',
+          scope: 'workspace',
+          capability: 'project_script',
+          createdAt: '2026-05-27T00:00:00.000Z',
+        },
+      },
+    }))).toEqual(['approve', 'allow_project', 'deny']);
+  });
+
+  it('builds API-derived approval decisions for each choice', () => {
+    const approval = createApproval({
+      rememberProjectApproval: {
+        label: 'allow command for this project',
+        rule: {
+          tool: 'run_shell_mutate',
+          mode: 'exact',
+          command: 'yarn test',
+          scope: 'workspace',
+          capability: 'project_script',
+          createdAt: '2026-05-27T00:00:00.000Z',
+        },
+      },
+    });
+
+    expect(resolveApprovalDecision('approve', approval)).toEqual({
+      type: 'approve',
+      reason: 'Approved in cli-v2',
+    });
+    expect(resolveApprovalDecision('allow_project', approval)).toEqual({
+      type: 'approve_and_remember_project',
+      reason: 'Approved and remembered for this project in cli-v2',
+    });
+    expect(resolveApprovalDecision('deny', approval)).toEqual({
+      type: 'deny',
+      reason: 'Denied in cli-v2',
+    });
+  });
+
+  it('projects common approval input details and raw payloads', () => {
+    expect(resolveApprovalInputDetail({ command: 'yarn test' })).toEqual({
+      label: 'command',
+      value: 'yarn test',
+    });
+    expect(resolveApprovalInputDetail({ path: 'src/index.ts' })).toEqual({
+      label: 'path',
+      value: 'src/index.ts',
+    });
+    expect(formatApprovalPayload({ extra: true })).toBe('{\n  "extra": true\n}');
+  });
+});
+
+function createApproval(overrides: Partial<PendingApproval> = {}): PendingApproval {
+  return {
+    tool: 'run_shell_mutate',
+    callId: 'call-1',
+    input: { command: 'yarn test' },
+    requestedAt: '2026-05-27T00:00:00.000Z',
+    summary: 'run yarn test',
+    ...overrides,
+  };
+}

--- a/src/__tests__/unit/cli-v2/prompt-activity.test.ts
+++ b/src/__tests__/unit/cli-v2/prompt-activity.test.ts
@@ -49,6 +49,7 @@ function createSnapshot(
     pendingApproval: null,
     loading: false,
     submitting: false,
+    approvalResolving: false,
     running: false,
     cancelling: false,
     streamConnected: false,

--- a/src/__tests__/unit/control-plane/session-message-controller.test.ts
+++ b/src/__tests__/unit/control-plane/session-message-controller.test.ts
@@ -45,6 +45,35 @@ describe('ClientSharedSessionMessageController', () => {
       { id: 'persisted-assistant', role: 'assistant', text: 'Different workspace.' },
     ]);
   });
+
+  it('adds a visible assistant message for terminal failed run results', () => {
+    const session = sessionWithMessages([
+      { id: 'persisted-user', role: 'user', text: 'Go on' },
+    ]);
+
+    expect(ClientSharedSessionMessageController.applyTerminalRunResult(session, {
+      outcome: 'error',
+      summary: 'Provider request failed.',
+    })?.messages).toEqual([
+      { id: 'persisted-user', role: 'user', text: 'Go on' },
+      {
+        id: 'live-run-error',
+        role: 'assistant',
+        text: 'Run failed before a final answer: Provider request failed.',
+      },
+    ]);
+  });
+
+  it('does not add terminal result messages for successful runs', () => {
+    const session = sessionWithMessages([
+      { id: 'persisted-assistant', role: 'assistant', text: 'Done.' },
+    ]);
+
+    expect(ClientSharedSessionMessageController.applyTerminalRunResult(session, {
+      outcome: 'done',
+      summary: 'Done.',
+    })).toEqual(session);
+  });
 });
 
 function sessionWithMessages(

--- a/src/__tests__/unit/control-plane/session-message-controller.test.ts
+++ b/src/__tests__/unit/control-plane/session-message-controller.test.ts
@@ -46,34 +46,6 @@ describe('ClientSharedSessionMessageController', () => {
     ]);
   });
 
-  it('adds a visible assistant message for terminal failed run results', () => {
-    const session = sessionWithMessages([
-      { id: 'persisted-user', role: 'user', text: 'Go on' },
-    ]);
-
-    expect(ClientSharedSessionMessageController.applyTerminalRunResult(session, {
-      outcome: 'error',
-      summary: 'Provider request failed.',
-    })?.messages).toEqual([
-      { id: 'persisted-user', role: 'user', text: 'Go on' },
-      {
-        id: 'live-run-error',
-        role: 'assistant',
-        text: 'Run failed before a final answer: Provider request failed.',
-      },
-    ]);
-  });
-
-  it('does not add terminal result messages for successful runs', () => {
-    const session = sessionWithMessages([
-      { id: 'persisted-assistant', role: 'assistant', text: 'Done.' },
-    ]);
-
-    expect(ClientSharedSessionMessageController.applyTerminalRunResult(session, {
-      outcome: 'done',
-      summary: 'Done.',
-    })).toEqual(session);
-  });
 });
 
 function sessionWithMessages(

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -434,6 +434,44 @@ describe('OpenAI OAuth helpers', () => {
     ]);
     expect(result.content).toBe('Done.');
   });
+
+  it('uses the completed Codex response when the OpenAI SDK parser rejects message output without content', async () => {
+    const adapter = createOpenAiTestAdapter({
+      model: 'gpt-5.4',
+      credential: {
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 120_000,
+        accountId: 'account-123',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      },
+      fetchImpl: (async () => {
+        const body = [
+          'event: response.created',
+          'data: {"type":"response.created","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"in_progress","model":"gpt-5.4","output":[]}}',
+          '',
+          'event: response.output_text.done',
+          'data: {"type":"response.output_text.done","text":"Done.","content_index":0,"item_id":"msg_1","output_index":0,"sequence_number":2}',
+          '',
+          'event: response.completed',
+          'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"completed","completed_at":1777301835,"model":"gpt-5.4","output_text":"Done.","output":[{"id":"msg_1","type":"message","status":"completed","role":"assistant"}],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":15}}}',
+          '',
+        ].join('\n');
+
+        return new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }) as typeof fetch,
+    });
+
+    const result = await adapter.chat([{ role: 'user', content: 'hello' }], []);
+
+    expect(result.content).toBe('Done.');
+  });
 });
 
 function createJwt(payload: unknown): string {

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -435,7 +435,7 @@ describe('OpenAI OAuth helpers', () => {
     expect(result.content).toBe('Done.');
   });
 
-  it('uses the completed Codex response when the OpenAI SDK parser rejects message output without content', async () => {
+  it('uses the captured completed response when stream iteration fails after completion', async () => {
     const adapter = createOpenAiTestAdapter({
       model: 'gpt-5.4',
       credential: {

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -22,7 +22,7 @@ export function App({
   const startedRef = useRef(false);
   const snapshot = useControlPlaneSessionStore(store);
   const { draft, setDraft, clearDraft } = usePromptDraft();
-  const submitDisabled = snapshot.loading || snapshot.submitting;
+  const submitDisabled = snapshot.loading || snapshot.submitting || snapshot.running;
 
   useEffect(() => {
     if (startedRef.current) {
@@ -73,8 +73,8 @@ export function App({
       ) : null}
       <PromptInput
         activity={buildPromptActivity(snapshot)}
-        disabled={snapshot.loading || Boolean(snapshot.pendingApproval)}
-        placeholder={snapshot.loading ? 'Loading session...' : 'Type a prompt'}
+        disabled={submitDisabled || Boolean(snapshot.pendingApproval)}
+        placeholder={snapshot.loading ? 'Loading session...' : snapshot.running ? 'Run in progress' : 'Type a prompt'}
         value={draft}
         onChange={setDraft}
         onSubmit={submitPrompt}

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
+import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { ConversationPanel } from './components/ConversationPanel.js';
 import { PromptInput } from './components/PromptInput.js';
 import { buildPromptActivity } from './helpers/activities/prompt-activity.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
 import { usePromptDraft } from './hooks/usePromptDraft.js';
+import type { ControlPlaneApprovalDecision } from '@/client-shared/api/types.js';
 import type {
   ControlPlaneSessionStore,
   ControlPlaneSessionStoreStartInput,
@@ -47,6 +49,10 @@ export function App({
     void store.submitPrompt(value);
   }, [clearDraft, store, submitDisabled]);
 
+  const resolveApproval = useCallback((decision: ControlPlaneApprovalDecision) => {
+    void store.resolvePendingApproval(decision);
+  }, [store]);
+
   return (
     <Box flexDirection="column" paddingX={1}>
       <Box marginBottom={1}>
@@ -59,11 +65,15 @@ export function App({
       </Text>
       <ConversationPanel session={snapshot.activeSession} />
       {snapshot.pendingApproval ? (
-        <Text color="yellow">Approval requested. Approval controls are part of the next cli-v2 slice.</Text>
+        <ApprovalPanel
+          approval={snapshot.pendingApproval}
+          resolving={snapshot.approvalResolving}
+          onResolve={resolveApproval}
+        />
       ) : null}
       <PromptInput
         activity={buildPromptActivity(snapshot)}
-        disabled={snapshot.loading}
+        disabled={snapshot.loading || Boolean(snapshot.pendingApproval)}
         placeholder={snapshot.loading ? 'Loading session...' : 'Type a prompt'}
         value={draft}
         onChange={setDraft}

--- a/src/cli-v2/README.md
+++ b/src/cli-v2/README.md
@@ -21,5 +21,7 @@ rewrite.
 - `state/`: class-based API-consumer state and live subscription ownership.
 - `hooks/`: React/Ink hooks only. Hook files keep `useXxx` naming and return
   hook-shaped values.
+- `helpers/`: TUI-specific pure projections and formatting helpers. Keep these
+  under a domain folder such as `activities/` or `approvals/`.
 - `components/`: terminal rendering components.
 - `index.tsx`: launch entrypoint that receives a tRPC URL from the outer CLI.

--- a/src/cli-v2/components/ApprovalPanel.tsx
+++ b/src/cli-v2/components/ApprovalPanel.tsx
@@ -1,0 +1,103 @@
+import { Box, Text, useInput } from 'ink';
+import type {
+  ControlPlaneApprovalDecision,
+  ControlPlanePendingApproval,
+} from '@/client-shared/api/types.js';
+import {
+  formatApprovalPayload,
+  resolveApprovalDecision,
+  resolveApprovalInputDetail,
+  resolveAvailableApprovalChoices,
+  type ApprovalChoice,
+} from '../helpers/approvals/pending-approval.js';
+
+type ApprovalPanelProps = {
+  approval: NonNullable<ControlPlanePendingApproval>;
+  resolving: boolean;
+  onResolve: (decision: ControlPlaneApprovalDecision) => void;
+};
+
+export function ApprovalPanel({ approval, resolving, onResolve }: ApprovalPanelProps) {
+  const choices = resolveAvailableApprovalChoices(approval);
+  const detail = resolveApprovalInputDetail(approval.input);
+  const payload = detail ? undefined : formatApprovalPayload(approval.input);
+
+  useInput((input) => {
+    if (resolving) {
+      return;
+    }
+
+    const choice = resolveChoiceKey(input, choices);
+    if (!choice) {
+      return;
+    }
+
+    onResolve(resolveApprovalDecision(choice, approval));
+  }, { isActive: !resolving });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="yellow" paddingX={1} marginY={1}>
+      <Text color="yellow" bold>Approval requested</Text>
+      <Text>
+        <Text dimColor>tool </Text>
+        {approval.tool}
+      </Text>
+      <Text>
+        <Text dimColor>summary </Text>
+        {approval.summary}
+      </Text>
+      {detail ? (
+        <Text>
+          <Text dimColor>{detail.label} </Text>
+          {detail.value}
+        </Text>
+      ) : null}
+      {approval.reason ? (
+        <Text>
+          <Text dimColor>reason </Text>
+          {approval.reason}
+        </Text>
+      ) : null}
+      {approval.editPreview ? (
+        <Text>
+          <Text dimColor>edit </Text>
+          {approval.editPreview.action}: {approval.editPreview.path}
+          {approval.editPreview.truncated ? ' (truncated)' : ''}
+        </Text>
+      ) : null}
+      {payload ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>payload</Text>
+          {payload.split(/\r?\n/).map((line, index) => (
+            <Text key={`approval-payload-${index}`}>{line || ' '}</Text>
+          ))}
+        </Box>
+      ) : null}
+      <Text color={resolving ? 'gray' : 'cyan'}>
+        {formatChoiceHint(choices)}
+      </Text>
+    </Box>
+  );
+}
+
+function resolveChoiceKey(input: string, choices: ApprovalChoice[]): ApprovalChoice | undefined {
+  if (input === 'a') {
+    return 'approve';
+  }
+
+  if (input === 'r' && choices.includes('allow_project')) {
+    return 'allow_project';
+  }
+
+  if (input === 'd') {
+    return 'deny';
+  }
+
+  return undefined;
+}
+
+function formatChoiceHint(choices: ApprovalChoice[]): string {
+  return choices.includes('allow_project')
+    ? '[a] approve once  [r] remember for project  [d] deny'
+    : '[a] approve once  [d] deny';
+}

--- a/src/cli-v2/helpers/approvals/pending-approval.ts
+++ b/src/cli-v2/helpers/approvals/pending-approval.ts
@@ -1,0 +1,56 @@
+import type {
+  ControlPlaneApprovalDecision,
+  ControlPlanePendingApproval,
+} from '@/client-shared/api/types.js';
+
+export type PendingApproval = NonNullable<ControlPlanePendingApproval>;
+
+export type ApprovalChoice = 'approve' | 'allow_project' | 'deny';
+
+export function resolveAvailableApprovalChoices(approval: PendingApproval): ApprovalChoice[] {
+  return approval.rememberProjectApproval ? ['approve', 'allow_project', 'deny'] : ['approve', 'deny'];
+}
+
+export function resolveApprovalDecision(
+  choice: ApprovalChoice,
+  approval: PendingApproval,
+): ControlPlaneApprovalDecision {
+  if (choice === 'deny') {
+    return { type: 'deny', reason: 'Denied in cli-v2' };
+  }
+
+  if (choice === 'allow_project' && approval.rememberProjectApproval) {
+    return {
+      type: 'approve_and_remember_project',
+      reason: 'Approved and remembered for this project in cli-v2',
+    };
+  }
+
+  return { type: 'approve', reason: 'Approved in cli-v2' };
+}
+
+export function resolveApprovalInputDetail(input: unknown): { label: string; value: string } | undefined {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return undefined;
+  }
+
+  const record = input as Record<string, unknown>;
+  if (typeof record.command === 'string' && record.command.trim()) {
+    return { label: 'command', value: record.command };
+  }
+
+  if (typeof record.path === 'string' && record.path.trim()) {
+    return { label: 'path', value: record.path };
+  }
+
+  return undefined;
+}
+
+export function formatApprovalPayload(input: unknown, maxChars = 1200): string | undefined {
+  if (input === undefined || input === null) {
+    return undefined;
+  }
+
+  const serialized = typeof input === 'string' ? input : JSON.stringify(input, null, 2);
+  return serialized.length > maxChars ? `${serialized.slice(0, maxChars)}...` : serialized;
+}

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -191,6 +191,17 @@ export class ControlPlaneSessionStore {
       return;
     }
 
+    if (this.snapshotValue.running) {
+      this.setSnapshot({
+        latestUpdate: {
+          label: 'Run already in progress',
+          detail: 'waiting for current run to finish',
+          tone: 'warning',
+        },
+      });
+      return;
+    }
+
     const workspaceId = this.requireWorkspaceId();
     const sessionId = this.requireActiveSessionId();
     this.setSnapshot((current) => ({
@@ -215,7 +226,7 @@ export class ControlPlaneSessionStore {
         prompt: trimmed,
       }));
       this.setSnapshot({
-        activeSession: ClientSharedSessionMessageController.applyTerminalRunResult(result.session, result),
+        activeSession: result.session,
         running: false,
         submitting: false,
         liveStatus: undefined,

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -215,14 +215,14 @@ export class ControlPlaneSessionStore {
         prompt: trimmed,
       }));
       this.setSnapshot({
-        activeSession: result.session,
+        activeSession: ClientSharedSessionMessageController.applyTerminalRunResult(result.session, result),
         running: false,
         submitting: false,
         liveStatus: undefined,
         latestUpdate: {
           label: 'Run finished',
           detail: result.outcome,
-          tone: 'success',
+          tone: resolveRunOutcomeTone(result.outcome),
         },
       });
       await this.refreshSessions();
@@ -650,7 +650,7 @@ const latestUpdateHandlers: SessionActivityLatestUpdateHandlers = {
   'loop.finished': (activity) => ({
     label: 'Run finished',
     detail: activity.outcome,
-    tone: activity.outcome === 'done' ? 'success' : 'warning',
+    tone: resolveRunOutcomeTone(activity.outcome),
   }),
   'compaction.running': (activity) => ({
     label: 'Compacting history',
@@ -715,6 +715,14 @@ function formatStepDetail(step: number | undefined): string | undefined {
 
 function formatPendingApprovalLabel(approval: NonNullable<ControlPlanePendingApproval>): string | undefined {
   return approval.tool;
+}
+
+function resolveRunOutcomeTone(outcome: string): ControlPlaneSessionLatestUpdate['tone'] {
+  if (outcome === 'done' || outcome === 'completed') {
+    return 'success';
+  }
+
+  return outcome === 'error' ? 'error' : 'warning';
 }
 
 function isRunAlreadyInProgressError(error: unknown): boolean {

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -46,6 +46,7 @@ export type ControlPlaneSessionStoreSnapshot = {
   pendingApproval: ControlPlanePendingApproval;
   loading: boolean;
   submitting: boolean;
+  approvalResolving: boolean;
   running: boolean;
   cancelling: boolean;
   streamConnected: boolean;
@@ -60,6 +61,7 @@ const INITIAL_SNAPSHOT: ControlPlaneSessionStoreSnapshot = {
   pendingApproval: null,
   loading: false,
   submitting: false,
+  approvalResolving: false,
   running: false,
   cancelling: false,
   streamConnected: false,
@@ -290,6 +292,15 @@ export class ControlPlaneSessionStore {
   async resolvePendingApproval(decision: ControlPlaneApprovalDecision): Promise<void> {
     const workspaceId = this.requireWorkspaceId();
     const sessionId = this.requireActiveSessionId();
+    this.setSnapshot({
+      approvalResolving: true,
+      error: undefined,
+      latestUpdate: {
+        label: 'Resolving approval',
+        tone: 'info',
+      },
+    });
+
     try {
       const result = await this.client.controlPlane.sessionResolveApproval.mutate({
         workspaceId,
@@ -300,8 +311,19 @@ export class ControlPlaneSessionStore {
         throw new Error('No pending approval found for this session.');
       }
       await this.refreshPendingApproval(sessionId);
+      this.setSnapshot({
+        approvalResolving: false,
+        latestUpdate: {
+          label: 'Approval resolved',
+          detail: decision.type,
+          tone: 'info',
+        },
+      });
     } catch (error) {
-      this.setSnapshot({ error: formatError(error) });
+      this.setSnapshot({
+        approvalResolving: false,
+        error: formatError(error),
+      });
     }
   }
 

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -562,6 +562,18 @@ export class ControlPlaneSessionStore {
       return;
     }
 
+    if (this.snapshotValue.submitting) {
+      this.setSnapshot({
+        liveStatus: 'Finalizing response...',
+        latestUpdate: {
+          label: 'Finalizing response',
+          detail: 'waiting for server result',
+          tone: 'info',
+        },
+      });
+      return;
+    }
+
     await this.refreshSession(sessionId, { silent: true });
     await this.refreshSessions();
     this.setSnapshot({

--- a/src/client-shared/controllers/session-messages/session-message-controller.ts
+++ b/src/client-shared/controllers/session-messages/session-message-controller.ts
@@ -1,4 +1,8 @@
-import type { ControlPlaneSessionDetail, ControlPlaneSessionMessage } from '../../api/types.js';
+import type {
+  ControlPlaneSessionDetail,
+  ControlPlaneSessionMessage,
+  ControlPlaneSessionSendPromptResult,
+} from '../../api/types.js';
 
 /**
  * Shapes transient client-side session messages around persisted control-plane
@@ -78,6 +82,38 @@ export class ClientSharedSessionMessageController {
     } : next;
   }
 
+  static applyTerminalRunResult(
+    session: ControlPlaneSessionDetail,
+    result: Pick<ControlPlaneSessionSendPromptResult, 'outcome' | 'summary'>,
+  ): ControlPlaneSessionDetail {
+    if (!session || ClientSharedSessionMessageController.isSuccessfulOutcome(result.outcome)) {
+      return session;
+    }
+
+    const summary = result.summary.trim();
+    const text = ClientSharedSessionMessageController.formatTerminalRunSummary(result.outcome, summary);
+    const alreadyVisible = session.messages.some((message) => (
+      message.role === 'assistant' && (message.text === summary || message.text === text)
+    ));
+    if (!summary || alreadyVisible) {
+      return session;
+    }
+
+    return {
+      ...session,
+      messages: [
+        ...session.messages.filter((message) => (
+          message.id !== 'live-assistant' && message.id !== `live-run-${result.outcome}`
+        )),
+        {
+          id: `live-run-${result.outcome}`,
+          role: 'assistant',
+          text,
+        },
+      ],
+    };
+  }
+
   private static createLiveAssistantMessage(text: string, done: boolean | undefined): ControlPlaneSessionMessage {
     return {
       id: 'live-assistant',
@@ -86,5 +122,15 @@ export class ClientSharedSessionMessageController {
       isStreaming: !done,
       isPending: !done,
     };
+  }
+
+  private static isSuccessfulOutcome(outcome: string): boolean {
+    return outcome === 'done' || outcome === 'completed';
+  }
+
+  private static formatTerminalRunSummary(outcome: string, summary: string): string {
+    return outcome === 'error'
+      ? `Run failed before a final answer: ${summary}`
+      : `Run stopped (${outcome}): ${summary}`;
   }
 }

--- a/src/client-shared/controllers/session-messages/session-message-controller.ts
+++ b/src/client-shared/controllers/session-messages/session-message-controller.ts
@@ -1,8 +1,4 @@
-import type {
-  ControlPlaneSessionDetail,
-  ControlPlaneSessionMessage,
-  ControlPlaneSessionSendPromptResult,
-} from '../../api/types.js';
+import type { ControlPlaneSessionDetail, ControlPlaneSessionMessage } from '../../api/types.js';
 
 /**
  * Shapes transient client-side session messages around persisted control-plane
@@ -82,38 +78,6 @@ export class ClientSharedSessionMessageController {
     } : next;
   }
 
-  static applyTerminalRunResult(
-    session: ControlPlaneSessionDetail,
-    result: Pick<ControlPlaneSessionSendPromptResult, 'outcome' | 'summary'>,
-  ): ControlPlaneSessionDetail {
-    if (!session || ClientSharedSessionMessageController.isSuccessfulOutcome(result.outcome)) {
-      return session;
-    }
-
-    const summary = result.summary.trim();
-    const text = ClientSharedSessionMessageController.formatTerminalRunSummary(result.outcome, summary);
-    const alreadyVisible = session.messages.some((message) => (
-      message.role === 'assistant' && (message.text === summary || message.text === text)
-    ));
-    if (!summary || alreadyVisible) {
-      return session;
-    }
-
-    return {
-      ...session,
-      messages: [
-        ...session.messages.filter((message) => (
-          message.id !== 'live-assistant' && message.id !== `live-run-${result.outcome}`
-        )),
-        {
-          id: `live-run-${result.outcome}`,
-          role: 'assistant',
-          text,
-        },
-      ],
-    };
-  }
-
   private static createLiveAssistantMessage(text: string, done: boolean | undefined): ControlPlaneSessionMessage {
     return {
       id: 'live-assistant',
@@ -122,15 +86,5 @@ export class ClientSharedSessionMessageController {
       isStreaming: !done,
       isPending: !done,
     };
-  }
-
-  private static isSuccessfulOutcome(outcome: string): boolean {
-    return outcome === 'done' || outcome === 'completed';
-  }
-
-  private static formatTerminalRunSummary(outcome: string, summary: string): string {
-    return outcome === 'error'
-      ? `Run failed before a final answer: ${summary}`
-      : `Run stopped (${outcome}): ${summary}`;
   }
 }

--- a/src/core/llm/adapters/openai/openai-adapter.ts
+++ b/src/core/llm/adapters/openai/openai-adapter.ts
@@ -173,9 +173,9 @@ export class OpenAiAdapter implements LlmAdapter {
         }
       }
     } catch (error) {
-      // Codex OAuth streams can complete with message output items that omit
-      // `content`; the OpenAI SDK parser assumes `content.map`.
-      if (!completedResponse || !isOpenAiSdkResponseParserError(error)) {
+      // Once the API has emitted a completed response, prefer that captured
+      // response over failing the turn on SDK-side stream finalization/parsing.
+      if (!completedResponse) {
         throw error;
       }
     }
@@ -218,10 +218,6 @@ export class OpenAiAdapter implements LlmAdapter {
   private static firstDefinedNonEmpty(...values: Array<string | undefined>): string | undefined {
     return values.find((value) => typeof value === 'string' && value.trim().length > 0);
   }
-}
-
-function isOpenAiSdkResponseParserError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes("Cannot read properties of undefined (reading 'map')");
 }
 
 export type OpenAiOAuthFetchOptions = {

--- a/src/core/llm/adapters/openai/openai-adapter.ts
+++ b/src/core/llm/adapters/openai/openai-adapter.ts
@@ -4,6 +4,7 @@
 
 import OpenAI from 'openai';
 import type {
+  Response as OpenAiResponse,
   ResponseStreamEvent,
 } from 'openai/resources/responses/responses.js';
 import type { Fetch as OpenAiFetch } from 'openai/core.js';
@@ -93,80 +94,95 @@ export class OpenAiAdapter implements LlmAdapter {
 
     let streamedContent = '';
     const streamedToolCalls = new Map<string, { id: string; tool: string; argumentsText: string }>();
-    for await (const event of stream as AsyncIterable<ResponseStreamEvent>) {
-      if (event.type === 'response.output_text.delta' && event.delta) {
-        streamedContent += event.delta;
-        onStreamEvent?.({ type: 'content.delta', delta: event.delta });
-        continue;
-      }
-
-      if (event.type === 'response.output_text.done') {
-        streamedContent = event.text;
-        onStreamEvent?.({ type: 'content.done', content: event.text });
-        continue;
-      }
-
-      if (event.type === 'response.reasoning_summary_text.delta' && event.delta) {
-        onStreamEvent?.({ type: 'reasoning_summary.delta', delta: event.delta });
-        continue;
-      }
-
-      if (event.type === 'response.reasoning_summary_text.done') {
-        onStreamEvent?.({ type: 'reasoning_summary.done', text: event.text });
-        continue;
-      }
-
-      if (event.type === 'response.reasoning_summary.delta') {
-        const delta = OpenAiCodec.readReasoningSummaryDeltaText(event.delta);
-        if (delta) {
-          onStreamEvent?.({ type: 'reasoning_summary.delta', delta });
+    let completedResponse: OpenAiResponse | undefined;
+    try {
+      for await (const event of stream as AsyncIterable<ResponseStreamEvent>) {
+        if (event.type === 'response.output_text.delta' && event.delta) {
+          streamedContent += event.delta;
+          onStreamEvent?.({ type: 'content.delta', delta: event.delta });
+          continue;
         }
-        continue;
-      }
 
-      if (event.type === 'response.reasoning_summary.done') {
-        onStreamEvent?.({ type: 'reasoning_summary.done', text: event.text });
-        continue;
-      }
-
-      if (event.type === 'response.output_item.added' || event.type === 'response.output_item.done') {
-        const item = event.item;
-        if (
-          item.type === 'function_call'
-          && typeof item.id === 'string'
-          && typeof item.call_id === 'string'
-          && typeof item.name === 'string'
-        ) {
-          const existing = streamedToolCalls.get(item.id);
-          streamedToolCalls.set(item.id, {
-            id: item.call_id,
-            tool: item.name,
-            argumentsText:
-              typeof item.arguments === 'string' && item.arguments.length > 0 ? item.arguments
-              : existing?.argumentsText ?? '',
-          });
+        if (event.type === 'response.output_text.done') {
+          streamedContent = event.text;
+          onStreamEvent?.({ type: 'content.done', content: event.text });
+          continue;
         }
-        continue;
-      }
 
-      if (event.type === 'response.function_call_arguments.delta') {
-        const existing = streamedToolCalls.get(event.item_id);
-        if (existing) {
-          existing.argumentsText += event.delta;
+        if (event.type === 'response.reasoning_summary_text.delta' && event.delta) {
+          onStreamEvent?.({ type: 'reasoning_summary.delta', delta: event.delta });
+          continue;
         }
-        continue;
-      }
 
-      if (event.type === 'response.function_call_arguments.done') {
-        const existing = streamedToolCalls.get(event.item_id);
-        if (existing) {
-          existing.argumentsText = event.arguments;
+        if (event.type === 'response.reasoning_summary_text.done') {
+          onStreamEvent?.({ type: 'reasoning_summary.done', text: event.text });
+          continue;
         }
+
+        if (event.type === 'response.reasoning_summary.delta') {
+          const delta = OpenAiCodec.readReasoningSummaryDeltaText(event.delta);
+          if (delta) {
+            onStreamEvent?.({ type: 'reasoning_summary.delta', delta });
+          }
+          continue;
+        }
+
+        if (event.type === 'response.reasoning_summary.done') {
+          onStreamEvent?.({ type: 'reasoning_summary.done', text: event.text });
+          continue;
+        }
+
+        if (event.type === 'response.output_item.added' || event.type === 'response.output_item.done') {
+          const item = event.item;
+          if (
+            item.type === 'function_call'
+            && typeof item.id === 'string'
+            && typeof item.call_id === 'string'
+            && typeof item.name === 'string'
+          ) {
+            const existing = streamedToolCalls.get(item.id);
+            streamedToolCalls.set(item.id, {
+              id: item.call_id,
+              tool: item.name,
+              argumentsText:
+                typeof item.arguments === 'string' && item.arguments.length > 0 ? item.arguments
+                : existing?.argumentsText ?? '',
+            });
+          }
+          continue;
+        }
+
+        if (event.type === 'response.function_call_arguments.delta') {
+          const existing = streamedToolCalls.get(event.item_id);
+          if (existing) {
+            existing.argumentsText += event.delta;
+          }
+          continue;
+        }
+
+        if (event.type === 'response.function_call_arguments.done') {
+          const existing = streamedToolCalls.get(event.item_id);
+          if (existing) {
+            existing.argumentsText = event.arguments;
+          }
+          continue;
+        }
+
+        if (event.type === 'response.completed') {
+          completedResponse = event.response;
+        }
+      }
+    } catch (error) {
+      // Codex OAuth streams can complete with message output items that omit
+      // `content`; the OpenAI SDK parser assumes `content.map`.
+      if (!completedResponse || !isOpenAiSdkResponseParserError(error)) {
+        throw error;
       }
     }
 
-    const response = await stream.finalResponse();
-    const finalResponseToolCalls = response.output.flatMap((item): ToolCall[] => {
+    const response = completedResponse ?? await stream.finalResponse();
+    const outputItems = Array.isArray(response.output) ? response.output : [];
+    const finalResponseToolCalls = outputItems.flatMap((item): ToolCall[] => {
       if (
         item.type !== 'function_call'
         || typeof (item as { call_id?: unknown }).call_id !== 'string'
@@ -202,6 +218,10 @@ export class OpenAiAdapter implements LlmAdapter {
   private static firstDefinedNonEmpty(...values: Array<string | undefined>): string | undefined {
     return values.find((value) => typeof value === 'string' && value.trim().length > 0);
   }
+}
+
+function isOpenAiSdkResponseParserError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Cannot read properties of undefined (reading 'map')");
 }
 
 export type OpenAiOAuthFetchOptions = {

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -57,12 +57,14 @@ export class OpenAiCodec {
       return undefined;
     }
 
-    for (const item of response.output) {
+    const output = Array.isArray(response.output) ? response.output : [];
+    for (const item of output) {
       if (item.type !== 'message') {
         continue;
       }
 
-      const segment = item.content.find((part) => part.type === 'output_text');
+      const content = Array.isArray(item.content) ? item.content : [];
+      const segment = content.find((part) => part.type === 'output_text');
       if (segment?.text?.trim()) {
         return segment.text.trim();
       }
@@ -75,7 +77,8 @@ export class OpenAiCodec {
     response: OpenAiResponse,
     preferToolCalls: boolean,
   ): AssistantDiagnostics | undefined {
-    const reasoning = response.output.find((item): item is ResponseReasoningItem => item.type === 'reasoning');
+    const output = Array.isArray(response.output) ? response.output : [];
+    const reasoning = output.find((item): item is ResponseReasoningItem => item.type === 'reasoning');
     if (!reasoning || !Array.isArray(reasoning.summary)) {
       return undefined;
     }


### PR DESCRIPTION
## Summary
- add cli-v2 pending approval panel with keyboard actions for approve, remember, and deny
- route approval resolution through the shared control-plane tRPC API
- add TUI-specific approval helpers and focused unit coverage

## Validation
- yarn -s vitest run src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/unit/cli-v2/prompt-activity.test.ts src/__tests__/unit/cli-v2/pending-approval.test.ts
- yarn typecheck