### PR TITLE
[codex] Add prompt editing and history

### DIFF
--- a/src/__tests__/unit/cli-v2/prompt-line-editor-service.test.ts
+++ b/src/__tests__/unit/cli-v2/prompt-line-editor-service.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { CliV2PromptLineEditorService } from '../../../cli-v2/services/prompt-input/index.js';
+
+describe('CliV2PromptLineEditorService', () => {
+  it('maps terminal editing shortcuts to prompt commands', () => {
+    expect(CliV2PromptLineEditorService.resolveCommand('', { meta: true, backspace: true })).toEqual({
+      kind: 'deletePreviousWord',
+    });
+    expect(CliV2PromptLineEditorService.resolveCommand('', { super: true, backspace: true })).toEqual({
+      kind: 'deleteBeforeCursor',
+    });
+    expect(CliV2PromptLineEditorService.resolveCommand('', { meta: true, leftArrow: true })).toEqual({
+      kind: 'move',
+      direction: 'previousWord',
+    });
+    expect(CliV2PromptLineEditorService.resolveCommand('', { super: true, rightArrow: true })).toEqual({
+      kind: 'move',
+      direction: 'end',
+    });
+  });
+
+  it('applies cursor-aware editing commands', () => {
+    expect(CliV2PromptLineEditorService.applyCommand(
+      { kind: 'insert', input: '!' },
+      { value: 'hello', cursor: 5 },
+    )).toEqual({
+      value: 'hello!',
+      cursor: 6,
+    });
+
+    expect(CliV2PromptLineEditorService.applyCommand(
+      { kind: 'move', direction: 'previousWord' },
+      { value: 'hello world', cursor: 11 },
+    )).toEqual({
+      value: 'hello world',
+      cursor: 6,
+    });
+  });
+});

--- a/src/__tests__/unit/client-shared/prompt-input-service.test.ts
+++ b/src/__tests__/unit/client-shared/prompt-input-service.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
+
+describe('ClientSharedPromptInputService', () => {
+  it('edits text around the cursor', () => {
+    expect(ClientSharedPromptInputService.insertText({ value: 'helo', cursor: 2 }, 'l')).toEqual({
+      value: 'hello',
+      cursor: 3,
+    });
+    expect(ClientSharedPromptInputService.deletePreviousWord({ value: 'hello world', cursor: 11 })).toEqual({
+      value: 'hello ',
+      cursor: 6,
+    });
+    expect(ClientSharedPromptInputService.deleteBeforeCursor({ value: 'hello world', cursor: 6 })).toEqual({
+      value: 'world',
+      cursor: 0,
+    });
+  });
+
+  it('navigates prompt history while preserving an in-progress draft', () => {
+    const history = ClientSharedPromptInputService.recordPrompt(
+      ClientSharedPromptInputService.recordPrompt({ entries: [] }, 'first prompt'),
+      'second prompt',
+    );
+    const currentDraft = { value: 'draft in progress', cursor: 5 };
+    const previous = ClientSharedPromptInputService.navigateHistory({
+      state: history,
+      currentDraft,
+      direction: 'previous',
+    });
+
+    expect(previous).toEqual({
+      history: {
+        entries: ['first prompt', 'second prompt'],
+        index: 1,
+        savedDraft: currentDraft,
+      },
+      draft: { value: 'second prompt', cursor: 'second prompt'.length },
+    });
+
+    expect(ClientSharedPromptInputService.navigateHistory({
+      state: previous?.history ?? history,
+      currentDraft: previous?.draft ?? currentDraft,
+      direction: 'next',
+    })).toEqual({
+      history: {
+        entries: ['first prompt', 'second prompt'],
+        index: undefined,
+        savedDraft: undefined,
+      },
+      draft: currentDraft,
+    });
+  });
+
+  it('limits multiline history navigation to the first and last logical lines', () => {
+    const value = 'first\nsecond\nthird';
+
+    expect(ClientSharedPromptInputService.canNavigateHistory('previous', { value, cursor: 2 })).toBe(true);
+    expect(ClientSharedPromptInputService.canNavigateHistory('previous', { value, cursor: 8 })).toBe(false);
+    expect(ClientSharedPromptInputService.canNavigateHistory('next', { value, cursor: 8 })).toBe(false);
+    expect(ClientSharedPromptInputService.canNavigateHistory('next', { value, cursor: value.length })).toBe(true);
+  });
+});

--- a/src/__tests__/unit/web-v2/prompt-history-navigation.test.tsx
+++ b/src/__tests__/unit/web-v2/prompt-history-navigation.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { createRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import { describe, expect, it } from 'vitest';
+import { usePromptHistoryNavigation } from '../../../web-v2/hooks/conversation/usePromptHistoryNavigation.js';
+
+describe('usePromptHistoryNavigation', () => {
+  it('recalls submitted prompts with ArrowUp and restores the draft with ArrowDown', () => {
+    const textarea = document.createElement('textarea');
+    const textareaRef = createRef<HTMLTextAreaElement>();
+    textareaRef.current = textarea;
+
+    const { result } = renderHook(() => {
+      const [value, setValue] = useState('draft');
+      const history = usePromptHistoryNavigation({
+        value,
+        onValueChange: setValue,
+        textareaRef,
+      });
+
+      return { value, setValue, history };
+    });
+
+    act(() => {
+      result.current.history.recordPrompt('first prompt');
+      result.current.history.recordPrompt('second prompt');
+    });
+
+    textarea.value = 'draft';
+    textarea.selectionStart = 0;
+    textarea.selectionEnd = 0;
+    act(() => {
+      result.current.history.handleKeyDown(createKeyEvent('ArrowUp', textarea));
+    });
+
+    expect(result.current.value).toBe('second prompt');
+
+    textarea.value = 'second prompt';
+    textarea.selectionStart = 'second prompt'.length;
+    textarea.selectionEnd = 'second prompt'.length;
+    act(() => {
+      result.current.history.handleKeyDown(createKeyEvent('ArrowDown', textarea));
+    });
+
+    expect(result.current.value).toBe('draft');
+  });
+});
+
+function createKeyEvent(key: string, currentTarget: HTMLTextAreaElement) {
+  return {
+    key,
+    currentTarget,
+    defaultPrevented: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    ctrlKey: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+  } as unknown as KeyboardEvent<HTMLTextAreaElement>;
+}

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -36,7 +36,15 @@ export function App({
 }) {
   const startedRef = useRef(false);
   const snapshot = useControlPlaneSessionStore(store);
-  const { draft, setDraft, clearDraft } = usePromptDraft();
+  const {
+    draft,
+    cursor,
+    setDraft,
+    setDraftState,
+    clearDraft,
+    recordSubmittedPrompt,
+    navigateHistory,
+  } = usePromptDraft();
   const submitDisabled = snapshot.loading || snapshot.submitting || snapshot.running;
   const inputDisabled = snapshot.loading;
   const slashCommandHints = store.getSlashCommandHints(draft);
@@ -88,10 +96,14 @@ export function App({
     }
 
     clearDraft();
+    if (!trimmed.startsWith('/')) {
+      recordSubmittedPrompt(trimmed);
+    }
     void store.submitPrompt(value);
   }, [
     clearDraft,
     pickers,
+    recordSubmittedPrompt,
     store,
     submitDisabled,
   ]);
@@ -176,9 +188,11 @@ export function App({
           : 'Type a prompt'
         }
         value={draft}
-        onChange={setDraft}
+        cursor={cursor}
+        onChange={setDraftState}
         onSubmit={submitPrompt}
         onComplete={(value) => store.completeSlashCommandDraft(value)}
+        onHistory={navigateHistory}
         onSpecialKey={(input, key) => fileMentions.handleSpecialKey(input, key) || pickers.handleSpecialKey(input, key)}
       />
       <RuntimeStatusBar snapshot={snapshot} />

--- a/src/cli-v2/components/PromptInput.tsx
+++ b/src/cli-v2/components/PromptInput.tsx
@@ -1,11 +1,23 @@
-import type { Dispatch, SetStateAction } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
+import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
+import type {
+  ClientSharedPromptDraftState,
+  ClientSharedPromptHistoryDirection,
+} from '@/client-shared/services/prompt-input/index.js';
+import { CliV2PromptLineEditorService } from '../services/prompt-input/index.js';
+
+const PROMPT_PREFIX_WIDTH = 2;
+const FALLBACK_RENDER_WIDTH = 80;
+const MAX_VISIBLE_INPUT_LINES = 6;
 
 export type PromptInputKey = {
   upArrow?: boolean;
   downArrow?: boolean;
   leftArrow?: boolean;
   rightArrow?: boolean;
+  home?: boolean;
+  end?: boolean;
   return?: boolean;
   escape?: boolean;
   tab?: boolean;
@@ -13,6 +25,8 @@ export type PromptInputKey = {
   delete?: boolean;
   ctrl?: boolean;
   meta?: boolean;
+  super?: boolean;
+  shift?: boolean;
 };
 
 export function PromptInput({
@@ -20,22 +34,41 @@ export function PromptInput({
   placeholder,
   submitDisabled,
   value,
+  cursor,
   onChange,
   onSubmit,
   onComplete,
+  onHistory,
   onSpecialKey,
 }: {
   disabled: boolean;
   placeholder: string;
   submitDisabled?: boolean;
   value: string;
-  onChange: Dispatch<SetStateAction<string>>;
+  cursor: number;
+  onChange: (state: ClientSharedPromptDraftState) => void;
   onSubmit: (value: string) => void;
   onComplete?: (value: string) => string | undefined;
+  onHistory?: (direction: ClientSharedPromptHistoryDirection) => void;
   onSpecialKey?: (input: string, key: PromptInputKey) => boolean;
 }) {
   const { stdout } = useStdout();
   const separator = repeatSeparator((stdout.columns ?? 0) - 2);
+  const valueRef = useRef(value);
+  const cursorRef = useRef(cursor);
+  const renderWidth = resolvePromptInputRenderWidth(stdout.columns);
+  const lines = useMemo(
+    () => buildPromptRenderLines(value, cursor, MAX_VISIBLE_INPUT_LINES, renderWidth),
+    [cursor, renderWidth, value],
+  );
+
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  useEffect(() => {
+    cursorRef.current = ClientSharedPromptInputService.clampCursor(valueRef.current, cursor);
+  }, [cursor]);
 
   useInput((input, key) => {
     if (disabled) {
@@ -46,47 +79,154 @@ export function PromptInput({
       return;
     }
 
-    if (key.return) {
-      if (submitDisabled) {
-        return;
-      }
-
-      onSubmit(value);
-      return;
-    }
-
     if (key.tab) {
-      const completed = onComplete?.(value);
+      const completed = onComplete?.(valueRef.current);
       if (completed !== undefined) {
-        onChange(completed);
+        applyState({ value: completed, cursor: completed.length });
       }
       return;
     }
 
-    if (key.backspace || key.delete) {
-      onChange((current) => current.slice(0, -1));
+    const command = CliV2PromptLineEditorService.resolveCommand(input, key);
+    if (!command) {
       return;
     }
 
-    if (!key.ctrl && !key.meta && input) {
-      onChange((current) => `${current}${input}`);
+    if (command.kind === 'submit') {
+      if (!submitDisabled) {
+        onSubmit(valueRef.current);
+      }
+      return;
     }
+
+    const current = {
+      value: valueRef.current,
+      cursor: ClientSharedPromptInputService.clampCursor(valueRef.current, cursorRef.current),
+    };
+
+    if (command.kind === 'history') {
+      if (ClientSharedPromptInputService.canNavigateHistory(command.direction, current)) {
+        onHistory?.(command.direction);
+      }
+      return;
+    }
+
+    applyState(CliV2PromptLineEditorService.applyCommand(command, current));
   }, { isActive: !disabled });
+
+  function applyState(nextState: ClientSharedPromptDraftState) {
+    const normalized = {
+      value: nextState.value,
+      cursor: ClientSharedPromptInputService.clampCursor(nextState.value, nextState.cursor),
+    };
+    valueRef.current = normalized.value;
+    cursorRef.current = normalized.cursor;
+    onChange(normalized);
+  }
 
   return (
     <Box flexDirection="column" marginTop={1} marginBottom={1}>
       <Box overflow="hidden">
         <Text dimColor wrap="truncate-end">{separator}</Text>
       </Box>
-      <Box>
-        <Text color="cyan">› </Text>
-        <Text>{value || <Text dimColor>{placeholder}</Text>}</Text>
-      </Box>
+      {value ? (
+        lines.map((line, index) => (
+          <Box key={`${index}-${line.before}-${line.cursor}-${line.after}-${line.hasCursor}`}>
+            <Text color="cyan">{index === 0 ? '› ' : '  '}</Text>
+            <Text>
+              {line.hasCursor ? (
+                <>
+                  {line.before}
+                  <Text inverse>{line.cursor}</Text>
+                  {line.after}
+                </>
+              ) : (line.before || ' ')}
+            </Text>
+          </Box>
+        ))
+      ) : (
+        <Box>
+          <Text color="cyan">› </Text>
+          <Text dimColor>{placeholder}</Text>
+        </Box>
+      )}
       <Box overflow="hidden">
         <Text dimColor wrap="truncate-end">{separator}</Text>
       </Box>
     </Box>
   );
+}
+
+export type PromptRenderLine = {
+  before: string;
+  cursor: string;
+  after: string;
+  hasCursor: boolean;
+};
+
+export function buildPromptRenderLines(
+  value: string,
+  cursor: number,
+  maxVisibleLines: number,
+  width = FALLBACK_RENDER_WIDTH,
+): PromptRenderLine[] {
+  const rawLines = value.split('\n');
+  const rendered: PromptRenderLine[] = [];
+  const contentWidth = Math.max(1, width - PROMPT_PREFIX_WIDTH);
+  let logicalOffset = 0;
+
+  for (let lineIndex = 0; lineIndex < rawLines.length; lineIndex += 1) {
+    const line = rawLines[lineIndex] ?? '';
+    const wrapped = wrapLine(line, contentWidth);
+    const lineStart = logicalOffset;
+    const lineEnd = lineStart + line.length;
+    const isLastLogicalLine = lineIndex === rawLines.length - 1;
+    let segmentStart = lineStart;
+
+    for (const segment of wrapped) {
+      const segmentEnd = segmentStart + segment.length;
+      const isLastWrappedSegment = segmentEnd === lineEnd;
+      const hasCursor = cursor >= segmentStart && (
+        cursor < segmentEnd ||
+        (segment.length === 0 && cursor === segmentStart) ||
+        (isLastWrappedSegment && isLastLogicalLine && cursor === lineEnd)
+      );
+
+      rendered.push(hasCursor ? {
+        before: segment.slice(0, cursor - segmentStart),
+        cursor: segment[cursor - segmentStart] ?? ' ',
+        after: segment.slice(cursor - segmentStart + 1),
+        hasCursor: true,
+      } : {
+        before: segment,
+        cursor: '',
+        after: '',
+        hasCursor: false,
+      });
+
+      segmentStart = segmentEnd;
+    }
+
+    logicalOffset = lineEnd + 1;
+  }
+
+  return rendered.length <= maxVisibleLines ? rendered : rendered.slice(rendered.length - maxVisibleLines);
+}
+
+export function resolvePromptInputRenderWidth(stdoutColumns?: number): number {
+  return Math.max(PROMPT_PREFIX_WIDTH + 1, Math.floor(stdoutColumns ?? FALLBACK_RENDER_WIDTH));
+}
+
+function wrapLine(line: string, width: number): string[] {
+  if (line.length === 0) {
+    return [''];
+  }
+
+  const segments: string[] = [];
+  for (let start = 0; start < line.length; start += width) {
+    segments.push(line.slice(start, start + width));
+  }
+  return segments;
 }
 
 function repeatSeparator(width: number): string {

--- a/src/cli-v2/components/PromptInput.tsx
+++ b/src/cli-v2/components/PromptInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
 import type {
@@ -70,6 +70,16 @@ export function PromptInput({
     cursorRef.current = ClientSharedPromptInputService.clampCursor(valueRef.current, cursor);
   }, [cursor]);
 
+  const applyState = useCallback((nextState: ClientSharedPromptDraftState) => {
+    const normalized = {
+      value: nextState.value,
+      cursor: ClientSharedPromptInputService.clampCursor(nextState.value, nextState.cursor),
+    };
+    valueRef.current = normalized.value;
+    cursorRef.current = normalized.cursor;
+    onChange(normalized);
+  }, [onChange]);
+
   useInput((input, key) => {
     if (disabled) {
       return;
@@ -113,16 +123,6 @@ export function PromptInput({
 
     applyState(CliV2PromptLineEditorService.applyCommand(command, current));
   }, { isActive: !disabled });
-
-  function applyState(nextState: ClientSharedPromptDraftState) {
-    const normalized = {
-      value: nextState.value,
-      cursor: ClientSharedPromptInputService.clampCursor(nextState.value, nextState.cursor),
-    };
-    valueRef.current = normalized.value;
-    cursorRef.current = normalized.cursor;
-    onChange(normalized);
-  }
 
   return (
     <Box flexDirection="column" marginTop={1} marginBottom={1}>

--- a/src/cli-v2/hooks/usePromptDraft.ts
+++ b/src/cli-v2/hooks/usePromptDraft.ts
@@ -1,15 +1,60 @@
 import { useCallback, useState } from 'react';
+import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
+import type {
+  ClientSharedPromptDraftState,
+  ClientSharedPromptHistoryDirection,
+  ClientSharedPromptHistoryState,
+} from '@/client-shared/services/prompt-input/index.js';
 
 export function usePromptDraft() {
-  const [draft, setDraft] = useState('');
+  const [draftState, setDraftStateValue] = useState<ClientSharedPromptDraftState>({ value: '', cursor: 0 });
+  const [historyState, setHistoryState] = useState<ClientSharedPromptHistoryState>({ entries: [] });
 
-  const clearDraft = useCallback(() => {
-    setDraft('');
+  const setDraftState = useCallback((nextState: ClientSharedPromptDraftState) => {
+    setDraftStateValue({
+      value: nextState.value,
+      cursor: ClientSharedPromptInputService.clampCursor(nextState.value, nextState.cursor),
+    });
+    setHistoryState((current) => ({
+      entries: current.entries,
+      index: undefined,
+      savedDraft: undefined,
+    }));
   }, []);
 
+  const setDraft = useCallback((value: string) => {
+    setDraftState({ value, cursor: value.length });
+  }, [setDraftState]);
+
+  const clearDraft = useCallback(() => {
+    setDraftState({ value: '', cursor: 0 });
+  }, [setDraftState]);
+
+  const recordSubmittedPrompt = useCallback((value: string) => {
+    setHistoryState((current) => ClientSharedPromptInputService.recordPrompt(current, value));
+  }, []);
+
+  const navigateHistory = useCallback((direction: ClientSharedPromptHistoryDirection) => {
+    const next = ClientSharedPromptInputService.navigateHistory({
+      state: historyState,
+      currentDraft: draftState,
+      direction,
+    });
+    if (!next) {
+      return;
+    }
+
+    setHistoryState(next.history);
+    setDraftStateValue(next.draft);
+  }, [draftState, historyState]);
+
   return {
-    draft,
+    draft: draftState.value,
+    cursor: draftState.cursor,
     setDraft,
+    setDraftState,
     clearDraft,
+    recordSubmittedPrompt,
+    navigateHistory,
   };
 }

--- a/src/cli-v2/services/prompt-input/index.ts
+++ b/src/cli-v2/services/prompt-input/index.ts
@@ -1,0 +1,4 @@
+export {
+  CliV2PromptLineEditorService,
+  type CliV2PromptInputCommand,
+} from './prompt-line-editor-service.js';

--- a/src/cli-v2/services/prompt-input/prompt-line-editor-service.ts
+++ b/src/cli-v2/services/prompt-input/prompt-line-editor-service.ts
@@ -1,0 +1,132 @@
+import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
+import type { ClientSharedPromptDraftState } from '@/client-shared/services/prompt-input/index.js';
+import type { PromptInputKey } from '../../components/PromptInput.js';
+
+export type CliV2PromptInputCommand =
+  | { kind: 'submit' }
+  | { kind: 'insert'; input: string }
+  | { kind: 'history'; direction: 'previous' | 'next' }
+  | { kind: 'deletePreviousCharacter' }
+  | { kind: 'deletePreviousWord' }
+  | { kind: 'deleteBeforeCursor' }
+  | { kind: 'deleteAfterCursor' }
+  | { kind: 'move'; direction: 'start' | 'end' | 'previousCharacter' | 'nextCharacter' | 'previousWord' | 'nextWord' };
+
+const CTRL_TEXT_COMMANDS = new Map<string, CliV2PromptInputCommand>([
+  ['a', { kind: 'move', direction: 'start' }],
+  ['e', { kind: 'move', direction: 'end' }],
+  ['k', { kind: 'deleteAfterCursor' }],
+  ['u', { kind: 'deleteBeforeCursor' }],
+  ['w', { kind: 'deletePreviousWord' }],
+]);
+
+const META_TEXT_COMMANDS = new Map<string, CliV2PromptInputCommand>([
+  ['b', { kind: 'move', direction: 'previousWord' }],
+  ['f', { kind: 'move', direction: 'nextWord' }],
+]);
+
+/**
+ * Owns cli-v2 terminal key translation for the prompt line editor.
+ *
+ * Terminal input is host-specific: Option usually arrives as Meta, while Cmd
+ * only arrives as Super in terminals that support the Kitty keyboard protocol.
+ * This service maps the keys Ink exposes into shared prompt text operations.
+ */
+export class CliV2PromptLineEditorService {
+  static resolveCommand(input: string, key: PromptInputKey): CliV2PromptInputCommand | undefined {
+    if (key.return) {
+      return key.shift ? { kind: 'insert', input: '\n' } : { kind: 'submit' };
+    }
+
+    if (key.ctrl && input) {
+      return CTRL_TEXT_COMMANDS.get(input);
+    }
+
+    if (key.meta && input) {
+      return META_TEXT_COMMANDS.get(input);
+    }
+
+    if (key.super && key.backspace) {
+      return { kind: 'deleteBeforeCursor' };
+    }
+
+    if (key.meta && key.backspace) {
+      return { kind: 'deletePreviousWord' };
+    }
+
+    if (key.backspace || key.delete) {
+      return { kind: 'deletePreviousCharacter' };
+    }
+
+    if (key.super && key.leftArrow) {
+      return { kind: 'move', direction: 'start' };
+    }
+
+    if (key.super && key.rightArrow) {
+      return { kind: 'move', direction: 'end' };
+    }
+
+    if (key.meta && key.leftArrow) {
+      return { kind: 'move', direction: 'previousWord' };
+    }
+
+    if (key.meta && key.rightArrow) {
+      return { kind: 'move', direction: 'nextWord' };
+    }
+
+    if (key.leftArrow) {
+      return { kind: 'move', direction: 'previousCharacter' };
+    }
+
+    if (key.rightArrow) {
+      return { kind: 'move', direction: 'nextCharacter' };
+    }
+
+    if (key.upArrow) {
+      return { kind: 'history', direction: 'previous' };
+    }
+
+    if (key.downArrow) {
+      return { kind: 'history', direction: 'next' };
+    }
+
+    if (key.home) {
+      return { kind: 'move', direction: 'start' };
+    }
+
+    if (key.end) {
+      return { kind: 'move', direction: 'end' };
+    }
+
+    if (key.ctrl || key.meta || key.super || key.escape || key.tab || !input) {
+      return undefined;
+    }
+
+    return { kind: 'insert', input };
+  }
+
+  static applyCommand(
+    command: Exclude<CliV2PromptInputCommand, { kind: 'submit' | 'history' }>,
+    state: ClientSharedPromptDraftState,
+  ): ClientSharedPromptDraftState {
+    if (command.kind === 'insert') {
+      return ClientSharedPromptInputService.insertText(state, command.input);
+    }
+
+    if (command.kind === 'move') {
+      return {
+        value: state.value,
+        cursor: ClientSharedPromptInputService.moveCursor(state, command.direction),
+      };
+    }
+
+    const actions: Record<typeof command.kind, () => ClientSharedPromptDraftState> = {
+      deletePreviousCharacter: () => ClientSharedPromptInputService.deletePreviousCharacter(state),
+      deletePreviousWord: () => ClientSharedPromptInputService.deletePreviousWord(state),
+      deleteBeforeCursor: () => ClientSharedPromptInputService.deleteBeforeCursor(state),
+      deleteAfterCursor: () => ClientSharedPromptInputService.deleteAfterCursor(state),
+    };
+
+    return actions[command.kind]();
+  }
+}

--- a/src/client-shared/services/prompt-input/index.ts
+++ b/src/client-shared/services/prompt-input/index.ts
@@ -1,0 +1,6 @@
+export {
+  ClientSharedPromptInputService,
+  type ClientSharedPromptDraftState,
+  type ClientSharedPromptHistoryDirection,
+  type ClientSharedPromptHistoryState,
+} from './prompt-input-service.js';

--- a/src/client-shared/services/prompt-input/prompt-input-service.ts
+++ b/src/client-shared/services/prompt-input/prompt-input-service.ts
@@ -1,0 +1,210 @@
+export type ClientSharedPromptDraftState = {
+  value: string;
+  cursor: number;
+};
+
+export type ClientSharedPromptHistoryState = {
+  entries: string[];
+  index?: number;
+  savedDraft?: ClientSharedPromptDraftState;
+};
+
+export type ClientSharedPromptHistoryDirection = 'previous' | 'next';
+
+const DEFAULT_MAX_PROMPT_HISTORY_ENTRIES = 100;
+
+/**
+ * Owns interface-neutral prompt draft and prompt history semantics.
+ *
+ * Interfaces own key-event capture and rendering. This service owns the pure
+ * text-editing and prompt-history rules so web-v2 and cli-v2 do not drift on
+ * which submitted prompts are recorded or how history navigation restores a
+ * draft that was in progress before browsing history.
+ */
+export class ClientSharedPromptInputService {
+  static clampCursor(value: string, cursor: number): number {
+    return Math.min(Math.max(0, cursor), value.length);
+  }
+
+  static insertText(state: ClientSharedPromptDraftState, input: string): ClientSharedPromptDraftState {
+    const cursor = this.clampCursor(state.value, state.cursor);
+    return {
+      value: `${state.value.slice(0, cursor)}${input}${state.value.slice(cursor)}`,
+      cursor: cursor + input.length,
+    };
+  }
+
+  static deletePreviousCharacter(state: ClientSharedPromptDraftState): ClientSharedPromptDraftState {
+    const cursor = this.clampCursor(state.value, state.cursor);
+    if (cursor === 0) {
+      return { value: state.value, cursor };
+    }
+
+    return {
+      value: this.removeRange(state.value, cursor - 1, cursor),
+      cursor: cursor - 1,
+    };
+  }
+
+  static deletePreviousWord(state: ClientSharedPromptDraftState): ClientSharedPromptDraftState {
+    const cursor = this.clampCursor(state.value, state.cursor);
+    const nextCursor = this.findPreviousWordBoundary(state.value, cursor);
+    return {
+      value: this.removeRange(state.value, nextCursor, cursor),
+      cursor: nextCursor,
+    };
+  }
+
+  static deleteBeforeCursor(state: ClientSharedPromptDraftState): ClientSharedPromptDraftState {
+    const cursor = this.clampCursor(state.value, state.cursor);
+    return {
+      value: state.value.slice(cursor),
+      cursor: 0,
+    };
+  }
+
+  static deleteAfterCursor(state: ClientSharedPromptDraftState): ClientSharedPromptDraftState {
+    const cursor = this.clampCursor(state.value, state.cursor);
+    return {
+      value: state.value.slice(0, cursor),
+      cursor,
+    };
+  }
+
+  static moveCursor(
+    state: ClientSharedPromptDraftState,
+    direction: 'start' | 'end' | 'previousCharacter' | 'nextCharacter' | 'previousWord' | 'nextWord',
+  ): number {
+    const cursor = this.clampCursor(state.value, state.cursor);
+    const movements: Record<typeof direction, () => number> = {
+      start: () => 0,
+      end: () => state.value.length,
+      previousCharacter: () => Math.max(0, cursor - 1),
+      nextCharacter: () => Math.min(state.value.length, cursor + 1),
+      previousWord: () => this.findPreviousWordBoundary(state.value, cursor),
+      nextWord: () => this.findNextWordBoundary(state.value, cursor),
+    };
+
+    return movements[direction]();
+  }
+
+  static recordPrompt(
+    state: ClientSharedPromptHistoryState,
+    value: string,
+    maxEntries = DEFAULT_MAX_PROMPT_HISTORY_ENTRIES,
+  ): ClientSharedPromptHistoryState {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return state;
+    }
+
+    return {
+      entries: [...state.entries.filter((entry) => entry !== trimmed), trimmed].slice(-maxEntries),
+      index: undefined,
+      savedDraft: undefined,
+    };
+  }
+
+  static navigateHistory(args: {
+    state: ClientSharedPromptHistoryState;
+    currentDraft: ClientSharedPromptDraftState;
+    direction: ClientSharedPromptHistoryDirection;
+  }): { history: ClientSharedPromptHistoryState; draft: ClientSharedPromptDraftState } | undefined {
+    const { entries, index, savedDraft } = args.state;
+    if (entries.length === 0) {
+      return undefined;
+    }
+
+    if (args.direction === 'previous') {
+      const nextIndex = index === undefined ? entries.length - 1 : Math.max(0, index - 1);
+      const value = entries[nextIndex] ?? '';
+      return {
+        history: {
+          entries,
+          index: nextIndex,
+          savedDraft: savedDraft ?? args.currentDraft,
+        },
+        draft: { value, cursor: value.length },
+      };
+    }
+
+    if (index === undefined) {
+      return undefined;
+    }
+
+    if (index < entries.length - 1) {
+      const nextIndex = index + 1;
+      const value = entries[nextIndex] ?? '';
+      return {
+        history: {
+          entries,
+          index: nextIndex,
+          savedDraft,
+        },
+        draft: { value, cursor: value.length },
+      };
+    }
+
+    return {
+      history: {
+        entries,
+        index: undefined,
+        savedDraft: undefined,
+      },
+      draft: savedDraft ?? { value: '', cursor: 0 },
+    };
+  }
+
+  static canNavigateHistory(
+    direction: ClientSharedPromptHistoryDirection,
+    state: ClientSharedPromptDraftState,
+  ): boolean {
+    if (!state.value.includes('\n')) {
+      return true;
+    }
+
+    if (direction === 'previous') {
+      const firstLineEnd = state.value.indexOf('\n');
+      return state.cursor <= firstLineEnd;
+    }
+
+    const lastLineStart = state.value.lastIndexOf('\n') + 1;
+    return state.cursor >= lastLineStart;
+  }
+
+  private static removeRange(value: string, start: number, end: number): string {
+    return `${value.slice(0, start)}${value.slice(end)}`;
+  }
+
+  private static findPreviousWordBoundary(value: string, cursor: number): number {
+    let index = cursor;
+
+    while (index > 0 && isWordBoundary(value[index - 1])) {
+      index--;
+    }
+
+    while (index > 0 && !isWordBoundary(value[index - 1])) {
+      index--;
+    }
+
+    return index;
+  }
+
+  private static findNextWordBoundary(value: string, cursor: number): number {
+    let index = cursor;
+
+    while (index < value.length && isWordBoundary(value[index])) {
+      index++;
+    }
+
+    while (index < value.length && !isWordBoundary(value[index])) {
+      index++;
+    }
+
+    return index;
+  }
+}
+
+function isWordBoundary(char: string | undefined): boolean {
+  return !char || /\s|[.,/#!$%^&*;:{}=\-_`~()\[\]"'<>?\\|]/.test(char);
+}

--- a/src/web-v2/components/conversation/ConversationComposer.tsx
+++ b/src/web-v2/components/conversation/ConversationComposer.tsx
@@ -11,6 +11,7 @@ import { useComposerImageDrop } from '@web/hooks/conversation/useComposerImageDr
 import { useComposerTextareaAutosize } from '@web/hooks/conversation/useComposerTextareaAutosize';
 import { useComposerImageUploadToasts } from '@web/hooks/conversation/useComposerImageUploadToasts';
 import { useFileMentionAutocomplete } from '@web/hooks/conversation/useFileMentionAutocomplete';
+import { usePromptHistoryNavigation } from '@web/hooks/conversation/usePromptHistoryNavigation';
 import {
   ComposerImageUploadControls,
   type ComposerImageUploadControlsHandle,
@@ -97,6 +98,13 @@ export function ConversationComposer({
   });
   useComposerImageUploadToasts(imageUploadError);
 
+  const promptHistory = usePromptHistoryNavigation({
+    value: draft,
+    onValueChange: setDraft,
+    textareaRef,
+    disabled: inputDisabled,
+  });
+  const { recordPrompt } = promptHistory;
   const handleSubmit = useCallback(async () => {
     const prompt = appendUploadedImagePaths(draft.trim(), uploadedImagePaths);
     if (!prompt || sendDisabled) {
@@ -104,9 +112,10 @@ export function ConversationComposer({
     }
 
     await onSubmitPrompt(prompt);
+    recordPrompt(prompt);
     setDraft('');
     clearUploadedAttachments();
-  }, [clearUploadedAttachments, draft, onSubmitPrompt, sendDisabled, uploadedImagePaths]);
+  }, [clearUploadedAttachments, draft, onSubmitPrompt, recordPrompt, sendDisabled, uploadedImagePaths]);
   const fileMentions = useFileMentionAutocomplete({
     workspaceId,
     value: draft,
@@ -147,7 +156,13 @@ export function ConversationComposer({
         value={draft}
         onChange={fileMentions.textareaProps.onChange}
         onClick={fileMentions.textareaProps.onClick}
-        onKeyDown={fileMentions.textareaProps.onKeyDown}
+        onKeyDown={(event) => {
+          if (fileMentions.handleKeyDown(event)) {
+            return;
+          }
+
+          promptHistory.handleKeyDown(event);
+        }}
         onSelect={fileMentions.textareaProps.onSelect}
       />
       {fileMentions.isOpen ? <FileMentionMenu {...fileMentions.menuProps} /> : null}

--- a/src/web-v2/hooks/conversation/usePromptHistoryNavigation.ts
+++ b/src/web-v2/hooks/conversation/usePromptHistoryNavigation.ts
@@ -1,0 +1,75 @@
+import { useCallback, useRef, useState } from 'react';
+import type { KeyboardEvent, RefObject } from 'react';
+import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
+import type { ClientSharedPromptHistoryState } from '@/client-shared/services/prompt-input/index.js';
+
+export function usePromptHistoryNavigation({
+  value,
+  onValueChange,
+  textareaRef,
+  disabled = false,
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  disabled?: boolean;
+}) {
+  const valueRef = useRef(value);
+  const [historyState, setHistoryState] = useState<ClientSharedPromptHistoryState>({ entries: [] });
+  valueRef.current = value;
+
+  const recordPrompt = useCallback((prompt: string) => {
+    setHistoryState((current) => ClientSharedPromptInputService.recordPrompt(current, prompt));
+  }, []);
+
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (disabled || event.defaultPrevented || event.shiftKey || event.altKey || event.metaKey || event.ctrlKey) {
+      return false;
+    }
+
+    const direction =
+      event.key === 'ArrowUp' ? 'previous'
+      : event.key === 'ArrowDown' ? 'next'
+      : undefined;
+    if (!direction) {
+      return false;
+    }
+
+    const textarea = event.currentTarget;
+    if (textarea.selectionStart !== textarea.selectionEnd) {
+      return false;
+    }
+
+    const currentDraft = {
+      value: valueRef.current,
+      cursor: textarea.selectionStart,
+    };
+    if (!ClientSharedPromptInputService.canNavigateHistory(direction, currentDraft)) {
+      return false;
+    }
+
+    const next = ClientSharedPromptInputService.navigateHistory({
+      state: historyState,
+      currentDraft,
+      direction,
+    });
+    if (!next) {
+      return false;
+    }
+
+    event.preventDefault();
+    setHistoryState(next.history);
+    onValueChange(next.draft.value);
+
+    window.requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+      textareaRef.current?.setSelectionRange(next.draft.cursor, next.draft.cursor);
+    });
+    return true;
+  }, [disabled, historyState, onValueChange, textareaRef]);
+
+  return {
+    recordPrompt,
+    handleKeyDown,
+  };
+}


### PR DESCRIPTION
## Summary
- add shared prompt input/history semantics for draft editing and history navigation
- make cli-v2 PromptInput cursor-aware with word movement/deletion, line movement/deletion, newline insertion, and prompt history
- add web-v2 ArrowUp/ArrowDown prompt history while preserving native textarea editing and file mention handling

## Notes
- Cmd/Super shortcuts are best-effort because terminals only expose them when supported, such as via Kitty keyboard protocol. Ctrl fallbacks are included.

## Validation
- yarn build
- yarn test:unit
- focused vitest: shared prompt input service, cli-v2 prompt line editor service, web-v2 prompt history navigation
- git diff --check
- cli-v2 boundary grep: no core/server/old-cli imports