### PR TITLE
Fix session activity status and stale daemon leases

### DIFF
--- a/src/__tests__/unit/chat/chat-session-lease.test.ts
+++ b/src/__tests__/unit/chat/chat-session-lease.test.ts
@@ -92,6 +92,26 @@ describe('chat session leases', () => {
     })).toBeUndefined();
   });
 
+  it('recognizes restarted daemon leases as dead local process leases', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), {
+      ownerKind: 'daemon',
+      ownerId: 'daemon-4686-1779894401584',
+      clientLabel: 'control plane',
+    }, {
+      now: Date.parse('2026-04-21T01:00:00.000Z'),
+    });
+
+    expect(ChatSessionLeases.isOwnedByDeadLocalProcess(leased.lease, { isProcessAlive: () => false })).toBe(true);
+    expect(ChatSessionLeases.conflict(leased, {
+      ownerKind: 'daemon',
+      ownerId: 'daemon-9999-1779894500000',
+      clientLabel: 'control plane',
+    }, {
+      now: Date.parse('2026-04-21T01:01:00.000Z'),
+      isProcessAlive: () => false,
+    })).toBeUndefined();
+  });
+
   it('still reports fresh local process leases when the owner is alive', () => {
     const leased = ChatSessionLeases.acquire(createSession(), {
       ownerKind: 'tui',

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -319,7 +319,7 @@ describe('ControlPlaneSessionStore', () => {
         isStreaming: false,
         isPending: false,
       });
-      expect(store.getSnapshot().liveStatus).toBeUndefined();
+      expect(store.getSnapshot().liveStatus).toBe('Receiving assistant response...');
       store.dispose();
     } finally {
       vi.useRealTimers();

--- a/src/__tests__/unit/client-shared/session-activity-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-activity-service.test.ts
@@ -52,11 +52,11 @@ describe('ClientSharedSessionActivityService', () => {
       summary: 'Done.',
       timestamp: new Date().toISOString(),
     } as ControlPlaneSessionActivity, {
-      onRunFinished: () => effects.push('finished'),
+      onRunFinished: (_activity, liveStatus) => effects.push(`finished:${liveStatus}`),
       onWorkspaceChanged: () => effects.push('workspace changed'),
     });
 
-    expect(effects).toEqual(['finished', 'workspace changed']);
+    expect(effects).toEqual(['finished:Run finished: done', 'workspace changed']);
   });
 
   it('uses derived tool labels when the API provides them', () => {

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -417,11 +417,11 @@ export class ControlPlaneSessionStore {
             latestUpdate: SessionActivityService.resolveLatestUpdate(runActivity),
           });
         },
-        onRunFinished: (runActivity) => {
+        onRunFinished: (runActivity, liveStatus) => {
           this.assistantStreamBuffer.flush();
           this.setSnapshot({
             running: false,
-            liveStatus: undefined,
+            ...(liveStatus !== undefined ? { liveStatus } : {}),
             latestUpdate: SessionActivityService.resolveLatestUpdate(runActivity),
           });
           void this.refreshSession(event.sessionId, { silent: true });
@@ -452,7 +452,7 @@ export class ControlPlaneSessionStore {
         update.text,
         update.done,
       ),
-      liveStatus: update.done ? undefined : 'Receiving assistant response...',
+      ...(!update.done ? { liveStatus: 'Receiving assistant response...' } : {}),
     }));
   }
 

--- a/src/client-shared/services/session-activities/session-activity-service.ts
+++ b/src/client-shared/services/session-activities/session-activity-service.ts
@@ -23,7 +23,7 @@ type SessionActivityEffectHandlers = {
 export type ClientSharedSessionActivityEffects = {
   onAssistantStream?: (activity: ActivityOf<'assistant.stream'>, liveStatus: string | undefined) => void;
   onRunStarted?: (activity: ActivityOf<'loop.started'>, liveStatus: string | undefined) => void;
-  onRunFinished?: (activity: ActivityOf<'loop.finished'>) => void;
+  onRunFinished?: (activity: ActivityOf<'loop.finished'>, liveStatus: string | undefined) => void;
   onLiveStatus?: (activity: ClientSharedSessionActivity, liveStatus: string | undefined) => void;
   onPendingApprovalChanged?: (activity: PendingApprovalActivity) => void;
   onWorkspaceChanged?: (activity: WorkspaceChangedActivity) => void;
@@ -41,7 +41,7 @@ export class ClientSharedSessionActivityService {
       effects.onRunStarted?.(activity, ClientSharedSessionActivityService.formatLiveStatus(activity));
     },
     'loop.finished': (activity, effects) => {
-      effects.onRunFinished?.(activity);
+      effects.onRunFinished?.(activity, ClientSharedSessionActivityService.formatLiveStatus(activity));
       effects.onWorkspaceChanged?.(activity);
     },
     'tool.calling': (activity, effects) => {
@@ -72,6 +72,7 @@ export class ClientSharedSessionActivityService {
 
   private static readonly liveStatusHandlers: SessionActivityStatusHandlers = {
     'loop.started': () => 'Run started...',
+    'loop.finished': (activity) => `Run finished: ${activity.outcome}`,
     'tool.calling': (activity) => `Working... running ${ClientSharedSessionActivityService.formatToolLabel(activity)}${ClientSharedSessionActivityService.formatStep(activity.step)}`,
     'tool.completed': (activity) => `${activity.tool} finished in ${Math.round(activity.durationMs)}ms`,
     'tool.approval_requested': (activity) => `Approval requested for ${ClientSharedSessionActivityService.formatToolLabel(activity)}`,

--- a/src/core/chat/engine/sessions/leases/leases.ts
+++ b/src/core/chat/engine/sessions/leases/leases.ts
@@ -9,7 +9,7 @@ import type { ChatSession, ChatSessionLease } from '@/core/chat/types.js';
 import type { ChatSessionLeaseConflictOptions, ChatSessionLeaseOwner } from './types.js';
 
 const DEFAULT_SESSION_LEASE_STALE_AFTER_MS = 15 * 60 * 1000;
-const LOCAL_PROCESS_LEASE_OWNER_PATTERN = /^(?:tui|ask|submit|daemon)-(\d+)$/;
+const LOCAL_PROCESS_LEASE_OWNER_PATTERN = /^(?:tui|ask|submit|daemon)-(\d+)(?:-\d+)?$/;
 
 export class ChatSessionLeases {
   static isFresh(

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
@@ -159,19 +159,25 @@ function applySessionActivity(activity: ControlPlaneSessionActivity, context: Se
           streamActivity.done,
         )
       ));
-      context.setLiveStatus(liveStatus);
+      if (liveStatus !== undefined) {
+        context.setLiveStatus(liveStatus);
+      }
     },
     onRunStarted: (_runActivity, liveStatus) => {
       context.setRunning(true);
       context.setLiveStatus(liveStatus);
     },
-    onRunFinished: () => {
+    onRunFinished: (_runActivity, liveStatus) => {
       context.setRunning(false);
-      context.setLiveStatus(undefined);
+      if (liveStatus !== undefined) {
+        context.setLiveStatus(liveStatus);
+      }
       void context.refresh(context.sessionId, { silent: true });
     },
     onLiveStatus: (_statusActivity, liveStatus) => {
-      context.setLiveStatus(liveStatus);
+      if (liveStatus !== undefined) {
+        context.setLiveStatus(liveStatus);
+      }
     },
     onPendingApprovalChanged: () => {
       context.refreshPendingApproval(context.sessionId);

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionRunControl.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionRunControl.ts
@@ -31,6 +31,7 @@ export function useControlPlaneSessionRunControl({
   const [cancelError, setCancelError] = useState<string | undefined>();
   const serverConfirmedRunningRef = useRef(false);
   const runStateBaselineUpdatedAtRef = useRef(0);
+  const runStateDataUpdatedAtRef = useRef(0);
   const sessionRunStateQuery = trpcReact.controlPlane.sessionRunState.useQuery(
     sessionId && workspaceId ? { id: sessionId, workspaceId } : skipToken,
     {
@@ -40,6 +41,10 @@ export function useControlPlaneSessionRunControl({
     },
   );
   const cancelMutation = trpcReact.controlPlane.sessionCancel.useMutation();
+
+  useEffect(() => {
+    runStateDataUpdatedAtRef.current = sessionRunStateQuery.dataUpdatedAt;
+  }, [sessionRunStateQuery.dataUpdatedAt]);
 
   useEffect(() => {
     setRunningState(false);
@@ -62,7 +67,6 @@ export function useControlPlaneSessionRunControl({
       serverConfirmedRunningRef.current = false;
       setRunningState(false);
       setCancelling(false);
-      setLiveStatus(undefined);
       if (sessionId && workspaceId) {
         void Promise.all([
           utils.controlPlane.session.invalidate({ id: sessionId, workspaceId }),
@@ -86,7 +90,7 @@ export function useControlPlaneSessionRunControl({
     setRunningState((current) => {
       const resolved = typeof nextRunning === 'function' ? nextRunning(current) : nextRunning;
       if (resolved) {
-        runStateBaselineUpdatedAtRef.current = sessionRunStateQuery.dataUpdatedAt;
+        runStateBaselineUpdatedAtRef.current = runStateDataUpdatedAtRef.current;
       } else {
         serverConfirmedRunningRef.current = false;
       }
@@ -95,7 +99,7 @@ export function useControlPlaneSessionRunControl({
     });
     setCancelling(false);
     setCancelError(undefined);
-  }, [sessionRunStateQuery.dataUpdatedAt]);
+  }, []);
 
   const cancelRun = useCallback(async () => {
     if (!sessionId || !workspaceId || cancelMutation.isPending) {


### PR DESCRIPTION
## Summary
- keep web-v2 and cli-v2 session activity visible instead of clearing on run-state polling or stream completion
- preserve final run activity labels through the shared session activity service
- recognize daemon owner ids with startup timestamps as local process leases so dead/restarted daemon leases do not block the next submit

## Verification
- yarn -s vitest run src/__tests__/unit/chat/chat-session-lease.test.ts src/__tests__/unit/client-shared/session-activity-service.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
- yarn -s typecheck
- yarn -s build