### PR TITLE
[codex] Refactor session welcome context

### DIFF
--- a/src/__tests__/integration/chat/chat-runtime.test.ts
+++ b/src/__tests__/integration/chat/chat-runtime.test.ts
@@ -656,7 +656,7 @@ describe('conversation turn lifecycle', () => {
       },
     })).rejects.toThrow('loop failed');
 
-    const persisted = new FileChatSessionRepository({ sessionStoragePath: storage.sessionStoragePath }).list(true)
+    const persisted = new FileChatSessionRepository({ sessionStoragePath: storage.sessionStoragePath }).list()
       .find((session) => session.id === storage.sessionId);
     expect(persisted?.lease).toBeUndefined();
     expect(persisted?.turns).toEqual([]);

--- a/src/__tests__/integration/chat/chat-storage.test.ts
+++ b/src/__tests__/integration/chat/chat-storage.test.ts
@@ -14,7 +14,6 @@ describe('chat session storage layout', () => {
       ...ChatSessionRecords.create({
         id: 'session-1',
         name: 'Session 1',
-        apiKeyPresent: true,
         workspaceId: 'workspace-1',
       }),
       model: 'gpt-5.1-codex-mini',
@@ -40,7 +39,7 @@ describe('chat session storage layout', () => {
       sessions: Array<Record<string, unknown>>;
     };
     const storedCatalog = new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).readCatalog();
-    const storedSession = new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).read('session-1', true);
+    const storedSession = new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).read('session-1');
 
     expect(catalog.version).toBe(1);
     expect(storedCatalog[0]).toEqual(expect.objectContaining({
@@ -112,7 +111,7 @@ describe('chat session storage layout', () => {
       ],
     }, null, 2));
 
-    const session = new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).read('session-1', true);
+    const session = new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).read('session-1');
 
     expect(session).toEqual(expect.objectContaining({
       id: 'session-1',
@@ -132,6 +131,37 @@ describe('chat session storage layout', () => {
     }));
   });
 
+  it('drops legacy welcome assistant lines from visible session messages', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-chat-storage-legacy-welcome-'));
+    const sessionsFile = join(dir, 'chat-sessions.catalog.json');
+
+    writeFileSync(join(dir, 'chat-sessions.catalog.json'), JSON.stringify({
+      version: 1,
+      sessions: [{
+        id: 'session-1',
+        name: 'Session 1',
+        createdAt: '2026-04-13T00:00:00.000Z',
+        updatedAt: '2026-04-13T01:00:00.000Z',
+      }],
+    }, null, 2));
+    const sessionsDir = join(dir, 'chat-sessions');
+    mkdirSync(sessionsDir);
+    writeFileSync(join(sessionsDir, 'session-1.json'), JSON.stringify({
+      id: 'session-1',
+      history: [],
+      messages: [
+        { id: 'intro', role: 'assistant', text: 'Heddle conversational mode.' },
+        { id: 'missing-key', role: 'assistant', text: 'No provider credential detected.' },
+        { id: 'm1', role: 'assistant', text: 'real assistant output' },
+      ],
+      turns: [],
+    }, null, 2));
+
+    expect(new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).read('session-1')?.messages).toEqual([
+      { id: 'm1', role: 'assistant', text: 'real assistant output' },
+    ]);
+  });
+
   it('persists reasoning effort in catalog and per-session storage when configured', () => {
     const dir = mkdtempSync(join(tmpdir(), 'heddle-chat-storage-reasoning-'));
     const sessionsFile = join(dir, 'chat-sessions.catalog.json');
@@ -139,7 +169,6 @@ describe('chat session storage layout', () => {
       ...ChatSessionRecords.create({
         id: 'session-1',
         name: 'Session 1',
-        apiKeyPresent: true,
         workspaceId: 'workspace-1',
       }),
       model: 'gpt-5.5',
@@ -153,7 +182,7 @@ describe('chat session storage layout', () => {
       model: 'gpt-5.5',
       reasoningEffort: 'high',
     }));
-    expect(new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).read('session-1', true)).toEqual(expect.objectContaining({
+    expect(new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).read('session-1')).toEqual(expect.objectContaining({
       id: 'session-1',
       model: 'gpt-5.5',
       reasoningEffort: 'high',
@@ -166,7 +195,6 @@ describe('chat session storage layout', () => {
     const session = ChatSessionRecords.create({
       id: 'session-1',
       name: 'Session 1',
-      apiKeyPresent: true,
     });
 
     new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).save([session]);

--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -265,6 +265,11 @@ describe('control-plane session lifecycle API', () => {
       contextWindow: 400000,
       driftEnabled: true,
       running: false,
+      welcomeGuide: {
+        mode: 'conversation',
+        hasProviderCredential: expect.any(Boolean),
+        carriesTranscriptAcrossTurns: true,
+      },
     });
   });
 

--- a/src/__tests__/integration/tui/ask-cli.test.ts
+++ b/src/__tests__/integration/tui/ask-cli.test.ts
@@ -61,7 +61,7 @@ describe('AskCliHost.run', () => {
     const catalog = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).readCatalog();
     expect(catalog).toHaveLength(1);
     expect(catalog[0]?.retention).toBe('one_off');
-    const session = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).read(catalog[0]!.id, true);
+    const session = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).read(catalog[0]!.id);
     expect(session?.retention).toBe('one_off');
     expect(session?.history).toEqual(result.transcript);
     expect(session?.turns).toHaveLength(1);
@@ -103,7 +103,7 @@ describe('AskCliHost.run', () => {
     expect(catalog[0]?.name).toBe('Ask test session');
     expect(catalog[0]?.retention).toBe('reusable');
 
-    const session = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).read(catalog[0]!.id, true);
+    const session = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).read(catalog[0]!.id);
     expect(session?.retention).toBe('reusable');
     expect(session?.history).toEqual(result.transcript);
     expect(session?.turns).toHaveLength(1);
@@ -166,7 +166,7 @@ describe('AskCliHost.run', () => {
       sessionId: existingSession.id,
     });
 
-    const updated = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).read(existingSession.id, true);
+    const updated = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).read(existingSession.id);
     expect(runAgentLoopSpy).toHaveBeenCalledTimes(1);
     expect(updated?.history).toEqual(result.transcript);
     expect(updated?.turns).toHaveLength(1);
@@ -299,7 +299,7 @@ describe('AskCliHost.run', () => {
 
     expect(compactionSpy).toHaveBeenCalledTimes(2);
     expect(runAgentLoopSpy).toHaveBeenCalledTimes(1);
-    expect(new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).read(existingSession.id, true)?.archives).toHaveLength(1);
+    expect(new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).read(existingSession.id)?.archives).toHaveLength(1);
   });
 
   it('attaches default ask to a live daemon host through a persisted one-off session', async () => {
@@ -358,7 +358,7 @@ describe('AskCliHost.run', () => {
     const catalog = sessionRepository.readCatalog();
     expect(catalog).toHaveLength(1);
     expect(catalog[0]?.retention).toBe('one_off');
-    const session = sessionRepository.read(catalog[0]!.id, true);
+    const session = sessionRepository.read(catalog[0]!.id);
     expect(session?.history).toEqual(result.transcript);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`Session: ${catalog[0]?.id}`));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Trace:'));

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -818,6 +818,11 @@ function createRuntimeContext(
     estimatedInputTokens: undefined,
     driftEnabled: false,
     running: false,
+    welcomeGuide: {
+      mode: 'conversation',
+      hasProviderCredential: true,
+      carriesTranscriptAcrossTurns: true,
+    },
     ...overrides,
   };
 }

--- a/src/__tests__/unit/cli-v2/runtime-status.test.ts
+++ b/src/__tests__/unit/cli-v2/runtime-status.test.ts
@@ -49,6 +49,11 @@ function createSnapshot(overrides: Partial<ControlPlaneSessionStoreSnapshot> = {
       contextWindow: 400000,
       driftEnabled: false,
       running: false,
+      welcomeGuide: {
+        mode: 'conversation',
+        hasProviderCredential: true,
+        carriesTranscriptAcrossTurns: true,
+      },
     },
     pendingApproval: null,
     loading: false,

--- a/src/__tests__/unit/core/chat-turn-memory-maintenance.test.ts
+++ b/src/__tests__/unit/core/chat-turn-memory-maintenance.test.ts
@@ -62,7 +62,7 @@ describe('chat turn memory maintenance helpers', () => {
       'memory.candidate_recorded',
       'memory.maintenance_finished',
     ]);
-    expect(new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list(true)[0]?.turns[0]?.events).toEqual([
+    expect(new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list()[0]?.turns[0]?.events).toEqual([
       'memory candidate recorded: candidate-1',
       'memory maintenance finished: done',
     ]);

--- a/src/__tests__/unit/core/chat-turn-persistence.test.ts
+++ b/src/__tests__/unit/core/chat-turn-persistence.test.ts
@@ -116,7 +116,7 @@ describe('chat turn persistence', () => {
       credentialSource: { type: 'explicit-api-key' },
     });
 
-    const stored = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list(true)[0];
+    const stored = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list()[0];
     expect(stored?.id).toBe(session.id);
     expect(stored?.lastContinuePrompt).toBe('Persist this turn.');
     expect(stored?.messages.map((message) => message.text)).toEqual(['Persist this turn.', 'Done.']);
@@ -168,7 +168,7 @@ describe('chat turn persistence', () => {
       credentialSource: { type: 'explicit-api-key' },
     });
 
-    const stored = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list(true)[0];
+    const stored = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list()[0];
     expect(stored?.messages).toEqual([
       expect.objectContaining({
         role: 'user',

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -242,7 +242,7 @@ describe('chat turn preparation modules', () => {
       archivePath: '.heddle/chat-sessions/session-1/archives/archive-1.jsonl',
     });
 
-    const nextSession = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list(true)[0];
+    const nextSession = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list()[0];
     expect(nextSession?.context?.compaction?.status).toBe('running');
     expect(nextSession?.context?.archive?.lastArchivePath).toBe('.heddle/chat-sessions/session-1/archives/archive-1.jsonl');
     expect(nextSession?.lease).toEqual(leasedSession.lease);
@@ -278,7 +278,7 @@ describe('chat turn preparation modules', () => {
       },
     });
 
-    const persisted = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list(true)[0];
+    const persisted = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list()[0];
     expect(preparedSession.session.history).toHaveLength(2);
     expect(persisted?.history).toEqual(preparedSession.session.history);
     expect(persisted?.messages.map((message) => message.text)).toEqual(['Earlier prompt', 'Earlier answer']);
@@ -317,7 +317,7 @@ describe('chat turn preparation modules', () => {
       },
     });
 
-    const persisted = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list(true)[0];
+    const persisted = new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).list()[0];
     expect(persisted?.messages).toEqual([
       expect.objectContaining({ role: 'user', text: 'Earlier prompt' }),
       expect.objectContaining({ role: 'assistant', text: 'Earlier answer' }),
@@ -362,7 +362,7 @@ describe('chat turn preparation modules', () => {
       },
     });
 
-    const persisted = new FileChatSessionRepository({ sessionStoragePath }).list(true)[0];
+    const persisted = new FileChatSessionRepository({ sessionStoragePath }).list()[0];
     expect(persisted?.messages).toEqual([
       expect.objectContaining({ role: 'user', text: 'Repeat this prompt' }),
       expect.objectContaining({ role: 'assistant', text: 'Earlier answer' }),

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -18,7 +18,7 @@ describe('createConversationEngine', () => {
       outcome: 'done',
       summary: 'ok',
       session: new FileChatSessionRepository({ sessionStoragePath: args.sessionStoragePath })
-        .read(args.sessionId, true) as ChatSession,
+        .read(args.sessionId) as ChatSession,
     }));
   });
 
@@ -57,10 +57,12 @@ describe('createConversationEngine', () => {
       model: 'gpt-5.4',
       workspaceId: 'workspace-1',
     }));
-    expect(sessionRepository.read(session.id, true)).toEqual(expect.objectContaining({
+    expect(sessionRepository.read(session.id)).toEqual(expect.objectContaining({
       id: session.id,
       model: 'gpt-5.4',
       workspaceId: 'workspace-1',
+      history: [],
+      messages: [],
     }));
   });
 
@@ -98,11 +100,11 @@ describe('createConversationEngine', () => {
     const sessionRepository = new FileChatSessionRepository({
       sessionStoragePath: join(stateRoot, 'chat-sessions.catalog.json'),
     });
-    expect(sessionRepository.list(true).map((session) => session.id)).toEqual(['session-a']);
+    expect(sessionRepository.list().map((session) => session.id)).toEqual(['session-a']);
     expect(engine.sessions.delete(first.id)).toBe(true);
     expect(engine.sessions.delete('session-1')).toBe(true);
     expect(engine.sessions.delete('missing')).toBe(false);
-    expect(sessionRepository.list(true).map((session) => session.id)).toEqual(['session-1']);
+    expect(sessionRepository.list().map((session) => session.id)).toEqual(['session-1']);
   });
 
   it('updates shared session settings for TUI and control-plane clients', () => {
@@ -309,17 +311,14 @@ describe('createConversationEngine', () => {
     const withDrift = engine.sessions.setDriftEnabled(session.id, true);
     expect(withDrift.driftEnabled).toBe(true);
 
-    const reset = engine.sessions.resetConversation(session.id, { apiKeyPresent: false });
+    const reset = engine.sessions.resetConversation(session.id);
     expect(reset.history).toEqual([]);
     expect(reset.turns).toEqual([]);
     expect(reset.lastContinuePrompt).toBeUndefined();
-    expect(reset.messages.map((message) => message.id)).toEqual(['intro', 'missing-key']);
+    expect(reset.messages).toEqual([]);
     expect(engine.sessions.read(session.id)).toEqual(expect.objectContaining({
       driftEnabled: true,
-      messages: expect.arrayContaining([
-        expect.objectContaining({ id: 'intro' }),
-        expect.objectContaining({ id: 'missing-key' }),
-      ]),
+      messages: [],
     }));
   });
 
@@ -558,11 +557,11 @@ describe('createConversationEngine', () => {
     const sessionRepository = new FileChatSessionRepository({
       sessionStoragePath: join(stateRoot, 'chat-sessions.catalog.json'),
     });
-    const stored = sessionRepository.read(session.id, true) as ChatSession;
+    const stored = sessionRepository.read(session.id) as ChatSession;
     stored.lastContinuePrompt = 'continue investigating';
     stored.history = [{ role: 'user', content: 'prior' }];
     stored.updatedAt = '2026-05-03T00:00:00.000Z';
-    const otherSessions = sessionRepository.list(true)
+    const otherSessions = sessionRepository.list()
       .filter((candidate) => candidate.id !== session.id);
     sessionRepository.save([stored, ...otherSessions]);
 
@@ -604,7 +603,7 @@ describe('createConversationEngine', () => {
     const sessionRepository = new FileChatSessionRepository({
       sessionStoragePath: join(stateRoot, 'chat-sessions.catalog.json'),
     });
-    expect(sessionRepository.read('session-1', true)?.lease).toBeUndefined();
+    expect(sessionRepository.read('session-1')?.lease).toBeUndefined();
   });
 });
 

--- a/src/__tests__/unit/tui/chat-drift.test.ts
+++ b/src/__tests__/unit/tui/chat-drift.test.ts
@@ -30,7 +30,7 @@ describe('chat drift defaults and footer formatting', () => {
       updatedAt: '2026-04-13T00:00:00.000Z',
     }]));
 
-    const [session] = new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).list(true);
+    const [session] = new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).list();
 
     expect(session?.driftEnabled).toBe(false);
   });
@@ -49,7 +49,7 @@ describe('chat drift defaults and footer formatting', () => {
       driftEnabled: false,
     }]));
 
-    const [session] = new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).list(true);
+    const [session] = new FileChatSessionRepository({ sessionStoragePath: sessionsFile }).list();
 
     expect(session?.driftEnabled).toBe(false);
   });

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -106,7 +106,7 @@ export function App({
         {snapshot.workspaceId ? `Workspace ${snapshot.workspaceId}` : 'Loading workspace...'}
         {snapshot.activeSession ? ` · ${snapshot.activeSession.name}` : ''}
       </Text>
-      <ConversationPanel session={snapshot.activeSession} />
+      <ConversationPanel runtimeContext={snapshot.runtimeContext} session={snapshot.activeSession} />
       <CommandResultPanel results={snapshot.commandResults} />
       {snapshot.pendingApproval ? (
         <ApprovalPanel

--- a/src/cli-v2/components/ConversationPanel.tsx
+++ b/src/cli-v2/components/ConversationPanel.tsx
@@ -1,14 +1,22 @@
 import React, { memo } from 'react';
 import { Box, Text } from 'ink';
-import type { ControlPlaneSessionDetail } from '@/client-shared/api/types.js';
+import type { ControlPlaneSessionDetail, ControlPlaneSessionRuntimeContext } from '@/client-shared/api/types.js';
 
-export const ConversationPanel = memo(function ConversationPanel({ session }: { session: ControlPlaneSessionDetail }) {
+export const ConversationPanel = memo(function ConversationPanel({
+  runtimeContext,
+  session,
+}: {
+  runtimeContext?: ControlPlaneSessionRuntimeContext;
+  session: ControlPlaneSessionDetail;
+}) {
   const messages = session?.messages.slice(-10) ?? [];
+  const showWelcome = Boolean(session && runtimeContext?.welcomeGuide && !session.messages.some((message) => message.role === 'user'));
 
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Text bold>Conversation</Text>
-      {messages.length === 0 ? <Text dimColor>No messages yet.</Text> : null}
+      {showWelcome && runtimeContext?.welcomeGuide ? <WelcomeGuide runtimeContext={runtimeContext} /> : null}
+      {messages.length === 0 && !showWelcome ? <Text dimColor>No messages yet.</Text> : null}
       {messages.map((message, index) => (
         <Box key={message.id} flexDirection="column" marginBottom={1}>
           <Text dimColor>
@@ -27,3 +35,23 @@ export const ConversationPanel = memo(function ConversationPanel({ session }: { 
     </Box>
   );
 });
+
+function WelcomeGuide({ runtimeContext }: { runtimeContext: ControlPlaneSessionRuntimeContext }) {
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text dimColor>┌ Heddle</Text>
+      <Box paddingLeft={2} flexDirection="column">
+        <Text>Heddle conversational mode.</Text>
+        <Text> </Text>
+        <Text>Ask a question about this workspace.</Text>
+        {runtimeContext.welcomeGuide.carriesTranscriptAcrossTurns ? (
+          <Text>Each turn runs the current agent loop and carries the transcript into the next turn.</Text>
+        ) : null}
+        {!runtimeContext.welcomeGuide.hasProviderCredential ? (
+          <Text color="yellow">No provider credential detected. Use /auth login openai or set a provider API key.</Text>
+        ) : null}
+      </Box>
+      <Text dimColor>└────────────────────────────────────────────────────────</Text>
+    </Box>
+  );
+}

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -255,7 +255,6 @@ export class AskCliHost {
       }).activeWorkspace;
       return options.engine.sessions.create({
         name: options.createSessionName.trim() || undefined,
-        apiKeyPresent: options.apiKeyPresent,
         model: options.model,
         workspaceId: workspace.id,
       });
@@ -279,7 +278,6 @@ export class AskCliHost {
     }).activeWorkspace;
     return options.engine.sessions.createOneOff({
       name: `Ask ${new Date().toISOString()}`,
-      apiKeyPresent: options.apiKeyPresent,
       model: options.model,
       workspaceId: workspace.id,
     });

--- a/src/cli/chat/hooks/controllers/useChatAppController.ts
+++ b/src/cli/chat/hooks/controllers/useChatAppController.ts
@@ -35,7 +35,6 @@ export function useChatAppController({
     removeSession,
   } = useChatSessions({
     sessionCatalogFile: runtime.sessionCatalogFile,
-    apiKeyPresent: runtime.providerCredentialPresent,
     defaultModel: runtime.model,
     workspaceRoot: runtime.workspaceRoot,
     stateRoot: runtime.stateRoot,

--- a/src/cli/chat/hooks/useChatSessions.ts
+++ b/src/cli/chat/hooks/useChatSessions.ts
@@ -20,13 +20,12 @@ import { FileConversationSessionService } from '../../../core/chat/engine/sessio
 
 type UseChatSessionsArgs = {
   sessionCatalogFile: string;
-  apiKeyPresent: boolean;
   defaultModel: string;
   workspaceRoot: string;
   stateRoot: string;
 };
 
-export function useChatSessions({ sessionCatalogFile, apiKeyPresent, defaultModel, workspaceRoot, stateRoot }: UseChatSessionsArgs) {
+export function useChatSessions({ sessionCatalogFile, defaultModel, workspaceRoot, stateRoot }: UseChatSessionsArgs) {
   const workspaceId = useMemo(
     () => RuntimeWorkspaceService.resolveContext({ workspaceRoot, stateRoot }).activeWorkspace.id,
     [workspaceRoot, stateRoot],
@@ -42,10 +41,9 @@ export function useChatSessions({ sessionCatalogFile, apiKeyPresent, defaultMode
         stateRoot,
         sessionStoragePath: sessionCatalogFile,
         model: defaultModel,
-        apiKeyPresent,
         workspaceId,
       }),
-    [apiKeyPresent, defaultModel, sessionCatalogFile, stateRoot, workspaceId, workspaceRoot],
+    [defaultModel, sessionCatalogFile, stateRoot, workspaceId, workspaceRoot],
   );
   const initialSessions = useMemo(() => sessionService.list(), [sessionService]);
   const [sessions, setSessions] = useState<ChatSession[]>(initialSessions);
@@ -114,14 +112,13 @@ export function useChatSessions({ sessionCatalogFile, apiKeyPresent, defaultMode
     const nextSession = sessionService.create({
       id: `session-${Date.now()}`,
       name,
-      apiKeyPresent,
       ...nextPreferences,
       workspaceId,
     });
     setSessions(sessionService.list().slice(0, 24));
     setActiveSessionId(nextSession.id);
     return nextSession;
-  }, [apiKeyPresent, defaultModel, sessionService, workspaceId]);
+  }, [defaultModel, sessionService, workspaceId]);
 
   const renameSession = useCallback((name: string) => {
     sessionService.rename(activeSessionId, name);

--- a/src/cli/chat/submit.ts
+++ b/src/cli/chat/submit.ts
@@ -68,7 +68,7 @@ export async function submitChatPrompt(args: SubmitChatPromptArgs): Promise<void
     renameSession: args.renameSession,
     removeSession: args.closeSession,
     clearConversation: () => {
-      args.sessionService.resetConversation(args.activeSessionId, { apiKeyPresent: args.apiKeyPresent });
+      args.sessionService.resetConversation(args.activeSessionId);
       args.refreshSessions();
     },
     compactConversation: () => {

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -22,7 +22,6 @@ export type {
   ConversationTurnService,
   CreateConversationSessionInput,
   ContinueConversationTurnInput,
-  ResetConversationSessionInput,
   SubmitConversationTurnInput,
   SubmitConversationTurnResult,
   UpdateConversationSessionSettingsInput,

--- a/src/core/chat/engine/sessions/records/records.ts
+++ b/src/core/chat/engine/sessions/records/records.ts
@@ -19,25 +19,6 @@ import type {
 } from './types.js';
 
 export class ChatSessionRecords {
-  static createInitialMessages(apiKeyPresent: boolean): ConversationLine[] {
-    return [
-      {
-        id: 'intro',
-        role: 'assistant',
-        text:
-          'Heddle conversational mode.\n\nAsk a question about this workspace.\nEach turn runs the current agent loop and carries the transcript into the next turn.\nUse !<command> to run a shell command directly in chat.',
-      },
-      ...(!apiKeyPresent ?
-        [{
-          id: 'missing-key',
-          role: 'assistant' as const,
-          text:
-            'No provider credential detected. For OpenAI, run `heddle auth login openai` or set OPENAI_API_KEY. For Anthropic, set ANTHROPIC_API_KEY. Dev fallback conventions also work: PERSONAL_OPENAI_API_KEY and PERSONAL_ANTHROPIC_API_KEY.',
-        }]
-      : []),
-    ];
-  }
-
   static create(options: CreateChatSessionRecordOptions): ChatSession {
     const now = new Date().toISOString();
     return {
@@ -46,7 +27,7 @@ export class ChatSessionRecords {
       retention: options.retention ?? 'reusable',
       workspaceId: options.workspaceId,
       history: [],
-      messages: ChatSessionRecords.createInitialMessages(options.apiKeyPresent),
+      messages: [],
       turns: [],
       createdAt: now,
       updatedAt: now,

--- a/src/core/chat/engine/sessions/records/types.ts
+++ b/src/core/chat/engine/sessions/records/types.ts
@@ -7,7 +7,6 @@ import type { ChatSession, ChatSessionRetention, ConversationLine, TurnSummary }
 export type CreateChatSessionRecordOptions = {
   id: string;
   name: string;
-  apiKeyPresent: boolean;
   model?: string;
   reasoningEffort?: ReasoningEffort;
   workspaceId?: string;

--- a/src/core/chat/engine/sessions/repository/chat-session-codec.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-codec.ts
@@ -3,10 +3,10 @@
  *
  * The schema file owns the JSON contract. This class owns the read/write
  * behavior around that contract: graceful read degradation, strict write
- * validation, catalog projection, and fallback visible messages.
+ * validation, catalog projection, and compatibility cleanup for legacy visible
+ * welcome messages.
  */
 import type { ChatSession } from '@/core/chat/types.js';
-import { ChatSessionRecords } from '../records/index.js';
 import {
   CatalogEntryReadSchema,
   CatalogEntryWriteSchema,
@@ -34,7 +34,7 @@ export class ChatSessionCodec {
 
   static parseSessionBody(
     value: unknown,
-    args: { entry: ChatSessionCatalogEntry; apiKeyPresent: boolean },
+    args: { entry: ChatSessionCatalogEntry },
   ): ChatSession[] {
     const parsed = SessionBodyReadSchema.safeParse(value);
     if (!parsed.success) {
@@ -45,7 +45,7 @@ export class ChatSessionCodec {
       ...parsed.data,
       ...args.entry,
       history: parsed.data.history ?? [],
-      messages: ChatSessionCodec.resolveMessages(parsed.data.messages, args.apiKeyPresent),
+      messages: ChatSessionCodec.resolveMessages(parsed.data.messages),
       turns: parsed.data.turns ?? [],
     }];
   }
@@ -87,8 +87,7 @@ export class ChatSessionCodec {
 
   private static resolveMessages(
     messages: ConversationLineValue[] | undefined,
-    apiKeyPresent: boolean,
   ): ConversationLineValue[] {
-    return messages && messages.length > 0 ? messages : ChatSessionRecords.createInitialMessages(apiKeyPresent);
+    return (messages ?? []).filter((message) => message.id !== 'intro' && message.id !== 'missing-key');
   }
 }

--- a/src/core/chat/engine/sessions/repository/file-chat-session-repository.ts
+++ b/src/core/chat/engine/sessions/repository/file-chat-session-repository.ts
@@ -25,8 +25,8 @@ export class FileChatSessionRepository implements ChatSessionRepository {
     this.storagePaths = FileChatSessionRepository.deriveStoragePaths(args.sessionStoragePath);
   }
 
-  list(apiKeyPresent: boolean): ChatSession[] {
-    const resolved = this.loadFromCurrentStorage(apiKeyPresent);
+  list(): ChatSession[] {
+    const resolved = this.loadFromCurrentStorage();
     if (resolved.length > 0) {
       return resolved;
     }
@@ -35,7 +35,6 @@ export class FileChatSessionRepository implements ChatSessionRepository {
       ChatSessionRecords.create({
         id: 'session-1',
         name: 'Session 1',
-        apiKeyPresent,
       }),
     ];
   }
@@ -45,7 +44,7 @@ export class FileChatSessionRepository implements ChatSessionRepository {
     return catalog?.sessions.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)) ?? [];
   }
 
-  read(sessionId: string, apiKeyPresent: boolean): ChatSession | undefined {
+  read(sessionId: string): ChatSession | undefined {
     const paths = this.deriveStoragePaths();
     const catalog = FileChatSessionRepository.readCatalogFile(paths.catalogPath);
     const entry = catalog?.sessions.find((candidate) => candidate.id === sessionId);
@@ -53,7 +52,7 @@ export class FileChatSessionRepository implements ChatSessionRepository {
       return undefined;
     }
 
-    return FileChatSessionRepository.readSessionFile(paths.sessionsDir, entry, apiKeyPresent)[0];
+    return FileChatSessionRepository.readSessionFile(paths.sessionsDir, entry)[0];
   }
 
   save(sessions: ChatSession[]): void {
@@ -118,11 +117,11 @@ export class FileChatSessionRepository implements ChatSessionRepository {
     };
   }
 
-  private loadFromCurrentStorage(apiKeyPresent: boolean): ChatSession[] {
-    return this.loadSessionsFromCatalog(this.deriveStoragePaths(), apiKeyPresent);
+  private loadFromCurrentStorage(): ChatSession[] {
+    return this.loadSessionsFromCatalog(this.deriveStoragePaths());
   }
 
-  private loadSessionsFromCatalog(paths: SessionStoragePaths, apiKeyPresent: boolean): ChatSession[] {
+  private loadSessionsFromCatalog(paths: SessionStoragePaths): ChatSession[] {
     if (!existsSync(paths.catalogPath)) {
       return [];
     }
@@ -135,7 +134,7 @@ export class FileChatSessionRepository implements ChatSessionRepository {
       }
 
       const sessions = catalog.sessions.flatMap((entry) =>
-        FileChatSessionRepository.readSessionFile(paths.sessionsDir, entry, apiKeyPresent),
+        FileChatSessionRepository.readSessionFile(paths.sessionsDir, entry),
       );
       return sessions.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
     } catch (error) {
@@ -149,7 +148,6 @@ export class FileChatSessionRepository implements ChatSessionRepository {
   private static readSessionFile(
     sessionsDir: string,
     entry: ChatSessionCatalogEntry,
-    apiKeyPresent: boolean,
   ): ChatSession[] {
     const path = FileChatSessionRepository.sessionFilePath(sessionsDir, entry.id);
     if (!existsSync(path)) {
@@ -158,7 +156,7 @@ export class FileChatSessionRepository implements ChatSessionRepository {
 
     try {
       const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
-      return ChatSessionCodec.parseSessionBody(parsed, { entry, apiKeyPresent });
+      return ChatSessionCodec.parseSessionBody(parsed, { entry });
     } catch (error) {
       process.stderr.write(
         `Failed to load chat session file ${path}: ${error instanceof Error ? error.message : String(error)}\n`,

--- a/src/core/chat/engine/sessions/repository/types.ts
+++ b/src/core/chat/engine/sessions/repository/types.ts
@@ -28,9 +28,9 @@ export type SessionStoragePaths = {
 };
 
 export type ChatSessionRepository = {
-  list(apiKeyPresent: boolean): ChatSession[];
+  list(): ChatSession[];
   readCatalog(): ChatSessionCatalogEntry[];
-  read(sessionId: string, apiKeyPresent: boolean): ChatSession | undefined;
+  read(sessionId: string): ChatSession | undefined;
   save(sessions: ChatSession[]): void;
   deriveStoragePaths(): SessionStoragePaths;
 };

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -34,7 +34,6 @@ import type {
   MarkAcceptedConversationUserMessageFailedInput,
   MarkAcceptedConversationUserMessageInput,
   MarkConversationCompactionRunningInput,
-  ResetConversationSessionInput,
   RestoreConversationCompactionStateInput,
   UpdateConversationSessionSettingsInput,
 } from '../types.js';
@@ -87,11 +86,10 @@ export class FileConversationSessionService implements ConversationSessionServic
   }
 
   create(input?: CreateConversationSessionInput): ChatSession {
-    const existing = this.loadExistingSessions(input?.apiKeyPresent ?? this.config.apiKeyPresent);
+    const existing = this.loadExistingSessions();
     const session = ChatSessionRecords.create({
       id: input?.id?.trim() || `session-${randomUUID()}`,
       name: input?.name?.trim() || `Session ${FileConversationSessionService.getNextSessionNumber(existing)}`,
-      apiKeyPresent: input?.apiKeyPresent ?? this.config.apiKeyPresent,
       model: input?.model ?? this.config.model,
       reasoningEffort: input?.reasoningEffort ?? this.config.reasoningEffort,
       workspaceId: input?.workspaceId ?? this.config.workspaceId,
@@ -171,13 +169,13 @@ export class FileConversationSessionService implements ConversationSessionServic
     ));
   }
 
-  resetConversation(id: string, input: ResetConversationSessionInput): ChatSession {
+  resetConversation(id: string): ChatSession {
     return this.updateRequiredSession(id, (session) => ({
       ...session,
       history: [],
       turns: [],
       lastContinuePrompt: undefined,
-      messages: ChatSessionRecords.createInitialMessages(input.apiKeyPresent),
+      messages: [],
     }));
   }
 
@@ -290,21 +288,21 @@ export class FileConversationSessionService implements ConversationSessionServic
     return true;
   }
 
-  private loadSessions(apiKeyPresent = this.config.apiKeyPresent): ChatSession[] {
-    const sessions = this.repository.list(apiKeyPresent);
+  private loadSessions(): ChatSession[] {
+    const sessions = this.repository.list();
     if (this.repository.readCatalog().length === 0) {
-      const fallback = this.createFallbackSession(apiKeyPresent);
+      const fallback = this.createFallbackSession();
       this.repository.save([fallback]);
       return [fallback];
     }
     return sessions;
   }
 
-  private loadExistingSessions(apiKeyPresent = this.config.apiKeyPresent): ChatSession[] {
+  private loadExistingSessions(): ChatSession[] {
     const catalog = this.repository.readCatalog();
     if (catalog.length > 0) {
       return catalog
-        .map((entry) => this.repository.read(entry.id, apiKeyPresent))
+        .map((entry) => this.repository.read(entry.id))
         .filter((session): session is ChatSession => Boolean(session));
     }
 
@@ -323,11 +321,10 @@ export class FileConversationSessionService implements ConversationSessionServic
     return updated;
   }
 
-  private createFallbackSession(apiKeyPresent = this.config.apiKeyPresent): ChatSession {
+  private createFallbackSession(): ChatSession {
     return ChatSessionRecords.create({
       id: 'session-1',
       name: 'Session 1',
-      apiKeyPresent,
       model: this.config.model,
       reasoningEffort: this.config.reasoningEffort,
       workspaceId: this.config.workspaceId,
@@ -375,7 +372,6 @@ export class FileConversationSessionService implements ConversationSessionServic
       reasoningEffort: config.reasoningEffort,
       sessionStoragePath: resolve(config.sessionStoragePath ?? join(stateRoot, 'chat-sessions.catalog.json')),
       workspaceId: config.workspaceId,
-      apiKeyPresent: config.apiKeyPresent ?? false,
     };
   }
 

--- a/src/core/chat/engine/sessions/types.ts
+++ b/src/core/chat/engine/sessions/types.ts
@@ -3,12 +3,12 @@ import type { NormalizedConversationEngineConfig } from '../config.js';
 
 export type ConversationSessionServiceConfig = Pick<
   ConversationEngineConfig,
-  'workspaceRoot' | 'stateRoot' | 'model' | 'reasoningEffort' | 'sessionStoragePath' | 'workspaceId' | 'apiKeyPresent'
+  'workspaceRoot' | 'stateRoot' | 'model' | 'reasoningEffort' | 'sessionStoragePath' | 'workspaceId'
 >;
 
 export type NormalizedConversationSessionServiceConfig = Pick<
   NormalizedConversationEngineConfig,
-  'workspaceRoot' | 'stateRoot' | 'model' | 'reasoningEffort' | 'sessionStoragePath' | 'workspaceId' | 'apiKeyPresent'
+  'workspaceRoot' | 'stateRoot' | 'model' | 'reasoningEffort' | 'sessionStoragePath' | 'workspaceId'
 >;
 
 export type FileConversationSessionServiceContract = ConversationSessionService;

--- a/src/core/chat/engine/turns/context/turn-context-builder.ts
+++ b/src/core/chat/engine/turns/context/turn-context-builder.ts
@@ -14,7 +14,7 @@ import type { ConversationTurnRuntimeConfig } from '../runtime/index.js';
  */
 export class ConversationTurnContextBuilder {
   static build(args: PrepareConversationTurnContextArgs): ConversationTurnContext {
-    const sessions = new FileChatSessionRepository({ sessionStoragePath: args.sessionStoragePath }).list(true);
+    const sessions = new FileChatSessionRepository({ sessionStoragePath: args.sessionStoragePath }).list();
     const session = sessions.find((candidate) => candidate.id === args.sessionId);
     if (!session) {
       throw new Error(`Chat session not found: ${args.sessionId}`);

--- a/src/core/chat/engine/turns/memory/turn-memory-maintenance.ts
+++ b/src/core/chat/engine/turns/memory/turn-memory-maintenance.ts
@@ -84,7 +84,7 @@ export class ConversationTurnMemoryMaintenance {
     writeFileSync(args.traceFile, `${JSON.stringify(nextTrace, null, 2)}\n`, 'utf8');
 
     const repository = new FileChatSessionRepository({ sessionStoragePath: args.sessionStoragePath });
-    const sessions = repository.list(true);
+    const sessions = repository.list();
     const nextSessions = sessions.map((session) => {
       if (session.id !== args.sessionId) {
         return session;

--- a/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
+++ b/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
@@ -18,7 +18,7 @@ import type {
 export class ConversationTurnPreflightService {
   static async prepare(args: PrepareChatSessionTurnArgs): Promise<PrepareChatSessionTurnResult> {
     const persistedSession = new FileChatSessionRepository({ sessionStoragePath: args.sessionStoragePath })
-      .read(args.sessionId, true);
+      .read(args.sessionId);
     const leaseConflict = persistedSession ? ChatSessionLeases.conflict(persistedSession, args.leaseOwner) : undefined;
     if (leaseConflict) {
       return {

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -165,7 +165,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
 
   static clearLeaseFromStorage(sessionStoragePath: string, sessionId: string, owner: ChatSessionLeaseOwner): void {
     const repository = new FileChatSessionRepository({ sessionStoragePath });
-    const sessions = repository.list(true);
+    const sessions = repository.list();
     const session = sessions.find((candidate) => candidate.id === sessionId);
     if (!session?.lease) {
       return;

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -69,7 +69,7 @@ export type ConversationSessionService = {
   markAcceptedUserMessageFailed(id: string, input: MarkAcceptedConversationUserMessageFailedInput): ChatSession;
 
   // Conversation state
-  resetConversation(id: string, input: ResetConversationSessionInput): ChatSession;
+  resetConversation(id: string): ChatSession;
   setLastContinuePrompt(id: string, prompt: string | undefined): ChatSession;
 
   // Compaction state
@@ -89,7 +89,6 @@ export type CreateConversationSessionInput = {
   model?: string;
   reasoningEffort?: ReasoningEffort;
   workspaceId?: string;
-  apiKeyPresent?: boolean;
   retention?: ChatSessionRetention;
 };
 
@@ -130,10 +129,6 @@ export type AcceptConversationUserMessageInput = MarkAcceptedConversationUserMes
 export type MarkAcceptedConversationUserMessageFailedInput = {
   runId: string;
   failureMessage: AppendConversationMessageInput;
-};
-
-export type ResetConversationSessionInput = {
-  apiKeyPresent: boolean;
 };
 
 export type MarkConversationCompactionRunningInput = {

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -150,6 +150,12 @@ export type ChatSessionDetail = ChatSessionView & {
   lastContinuePrompt?: string;
 };
 
+export type ControlPlaneSessionWelcomeGuide = {
+  mode: 'conversation';
+  hasProviderCredential: boolean;
+  carriesTranscriptAcrossTurns: boolean;
+};
+
 export type ControlPlaneSessionRuntimeContext = {
   workspaceId: string;
   sessionId: string;
@@ -166,6 +172,7 @@ export type ControlPlaneSessionRuntimeContext = {
   driftLevel?: ChatSessionView['driftLevel'];
   compactionStatus?: NonNullable<NonNullable<ChatSessionView['context']>['compaction']>['status'];
   running: boolean;
+  welcomeGuide: ControlPlaneSessionWelcomeGuide;
 };
 
 export type ControlPlaneAcceptedSessionRun = {

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -112,20 +112,13 @@ export class ControlPlaneChatSessionsController {
   createSession(args: CreateControlPlaneChatSessionArgs): ChatSessionDetail {
     const { suggestedName, ...engineInput } = args;
     const model = this.resolveSessionCreationModel(args);
-    const credentialRuntime = {
-      preferApiKey: args.preferApiKey,
-      credentialStorePath: args.credentialStorePath,
-    };
-    const apiKeyPresent = args.apiKeyPresent ?? RuntimeCredentialService.hasCredentialForModel(model, credentialRuntime);
     const engine = createConversationEngine({
       ...engineInput,
       model,
-      apiKeyPresent,
     });
 
     const session = engine.sessions.create({
       name: suggestedName,
-      apiKeyPresent,
       model,
       workspaceId: args.workspaceId,
       retention: args.retention,
@@ -161,15 +154,7 @@ export class ControlPlaneChatSessionsController {
     const { sessionId, leaseOwner, ...engineInput } = args;
     const sessions = this.createEngine(engineInput).sessions;
     this.assertNoLeaseConflict(sessions, sessionId, leaseOwner);
-    const session = sessions.require(sessionId);
-    const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
-    const updated = sessions.resetConversation(sessionId, {
-      apiKeyPresent: RuntimeCredentialService.hasCredentialForModel(model, {
-        apiKey: args.apiKey,
-        credentialStorePath: args.credentialStorePath,
-        preferApiKey: args.preferApiKey,
-      }),
-    });
+    const updated = sessions.resetConversation(sessionId);
     return ControlPlaneChatSessionPresenter.projectDetail(updated)[0] as ChatSessionDetail;
   }
 
@@ -620,7 +605,7 @@ export class ControlPlaneChatSessionsController {
     // This is the only control-plane session path that should mutate the file
     // repository directly.
     const repository = new FileChatSessionRepository({ sessionStoragePath: args.sessionStoragePath });
-    const session = repository.read(args.sessionId, true);
+    const session = repository.read(args.sessionId);
     if (!session) {
       throw new Error(`Chat session not found: ${args.sessionId}`);
     }
@@ -654,7 +639,7 @@ export class ControlPlaneChatSessionsController {
 
     repository.save(
       repository.readCatalog()
-        .map((entry) => repository.read(entry.id, true))
+        .map((entry) => repository.read(entry.id))
         .filter((candidate): candidate is ChatSession => Boolean(candidate))
         .map((candidate) => candidate.id === session.id ? updatedSession : candidate),
     );

--- a/src/server/services/control-plane/session-runtime-context-service.ts
+++ b/src/server/services/control-plane/session-runtime-context-service.ts
@@ -29,7 +29,12 @@ export type ControlPlaneResolvedSessionRuntimeContext = {
 };
 
 /**
- * Resolves selected-session runtime facts once for API views and command ports.
+ * Owns selected-session runtime facts for control-plane consumers.
+ *
+ * Keep facts here when they describe the current executable session context
+ * rather than persisted transcript data: selected model, resolved credentials,
+ * model capabilities, context-window estimates, drift/run state, and empty
+ * session welcome facts. Interface layers decide how to render those facts.
  */
 export class ControlPlaneSessionRuntimeContextService {
   read(
@@ -51,6 +56,7 @@ export class ControlPlaneSessionRuntimeContextService {
     const session = sessions.require(args.sessionId);
     const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
     const estimatedInputTokens = session.context?.request?.usage?.inputTokens ?? session.context?.request?.estimatedTokens;
+    const credentialSource = RuntimeCredentialService.resolveCredentialSourceForModel(model, args);
 
     return {
       args,
@@ -69,13 +75,18 @@ export class ControlPlaneSessionRuntimeContextService {
         }),
         reasoningSupported: ModelPolicyService.supportsReasoningEffort(model),
         reasoningOptions: ModelPolicyService.buildReasoningEffortOptions(model),
-        credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(model, args),
+        credentialSource,
         contextWindow: ModelCatalogService.estimateBuiltInContextWindow(model),
         estimatedInputTokens,
         driftEnabled: session.driftEnabled ?? false,
         driftLevel: options.driftLevel ?? ControlPlaneSessionDriftService.readLatestDriftLevel(session.turns),
         compactionStatus: session.context?.compaction?.status,
         running: options.running ?? false,
+        welcomeGuide: {
+          mode: 'conversation',
+          hasProviderCredential: credentialSource.type !== 'missing',
+          carriesTranscriptAcrossTurns: true,
+        },
       },
     };
   }

--- a/src/server/services/control-plane/slash-command-execution-context-service.ts
+++ b/src/server/services/control-plane/slash-command-execution-context-service.ts
@@ -77,9 +77,7 @@ export class ControlPlaneSlashCommandExecutionContextService {
           sessions.delete(id);
         },
         clear: () => {
-          sessions.resetConversation(args.sessionId, {
-            apiKeyPresent: runtimeContext.credentialSource.type !== 'missing',
-          });
+          sessions.resetConversation(args.sessionId);
         },
         summarize: ChatSessionRecords.summarize,
       },

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -5,6 +5,7 @@ import type {
   ControlPlanePendingApproval,
   ControlPlaneSessionDetail,
 } from '@web/hooks/sessions/useControlPlaneSessionDetail';
+import type { ControlPlaneSessionRuntimeContext } from '@web/api/client';
 import { useConversationAutoScroll } from '@web/hooks/conversation/useConversationAutoScroll';
 import type { ClientSharedSessionPlan } from '@/client-shared/services/session-activities';
 import type {
@@ -16,6 +17,7 @@ import { AgentPlanPanel } from './AgentPlanPanel';
 import { ApprovalPanel } from './ApprovalPanel';
 import { ConversationComposer } from './ConversationComposer';
 import { ConversationMessage } from './ConversationMessage';
+import { ConversationWelcomePanel } from './ConversationWelcomePanel';
 import { Loader2 } from 'lucide-react';
 
 interface ConversationThreadProps {
@@ -29,6 +31,7 @@ interface ConversationThreadProps {
   currentActivity?: ClientSharedAgentActivityStatus;
   latestUpdate?: ClientSharedSessionLatestUpdate;
   activePlan?: ClientSharedSessionPlan;
+  runtimeContext?: ControlPlaneSessionRuntimeContext;
   pendingApproval: ControlPlanePendingApproval;
   approvalResolving: boolean;
   approvalError?: string;
@@ -56,6 +59,7 @@ export function ConversationThread({
   currentActivity,
   latestUpdate,
   activePlan,
+  runtimeContext,
   pendingApproval,
   approvalResolving,
   approvalError,
@@ -70,6 +74,8 @@ export function ConversationThread({
   onUpdateReasoningEffort,
   onResolveApproval,
 }: ConversationThreadProps) {
+  const hasUserMessage = session?.messages.some((message) => message.role === 'user') ?? false;
+  const showWelcome = Boolean(runtimeContext?.welcomeGuide && !hasUserMessage && !submitting);
   const conversationAutoScroll = useConversationAutoScroll({
     liveStatus,
     messages: session?.messages ?? [],
@@ -113,12 +119,15 @@ export function ConversationThread({
         className="v2-conversation-scroll v2-scrollbar-hidden min-h-0 flex-1 overflow-auto"
         {...conversationAutoScroll.scrollContainerProps}
       >
-        <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-6 py-8">
+        <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-5 px-6 py-8">
           {loading ? (
             <div className="v2-type-panel-subtitle inline-flex items-center gap-2 text-muted-foreground">
               <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
               Updating conversation...
             </div>
+          ) : null}
+          {showWelcome && runtimeContext?.welcomeGuide ? (
+            <ConversationWelcomePanel welcomeGuide={runtimeContext.welcomeGuide} />
           ) : null}
           {session.messages.map((message) => (
             <ConversationMessage key={message.id} message={message} />

--- a/src/web-v2/components/conversation/ConversationWelcomePanel.tsx
+++ b/src/web-v2/components/conversation/ConversationWelcomePanel.tsx
@@ -1,0 +1,26 @@
+import type { ControlPlaneSessionRuntimeContext } from '@web/api/client';
+
+type ConversationWelcomePanelProps = {
+  welcomeGuide: ControlPlaneSessionRuntimeContext['welcomeGuide'];
+};
+
+export function ConversationWelcomePanel({ welcomeGuide }: ConversationWelcomePanelProps) {
+  return (
+    <section className="v2-conversation-welcome" aria-label="Welcome to Heddle">
+      <div className="v2-conversation-welcome-copy">
+        <p className="v2-conversation-welcome-kicker">Heddle</p>
+        <h2 className="v2-conversation-welcome-title text-balance">
+          Ask about this workspace
+        </h2>
+        <p className="v2-conversation-welcome-body text-pretty">
+          Each turn runs the agent with this session&apos;s context and carries the conversation forward.
+        </p>
+        {!welcomeGuide.hasProviderCredential ? (
+          <p className="v2-conversation-welcome-note text-pretty">
+            Connect a provider credential before running model-backed turns.
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/web-v2/components/conversation/index.ts
+++ b/src/web-v2/components/conversation/index.ts
@@ -5,6 +5,7 @@ export { ApprovalPanel } from './ApprovalPanel';
 export { ConversationComposer } from './ConversationComposer';
 export { ConversationMessage } from './ConversationMessage';
 export { ConversationThread } from './ConversationThread';
+export { ConversationWelcomePanel } from './ConversationWelcomePanel';
 export { FileMentionMenu } from './FileMentionMenu';
 export {
   SessionDriftMenuSection,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { ControlPlaneSessionDetail } from '@web/api/client';
+import type { ControlPlaneSessionDetail, ControlPlaneSessionRuntimeContext } from '@web/api/client';
 import {
   type ClientSharedAgentActivityStatus,
   type ClientSharedSessionLatestUpdate,
@@ -10,6 +10,7 @@ import { useControlPlaneSessionLoader } from './useControlPlaneSessionLoader';
 import { useControlPlanePendingApproval } from './useControlPlanePendingApproval';
 import { useControlPlaneSessionPromptSubmit } from './useControlPlaneSessionPromptSubmit';
 import { useControlPlaneSessionRunControl } from './useControlPlaneSessionRunControl';
+import { useControlPlaneSessionRuntimeContext } from './useControlPlaneSessionRuntimeContext';
 import { useControlPlaneSessionSettings } from './useControlPlaneSessionSettings';
 
 export type { ControlPlaneApprovalDecision, ControlPlanePendingApproval, ControlPlaneSessionDetail } from '@web/api/client';
@@ -26,6 +27,7 @@ type ControlPlaneSessionDetailState = {
   currentActivity?: ClientSharedAgentActivityStatus;
   latestUpdate?: ClientSharedSessionLatestUpdate;
   activePlan?: ClientSharedSessionPlan;
+  runtimeContext?: ControlPlaneSessionRuntimeContext;
   cancelError?: string;
   pendingApproval: ReturnType<typeof useControlPlanePendingApproval>['pendingApproval'];
   approvalResolving: boolean;
@@ -62,6 +64,11 @@ export function useControlPlaneSessionDetail({
     sessionId,
     setLiveStatus,
     setError: loader.setError,
+  });
+  const runtimeContext = useControlPlaneSessionRuntimeContext({
+    workspaceId,
+    sessionId,
+    running: runControl.running,
   });
   const approval = useControlPlanePendingApproval({ workspaceId, sessionId }, {
     pollingEnabled: runControl.running,
@@ -111,6 +118,7 @@ export function useControlPlaneSessionDetail({
     currentActivity,
     latestUpdate,
     activePlan,
+    runtimeContext: runtimeContext.runtimeContext,
     cancelError: runControl.cancelError,
     pendingApproval: approval.pendingApproval,
     approvalResolving: approval.approvalResolving,
@@ -142,6 +150,7 @@ export function useControlPlaneSessionDetail({
     runControl.cancelRun,
     runControl.cancelling,
     runControl.running,
+    runtimeContext.runtimeContext,
     settings.modelOptions,
     settings.settingsError,
     settings.settingsUpdating,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
@@ -97,6 +97,7 @@ export function useControlPlaneSessionPromptSubmit({
         utils.controlPlane.sessions.invalidate({ workspaceId: submission.workspaceId }),
         utils.controlPlane.session.invalidate({ id: submission.sessionId, workspaceId: submission.workspaceId }),
         utils.controlPlane.sessionRunState.invalidate({ id: submission.sessionId, workspaceId: submission.workspaceId }),
+        utils.controlPlane.sessionRuntimeContext.invalidate({ sessionId: submission.sessionId, workspaceId: submission.workspaceId }),
       ]).catch(() => undefined);
 
       if (isCurrentSubmission()) {
@@ -116,6 +117,7 @@ export function useControlPlaneSessionPromptSubmit({
     sessionSendPromptMutation,
     utils.controlPlane.session,
     utils.controlPlane.sessionRunState,
+    utils.controlPlane.sessionRuntimeContext,
     utils.controlPlane.sessions,
   ]);
 

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionRuntimeContext.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionRuntimeContext.ts
@@ -1,0 +1,34 @@
+import { skipToken } from '@tanstack/react-query';
+import { trpcReact, type ControlPlaneSessionRuntimeContext } from '@web/api/client';
+
+type UseControlPlaneSessionRuntimeContextArgs = {
+  workspaceId?: string;
+  sessionId?: string;
+  running: boolean;
+};
+
+export type ControlPlaneSessionRuntimeContextState = {
+  runtimeContext?: ControlPlaneSessionRuntimeContext;
+};
+
+// Owns web-v2 consumption of control-plane runtime facts. Runtime fact
+// ownership stays on the server; this hook only binds the shared API data to
+// React Query so components can render interface-specific guidance/status.
+export function useControlPlaneSessionRuntimeContext({
+  workspaceId,
+  sessionId,
+  running,
+}: UseControlPlaneSessionRuntimeContextArgs): ControlPlaneSessionRuntimeContextState {
+  const runtimeContextQuery = trpcReact.controlPlane.sessionRuntimeContext.useQuery(
+    sessionId && workspaceId ? { sessionId, workspaceId } : skipToken,
+    {
+      enabled: Boolean(sessionId && workspaceId),
+      refetchInterval: running ? 1000 : false,
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  return {
+    runtimeContext: runtimeContextQuery.data,
+  };
+}

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionSettings.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionSettings.ts
@@ -54,6 +54,7 @@ export function useControlPlaneSessionSettings({
         utils.controlPlane.state.invalidate(),
         utils.controlPlane.sessions.invalidate({ workspaceId }),
         utils.controlPlane.session.invalidate({ id: sessionId, workspaceId }),
+        utils.controlPlane.sessionRuntimeContext.invalidate({ sessionId, workspaceId }),
       ]);
     } catch (settingsError) {
       setError(settingsError instanceof Error ? settingsError.message : String(settingsError));

--- a/src/web-v2/hooks/useControlPlaneAppState.ts
+++ b/src/web-v2/hooks/useControlPlaneAppState.ts
@@ -144,6 +144,7 @@ export function useControlPlaneAppState() {
         currentActivity: selectedSession.currentActivity,
         latestUpdate: selectedSession.latestUpdate,
         activePlan: selectedSession.activePlan,
+        runtimeContext: selectedSession.runtimeContext,
         pendingApproval: selectedSession.pendingApproval,
         approvalResolving: selectedSession.approvalResolving,
         approvalError: selectedSession.approvalError,

--- a/src/web-v2/styles/conversation.css
+++ b/src/web-v2/styles/conversation.css
@@ -162,6 +162,50 @@
     color: color-mix(in oklab, var(--color-destructive) 82%, var(--color-foreground));
   }
 
+  .v2-conversation-welcome {
+    display: flex;
+    min-height: 18rem;
+    flex: 1 1 auto;
+    align-items: center;
+    justify-content: center;
+    padding-block: 2rem;
+  }
+
+  .v2-conversation-welcome-copy {
+    width: min(100%, 32rem);
+    text-align: center;
+  }
+
+  .v2-conversation-welcome-kicker {
+    margin-bottom: 0.45rem;
+    color: var(--color-muted-foreground);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.35;
+  }
+
+  .v2-conversation-welcome-title {
+    margin-bottom: 0.65rem;
+    color: var(--color-foreground);
+    font-size: 1.35rem;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+
+  .v2-conversation-welcome-body,
+  .v2-conversation-welcome-note {
+    margin-inline: auto;
+    max-width: 28rem;
+    color: var(--color-muted-foreground);
+    font-size: 0.9375rem;
+    line-height: 1.55;
+  }
+
+  .v2-conversation-welcome-note {
+    margin-top: 0.85rem;
+    color: color-mix(in oklab, var(--color-warning, hsl(45 92% 70%)) 74%, var(--color-foreground));
+  }
+
   .v2-agent-activity-region {
     padding: 0 1.5rem 0.45rem;
   }


### PR DESCRIPTION
## Summary
- move empty-session welcome facts into control-plane session runtime context instead of persisted chat messages
- render interface-owned welcome guidance in web-v2 and cli-v2
- strip legacy intro/missing-key visible messages when reading stored sessions and remove credential plumbing from session records

## Validation
- yarn typecheck
- ./node_modules/.bin/vitest run src/__tests__/unit/core/conversation-engine.test.ts src/__tests__/integration/chat/chat-storage.test.ts src/__tests__/integration/control-plane/session-lifecycle.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/unit/cli-v2/runtime-status.test.ts