### PR TITLE
Add cli v2 run controls

### DIFF
--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -140,6 +140,37 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('cancels the active run through sessionCancel', async () => {
+    const fixture = createClientFixture();
+    const pendingSubmit = createDeferred<Awaited<ReturnType<typeof fixture.calls.sessionSendPromptMutate>>>();
+    fixture.calls.sessionSendPromptMutate.mockReturnValueOnce(pendingSubmit.promise);
+    fixture.calls.sessionCancelMutate.mockResolvedValueOnce({ cancelled: true });
+    fixture.calls.sessionRunningQuery
+      .mockResolvedValueOnce({ running: false })
+      .mockResolvedValueOnce({ running: false });
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    const submit = store.submitPrompt('Long run');
+    await store.cancelRun();
+
+    expect(fixture.calls.sessionCancelMutate).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      id: 'session-1',
+    });
+    expect(store.getSnapshot()).toMatchObject({
+      running: false,
+      cancelling: false,
+      latestUpdate: {
+        label: 'Stop request accepted',
+        tone: 'warning',
+      },
+    });
+    pendingSubmit.resolve(createSubmitResult());
+    await submit;
+    store.dispose();
+  });
+
   it('resolves pending approvals through the shared control-plane API', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });
@@ -298,6 +329,7 @@ function createClientFixture() {
       outcome: 'completed',
       summary: 'Done.',
     })),
+    sessionCancelMutate: vi.fn(async () => ({ cancelled: false })),
     sessionResolveApprovalMutate: vi.fn(async () => ({ resolved: true })),
   };
   const client = {
@@ -322,7 +354,7 @@ function createClientFixture() {
       sessionRunState: { query: calls.sessionRunStateQuery },
       sessionPendingApproval: { query: calls.sessionPendingApprovalQuery },
       sessionSendPrompt: { mutate: calls.sessionSendPromptMutate },
-      sessionCancel: { mutate: vi.fn(async () => ({ cancelled: false })) },
+      sessionCancel: { mutate: calls.sessionCancelMutate },
       sessionResolveApproval: { mutate: calls.sessionResolveApprovalMutate },
     },
   } as unknown as ControlPlaneProxyClient;

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from 'ink';
 import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { ConversationPanel } from './components/ConversationPanel.js';
 import { PromptInput } from './components/PromptInput.js';
+import { RunControls } from './components/RunControls.js';
 import { buildPromptActivity } from './helpers/activities/prompt-activity.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
 import { usePromptDraft } from './hooks/usePromptDraft.js';
@@ -37,7 +38,8 @@ export function App({
   }, [initialSelection, store]);
 
   const submitPrompt = useCallback((value: string) => {
-    if (!value.trim()) {
+    const trimmed = value.trim();
+    if (!trimmed) {
       return;
     }
 
@@ -51,6 +53,10 @@ export function App({
 
   const resolveApproval = useCallback((decision: ControlPlaneApprovalDecision) => {
     void store.resolvePendingApproval(decision);
+  }, [store]);
+
+  const cancelRun = useCallback(() => {
+    void store.cancelRun();
   }, [store]);
 
   return (
@@ -71,10 +77,19 @@ export function App({
           onResolve={resolveApproval}
         />
       ) : null}
+      <RunControls
+        running={snapshot.running}
+        cancelling={snapshot.cancelling}
+        onCancel={cancelRun}
+      />
       <PromptInput
         activity={buildPromptActivity(snapshot)}
         disabled={submitDisabled || Boolean(snapshot.pendingApproval)}
-        placeholder={snapshot.loading ? 'Loading session...' : snapshot.running ? 'Run in progress' : 'Type a prompt'}
+        placeholder={
+          snapshot.loading ? 'Loading session...'
+          : snapshot.running ? 'Run in progress'
+          : 'Type a prompt'
+        }
         value={draft}
         onChange={setDraft}
         onSubmit={submitPrompt}

--- a/src/cli-v2/components/RunControls.tsx
+++ b/src/cli-v2/components/RunControls.tsx
@@ -1,0 +1,29 @@
+import { Box, Text, useInput } from 'ink';
+
+type RunControlsProps = {
+  running: boolean;
+  cancelling: boolean;
+  onCancel: () => void;
+};
+
+export function RunControls({ running, cancelling, onCancel }: RunControlsProps) {
+  useInput((_input, key) => {
+    if (!running || cancelling || !key.escape) {
+      return;
+    }
+
+    onCancel();
+  }, { isActive: running && !cancelling });
+
+  if (running || cancelling) {
+    return (
+      <Box marginTop={1}>
+        <Text color="yellow">
+          {cancelling ? 'Stop requested...' : 'Run active · Esc to stop'}
+        </Text>
+      </Box>
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add cli-v2 run controls for stopping active runs and resuming interrupted runs with /continue
- route continue/cancel through shared control-plane tRPC APIs
- cover continue and in-flight cancel behavior in cli-v2 session store tests

## Validation
- yarn -s vitest run src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/unit/cli-v2/pending-approval.test.ts src/__tests__/unit/cli-v2/prompt-activity.test.ts src/__tests__/unit/core/import-boundaries.test.ts
- yarn typecheck
- git diff --check