### PR TITLE
Refactor control-plane session runs async

### DIFF
--- a/docs/architecture/chat-layering.md
+++ b/docs/architecture/chat-layering.md
@@ -6,6 +6,10 @@ The goal is to make the codebase easy to reason about in the same way mature
 frameworks make placement obvious: when a feature touches chat, a contributor
 should know where the code belongs before they start wiring it.
 
+For the concrete control-plane prompt submission flow, including sync vs async
+API usage, accepted user-message persistence, and streaming synchronization, see
+`docs/architecture/control-plane-chat-submission.md`.
+
 ## Terminology
 
 - **Host**: a concrete user interaction surface such as the TUI, web control

--- a/docs/architecture/control-plane-chat-submission.md
+++ b/docs/architecture/control-plane-chat-submission.md
@@ -1,0 +1,220 @@
+# Control-Plane Chat Submission
+
+This document explains how browser and terminal control-plane clients submit a
+chat prompt, how the accepted user message becomes durable session state, and
+how live streaming and final synchronization work.
+
+It complements:
+
+- `docs/architecture/chat-layering.md`, which defines ownership boundaries.
+- `docs/architecture/live-events.md`, which defines live activity delivery.
+
+## Goal
+
+Interactive clients should not wait on a long-running prompt mutation before
+they can return control to the user. A prompt submission has two separate
+moments:
+
+1. The server accepts the user prompt and records it on the session.
+2. The agent run streams activity and eventually persists the completed turn.
+
+Web-v2, cli-v2, and future mobile clients should all consume the same
+control-plane API. No API or controller should be named for a specific client.
+
+## API Options
+
+The control-plane router exposes two prompt submission shapes.
+
+### `controlPlane.sessionSendPromptAsync`
+
+Use this for interactive clients such as web-v2, cli-v2, and future mobile
+surfaces.
+
+The endpoint returns after the server accepts the prompt:
+
+```ts
+type ControlPlaneAcceptedSessionRun = {
+  accepted: true;
+  workspaceId: string;
+  sessionId: string;
+  runId: string;
+  acceptedAt: string;
+};
+```
+
+After the accepted response, clients render the run from:
+
+- persisted session state from `controlPlane.session`;
+- live activity from `controlPlane.sessionEvents`;
+- fallback run state from `controlPlane.sessionRunState`.
+
+### `controlPlane.sessionSendPrompt`
+
+Use this for completion-oriented callers that intentionally want to wait for the
+final result.
+
+The endpoint starts the same run path, but waits until the engine turn resolves
+and returns the final result:
+
+```ts
+type ControlPlaneSessionSendPromptResult = {
+  outcome: string;
+  summary: string;
+  session: ControlPlaneSessionDetail | null;
+};
+```
+
+Do not use this from interactive browser or terminal UI code. It makes one
+mutation represent both "request accepted" and "agent finished", which causes
+stale loading states and blocks normal run synchronization.
+
+## Accepted User Message
+
+When `sessionSendPromptAsync` accepts a prompt, the server immediately persists
+the user message through the core conversation session service.
+
+The accepted line is a normal visible session message:
+
+```ts
+type ConversationLine = {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+  isPending?: boolean;
+};
+```
+
+For an active accepted run, the user line uses `isPending: true`. It is durable
+host-facing state, not a local optimistic UI message.
+
+This is important for cross-device continuity:
+
+- if a prompt is submitted from cli-v2, web-v2 should show it;
+- if a prompt is submitted from web-v2, cli-v2 should show it;
+- if the daemon restarts after accepting the prompt, the session should still
+  show what the user sent;
+- agent thinking, tool activity, and assistant streaming should not appear above
+  or without the user prompt that caused them.
+
+The accepted prompt is not pre-appended to model-facing `session.history`.
+During the turn, the chat engine receives the prompt as the current turn input.
+Final turn persistence rebuilds `session.history` and visible messages from the
+completed transcript.
+
+## Server Flow
+
+The main flow is:
+
+```text
+client
+  -> controlPlane.sessionSendPromptAsync
+  -> ControlPlaneChatSessionsController.submitPromptAsync
+  -> ControlPlaneSessionRunService.start
+  -> ConversationSessionService.acceptUserMessage
+  -> background ConversationEngine.turns.submit
+  -> controlPlane.sessionEvents live activity
+  -> final ConversationEngine persistence
+  -> session.updated / sessionRunState false / refreshed session detail
+```
+
+`ControlPlaneSessionRunService` owns process-local run coordination:
+
+- in-flight run registry;
+- accepted run id generation;
+- abort controller lifecycle;
+- pending approval resolver cleanup;
+- async start vs wait-for-result behavior.
+
+It does not own persisted chat meaning. Core chat/session services own:
+
+- accepted user-message semantics;
+- lease admission before acceptance;
+- preserving accepted messages through preflight persistence;
+- clearing accepted pending state on final success or failure;
+- rebuilding final transcript state.
+
+## Admission and Failure
+
+Async acceptance is an admission boundary, not just a background promise start.
+The server must reject before returning `accepted` when a session cannot accept
+a run, including active-run and lease conflicts.
+
+If execution fails after acceptance, the accepted user message remains durable,
+but the pending marker is cleared and an assistant failure message is appended.
+The user should see that their message was accepted and that the run failed,
+rather than seeing a disappearing prompt or a permanently pending user line.
+
+## Streaming and Synchronization
+
+Live streaming is primary:
+
+- `controlPlane.sessionEvents` carries `session.event` envelopes for assistant
+  stream deltas, tool activity, approvals, compaction, and run lifecycle.
+- `session.updated` tells clients to refetch persisted session detail.
+
+Polling is a fallback:
+
+- clients query `controlPlane.sessionRunState` while a run is believed active;
+- when polling observes `running: false`, clients refetch session detail,
+  session list, and pending approval state;
+- polling protects clients that missed a live finalization event because
+  current live events are process-local and not replayable.
+
+Do not poll the whole session for every stream delta. Streaming activities
+should update interface-local transient state, while durable session refreshes
+should happen at session update and finalization boundaries.
+
+## Client Responsibilities
+
+Interactive clients should:
+
+- call `sessionSendPromptAsync`;
+- treat `submitting` as "waiting for accepted response";
+- treat `running` as "server run active or believed active";
+- keep draft typing available while a run is active;
+- block sending another prompt while the selected session has an active run;
+- render the accepted user prompt from server session state;
+- render assistant stream and tool status from `sessionEvents`;
+- refresh session detail when receiving `session.updated` or when
+  `sessionRunState` changes from active to inactive.
+
+Interactive clients should not:
+
+- add client-only optimistic user messages for accepted prompts;
+- call core chat services directly;
+- use `sessionSendPrompt` for normal interactive chat;
+- infer run completion only from a mutation finishing;
+- let cached `sessionRunState.running === false` cancel a freshly submitted run
+  before a post-submit run-state refetch returns.
+
+## Current Consumers
+
+Current intended usage:
+
+- `src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts` uses
+  `sessionSendPromptAsync`.
+- `src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts` consumes
+  `sessionEvents`.
+- `src/web-v2/hooks/sessions/useControlPlaneSessionRunControl.ts` handles
+  run-state fallback polling and cancellation.
+- `src/cli-v2/services/sessions/control-plane-session-api-service.ts` exposes
+  `sendPromptAsync`.
+- `src/cli-v2/state/control-plane-session-store.ts` coordinates cli-v2 session
+  loading, async submit, event subscription, and run-state fallback.
+
+Completion-oriented or compatibility callers may still use
+`sessionSendPrompt`, but new interactive clients should not.
+
+## Extending This Flow
+
+When adding new chat submission behavior:
+
+1. Decide whether it belongs to prompt acceptance, live run activity, or final
+   transcript persistence.
+2. Put persisted meaning in `src/core/chat/engine`.
+3. Put process-local control-plane orchestration in
+   `src/server/services/control-plane`.
+4. Put transport exposure in `src/server/routes/trpc/control-plane.ts`.
+5. Put shared API-consumer types in `src/client-shared`.
+6. Keep web-v2 and cli-v2 consumers aligned unless the difference is purely
+   rendering or input ergonomics.

--- a/docs/architecture/live-events.md
+++ b/docs/architecture/live-events.md
@@ -3,6 +3,10 @@
 This document explains how Heddle streams live conversation updates from the
 engine to user interfaces. It is a maintenance map, not a transport API spec.
 
+For the surrounding prompt submission flow, including accepted user-message
+persistence, sync vs async control-plane APIs, and run-state fallback polling,
+see `docs/architecture/control-plane-chat-submission.md`.
+
 ## Goal
 
 Live updates let interfaces show an in-progress run without polling the whole

--- a/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
+++ b/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
@@ -161,7 +161,6 @@ test('submits a prompt and renders the mocked session response', async ({ page }
   await expectComposerActionButtonCircle(stopButton);
   await expect(page.getByText('Run the web v2 submit smoke', { exact: true })).toBeVisible();
   await expect(page.getByText('Mocked browser integration agent response', { exact: true })).toBeVisible();
-  await expect(page.getByTestId('web-v2-live-status')).toHaveText('Receiving assistant response...');
   await expect(page.getByTestId('web-v2-workbench-body').getByText(
     'Mocked browser integration agent response: Run the web v2 submit smoke',
     { exact: true },

--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -261,11 +261,12 @@ describe('control-plane session lifecycle API', () => {
   it('settles the accepted user message when an async run fails before a final answer', async () => {
     vi.spyOn(AgentLoopRuntimeService, 'run').mockRejectedValueOnce(new Error('loop failed'));
     const { caller } = createControlPlaneCaller();
-    const session = await caller.sessionCreate({ name: 'Async failure session' });
+    const session = await caller.sessionCreate({ name: 'Async failure session', apiKeyPresent: true });
 
     await expect(caller.sessionSendPromptAsync({
       sessionId: session.id,
       prompt: 'This run will fail',
+      apiKey: 'test-api-key',
     })).resolves.toMatchObject({
       accepted: true,
       sessionId: session.id,

--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
 import { createConversationEngine } from '@/core/chat/engine/conversation-engine.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
+import { AgentLoopRuntimeService } from '@/core/runtime/loop/index.js';
 import { DEFAULT_WORKSPACE_ID, RuntimeWorkspaceService, type WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
 import type { HeddleServerContext } from '@/server/types.js';
@@ -19,6 +20,7 @@ const EXTERNAL_TUI_LEASE_OWNER: ChatSessionLeaseOwner = {
 describe('control-plane session lifecycle API', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('renames sessions through the workspace-scoped API', async () => {
@@ -122,10 +124,15 @@ describe('control-plane session lifecycle API', () => {
     await expect(caller.sessionDelete({ id: session.id })).rejects.toThrow('already active');
     await expect(caller.sessionReset({ id: session.id })).rejects.toThrow('already active');
     await expect(caller.sessionCompact({ id: session.id, force: true })).rejects.toThrow('already active');
+    await expect(caller.sessionSendPromptAsync({
+      sessionId: session.id,
+      prompt: 'should not be accepted',
+    })).rejects.toThrow('already active');
     await expect(caller.sessionRunState({ id: session.id })).resolves.toEqual({
       running: false,
       pendingApproval: null,
     });
+    expect(engine.sessions.require(session.id).messages.map((message) => message.text)).not.toContain('should not be accepted');
   });
 
   it('compacts a session through the API without requiring clients to call compaction services', async () => {
@@ -198,7 +205,99 @@ describe('control-plane session lifecycle API', () => {
       pendingApproval: null,
     });
   });
+
+  it('accepts async prompt submits before the final session result is ready', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT', '1');
+    try {
+      const { caller } = createControlPlaneCaller();
+      const session = await caller.sessionCreate({ name: 'Async submit session' });
+
+      const accepted = await caller.sessionSendPromptAsync({
+        sessionId: session.id,
+        prompt: 'Explain async submit',
+      });
+
+      expect(accepted).toMatchObject({
+        accepted: true,
+        sessionId: session.id,
+        workspaceId: DEFAULT_WORKSPACE_ID,
+      });
+      await expect(caller.sessionRunState({ id: session.id })).resolves.toMatchObject({
+        running: true,
+      });
+      await expect(caller.session({ id: session.id })).resolves.toMatchObject({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'user',
+            text: 'Explain async submit',
+            isPending: true,
+          }),
+        ]),
+      });
+      await expect(caller.sessionSendPromptAsync({
+        sessionId: session.id,
+        prompt: 'Second prompt',
+      })).rejects.toThrow('A run is already in progress for this session.');
+
+      await vi.advanceTimersByTimeAsync(800);
+      await Promise.resolve();
+
+      await expect(caller.sessionRunState({ id: session.id })).resolves.toEqual({
+        running: false,
+        pendingApproval: null,
+      });
+      const completed = await caller.session({ id: session.id });
+      expect(completed?.messages.map((message) => message.text)).toEqual([
+        'Explain async submit',
+        'Mocked browser integration agent response: Explain async submit',
+      ]);
+      expect(completed?.messages.some((message) => message.isPending)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('settles the accepted user message when an async run fails before a final answer', async () => {
+    vi.spyOn(AgentLoopRuntimeService, 'run').mockRejectedValueOnce(new Error('loop failed'));
+    const { caller } = createControlPlaneCaller();
+    const session = await caller.sessionCreate({ name: 'Async failure session' });
+
+    await expect(caller.sessionSendPromptAsync({
+      sessionId: session.id,
+      prompt: 'This run will fail',
+    })).resolves.toMatchObject({
+      accepted: true,
+      sessionId: session.id,
+    });
+
+    await flushPromises();
+
+    await expect(caller.sessionRunState({ id: session.id })).resolves.toMatchObject({
+      running: false,
+    });
+    const failedSession = await caller.session({ id: session.id });
+    expect(failedSession?.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: expect.stringMatching(/^accepted-user-/),
+        role: 'user',
+        text: 'This run will fail',
+        isPending: undefined,
+      }),
+      expect.objectContaining({
+        id: expect.stringMatching(/^accepted-run-error-/),
+        role: 'assistant',
+        text: 'Run failed before a final answer: loop failed',
+      }),
+    ]));
+  });
 });
+
+async function flushPromises(): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
 
 function createControlPlaneCaller() {
   const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-session-lifecycle-'));

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -4,7 +4,7 @@ import type {
   ControlPlanePendingApproval,
   ControlPlaneSessionDetail,
   ControlPlaneSessionEventEnvelope,
-  ControlPlaneSessionSendPromptResult,
+  ControlPlaneSessionSendPromptAsyncResult,
   ControlPlaneSessionView,
   ControlPlaneSessionsEventEnvelope,
 } from '../../../client-shared/api/types.js';
@@ -33,7 +33,7 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
-  it('submits prompts through sessionSendPrompt without a direct runtime fallback', async () => {
+  it('submits prompts through sessionSendPromptAsync without a direct runtime fallback', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({
       client: fixture.client,
@@ -41,10 +41,22 @@ describe('ControlPlaneSessionStore', () => {
       searchIgnoreDirs: ['node_modules'],
     });
     await store.start();
+    fixture.calls.sessionQuery.mockResolvedValueOnce({
+      ...createSessionDetail(),
+      messages: [
+        ...createSessionDetail().messages,
+        {
+          id: 'accepted-user-run-1',
+          role: 'user',
+          text: 'Build the next slice',
+          isPending: true,
+        },
+      ],
+    });
 
     await store.submitPrompt('  Build the next slice  ');
 
-    expect(fixture.calls.sessionSendPromptMutate).toHaveBeenCalledWith({
+    expect(fixture.calls.sessionSendPromptAsyncMutate).toHaveBeenCalledWith({
       workspaceId: 'workspace-1',
       sessionId: 'session-1',
       prompt: 'Build the next slice',
@@ -55,9 +67,10 @@ describe('ControlPlaneSessionStore', () => {
       systemContext: undefined,
     });
     expect(store.getSnapshot().activeSession?.messages.at(-1)).toEqual({
-      id: 'message-2',
-      role: 'assistant',
-      text: 'Done.',
+      id: 'accepted-user-run-1',
+      role: 'user',
+      text: 'Build the next slice',
+      isPending: true,
     });
     store.dispose();
   });
@@ -66,8 +79,8 @@ describe('ControlPlaneSessionStore', () => {
     vi.useFakeTimers();
     try {
       const fixture = createClientFixture();
-      const pendingSubmit = createDeferred<Awaited<ReturnType<typeof fixture.calls.sessionSendPromptMutate>>>();
-      fixture.calls.sessionSendPromptMutate.mockReturnValueOnce(pendingSubmit.promise);
+      const pendingSubmit = createDeferred<Awaited<ReturnType<typeof fixture.calls.sessionSendPromptAsyncMutate>>>();
+      fixture.calls.sessionSendPromptAsyncMutate.mockReturnValueOnce(pendingSubmit.promise);
       const store = new ControlPlaneSessionStore({ client: fixture.client });
       await store.start();
 
@@ -77,20 +90,21 @@ describe('ControlPlaneSessionStore', () => {
       expect(store.getSnapshot()).toMatchObject({
         submitting: true,
         latestUpdate: {
-          label: 'Finalizing response',
-          detail: 'waiting for server result',
+          label: 'Run starting',
+          detail: 'waiting for server acceptance',
           tone: 'info',
         },
       });
 
-      pendingSubmit.resolve(createSubmitResult());
+      pendingSubmit.resolve(createAcceptedResult());
       await submit;
       expect(store.getSnapshot()).toMatchObject({
         submitting: false,
+        running: true,
         latestUpdate: {
-          label: 'Run finished',
-          detail: 'completed',
-          tone: 'success',
+          label: 'Run accepted',
+          detail: 'session-run-1',
+          tone: 'info',
         },
       });
       store.dispose();
@@ -101,7 +115,7 @@ describe('ControlPlaneSessionStore', () => {
 
   it('treats an in-progress submit rejection as active run state', async () => {
     const fixture = createClientFixture();
-    fixture.calls.sessionSendPromptMutate.mockRejectedValueOnce(new Error('A run is already in progress for this session.'));
+    fixture.calls.sessionSendPromptAsyncMutate.mockRejectedValueOnce(new Error('A run is already in progress for this session.'));
     const store = new ControlPlaneSessionStore({ client: fixture.client });
     await store.start();
 
@@ -128,7 +142,7 @@ describe('ControlPlaneSessionStore', () => {
 
     await store.submitPrompt('Next prompt');
 
-    expect(fixture.calls.sessionSendPromptMutate).not.toHaveBeenCalled();
+    expect(fixture.calls.sessionSendPromptAsyncMutate).not.toHaveBeenCalled();
     expect(store.getSnapshot()).toMatchObject({
       running: true,
       latestUpdate: {
@@ -142,8 +156,8 @@ describe('ControlPlaneSessionStore', () => {
 
   it('cancels the active run through sessionCancel', async () => {
     const fixture = createClientFixture();
-    const pendingSubmit = createDeferred<Awaited<ReturnType<typeof fixture.calls.sessionSendPromptMutate>>>();
-    fixture.calls.sessionSendPromptMutate.mockReturnValueOnce(pendingSubmit.promise);
+    const pendingSubmit = createDeferred<Awaited<ReturnType<typeof fixture.calls.sessionSendPromptAsyncMutate>>>();
+    fixture.calls.sessionSendPromptAsyncMutate.mockReturnValueOnce(pendingSubmit.promise);
     fixture.calls.sessionCancelMutate.mockResolvedValueOnce({ cancelled: true });
     fixture.calls.sessionRunningQuery
       .mockResolvedValueOnce({ running: false })
@@ -166,7 +180,7 @@ describe('ControlPlaneSessionStore', () => {
         tone: 'warning',
       },
     });
-    pendingSubmit.resolve(createSubmitResult());
+    pendingSubmit.resolve(createAcceptedResult());
     await submit;
     store.dispose();
   });
@@ -390,13 +404,7 @@ function createClientFixture() {
     messageCount: 1,
     turnCount: 0,
   };
-  const sessionDetail: NonNullable<ControlPlaneSessionDetail> = {
-    ...sessionView,
-    messages: [
-      { id: 'message-1', role: 'assistant', text: 'Ready.' },
-    ],
-    turns: [],
-  };
+  const sessionDetail = createSessionDetail();
   const pendingApproval: ControlPlanePendingApproval = null;
   let sessionEvents: SubscriptionOptions<ControlPlaneSessionEventEnvelope> | undefined;
   let sessionsEvents: SubscriptionOptions<ControlPlaneSessionsEventEnvelope> | undefined;
@@ -418,6 +426,7 @@ function createClientFixture() {
       outcome: 'completed',
       summary: 'Done.',
     })),
+    sessionSendPromptAsyncMutate: vi.fn(async () => createAcceptedResult()),
     sessionCancelMutate: vi.fn(async () => ({ cancelled: false })),
     sessionResolveApprovalMutate: vi.fn(async () => ({ resolved: true })),
   };
@@ -443,6 +452,7 @@ function createClientFixture() {
       sessionRunState: { query: calls.sessionRunStateQuery },
       sessionPendingApproval: { query: calls.sessionPendingApprovalQuery },
       sessionSendPrompt: { mutate: calls.sessionSendPromptMutate },
+      sessionSendPromptAsync: { mutate: calls.sessionSendPromptAsyncMutate },
       sessionCancel: { mutate: calls.sessionCancelMutate },
       sessionResolveApproval: { mutate: calls.sessionResolveApprovalMutate },
     },
@@ -470,21 +480,26 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
-function createSubmitResult(): ControlPlaneSessionSendPromptResult {
+function createSessionDetail(): NonNullable<ControlPlaneSessionDetail> {
   return {
-    session: {
-      id: 'session-1',
-      name: 'Session 1',
-      workspaceId: 'workspace-1',
-      messageCount: 1,
-      turnCount: 0,
-      messages: [
-        { id: 'message-1', role: 'assistant', text: 'Ready.' },
-        { id: 'message-2', role: 'assistant', text: 'Done.' },
-      ],
-      turns: [],
-    },
-    outcome: 'completed',
-    summary: 'Done.',
+    id: 'session-1',
+    name: 'Session 1',
+    workspaceId: 'workspace-1',
+    messageCount: 1,
+    turnCount: 0,
+    messages: [
+      { id: 'message-1', role: 'assistant', text: 'Ready.' },
+    ],
+    turns: [],
+  };
+}
+
+function createAcceptedResult(): ControlPlaneSessionSendPromptAsyncResult {
+  return {
+    accepted: true,
+    workspaceId: 'workspace-1',
+    sessionId: 'session-1',
+    runId: 'session-run-1',
+    acceptedAt: '2026-05-27T00:00:00.000Z',
   };
 }

--- a/src/__tests__/unit/control-plane/session-cancel.test.ts
+++ b/src/__tests__/unit/control-plane/session-cancel.test.ts
@@ -6,17 +6,16 @@ import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js
 import type { ChatSession } from '@/core/chat/types.js';
 import type { ToolApprovalRequest, ToolApprovalUserDecision } from '@/core/approvals/index.js';
 import { ControlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
+import type {
+  ControlPlaneSessionRunContext,
+  ControlPlaneSessionRunService,
+} from '@/server/services/control-plane/session-run-service.js';
 
 type ControllerInternals = {
-  pendingApprovals: Map<string, {
-    approval: ToolApprovalRequest;
-    resolve: (decision: ToolApprovalUserDecision) => void;
-  }>;
-  inFlightRuns: Map<string, {
-    controller: AbortController;
-  }>;
+  runService: ControlPlaneSessionRunService;
   runEngineTurn: (
     args: Record<string, unknown>,
+    runContext: ControlPlaneSessionRunContext,
     run: (input: {
       abortSignal: AbortSignal;
       shouldStop: () => boolean;
@@ -32,14 +31,19 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
   it('aborts the active run and resolves pending approval as denied', () => {
     const controller = new ControlPlaneChatSessionsController();
     const internals = controller as unknown as ControllerInternals;
-    const abortController = new AbortController();
     const decisions: ToolApprovalUserDecision[] = [];
     const workspaceId = 'workspace-cancel';
     const sessionId = 'session-cancel-approval';
-    const sessionKey = `${workspaceId}:${sessionId}`;
+    let abortSignal: AbortSignal | undefined;
 
-    internals.inFlightRuns.set(sessionKey, { controller: abortController });
-    internals.pendingApprovals.set(sessionKey, {
+    internals.runService.start({
+      address: { workspaceId, sessionId },
+      onAccepted: (run) => {
+        abortSignal = run.controller.signal;
+      },
+      execute: async () => await new Promise<never>(() => undefined),
+    });
+    internals.runService.storePendingApproval({ workspaceId, sessionId }, {
       approval: createApprovalRequest(),
       resolve: (decision) => {
         decisions.push(decision);
@@ -47,8 +51,8 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
     });
 
     expect(controller.cancelRun({ workspaceId, sessionId })).toBe(true);
-    expect(abortController.signal.aborted).toBe(true);
-    expect(internals.pendingApprovals.has(sessionKey)).toBe(false);
+    expect(abortSignal?.aborted).toBe(true);
+    expect(internals.runService.getPendingApproval({ workspaceId, sessionId })).toBeUndefined();
     expect(decisions).toEqual([{
       type: 'deny',
       reason: 'Cancelled by user',
@@ -75,27 +79,32 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
     });
     const observedShouldStop: boolean[] = [];
 
-    await internals.runEngineTurn({
-      workspaceId,
-      workspaceRoot: stateRoot,
-      stateRoot,
-      sessionStoragePath: join(stateRoot, 'chat-sessions.catalog.json'),
-      sessionId,
-      prompt: 'Stop this run.',
-      leaseOwner: {
-        ownerKind: 'daemon',
-        ownerId: 'test-daemon',
-        clientLabel: 'test',
+    await internals.runService.startAndWait({
+      address: { workspaceId, sessionId },
+      execute: async (runContext) => {
+        return await internals.runEngineTurn({
+          workspaceId,
+          workspaceRoot: stateRoot,
+          stateRoot,
+          sessionStoragePath: join(stateRoot, 'chat-sessions.catalog.json'),
+          sessionId,
+          prompt: 'Stop this run.',
+          leaseOwner: {
+            ownerKind: 'daemon',
+            ownerId: 'test-daemon',
+            clientLabel: 'test',
+          },
+        }, runContext, async ({ shouldStop }) => {
+          observedShouldStop.push(shouldStop());
+          expect(controller.cancelRun({ workspaceId, sessionId })).toBe(true);
+          observedShouldStop.push(shouldStop());
+          return {
+            outcome: 'interrupted',
+            summary: 'Run interrupted by host request',
+            session,
+          };
+        });
       },
-    }, async ({ shouldStop }) => {
-      observedShouldStop.push(shouldStop());
-      expect(controller.cancelRun({ workspaceId, sessionId })).toBe(true);
-      observedShouldStop.push(shouldStop());
-      return {
-        outcome: 'interrupted',
-        summary: 'Run interrupted by host request',
-        session,
-      };
     });
 
     expect(observedShouldStop).toEqual([false, true]);

--- a/src/__tests__/unit/control-plane/session-message-service.test.ts
+++ b/src/__tests__/unit/control-plane/session-message-service.test.ts
@@ -3,9 +3,35 @@ import type { ControlPlaneSessionDetail } from '../../../client-shared/api/types
 import { ClientSharedSessionMessageService } from '../../../client-shared/services/session-messages/session-message-service.js';
 
 describe('ClientSharedSessionMessageService', () => {
-  it('preserves optimistic user messages across stale persisted snapshots', () => {
+  it('preserves live assistant messages across stale persisted snapshots', () => {
     const current = sessionWithMessages([
       { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
+      {
+        id: 'live-assistant',
+        role: 'assistant',
+        text: 'Thinking: Investigating project details',
+        isPending: true,
+        isStreaming: true,
+      },
+    ]);
+    const stale = sessionWithMessages([
+      { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
+    ]);
+
+    expect(ClientSharedSessionMessageService.mergeTransientMessages(current, stale)?.messages).toEqual([
+      { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
+      {
+        id: 'live-assistant',
+        role: 'assistant',
+        text: 'Thinking: Investigating project details',
+        isPending: true,
+        isStreaming: true,
+      },
+    ]);
+  });
+
+  it('drops transient user messages because accepted prompts are server-owned', () => {
+    const current = sessionWithMessages([
       { id: 'live-user', role: 'user', text: 'What is this project about?' },
     ]);
     const stale = sessionWithMessages([
@@ -14,30 +40,13 @@ describe('ClientSharedSessionMessageService', () => {
 
     expect(ClientSharedSessionMessageService.mergeTransientMessages(current, stale)?.messages).toEqual([
       { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
-      { id: 'live-user', role: 'user', text: 'What is this project about?' },
     ]);
   });
 
-  it('drops optimistic user messages once the persisted transcript contains the same turn', () => {
-    const current = sessionWithMessages([
-      { id: 'live-user', role: 'user', text: 'What is this project about?' },
-    ]);
-    const persisted = sessionWithMessages([
-      { id: 'persisted-user', role: 'user', text: 'What is this project about?' },
-      { id: 'persisted-assistant', role: 'assistant', text: 'Heddle is a coding agent runtime.' },
-    ]);
-
-    expect(ClientSharedSessionMessageService.mergeTransientMessages(current, persisted)?.messages).toEqual([
-      { id: 'persisted-user', role: 'user', text: 'What is this project about?' },
-      { id: 'persisted-assistant', role: 'assistant', text: 'Heddle is a coding agent runtime.' },
-    ]);
-  });
-
-  it('keeps live assistant stream idempotent and after the optimistic user turn', () => {
+  it('keeps live assistant stream idempotent after persisted messages', () => {
     const current = sessionWithMessages([
       { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
       { id: 'live-assistant', role: 'assistant', text: 'Thinking: Inspecting project details' },
-      { id: 'live-user', role: 'user', text: 'What is this project about?' },
     ]);
 
     expect(ClientSharedSessionMessageService.upsertLiveAssistantMessage(
@@ -46,7 +55,6 @@ describe('ClientSharedSessionMessageService', () => {
       false,
     )?.messages).toEqual([
       { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
-      { id: 'live-user', role: 'user', text: 'What is this project about?' },
       {
         id: 'live-assistant',
         role: 'assistant',
@@ -57,7 +65,7 @@ describe('ClientSharedSessionMessageService', () => {
     ]);
   });
 
-  it('keeps transient user before transient assistant during stale snapshot merges', () => {
+  it('does not preserve other transient message ids during stale snapshot merges', () => {
     const current = sessionWithMessages([
       { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
       {
@@ -68,6 +76,7 @@ describe('ClientSharedSessionMessageService', () => {
         isStreaming: true,
       },
       { id: 'live-user', role: 'user', text: 'What is this project about?' },
+      { id: 'live-run-status', role: 'assistant', text: 'Running...' },
     ]);
     const stale = sessionWithMessages([
       { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
@@ -75,7 +84,6 @@ describe('ClientSharedSessionMessageService', () => {
 
     expect(ClientSharedSessionMessageService.mergeTransientMessages(current, stale)?.messages).toEqual([
       { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
-      { id: 'live-user', role: 'user', text: 'What is this project about?' },
       {
         id: 'live-assistant',
         role: 'assistant',

--- a/src/__tests__/unit/core/chat-turn-persistence.test.ts
+++ b/src/__tests__/unit/core/chat-turn-persistence.test.ts
@@ -124,6 +124,63 @@ describe('chat turn persistence', () => {
     expect(stored?.turns[0]?.traceFile).toBe(persisted.traceFile);
     expect(stored?.lease).toBeUndefined();
   });
+
+  it('normalizes an accepted user message without duplicating it after completion', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-turn-persistence-accepted-'));
+    const sessionStoragePath = join(stateRoot, 'chat-sessions.catalog.json');
+    const session = {
+      ...createSession(),
+      messages: [
+        {
+          id: 'accepted-user-run-1',
+          role: 'user' as const,
+          text: 'Persist this accepted prompt.',
+          isPending: true,
+        },
+      ],
+    };
+    new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).save([session]);
+
+    const result: AgentLoopResult = {
+      outcome: 'done',
+      summary: 'Done.',
+      trace: [],
+      transcript: [
+        { role: 'user', content: 'Persist this accepted prompt.' },
+        { role: 'assistant', content: 'Done.' },
+      ],
+      model: 'gpt-5.4',
+      provider: 'openai',
+      workspaceRoot: stateRoot,
+    };
+
+    await ConversationTurnPersistenceService.persistCompleted({
+      result,
+      prompt: 'Persist this accepted prompt.',
+      session,
+      sessions: [session],
+      sessionStoragePath,
+      model: 'gpt-5.4',
+      stateRoot,
+      traceDir: join(stateRoot, 'traces'),
+      toolNames: [],
+      historyForTokenEstimate: session.history,
+      credentialSource: { type: 'explicit-api-key' },
+    });
+
+    const stored = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list(true)[0];
+    expect(stored?.messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        text: 'Persist this accepted prompt.',
+      }),
+      expect.objectContaining({
+        role: 'assistant',
+        text: 'Done.',
+      }),
+    ]);
+    expect(stored?.messages[0]).not.toHaveProperty('isPending');
+  });
 });
 
 function createSession(): ChatSession {

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -284,4 +284,94 @@ describe('chat turn preparation modules', () => {
     expect(persisted?.messages.map((message) => message.text)).toEqual(['Earlier prompt', 'Earlier answer']);
     expect(persisted?.context?.estimatedHistoryTokens).toBe(42);
   });
+
+  it('preserves accepted visible user messages through preflight persistence', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-preflight-accepted-user-'));
+    const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');
+    const session = ChatSessionRecords.markAcceptedUserMessage(ChatSessionRecords.create({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.4',
+    }), {
+      runId: 'run-1',
+      prompt: 'New prompt still running',
+    });
+    new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).save([session]);
+
+    ConversationTurnPreflightService.persistPrepared({
+      sessionStoragePath,
+      sessions: [session],
+      session,
+      compacted: {
+        history: [
+          { role: 'user', content: 'Earlier prompt' },
+          { role: 'assistant', content: 'Earlier answer' },
+        ],
+        context: {
+          estimatedHistoryTokens: 42,
+        },
+        archive: {
+          archives: [],
+        },
+      },
+    });
+
+    const persisted = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list(true)[0];
+    expect(persisted?.messages).toEqual([
+      expect.objectContaining({ role: 'user', text: 'Earlier prompt' }),
+      expect.objectContaining({ role: 'assistant', text: 'Earlier answer' }),
+      expect.objectContaining({
+        id: 'accepted-user-run-1',
+        role: 'user',
+        text: 'New prompt still running',
+        isPending: true,
+      }),
+    ]);
+  });
+
+  it('preserves an accepted prompt even when the same text already exists in history', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-preflight-repeated-prompt-'));
+    const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');
+    const session = ChatSessionRecords.markAcceptedUserMessage(ChatSessionRecords.create({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.4',
+    }), {
+      runId: 'run-1',
+      prompt: 'Repeat this prompt',
+    });
+    new FileChatSessionRepository({ sessionStoragePath }).save([session]);
+
+    ConversationTurnPreflightService.persistPrepared({
+      sessionStoragePath,
+      sessions: [session],
+      session,
+      compacted: {
+        history: [
+          { role: 'user', content: 'Repeat this prompt' },
+          { role: 'assistant', content: 'Earlier answer' },
+        ],
+        context: {
+          estimatedHistoryTokens: 42,
+        },
+        archive: {
+          archives: [],
+        },
+      },
+    });
+
+    const persisted = new FileChatSessionRepository({ sessionStoragePath }).list(true)[0];
+    expect(persisted?.messages).toEqual([
+      expect.objectContaining({ role: 'user', text: 'Repeat this prompt' }),
+      expect.objectContaining({ role: 'assistant', text: 'Earlier answer' }),
+      expect.objectContaining({
+        id: 'accepted-user-run-1',
+        role: 'user',
+        text: 'Repeat this prompt',
+        isPending: true,
+      }),
+    ]);
+  });
 });

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -24,6 +24,7 @@ export function App({
   const snapshot = useControlPlaneSessionStore(store);
   const { draft, setDraft, clearDraft } = usePromptDraft();
   const submitDisabled = snapshot.loading || snapshot.submitting || snapshot.running;
+  const inputDisabled = snapshot.loading;
 
   useEffect(() => {
     if (startedRef.current) {
@@ -84,7 +85,8 @@ export function App({
       />
       <PromptInput
         activity={PromptActivityService.build(snapshot)}
-        disabled={submitDisabled || Boolean(snapshot.pendingApproval)}
+        disabled={inputDisabled}
+        submitDisabled={submitDisabled || Boolean(snapshot.pendingApproval)}
         placeholder={
           snapshot.loading ? 'Loading session...'
           : snapshot.running ? 'Run in progress'

--- a/src/cli-v2/components/PromptInput.tsx
+++ b/src/cli-v2/components/PromptInput.tsx
@@ -6,6 +6,7 @@ export function PromptInput({
   activity,
   disabled,
   placeholder,
+  submitDisabled,
   value,
   onChange,
   onSubmit,
@@ -13,6 +14,7 @@ export function PromptInput({
   activity?: PromptActivityView;
   disabled: boolean;
   placeholder: string;
+  submitDisabled?: boolean;
   value: string;
   onChange: Dispatch<SetStateAction<string>>;
   onSubmit: (value: string) => void;
@@ -23,6 +25,10 @@ export function PromptInput({
     }
 
     if (key.return) {
+      if (submitDisabled) {
+        return;
+      }
+
       onSubmit(value);
       return;
     }

--- a/src/cli-v2/services/sessions/control-plane-session-api-service.ts
+++ b/src/cli-v2/services/sessions/control-plane-session-api-service.ts
@@ -6,6 +6,7 @@ import type {
 
 export type ControlPlaneSessionCreateInput = Exclude<NonNullable<RouterInputs['controlPlane']['sessionCreate']>, void>;
 type SessionSendPromptInput = RouterInputs['controlPlane']['sessionSendPrompt'];
+type SessionSendPromptAsyncInput = RouterInputs['controlPlane']['sessionSendPromptAsync'];
 
 export type ControlPlaneSessionApiServiceOptions = {
   client: ControlPlaneProxyClient;
@@ -77,6 +78,17 @@ export class ControlPlaneSessionApiService {
 
   async sendPrompt(input: Pick<SessionSendPromptInput, 'workspaceId' | 'sessionId' | 'prompt'>) {
     return this.client.controlPlane.sessionSendPrompt.mutate({
+      ...input,
+      maxSteps: this.defaults.maxSteps,
+      searchIgnoreDirs: this.defaults.searchIgnoreDirs,
+      apiKey: this.defaults.apiKey,
+      preferApiKey: this.defaults.preferApiKey,
+      systemContext: this.defaults.systemContext,
+    });
+  }
+
+  async sendPromptAsync(input: Pick<SessionSendPromptAsyncInput, 'workspaceId' | 'sessionId' | 'prompt'>) {
+    return this.client.controlPlane.sessionSendPromptAsync.mutate({
       ...input,
       maxSteps: this.defaults.maxSteps,
       searchIgnoreDirs: this.defaults.searchIgnoreDirs,

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -228,27 +228,28 @@ export class ControlPlaneSessionStore {
         detail: 'waiting for model or tool activity',
         tone: 'info',
       },
-      activeSession: ClientSharedSessionMessageService.appendOptimisticUserTurn(current.activeSession, trimmed),
     }));
 
     try {
-      const result = await this.api.sendPrompt({
+      const result = await this.api.sendPromptAsync({
         workspaceId,
         sessionId,
         prompt: trimmed,
       });
       this.assistantStreamBuffer.reset();
       this.setSnapshot({
-        activeSession: result.session,
-        running: false,
         submitting: false,
-        liveStatus: undefined,
+        running: true,
+        liveStatus: this.snapshotValue.streamConnected
+          ? 'Heddle is working...'
+          : 'Heddle is working... reconnecting live stream if needed.',
         latestUpdate: {
-          label: 'Run finished',
-          detail: result.outcome,
-          tone: SessionActivityService.resolveRunOutcomeTone(result.outcome),
+          label: 'Run accepted',
+          detail: result.runId,
+          tone: 'info',
         },
       });
+      await this.refreshSession(sessionId, { silent: true });
       await this.refreshSessions();
       await this.refreshPendingApproval(sessionId);
     } catch (error) {
@@ -275,6 +276,7 @@ export class ControlPlaneSessionStore {
         submitting: false,
         liveStatus: undefined,
       });
+      await this.refreshSession(sessionId, { silent: true }).catch(() => undefined);
       this.assistantStreamBuffer.reset();
     }
   }
@@ -526,10 +528,10 @@ export class ControlPlaneSessionStore {
 
     if (this.snapshotValue.submitting) {
       this.setSnapshot({
-        liveStatus: 'Finalizing response...',
+        liveStatus: 'Waiting for run acceptance...',
         latestUpdate: {
-          label: 'Finalizing response',
-          detail: 'waiting for server result',
+          label: 'Run starting',
+          detail: 'waiting for server acceptance',
           tone: 'info',
         },
       });

--- a/src/client-shared/api/types.ts
+++ b/src/client-shared/api/types.ts
@@ -20,6 +20,7 @@ export type ControlPlaneSessionMessage = NonNullable<ControlPlaneSessionDetail>[
 export type ControlPlanePendingApproval = RouterOutputs['controlPlane']['sessionPendingApproval'];
 export type ControlPlaneApprovalDecision = RouterInputs['controlPlane']['sessionResolveApproval']['decision'];
 export type ControlPlaneSessionSendPromptResult = RouterOutputs['controlPlane']['sessionSendPrompt'];
+export type ControlPlaneSessionSendPromptAsyncResult = RouterOutputs['controlPlane']['sessionSendPromptAsync'];
 export type ControlPlaneModelOptions = RouterOutputs['controlPlane']['modelOptions'];
 export type ControlPlaneSessionSettingsInput = RouterInputs['controlPlane']['sessionSettingsUpdate'];
 export type ControlPlaneHeartbeatTasks = RouterOutputs['controlPlane']['heartbeatTasks'];

--- a/src/client-shared/services/session-messages/session-message-service.ts
+++ b/src/client-shared/services/session-messages/session-message-service.ts
@@ -1,29 +1,12 @@
 import type { ControlPlaneSessionDetail, ControlPlaneSessionMessage } from '../../api/types.js';
 
 /**
- * Shapes transient client-side session messages around persisted control-plane
- * session detail. This is shared by browser and terminal clients because the
- * behavior belongs to API-consumer state, not to a specific UI renderer.
+ * Shapes transient assistant stream messages around persisted control-plane
+ * session detail. Accepted user messages are server-owned and must arrive from
+ * the API snapshot, so this service intentionally does not preserve client-only
+ * user messages.
  */
 export class ClientSharedSessionMessageService {
-  static appendOptimisticUserTurn(session: ControlPlaneSessionDetail, prompt: string): ControlPlaneSessionDetail {
-    if (!session) {
-      return session;
-    }
-
-    return {
-      ...session,
-      messages: [
-        ...session.messages.filter((message) => !message.id.startsWith('live-')),
-        {
-          id: 'live-user',
-          role: 'user',
-          text: prompt,
-        },
-      ],
-    };
-  }
-
   static upsertLiveAssistantMessage(
     session: ControlPlaneSessionDetail,
     text: string,
@@ -56,21 +39,16 @@ export class ClientSharedSessionMessageService {
 
     const nextMessageIds = new Set(next.messages.map((message) => message.id));
     const transientMessages = current.messages.filter((message) => (
-      message.id.startsWith('live-') &&
+      message.id === 'live-assistant' &&
       !nextMessageIds.has(message.id) &&
       !next.messages.some((persisted) => persisted.role === message.role && persisted.text === message.text)
     ));
-    const orderedTransientMessages = [
-      transientMessages.find((message) => message.id === 'live-user'),
-      transientMessages.find((message) => message.id === 'live-assistant'),
-      ...transientMessages.filter((message) => message.id !== 'live-user' && message.id !== 'live-assistant'),
-    ].filter((message): message is ControlPlaneSessionMessage => Boolean(message));
 
-    return orderedTransientMessages.length ? {
+    return transientMessages.length ? {
       ...next,
       messages: [
         ...next.messages,
-        ...orderedTransientMessages,
+        ...transientMessages,
       ],
     } : next;
   }

--- a/src/core/chat/engine/sessions/records/records.ts
+++ b/src/core/chat/engine/sessions/records/records.ts
@@ -14,6 +14,8 @@ import type {
   ApplyCompletedChatSessionTurnInput,
   BuildChatTurnSummaryInput,
   CreateChatSessionRecordOptions,
+  MarkAcceptedConversationUserMessageFailedInput,
+  MarkAcceptedConversationUserMessageInput,
 } from './types.js';
 
 export class ChatSessionRecords {
@@ -84,12 +86,15 @@ export class ChatSessionRecords {
   }
 
   static applyCompactedHistory(input: ApplyCompactedChatSessionHistoryInput): ChatSession {
+    const messages = ConversationLines.fromHistory(input.compacted.history);
     return {
       ...input.session,
       history: input.compacted.history,
       context: input.compacted.context,
       archives: input.compacted.archive.archives,
-      messages: ConversationLines.fromHistory(input.compacted.history),
+      messages: input.preserveAcceptedUserMessages
+        ? ChatSessionRecords.withAcceptedUserMessages(messages, input.session.messages)
+        : messages,
     };
   }
 
@@ -102,6 +107,30 @@ export class ChatSessionRecords {
     });
   }
 
+  static markAcceptedUserMessage(
+    session: ChatSession,
+    input: MarkAcceptedConversationUserMessageInput,
+  ): ChatSession {
+    const message: ConversationLine = {
+      id: ChatSessionRecords.acceptedUserMessageId(input.runId),
+      role: 'user',
+      text: input.prompt,
+      isPending: true,
+    };
+
+    if (session.messages.some((candidate) => candidate.id === message.id)) {
+      return session;
+    }
+
+    return ChatSessionRecords.touch({
+      ...session,
+      messages: [
+        ...session.messages.filter((candidate) => !ChatSessionRecords.isLiveMessage(candidate)),
+        message,
+      ],
+    });
+  }
+
   static isGenericName(name: string): boolean {
     return /^Session \d+$/.test(name.trim());
   }
@@ -109,5 +138,52 @@ export class ChatSessionRecords {
   static canAutoRenameAfterFirstUserMessage(session: ChatSession): boolean {
     return ChatSessionRecords.isGenericName(session.name)
       && session.history.filter((message) => message.role === 'user').length === 1;
+  }
+
+  private static withAcceptedUserMessages(
+    messages: ConversationLine[],
+    currentMessages: ConversationLine[],
+  ): ConversationLine[] {
+    const acceptedMessages = currentMessages.filter((message) => (
+      ChatSessionRecords.isAcceptedUserMessage(message)
+      && !messages.some((candidate) => candidate.id === message.id)
+    ));
+
+    return acceptedMessages.length ? [...messages, ...acceptedMessages] : messages;
+  }
+
+  static markAcceptedUserMessageFailed(
+    session: ChatSession,
+    input: MarkAcceptedConversationUserMessageFailedInput,
+  ): ChatSession {
+    const acceptedId = ChatSessionRecords.acceptedUserMessageId(input.runId);
+    const failureId = input.failureMessage.id;
+    const messages = session.messages
+      .filter((message) => message.id !== failureId)
+      .map((message) => {
+        if (message.id !== acceptedId) {
+          return message;
+        }
+
+        const { isPending: _isPending, ...settledMessage } = message;
+        return settledMessage;
+      });
+
+    return ChatSessionRecords.touch({
+      ...session,
+      messages: [...messages, input.failureMessage],
+    });
+  }
+
+  private static acceptedUserMessageId(runId: string): string {
+    return `accepted-user-${runId}`;
+  }
+
+  private static isAcceptedUserMessage(message: ConversationLine): boolean {
+    return message.role === 'user' && message.isPending === true && message.id.startsWith('accepted-user-');
+  }
+
+  private static isLiveMessage(message: ConversationLine): boolean {
+    return message.id.startsWith('live-');
   }
 }

--- a/src/core/chat/engine/sessions/records/types.ts
+++ b/src/core/chat/engine/sessions/records/types.ts
@@ -2,7 +2,7 @@ import type { ReasoningEffort } from '@/core/llm/types.js';
 import type { TraceSummaryService } from '@/core/observability/index.js';
 import type { ConversationCompactionResult } from '@/core/chat/engine/compaction/index.js';
 import type { RunResult } from '@/core/types.js';
-import type { ChatSession, ChatSessionRetention, TurnSummary } from '@/core/chat/types.js';
+import type { ChatSession, ChatSessionRetention, ConversationLine, TurnSummary } from '@/core/chat/types.js';
 
 export type CreateChatSessionRecordOptions = {
   id: string;
@@ -30,9 +30,20 @@ export type BuildChatTurnSummaryInput = {
 export type ApplyCompactedChatSessionHistoryInput = {
   session: ChatSession;
   compacted: ConversationCompactionResult;
+  preserveAcceptedUserMessages?: boolean;
 };
 
 export type ApplyCompletedChatSessionTurnInput = ApplyCompactedChatSessionHistoryInput & {
   prompt: string;
   turn: TurnSummary;
+};
+
+export type MarkAcceptedConversationUserMessageInput = {
+  runId: string;
+  prompt: string;
+};
+
+export type MarkAcceptedConversationUserMessageFailedInput = {
+  runId: string;
+  failureMessage: ConversationLine;
 };

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -54,7 +54,7 @@ export const ConversationLineSchema = z.object({
     .describe('Whether this visible line was still streaming when captured.')
     .optional(),
   isPending: z.boolean()
-    .describe('Whether this visible line represented pending local UI state.')
+    .describe('Whether this visible line represents an accepted but unfinished user/assistant update.')
     .optional(),
 });
 

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -24,11 +24,14 @@ import type { ChatSession } from '@/core/chat/types.js';
 import type { NormalizedConversationEngineConfig } from '../config.js';
 import type {
   AppendConversationMessageInput,
+  AcceptConversationUserMessageInput,
   AutoRenameConversationSessionInput,
   AutoRenameConversationSessionResult,
   ApplyConversationCompactionResultInput,
   ConversationSessionService,
   CreateConversationSessionInput,
+  MarkAcceptedConversationUserMessageFailedInput,
+  MarkAcceptedConversationUserMessageInput,
   MarkConversationCompactionRunningInput,
   ResetConversationSessionInput,
   RestoreConversationCompactionStateInput,
@@ -139,6 +142,32 @@ export class FileConversationSessionService implements ConversationSessionServic
       ...session,
       messages: [...session.messages, ...inputs],
     }));
+  }
+
+  markAcceptedUserMessage(id: string, input: MarkAcceptedConversationUserMessageInput): ChatSession {
+    return this.updateRequiredSession(id, (session) => (
+      ChatSessionRecords.markAcceptedUserMessage(session, input)
+    ));
+  }
+
+  acceptUserMessage(id: string, input: AcceptConversationUserMessageInput): ChatSession {
+    return this.updateRequiredSession(id, (session) => {
+      const conflict = ChatSessionLeases.conflict(session, input.leaseOwner);
+      if (conflict) {
+        throw new Error(conflict);
+      }
+
+      return ChatSessionRecords.markAcceptedUserMessage(
+        ChatSessionLeases.acquire(session, input.leaseOwner),
+        input,
+      );
+    });
+  }
+
+  markAcceptedUserMessageFailed(id: string, input: MarkAcceptedConversationUserMessageFailedInput): ChatSession {
+    return this.updateRequiredSession(id, (session) => (
+      ChatSessionRecords.markAcceptedUserMessageFailed(session, input)
+    ));
   }
 
   resetConversation(id: string, input: ResetConversationSessionInput): ChatSession {

--- a/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
+++ b/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
@@ -73,6 +73,7 @@ export class ConversationTurnPreflightService {
     const preparedSession = ChatSessionRecords.touch(ChatSessionRecords.applyCompactedHistory({
       session: args.session,
       compacted: args.compacted,
+      preserveAcceptedUserMessages: true,
     }));
 
     new FileChatSessionRepository({ sessionStoragePath: args.sessionStoragePath })

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -64,6 +64,9 @@ export type ConversationSessionService = {
   // Messages
   appendMessage(id: string, input: AppendConversationMessageInput): ChatSession;
   appendMessages(id: string, inputs: AppendConversationMessageInput[]): ChatSession;
+  acceptUserMessage(id: string, input: AcceptConversationUserMessageInput): ChatSession;
+  markAcceptedUserMessage(id: string, input: MarkAcceptedConversationUserMessageInput): ChatSession;
+  markAcceptedUserMessageFailed(id: string, input: MarkAcceptedConversationUserMessageFailedInput): ChatSession;
 
   // Conversation state
   resetConversation(id: string, input: ResetConversationSessionInput): ChatSession;
@@ -113,6 +116,20 @@ export type AppendConversationMessageInput = {
   text: string;
   isStreaming?: boolean;
   isPending?: boolean;
+};
+
+export type MarkAcceptedConversationUserMessageInput = {
+  runId: string;
+  prompt: string;
+};
+
+export type AcceptConversationUserMessageInput = MarkAcceptedConversationUserMessageInput & {
+  leaseOwner: ChatSessionLeaseOwner;
+};
+
+export type MarkAcceptedConversationUserMessageFailedInput = {
+  runId: string;
+  failureMessage: AppendConversationMessageInput;
 };
 
 export type ResetConversationSessionInput = {

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -149,6 +149,14 @@ export type ChatSessionDetail = ChatSessionView & {
   lastContinuePrompt?: string;
 };
 
+export type ControlPlaneAcceptedSessionRun = {
+  accepted: true;
+  workspaceId: string;
+  sessionId: string;
+  runId: string;
+  acceptedAt: string;
+};
+
 export type ControlPlaneSessionLiveEvent = {
   sessionId: string;
   timestamp: string;

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -47,10 +47,15 @@ import type {
   ChatSessionDetail,
   ChatSessionView,
   ChatTurnReview,
+  ControlPlaneAcceptedSessionRun,
   ControlPlaneSessionEventEnvelope,
   ControlPlaneSessionLiveEvent,
   ControlPlaneSessionsEventEnvelope,
 } from '@/server/control-plane-types.js';
+import {
+  ControlPlaneSessionRunService,
+  type ControlPlaneSessionRunContext,
+} from '@/server/services/control-plane/session-run-service.js';
 
 type ControlPlaneSessionReadArgs = Omit<ConversationEngineConfig, 'model' | 'workspaceId'> & {
   model?: string;
@@ -100,19 +105,9 @@ type ContinueChatPromptArgs = Omit<SubmitChatPromptArgs, 'prompt'>;
 
 type ControlPlaneTurnPublisher = ReturnType<typeof ControlPlaneChatSessionEventsController.createSessionEventPublisher>;
 
-type PendingControlPlaneApproval = {
-  approval: ToolApprovalRequest;
-  resolve: (decision: ToolApprovalUserDecision) => void;
-};
-
-type InFlightControlPlaneRun = {
-  controller: AbortController;
-};
-
 export class ControlPlaneChatSessionsController {
   private readonly sessionEventBus = new EventEmitter();
-  private readonly pendingApprovals = new Map<string, PendingControlPlaneApproval>();
-  private readonly inFlightRuns = new Map<string, InFlightControlPlaneRun>();
+  private readonly runService = new ControlPlaneSessionRunService();
 
   createSession(args: CreateControlPlaneChatSessionArgs): ChatSessionDetail {
     const { suggestedName, ...engineInput } = args;
@@ -179,62 +174,62 @@ export class ControlPlaneChatSessionsController {
   }
 
   async compactSession(args: CompactControlPlaneChatSessionArgs): Promise<ChatSessionDetail> {
-    this.assertNoActiveRun(args);
-    const sessionKey = ControlPlaneChatSessionsController.sessionAddressKey(args);
-    const controller = new AbortController();
-    this.inFlightRuns.set(sessionKey, { controller });
-    const { sessionId, force = true, leaseOwner, ...engineInput } = args;
-    const sessions = this.createEngine(engineInput).sessions;
-    let leaseAcquired = false;
-    let previousCompactionState: Pick<ChatSession, 'context' | 'archives'> | undefined;
+    return await this.runService.startAndWait({
+      address: args,
+      execute: async () => {
+        const { sessionId, force = true, leaseOwner, ...engineInput } = args;
+        const sessions = this.createEngine(engineInput).sessions;
+        let leaseAcquired = false;
+        let previousCompactionState: Pick<ChatSession, 'context' | 'archives'> | undefined;
 
-    try {
-      this.assertNoLeaseConflict(sessions, sessionId, leaseOwner);
-      const session = sessions.acquireLease(sessionId, leaseOwner);
-      leaseAcquired = true;
-      const publisher = ControlPlaneChatSessionEventsController.createSessionEventPublisher({
-        eventBus: this.sessionEventBus,
-        workspaceId: args.workspaceId,
-        sessionId,
-      });
-      previousCompactionState = {
-        context: session.context,
-        archives: session.archives,
-      };
+        try {
+          this.assertNoLeaseConflict(sessions, sessionId, leaseOwner);
+          const session = sessions.acquireLease(sessionId, leaseOwner);
+          leaseAcquired = true;
+          const publisher = ControlPlaneChatSessionEventsController.createSessionEventPublisher({
+            eventBus: this.sessionEventBus,
+            workspaceId: args.workspaceId,
+            sessionId,
+          });
+          previousCompactionState = {
+            context: session.context,
+            archives: session.archives,
+          };
 
-      sessions.markCompactionRunning(sessionId, { sourceHistory: session.history });
-      const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
-      const compacted = await ConversationCompactionService.compact({
-        history: session.history,
-        runtime: {
-          model,
-          stateRoot: args.stateRoot,
-          systemContext: args.systemContext,
-        },
-        session,
-        force,
-        summarizer: {
-          credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(model, {
-            apiKey: args.apiKey,
-            credentialStorePath: args.credentialStorePath,
-            preferApiKey: args.preferApiKey,
-          }),
-        },
-        onStatusChange: publisher.publishActivity,
-      });
-      const updated = sessions.applyCompactionResult(sessionId, compacted);
-      return ControlPlaneChatSessionPresenter.projectDetail(updated)[0] as ChatSessionDetail;
-    } catch (error) {
-      if (previousCompactionState) {
-        sessions.restoreCompactionState(sessionId, previousCompactionState);
-      }
-      throw error;
-    } finally {
-      if (leaseAcquired) {
-        sessions.releaseLease(sessionId, leaseOwner);
-      }
-      this.inFlightRuns.delete(sessionKey);
-    }
+          sessions.markCompactionRunning(sessionId, { sourceHistory: session.history });
+          const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
+          const compacted = await ConversationCompactionService.compact({
+            history: session.history,
+            runtime: {
+              model,
+              stateRoot: args.stateRoot,
+              systemContext: args.systemContext,
+            },
+            session,
+            force,
+            summarizer: {
+              credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(model, {
+                apiKey: args.apiKey,
+                credentialStorePath: args.credentialStorePath,
+                preferApiKey: args.preferApiKey,
+              }),
+            },
+            onStatusChange: publisher.publishActivity,
+          });
+          const updated = sessions.applyCompactionResult(sessionId, compacted);
+          return ControlPlaneChatSessionPresenter.projectDetail(updated)[0] as ChatSessionDetail;
+        } catch (error) {
+          if (previousCompactionState) {
+            sessions.restoreCompactionState(sessionId, previousCompactionState);
+          }
+          throw error;
+        } finally {
+          if (leaseAcquired) {
+            sessions.releaseLease(sessionId, leaseOwner);
+          }
+        }
+      },
+    });
   }
 
   readRunState(sessionAddress: ControlPlaneSessionAddress) {
@@ -245,52 +240,15 @@ export class ControlPlaneChatSessionsController {
   }
 
   async submitPrompt(args: SubmitChatPromptArgs) {
-    if (process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1') {
-      return await this.runFakeBrowserIntegrationSessionPrompt(args);
-    }
+    return await this.runService.startAndWait(this.buildSubmitPromptRun(args));
+  }
 
-    const result = await this.runEngineTurn(args, async ({ engine, host, abortSignal, shouldStop }) => {
-      return await engine.turns.submit({
-        sessionId: args.sessionId,
-        prompt: args.prompt,
-        maxSteps: args.maxSteps,
-        searchIgnoreDirs: args.searchIgnoreDirs,
-        includePlanTool: args.includePlanTool,
-        host,
-        abortSignal,
-        shouldStop,
-        leaseOwner: args.leaseOwner,
-      });
-    });
-    this.scheduleAutoRenameAfterFirstUserMessage(args, {
-      responseText: result.summary,
-      sessionModel: result.session?.model,
-    });
-    return result;
+  submitPromptAsync(args: SubmitChatPromptArgs): ControlPlaneAcceptedSessionRun {
+    return this.runService.start(this.buildSubmitPromptRun(args));
   }
 
   async continuePrompt(args: ContinueChatPromptArgs) {
-    if (process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1') {
-      const session = this.createEngine(args).sessions.require(args.sessionId);
-      if (!session.history.length || !session.lastContinuePrompt) {
-        throw new Error('There is no interrupted or prior run to continue yet.');
-      }
-
-      return await this.runFakeBrowserIntegrationSessionPrompt({
-        ...args,
-        prompt: session.lastContinuePrompt,
-      });
-    }
-
-    return await this.runEngineTurn(args, async ({ engine, host, abortSignal, shouldStop }) => {
-      return await engine.turns.continue({
-        sessionId: args.sessionId,
-        host,
-        abortSignal,
-        shouldStop,
-        leaseOwner: args.leaseOwner,
-      });
-    });
+    return await this.runService.startAndWait(this.buildContinuePromptRun(args));
   }
 
   subscribeToEvents(
@@ -381,47 +339,22 @@ export class ControlPlaneChatSessionsController {
   }
 
   getPendingApproval(sessionAddress: ControlPlaneSessionAddress): ToolApprovalRequest | undefined {
-    return this.pendingApprovals.get(ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress))?.approval;
+    return this.runService.getPendingApproval(sessionAddress);
   }
 
   isRunning(sessionAddress: ControlPlaneSessionAddress): boolean {
-    return this.inFlightRuns.has(ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress));
+    return this.runService.isRunning(sessionAddress);
   }
 
   cancelRun(sessionAddress: ControlPlaneSessionAddress): boolean {
-    const key = ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress);
-    const run = this.inFlightRuns.get(key);
-    if (!run) {
-      return false;
-    }
-
-    run.controller.abort();
-    const pending = this.pendingApprovals.get(key);
-    if (pending) {
-      this.pendingApprovals.delete(key);
-      pending.resolve({
-        type: 'deny',
-        reason: 'Cancelled by user',
-      });
-    }
-    return true;
+    return this.runService.cancelRun(sessionAddress);
   }
 
   resolvePendingApproval(
     sessionAddress: ControlPlaneSessionAddress,
     decision: ToolApprovalUserDecision,
   ): boolean {
-    const key = ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress);
-    const pending = this.pendingApprovals.get(key);
-    if (!pending) {
-      return false;
-    }
-
-    this.pendingApprovals.delete(key);
-    // This resolves the promise created by ToolApprovalService.requestHumanApproval.
-    // The paused agent turn resumes immediately after this call returns.
-    pending.resolve(decision);
-    return true;
+    return this.runService.resolvePendingApproval(sessionAddress, decision);
   }
 
   readViews(args: ControlPlaneSessionReadArgs): ChatSessionView[] {
@@ -449,8 +382,75 @@ export class ControlPlaneChatSessionsController {
     return join(stateRoot, 'chat-sessions', `${sessionId}.json`);
   }
 
+  private buildSubmitPromptRun(args: SubmitChatPromptArgs) {
+    return {
+      address: args,
+      onAccepted: (run: ControlPlaneSessionRunContext) => {
+        this.createEngine(args).sessions.acceptUserMessage(args.sessionId, {
+          runId: run.runId,
+          prompt: args.prompt,
+          leaseOwner: args.leaseOwner,
+        });
+      },
+      execute: async (run: ControlPlaneSessionRunContext) => {
+        const result = process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1'
+          ? await this.runFakeBrowserIntegrationSessionPrompt(args)
+          : await this.runEngineTurn(args, run, async ({ engine, host, abortSignal, shouldStop }) => {
+            return await engine.turns.submit({
+              ...args,
+              host,
+              abortSignal,
+              shouldStop,
+            });
+          });
+
+        this.scheduleAutoRenameAfterFirstUserMessage(args, {
+          responseText: result.summary,
+          sessionModel: result.session?.model,
+        });
+        return result;
+      },
+      onError: (error: unknown, run: ControlPlaneSessionRunContext) => {
+        this.persistRunFailureMessage(args, run, error);
+      },
+    };
+  }
+
+  private buildContinuePromptRun(args: ContinueChatPromptArgs) {
+    return {
+      address: args,
+      execute: async (run: ControlPlaneSessionRunContext) => {
+        if (process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1') {
+          const session = this.createEngine(args).sessions.require(args.sessionId);
+          if (!session.history.length || !session.lastContinuePrompt) {
+            throw new Error('There is no interrupted or prior run to continue yet.');
+          }
+
+          return await this.runFakeBrowserIntegrationSessionPrompt({
+            ...args,
+            prompt: session.lastContinuePrompt,
+          });
+        }
+
+        return await this.runEngineTurn(args, run, async ({ engine, host, abortSignal, shouldStop }) => {
+          return await engine.turns.continue({
+            sessionId: args.sessionId,
+            host,
+            abortSignal,
+            shouldStop,
+            leaseOwner: args.leaseOwner,
+          });
+        });
+      },
+      onError: (error: unknown, run: ControlPlaneSessionRunContext) => {
+        this.persistRunFailureMessage(args, run, error);
+      },
+    };
+  }
+
   private async runEngineTurn(
     args: ContinueChatPromptArgs,
+    runContext: ControlPlaneSessionRunContext,
     run: (input: {
       engine: ConversationEngine;
       host: ConversationEngineHost;
@@ -458,34 +458,38 @@ export class ControlPlaneChatSessionsController {
       shouldStop: () => boolean;
     }) => ReturnType<ConversationEngine['turns']['submit']>,
   ) {
-    const sessionKey = ControlPlaneChatSessionsController.sessionAddressKey(args);
-    if (this.inFlightRuns.has(sessionKey)) {
-      throw new Error('A run is already in progress for this session.');
-    }
-
-    const controller = new AbortController();
-    this.inFlightRuns.set(sessionKey, { controller });
     const publisher = ControlPlaneChatSessionEventsController.createSessionEventPublisher({
       eventBus: this.sessionEventBus,
       workspaceId: args.workspaceId,
       sessionId: args.sessionId,
     });
 
-    try {
-      const result = await run({
-        engine: this.createEngine(args),
-        host: this.createEngineHost(args, publisher),
-        abortSignal: controller.signal,
-        shouldStop: () => controller.signal.aborted,
-      });
-      return {
-        ...result,
-        session: ControlPlaneChatSessionPresenter.projectDetail(result.session)[0] ?? null,
-      };
-    } finally {
-      this.pendingApprovals.delete(sessionKey);
-      this.inFlightRuns.delete(sessionKey);
-    }
+    const result = await run({
+      engine: this.createEngine(args),
+      host: this.createEngineHost(args, publisher),
+      abortSignal: runContext.controller.signal,
+      shouldStop: () => runContext.controller.signal.aborted,
+    });
+    return {
+      ...result,
+      session: ControlPlaneChatSessionPresenter.projectDetail(result.session)[0] ?? null,
+    };
+  }
+
+  private persistRunFailureMessage(
+    args: ContinueChatPromptArgs,
+    run: ControlPlaneSessionRunContext,
+    error: unknown,
+  ): void {
+    const message = error instanceof Error ? error.message : String(error);
+    this.createEngine(args).sessions.markAcceptedUserMessageFailed(args.sessionId, {
+      runId: run.runId,
+      failureMessage: {
+        id: `accepted-run-error-${run.runId}`,
+        role: 'assistant',
+        text: `Run failed before a final answer: ${message}`,
+      },
+    });
   }
 
   private scheduleAutoRenameAfterFirstUserMessage(
@@ -552,7 +556,6 @@ export class ControlPlaneChatSessionsController {
   }
 
   private createEngineHost(args: ControlPlaneSessionReadArgs & ControlPlaneSessionAddress, publisher: ControlPlaneTurnPublisher): ConversationEngineHost {
-    const sessionKey = ControlPlaneChatSessionsController.sessionAddressKey(args);
     const approvalService = this.createApprovalService(args);
 
     return {
@@ -568,13 +571,13 @@ export class ControlPlaneChatSessionsController {
             storePending: ({ request, resolve }) => {
               // Keep the resolver in memory while the browser renders the
               // request. sessionResolveApproval later calls this resolver.
-              this.pendingApprovals.set(sessionKey, {
+              this.runService.storePendingApproval(args, {
                 approval: request,
                 resolve,
               });
             },
           });
-          this.pendingApprovals.delete(sessionKey);
+          this.runService.clearPendingApproval(args);
           return decision;
         },
       },

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import type { z } from 'zod';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import { BUILT_IN_MODEL_GROUPS, ModelPolicyService } from '@/core/llm/models/index.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
@@ -16,7 +17,7 @@ import { ControlPlaneWorkspaceFilesController } from '@/server/controllers/trpc/
 import { ControlPlaneWorkspaceDiffController } from '@/server/controllers/trpc/control-plane/workspace-diff.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
-import { controlPlaneWorkspaceProcedure } from './control-plane-workspace.js';
+import { controlPlaneWorkspaceProcedure, type ControlPlaneWorkspaceContext } from './control-plane-workspace.js';
 import {
   agentAskInputSchema,
   createSessionInputSchema,
@@ -207,21 +208,10 @@ export const controlPlaneRouter = router({
     };
   }),
   sessionSendPrompt: controlPlaneWorkspaceProcedure.input(sessionMessageInputSchema).mutation(async ({ ctx, input }) => {
-    const { logger, sessionEngineArgs } = ctx.requestWorkspace;
-    return await controlPlaneChatSessionsController.submitPrompt({
-      ...sessionEngineArgs,
-      sessionId: input.sessionId,
-      prompt: input.prompt,
-      maxSteps: input.maxSteps,
-      searchIgnoreDirs: input.searchIgnoreDirs,
-      includePlanTool: input.includePlanTool,
-      apiKey: input.apiKey,
-      preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
-      logger,
-      systemContext: input.systemContext,
-      memoryMaintenanceMode: input.memoryMaintenanceMode,
-      leaseOwner: resolveControlPlaneLeaseOwner(ctx),
-    });
+    return await controlPlaneChatSessionsController.submitPrompt(buildSubmitPromptArgs(ctx, input));
+  }),
+  sessionSendPromptAsync: controlPlaneWorkspaceProcedure.input(sessionMessageInputSchema).mutation(({ ctx, input }) => {
+    return controlPlaneChatSessionsController.submitPromptAsync(buildSubmitPromptArgs(ctx, input));
   }),
   sessionContinue: controlPlaneWorkspaceProcedure.input(sessionInputSchema).mutation(async ({ ctx, input }) => {
     const { sessionEngineArgs } = ctx.requestWorkspace;
@@ -472,6 +462,19 @@ export const controlPlaneRouter = router({
     return await ControlPlaneLayoutSnapshotsController.save(workspace.stateRoot, input.snapshot);
   }),
 });
+
+type SessionMessageInput = z.infer<typeof sessionMessageInputSchema>;
+
+function buildSubmitPromptArgs(ctx: ControlPlaneWorkspaceContext, input: SessionMessageInput) {
+  const { logger, sessionEngineArgs } = ctx.requestWorkspace;
+  return {
+    ...input,
+    ...sessionEngineArgs,
+    preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
+    logger,
+    leaseOwner: resolveControlPlaneLeaseOwner(ctx),
+  };
+}
 
 function resolveControlPlaneLeaseOwner(ctx: Pick<HeddleServerContext, 'runtimeHost'>): ChatSessionLeaseOwner {
   return {

--- a/src/server/services/control-plane/README.md
+++ b/src/server/services/control-plane/README.md
@@ -1,0 +1,17 @@
+# Control-plane services
+
+This folder contains server-side services for daemon/control-plane application
+behavior that is not core domain semantics and not UI rendering.
+
+Use this folder for process-local orchestration around the public API surface:
+long-running run coordination, upload handling, transport-facing recovery, and
+other server responsibilities that sit between tRPC/REST routes and core
+services.
+
+Do not put client-specific behavior here. Web, mobile, and terminal clients
+should all see the same API behavior.
+
+Do not put core chat/session meaning here. For example, whether a conversation
+line is durable, pending, compacted, or model-facing belongs in
+`src/core/chat/engine`, while this folder can coordinate when that core behavior
+is invoked for a control-plane request.

--- a/src/server/services/control-plane/session-run-service.ts
+++ b/src/server/services/control-plane/session-run-service.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  ToolApprovalRequest,
+  ToolApprovalUserDecision,
+} from '@/core/approvals/index.js';
+import type { ControlPlaneAcceptedSessionRun } from '@/server/control-plane-types.js';
+
+export type ControlPlaneSessionRunAddress = {
+  workspaceId: string;
+  sessionId: string;
+};
+
+export type PendingControlPlaneApproval = {
+  approval: ToolApprovalRequest;
+  resolve: (decision: ToolApprovalUserDecision) => void;
+};
+
+export type ControlPlaneSessionRunContext = {
+  runId: string;
+  acceptedAt: string;
+  controller: AbortController;
+};
+
+type StartControlPlaneSessionRunInput<Result> = {
+  address: ControlPlaneSessionRunAddress;
+  onAccepted?: (run: ControlPlaneSessionRunContext) => void;
+  execute: (run: ControlPlaneSessionRunContext) => Promise<Result>;
+  onError?: (error: unknown, run: ControlPlaneSessionRunContext) => void | Promise<void>;
+};
+
+type InFlightControlPlaneRun<Result = unknown> = ControlPlaneSessionRunContext & {
+  result: Promise<Result>;
+};
+
+/**
+ * Owns control-plane run coordination for session-scoped long-running work.
+ *
+ * Core chat services own persisted conversation semantics. This service owns
+ * process-local runtime coordination: in-flight runs, abort controllers,
+ * approval resolvers, and the async-start vs wait-for-result split.
+ */
+export class ControlPlaneSessionRunService {
+  private readonly pendingApprovals = new Map<string, PendingControlPlaneApproval>();
+  private readonly inFlightRuns = new Map<string, InFlightControlPlaneRun>();
+
+  start<Result>(input: StartControlPlaneSessionRunInput<Result>): ControlPlaneAcceptedSessionRun {
+    const key = ControlPlaneSessionRunService.addressKey(input.address);
+    if (this.inFlightRuns.has(key)) {
+      throw new Error('A run is already in progress for this session.');
+    }
+
+    const run: Omit<InFlightControlPlaneRun<Result>, 'result'> = {
+      runId: `session-run-${randomUUID()}`,
+      acceptedAt: new Date().toISOString(),
+      controller: new AbortController(),
+    };
+
+    let accepted = false;
+    let acceptanceError: unknown;
+
+    const result = Promise.resolve()
+      .then(() => {
+        if (!accepted) {
+          throw acceptanceError ?? new Error(`Accepted run never started: ${run.runId}`);
+        }
+
+        return input.execute(run);
+      })
+      .catch(async (error: unknown) => {
+        if (accepted) {
+          await input.onError?.(error, run);
+        }
+        throw error;
+      })
+      .finally(() => {
+        this.pendingApprovals.delete(key);
+        this.inFlightRuns.delete(key);
+      });
+
+    this.inFlightRuns.set(key, { ...run, result });
+    result.catch(() => undefined);
+
+    try {
+      input.onAccepted?.(run);
+      accepted = true;
+    } catch (error) {
+      acceptanceError = error;
+      this.pendingApprovals.delete(key);
+      this.inFlightRuns.delete(key);
+      throw error;
+    }
+
+    return {
+      accepted: true,
+      workspaceId: input.address.workspaceId,
+      sessionId: input.address.sessionId,
+      runId: run.runId,
+      acceptedAt: run.acceptedAt,
+    };
+  }
+
+  async startAndWait<Result>(input: StartControlPlaneSessionRunInput<Result>): Promise<Result> {
+    const accepted = this.start(input);
+    return await this.requireRun<Result>(input.address, accepted.runId).result;
+  }
+
+  isRunning(address: ControlPlaneSessionRunAddress): boolean {
+    return this.inFlightRuns.has(ControlPlaneSessionRunService.addressKey(address));
+  }
+
+  cancelRun(address: ControlPlaneSessionRunAddress): boolean {
+    const key = ControlPlaneSessionRunService.addressKey(address);
+    const run = this.inFlightRuns.get(key);
+    if (!run) {
+      return false;
+    }
+
+    run.controller.abort();
+    const pending = this.pendingApprovals.get(key);
+    if (pending) {
+      this.pendingApprovals.delete(key);
+      pending.resolve({
+        type: 'deny',
+        reason: 'Cancelled by user',
+      });
+    }
+    return true;
+  }
+
+  getPendingApproval(address: ControlPlaneSessionRunAddress): ToolApprovalRequest | undefined {
+    return this.pendingApprovals.get(ControlPlaneSessionRunService.addressKey(address))?.approval;
+  }
+
+  storePendingApproval(address: ControlPlaneSessionRunAddress, pending: PendingControlPlaneApproval): void {
+    this.pendingApprovals.set(ControlPlaneSessionRunService.addressKey(address), pending);
+  }
+
+  clearPendingApproval(address: ControlPlaneSessionRunAddress): void {
+    this.pendingApprovals.delete(ControlPlaneSessionRunService.addressKey(address));
+  }
+
+  resolvePendingApproval(
+    address: ControlPlaneSessionRunAddress,
+    decision: ToolApprovalUserDecision,
+  ): boolean {
+    const key = ControlPlaneSessionRunService.addressKey(address);
+    const pending = this.pendingApprovals.get(key);
+    if (!pending) {
+      return false;
+    }
+
+    this.pendingApprovals.delete(key);
+    pending.resolve(decision);
+    return true;
+  }
+
+  private requireRun<Result>(address: ControlPlaneSessionRunAddress, runId: string): InFlightControlPlaneRun<Result> {
+    const run = this.inFlightRuns.get(ControlPlaneSessionRunService.addressKey(address));
+    if (!run || run.runId !== runId) {
+      throw new Error(`Accepted run is no longer active: ${runId}`);
+    }
+
+    return run as InFlightControlPlaneRun<Result>;
+  }
+
+  private static addressKey(address: ControlPlaneSessionRunAddress): string {
+    return `${address.workspaceId}:${address.sessionId}`;
+  }
+}

--- a/src/web-v2/components/conversation/ConversationComposer.tsx
+++ b/src/web-v2/components/conversation/ConversationComposer.tsx
@@ -78,7 +78,8 @@ export function ConversationComposer({
     uploadImages,
   } = useComposerImageAttachments({ workspaceId, sessionId });
   const turnActive = Boolean(submitting || running || cancelling);
-  const controlsDisabled = disabled || turnActive;
+  const inputDisabled = Boolean(disabled || submitting || cancelling);
+  const controlsDisabled = Boolean(disabled || submitting || cancelling);
   const sendDisabled = disabled
     || turnActive
     || imageUploading
@@ -102,16 +103,16 @@ export function ConversationComposer({
       return;
     }
 
+    await onSubmitPrompt(prompt);
     setDraft('');
     clearUploadedAttachments();
-    await onSubmitPrompt(prompt);
   }, [clearUploadedAttachments, draft, onSubmitPrompt, sendDisabled, uploadedImagePaths]);
   const fileMentions = useFileMentionAutocomplete({
     workspaceId,
     value: draft,
     onValueChange: setDraft,
     textareaRef,
-    disabled: controlsDisabled,
+    disabled: inputDisabled,
     onSubmit: handleSubmit,
   });
   useComposerTextareaAutosize(textareaRef, draft);
@@ -134,7 +135,7 @@ export function ConversationComposer({
         aria-controls={fileMentions.textareaProps['aria-controls']}
         aria-expanded={fileMentions.textareaProps['aria-expanded']}
         className="v2-composer-textarea"
-        disabled={controlsDisabled}
+        disabled={inputDisabled}
         autoCapitalize="sentences"
         autoComplete="off"
         autoCorrect="on"

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
@@ -68,7 +68,6 @@ export function useControlPlaneSessionDetail({
     workspaceId,
     sessionId,
     streamConnected: events.streamConnected,
-    setSession: loader.setSession,
     setRunning: runControl.setRunning,
     setError: loader.setError,
     setLiveStatus,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionLoader.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionLoader.ts
@@ -23,7 +23,7 @@ type UseControlPlaneSessionLoaderArgs = {
 };
 
 // Loads persisted session detail through React Query and preserves browser-only
-// transient messages during silent refreshes.
+// assistant stream messages during silent refreshes.
 export function useControlPlaneSessionLoader({
   workspaceId,
   sessionId,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
@@ -1,12 +1,10 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
-import { trpcReact, type ControlPlaneSessionDetail } from '@web/api/client';
-import { ClientSharedSessionMessageService } from '@/client-shared/services/session-messages';
+import { trpcReact } from '@web/api/client';
 
 type UseControlPlaneSessionPromptSubmitArgs = {
   workspaceId?: string;
   sessionId?: string;
   streamConnected: boolean;
-  setSession: Dispatch<SetStateAction<ControlPlaneSessionDetail>>;
   setRunning: Dispatch<SetStateAction<boolean>>;
   setError: Dispatch<SetStateAction<string | undefined>>;
   setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
@@ -28,7 +26,6 @@ export function useControlPlaneSessionPromptSubmit({
   workspaceId,
   sessionId,
   streamConnected,
-  setSession,
   setRunning,
   setError,
   setLiveStatus,
@@ -37,7 +34,7 @@ export function useControlPlaneSessionPromptSubmit({
   const activeSubmissionRef = useRef<PromptSubmission | null>(null);
   const submissionSequenceRef = useRef(0);
   const utils = trpcReact.useUtils();
-  const sessionSendPromptMutation = trpcReact.controlPlane.sessionSendPrompt.useMutation();
+  const sessionSendPromptMutation = trpcReact.controlPlane.sessionSendPromptAsync.useMutation();
 
   useEffect(() => {
     activeSubmissionRef.current = null;
@@ -72,22 +69,12 @@ export function useControlPlaneSessionPromptSubmit({
     setRunning(true);
     setError(undefined);
     setLiveStatus(streamConnected ? 'Heddle is working...' : 'Heddle is working... reconnecting live stream if needed.');
-    utils.controlPlane.session.setData(
-      { id: sessionId, workspaceId },
-      (current) => ClientSharedSessionMessageService.appendOptimisticUserTurn(current ?? null, trimmed),
-    );
-    setSession((current) => ClientSharedSessionMessageService.appendOptimisticUserTurn(current, trimmed));
 
     try {
-      const result = await sessionSendPromptMutation.mutateAsync({ workspaceId, sessionId, prompt: trimmed });
-      utils.controlPlane.session.setData(
-        { id: submission.sessionId, workspaceId: submission.workspaceId },
-        result.session,
-      );
+      await sessionSendPromptMutation.mutateAsync({ workspaceId, sessionId, prompt: trimmed });
       if (isCurrentSubmission()) {
-        setSession(result.session);
-        setRunning(false);
-        setLiveStatus(undefined);
+        setRunning(true);
+        setLiveStatus(streamConnected ? 'Heddle is working...' : 'Heddle is working... reconnecting live stream if needed.');
       }
     } catch (submitError) {
       if (isCurrentSubmission()) {
@@ -99,7 +86,7 @@ export function useControlPlaneSessionPromptSubmit({
       void Promise.all([
         utils.controlPlane.sessions.invalidate({ workspaceId: submission.workspaceId }),
         utils.controlPlane.session.invalidate({ id: submission.sessionId, workspaceId: submission.workspaceId }),
-        utils.controlPlane.sessionRunning.invalidate({ id: submission.sessionId, workspaceId: submission.workspaceId }),
+        utils.controlPlane.sessionRunState.invalidate({ id: submission.sessionId, workspaceId: submission.workspaceId }),
       ]).catch(() => undefined);
 
       if (isCurrentSubmission()) {
@@ -113,12 +100,11 @@ export function useControlPlaneSessionPromptSubmit({
     setError,
     setLiveStatus,
     setRunning,
-    setSession,
     streamConnected,
     submitting,
     sessionSendPromptMutation,
     utils.controlPlane.session,
-    utils.controlPlane.sessionRunning,
+    utils.controlPlane.sessionRunState,
     utils.controlPlane.sessions,
   ]);
 

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
@@ -74,7 +74,9 @@ export function useControlPlaneSessionPromptSubmit({
       await sessionSendPromptMutation.mutateAsync({ workspaceId, sessionId, prompt: trimmed });
       if (isCurrentSubmission()) {
         setRunning(true);
-        setLiveStatus(streamConnected ? 'Heddle is working...' : 'Heddle is working... reconnecting live stream if needed.');
+        setLiveStatus((current) => (
+          current ?? (streamConnected ? 'Heddle is working...' : 'Heddle is working... reconnecting live stream if needed.')
+        ));
       }
     } catch (submitError) {
       if (isCurrentSubmission()) {

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionRunControl.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionRunControl.ts
@@ -30,7 +30,8 @@ export function useControlPlaneSessionRunControl({
   const [cancelling, setCancelling] = useState(false);
   const [cancelError, setCancelError] = useState<string | undefined>();
   const serverConfirmedRunningRef = useRef(false);
-  const sessionRunningQuery = trpcReact.controlPlane.sessionRunning.useQuery(
+  const runStateBaselineUpdatedAtRef = useRef(0);
+  const sessionRunStateQuery = trpcReact.controlPlane.sessionRunState.useQuery(
     sessionId && workspaceId ? { id: sessionId, workspaceId } : skipToken,
     {
       enabled: Boolean(sessionId && workspaceId),
@@ -45,34 +46,56 @@ export function useControlPlaneSessionRunControl({
     setCancelling(false);
     setCancelError(undefined);
     serverConfirmedRunningRef.current = false;
+    runStateBaselineUpdatedAtRef.current = 0;
   }, [sessionId, workspaceId]);
 
   useEffect(() => {
-    const serverRunning = sessionRunningQuery.data?.running;
+    const serverRunning = sessionRunStateQuery.data?.running;
+    const hasFreshRunState = sessionRunStateQuery.dataUpdatedAt > runStateBaselineUpdatedAtRef.current;
     if (serverRunning) {
       serverConfirmedRunningRef.current = true;
       setRunningState(true);
       return;
     }
 
-    if (serverRunning === false && (running || cancelling || serverConfirmedRunningRef.current)) {
+    if (serverRunning === false && (cancelling || serverConfirmedRunningRef.current || (running && hasFreshRunState))) {
       serverConfirmedRunningRef.current = false;
       setRunningState(false);
       setCancelling(false);
       setLiveStatus(undefined);
+      if (sessionId && workspaceId) {
+        void Promise.all([
+          utils.controlPlane.session.invalidate({ id: sessionId, workspaceId }),
+          utils.controlPlane.sessions.invalidate({ workspaceId }),
+          utils.controlPlane.sessionPendingApproval.invalidate({ id: sessionId, workspaceId }),
+        ]).catch(() => undefined);
+      }
     }
-  }, [cancelling, running, sessionRunningQuery.data?.running, setLiveStatus]);
+  }, [
+    cancelling,
+    running,
+    sessionId,
+    sessionRunStateQuery.data?.running,
+    sessionRunStateQuery.dataUpdatedAt,
+    setLiveStatus,
+    utils,
+    workspaceId,
+  ]);
 
   const setRunning = useCallback<Dispatch<SetStateAction<boolean>>>((nextRunning) => {
-    setRunningState((current) => (
-      typeof nextRunning === 'function' ? nextRunning(current) : nextRunning
-    ));
-    if (nextRunning === false) {
-      serverConfirmedRunningRef.current = false;
-    }
+    setRunningState((current) => {
+      const resolved = typeof nextRunning === 'function' ? nextRunning(current) : nextRunning;
+      if (resolved) {
+        runStateBaselineUpdatedAtRef.current = sessionRunStateQuery.dataUpdatedAt;
+      } else {
+        serverConfirmedRunningRef.current = false;
+      }
+
+      return resolved;
+    });
     setCancelling(false);
     setCancelError(undefined);
-  }, []);
+  }, [sessionRunStateQuery.dataUpdatedAt]);
 
   const cancelRun = useCallback(async () => {
     if (!sessionId || !workspaceId || cancelMutation.isPending) {
@@ -86,7 +109,7 @@ export function useControlPlaneSessionRunControl({
     try {
       const result = await cancelMutation.mutateAsync({ id: sessionId, workspaceId });
       await utils.controlPlane.sessionPendingApproval.invalidate({ id: sessionId, workspaceId });
-      await utils.controlPlane.sessionRunning.invalidate({ id: sessionId, workspaceId });
+      await utils.controlPlane.sessionRunState.invalidate({ id: sessionId, workspaceId });
       if (!result.cancelled) {
         setRunningState(false);
         setCancelling(false);


### PR DESCRIPTION
## Summary
- add sessionSendPromptAsync for interactive clients so submit acknowledgement is separate from long-running agent work
- persist accepted user prompts through core session ownership before streaming activity starts
- update web-v2 and cli-v2 to consume async runs, keep typing available during active runs, and rely on shared API state instead of local optimistic user messages

## Validation
- yarn -s vitest run src/__tests__/integration/control-plane/session-lifecycle.test.ts src/__tests__/unit/core/chat-turn-runtime.test.ts src/__tests__/unit/core/chat-turn-persistence.test.ts src/__tests__/unit/control-plane/session-cancel.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/unit/control-plane/session-message-service.test.ts
- yarn -s typecheck
- yarn -s build