### PR TITLE
[codex] Add cli-v2 file mention picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "clsx": "^2.1.1",
     "commander": "^14.0.1",
     "dayjs": "^1.11.20",
+    "debounce": "^3.0.0",
     "eventsource": "4.1.0",
     "express": "^5.2.1",
     "gitdiff-parser": "^0.3.1",

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -138,6 +138,23 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('searches file mention suggestions through the control-plane API', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    await expect(store.searchWorkspaceFileMentions('src', 8)).resolves.toEqual([
+      { path: 'src/example.ts' },
+    ]);
+
+    expect(fixture.calls.workspaceFileSearchQuery).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      query: 'src',
+      limit: 8,
+    });
+    store.dispose();
+  });
+
   it('executes picker selections through slash commands', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });
@@ -677,6 +694,10 @@ function createClientFixture() {
       kind: 'message',
       message: 'Current model: gpt-5.4',
     })),
+    workspaceFileSearchQuery: vi.fn(async () => ({
+      workspaceId: 'workspace-1',
+      files: [{ path: 'src/example.ts' }],
+    })),
     sessionContinueMutate: vi.fn(async () => ({
       outcome: 'done',
       summary: 'Continued.',
@@ -712,6 +733,7 @@ function createClientFixture() {
       sessionSendPromptAsync: { mutate: calls.sessionSendPromptAsyncMutate },
       slashCommandCatalog: { query: calls.slashCommandCatalogQuery },
       slashCommandExecute: { mutate: calls.slashCommandExecuteMutate },
+      workspaceFileSearch: { query: calls.workspaceFileSearchQuery },
       sessionContinue: { mutate: calls.sessionContinueMutate },
       sessionCancel: { mutate: calls.sessionCancelMutate },
       sessionResolveApproval: { mutate: calls.sessionResolveApprovalMutate },

--- a/src/__tests__/unit/cli-v2/file-mention-picker.test.tsx
+++ b/src/__tests__/unit/cli-v2/file-mention-picker.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useFileMentionPicker } from '../../../cli-v2/hooks/useFileMentionPicker.js';
+import type {
+  ControlPlaneSessionStore,
+  ControlPlaneSessionStoreSnapshot,
+} from '../../../cli-v2/state/control-plane-session-store.js';
+
+describe('useFileMentionPicker', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces workspace file searches and inserts the highlighted result', async () => {
+    vi.useFakeTimers();
+    const searchWorkspaceFileMentions = vi.fn(async () => [
+      { path: 'src/alpha.ts' },
+      { path: 'src/beta.ts' },
+    ]);
+    const store = { searchWorkspaceFileMentions } as unknown as ControlPlaneSessionStore;
+
+    const { result } = renderHook(() => {
+      const [draft, setDraft] = useState('');
+      const picker = useFileMentionPicker({
+        draft,
+        setDraft,
+        snapshot: createSnapshot(),
+        store,
+      });
+
+      return { draft, setDraft, picker };
+    });
+
+    act(() => {
+      result.current.setDraft('@s');
+      result.current.setDraft('@sr');
+      result.current.setDraft('@src');
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(219);
+    });
+    expect(searchWorkspaceFileMentions).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+    });
+
+    expect(result.current.picker.suggestions).toHaveLength(2);
+    expect(searchWorkspaceFileMentions).toHaveBeenCalledTimes(1);
+    expect(searchWorkspaceFileMentions).toHaveBeenCalledWith('src', 20);
+
+    act(() => {
+      result.current.picker.handleSpecialKey('', { downArrow: true });
+    });
+    act(() => {
+      result.current.picker.handleSpecialKey('', { tab: true });
+    });
+
+    expect(result.current.draft).toBe('@src/beta.ts ');
+  });
+});
+
+function createSnapshot(): ControlPlaneSessionStoreSnapshot {
+  return {
+    workspaceId: 'workspace-1',
+    sessions: [],
+    activeSession: null,
+    pendingApproval: null,
+    loading: false,
+    submitting: false,
+    approvalResolving: false,
+    running: false,
+    cancelling: false,
+    streamConnected: false,
+    commandResults: [],
+  };
+}

--- a/src/__tests__/unit/client-shared/file-mention-service.test.ts
+++ b/src/__tests__/unit/client-shared/file-mention-service.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { ClientSharedFileMentionService } from '@/client-shared/services/file-mentions/index.js';
+
+describe('ClientSharedFileMentionService', () => {
+  it('detects active mention tokens without matching email addresses', () => {
+    expect(ClientSharedFileMentionService.findToken('Compare @REA', 12)).toEqual({
+      query: 'REA',
+      start: 8,
+      end: 12,
+    });
+    expect(ClientSharedFileMentionService.findToken('test@example.com', 16)).toBeNull();
+  });
+
+  it('inserts a selected file mention at the active token', () => {
+    expect(ClientSharedFileMentionService.insertSelection(
+      'Compare @REA',
+      { query: 'REA', start: 8, end: 12 },
+      'README.md',
+    )).toEqual({
+      value: 'Compare @README.md ',
+      cursor: 19,
+    });
+  });
+});

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -7,6 +7,7 @@ import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { AgentPlanPanel } from './components/AgentPlanPanel.js';
 import { CommandResultPanel } from './components/CommandResultPanel.js';
 import { ConversationPanel } from './components/ConversationPanel.js';
+import { FileMentionPickerPanel } from './components/FileMentionPickerPanel.js';
 import { ModelPickerPanel } from './components/ModelPickerPanel.js';
 import { PromptInput } from './components/PromptInput.js';
 import { PromptStatusPanel } from './components/PromptStatusPanel.js';
@@ -16,6 +17,7 @@ import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
 import { SessionPickerPanel } from './components/SessionPickerPanel.js';
 import { SlashCommandHintPanel } from './components/SlashCommandHintPanel.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
+import { useFileMentionPicker } from './hooks/useFileMentionPicker.js';
 import { usePromptPickers } from './hooks/usePromptPickers.js';
 import { usePromptDraft } from './hooks/usePromptDraft.js';
 import { PromptActivityService } from './services/activities/prompt-activity-service.js';
@@ -51,6 +53,12 @@ export function App({
     onSelectSession: (sessionId) => {
       void store.selectSessionFromPicker(sessionId);
     },
+  });
+  const fileMentions = useFileMentionPicker({
+    draft,
+    setDraft,
+    snapshot,
+    store,
   });
 
   useEffect(() => {
@@ -145,7 +153,16 @@ export function App({
           highlightedIndex={pickers.session.highlightedIndex}
         />
       ) : null}
-      {!pickers.visible ? <SlashCommandHintPanel hints={slashCommandHints} /> : null}
+      {fileMentions.visible ? (
+        <FileMentionPickerPanel
+          query={fileMentions.query}
+          suggestions={fileMentions.suggestions}
+          highlightedIndex={fileMentions.highlightedIndex}
+          loading={fileMentions.loading}
+          error={fileMentions.error}
+        />
+      ) : null}
+      {!pickers.visible && !fileMentions.visible ? <SlashCommandHintPanel hints={slashCommandHints} /> : null}
       <PromptStatusPanel
         currentActivity={snapshot.currentActivity}
         latestActivity={PromptActivityService.build(snapshot)}
@@ -162,7 +179,7 @@ export function App({
         onChange={setDraft}
         onSubmit={submitPrompt}
         onComplete={(value) => store.completeSlashCommandDraft(value)}
-        onSpecialKey={pickers.handleSpecialKey}
+        onSpecialKey={(input, key) => fileMentions.handleSpecialKey(input, key) || pickers.handleSpecialKey(input, key)}
       />
       <RuntimeStatusBar snapshot={snapshot} />
     </Box>

--- a/src/cli-v2/components/FileMentionPickerPanel.tsx
+++ b/src/cli-v2/components/FileMentionPickerPanel.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { ControlPlaneWorkspaceFileSuggestion } from '@/client-shared/api/types.js';
+
+const MAX_VISIBLE_FILES = 8;
+
+export function FileMentionPickerPanel({
+  query,
+  suggestions,
+  highlightedIndex,
+  loading,
+  error,
+}: {
+  query: string;
+  suggestions: ControlPlaneWorkspaceFileSuggestion[];
+  highlightedIndex: number;
+  loading: boolean;
+  error?: string;
+}) {
+  const { visibleSuggestions, startIndex } = getVisibleSuggestions(suggestions, highlightedIndex);
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text dimColor>File mentions</Text>
+      <Text dimColor>
+        {query ? `Search: ${query}` : 'Type after @ to search workspace files. Use up/down and Tab to choose.'}
+      </Text>
+      {error ? (
+        <Text color="yellow">File search unavailable: {error}</Text>
+      ) : visibleSuggestions.length > 0 ? (
+        visibleSuggestions.map((suggestion, index) => {
+          const absoluteIndex = startIndex + index;
+          const isHighlighted = absoluteIndex === highlightedIndex;
+          return (
+            <Text
+              key={suggestion.path}
+              color={isHighlighted ? 'cyan' : undefined}
+              dimColor={!isHighlighted}
+            >
+              {`${isHighlighted ? '◉' : '○'} @${suggestion.path}`}
+            </Text>
+          );
+        })
+      ) : (
+        <Text dimColor>{loading ? 'Searching workspace files...' : 'No matching files.'}</Text>
+      )}
+    </Box>
+  );
+}
+
+function getVisibleSuggestions(
+  suggestions: ControlPlaneWorkspaceFileSuggestion[],
+  highlightedIndex: number,
+): { visibleSuggestions: ControlPlaneWorkspaceFileSuggestion[]; startIndex: number } {
+  if (suggestions.length <= MAX_VISIBLE_FILES) {
+    return { visibleSuggestions: suggestions, startIndex: 0 };
+  }
+
+  const half = Math.floor(MAX_VISIBLE_FILES / 2);
+  const startIndex = Math.min(
+    Math.max(0, highlightedIndex - half),
+    Math.max(0, suggestions.length - MAX_VISIBLE_FILES),
+  );
+
+  return {
+    visibleSuggestions: suggestions.slice(startIndex, startIndex + MAX_VISIBLE_FILES),
+    startIndex,
+  };
+}

--- a/src/cli-v2/hooks/useFileMentionPicker.ts
+++ b/src/cli-v2/hooks/useFileMentionPicker.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import debounce from 'debounce';
+import type { ControlPlaneWorkspaceFileSuggestion } from '@/client-shared/api/types.js';
+import { ClientSharedFileMentionService } from '@/client-shared/services/file-mentions/index.js';
+import type { PromptInputKey } from '../components/PromptInput.js';
+import { CliV2PickerService } from '../services/pickers/index.js';
+import type {
+  ControlPlaneSessionStore,
+  ControlPlaneSessionStoreSnapshot,
+} from '../state/control-plane-session-store.js';
+
+const FILE_MENTION_DEBOUNCE_MS = 220;
+const FILE_MENTION_LIMIT = 20;
+
+export function useFileMentionPicker({
+  draft,
+  setDraft,
+  snapshot,
+  store,
+}: {
+  draft: string;
+  setDraft: (value: string) => void;
+  snapshot: ControlPlaneSessionStoreSnapshot;
+  store: ControlPlaneSessionStore;
+}) {
+  const [suggestions, setSuggestions] = useState<ControlPlaneWorkspaceFileSuggestion[]>([]);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [dismissedTokenKey, setDismissedTokenKey] = useState<string | undefined>();
+  const currentTokenKeyRef = useRef<string | undefined>(undefined);
+  const mentionToken = ClientSharedFileMentionService.findToken(draft, draft.length);
+  const tokenKey = mentionToken ? ClientSharedFileMentionService.tokenKey(mentionToken) : undefined;
+  const query = mentionToken?.query ?? '';
+  const visible = Boolean(mentionToken && tokenKey !== dismissedTokenKey);
+
+  const search = useMemo(() => debounce(async (query: string, requestedTokenKey: string) => {
+    try {
+      const files = await store.searchWorkspaceFileMentions(query, FILE_MENTION_LIMIT);
+      if (currentTokenKeyRef.current !== requestedTokenKey) {
+        return;
+      }
+
+      setSuggestions(files);
+      setError(undefined);
+    } catch (caught) {
+      setSuggestions([]);
+      setError(formatError(caught));
+    } finally {
+      if (currentTokenKeyRef.current === requestedTokenKey) {
+        setLoading(false);
+      }
+    }
+  }, FILE_MENTION_DEBOUNCE_MS), [store]);
+
+  useEffect(() => {
+    currentTokenKeyRef.current = tokenKey;
+
+    if (!tokenKey || !visible || !snapshot.workspaceId) {
+      search.clear();
+      setSuggestions([]);
+      setLoading(false);
+      setError(undefined);
+      return;
+    }
+
+    setLoading(true);
+    search(query, tokenKey);
+
+    return () => search.clear();
+  }, [query, search, snapshot.workspaceId, tokenKey, visible]);
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [mentionToken?.query]);
+
+  useEffect(() => {
+    setHighlightedIndex((index) => CliV2PickerService.clampIndex(index, suggestions.length));
+  }, [suggestions.length]);
+
+  useEffect(() => {
+    if (tokenKey !== dismissedTokenKey) {
+      setDismissedTokenKey(undefined);
+    }
+  }, [dismissedTokenKey, tokenKey]);
+
+  const insertSuggestion = useCallback((suggestion: ControlPlaneWorkspaceFileSuggestion) => {
+    if (!mentionToken) {
+      return;
+    }
+
+    setDraft(ClientSharedFileMentionService.insertSelection(draft, mentionToken, suggestion.path).value);
+    setSuggestions([]);
+    setHighlightedIndex(0);
+    setDismissedTokenKey(undefined);
+  }, [draft, mentionToken, setDraft]);
+
+  const handleSpecialKey = useCallback((_input: string, key: PromptInputKey) => {
+    if (!visible) {
+      return false;
+    }
+
+    if ((key.upArrow || key.leftArrow) && suggestions.length > 0) {
+      setHighlightedIndex((current) => CliV2PickerService.previousIndex(current, suggestions.length));
+      return true;
+    }
+
+    if ((key.downArrow || key.rightArrow) && suggestions.length > 0) {
+      setHighlightedIndex((current) => CliV2PickerService.nextIndex(current, suggestions.length));
+      return true;
+    }
+
+    if ((key.tab || key.return) && suggestions[highlightedIndex]) {
+      insertSuggestion(suggestions[highlightedIndex]);
+      return true;
+    }
+
+    if ((key.tab || key.return) && loading) {
+      return true;
+    }
+
+    if (key.escape) {
+      setDismissedTokenKey(tokenKey);
+      setSuggestions([]);
+      setLoading(false);
+      return true;
+    }
+
+    return false;
+  }, [highlightedIndex, insertSuggestion, loading, suggestions, tokenKey, visible]);
+
+  return {
+    visible,
+    query,
+    suggestions,
+    highlightedIndex,
+    loading,
+    error,
+    handleSpecialKey,
+  };
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : 'File search failed';
+}

--- a/src/cli-v2/services/sessions/control-plane-session-api-service.ts
+++ b/src/cli-v2/services/sessions/control-plane-session-api-service.ts
@@ -8,6 +8,7 @@ export type ControlPlaneSessionCreateInput = Exclude<NonNullable<RouterInputs['c
 type SessionSendPromptInput = RouterInputs['controlPlane']['sessionSendPrompt'];
 type SessionSendPromptAsyncInput = RouterInputs['controlPlane']['sessionSendPromptAsync'];
 type SlashCommandExecuteInput = RouterInputs['controlPlane']['slashCommandExecute'];
+type WorkspaceFileSearchInput = RouterInputs['controlPlane']['workspaceFileSearch'];
 
 export type ControlPlaneSessionApiServiceOptions = {
   client: ControlPlaneProxyClient;
@@ -87,6 +88,10 @@ export class ControlPlaneSessionApiService {
 
   async getSlashCommandCatalog(workspaceId: string) {
     return this.client.controlPlane.slashCommandCatalog.query({ workspaceId });
+  }
+
+  async searchWorkspaceFiles(input: WorkspaceFileSearchInput) {
+    return this.client.controlPlane.workspaceFileSearch.query(input);
   }
 
   async sendPrompt(input: Pick<SessionSendPromptInput, 'workspaceId' | 'sessionId' | 'prompt'>) {

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -34,6 +34,7 @@ import type {
   ControlPlaneSlashCommandCatalog,
   ControlPlaneSlashCommandHint,
   ControlPlaneSlashCommandResult,
+  ControlPlaneWorkspaceFileSuggestion,
 } from '@/client-shared/api/types.js';
 
 const ASSISTANT_STREAM_RENDER_INTERVAL_MS = 75;
@@ -182,6 +183,12 @@ export class ControlPlaneSessionStore {
     const sessions = await this.api.listSessions(workspaceId);
     this.setSnapshot({ sessions });
     return sessions;
+  }
+
+  async searchWorkspaceFileMentions(query: string, limit = 20): Promise<ControlPlaneWorkspaceFileSuggestion[]> {
+    const workspaceId = this.requireWorkspaceId();
+    const result = await this.api.searchWorkspaceFiles({ workspaceId, query, limit });
+    return result.workspaceId === workspaceId ? result.files : [];
   }
 
   async createSession(input: ControlPlaneSessionCreateInput = {}): Promise<ControlPlaneSessionView> {

--- a/src/client-shared/api/types.ts
+++ b/src/client-shared/api/types.ts
@@ -41,3 +41,5 @@ export type ControlPlaneMemoryStatus = RouterOutputs['controlPlane']['memoryStat
 export type ControlPlaneWorkspaceChanges = RouterOutputs['controlPlane']['workspaceChanges'];
 export type ControlPlaneWorkspaceChangedFile = ControlPlaneWorkspaceChanges['files'][number];
 export type ControlPlaneWorkspaceFileDiff = RouterOutputs['controlPlane']['workspaceFileDiff'];
+export type ControlPlaneWorkspaceFileSearch = RouterOutputs['controlPlane']['workspaceFileSearch'];
+export type ControlPlaneWorkspaceFileSuggestion = ControlPlaneWorkspaceFileSearch['files'][number];

--- a/src/client-shared/services/file-mentions/file-mention-service.ts
+++ b/src/client-shared/services/file-mentions/file-mention-service.ts
@@ -1,0 +1,53 @@
+export type ClientSharedFileMentionToken = {
+  query: string;
+  start: number;
+  end: number;
+};
+
+/**
+ * Owns interface-neutral @file mention text semantics.
+ *
+ * UIs own rendering, keyboard behavior, and API timing. The control plane owns
+ * workspace file search. This service owns only the shared local text rules
+ * for detecting the active mention token and replacing it with a selected path.
+ */
+export class ClientSharedFileMentionService {
+  static findToken(value: string, cursor: number): ClientSharedFileMentionToken | null {
+    const beforeCursor = value.slice(0, cursor);
+    const match = beforeCursor.match(/(^|[\s([{"'`])@([^\s@]*)$/);
+    if (!match || match.index === undefined) {
+      return null;
+    }
+
+    const prefix = match[1] ?? '';
+    const start = match.index + prefix.length;
+    const previousCharacter = value[start - 1];
+    if (previousCharacter && /[\w.-]/.test(previousCharacter)) {
+      return null;
+    }
+
+    return {
+      query: match[2] ?? '',
+      start,
+      end: cursor,
+    };
+  }
+
+  static insertSelection(
+    value: string,
+    token: ClientSharedFileMentionToken,
+    selectedPath: string,
+  ): { value: string; cursor: number } {
+    const insertedMention = `@${selectedPath}`;
+    const nextValue = `${value.slice(0, token.start)}${insertedMention} ${value.slice(token.end)}`;
+
+    return {
+      value: nextValue,
+      cursor: token.start + insertedMention.length + 1,
+    };
+  }
+
+  static tokenKey(token: ClientSharedFileMentionToken): string {
+    return `${token.start}:${token.end}:${token.query}`;
+  }
+}

--- a/src/client-shared/services/file-mentions/index.ts
+++ b/src/client-shared/services/file-mentions/index.ts
@@ -1,0 +1,4 @@
+export {
+  ClientSharedFileMentionService,
+  type ClientSharedFileMentionToken,
+} from './file-mention-service.js';

--- a/src/web-v2/hooks/conversation/useFileMentionAutocomplete.ts
+++ b/src/web-v2/hooks/conversation/useFileMentionAutocomplete.ts
@@ -1,4 +1,5 @@
 import { skipToken } from '@tanstack/react-query';
+import debounce from 'debounce';
 import {
   useCallback,
   useEffect,
@@ -14,14 +15,9 @@ import type {
   SyntheticEvent,
 } from 'react';
 import { trpcReact, type RouterOutputs } from '@web/api/client';
+import { ClientSharedFileMentionService } from '@/client-shared/services/file-mentions/index.js';
 
 export type FileMentionSuggestion = RouterOutputs['controlPlane']['workspaceFileSearch']['files'][number];
-
-type FileMentionToken = {
-  query: string;
-  start: number;
-  end: number;
-};
 
 type TextareaRef = RefObject<HTMLTextAreaElement | null>;
 
@@ -51,38 +47,39 @@ export function useFileMentionAutocomplete({
   const listboxId = useId();
   const optionIdPrefix = `${listboxId}-option`;
   const cursorRef = useRef(value.length);
-  const [mentionToken, setMentionToken] = useState<FileMentionToken | null>(null);
-  const [debouncedMentionToken, setDebouncedMentionToken] = useState<FileMentionToken | null>(null);
+  const [mentionToken, setMentionToken] = useState(ClientSharedFileMentionService.findToken(value, value.length));
+  const [debouncedMentionToken, setDebouncedMentionToken] = useState(ClientSharedFileMentionService.findToken(value, value.length));
   const [activeIndex, setActiveIndex] = useState(0);
+  const debouncedTokenUpdate = useMemo(() => debounce(setDebouncedMentionToken, debounceMs), [debounceMs]);
 
   const updateMentionToken = useCallback((nextValue: string, cursor: number | null) => {
     const nextCursor = cursor ?? nextValue.length;
     cursorRef.current = nextCursor;
-    setMentionToken(findFileMentionToken(nextValue, nextCursor));
+    setMentionToken(ClientSharedFileMentionService.findToken(nextValue, nextCursor));
   }, []);
 
   useEffect(() => {
     if (disabled) {
       setMentionToken(null);
       setDebouncedMentionToken(null);
+      debouncedTokenUpdate.clear();
       return;
     }
 
     updateMentionToken(value, Math.min(cursorRef.current, value.length));
-  }, [disabled, updateMentionToken, value]);
+  }, [debouncedTokenUpdate, disabled, updateMentionToken, value]);
 
   useEffect(() => {
     if (!mentionToken || disabled) {
       setDebouncedMentionToken(null);
+      debouncedTokenUpdate.clear();
       return;
     }
 
-    const timeout = window.setTimeout(() => {
-      setDebouncedMentionToken(mentionToken);
-    }, debounceMs);
+    debouncedTokenUpdate(mentionToken);
 
-    return () => window.clearTimeout(timeout);
-  }, [debounceMs, disabled, mentionToken]);
+    return () => debouncedTokenUpdate.clear();
+  }, [debouncedTokenUpdate, disabled, mentionToken]);
 
   const queryInput = debouncedMentionToken && workspaceId ? {
     workspaceId,
@@ -141,17 +138,15 @@ export function useFileMentionAutocomplete({
       return;
     }
 
-    const insertedMention = `@${suggestion.path}`;
-    const nextValue = `${value.slice(0, mentionToken.start)}${insertedMention} ${value.slice(mentionToken.end)}`;
-    const nextCursor = mentionToken.start + insertedMention.length + 1;
+    const inserted = ClientSharedFileMentionService.insertSelection(value, mentionToken, suggestion.path);
 
-    onValueChange(nextValue);
+    onValueChange(inserted.value);
     close();
-    cursorRef.current = nextCursor;
+    cursorRef.current = inserted.cursor;
 
     window.requestAnimationFrame(() => {
       resolvedTextareaRef.current?.focus();
-      resolvedTextareaRef.current?.setSelectionRange(nextCursor, nextCursor);
+      resolvedTextareaRef.current?.setSelectionRange(inserted.cursor, inserted.cursor);
     });
   }, [close, disabled, mentionToken, onValueChange, resolvedTextareaRef, value]);
 
@@ -279,25 +274,4 @@ export function shouldSubmitFromKeyDown(event: KeyboardEvent<HTMLTextAreaElement
     !event.metaKey &&
     !event.ctrlKey
   );
-}
-
-function findFileMentionToken(value: string, cursor: number): FileMentionToken | null {
-  const beforeCursor = value.slice(0, cursor);
-  const match = beforeCursor.match(/(^|[\s([{"'`])@([^\s@]*)$/);
-  if (!match || match.index === undefined) {
-    return null;
-  }
-
-  const prefix = match[1] ?? '';
-  const start = match.index + prefix.length;
-  const previousCharacter = value[start - 1];
-  if (previousCharacter && /[\w.-]/.test(previousCharacter)) {
-    return null;
-  }
-
-  return {
-    query: match[2] ?? '',
-    start,
-    end: cursor,
-  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2250,6 +2250,11 @@ dayjs@^1.11.20:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.20.tgz#88d919fd639dc991415da5f4cb6f1b6650811938"
   integrity sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==
 
+debounce@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-3.0.0.tgz#7633adff3bcd92cdfe13370c2f46e87bdb946a1b"
+  integrity sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==
+
 debug@^4.0.0, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"


### PR DESCRIPTION
## Summary
- add shared client-side file mention token/insert semantics
- add API-backed cli-v2 file mention search, debounced with the npm debounce package
- reuse the shared mention semantics from web-v2 while keeping control-plane search API-owned

## Validation
- yarn build
- yarn test:unit
- focused vitest: client-shared file mention service, cli-v2 file mention picker, cli-v2 control-plane session store
- boundary grep: cli-v2 has no core/server/old-cli imports