### PR TITLE
Fix web approval sequencing

### DIFF
--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -347,6 +347,32 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('refreshes pending approval from control-plane approval state events', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+    fixture.calls.sessionPendingApprovalQuery.mockClear();
+    fixture.calls.sessionPendingApprovalQuery.mockResolvedValueOnce(createPendingApproval());
+
+    fixture.sessionEvents?.onData?.({
+      type: 'session.approval.updated',
+      sessionId: 'session-1',
+      timestamp: new Date().toISOString(),
+    });
+    await vi.waitFor(() => {
+      expect(store.getSnapshot().pendingApproval).toEqual(expect.objectContaining({
+        callId: 'call-1',
+        tool: 'run_shell_mutate',
+      }));
+    });
+
+    expect(fixture.calls.sessionPendingApprovalQuery).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      id: 'session-1',
+    });
+    store.dispose();
+  });
+
   it('applies live assistant stream events from the session subscription', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });
@@ -697,6 +723,16 @@ function createClientFixture() {
     get sessionsEvents() {
       return sessionsEvents;
     },
+  };
+}
+
+function createPendingApproval(): NonNullable<ControlPlanePendingApproval> {
+  return {
+    tool: 'run_shell_mutate',
+    callId: 'call-1',
+    input: { command: 'touch queued.txt' },
+    requestedAt: new Date().toISOString(),
+    summary: 'run shell command',
   };
 }
 

--- a/src/__tests__/unit/control-plane/session-cancel.test.ts
+++ b/src/__tests__/unit/control-plane/session-cancel.test.ts
@@ -1,10 +1,11 @@
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
 import type { ChatSession } from '@/core/chat/types.js';
 import type { ToolApprovalRequest, ToolApprovalUserDecision } from '@/core/approvals/index.js';
+import type { ToolCall, ToolDefinition } from '@/core/types.js';
 import { ControlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
 import type {
   ControlPlaneSessionRunContext,
@@ -13,6 +14,17 @@ import type {
 
 type ControllerInternals = {
   runService: ControlPlaneSessionRunService;
+  createEngineHost: (
+    args: Record<string, unknown>,
+    publisher: {
+      publishActivity: (activity: unknown) => void;
+      publishApprovalUpdated: () => void;
+    },
+  ) => {
+    approvals?: {
+      requestToolApproval: (args: { call: ToolCall; tool: ToolDefinition }) => Promise<{ approved: boolean; reason?: string }>;
+    };
+  };
   runEngineTurn: (
     args: Record<string, unknown>,
     runContext: ControlPlaneSessionRunContext,
@@ -109,6 +121,57 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
 
     expect(observedShouldStop).toEqual([false, true]);
     expect(controller.isRunning({ workspaceId, sessionId })).toBe(false);
+  });
+
+  it('publishes approval state changes after pending approval storage is queryable', async () => {
+    const controller = new ControlPlaneChatSessionsController();
+    const internals = controller as unknown as ControllerInternals;
+    const workspaceId = 'workspace-approval-state';
+    const sessionId = 'session-approval-state';
+    const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-control-plane-approval-'));
+    const publisher = {
+      publishActivity: vi.fn(),
+      publishApprovalUpdated: vi.fn(),
+    };
+    const host = internals.createEngineHost({
+      workspaceId,
+      sessionId,
+      workspaceRoot: stateRoot,
+      stateRoot,
+    }, publisher);
+
+    const approval = host.approvals?.requestToolApproval({
+      call: {
+        id: 'call-approval-state',
+        tool: 'run_shell_mutate',
+        input: { command: 'touch approval-state.txt' },
+      },
+      tool: {
+        name: 'run_shell_mutate',
+        description: 'mutates workspace',
+        requiresApproval: true,
+        parameters: {},
+        execute: async () => ({ ok: true }),
+      },
+    });
+    await Promise.resolve();
+
+    expect(controller.getPendingApproval({ workspaceId, sessionId })).toEqual(expect.objectContaining({
+      callId: 'call-approval-state',
+      tool: 'run_shell_mutate',
+    }));
+    expect(publisher.publishApprovalUpdated).toHaveBeenCalledTimes(1);
+
+    expect(controller.resolvePendingApproval({ workspaceId, sessionId }, {
+      type: 'approve',
+      reason: 'Approved in test',
+    })).toBe(true);
+    await expect(approval).resolves.toEqual({
+      approved: true,
+      reason: 'Approved in test',
+    });
+    expect(controller.getPendingApproval({ workspaceId, sessionId })).toBeUndefined();
+    expect(publisher.publishApprovalUpdated).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -541,6 +541,11 @@ export class ControlPlaneSessionStore {
       return;
     }
 
+    if (event.type === 'session.approval.updated') {
+      void this.refreshPendingApproval(event.sessionId);
+      return;
+    }
+
     if (event.type !== 'session.event') {
       return;
     }

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -185,6 +185,11 @@ export type ControlPlaneSessionLiveEvent = {
 export type ControlPlaneSessionEventEnvelope =
   | (ControlPlaneSessionLiveEvent & { type: 'session.event' })
   | {
+    type: 'session.approval.updated';
+    sessionId: string;
+    timestamp: string;
+  }
+  | {
     type: 'session.updated' | 'waiting';
     sessionId: string;
     timestamp: string;

--- a/src/server/controllers/trpc/control-plane/chat-session-events.ts
+++ b/src/server/controllers/trpc/control-plane/chat-session-events.ts
@@ -1,6 +1,6 @@
 import type { EventEmitter } from 'node:events';
 import type { ConversationActivity } from '@/core/live/index.js';
-import type { ControlPlaneSessionLiveEvent } from '@/server/control-plane-types.js';
+import type { ControlPlaneSessionEventEnvelope, ControlPlaneSessionLiveEvent } from '@/server/control-plane-types.js';
 
 export class ControlPlaneChatSessionEventsController {
   static emitSessionActivities(args: {
@@ -40,6 +40,14 @@ export class ControlPlaneChatSessionEventsController {
       },
 
       publishActivities,
+
+      publishApprovalUpdated() {
+        args.eventBus.emit(ControlPlaneChatSessionEventsController.sessionAddressKey(args), {
+          type: 'session.approval.updated',
+          sessionId: args.sessionId,
+          timestamp: new Date().toISOString(),
+        } satisfies ControlPlaneSessionEventEnvelope);
+      },
     };
 
     return publisher;

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -253,7 +253,7 @@ export class ControlPlaneChatSessionsController {
 
   subscribeToEvents(
     sessionAddress: ControlPlaneSessionAddress,
-    listener: (event: ControlPlaneSessionLiveEvent) => void,
+    listener: (event: ControlPlaneSessionLiveEvent | Extract<ControlPlaneSessionEventEnvelope, { type: 'session.approval.updated' }>) => void,
   ): () => void {
     const key = ControlPlaneChatSessionsController.sessionAddressKey(sessionAddress);
     this.sessionEventBus.on(key, listener);
@@ -275,6 +275,11 @@ export class ControlPlaneChatSessionsController {
         // bus. This path streams assistant text without touching the session
         // file for each model delta.
         (sink) => this.subscribeToEvents(args, (event) => {
+          if ('type' in event) {
+            sink.push(event);
+            return;
+          }
+
           sink.push({
             ...event,
             type: 'session.event',
@@ -575,9 +580,11 @@ export class ControlPlaneChatSessionsController {
                 approval: request,
                 resolve,
               });
+              publisher.publishApprovalUpdated();
             },
           });
           this.runService.clearPendingApproval(args);
+          publisher.publishApprovalUpdated();
           return decision;
         },
       },

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
@@ -60,6 +60,11 @@ export function useControlPlaneSessionEvents({
       return;
     }
 
+    if (event.type === 'session.approval.updated') {
+      refreshPendingApproval(event.sessionId);
+      return;
+    }
+
     if (event.type !== 'session.event') {
       return;
     }


### PR DESCRIPTION
## Summary
- emit a control-plane approval state event after pending approval storage changes
- refresh web-v2 and cli-v2 pending approvals from that queryable server state
- keep approval execution one-by-one without retry timers or queue API changes

## Tests
- ./node_modules/.bin/vitest run src/__tests__/unit/control-plane/session-cancel.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
- yarn typecheck