### PR TITLE
[codex] Add cli-v2 model and session pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ The terminal composer supports multiline prompts, prompt undo/redo, prompt histo
 
 More: [Chat and sessions guide](docs/guides/chat-and-sessions.md)
 
+### Terminal UI v2 status
+
+`cli-v2` is actively under development, but it is not released as the default terminal experience yet. The current work is intentionally architectural: the new TUI consumes the same local control-plane API as the browser UI and does not reach directly into core services.
+
+For users, the goal is one behavior model across interfaces. A saved conversation, selected model, reasoning setting, approval state, and live run status should be the same whether you are looking from the terminal, the browser control plane, or another device connected to the same local daemon. Conversation state is inherently synchronized because each interface is a client of the same session/control-plane path rather than a separate runtime.
+
+For contributors, the goal is a cleaner implementation path: TUI-specific rendering and keyboard behavior stay in `cli-v2`, shared semantics stay in core and server-owned control-plane APIs, and future advanced features can build on a maintainable API-first foundation instead of duplicating command/session logic in each interface.
+
 ### Project instructions
 
 Heddle can load a short project instruction file at startup so a fresh session starts with the repository's operating context. By default it loads the first non-empty file found in this order: `HEDDLE.md`, `AGENTS.md`, `CLAUDE.md`.

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ControlPlaneProxyClient } from '../../../client-shared/api/proxy.js';
 import type {
   ControlPlanePendingApproval,
+  ControlPlaneModelOptions,
   ControlPlaneSessionDetail,
   ControlPlaneSessionEventEnvelope,
   ControlPlaneSessionRuntimeContext,
@@ -19,6 +20,7 @@ describe('ControlPlaneSessionStore', () => {
     await store.start();
 
     expect(fixture.calls.stateQuery).toHaveBeenCalledWith(undefined);
+    expect(fixture.calls.modelOptionsQuery).toHaveBeenCalledTimes(1);
     expect(fixture.calls.slashCommandCatalogQuery).toHaveBeenCalledTimes(1);
     expect(fixture.calls.slashCommandCatalogQuery).toHaveBeenCalledWith({ workspaceId: 'workspace-1' });
     expect(fixture.calls.sessionsQuery).toHaveBeenCalledWith({ workspaceId: 'workspace-1' });
@@ -133,6 +135,28 @@ describe('ControlPlaneSessionStore', () => {
 
     expect(store.completeSlashCommandDraft('/sess')).toBe('/session ');
     expect(fixture.calls.slashCommandCatalogQuery).toHaveBeenCalledTimes(1);
+    store.dispose();
+  });
+
+  it('executes picker selections through slash commands', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    await store.selectModelFromPicker('gpt-5.4-mini');
+    await store.selectSessionFromPicker('session-2');
+
+    expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenNthCalledWith(1, {
+      workspaceId: 'workspace-1',
+      sessionId: 'session-1',
+      command: '/model gpt-5.4-mini',
+    });
+    expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenNthCalledWith(2, {
+      workspaceId: 'workspace-1',
+      sessionId: 'session-1',
+      command: '/session switch session-2',
+    });
+    expect(fixture.calls.sessionSendPromptAsyncMutate).not.toHaveBeenCalled();
     store.dispose();
   });
 
@@ -518,6 +542,7 @@ function createClientFixture() {
     sessionRunningQuery: vi.fn(async () => ({ running: false })),
     sessionRunStateQuery: vi.fn(async () => ({ running: false, pendingApproval })),
     sessionRuntimeContextQuery: vi.fn(async () => createRuntimeContext()),
+    modelOptionsQuery: vi.fn(async () => createModelOptions()),
     sessionPendingApprovalQuery: vi.fn(async () => pendingApproval),
     sessionSendPromptMutate: vi.fn(async () => ({
       session: {
@@ -589,6 +614,7 @@ function createClientFixture() {
       sessionRunning: { query: calls.sessionRunningQuery },
       sessionRunState: { query: calls.sessionRunStateQuery },
       sessionRuntimeContext: { query: calls.sessionRuntimeContextQuery },
+      modelOptions: { query: calls.modelOptionsQuery },
       sessionPendingApproval: { query: calls.sessionPendingApprovalQuery },
       sessionSendPrompt: { mutate: calls.sessionSendPromptMutate },
       sessionSendPromptAsync: { mutate: calls.sessionSendPromptAsyncMutate },
@@ -658,6 +684,21 @@ function createRuntimeContext(
     driftEnabled: false,
     running: false,
     ...overrides,
+  };
+}
+
+function createModelOptions(): ControlPlaneModelOptions {
+  return {
+    groups: [
+      {
+        label: 'OpenAI',
+        models: ['gpt-5.4', 'gpt-5.4-mini'],
+        options: [
+          { id: 'gpt-5.4', disabled: false },
+          { id: 'gpt-5.4-mini', disabled: false },
+        ],
+      },
+    ],
   };
 }
 

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -144,6 +144,8 @@ describe('ControlPlaneSessionStore', () => {
     await store.start();
 
     await store.selectModelFromPicker('gpt-5.4-mini');
+    await store.selectReasoningFromPicker('medium');
+    await store.selectReasoningFromPicker('default');
     await store.selectSessionFromPicker('session-2');
 
     expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenNthCalledWith(1, {
@@ -152,6 +154,16 @@ describe('ControlPlaneSessionStore', () => {
       command: '/model gpt-5.4-mini',
     });
     expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenNthCalledWith(2, {
+      workspaceId: 'workspace-1',
+      sessionId: 'session-1',
+      command: '/reasoning medium',
+    });
+    expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenNthCalledWith(3, {
+      workspaceId: 'workspace-1',
+      sessionId: 'session-1',
+      command: '/reasoning default',
+    });
+    expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenNthCalledWith(4, {
       workspaceId: 'workspace-1',
       sessionId: 'session-1',
       command: '/session switch session-2',
@@ -673,6 +685,39 @@ function createRuntimeContext(
     reasoningEffort: 'medium',
     effectiveReasoningEffort: 'medium',
     reasoningSupported: true,
+    reasoningOptions: [
+      {
+        id: 'default',
+        label: 'default',
+        description: 'Use gpt-5.4 default (medium)',
+        disabled: false,
+      },
+      {
+        id: 'low',
+        label: 'low',
+        description: 'Set explicit low effort',
+        disabled: false,
+      },
+      {
+        id: 'medium',
+        label: 'medium',
+        description: 'Set explicit medium effort',
+        disabled: false,
+      },
+      {
+        id: 'high',
+        label: 'high',
+        description: 'Set explicit high effort',
+        disabled: false,
+      },
+      {
+        id: 'ultrahigh',
+        label: 'ultrahigh',
+        description: 'Reserved; not accepted by current OpenAI requests',
+        disabled: true,
+        disabledReason: 'Reserved',
+      },
+    ],
     credentialSource: {
       type: 'oauth',
       provider: 'openai',

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -713,9 +713,9 @@ function createRuntimeContext(
       {
         id: 'ultrahigh',
         label: 'ultrahigh',
-        description: 'Reserved; not accepted by current OpenAI requests',
+        description: 'Set explicit ultrahigh effort',
         disabled: true,
-        disabledReason: 'Reserved',
+        disabledReason: 'Not supported by request path',
       },
     ],
     credentialSource: {

--- a/src/__tests__/unit/cli-v2/picker-service.test.ts
+++ b/src/__tests__/unit/cli-v2/picker-service.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { ControlPlaneModelOptions, ControlPlaneSessionView } from '../../../client-shared/api/types.js';
+import { CliV2PickerService } from '../../../cli-v2/services/pickers/index.js';
+
+describe('CliV2PickerService', () => {
+  it('filters cached model options for the /model set picker', () => {
+    const modelOptions: ControlPlaneModelOptions = {
+      groups: [
+        {
+          label: 'OpenAI',
+          models: ['gpt-5.4', 'gpt-5.4-mini'],
+          options: [
+            { id: 'gpt-5.4', disabled: false },
+            { id: 'gpt-5.4-mini', disabled: false },
+          ],
+        },
+      ],
+    };
+
+    const query = CliV2PickerService.modelQuery('/model set mini');
+
+    expect(query).toBe('mini');
+    expect(CliV2PickerService.filterModels(modelOptions, query)).toEqual([
+      { id: 'gpt-5.4-mini', disabled: false },
+    ]);
+  });
+
+  it('filters cached sessions for the /session choose picker', () => {
+    const sessions: ControlPlaneSessionView[] = [
+      { id: 'session-1', name: 'Planning', messageCount: 0, turnCount: 0 },
+      { id: 'session-2', name: 'Implementation', messageCount: 0, turnCount: 0 },
+    ];
+
+    const query = CliV2PickerService.sessionQuery('/session choose impl');
+
+    expect(query).toBe('impl');
+    expect(CliV2PickerService.filterSessions(sessions, query)).toEqual([
+      { id: 'session-2', name: 'Implementation' },
+    ]);
+  });
+
+  it('cycles picker indexes locally', () => {
+    expect(CliV2PickerService.nextIndex(1, 2)).toBe(0);
+    expect(CliV2PickerService.previousIndex(0, 2)).toBe(1);
+    expect(CliV2PickerService.clampIndex(4, 2)).toBe(1);
+  });
+});

--- a/src/__tests__/unit/cli-v2/picker-service.test.ts
+++ b/src/__tests__/unit/cli-v2/picker-service.test.ts
@@ -39,6 +39,38 @@ describe('CliV2PickerService', () => {
     ]);
   });
 
+  it('filters runtime reasoning options for the /reasoning set picker', () => {
+    const runtimeContext = {
+      reasoningOptions: [
+        {
+          id: 'default',
+          label: 'default',
+          description: 'Use model default',
+          disabled: false,
+        },
+        {
+          id: 'medium',
+          label: 'medium',
+          description: 'Set explicit medium effort',
+          disabled: false,
+        },
+      ],
+    } as const;
+
+    const query = CliV2PickerService.reasoningQuery('/reasoning set med');
+
+    expect(query).toBe('med');
+    expect(CliV2PickerService.filterReasoningOptions(runtimeContext, query)).toEqual([
+      {
+        id: 'medium',
+        label: 'medium',
+        description: 'Set explicit medium effort',
+        disabled: false,
+      },
+    ]);
+  });
+
+
   it('cycles picker indexes locally', () => {
     expect(CliV2PickerService.nextIndex(1, 2)).toBe(0);
     expect(CliV2PickerService.previousIndex(0, 2)).toBe(1);

--- a/src/__tests__/unit/cli-v2/runtime-status.test.ts
+++ b/src/__tests__/unit/cli-v2/runtime-status.test.ts
@@ -5,7 +5,7 @@ import type { ControlPlaneSessionStoreSnapshot } from '../../../cli-v2/state/con
 describe('RuntimeStatusService', () => {
   it('formats runtime context for the cli-v2 status bar', () => {
     expect(RuntimeStatusService.build(createSnapshot())).toBe(
-      'model=gpt-5.4 • reasoning=medium • auth=openai-oauth:acct-tes • context window ~400,000 tokens • drift=off • session=session-1 (Session 1)',
+      'model=gpt-5.4 • reasoning=medium • auth=openai-oauth • context window ~400,000 tokens • drift=off • session=session-1 (Session 1)',
     );
   });
 
@@ -20,7 +20,7 @@ describe('RuntimeStatusService', () => {
         running: true,
       },
     }))).toBe(
-      'model=gpt-5.4 • reasoning=medium • auth=openai-oauth:acct-tes • estimated input 20,000 / 400,000 tokens (5%) • drift=low • session=session-1 (Session 1) • status=running',
+      'model=gpt-5.4 • reasoning=medium • auth=openai-oauth • estimated input 20,000 / 400,000 tokens (5%) • drift=low • session=session-1 (Session 1) • status=running',
     );
   });
 });
@@ -39,6 +39,7 @@ function createSnapshot(overrides: Partial<ControlPlaneSessionStoreSnapshot> = {
       reasoningEffort: 'medium',
       effectiveReasoningEffort: 'medium',
       reasoningSupported: true,
+      reasoningOptions: [],
       credentialSource: {
         type: 'oauth',
         provider: 'openai',

--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -131,4 +131,16 @@ describe('llm adapter factory', () => {
       warning: 'Model gpt-5.4-pro is not supported with OpenAI account sign-in. Switched to gpt-5.4 for this session.',
     });
   });
+
+  it('owns per-model reasoning effort support', () => {
+    expect(ModelPolicyService.supportsOpenAiRequestReasoningEffortLevel('gpt-5.4', 'ultrahigh')).toBe(false);
+    expect(ModelPolicyService.supportsOpenAiRequestReasoningEffortLevel('gpt-5.5', 'ultrahigh')).toBe(true);
+    expect(ModelPolicyService.buildReasoningEffortOptions('gpt-5.5')).toContainEqual({
+      id: 'ultrahigh',
+      label: 'ultrahigh',
+      description: 'Set explicit ultrahigh effort',
+      disabled: false,
+      disabledReason: undefined,
+    });
+  });
 });

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -282,7 +282,7 @@ describe('OpenAI OAuth helpers', () => {
     expect(body.reasoning?.effort).toBe('medium');
   });
 
-  it('rejects ultrahigh reasoning effort instead of silently dropping it', async () => {
+  it('includes ultrahigh reasoning effort for models that support it', async () => {
     const requests: Array<{ url: string; body: string }> = [];
     const adapter = createOpenAiTestAdapter({
       model: 'gpt-5.5',
@@ -303,8 +303,9 @@ describe('OpenAI OAuth helpers', () => {
       }) as typeof fetch,
     });
 
-    await expect(adapter.chat([{ role: 'user', content: 'hello' }], [])).rejects.toThrow('ultrahigh');
-    expect(requests).toEqual([]);
+    await expect(adapter.chat([{ role: 'user', content: 'hello' }], [])).rejects.toThrow();
+    const body = JSON.parse(requests[0]?.body ?? '{}') as { reasoning?: { effort?: string } };
+    expect(body.reasoning?.effort).toBe('ultrahigh');
   });
 
   it('reconstructs tool calls from streamed Codex OAuth events when final response output is empty', async () => {

--- a/src/__tests__/unit/core/slash-command-modules.test.ts
+++ b/src/__tests__/unit/core/slash-command-modules.test.ts
@@ -185,6 +185,40 @@ describe('core slash command modules', () => {
     expect(setActive).not.toHaveBeenCalled();
   });
 
+  it('uses shared reasoning policy before setting reasoning effort', async () => {
+    const setReasoningEffort = vi.fn();
+    const context = createContext({
+      model: {
+        active: () => 'gpt-5.4',
+        activeReasoningEffort: () => undefined,
+        setActive: vi.fn(),
+        setReasoningEffort,
+        credentialSource: () => undefined,
+      },
+    });
+
+    await expect(registry.run(context, '/reasoning ultrahigh')).resolves.toMatchObject({
+      kind: 'message',
+      message: 'Reasoning effort "ultrahigh" is not supported by the OpenAI request path for model gpt-5.4.',
+    });
+    expect(setReasoningEffort).not.toHaveBeenCalled();
+
+    const supportedContext = createContext({
+      model: {
+        active: () => 'gpt-5.5',
+        activeReasoningEffort: () => undefined,
+        setActive: vi.fn(),
+        setReasoningEffort,
+        credentialSource: () => undefined,
+      },
+    });
+    await expect(registry.run(supportedContext, '/reasoning ultrahigh')).resolves.toMatchObject({
+      kind: 'message',
+      message: 'Set reasoning effort to ultrahigh for gpt-5.5.',
+    });
+    expect(setReasoningEffort).toHaveBeenCalledWith('ultrahigh');
+  });
+
   it('routes auth, compaction, and drift commands through host ports', async () => {
     const context = createContext();
 

--- a/src/__tests__/unit/tui/local-commands.test.ts
+++ b/src/__tests__/unit/tui/local-commands.test.ts
@@ -585,7 +585,7 @@ describe('runLocalCommand', () => {
     expect(setActiveReasoningEffort).toHaveBeenCalledWith('medium');
   });
 
-  it('rejects reserved ultrahigh reasoning effort before a run starts', async () => {
+  it('rejects unsupported ultrahigh reasoning effort before a run starts', async () => {
     const setActiveReasoningEffort = vi.fn();
     const result = await runLocalCommand(createCommandArgs({
       prompt: '/reasoning ultrahigh',
@@ -599,6 +599,20 @@ describe('runLocalCommand', () => {
       message: expect.stringContaining('ultrahigh'),
     });
     expect(setActiveReasoningEffort).not.toHaveBeenCalled();
+  });
+
+  it('accepts ultrahigh reasoning effort for models that support it', async () => {
+    const setActiveReasoningEffort = vi.fn();
+    await expect(runLocalCommand(createCommandArgs({
+      prompt: '/reasoning ultrahigh',
+      activeModel: 'gpt-5.5',
+      setActiveReasoningEffort,
+    }))).resolves.toEqual({
+      handled: true,
+      kind: 'message',
+      message: 'Set reasoning effort to ultrahigh for gpt-5.5.',
+    });
+    expect(setActiveReasoningEffort).toHaveBeenCalledWith('ultrahigh');
   });
 
   it('autocompletes shared prefixes while preserving leading whitespace', () => {

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -1,16 +1,20 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
 import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { CommandResultPanel } from './components/CommandResultPanel.js';
 import { ConversationPanel } from './components/ConversationPanel.js';
+import { ModelPickerPanel } from './components/ModelPickerPanel.js';
 import { PromptInput } from './components/PromptInput.js';
 import { RunControls } from './components/RunControls.js';
 import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
+import { SessionPickerPanel } from './components/SessionPickerPanel.js';
 import { SlashCommandHintPanel } from './components/SlashCommandHintPanel.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
 import { usePromptDraft } from './hooks/usePromptDraft.js';
 import { PromptActivityService } from './services/activities/prompt-activity-service.js';
+import { CliV2PickerService } from './services/pickers/index.js';
 import type { ControlPlaneApprovalDecision } from '@/client-shared/api/types.js';
+import type { PromptInputKey } from './components/PromptInput.js';
 import type {
   ControlPlaneSessionStore,
   ControlPlaneSessionStoreStartInput,
@@ -29,6 +33,17 @@ export function App({
   const submitDisabled = snapshot.loading || snapshot.submitting || snapshot.running;
   const inputDisabled = snapshot.loading;
   const slashCommandHints = store.getSlashCommandHints(draft);
+  const [modelPickerIndex, setModelPickerIndex] = useState(0);
+  const [sessionPickerIndex, setSessionPickerIndex] = useState(0);
+  const modelPickerQuery = CliV2PickerService.modelQuery(draft);
+  const sessionPickerQuery = CliV2PickerService.sessionQuery(draft);
+  const modelPickerItems = CliV2PickerService.filterModels(snapshot.modelOptions, modelPickerQuery);
+  const sessionPickerItems = CliV2PickerService.filterSessions(snapshot.sessions, sessionPickerQuery);
+  const safeModelPickerIndex = CliV2PickerService.clampIndex(modelPickerIndex, modelPickerItems.length);
+  const safeSessionPickerIndex = CliV2PickerService.clampIndex(sessionPickerIndex, sessionPickerItems.length);
+  const highlightedModel = modelPickerItems[safeModelPickerIndex];
+  const highlightedSession = sessionPickerItems[safeSessionPickerIndex];
+  const pickerVisible = modelPickerQuery !== undefined || sessionPickerQuery !== undefined;
 
   useEffect(() => {
     if (startedRef.current) {
@@ -42,6 +57,14 @@ export function App({
     };
   }, [initialSelection, store]);
 
+  useEffect(() => {
+    setModelPickerIndex(0);
+  }, [modelPickerQuery]);
+
+  useEffect(() => {
+    setSessionPickerIndex(0);
+  }, [sessionPickerQuery]);
+
   const submitPrompt = useCallback((value: string) => {
     const trimmed = value.trim();
     if (!trimmed) {
@@ -52,9 +75,81 @@ export function App({
       return;
     }
 
+    if (modelPickerQuery !== undefined && highlightedModel) {
+      if (highlightedModel.disabled) {
+        return;
+      }
+
+      clearDraft();
+      setModelPickerIndex(0);
+      void store.selectModelFromPicker(highlightedModel.id);
+      return;
+    }
+
+    if (sessionPickerQuery !== undefined && highlightedSession) {
+      clearDraft();
+      setSessionPickerIndex(0);
+      void store.selectSessionFromPicker(highlightedSession.id);
+      return;
+    }
+
     clearDraft();
     void store.submitPrompt(value);
-  }, [clearDraft, store, submitDisabled]);
+  }, [
+    clearDraft,
+    highlightedModel,
+    highlightedSession,
+    modelPickerQuery,
+    sessionPickerQuery,
+    store,
+    submitDisabled,
+  ]);
+
+  const handleSpecialKey = useCallback((_input: string, key: PromptInputKey) => {
+    if (modelPickerQuery !== undefined) {
+      if ((key.upArrow || key.leftArrow) && modelPickerItems.length > 0) {
+        setModelPickerIndex((current) => CliV2PickerService.previousIndex(current, modelPickerItems.length));
+        return true;
+      }
+
+      if ((key.downArrow || key.rightArrow || key.tab) && modelPickerItems.length > 0) {
+        setModelPickerIndex((current) => CliV2PickerService.nextIndex(current, modelPickerItems.length));
+        return true;
+      }
+
+      if (key.escape) {
+        clearDraft();
+        setModelPickerIndex(0);
+        return true;
+      }
+    }
+
+    if (sessionPickerQuery !== undefined) {
+      if ((key.upArrow || key.leftArrow) && sessionPickerItems.length > 0) {
+        setSessionPickerIndex((current) => CliV2PickerService.previousIndex(current, sessionPickerItems.length));
+        return true;
+      }
+
+      if ((key.downArrow || key.rightArrow || key.tab) && sessionPickerItems.length > 0) {
+        setSessionPickerIndex((current) => CliV2PickerService.nextIndex(current, sessionPickerItems.length));
+        return true;
+      }
+
+      if (key.escape) {
+        clearDraft();
+        setSessionPickerIndex(0);
+        return true;
+      }
+    }
+
+    return false;
+  }, [
+    clearDraft,
+    modelPickerItems.length,
+    modelPickerQuery,
+    sessionPickerItems.length,
+    sessionPickerQuery,
+  ]);
 
   const resolveApproval = useCallback((decision: ControlPlaneApprovalDecision) => {
     void store.resolvePendingApproval(decision);
@@ -88,7 +183,23 @@ export function App({
         cancelling={snapshot.cancelling}
         onCancel={cancelRun}
       />
-      <SlashCommandHintPanel hints={slashCommandHints} />
+      {modelPickerQuery !== undefined ? (
+        <ModelPickerPanel
+          query={modelPickerQuery}
+          models={modelPickerItems}
+          activeModel={snapshot.runtimeContext?.model}
+          highlightedIndex={safeModelPickerIndex}
+        />
+      ) : null}
+      {sessionPickerQuery !== undefined ? (
+        <SessionPickerPanel
+          query={sessionPickerQuery}
+          sessions={sessionPickerItems}
+          activeSessionId={snapshot.activeSessionId}
+          highlightedIndex={safeSessionPickerIndex}
+        />
+      ) : null}
+      {!pickerVisible ? <SlashCommandHintPanel hints={slashCommandHints} /> : null}
       <PromptInput
         activity={PromptActivityService.build(snapshot)}
         disabled={inputDisabled}
@@ -102,6 +213,7 @@ export function App({
         onChange={setDraft}
         onSubmit={submitPrompt}
         onComplete={(value) => store.completeSlashCommandDraft(value)}
+        onSpecialKey={handleSpecialKey}
       />
       <RuntimeStatusBar snapshot={snapshot} />
     </Box>

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -1,3 +1,6 @@
+// Keep this root component thin: wire top-level app state and render surfaces
+// only. Put feature behavior in cli-v2 hooks, services, or focused components
+// instead of growing App.tsx directly.
 import React, { useCallback, useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
 import { ApprovalPanel } from './components/ApprovalPanel.js';

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -5,6 +5,7 @@ import { CommandResultPanel } from './components/CommandResultPanel.js';
 import { ConversationPanel } from './components/ConversationPanel.js';
 import { ModelPickerPanel } from './components/ModelPickerPanel.js';
 import { PromptInput } from './components/PromptInput.js';
+import { ReasoningEffortPickerPanel } from './components/ReasoningEffortPickerPanel.js';
 import { RunControls } from './components/RunControls.js';
 import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
 import { SessionPickerPanel } from './components/SessionPickerPanel.js';
@@ -34,16 +35,21 @@ export function App({
   const inputDisabled = snapshot.loading;
   const slashCommandHints = store.getSlashCommandHints(draft);
   const [modelPickerIndex, setModelPickerIndex] = useState(0);
+  const [reasoningPickerIndex, setReasoningPickerIndex] = useState(0);
   const [sessionPickerIndex, setSessionPickerIndex] = useState(0);
   const modelPickerQuery = CliV2PickerService.modelQuery(draft);
+  const reasoningPickerQuery = CliV2PickerService.reasoningQuery(draft);
   const sessionPickerQuery = CliV2PickerService.sessionQuery(draft);
   const modelPickerItems = CliV2PickerService.filterModels(snapshot.modelOptions, modelPickerQuery);
+  const reasoningPickerItems = CliV2PickerService.filterReasoningOptions(snapshot.runtimeContext, reasoningPickerQuery);
   const sessionPickerItems = CliV2PickerService.filterSessions(snapshot.sessions, sessionPickerQuery);
   const safeModelPickerIndex = CliV2PickerService.clampIndex(modelPickerIndex, modelPickerItems.length);
+  const safeReasoningPickerIndex = CliV2PickerService.clampIndex(reasoningPickerIndex, reasoningPickerItems.length);
   const safeSessionPickerIndex = CliV2PickerService.clampIndex(sessionPickerIndex, sessionPickerItems.length);
   const highlightedModel = modelPickerItems[safeModelPickerIndex];
+  const highlightedReasoning = reasoningPickerItems[safeReasoningPickerIndex];
   const highlightedSession = sessionPickerItems[safeSessionPickerIndex];
-  const pickerVisible = modelPickerQuery !== undefined || sessionPickerQuery !== undefined;
+  const pickerVisible = modelPickerQuery !== undefined || reasoningPickerQuery !== undefined || sessionPickerQuery !== undefined;
 
   useEffect(() => {
     if (startedRef.current) {
@@ -60,6 +66,10 @@ export function App({
   useEffect(() => {
     setModelPickerIndex(0);
   }, [modelPickerQuery]);
+
+  useEffect(() => {
+    setReasoningPickerIndex(0);
+  }, [reasoningPickerQuery]);
 
   useEffect(() => {
     setSessionPickerIndex(0);
@@ -86,6 +96,17 @@ export function App({
       return;
     }
 
+    if (reasoningPickerQuery !== undefined && highlightedReasoning) {
+      if (highlightedReasoning.disabled) {
+        return;
+      }
+
+      clearDraft();
+      setReasoningPickerIndex(0);
+      void store.selectReasoningFromPicker(highlightedReasoning.id);
+      return;
+    }
+
     if (sessionPickerQuery !== undefined && highlightedSession) {
       clearDraft();
       setSessionPickerIndex(0);
@@ -98,8 +119,10 @@ export function App({
   }, [
     clearDraft,
     highlightedModel,
+    highlightedReasoning,
     highlightedSession,
     modelPickerQuery,
+    reasoningPickerQuery,
     sessionPickerQuery,
     store,
     submitDisabled,
@@ -120,6 +143,24 @@ export function App({
       if (key.escape) {
         clearDraft();
         setModelPickerIndex(0);
+        return true;
+      }
+    }
+
+    if (reasoningPickerQuery !== undefined) {
+      if ((key.upArrow || key.leftArrow) && reasoningPickerItems.length > 0) {
+        setReasoningPickerIndex((current) => CliV2PickerService.previousIndex(current, reasoningPickerItems.length));
+        return true;
+      }
+
+      if ((key.downArrow || key.rightArrow || key.tab) && reasoningPickerItems.length > 0) {
+        setReasoningPickerIndex((current) => CliV2PickerService.nextIndex(current, reasoningPickerItems.length));
+        return true;
+      }
+
+      if (key.escape) {
+        clearDraft();
+        setReasoningPickerIndex(0);
         return true;
       }
     }
@@ -147,6 +188,8 @@ export function App({
     clearDraft,
     modelPickerItems.length,
     modelPickerQuery,
+    reasoningPickerItems.length,
+    reasoningPickerQuery,
     sessionPickerItems.length,
     sessionPickerQuery,
   ]);
@@ -189,6 +232,14 @@ export function App({
           models={modelPickerItems}
           activeModel={snapshot.runtimeContext?.model}
           highlightedIndex={safeModelPickerIndex}
+        />
+      ) : null}
+      {reasoningPickerQuery !== undefined ? (
+        <ReasoningEffortPickerPanel
+          query={reasoningPickerQuery}
+          options={reasoningPickerItems}
+          activeReasoningEffort={snapshot.runtimeContext?.reasoningEffort}
+          highlightedIndex={safeReasoningPickerIndex}
         />
       ) : null}
       {sessionPickerQuery !== undefined ? (

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
 import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { CommandResultPanel } from './components/CommandResultPanel.js';
@@ -11,11 +11,10 @@ import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
 import { SessionPickerPanel } from './components/SessionPickerPanel.js';
 import { SlashCommandHintPanel } from './components/SlashCommandHintPanel.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
+import { usePromptPickers } from './hooks/usePromptPickers.js';
 import { usePromptDraft } from './hooks/usePromptDraft.js';
 import { PromptActivityService } from './services/activities/prompt-activity-service.js';
-import { CliV2PickerService } from './services/pickers/index.js';
 import type { ControlPlaneApprovalDecision } from '@/client-shared/api/types.js';
-import type { PromptInputKey } from './components/PromptInput.js';
 import type {
   ControlPlaneSessionStore,
   ControlPlaneSessionStoreStartInput,
@@ -34,22 +33,20 @@ export function App({
   const submitDisabled = snapshot.loading || snapshot.submitting || snapshot.running;
   const inputDisabled = snapshot.loading;
   const slashCommandHints = store.getSlashCommandHints(draft);
-  const [modelPickerIndex, setModelPickerIndex] = useState(0);
-  const [reasoningPickerIndex, setReasoningPickerIndex] = useState(0);
-  const [sessionPickerIndex, setSessionPickerIndex] = useState(0);
-  const modelPickerQuery = CliV2PickerService.modelQuery(draft);
-  const reasoningPickerQuery = CliV2PickerService.reasoningQuery(draft);
-  const sessionPickerQuery = CliV2PickerService.sessionQuery(draft);
-  const modelPickerItems = CliV2PickerService.filterModels(snapshot.modelOptions, modelPickerQuery);
-  const reasoningPickerItems = CliV2PickerService.filterReasoningOptions(snapshot.runtimeContext, reasoningPickerQuery);
-  const sessionPickerItems = CliV2PickerService.filterSessions(snapshot.sessions, sessionPickerQuery);
-  const safeModelPickerIndex = CliV2PickerService.clampIndex(modelPickerIndex, modelPickerItems.length);
-  const safeReasoningPickerIndex = CliV2PickerService.clampIndex(reasoningPickerIndex, reasoningPickerItems.length);
-  const safeSessionPickerIndex = CliV2PickerService.clampIndex(sessionPickerIndex, sessionPickerItems.length);
-  const highlightedModel = modelPickerItems[safeModelPickerIndex];
-  const highlightedReasoning = reasoningPickerItems[safeReasoningPickerIndex];
-  const highlightedSession = sessionPickerItems[safeSessionPickerIndex];
-  const pickerVisible = modelPickerQuery !== undefined || reasoningPickerQuery !== undefined || sessionPickerQuery !== undefined;
+  const pickers = usePromptPickers({
+    draft,
+    snapshot,
+    clearDraft,
+    onSelectModel: (model) => {
+      void store.selectModelFromPicker(model);
+    },
+    onSelectReasoning: (reasoningEffort) => {
+      void store.selectReasoningFromPicker(reasoningEffort);
+    },
+    onSelectSession: (sessionId) => {
+      void store.selectSessionFromPicker(sessionId);
+    },
+  });
 
   useEffect(() => {
     if (startedRef.current) {
@@ -63,18 +60,6 @@ export function App({
     };
   }, [initialSelection, store]);
 
-  useEffect(() => {
-    setModelPickerIndex(0);
-  }, [modelPickerQuery]);
-
-  useEffect(() => {
-    setReasoningPickerIndex(0);
-  }, [reasoningPickerQuery]);
-
-  useEffect(() => {
-    setSessionPickerIndex(0);
-  }, [sessionPickerQuery]);
-
   const submitPrompt = useCallback((value: string) => {
     const trimmed = value.trim();
     if (!trimmed) {
@@ -85,32 +70,7 @@ export function App({
       return;
     }
 
-    if (modelPickerQuery !== undefined && highlightedModel) {
-      if (highlightedModel.disabled) {
-        return;
-      }
-
-      clearDraft();
-      setModelPickerIndex(0);
-      void store.selectModelFromPicker(highlightedModel.id);
-      return;
-    }
-
-    if (reasoningPickerQuery !== undefined && highlightedReasoning) {
-      if (highlightedReasoning.disabled) {
-        return;
-      }
-
-      clearDraft();
-      setReasoningPickerIndex(0);
-      void store.selectReasoningFromPicker(highlightedReasoning.id);
-      return;
-    }
-
-    if (sessionPickerQuery !== undefined && highlightedSession) {
-      clearDraft();
-      setSessionPickerIndex(0);
-      void store.selectSessionFromPicker(highlightedSession.id);
+    if (pickers.submitSelection()) {
       return;
     }
 
@@ -118,80 +78,9 @@ export function App({
     void store.submitPrompt(value);
   }, [
     clearDraft,
-    highlightedModel,
-    highlightedReasoning,
-    highlightedSession,
-    modelPickerQuery,
-    reasoningPickerQuery,
-    sessionPickerQuery,
+    pickers,
     store,
     submitDisabled,
-  ]);
-
-  const handleSpecialKey = useCallback((_input: string, key: PromptInputKey) => {
-    if (modelPickerQuery !== undefined) {
-      if ((key.upArrow || key.leftArrow) && modelPickerItems.length > 0) {
-        setModelPickerIndex((current) => CliV2PickerService.previousIndex(current, modelPickerItems.length));
-        return true;
-      }
-
-      if ((key.downArrow || key.rightArrow || key.tab) && modelPickerItems.length > 0) {
-        setModelPickerIndex((current) => CliV2PickerService.nextIndex(current, modelPickerItems.length));
-        return true;
-      }
-
-      if (key.escape) {
-        clearDraft();
-        setModelPickerIndex(0);
-        return true;
-      }
-    }
-
-    if (reasoningPickerQuery !== undefined) {
-      if ((key.upArrow || key.leftArrow) && reasoningPickerItems.length > 0) {
-        setReasoningPickerIndex((current) => CliV2PickerService.previousIndex(current, reasoningPickerItems.length));
-        return true;
-      }
-
-      if ((key.downArrow || key.rightArrow || key.tab) && reasoningPickerItems.length > 0) {
-        setReasoningPickerIndex((current) => CliV2PickerService.nextIndex(current, reasoningPickerItems.length));
-        return true;
-      }
-
-      if (key.escape) {
-        clearDraft();
-        setReasoningPickerIndex(0);
-        return true;
-      }
-    }
-
-    if (sessionPickerQuery !== undefined) {
-      if ((key.upArrow || key.leftArrow) && sessionPickerItems.length > 0) {
-        setSessionPickerIndex((current) => CliV2PickerService.previousIndex(current, sessionPickerItems.length));
-        return true;
-      }
-
-      if ((key.downArrow || key.rightArrow || key.tab) && sessionPickerItems.length > 0) {
-        setSessionPickerIndex((current) => CliV2PickerService.nextIndex(current, sessionPickerItems.length));
-        return true;
-      }
-
-      if (key.escape) {
-        clearDraft();
-        setSessionPickerIndex(0);
-        return true;
-      }
-    }
-
-    return false;
-  }, [
-    clearDraft,
-    modelPickerItems.length,
-    modelPickerQuery,
-    reasoningPickerItems.length,
-    reasoningPickerQuery,
-    sessionPickerItems.length,
-    sessionPickerQuery,
   ]);
 
   const resolveApproval = useCallback((decision: ControlPlaneApprovalDecision) => {
@@ -226,31 +115,31 @@ export function App({
         cancelling={snapshot.cancelling}
         onCancel={cancelRun}
       />
-      {modelPickerQuery !== undefined ? (
+      {pickers.model.query !== undefined ? (
         <ModelPickerPanel
-          query={modelPickerQuery}
-          models={modelPickerItems}
+          query={pickers.model.query}
+          models={pickers.model.items}
           activeModel={snapshot.runtimeContext?.model}
-          highlightedIndex={safeModelPickerIndex}
+          highlightedIndex={pickers.model.highlightedIndex}
         />
       ) : null}
-      {reasoningPickerQuery !== undefined ? (
+      {pickers.reasoning.query !== undefined ? (
         <ReasoningEffortPickerPanel
-          query={reasoningPickerQuery}
-          options={reasoningPickerItems}
+          query={pickers.reasoning.query}
+          options={pickers.reasoning.items}
           activeReasoningEffort={snapshot.runtimeContext?.reasoningEffort}
-          highlightedIndex={safeReasoningPickerIndex}
+          highlightedIndex={pickers.reasoning.highlightedIndex}
         />
       ) : null}
-      {sessionPickerQuery !== undefined ? (
+      {pickers.session.query !== undefined ? (
         <SessionPickerPanel
-          query={sessionPickerQuery}
-          sessions={sessionPickerItems}
+          query={pickers.session.query}
+          sessions={pickers.session.items}
           activeSessionId={snapshot.activeSessionId}
-          highlightedIndex={safeSessionPickerIndex}
+          highlightedIndex={pickers.session.highlightedIndex}
         />
       ) : null}
-      {!pickerVisible ? <SlashCommandHintPanel hints={slashCommandHints} /> : null}
+      {!pickers.visible ? <SlashCommandHintPanel hints={slashCommandHints} /> : null}
       <PromptInput
         activity={PromptActivityService.build(snapshot)}
         disabled={inputDisabled}
@@ -264,7 +153,7 @@ export function App({
         onChange={setDraft}
         onSubmit={submitPrompt}
         onComplete={(value) => store.completeSlashCommandDraft(value)}
-        onSpecialKey={handleSpecialKey}
+        onSpecialKey={pickers.handleSpecialKey}
       />
       <RuntimeStatusBar snapshot={snapshot} />
     </Box>

--- a/src/cli-v2/components/ModelPickerPanel.tsx
+++ b/src/cli-v2/components/ModelPickerPanel.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { CliV2ModelPickerItem } from '../services/pickers/index.js';
+
+const MAX_VISIBLE_MODELS = 8;
+
+export function ModelPickerPanel({
+  query,
+  models,
+  activeModel,
+  highlightedIndex,
+}: {
+  query: string;
+  models: CliV2ModelPickerItem[];
+  activeModel?: string;
+  highlightedIndex: number;
+}) {
+  const { visibleModels, startIndex } = getVisibleModels(models, highlightedIndex);
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text dimColor>Model picker</Text>
+      <Text dimColor>
+        {query ? `Search: ${query}` : 'Type after /model set to filter. Use up/down or Tab to choose.'}
+      </Text>
+      {visibleModels.length > 0 ?
+        visibleModels.map((model, index) => {
+          const absoluteIndex = startIndex + index;
+          const isHighlighted = absoluteIndex === highlightedIndex;
+          const isActive = model.id === activeModel;
+          const marker = isHighlighted ? '◉' : '○';
+          const suffix = [
+            isActive ? '(current)' : undefined,
+            model.disabled ? `(${model.disabledReason ?? 'unavailable'})` : undefined,
+          ].filter(Boolean).join(' ');
+          return (
+            <Text
+              key={model.id}
+              color={isHighlighted ? 'cyan' : model.disabled ? 'yellow' : undefined}
+              dimColor={!isHighlighted && !model.disabled}
+            >
+              {`${marker} ${model.id}${suffix ? ` ${suffix}` : ''}`}
+              {isHighlighted && model.disabled ? ` - ${model.disabledReason ?? 'unavailable'}` : ''}
+            </Text>
+          );
+        })
+      : <Text dimColor>No matching models.</Text>}
+    </Box>
+  );
+}
+
+function getVisibleModels(
+  models: CliV2ModelPickerItem[],
+  highlightedIndex: number,
+): { visibleModels: CliV2ModelPickerItem[]; startIndex: number } {
+  if (models.length <= MAX_VISIBLE_MODELS) {
+    return { visibleModels: models, startIndex: 0 };
+  }
+
+  const half = Math.floor(MAX_VISIBLE_MODELS / 2);
+  const startIndex = Math.min(
+    Math.max(0, highlightedIndex - half),
+    Math.max(0, models.length - MAX_VISIBLE_MODELS),
+  );
+
+  return {
+    visibleModels: models.slice(startIndex, startIndex + MAX_VISIBLE_MODELS),
+    startIndex,
+  };
+}

--- a/src/cli-v2/components/PromptInput.tsx
+++ b/src/cli-v2/components/PromptInput.tsx
@@ -2,6 +2,20 @@ import type { Dispatch, SetStateAction } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import type { PromptActivityView } from '../services/activities/prompt-activity-service.js';
 
+export type PromptInputKey = {
+  upArrow?: boolean;
+  downArrow?: boolean;
+  leftArrow?: boolean;
+  rightArrow?: boolean;
+  return?: boolean;
+  escape?: boolean;
+  tab?: boolean;
+  backspace?: boolean;
+  delete?: boolean;
+  ctrl?: boolean;
+  meta?: boolean;
+};
+
 export function PromptInput({
   activity,
   disabled,
@@ -11,6 +25,7 @@ export function PromptInput({
   onChange,
   onSubmit,
   onComplete,
+  onSpecialKey,
 }: {
   activity?: PromptActivityView;
   disabled: boolean;
@@ -20,12 +35,17 @@ export function PromptInput({
   onChange: Dispatch<SetStateAction<string>>;
   onSubmit: (value: string) => void;
   onComplete?: (value: string) => string | undefined;
+  onSpecialKey?: (input: string, key: PromptInputKey) => boolean;
 }) {
   const { stdout } = useStdout();
   const separator = repeatSeparator((stdout.columns ?? 0) - 2);
 
   useInput((input, key) => {
     if (disabled) {
+      return;
+    }
+
+    if (onSpecialKey?.(input, key)) {
       return;
     }
 

--- a/src/cli-v2/components/ReasoningEffortPickerPanel.tsx
+++ b/src/cli-v2/components/ReasoningEffortPickerPanel.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { CliV2ReasoningPickerItem } from '../services/pickers/index.js';
+
+const MAX_VISIBLE_OPTIONS = 8;
+
+export function ReasoningEffortPickerPanel({
+  query,
+  options,
+  activeReasoningEffort,
+  highlightedIndex,
+}: {
+  query: string;
+  options: CliV2ReasoningPickerItem[];
+  activeReasoningEffort?: string;
+  highlightedIndex: number;
+}) {
+  const { visibleOptions, startIndex } = getVisibleOptions(options, highlightedIndex);
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text dimColor>Reasoning effort picker</Text>
+      <Text dimColor>
+        {query ? `Search: ${query}` : 'Type after /reasoning set to filter. Use up/down or Tab to choose.'}
+      </Text>
+      {visibleOptions.length > 0 ?
+        visibleOptions.map((option, index) => {
+          const absoluteIndex = startIndex + index;
+          const isHighlighted = absoluteIndex === highlightedIndex;
+          const isActive = option.id === (activeReasoningEffort ?? 'default');
+          const marker = isHighlighted ? '◉' : '○';
+          const suffix = [
+            isActive ? '(current)' : undefined,
+            option.disabled ? `(${option.disabledReason ?? 'unavailable'})` : undefined,
+          ].filter(Boolean).join(' ');
+          return (
+            <Text
+              key={option.id}
+              color={isHighlighted ? 'cyan' : option.disabled ? 'yellow' : undefined}
+              dimColor={!isHighlighted && !option.disabled}
+            >
+              {`${marker} ${option.label}${suffix ? ` ${suffix}` : ''} - ${option.description}`}
+            </Text>
+          );
+        })
+      : <Text dimColor>No matching reasoning efforts.</Text>}
+    </Box>
+  );
+}
+
+function getVisibleOptions(
+  options: CliV2ReasoningPickerItem[],
+  highlightedIndex: number,
+): { visibleOptions: CliV2ReasoningPickerItem[]; startIndex: number } {
+  if (options.length <= MAX_VISIBLE_OPTIONS) {
+    return { visibleOptions: options, startIndex: 0 };
+  }
+
+  const half = Math.floor(MAX_VISIBLE_OPTIONS / 2);
+  const startIndex = Math.min(
+    Math.max(0, highlightedIndex - half),
+    Math.max(0, options.length - MAX_VISIBLE_OPTIONS),
+  );
+
+  return {
+    visibleOptions: options.slice(startIndex, startIndex + MAX_VISIBLE_OPTIONS),
+    startIndex,
+  };
+}

--- a/src/cli-v2/components/SessionPickerPanel.tsx
+++ b/src/cli-v2/components/SessionPickerPanel.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { CliV2SessionPickerItem } from '../services/pickers/index.js';
+
+const MAX_VISIBLE_SESSIONS = 8;
+
+export function SessionPickerPanel({
+  query,
+  sessions,
+  activeSessionId,
+  highlightedIndex,
+}: {
+  query: string;
+  sessions: CliV2SessionPickerItem[];
+  activeSessionId?: string;
+  highlightedIndex: number;
+}) {
+  const { visibleSessions, startIndex } = getVisibleSessions(sessions, highlightedIndex);
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text dimColor>Session picker</Text>
+      <Text dimColor>
+        {query ? `Search: ${query}` : 'Type after /session choose to filter. Use up/down or Tab to choose.'}
+      </Text>
+      {visibleSessions.length > 0 ?
+        visibleSessions.map((session, index) => {
+          const absoluteIndex = startIndex + index;
+          const isHighlighted = absoluteIndex === highlightedIndex;
+          const isActive = session.id === activeSessionId;
+          const marker = isHighlighted ? '◉' : '○';
+          const suffix = isActive ? ' (current)' : '';
+          return (
+            <Text key={session.id} color={isHighlighted ? 'cyan' : undefined} dimColor={!isHighlighted}>
+              {`${marker} ${absoluteIndex + 1}. ${session.name} [${session.id}]${suffix}`}
+            </Text>
+          );
+        })
+      : <Text dimColor>No matching sessions.</Text>}
+    </Box>
+  );
+}
+
+function getVisibleSessions(
+  sessions: CliV2SessionPickerItem[],
+  highlightedIndex: number,
+): { visibleSessions: CliV2SessionPickerItem[]; startIndex: number } {
+  if (sessions.length <= MAX_VISIBLE_SESSIONS) {
+    return { visibleSessions: sessions, startIndex: 0 };
+  }
+
+  const half = Math.floor(MAX_VISIBLE_SESSIONS / 2);
+  const startIndex = Math.min(
+    Math.max(0, highlightedIndex - half),
+    Math.max(0, sessions.length - MAX_VISIBLE_SESSIONS),
+  );
+
+  return {
+    visibleSessions: sessions.slice(startIndex, startIndex + MAX_VISIBLE_SESSIONS),
+    startIndex,
+  };
+}

--- a/src/cli-v2/hooks/usePromptPickers.ts
+++ b/src/cli-v2/hooks/usePromptPickers.ts
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { PromptInputKey } from '../components/PromptInput.js';
+import { CliV2PickerService } from '../services/pickers/index.js';
+import type { ControlPlaneSessionStoreSnapshot } from '../state/control-plane-session-store.js';
+
+export function usePromptPickers({
+  draft,
+  snapshot,
+  clearDraft,
+  onSelectModel,
+  onSelectReasoning,
+  onSelectSession,
+}: {
+  draft: string;
+  snapshot: ControlPlaneSessionStoreSnapshot;
+  clearDraft: () => void;
+  onSelectModel: (model: string) => void;
+  onSelectReasoning: (reasoningEffort: string) => void;
+  onSelectSession: (sessionId: string) => void;
+}) {
+  const [modelIndex, setModelIndex] = useState(0);
+  const [reasoningIndex, setReasoningIndex] = useState(0);
+  const [sessionIndex, setSessionIndex] = useState(0);
+
+  const modelQuery = CliV2PickerService.modelQuery(draft);
+  const reasoningQuery = CliV2PickerService.reasoningQuery(draft);
+  const sessionQuery = CliV2PickerService.sessionQuery(draft);
+  const modelItems = CliV2PickerService.filterModels(snapshot.modelOptions, modelQuery);
+  const reasoningItems = CliV2PickerService.filterReasoningOptions(snapshot.runtimeContext, reasoningQuery);
+  const sessionItems = CliV2PickerService.filterSessions(snapshot.sessions, sessionQuery);
+  const modelHighlightedIndex = CliV2PickerService.clampIndex(modelIndex, modelItems.length);
+  const reasoningHighlightedIndex = CliV2PickerService.clampIndex(reasoningIndex, reasoningItems.length);
+  const sessionHighlightedIndex = CliV2PickerService.clampIndex(sessionIndex, sessionItems.length);
+
+  useEffect(() => {
+    setModelIndex(0);
+  }, [modelQuery]);
+
+  useEffect(() => {
+    setReasoningIndex(0);
+  }, [reasoningQuery]);
+
+  useEffect(() => {
+    setSessionIndex(0);
+  }, [sessionQuery]);
+
+  const handleSpecialKey = useCallback((_input: string, key: PromptInputKey) => {
+    if (modelQuery !== undefined) {
+      return handlePickerKey({
+        key,
+        itemCount: modelItems.length,
+        clearDraft,
+        resetIndex: () => setModelIndex(0),
+        advance: () => setModelIndex((current) => CliV2PickerService.nextIndex(current, modelItems.length)),
+        retreat: () => setModelIndex((current) => CliV2PickerService.previousIndex(current, modelItems.length)),
+      });
+    }
+
+    if (reasoningQuery !== undefined) {
+      return handlePickerKey({
+        key,
+        itemCount: reasoningItems.length,
+        clearDraft,
+        resetIndex: () => setReasoningIndex(0),
+        advance: () => setReasoningIndex((current) => CliV2PickerService.nextIndex(current, reasoningItems.length)),
+        retreat: () => setReasoningIndex((current) => CliV2PickerService.previousIndex(current, reasoningItems.length)),
+      });
+    }
+
+    if (sessionQuery !== undefined) {
+      return handlePickerKey({
+        key,
+        itemCount: sessionItems.length,
+        clearDraft,
+        resetIndex: () => setSessionIndex(0),
+        advance: () => setSessionIndex((current) => CliV2PickerService.nextIndex(current, sessionItems.length)),
+        retreat: () => setSessionIndex((current) => CliV2PickerService.previousIndex(current, sessionItems.length)),
+      });
+    }
+
+    return false;
+  }, [
+    clearDraft,
+    modelItems.length,
+    modelQuery,
+    reasoningItems.length,
+    reasoningQuery,
+    sessionItems.length,
+    sessionQuery,
+  ]);
+
+  const submitSelection = useCallback(() => {
+    const highlightedModel = modelItems[modelHighlightedIndex];
+    if (modelQuery !== undefined && highlightedModel) {
+      if (highlightedModel.disabled) {
+        return true;
+      }
+
+      clearDraft();
+      setModelIndex(0);
+      onSelectModel(highlightedModel.id);
+      return true;
+    }
+
+    const highlightedReasoning = reasoningItems[reasoningHighlightedIndex];
+    if (reasoningQuery !== undefined && highlightedReasoning) {
+      if (highlightedReasoning.disabled) {
+        return true;
+      }
+
+      clearDraft();
+      setReasoningIndex(0);
+      onSelectReasoning(highlightedReasoning.id);
+      return true;
+    }
+
+    const highlightedSession = sessionItems[sessionHighlightedIndex];
+    if (sessionQuery !== undefined && highlightedSession) {
+      clearDraft();
+      setSessionIndex(0);
+      onSelectSession(highlightedSession.id);
+      return true;
+    }
+
+    return false;
+  }, [
+    clearDraft,
+    modelHighlightedIndex,
+    modelItems,
+    modelQuery,
+    onSelectModel,
+    onSelectReasoning,
+    onSelectSession,
+    reasoningHighlightedIndex,
+    reasoningItems,
+    reasoningQuery,
+    sessionHighlightedIndex,
+    sessionItems,
+    sessionQuery,
+  ]);
+
+  return {
+    model: {
+      query: modelQuery,
+      items: modelItems,
+      highlightedIndex: modelHighlightedIndex,
+      highlighted: modelItems[modelHighlightedIndex],
+      resetIndex: () => setModelIndex(0),
+    },
+    reasoning: {
+      query: reasoningQuery,
+      items: reasoningItems,
+      highlightedIndex: reasoningHighlightedIndex,
+      highlighted: reasoningItems[reasoningHighlightedIndex],
+      resetIndex: () => setReasoningIndex(0),
+    },
+    session: {
+      query: sessionQuery,
+      items: sessionItems,
+      highlightedIndex: sessionHighlightedIndex,
+      highlighted: sessionItems[sessionHighlightedIndex],
+      resetIndex: () => setSessionIndex(0),
+    },
+    visible: modelQuery !== undefined || reasoningQuery !== undefined || sessionQuery !== undefined,
+    handleSpecialKey,
+    submitSelection,
+  };
+}
+
+function handlePickerKey({
+  key,
+  itemCount,
+  clearDraft,
+  resetIndex,
+  advance,
+  retreat,
+}: {
+  key: PromptInputKey;
+  itemCount: number;
+  clearDraft: () => void;
+  resetIndex: () => void;
+  advance: () => void;
+  retreat: () => void;
+}): boolean {
+  if ((key.upArrow || key.leftArrow) && itemCount > 0) {
+    retreat();
+    return true;
+  }
+
+  if ((key.downArrow || key.rightArrow || key.tab) && itemCount > 0) {
+    advance();
+    return true;
+  }
+
+  if (key.escape) {
+    clearDraft();
+    resetIndex();
+    return true;
+  }
+
+  return false;
+}

--- a/src/cli-v2/services/README.md
+++ b/src/cli-v2/services/README.md
@@ -27,6 +27,8 @@ Current domains:
   rendering.
 - `approvals/`: terminal approval choices, decisions, and keyboard-specific
   behavior.
+- `pickers/`: terminal picker filtering and keyboard index mechanics over
+  control-plane-provided model/session data.
 - `sessions/`: terminal session lifecycle mechanics such as stream buffering
   API runtime defaults, subscriptions, and run-state polling that are specific
   to Ink rendering and cli-v2 store coordination.

--- a/src/cli-v2/services/pickers/index.ts
+++ b/src/cli-v2/services/pickers/index.ts
@@ -1,5 +1,6 @@
 export {
   CliV2PickerService,
   type CliV2ModelPickerItem,
+  type CliV2ReasoningPickerItem,
   type CliV2SessionPickerItem,
 } from './picker-service.js';

--- a/src/cli-v2/services/pickers/index.ts
+++ b/src/cli-v2/services/pickers/index.ts
@@ -1,0 +1,5 @@
+export {
+  CliV2PickerService,
+  type CliV2ModelPickerItem,
+  type CliV2SessionPickerItem,
+} from './picker-service.js';

--- a/src/cli-v2/services/pickers/picker-service.ts
+++ b/src/cli-v2/services/pickers/picker-service.ts
@@ -1,0 +1,78 @@
+import type {
+  ControlPlaneModelOptions,
+  ControlPlaneSessionView,
+} from '@/client-shared/api/types.js';
+
+export type CliV2ModelPickerItem = ControlPlaneModelOptions['groups'][number]['options'][number];
+
+export type CliV2SessionPickerItem = Pick<ControlPlaneSessionView, 'id' | 'name'>;
+
+export class CliV2PickerService {
+  static modelQuery(draft: string): string | undefined {
+    return queryAfterPrefix(draft, '/model set');
+  }
+
+  static sessionQuery(draft: string): string | undefined {
+    return queryAfterPrefix(draft, '/session choose');
+  }
+
+  static filterModels(modelOptions: ControlPlaneModelOptions | undefined, query: string | undefined): CliV2ModelPickerItem[] {
+    if (query === undefined) {
+      return [];
+    }
+
+    const normalized = normalize(query);
+    const models = modelOptions?.groups.flatMap((group) => group.options) ?? [];
+    if (!normalized) {
+      return models;
+    }
+
+    return models.filter((model) => (
+      model.id.toLowerCase().includes(normalized) ||
+      (model.label ?? '').toLowerCase().includes(normalized)
+    ));
+  }
+
+  static filterSessions(sessions: ControlPlaneSessionView[], query: string | undefined): CliV2SessionPickerItem[] {
+    if (query === undefined) {
+      return [];
+    }
+
+    const normalized = normalize(query);
+    if (!normalized) {
+      return sessions.map(({ id, name }) => ({ id, name }));
+    }
+
+    return sessions
+      .filter((session) => (
+        session.id.toLowerCase().includes(normalized) ||
+        session.name.toLowerCase().includes(normalized)
+      ))
+      .map(({ id, name }) => ({ id, name }));
+  }
+
+  static clampIndex(index: number, itemCount: number): number {
+    return itemCount === 0 ? 0 : Math.min(index, Math.max(0, itemCount - 1));
+  }
+
+  static nextIndex(index: number, itemCount: number): number {
+    return itemCount === 0 ? 0 : (index + 1) % itemCount;
+  }
+
+  static previousIndex(index: number, itemCount: number): number {
+    return itemCount === 0 ? 0 : index <= 0 ? itemCount - 1 : index - 1;
+  }
+}
+
+function queryAfterPrefix(draft: string, prefix: string): string | undefined {
+  const trimmedStart = draft.trimStart();
+  if (!trimmedStart.startsWith(prefix)) {
+    return undefined;
+  }
+
+  return trimmedStart.slice(prefix.length).trim();
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}

--- a/src/cli-v2/services/pickers/picker-service.ts
+++ b/src/cli-v2/services/pickers/picker-service.ts
@@ -1,9 +1,12 @@
 import type {
   ControlPlaneModelOptions,
+  ControlPlaneSessionRuntimeContext,
   ControlPlaneSessionView,
 } from '@/client-shared/api/types.js';
 
 export type CliV2ModelPickerItem = ControlPlaneModelOptions['groups'][number]['options'][number];
+
+export type CliV2ReasoningPickerItem = ControlPlaneSessionRuntimeContext['reasoningOptions'][number];
 
 export type CliV2SessionPickerItem = Pick<ControlPlaneSessionView, 'id' | 'name'>;
 
@@ -14,6 +17,10 @@ export class CliV2PickerService {
 
   static sessionQuery(draft: string): string | undefined {
     return queryAfterPrefix(draft, '/session choose');
+  }
+
+  static reasoningQuery(draft: string): string | undefined {
+    return queryAfterPrefix(draft, '/reasoning set');
   }
 
   static filterModels(modelOptions: ControlPlaneModelOptions | undefined, query: string | undefined): CliV2ModelPickerItem[] {
@@ -49,6 +56,27 @@ export class CliV2PickerService {
         session.name.toLowerCase().includes(normalized)
       ))
       .map(({ id, name }) => ({ id, name }));
+  }
+
+  static filterReasoningOptions(
+    runtimeContext: ControlPlaneSessionRuntimeContext | undefined,
+    query: string | undefined,
+  ): CliV2ReasoningPickerItem[] {
+    if (query === undefined) {
+      return [];
+    }
+
+    const normalized = normalize(query);
+    const options = runtimeContext?.reasoningOptions ?? [];
+    if (!normalized) {
+      return options;
+    }
+
+    return options.filter((option) => (
+      option.id.toLowerCase().includes(normalized) ||
+      option.label.toLowerCase().includes(normalized) ||
+      option.description.toLowerCase().includes(normalized)
+    ));
   }
 
   static clampIndex(index: number, itemCount: number): number {

--- a/src/cli-v2/services/sessions/control-plane-session-api-service.ts
+++ b/src/cli-v2/services/sessions/control-plane-session-api-service.ts
@@ -53,6 +53,10 @@ export class ControlPlaneSessionApiService {
     return result.workspaceId === workspaceId ? result.sessions : [];
   }
 
+  async getModelOptions() {
+    return this.client.controlPlane.modelOptions.query();
+  }
+
   async createSession(workspaceId: string, input: ControlPlaneSessionCreateInput = {}) {
     return this.client.controlPlane.sessionCreate.mutate({
       ...input,

--- a/src/cli-v2/services/status/runtime-status-service.ts
+++ b/src/cli-v2/services/status/runtime-status-service.ts
@@ -35,7 +35,7 @@ export class RuntimeStatusService {
       case 'env-api-key':
         return `auth=${source.provider}-key`;
       case 'oauth':
-        return source.accountId ? `auth=${source.provider}-oauth:${source.accountId.slice(0, 8)}` : `auth=${source.provider}-oauth`;
+        return `auth=${source.provider}-oauth`;
       case 'missing':
         return `auth=missing-${source.provider}`;
     }

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -320,6 +320,10 @@ export class ControlPlaneSessionStore {
     await this.executeSlashCommand(`/session switch ${sessionId}`);
   }
 
+  async selectReasoningFromPicker(reasoningEffort: string): Promise<void> {
+    await this.executeSlashCommand(reasoningEffort === 'default' ? '/reasoning default' : `/reasoning ${reasoningEffort}`);
+  }
+
   async cancelRun(): Promise<void> {
     const workspaceId = this.requireWorkspaceId();
     const sessionId = this.requireActiveSessionId();

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -21,6 +21,7 @@ import {
 } from '../services/sessions/session-run-state-poller-service.js';
 import type {
   ControlPlaneApprovalDecision,
+  ControlPlaneModelOptions,
   ControlPlanePendingApproval,
   ControlPlaneSessionDetail,
   ControlPlaneSessionEventEnvelope,
@@ -55,6 +56,7 @@ export type ControlPlaneSessionStoreSnapshot = {
   activeSessionId?: string;
   activeSession: ControlPlaneSessionDetail;
   runtimeContext?: ControlPlaneSessionRuntimeContext;
+  modelOptions?: ControlPlaneModelOptions;
   pendingApproval: ControlPlanePendingApproval;
   loading: boolean;
   submitting: boolean;
@@ -73,6 +75,7 @@ const INITIAL_SNAPSHOT: ControlPlaneSessionStoreSnapshot = {
   sessions: [],
   activeSession: null,
   runtimeContext: undefined,
+  modelOptions: undefined,
   pendingApproval: null,
   loading: false,
   submitting: false,
@@ -147,8 +150,9 @@ export class ControlPlaneSessionStore {
     this.setSnapshot({ loading: true, error: undefined });
     try {
       const workspaceId = await this.api.resolveWorkspaceId(input.workspaceId);
+      const modelOptions = await this.api.getModelOptions();
 
-      this.setSnapshot({ workspaceId });
+      this.setSnapshot({ workspaceId, modelOptions });
       await this.refreshSlashCommandCatalog(workspaceId);
       this.subscriptions.subscribeToSessionList(workspaceId);
       const sessions = await this.refreshSessions();
@@ -306,6 +310,14 @@ export class ControlPlaneSessionStore {
 
   completeSlashCommandDraft(draft: string): string | undefined {
     return SlashCommandAutocompleteService.complete(draft, this.snapshotValue.slashCommandCatalog?.hints ?? []);
+  }
+
+  async selectModelFromPicker(modelId: string): Promise<void> {
+    await this.executeSlashCommand(`/model ${modelId}`);
+  }
+
+  async selectSessionFromPicker(sessionId: string): Promise<void> {
+    await this.executeSlashCommand(`/session switch ${sessionId}`);
   }
 
   async cancelRun(): Promise<void> {

--- a/src/core/commands/slash/modules/model/model-commands.ts
+++ b/src/core/commands/slash/modules/model/model-commands.ts
@@ -165,12 +165,8 @@ function setReasoningEffort(
     return slashMessageResult(`Reasoning effort is not supported for model ${context.model.active()}.`);
   }
 
-  if (selected === 'ultrahigh') {
-    return slashMessageResult('Reasoning effort "ultrahigh" is reserved but is not supported by the current OpenAI request path. Use low, medium, high, or default.');
-  }
-
-  if (!ModelPolicyService.supportsOpenAiRequestReasoningEffort(context.model.active())) {
-    return slashMessageResult(`Reasoning effort settings are not supported by the OpenAI request path for model ${context.model.active()}.`);
+  if (!ModelPolicyService.supportsOpenAiRequestReasoningEffortLevel(context.model.active(), selected)) {
+    return slashMessageResult(`Reasoning effort "${selected}" is not supported by the OpenAI request path for model ${context.model.active()}.`);
   }
 
   context.model.setReasoningEffort(selected);

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -164,9 +164,9 @@ export class OpenAiCodec {
       return undefined;
     }
 
-    if (!ModelPolicyService.supportsOpenAiRequestReasoningEffort(args.model)) {
+    if (!ModelPolicyService.supportsOpenAiRequestReasoningEffortLevel(args.model, effectiveEffort)) {
       if (args.explicitEffort) {
-        throw new Error(`Reasoning effort is not supported for OpenAI model ${args.model}.`);
+        throw new Error(`Reasoning effort "${effectiveEffort}" is not supported for OpenAI model ${args.model}.`);
       }
       return undefined;
     }
@@ -175,11 +175,7 @@ export class OpenAiCodec {
   }
 
   private static toOpenAiReasoningEffort(value: ReasoningEffort): OpenAiReasoningEffort {
-    if (value === 'low' || value === 'medium' || value === 'high') {
-      return value;
-    }
-
-    throw new Error('Reasoning effort "ultrahigh" is not supported by the current OpenAI Responses API. Use low, medium, high, or default.');
+    return value as OpenAiReasoningEffort;
   }
 
   private static toResponseInput(messages: ChatMessage[]): ResponseInputItem[] {

--- a/src/core/llm/models/README.md
+++ b/src/core/llm/models/README.md
@@ -1,0 +1,46 @@
+# Model Policy Boundary
+
+`src/core/llm/models` is Heddle's source of truth for model-specific product
+policy. If a decision depends on a model name, provider family, model
+capability, or model-specific default, it belongs here.
+
+This package owns:
+
+- the curated list of models Heddle exposes in user-facing pickers and command
+  help;
+- provider-specific model allowlists, including OpenAI account sign-in support;
+- reasoning-effort support, defaults, and per-model supported effort levels;
+- model-specific system selections such as compaction and session-title models;
+- credential-aware model availability and disabled-state explanations;
+- estimated context windows and other model-specific capability estimates;
+- future model-specific settings, limits, compatibility rules, and policy
+  messages.
+
+Other services should consume `ModelCatalogService` and `ModelPolicyService`.
+They should not recreate model lists, infer reasoning support, invent context
+window estimates, or decide model fallback policy locally.
+
+## Extension Rules
+
+- Add or update model availability in `model-catalog.ts`.
+- Add or update model policy in `model-policy-service.ts`.
+- Prefer named service methods over exporting raw constants for callers to
+  combine themselves.
+- Keep model fallback decisions here unless a caller needs a narrow operational
+  fallback only to keep the program running after missing or corrupt input.
+- When another layer needs model-specific data for UI, API, command execution,
+  or runtime request building, expose it from this package and pass the resolved
+  shape outward.
+
+## What Does Not Belong Elsewhere
+
+Do not put model-specific policy in control-plane controllers, terminal UI
+services, web components, slash-command modules, runtime hosts, or provider
+adapters when it can be represented here. Those layers may enforce or render
+the policy, but they should not be the place where Heddle decides what a model
+supports.
+
+Provider adapters can still translate an already-approved Heddle policy value
+into the provider wire format. If translation discovers a provider limitation,
+move that limitation back into `ModelPolicyService` so every interface sees the
+same behavior before a request is made.

--- a/src/core/llm/models/index.ts
+++ b/src/core/llm/models/index.ts
@@ -17,5 +17,6 @@ export {
 export type {
   CredentialAwareModelOption,
   ModelCredentialMode,
+  ReasoningEffortOption,
   SystemModelPurpose,
 } from './model-policy-service.js';

--- a/src/core/llm/models/model-policy-service.ts
+++ b/src/core/llm/models/model-policy-service.ts
@@ -13,6 +13,14 @@ export type CredentialAwareModelOption = {
   disabledReason?: string;
 };
 
+export type ReasoningEffortOption = {
+  id: 'default' | ReasoningEffort;
+  label: string;
+  description: string;
+  disabled: boolean;
+  disabledReason?: string;
+};
+
 export const OPENAI_API_KEY_COMPACTION_MODEL = 'gpt-5.1-codex-mini';
 export const OPENAI_OAUTH_SYSTEM_MODEL = 'gpt-5.4';
 export const ANTHROPIC_COMPACTION_MODEL = 'claude-haiku-4-5';
@@ -35,6 +43,13 @@ const OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS = [
   'gpt-5.5',
   'gpt-5.5-pro',
 ] as const;
+const OPENAI_REQUEST_REASONING_EFFORTS_BY_MODEL: Record<string, ReasoningEffort[]> = {
+  'gpt-5.4': ['low', 'medium', 'high'],
+  'gpt-5.4-pro': ['low', 'medium', 'high'],
+  'gpt-5.4-mini': ['low', 'medium', 'high'],
+  'gpt-5.5': ['low', 'medium', 'high', 'ultrahigh'],
+  'gpt-5.5-pro': ['low', 'medium', 'high', 'ultrahigh'],
+};
 const DEFAULT_OPENAI_REASONING_EFFORT: Record<string, ReasoningEffort> = {
   'gpt-5.4': 'medium',
   'gpt-5.4-pro': 'medium',
@@ -185,7 +200,45 @@ export class ModelPolicyService {
   }
 
   static supportsOpenAiRequestReasoningEffort(model: string): boolean {
-    return OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS.includes(model as (typeof OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS)[number]);
+    return ModelPolicyService.supportedOpenAiRequestReasoningEfforts(model).length > 0;
+  }
+
+  static supportsOpenAiRequestReasoningEffortLevel(model: string, effort: ReasoningEffort): boolean {
+    return ModelPolicyService.supportedOpenAiRequestReasoningEfforts(model).includes(effort);
+  }
+
+  static supportedOpenAiRequestReasoningEfforts(model: string): ReasoningEffort[] {
+    return OPENAI_REQUEST_REASONING_EFFORTS_BY_MODEL[model] ?? (
+      OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS.includes(model as (typeof OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS)[number]) ?
+        ['low', 'medium', 'high']
+      : []
+    );
+  }
+
+  static buildReasoningEffortOptions(model: string): ReasoningEffortOption[] {
+    const requestSupportedEfforts = new Set(ModelPolicyService.supportedOpenAiRequestReasoningEfforts(model));
+    const reasoningSupported = ModelPolicyService.supportsReasoningEffort(model);
+    const defaultEffort = ModelPolicyService.resolveDefaultReasoningEffort(model);
+    const disabledReason =
+      reasoningSupported ?
+        'Not supported by request path'
+      : 'Not supported';
+
+    return [
+      {
+        id: 'default',
+        label: 'default',
+        description: defaultEffort ? `Use ${model} default (${defaultEffort})` : `Do not send reasoning effort for ${model}`,
+        disabled: false,
+      },
+      ...(['low', 'medium', 'high', 'ultrahigh'] as const).map((effort) => ({
+        id: effort,
+        label: effort,
+        description: `Set explicit ${effort} effort`,
+        disabled: !requestSupportedEfforts.has(effort),
+        disabledReason: requestSupportedEfforts.has(effort) ? undefined : disabledReason,
+      })),
+    ];
   }
 
   static resolveDefaultReasoningEffort(model: string): ReasoningEffort | undefined {

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -157,6 +157,13 @@ export type ControlPlaneSessionRuntimeContext = {
   reasoningEffort?: ReasoningEffort;
   effectiveReasoningEffort?: ReasoningEffort;
   reasoningSupported: boolean;
+  reasoningOptions: Array<{
+    id: 'default' | ReasoningEffort;
+    label: string;
+    description: string;
+    disabled: boolean;
+    disabledReason?: string;
+  }>;
   credentialSource: ProviderCredentialSource;
   contextWindow?: number;
   estimatedInputTokens?: number;

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -4,6 +4,7 @@ import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import type { MemoryStatusView } from '@/core/memory/types.js';
 import type { ReviewDiffFile } from '@/core/review/index.js';
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
+import type { ReasoningEffortOption } from '@/core/llm/models/index.js';
 import type { ReasoningEffort } from '@/core/llm/types.js';
 import type { ChatSessionRetention } from '@/core/chat/types.js';
 import type { ConversationActivity } from '@/core/live/index.js';
@@ -157,13 +158,7 @@ export type ControlPlaneSessionRuntimeContext = {
   reasoningEffort?: ReasoningEffort;
   effectiveReasoningEffort?: ReasoningEffort;
   reasoningSupported: boolean;
-  reasoningOptions: Array<{
-    id: 'default' | ReasoningEffort;
-    label: string;
-    description: string;
-    disabled: boolean;
-    disabledReason?: string;
-  }>;
+  reasoningOptions: ReasoningEffortOption[];
   credentialSource: ProviderCredentialSource;
   contextWindow?: number;
   estimatedInputTokens?: number;

--- a/src/server/services/control-plane/session-runtime-context-service.ts
+++ b/src/server/services/control-plane/session-runtime-context-service.ts
@@ -4,6 +4,7 @@ import { resolveEffectiveReasoningEffort } from '@/core/chat/engine/sessions/pre
 import type { ChatSession } from '@/core/chat/types.js';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import { ModelCatalogService, ModelPolicyService } from '@/core/llm/models/index.js';
+import type { ReasoningEffort } from '@/core/llm/types.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import type { ChatSessionView, ControlPlaneSessionRuntimeContext } from '@/server/control-plane-types.js';
 import { ControlPlaneSessionDriftService } from './session-drift-service.js';
@@ -68,6 +69,7 @@ export class ControlPlaneSessionRuntimeContextService {
           reasoningEffort: session.reasoningEffort,
         }),
         reasoningSupported: ModelPolicyService.supportsReasoningEffort(model),
+        reasoningOptions: this.buildReasoningOptions(model),
         credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(model, args),
         contextWindow: ModelCatalogService.estimateBuiltInContextWindow(model),
         estimatedInputTokens,
@@ -77,6 +79,39 @@ export class ControlPlaneSessionRuntimeContextService {
         running: options.running ?? false,
       },
     };
+  }
+
+  private buildReasoningOptions(model: string): ControlPlaneSessionRuntimeContext['reasoningOptions'] {
+    const requestSupported = ModelPolicyService.supportsOpenAiRequestReasoningEffort(model);
+    const reasoningSupported = ModelPolicyService.supportsReasoningEffort(model);
+    const defaultEffort = ModelPolicyService.resolveDefaultReasoningEffort(model);
+    const disabledReason =
+      reasoningSupported ?
+        'Not supported by request path'
+      : 'Not supported';
+
+    return [
+      {
+        id: 'default',
+        label: 'default',
+        description: defaultEffort ? `Use ${model} default (${defaultEffort})` : `Do not send reasoning effort for ${model}`,
+        disabled: false,
+      },
+      ...(['low', 'medium', 'high'] as const).map((effort) => ({
+        id: effort,
+        label: effort,
+        description: `Set explicit ${effort} effort`,
+        disabled: !requestSupported,
+        disabledReason: requestSupported ? undefined : disabledReason,
+      })),
+      {
+        id: 'ultrahigh' as ReasoningEffort,
+        label: 'ultrahigh',
+        description: 'Reserved; not accepted by current OpenAI requests',
+        disabled: true,
+        disabledReason: 'Reserved',
+      },
+    ];
   }
 }
 

--- a/src/server/services/control-plane/session-runtime-context-service.ts
+++ b/src/server/services/control-plane/session-runtime-context-service.ts
@@ -4,7 +4,6 @@ import { resolveEffectiveReasoningEffort } from '@/core/chat/engine/sessions/pre
 import type { ChatSession } from '@/core/chat/types.js';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import { ModelCatalogService, ModelPolicyService } from '@/core/llm/models/index.js';
-import type { ReasoningEffort } from '@/core/llm/types.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import type { ChatSessionView, ControlPlaneSessionRuntimeContext } from '@/server/control-plane-types.js';
 import { ControlPlaneSessionDriftService } from './session-drift-service.js';
@@ -69,7 +68,7 @@ export class ControlPlaneSessionRuntimeContextService {
           reasoningEffort: session.reasoningEffort,
         }),
         reasoningSupported: ModelPolicyService.supportsReasoningEffort(model),
-        reasoningOptions: this.buildReasoningOptions(model),
+        reasoningOptions: ModelPolicyService.buildReasoningEffortOptions(model),
         credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(model, args),
         contextWindow: ModelCatalogService.estimateBuiltInContextWindow(model),
         estimatedInputTokens,
@@ -81,38 +80,6 @@ export class ControlPlaneSessionRuntimeContextService {
     };
   }
 
-  private buildReasoningOptions(model: string): ControlPlaneSessionRuntimeContext['reasoningOptions'] {
-    const requestSupported = ModelPolicyService.supportsOpenAiRequestReasoningEffort(model);
-    const reasoningSupported = ModelPolicyService.supportsReasoningEffort(model);
-    const defaultEffort = ModelPolicyService.resolveDefaultReasoningEffort(model);
-    const disabledReason =
-      reasoningSupported ?
-        'Not supported by request path'
-      : 'Not supported';
-
-    return [
-      {
-        id: 'default',
-        label: 'default',
-        description: defaultEffort ? `Use ${model} default (${defaultEffort})` : `Do not send reasoning effort for ${model}`,
-        disabled: false,
-      },
-      ...(['low', 'medium', 'high'] as const).map((effort) => ({
-        id: effort,
-        label: effort,
-        description: `Set explicit ${effort} effort`,
-        disabled: !requestSupported,
-        disabledReason: requestSupported ? undefined : disabledReason,
-      })),
-      {
-        id: 'ultrahigh' as ReasoningEffort,
-        label: 'ultrahigh',
-        description: 'Reserved; not accepted by current OpenAI requests',
-        disabled: true,
-        disabledReason: 'Reserved',
-      },
-    ];
-  }
 }
 
 export const controlPlaneSessionRuntimeContextService = new ControlPlaneSessionRuntimeContextService();


### PR DESCRIPTION
## Summary
- add cli-v2 model, reasoning effort, and session picker panels
- fetch model options once on startup and filter cached model/session data locally
- expose reasoning picker options from the control-plane runtime context while sourcing per-model support from core ModelPolicyService
- route picker selections through slashCommandExecute so core slash command semantics stay server-owned
- move picker state/keyboard/selection wiring into a cli-v2 hook to keep App.tsx focused on rendering
- remove the OAuth account short id from the cli-v2 status bar
- allow ultrahigh reasoning effort for GPT-5.5/GPT-5.5 Pro through centralized model policy
- document that cli-v2 is actively under development, unreleased, and moving the TUI to an API-only control-plane path
- add a model-policy README defining src/core/llm/models as the source of truth for model-specific settings and policy

## Validation
- yarn typecheck
- ./node_modules/.bin/vitest run src/__tests__/unit/core/llm-factory.test.ts src/__tests__/unit/core/openai-oauth.test.ts src/__tests__/unit/core/slash-command-modules.test.ts src/__tests__/unit/tui/local-commands.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/unit/cli-v2/picker-service.test.ts
- rg boundary check for cli-v2 core/server/old-cli imports
- rg check for removed ultrahigh reserved hardcoding