### PR TITLE
Show current and latest agent activity

### DIFF
--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -520,6 +520,10 @@ describe('ControlPlaneSessionStore', () => {
       detail: 'step 2',
       tone: 'info',
     });
+    expect(store.getSnapshot().currentActivity).toEqual(expect.objectContaining({
+      label: 'Running read_file',
+      detail: 'step 2',
+    }));
     expect(store.getSnapshot().liveStatus).toBe('Working... running read_file (step 2)');
     store.dispose();
   });

--- a/src/__tests__/unit/client-shared/session-activity-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-activity-service.test.ts
@@ -99,4 +99,67 @@ describe('ClientSharedSessionActivityService', () => {
       timestamp: new Date().toISOString(),
     } as ControlPlaneSessionActivity)).toBe('yarn test');
   });
+
+  it('projects current agent activity and elapsed time from session events', () => {
+    const currentActivity: string[] = [];
+
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'loop.started',
+      runId: 'run-1',
+      source: 'agent-loop',
+      goal: 'Inspect repo.',
+      model: 'gpt-5.4',
+      provider: 'openai',
+      workspaceRoot: '/repo',
+      timestamp: '2026-05-31T07:00:00.000Z',
+    } as ControlPlaneSessionActivity, {
+      onCurrentActivityChanged: (activity) => currentActivity.push(activity?.label ?? 'cleared'),
+    });
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'tool.calling',
+      tool: 'read_file',
+      toolCallId: 'call-1',
+      input: { path: 'README.md' },
+      requiresApproval: false,
+      step: 2,
+      runId: 'run-1',
+      source: 'agent-loop',
+      timestamp: '2026-05-31T07:00:05.000Z',
+      derived: {
+        kind: 'tool-summary',
+        summary: 'read_file README.md',
+      },
+    } as ControlPlaneSessionActivity, {
+      onCurrentActivityChanged: (activity) => currentActivity.push(
+        activity?.detail ? `${activity.label}:${activity.detail}` : (activity?.label ?? 'cleared'),
+      ),
+    });
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'assistant.stream',
+      runId: 'run-1',
+      source: 'agent-loop',
+      step: 2,
+      text: 'Final answer streaming',
+      done: false,
+      timestamp: '2026-05-31T07:00:07.000Z',
+    } as ControlPlaneSessionActivity, {
+      onCurrentActivityChanged: (activity) => currentActivity.push(activity?.label ?? 'cleared'),
+    });
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'loop.finished',
+      outcome: 'done',
+      runId: 'run-1',
+      source: 'agent-loop',
+      summary: 'Done.',
+      timestamp: '2026-05-31T07:00:10.000Z',
+    } as ControlPlaneSessionActivity, {
+      onCurrentActivityChanged: (activity) => currentActivity.push(activity?.label ?? 'cleared'),
+    });
+
+    expect(currentActivity).toEqual(['Thinking', 'Running read_file:step 2', 'cleared', 'cleared']);
+    expect(ClientSharedSessionActivityService.formatElapsed(
+      '2026-05-31T07:00:05.000Z',
+      new Date('2026-05-31T07:01:09.000Z'),
+    )).toBe('1m 4s');
+  });
 });

--- a/src/__tests__/unit/web-v2/agent-activity-status.test.tsx
+++ b/src/__tests__/unit/web-v2/agent-activity-status.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentActivityStatus } from '../../../web-v2/components/conversation/AgentActivityStatus.js';
+
+describe('AgentActivityStatus', () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('renders current activity with elapsed time', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-31T07:00:12.000Z'));
+
+    render(
+      <AgentActivityStatus
+        currentActivity={{
+          label: 'Thinking',
+          startedAt: '2026-05-31T07:00:00.000Z',
+          tone: 'info',
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('web-v2-agent-activity-status').textContent).toContain('Thinking');
+    expect(screen.getByTestId('web-v2-agent-activity-status').textContent).toContain('12s');
+  });
+});

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -9,6 +9,7 @@ import { CommandResultPanel } from './components/CommandResultPanel.js';
 import { ConversationPanel } from './components/ConversationPanel.js';
 import { ModelPickerPanel } from './components/ModelPickerPanel.js';
 import { PromptInput } from './components/PromptInput.js';
+import { PromptStatusPanel } from './components/PromptStatusPanel.js';
 import { ReasoningEffortPickerPanel } from './components/ReasoningEffortPickerPanel.js';
 import { RunControls } from './components/RunControls.js';
 import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
@@ -145,8 +146,11 @@ export function App({
         />
       ) : null}
       {!pickers.visible ? <SlashCommandHintPanel hints={slashCommandHints} /> : null}
+      <PromptStatusPanel
+        currentActivity={snapshot.currentActivity}
+        latestActivity={PromptActivityService.build(snapshot)}
+      />
       <PromptInput
-        activity={PromptActivityService.build(snapshot)}
         disabled={inputDisabled}
         submitDisabled={submitDisabled || Boolean(snapshot.pendingApproval)}
         placeholder={

--- a/src/cli-v2/components/PromptInput.tsx
+++ b/src/cli-v2/components/PromptInput.tsx
@@ -1,6 +1,5 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
-import type { PromptActivityView } from '../services/activities/prompt-activity-service.js';
 
 export type PromptInputKey = {
   upArrow?: boolean;
@@ -17,7 +16,6 @@ export type PromptInputKey = {
 };
 
 export function PromptInput({
-  activity,
   disabled,
   placeholder,
   submitDisabled,
@@ -27,7 +25,6 @@ export function PromptInput({
   onComplete,
   onSpecialKey,
 }: {
-  activity?: PromptActivityView;
   disabled: boolean;
   placeholder: string;
   submitDisabled?: boolean;
@@ -81,7 +78,6 @@ export function PromptInput({
       <Box overflow="hidden">
         <Text dimColor wrap="truncate-end">{separator}</Text>
       </Box>
-      {activity ? <Text color={activity.color}>{activity.text}</Text> : null}
       <Box>
         <Text color="cyan">› </Text>
         <Text>{value || <Text dimColor>{placeholder}</Text>}</Text>

--- a/src/cli-v2/components/PromptStatusPanel.tsx
+++ b/src/cli-v2/components/PromptStatusPanel.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import {
+  ClientSharedSessionActivityService,
+  type ClientSharedAgentActivityStatus,
+} from '@/client-shared/services/session-activities/index.js';
+import type { PromptActivityView } from '../services/activities/prompt-activity-service.js';
+
+type PromptStatusPanelProps = {
+  currentActivity?: ClientSharedAgentActivityStatus;
+  latestActivity?: PromptActivityView;
+};
+
+export function PromptStatusPanel({ currentActivity, latestActivity }: PromptStatusPanelProps) {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    if (!currentActivity) {
+      return undefined;
+    }
+
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, [currentActivity]);
+
+  if (!currentActivity && !latestActivity) {
+    return null;
+  }
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      {latestActivity ? <Text color={latestActivity.color}>{latestActivity.text}</Text> : null}
+      {currentActivity ? (
+        <Text color={currentActivity.tone === 'warning' ? 'yellow' : 'cyan'}>
+          {formatCurrentActivity(currentActivity, now)}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+function formatCurrentActivity(activity: ClientSharedAgentActivityStatus, now: Date): string {
+  const elapsed = ClientSharedSessionActivityService.formatElapsed(activity.startedAt, now);
+  const detail = activity.detail ? ` · ${activity.detail}` : '';
+  return activity.label === 'Thinking'
+    ? `Thinking... ${elapsed}`
+    : `${activity.label}${detail} · ${elapsed}`;
+}

--- a/src/cli-v2/services/activities/session-activity-service.ts
+++ b/src/cli-v2/services/activities/session-activity-service.ts
@@ -2,82 +2,20 @@ import type {
   ControlPlanePendingApproval,
   ControlPlaneSessionEventEnvelope,
 } from '@/client-shared/api/types.js';
-import { ClientSharedSessionActivityService } from '@/client-shared/services/session-activities/index.js';
+import {
+  ClientSharedSessionActivityService,
+  type ClientSharedSessionLatestUpdate,
+} from '@/client-shared/services/session-activities/index.js';
 
 type ControlPlaneSessionActivity = Extract<ControlPlaneSessionEventEnvelope, { type: 'session.event' }>['activities'][number];
-export type ControlPlaneSessionLatestUpdate = {
-  label: string;
-  detail?: string;
-  tone: 'info' | 'success' | 'warning' | 'error';
-};
-type SessionActivityLatestUpdateHandlers = {
-  [ActivityType in ControlPlaneSessionActivity['type']]?: (
-    activity: Extract<ControlPlaneSessionActivity, { type: ActivityType }>,
-  ) => ControlPlaneSessionLatestUpdate | undefined;
-};
+export type ControlPlaneSessionLatestUpdate = ClientSharedSessionLatestUpdate;
 
 /**
  * Projects control-plane session activities into terminal status text.
  */
 export class SessionActivityService {
-  private static readonly latestUpdateHandlers: SessionActivityLatestUpdateHandlers = {
-    'loop.started': (activity) => ({
-      label: 'Run started',
-      detail: `${activity.model} via ${activity.provider}`,
-      tone: 'info',
-    }),
-    'tool.calling': (activity) => ({
-      label: `Running ${ClientSharedSessionActivityService.formatToolLabel(activity)}`,
-      detail: ClientSharedSessionActivityService.formatStepDetail(activity.step),
-      tone: activity.requiresApproval ? 'warning' : 'info',
-    }),
-    'tool.completed': (activity) => ({
-      label: `${activity.tool} completed`,
-      detail: `${Math.round(activity.durationMs)}ms`,
-      tone: 'success',
-    }),
-    'tool.approval_requested': (activity) => ({
-      label: 'Approval requested',
-      detail: ClientSharedSessionActivityService.formatToolLabel(activity),
-      tone: 'warning',
-    }),
-    'tool.approval_resolved': (activity) => ({
-      label: activity.approved ? 'Approval granted' : 'Approval denied',
-      detail: activity.reason,
-      tone: activity.approved ? 'info' : 'warning',
-    }),
-    'tool.fallback': (activity) => ({
-      label: 'Tool fallback',
-      detail: ClientSharedSessionActivityService.formatToolFallbackLabel(activity),
-      tone: 'warning',
-    }),
-    'loop.finished': (activity) => ({
-      label: 'Run finished',
-      detail: activity.outcome,
-      tone: SessionActivityService.resolveRunOutcomeTone(activity.outcome),
-    }),
-    'compaction.running': (activity) => ({
-      label: 'Compacting history',
-      detail: activity.archivePath,
-      tone: 'info',
-    }),
-    'compaction.failed': (activity) => ({
-      label: 'Compaction failed',
-      detail: activity.error,
-      tone: 'error',
-    }),
-    'compaction.finished': (activity) => ({
-      label: 'Compaction finished',
-      detail: activity.summaryPath,
-      tone: 'success',
-    }),
-  };
-
   static resolveLatestUpdate(activity: ControlPlaneSessionActivity): ControlPlaneSessionLatestUpdate | undefined {
-    const handler = SessionActivityService.latestUpdateHandlers[activity.type] as (
-      (activity: ControlPlaneSessionActivity) => ControlPlaneSessionLatestUpdate | undefined
-    ) | undefined;
-    return handler?.(activity);
+    return ClientSharedSessionActivityService.resolveLatestUpdate(activity);
   }
 
   static formatPendingApprovalLabel(approval: NonNullable<ControlPlanePendingApproval>): string | undefined {
@@ -85,10 +23,6 @@ export class SessionActivityService {
   }
 
   static resolveRunOutcomeTone(outcome: string): ControlPlaneSessionLatestUpdate['tone'] {
-    if (outcome === 'done' || outcome === 'completed') {
-      return 'success';
-    }
-
-    return outcome === 'error' ? 'error' : 'warning';
+    return ClientSharedSessionActivityService.resolveRunOutcomeTone(outcome);
   }
 }

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -1,6 +1,9 @@
 import type { ControlPlaneProxyClient } from '@/client-shared/api/proxy.js';
 import { ClientSharedSessionActivityService } from '@/client-shared/services/session-activities/index.js';
-import type { ClientSharedSessionPlan } from '@/client-shared/services/session-activities/index.js';
+import type {
+  ClientSharedAgentActivityStatus,
+  ClientSharedSessionPlan,
+} from '@/client-shared/services/session-activities/index.js';
 import { ClientSharedSessionMessageService } from '@/client-shared/services/session-messages/index.js';
 import {
   SessionActivityService,
@@ -66,6 +69,7 @@ export type ControlPlaneSessionStoreSnapshot = {
   cancelling: boolean;
   streamConnected: boolean;
   liveStatus?: string;
+  currentActivity?: ClientSharedAgentActivityStatus;
   activePlan?: ClientSharedSessionPlan;
   latestUpdate?: ControlPlaneSessionLatestUpdate;
   slashCommandCatalog?: ControlPlaneSlashCommandCatalog;
@@ -196,6 +200,7 @@ export class ControlPlaneSessionStore {
       runtimeContext: undefined,
       pendingApproval: null,
       liveStatus: undefined,
+      currentActivity: undefined,
       activePlan: undefined,
       latestUpdate: undefined,
       error: undefined,
@@ -249,6 +254,7 @@ export class ControlPlaneSessionStore {
       running: true,
       error: undefined,
       activePlan: undefined,
+      currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
       liveStatus: current.streamConnected
         ? 'Heddle is working...'
         : 'Heddle is working... reconnecting live stream if needed.',
@@ -272,6 +278,7 @@ export class ControlPlaneSessionStore {
         liveStatus: this.snapshotValue.streamConnected
           ? 'Heddle is working...'
           : 'Heddle is working... reconnecting live stream if needed.',
+        currentActivity: this.snapshotValue.currentActivity ?? ClientSharedSessionActivityService.createThinkingStatus(),
         latestUpdate: {
           label: 'Run accepted',
           detail: result.runId,
@@ -290,6 +297,7 @@ export class ControlPlaneSessionStore {
           liveStatus: this.snapshotValue.streamConnected
             ? 'A run is already in progress for this session.'
             : 'A run is already in progress for this session. Reconnecting live stream if needed.',
+          currentActivity: this.snapshotValue.currentActivity ?? ClientSharedSessionActivityService.createThinkingStatus(),
           latestUpdate: {
             label: 'Run already in progress',
             detail: 'waiting for current run to finish',
@@ -304,6 +312,7 @@ export class ControlPlaneSessionStore {
         running: false,
         submitting: false,
         liveStatus: undefined,
+        currentActivity: undefined,
       });
       await this.refreshSession(sessionId, { silent: true }).catch(() => undefined);
       this.assistantStreamBuffer.reset();
@@ -351,6 +360,7 @@ export class ControlPlaneSessionStore {
         running: result.cancelled ? running.running : false,
         cancelling: false,
         liveStatus: result.cancelled && running.running ? this.snapshotValue.liveStatus : undefined,
+        currentActivity: result.cancelled && running.running ? this.snapshotValue.currentActivity : undefined,
         latestUpdate: {
           label: result.cancelled ? 'Stop request accepted' : 'No active run to stop',
           tone: result.cancelled ? 'warning' : 'info',
@@ -361,6 +371,7 @@ export class ControlPlaneSessionStore {
         error: formatError(error),
         cancelling: false,
         liveStatus: undefined,
+        currentActivity: undefined,
       });
     }
   }
@@ -494,6 +505,7 @@ export class ControlPlaneSessionStore {
     this.setSnapshot({
       running: true,
       activePlan: undefined,
+      currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
       liveStatus: 'Heddle is continuing from the current transcript...',
     });
     await this.api.continueSession(workspaceId, sessionId);
@@ -508,6 +520,7 @@ export class ControlPlaneSessionStore {
     this.setSnapshot({
       running: true,
       activePlan: undefined,
+      currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
       liveStatus: this.snapshotValue.streamConnected
         ? 'Heddle is working...'
         : 'Heddle is working... reconnecting live stream if needed.',
@@ -564,6 +577,7 @@ export class ControlPlaneSessionStore {
           this.setSnapshot({
             running: true,
             liveStatus,
+            currentActivity: ClientSharedSessionActivityService.createThinkingStatus(runActivity.timestamp),
             latestUpdate: SessionActivityService.resolveLatestUpdate(runActivity),
           });
         },
@@ -572,6 +586,7 @@ export class ControlPlaneSessionStore {
           this.setSnapshot({
             running: false,
             ...(liveStatus !== undefined ? { liveStatus } : {}),
+            currentActivity: undefined,
             latestUpdate: SessionActivityService.resolveLatestUpdate(runActivity),
           });
           void this.refreshSession(event.sessionId, { silent: true });
@@ -585,6 +600,9 @@ export class ControlPlaneSessionStore {
         },
         onPlanCleared: () => {
           this.setSnapshot({ activePlan: undefined });
+        },
+        onCurrentActivityChanged: (currentActivity) => {
+          this.setSnapshot({ currentActivity });
         },
         onLiveStatus: (statusActivity, liveStatus) => {
           const latestUpdate = SessionActivityService.resolveLatestUpdate(statusActivity);
@@ -703,6 +721,7 @@ export class ControlPlaneSessionStore {
       submitting: false,
       liveStatus: undefined,
       activePlan: undefined,
+      currentActivity: undefined,
       latestUpdate: {
         label: 'Run finished',
         tone: 'success',

--- a/src/client-shared/services/session-activities/index.ts
+++ b/src/client-shared/services/session-activities/index.ts
@@ -1,5 +1,7 @@
 export {
   ClientSharedSessionActivityService,
+  type ClientSharedAgentActivityStatus,
   type ClientSharedSessionActivity,
+  type ClientSharedSessionLatestUpdate,
   type ClientSharedSessionPlan,
 } from './session-activity-service.js';

--- a/src/client-shared/services/session-activities/session-activity-service.ts
+++ b/src/client-shared/services/session-activities/session-activity-service.ts
@@ -2,13 +2,33 @@ import type {
   ControlPlanePendingApproval,
   ControlPlaneSessionEventEnvelope,
 } from '../../api/types.js';
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration.js';
+
+dayjs.extend(duration);
 
 export type ClientSharedSessionActivity = Extract<ControlPlaneSessionEventEnvelope, { type: 'session.event' }>['activities'][number];
+export type ClientSharedAgentActivityStatus = {
+  label: string;
+  detail?: string;
+  startedAt: string;
+  tone: 'info' | 'warning';
+};
+export type ClientSharedSessionLatestUpdate = {
+  label: string;
+  detail?: string;
+  tone: 'info' | 'success' | 'warning' | 'error';
+};
 
 type SessionActivityStatusHandlers = {
   [ActivityType in ClientSharedSessionActivity['type']]?: (
     activity: Extract<ClientSharedSessionActivity, { type: ActivityType }>,
   ) => string | undefined;
+};
+type SessionActivityLatestUpdateHandlers = {
+  [ActivityType in ClientSharedSessionActivity['type']]?: (
+    activity: Extract<ClientSharedSessionActivity, { type: ActivityType }>,
+  ) => ClientSharedSessionLatestUpdate | undefined;
 };
 type ActivityOf<ActivityType extends ClientSharedSessionActivity['type']> = Extract<ClientSharedSessionActivity, { type: ActivityType }>;
 type PendingApprovalActivity = ActivityOf<'tool.approval_requested'> | ActivityOf<'tool.approval_resolved'>;
@@ -28,6 +48,7 @@ export type ClientSharedSessionActivityEffects = {
   onPlanUpdated?: (activity: ClientSharedSessionPlan) => void;
   onPlanCleared?: () => void;
   onLiveStatus?: (activity: ClientSharedSessionActivity, liveStatus: string | undefined) => void;
+  onCurrentActivityChanged?: (activity: ClientSharedAgentActivityStatus | undefined) => void;
   onPendingApprovalChanged?: (activity: PendingApprovalActivity) => void;
   onWorkspaceChanged?: (activity: WorkspaceChangedActivity) => void;
 };
@@ -41,23 +62,38 @@ export type ClientSharedSessionActivityEffects = {
  * run starts or the current run finishes.
  */
 export class ClientSharedSessionActivityService {
+  // Dispatches raw control-plane activity facts into frontend-neutral effects.
+  // Keep lifecycle policy here when both web-v2 and cli-v2 must react the same
+  // way, such as active plan lifetime, pending approval refresh, and current
+  // activity state. Do not put host-specific rendering, colors, layout, or
+  // keyboard behavior in this map.
   private static readonly effectHandlers: SessionActivityEffectHandlers = {
     'assistant.stream': (activity, effects) => {
       effects.onAssistantStream?.(activity, activity.done ? undefined : 'Receiving assistant response...');
+      effects.onCurrentActivityChanged?.(undefined);
     },
     'loop.started': (activity, effects) => {
       effects.onPlanCleared?.();
+      effects.onCurrentActivityChanged?.(ClientSharedSessionActivityService.createThinkingStatus(activity.timestamp));
       effects.onRunStarted?.(activity, ClientSharedSessionActivityService.formatLiveStatus(activity));
     },
     'loop.finished': (activity, effects) => {
       effects.onPlanCleared?.();
+      effects.onCurrentActivityChanged?.(undefined);
       effects.onRunFinished?.(activity, ClientSharedSessionActivityService.formatLiveStatus(activity));
       effects.onWorkspaceChanged?.(activity);
     },
     'tool.calling': (activity, effects) => {
+      effects.onCurrentActivityChanged?.({
+        label: `Running ${ClientSharedSessionActivityService.formatToolName(activity)}`,
+        detail: ClientSharedSessionActivityService.formatStepDetail(activity.step),
+        startedAt: activity.timestamp,
+        tone: activity.requiresApproval ? 'warning' : 'info',
+      });
       ClientSharedSessionActivityService.applyLiveStatus(activity, effects);
     },
     'tool.completed': (activity, effects) => {
+      effects.onCurrentActivityChanged?.(ClientSharedSessionActivityService.createThinkingStatus(activity.timestamp));
       ClientSharedSessionActivityService.applyLiveStatus(activity, effects);
       effects.onWorkspaceChanged?.(activity);
     },
@@ -66,10 +102,16 @@ export class ClientSharedSessionActivityService {
     },
     'tool.approval_requested': (activity, effects) => {
       effects.onPendingApprovalChanged?.(activity);
+      effects.onCurrentActivityChanged?.({
+        label: 'Waiting for approval',
+        startedAt: activity.timestamp,
+        tone: 'warning',
+      });
       ClientSharedSessionActivityService.applyLiveStatus(activity, effects);
     },
     'tool.approval_resolved': (activity, effects) => {
       effects.onPendingApprovalChanged?.(activity);
+      effects.onCurrentActivityChanged?.(ClientSharedSessionActivityService.createThinkingStatus(activity.timestamp));
       ClientSharedSessionActivityService.applyLiveStatus(activity, effects);
     },
     'compaction.running': (activity, effects) => {
@@ -83,6 +125,10 @@ export class ClientSharedSessionActivityService {
     },
   };
 
+  // Formats legacy/live status strings from activity facts. These strings are
+  // compatibility status text for existing host state, not the canonical
+  // current/latest activity UI. Prefer extending current/latest projections
+  // below for new user-visible run status surfaces.
   private static readonly liveStatusHandlers: SessionActivityStatusHandlers = {
     'loop.started': () => 'Run started...',
     'loop.finished': (activity) => `Run finished: ${activity.outcome}`,
@@ -101,11 +147,75 @@ export class ClientSharedSessionActivityService {
     ),
   };
 
+  // Projects activity facts into the stable "latest activity" breadcrumb shown
+  // near prompts/composers. This is intentionally allowed to include useful
+  // review detail such as command/path summaries because it describes what just
+  // happened. Do not use this for active timers or "what is running now" UI.
+  private static readonly latestUpdateHandlers: SessionActivityLatestUpdateHandlers = {
+    'loop.started': (activity) => ({
+      label: 'Run started',
+      detail: `${activity.model} via ${activity.provider}`,
+      tone: 'info',
+    }),
+    'tool.calling': (activity) => ({
+      label: `Running ${ClientSharedSessionActivityService.formatToolLabel(activity)}`,
+      detail: ClientSharedSessionActivityService.formatStepDetail(activity.step),
+      tone: activity.requiresApproval ? 'warning' : 'info',
+    }),
+    'tool.completed': (activity) => ({
+      label: `${activity.tool} completed`,
+      detail: `${Math.round(activity.durationMs)}ms`,
+      tone: 'success',
+    }),
+    'tool.approval_requested': (activity) => ({
+      label: 'Approval requested',
+      detail: ClientSharedSessionActivityService.formatToolLabel(activity),
+      tone: 'warning',
+    }),
+    'tool.approval_resolved': (activity) => ({
+      label: activity.approved ? 'Approval granted' : 'Approval denied',
+      detail: activity.reason,
+      tone: activity.approved ? 'info' : 'warning',
+    }),
+    'tool.fallback': (activity) => ({
+      label: 'Tool fallback',
+      detail: ClientSharedSessionActivityService.formatToolFallbackLabel(activity),
+      tone: 'warning',
+    }),
+    'loop.finished': (activity) => ({
+      label: 'Run finished',
+      detail: activity.outcome,
+      tone: ClientSharedSessionActivityService.resolveRunOutcomeTone(activity.outcome),
+    }),
+    'compaction.running': (activity) => ({
+      label: 'Compacting history',
+      detail: activity.archivePath,
+      tone: 'info',
+    }),
+    'compaction.failed': (activity) => ({
+      label: 'Compaction failed',
+      detail: activity.error,
+      tone: 'error',
+    }),
+    'compaction.finished': (activity) => ({
+      label: 'Compaction finished',
+      detail: activity.summaryPath,
+      tone: 'success',
+    }),
+  };
+
   static applyActivity(activity: ClientSharedSessionActivity, effects: ClientSharedSessionActivityEffects): void {
     const handler = ClientSharedSessionActivityService.effectHandlers[activity.type] as (
       (activity: ClientSharedSessionActivity, effects: ClientSharedSessionActivityEffects) => void
     ) | undefined;
     handler?.(activity, effects);
+  }
+
+  static resolveLatestUpdate(activity: ClientSharedSessionActivity): ClientSharedSessionLatestUpdate | undefined {
+    const handler = ClientSharedSessionActivityService.latestUpdateHandlers[activity.type] as (
+      (activity: ClientSharedSessionActivity) => ClientSharedSessionLatestUpdate | undefined
+    ) | undefined;
+    return handler?.(activity);
   }
 
   private static formatLiveStatus(activity: ClientSharedSessionActivity): string | undefined {
@@ -119,11 +229,29 @@ export class ClientSharedSessionActivityService {
     return approval.tool;
   }
 
+  // Rich label for review/history surfaces. This may include derived summaries
+  // such as command strings or file paths, so it belongs in latest activity,
+  // approval panels, and transcripts rather than the active "doing now" line.
   static formatToolLabel(activity: ClientSharedSessionActivity): string {
     if ('derived' in activity && activity.derived?.kind === 'tool-summary') {
       return activity.derived.summary;
     }
 
+    if ('tool' in activity && typeof activity.tool === 'string') {
+      return activity.tool;
+    }
+
+    if ('call' in activity && activity.call && 'tool' in activity.call && typeof activity.call.tool === 'string') {
+      return activity.call.tool;
+    }
+
+    return 'tool';
+  }
+
+  // Coarse tool name for current activity. Keep this payload-free so active
+  // status does not duplicate details already visible in approval cards or
+  // transcript/tool-result surfaces.
+  static formatToolName(activity: ClientSharedSessionActivity): string {
     if ('tool' in activity && typeof activity.tool === 'string') {
       return activity.tool;
     }
@@ -145,6 +273,41 @@ export class ClientSharedSessionActivityService {
 
   static formatStepDetail(step: number | undefined): string | undefined {
     return typeof step === 'number' ? `step ${step}` : undefined;
+  }
+
+  static createThinkingStatus(startedAt: string = new Date().toISOString()): ClientSharedAgentActivityStatus {
+    return {
+      label: 'Thinking',
+      startedAt,
+      tone: 'info',
+    };
+  }
+
+  // Shared elapsed formatter for web and TUI current-activity timers. Use dayjs
+  // here so hosts do not hand-roll duration math or drift in formatting.
+  static formatElapsed(startedAt: string, now: Date = new Date()): string {
+    const started = dayjs(startedAt);
+    if (!started.isValid()) {
+      return '0s';
+    }
+
+    const elapsed = dayjs.duration(Math.max(0, dayjs(now).diff(started, 'second')), 'seconds');
+    const seconds = Math.floor(elapsed.asSeconds());
+    if (seconds < 60) {
+      return `${seconds}s`;
+    }
+
+    const minutes = Math.floor(elapsed.asMinutes());
+    const remainingSeconds = seconds - (minutes * 60);
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+
+  static resolveRunOutcomeTone(outcome: string): ClientSharedSessionLatestUpdate['tone'] {
+    if (outcome === 'done' || outcome === 'completed') {
+      return 'success';
+    }
+
+    return outcome === 'error' ? 'error' : 'warning';
   }
 
   private static formatStep(step: number | undefined): string {

--- a/src/web-v2/components/conversation/AgentActivityStatus.tsx
+++ b/src/web-v2/components/conversation/AgentActivityStatus.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import {
+  ClientSharedSessionActivityService,
+  type ClientSharedAgentActivityStatus,
+  type ClientSharedSessionLatestUpdate,
+} from '@/client-shared/services/session-activities';
+
+type AgentActivityStatusProps = {
+  currentActivity?: ClientSharedAgentActivityStatus;
+  latestUpdate?: ClientSharedSessionLatestUpdate;
+};
+
+export function AgentActivityStatus({ currentActivity, latestUpdate }: AgentActivityStatusProps) {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    if (!currentActivity) {
+      return undefined;
+    }
+
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, [currentActivity]);
+
+  if (!currentActivity && !latestUpdate) {
+    return null;
+  }
+
+  return (
+    <div className="v2-agent-activity-stack" data-testid="web-v2-agent-activity-status">
+      {latestUpdate ? <LatestActivityLine update={latestUpdate} /> : null}
+      {currentActivity ? <CurrentActivityLine activity={currentActivity} now={now} /> : null}
+    </div>
+  );
+}
+
+function CurrentActivityLine({ activity, now }: { activity: ClientSharedAgentActivityStatus; now: Date }) {
+  const elapsed = ClientSharedSessionActivityService.formatElapsed(activity.startedAt, now);
+
+  return (
+    <div className="v2-agent-activity-status" data-tone={activity.tone}>
+      <Loader2 aria-hidden="true" className="v2-agent-activity-spinner motion-safe:animate-spin" />
+      <span className="v2-agent-activity-label">{activity.label}</span>
+      {activity.detail ? <span className="v2-agent-activity-detail">{activity.detail}</span> : null}
+      <span className="v2-agent-activity-elapsed">{elapsed}</span>
+    </div>
+  );
+}
+
+function LatestActivityLine({ update }: { update: ClientSharedSessionLatestUpdate }) {
+  return (
+    <div className="v2-agent-latest-status" data-tone={update.tone}>
+      <span className="v2-agent-latest-label">Latest: {update.label}</span>
+      {update.detail ? <span className="v2-agent-activity-detail">{update.detail}</span> : null}
+    </div>
+  );
+}

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -7,6 +7,11 @@ import type {
 } from '@web/hooks/sessions/useControlPlaneSessionDetail';
 import { useConversationAutoScroll } from '@web/hooks/conversation/useConversationAutoScroll';
 import type { ClientSharedSessionPlan } from '@/client-shared/services/session-activities';
+import type {
+  ClientSharedAgentActivityStatus,
+  ClientSharedSessionLatestUpdate,
+} from '@/client-shared/services/session-activities';
+import { AgentActivityStatus } from './AgentActivityStatus';
 import { AgentPlanPanel } from './AgentPlanPanel';
 import { ApprovalPanel } from './ApprovalPanel';
 import { ConversationComposer } from './ConversationComposer';
@@ -21,6 +26,8 @@ interface ConversationThreadProps {
   running: boolean;
   cancelling: boolean;
   liveStatus?: string;
+  currentActivity?: ClientSharedAgentActivityStatus;
+  latestUpdate?: ClientSharedSessionLatestUpdate;
   activePlan?: ClientSharedSessionPlan;
   pendingApproval: ControlPlanePendingApproval;
   approvalResolving: boolean;
@@ -46,6 +53,8 @@ export function ConversationThread({
   running,
   cancelling,
   liveStatus,
+  currentActivity,
+  latestUpdate,
   activePlan,
   pendingApproval,
   approvalResolving,
@@ -114,7 +123,6 @@ export function ConversationThread({
           {session.messages.map((message) => (
             <ConversationMessage key={message.id} message={message} />
           ))}
-          {liveStatus ? <p className="v2-live-status-line" data-testid="web-v2-live-status">{liveStatus}</p> : null}
         </div>
       </div>
       {pendingApproval ? (
@@ -130,6 +138,11 @@ export function ConversationThread({
       {activePlan ? (
         <div className="v2-agent-plan-region">
           <AgentPlanPanel plan={activePlan} />
+        </div>
+      ) : null}
+      {currentActivity || latestUpdate ? (
+        <div className="v2-agent-activity-region">
+          <AgentActivityStatus currentActivity={currentActivity} latestUpdate={latestUpdate} />
         </div>
       ) : null}
       <div className="v2-composer-region">

--- a/src/web-v2/components/conversation/index.ts
+++ b/src/web-v2/components/conversation/index.ts
@@ -1,5 +1,6 @@
 export { AssistantMarkdown } from './AssistantMarkdown';
 export { AgentPlanPanel } from './AgentPlanPanel';
+export { AgentActivityStatus } from './AgentActivityStatus';
 export { ApprovalPanel } from './ApprovalPanel';
 export { ConversationComposer } from './ConversationComposer';
 export { ConversationMessage } from './ConversationMessage';

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
@@ -1,6 +1,10 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { ControlPlaneSessionDetail } from '@web/api/client';
-import type { ClientSharedSessionPlan } from '@/client-shared/services/session-activities';
+import {
+  type ClientSharedAgentActivityStatus,
+  type ClientSharedSessionLatestUpdate,
+  type ClientSharedSessionPlan,
+} from '@/client-shared/services/session-activities';
 import { useControlPlaneSessionEvents } from './useControlPlaneSessionEvents';
 import { useControlPlaneSessionLoader } from './useControlPlaneSessionLoader';
 import { useControlPlanePendingApproval } from './useControlPlanePendingApproval';
@@ -19,6 +23,8 @@ type ControlPlaneSessionDetailState = {
   cancelling: boolean;
   error?: string;
   liveStatus?: string;
+  currentActivity?: ClientSharedAgentActivityStatus;
+  latestUpdate?: ClientSharedSessionLatestUpdate;
   activePlan?: ClientSharedSessionPlan;
   cancelError?: string;
   pendingApproval: ReturnType<typeof useControlPlanePendingApproval>['pendingApproval'];
@@ -47,6 +53,8 @@ export function useControlPlaneSessionDetail({
   sessionId,
 }: UseControlPlaneSessionDetailArgs): ControlPlaneSessionDetailState {
   const [liveStatus, setLiveStatus] = useState<string | undefined>();
+  const [currentActivity, setCurrentActivity] = useState<ClientSharedAgentActivityStatus | undefined>();
+  const [latestUpdate, setLatestUpdate] = useState<ClientSharedSessionLatestUpdate | undefined>();
   const [activePlan, setActivePlan] = useState<ClientSharedSessionPlan | undefined>();
   const loader = useControlPlaneSessionLoader({ workspaceId, sessionId });
   const runControl = useControlPlaneSessionRunControl({
@@ -67,6 +75,8 @@ export function useControlPlaneSessionDetail({
     setRunning: runControl.setRunning,
     setLiveStatus,
     setActivePlan,
+    setCurrentActivity,
+    setLatestUpdate,
   });
   const promptSubmit = useControlPlaneSessionPromptSubmit({
     workspaceId,
@@ -75,6 +85,7 @@ export function useControlPlaneSessionDetail({
     setRunning: runControl.setRunning,
     setError: loader.setError,
     setLiveStatus,
+    setCurrentActivity,
   });
   const settings = useControlPlaneSessionSettings({
     workspaceId,
@@ -82,6 +93,12 @@ export function useControlPlaneSessionDetail({
     setSession: loader.setSession,
     setError: loader.setError,
   });
+
+  useEffect(() => {
+    if (!runControl.running && !promptSubmit.submitting) {
+      setCurrentActivity(undefined);
+    }
+  }, [promptSubmit.submitting, runControl.running]);
 
   return useMemo(() => ({
     session: loader.session,
@@ -91,6 +108,8 @@ export function useControlPlaneSessionDetail({
     cancelling: runControl.cancelling,
     error: loader.error,
     liveStatus,
+    currentActivity,
+    latestUpdate,
     activePlan,
     cancelError: runControl.cancelError,
     pendingApproval: approval.pendingApproval,
@@ -111,6 +130,8 @@ export function useControlPlaneSessionDetail({
     approval.pendingApproval,
     approval.resolvePendingApproval,
     activePlan,
+    currentActivity,
+    latestUpdate,
     liveStatus,
     loader.error,
     loader.loading,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
@@ -6,7 +6,11 @@ import {
   type ControlPlaneSessionEventEnvelope,
 } from '@web/api/client';
 import { ClientSharedSessionActivityService } from '@/client-shared/services/session-activities';
-import type { ClientSharedSessionPlan } from '@/client-shared/services/session-activities';
+import type {
+  ClientSharedAgentActivityStatus,
+  ClientSharedSessionLatestUpdate,
+  ClientSharedSessionPlan,
+} from '@/client-shared/services/session-activities';
 import { ClientSharedSessionMessageService } from '@/client-shared/services/session-messages';
 import type { RefreshControlPlaneSession } from './useControlPlaneSessionLoader';
 
@@ -19,6 +23,8 @@ type UseControlPlaneSessionEventsArgs = {
   setRunning: Dispatch<SetStateAction<boolean>>;
   setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
   setActivePlan: Dispatch<SetStateAction<ClientSharedSessionPlan | undefined>>;
+  setCurrentActivity: Dispatch<SetStateAction<ClientSharedAgentActivityStatus | undefined>>;
+  setLatestUpdate: Dispatch<SetStateAction<ClientSharedSessionLatestUpdate | undefined>>;
 };
 
 export type ControlPlaneSessionEventsState = {
@@ -37,6 +43,8 @@ export function useControlPlaneSessionEvents({
   setRunning,
   setLiveStatus,
   setActivePlan,
+  setCurrentActivity,
+  setLatestUpdate,
 }: UseControlPlaneSessionEventsArgs): ControlPlaneSessionEventsState {
   const utils = trpcReact.useUtils();
   const [streamConnected, setStreamConnected] = useState(false);
@@ -85,9 +93,11 @@ export function useControlPlaneSessionEvents({
       },
       setLiveStatus,
       setActivePlan,
+      setCurrentActivity,
+      setLatestUpdate,
       setRunning,
     }));
-  }, [invalidateWorkspaceDiff, refresh, refreshPendingApproval, setActivePlan, setLiveStatus, setRunning, setSession, utils.controlPlane.session, workspaceId]);
+  }, [invalidateWorkspaceDiff, refresh, refreshPendingApproval, setActivePlan, setCurrentActivity, setLatestUpdate, setLiveStatus, setRunning, setSession, utils.controlPlane.session, workspaceId]);
 
   const subscription = trpcReact.controlPlane.sessionEvents.useSubscription(
     sessionId && workspaceId ? { sessionId, workspaceId } : skipToken,
@@ -112,6 +122,8 @@ export function useControlPlaneSessionEvents({
       setRunning(false);
       setLiveStatus(undefined);
       setActivePlan(undefined);
+      setCurrentActivity(undefined);
+      setLatestUpdate(undefined);
       setStreamConnected(false);
       return;
     }
@@ -119,7 +131,9 @@ export function useControlPlaneSessionEvents({
     setRunning(false);
     setLiveStatus(undefined);
     setActivePlan(undefined);
-  }, [sessionId, setActivePlan, setLiveStatus, setRunning, workspaceId]);
+    setCurrentActivity(undefined);
+    setLatestUpdate(undefined);
+  }, [sessionId, setActivePlan, setCurrentActivity, setLatestUpdate, setLiveStatus, setRunning, workspaceId]);
 
   useEffect(() => {
     setStreamConnected(subscription.status === 'pending');
@@ -158,11 +172,18 @@ type SessionActivityContext = {
   setRunning: Dispatch<SetStateAction<boolean>>;
   setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
   setActivePlan: Dispatch<SetStateAction<ClientSharedSessionPlan | undefined>>;
+  setCurrentActivity: Dispatch<SetStateAction<ClientSharedAgentActivityStatus | undefined>>;
+  setLatestUpdate: Dispatch<SetStateAction<ClientSharedSessionLatestUpdate | undefined>>;
 };
 
 type ControlPlaneSessionActivity = Extract<ControlPlaneSessionEventEnvelope, { type: 'session.event' }>['activities'][number];
 
 function applySessionActivity(activity: ControlPlaneSessionActivity, context: SessionActivityContext) {
+  const latestUpdate = ClientSharedSessionActivityService.resolveLatestUpdate(activity);
+  if (latestUpdate) {
+    context.setLatestUpdate(latestUpdate);
+  }
+
   ClientSharedSessionActivityService.applyActivity(activity, {
     onAssistantStream: (streamActivity, liveStatus) => {
       context.updateSession((current) => (
@@ -192,6 +213,9 @@ function applySessionActivity(activity: ControlPlaneSessionActivity, context: Se
     },
     onPlanCleared: () => {
       context.setActivePlan(undefined);
+    },
+    onCurrentActivityChanged: (currentActivity) => {
+      context.setCurrentActivity(currentActivity);
     },
     onLiveStatus: (_statusActivity, liveStatus) => {
       if (liveStatus !== undefined) {

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { trpcReact } from '@web/api/client';
+import {
+  ClientSharedSessionActivityService,
+  type ClientSharedAgentActivityStatus,
+} from '@/client-shared/services/session-activities';
 
 type UseControlPlaneSessionPromptSubmitArgs = {
   workspaceId?: string;
@@ -8,6 +12,7 @@ type UseControlPlaneSessionPromptSubmitArgs = {
   setRunning: Dispatch<SetStateAction<boolean>>;
   setError: Dispatch<SetStateAction<string | undefined>>;
   setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
+  setCurrentActivity: Dispatch<SetStateAction<ClientSharedAgentActivityStatus | undefined>>;
 };
 
 export type ControlPlaneSessionPromptSubmitState = {
@@ -29,6 +34,7 @@ export function useControlPlaneSessionPromptSubmit({
   setRunning,
   setError,
   setLiveStatus,
+  setCurrentActivity,
 }: UseControlPlaneSessionPromptSubmitArgs): ControlPlaneSessionPromptSubmitState {
   const [submitting, setSubmitting] = useState(false);
   const activeSubmissionRef = useRef<PromptSubmission | null>(null);
@@ -69,6 +75,7 @@ export function useControlPlaneSessionPromptSubmit({
     setRunning(true);
     setError(undefined);
     setLiveStatus(streamConnected ? 'Heddle is working...' : 'Heddle is working... reconnecting live stream if needed.');
+    setCurrentActivity(ClientSharedSessionActivityService.createThinkingStatus());
 
     try {
       await sessionSendPromptMutation.mutateAsync({ workspaceId, sessionId, prompt: trimmed });
@@ -83,6 +90,7 @@ export function useControlPlaneSessionPromptSubmit({
         setError(submitError instanceof Error ? submitError.message : String(submitError));
         setRunning(false);
         setLiveStatus(undefined);
+        setCurrentActivity(undefined);
       }
     } finally {
       void Promise.all([
@@ -101,6 +109,7 @@ export function useControlPlaneSessionPromptSubmit({
     workspaceId,
     setError,
     setLiveStatus,
+    setCurrentActivity,
     setRunning,
     streamConnected,
     submitting,

--- a/src/web-v2/hooks/useControlPlaneAppState.ts
+++ b/src/web-v2/hooks/useControlPlaneAppState.ts
@@ -141,6 +141,8 @@ export function useControlPlaneAppState() {
         running: selectedSession.running,
         cancelling: selectedSession.cancelling,
         liveStatus: selectedSession.liveStatus,
+        currentActivity: selectedSession.currentActivity,
+        latestUpdate: selectedSession.latestUpdate,
         activePlan: selectedSession.activePlan,
         pendingApproval: selectedSession.pendingApproval,
         approvalResolving: selectedSession.approvalResolving,

--- a/src/web-v2/styles/conversation.css
+++ b/src/web-v2/styles/conversation.css
@@ -162,6 +162,63 @@
     color: color-mix(in oklab, var(--color-destructive) 82%, var(--color-foreground));
   }
 
+  .v2-agent-activity-region {
+    padding: 0 1.5rem 0.45rem;
+  }
+
+  .v2-agent-activity-stack {
+    margin-inline: auto;
+    display: flex;
+    width: min(100%, 48rem);
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .v2-agent-activity-status,
+  .v2-agent-latest-status {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.45rem;
+    color: var(--color-muted-foreground);
+    font-size: 0.8125rem;
+    line-height: 1.35;
+  }
+
+  .v2-agent-activity-status[data-tone="warning"] {
+    color: color-mix(in oklab, var(--color-warning, hsl(45 92% 70%)) 78%, var(--color-foreground));
+  }
+
+  .v2-agent-activity-spinner {
+    height: 0.875rem;
+    width: 0.875rem;
+    flex: 0 0 auto;
+  }
+
+  .v2-agent-activity-label {
+    flex: 0 0 auto;
+    color: var(--color-foreground);
+    font-weight: 500;
+  }
+
+  .v2-agent-latest-label {
+    flex: 0 0 auto;
+    font-weight: 500;
+  }
+
+  .v2-agent-activity-detail {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .v2-agent-activity-elapsed {
+    flex: 0 0 auto;
+    font-variant-numeric: tabular-nums;
+  }
+
   .v2-agent-plan-region {
     padding: 0 1.5rem 0.5rem;
   }


### PR DESCRIPTION
## Summary
- add shared current/latest agent activity projections in client-shared
- show latest activity above current activity in web-v2 and cli-v2
- keep current activity coarse and hide it during assistant streaming
- move cli-v2 prompt activity above the prompt input box

## Deferred
- initial/welcome messages as runtime context are intentionally not changed in this PR

## Tests
- ./node_modules/.bin/vitest run src/__tests__/unit/client-shared/session-activity-service.test.ts src/__tests__/unit/web-v2/agent-activity-status.test.tsx src/__tests__/unit/cli-v2/prompt-activity.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
- yarn typecheck