### PR TITLE
[codex] Add cli-v2 undo and auth parity

### DIFF
--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import pino from 'pino';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProviderCredentialCommandService } from '@/core/auth/index.js';
 import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
 import { createConversationEngine } from '@/core/chat/engine/conversation-engine.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
@@ -241,6 +242,23 @@ describe('control-plane session lifecycle API', () => {
       kind: 'message',
       message: 'Current model: gpt-5.4',
     });
+  });
+
+  it('executes auth login through the shared core auth command service', async () => {
+    const login = vi.spyOn(ProviderCredentialCommandService, 'loginProviderWithOAuth')
+      .mockResolvedValue('Stored OpenAI OAuth credential.');
+    const { caller } = createControlPlaneCaller();
+    const session = await caller.sessionCreate({ name: 'Auth slash command session' });
+
+    await expect(caller.slashCommandExecute({
+      sessionId: session.id,
+      command: '/auth login openai',
+    })).resolves.toEqual({
+      handled: true,
+      kind: 'message',
+      message: 'Stored OpenAI OAuth credential.',
+    });
+    expect(login).toHaveBeenCalledWith('openai', { storePath: undefined });
   });
 
   it('returns selected-session runtime context for commands and status surfaces', async () => {

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -111,6 +111,21 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('submits selected file mentions as user-authored @path text', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    await store.submitPrompt('Look at @AGENTS.md');
+
+    expect(fixture.calls.sessionSendPromptAsyncMutate).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceId: 'workspace-1',
+      sessionId: 'session-1',
+      prompt: 'Look at @AGENTS.md',
+    }));
+    store.dispose();
+  });
+
   it('filters slash command hints locally without querying the API per keystroke', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });

--- a/src/__tests__/unit/cli-v2/prompt-line-editor-service.test.ts
+++ b/src/__tests__/unit/cli-v2/prompt-line-editor-service.test.ts
@@ -17,6 +17,15 @@ describe('CliV2PromptLineEditorService', () => {
       kind: 'move',
       direction: 'end',
     });
+    expect(CliV2PromptLineEditorService.resolveCommand('z', { ctrl: true })).toEqual({
+      kind: 'undo',
+    });
+    expect(CliV2PromptLineEditorService.resolveCommand('Z', { ctrl: true, shift: true })).toEqual({
+      kind: 'redo',
+    });
+    expect(CliV2PromptLineEditorService.resolveCommand('y', { ctrl: true })).toEqual({
+      kind: 'redo',
+    });
   });
 
   it('applies cursor-aware editing commands', () => {

--- a/src/__tests__/unit/client-shared/prompt-input-service.test.ts
+++ b/src/__tests__/unit/client-shared/prompt-input-service.test.ts
@@ -60,4 +60,33 @@ describe('ClientSharedPromptInputService', () => {
     expect(ClientSharedPromptInputService.canNavigateHistory('next', { value, cursor: 8 })).toBe(false);
     expect(ClientSharedPromptInputService.canNavigateHistory('next', { value, cursor: value.length })).toBe(true);
   });
+
+  it('tracks prompt undo and redo stacks without recording no-op edits', () => {
+    const initial = { value: 'hello', cursor: 5 };
+    const edited = { value: 'hello!', cursor: 6 };
+    const history = ClientSharedPromptInputService.recordUndoState(
+      ClientSharedPromptInputService.clearUndoRedo(),
+      initial,
+      edited,
+    );
+
+    expect(ClientSharedPromptInputService.recordUndoState(history, edited, edited)).toBe(history);
+
+    const undo = ClientSharedPromptInputService.undoPromptEdit(history, edited);
+    expect(undo).toEqual({
+      history: {
+        undoStack: [],
+        redoStack: [edited],
+      },
+      draft: initial,
+    });
+
+    expect(ClientSharedPromptInputService.redoPromptEdit(undo?.history ?? history, initial)).toEqual({
+      history: {
+        undoStack: [initial],
+        redoStack: [],
+      },
+      draft: edited,
+    });
+  });
 });

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -44,6 +44,8 @@ export function App({
     clearDraft,
     recordSubmittedPrompt,
     navigateHistory,
+    undoPromptEdit,
+    redoPromptEdit,
   } = usePromptDraft();
   const submitDisabled = snapshot.loading || snapshot.submitting || snapshot.running;
   const inputDisabled = snapshot.loading;
@@ -193,6 +195,8 @@ export function App({
         onSubmit={submitPrompt}
         onComplete={(value) => store.completeSlashCommandDraft(value)}
         onHistory={navigateHistory}
+        onUndo={undoPromptEdit}
+        onRedo={redoPromptEdit}
         onSpecialKey={(input, key) => fileMentions.handleSpecialKey(input, key) || pickers.handleSpecialKey(input, key)}
       />
       <RuntimeStatusBar snapshot={snapshot} />

--- a/src/cli-v2/components/PromptInput.tsx
+++ b/src/cli-v2/components/PromptInput.tsx
@@ -39,6 +39,8 @@ export function PromptInput({
   onSubmit,
   onComplete,
   onHistory,
+  onUndo,
+  onRedo,
   onSpecialKey,
 }: {
   disabled: boolean;
@@ -50,6 +52,8 @@ export function PromptInput({
   onSubmit: (value: string) => void;
   onComplete?: (value: string) => string | undefined;
   onHistory?: (direction: ClientSharedPromptHistoryDirection) => void;
+  onUndo?: () => void;
+  onRedo?: () => void;
   onSpecialKey?: (input: string, key: PromptInputKey) => boolean;
 }) {
   const { stdout } = useStdout();
@@ -118,6 +122,16 @@ export function PromptInput({
       if (ClientSharedPromptInputService.canNavigateHistory(command.direction, current)) {
         onHistory?.(command.direction);
       }
+      return;
+    }
+
+    if (command.kind === 'undo') {
+      onUndo?.();
+      return;
+    }
+
+    if (command.kind === 'redo') {
+      onRedo?.();
       return;
     }
 

--- a/src/cli-v2/hooks/usePromptDraft.ts
+++ b/src/cli-v2/hooks/usePromptDraft.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
 import type {
   ClientSharedPromptDraftState,
@@ -7,28 +7,49 @@ import type {
 } from '@/client-shared/services/prompt-input/index.js';
 
 export function usePromptDraft() {
-  const [draftState, setDraftStateValue] = useState<ClientSharedPromptDraftState>({ value: '', cursor: 0 });
+  const initialDraftState = { value: '', cursor: 0 };
+  const [draftState, setDraftStateValue] = useState<ClientSharedPromptDraftState>(initialDraftState);
   const [historyState, setHistoryState] = useState<ClientSharedPromptHistoryState>({ entries: [] });
+  const draftStateRef = useRef<ClientSharedPromptDraftState>(initialDraftState);
+  const undoRedoStateRef = useRef(ClientSharedPromptInputService.clearUndoRedo());
 
-  const setDraftState = useCallback((nextState: ClientSharedPromptDraftState) => {
-    setDraftStateValue({
+  const applyDraftState = useCallback((nextState: ClientSharedPromptDraftState, options: { recordUndo: boolean }) => {
+    const normalized = {
       value: nextState.value,
       cursor: ClientSharedPromptInputService.clampCursor(nextState.value, nextState.cursor),
-    });
+    };
+
+    if (options.recordUndo) {
+      const nextUndoRedo = ClientSharedPromptInputService.recordUndoState(
+        undoRedoStateRef.current,
+        draftStateRef.current,
+        normalized,
+      );
+      undoRedoStateRef.current = nextUndoRedo;
+    }
+
+    draftStateRef.current = normalized;
+    setDraftStateValue(normalized);
+  }, []);
+
+  const setDraftState = useCallback((nextState: ClientSharedPromptDraftState) => {
+    applyDraftState(nextState, { recordUndo: true });
     setHistoryState((current) => ({
       entries: current.entries,
       index: undefined,
       savedDraft: undefined,
     }));
-  }, []);
+  }, [applyDraftState]);
 
   const setDraft = useCallback((value: string) => {
     setDraftState({ value, cursor: value.length });
   }, [setDraftState]);
 
   const clearDraft = useCallback(() => {
-    setDraftState({ value: '', cursor: 0 });
-  }, [setDraftState]);
+    const clearedUndoRedo = ClientSharedPromptInputService.clearUndoRedo();
+    undoRedoStateRef.current = clearedUndoRedo;
+    applyDraftState({ value: '', cursor: 0 }, { recordUndo: false });
+  }, [applyDraftState]);
 
   const recordSubmittedPrompt = useCallback((value: string) => {
     setHistoryState((current) => ClientSharedPromptInputService.recordPrompt(current, value));
@@ -45,8 +66,30 @@ export function usePromptDraft() {
     }
 
     setHistoryState(next.history);
-    setDraftStateValue(next.draft);
-  }, [draftState, historyState]);
+    const clearedUndoRedo = ClientSharedPromptInputService.clearUndoRedo();
+    undoRedoStateRef.current = clearedUndoRedo;
+    applyDraftState(next.draft, { recordUndo: false });
+  }, [applyDraftState, draftState, historyState]);
+
+  const undoPromptEdit = useCallback(() => {
+    const next = ClientSharedPromptInputService.undoPromptEdit(undoRedoStateRef.current, draftStateRef.current);
+    if (!next) {
+      return;
+    }
+
+    undoRedoStateRef.current = next.history;
+    applyDraftState(next.draft, { recordUndo: false });
+  }, [applyDraftState]);
+
+  const redoPromptEdit = useCallback(() => {
+    const next = ClientSharedPromptInputService.redoPromptEdit(undoRedoStateRef.current, draftStateRef.current);
+    if (!next) {
+      return;
+    }
+
+    undoRedoStateRef.current = next.history;
+    applyDraftState(next.draft, { recordUndo: false });
+  }, [applyDraftState]);
 
   return {
     draft: draftState.value,
@@ -56,5 +99,7 @@ export function usePromptDraft() {
     clearDraft,
     recordSubmittedPrompt,
     navigateHistory,
+    undoPromptEdit,
+    redoPromptEdit,
   };
 }

--- a/src/cli-v2/services/prompt-input/prompt-line-editor-service.ts
+++ b/src/cli-v2/services/prompt-input/prompt-line-editor-service.ts
@@ -6,6 +6,8 @@ export type CliV2PromptInputCommand =
   | { kind: 'submit' }
   | { kind: 'insert'; input: string }
   | { kind: 'history'; direction: 'previous' | 'next' }
+  | { kind: 'undo' }
+  | { kind: 'redo' }
   | { kind: 'deletePreviousCharacter' }
   | { kind: 'deletePreviousWord' }
   | { kind: 'deleteBeforeCursor' }
@@ -18,6 +20,7 @@ const CTRL_TEXT_COMMANDS = new Map<string, CliV2PromptInputCommand>([
   ['k', { kind: 'deleteAfterCursor' }],
   ['u', { kind: 'deleteBeforeCursor' }],
   ['w', { kind: 'deletePreviousWord' }],
+  ['y', { kind: 'redo' }],
 ]);
 
 const META_TEXT_COMMANDS = new Map<string, CliV2PromptInputCommand>([
@@ -39,6 +42,9 @@ export class CliV2PromptLineEditorService {
     }
 
     if (key.ctrl && input) {
+      if (input.toLowerCase() === 'z') {
+        return key.shift || input === 'Z' ? { kind: 'redo' } : { kind: 'undo' };
+      }
       return CTRL_TEXT_COMMANDS.get(input);
     }
 
@@ -106,7 +112,7 @@ export class CliV2PromptLineEditorService {
   }
 
   static applyCommand(
-    command: Exclude<CliV2PromptInputCommand, { kind: 'submit' | 'history' }>,
+    command: Exclude<CliV2PromptInputCommand, { kind: 'submit' | 'history' | 'undo' | 'redo' }>,
     state: ClientSharedPromptDraftState,
   ): ClientSharedPromptDraftState {
     if (command.kind === 'insert') {

--- a/src/client-shared/services/prompt-input/prompt-input-service.ts
+++ b/src/client-shared/services/prompt-input/prompt-input-service.ts
@@ -11,7 +11,13 @@ export type ClientSharedPromptHistoryState = {
 
 export type ClientSharedPromptHistoryDirection = 'previous' | 'next';
 
+export type ClientSharedPromptUndoRedoState = {
+  undoStack: ClientSharedPromptDraftState[];
+  redoStack: ClientSharedPromptDraftState[];
+};
+
 const DEFAULT_MAX_PROMPT_HISTORY_ENTRIES = 100;
+const DEFAULT_MAX_PROMPT_UNDO_STATES = 100;
 
 /**
  * Owns interface-neutral prompt draft and prompt history semantics.
@@ -172,8 +178,68 @@ export class ClientSharedPromptInputService {
     return state.cursor >= lastLineStart;
   }
 
+  static recordUndoState(
+    state: ClientSharedPromptUndoRedoState,
+    currentDraft: ClientSharedPromptDraftState,
+    nextDraft: ClientSharedPromptDraftState,
+    maxStates = DEFAULT_MAX_PROMPT_UNDO_STATES,
+  ): ClientSharedPromptUndoRedoState {
+    if (this.areDraftsEqual(currentDraft, nextDraft)) {
+      return state;
+    }
+
+    return {
+      undoStack: [...state.undoStack, currentDraft].slice(-maxStates),
+      redoStack: [],
+    };
+  }
+
+  static undoPromptEdit(
+    state: ClientSharedPromptUndoRedoState,
+    currentDraft: ClientSharedPromptDraftState,
+  ): { history: ClientSharedPromptUndoRedoState; draft: ClientSharedPromptDraftState } | undefined {
+    const previous = state.undoStack.at(-1);
+    if (!previous) {
+      return undefined;
+    }
+
+    return {
+      history: {
+        undoStack: state.undoStack.slice(0, -1),
+        redoStack: [...state.redoStack, currentDraft],
+      },
+      draft: previous,
+    };
+  }
+
+  static redoPromptEdit(
+    state: ClientSharedPromptUndoRedoState,
+    currentDraft: ClientSharedPromptDraftState,
+  ): { history: ClientSharedPromptUndoRedoState; draft: ClientSharedPromptDraftState } | undefined {
+    const next = state.redoStack.at(-1);
+    if (!next) {
+      return undefined;
+    }
+
+    return {
+      history: {
+        undoStack: [...state.undoStack, currentDraft],
+        redoStack: state.redoStack.slice(0, -1),
+      },
+      draft: next,
+    };
+  }
+
+  static clearUndoRedo(): ClientSharedPromptUndoRedoState {
+    return { undoStack: [], redoStack: [] };
+  }
+
   private static removeRange(value: string, start: number, end: number): string {
     return `${value.slice(0, start)}${value.slice(end)}`;
+  }
+
+  private static areDraftsEqual(left: ClientSharedPromptDraftState, right: ClientSharedPromptDraftState): boolean {
+    return left.value === right.value && left.cursor === right.cursor;
   }
 
   private static findPreviousWordBoundary(value: string, cursor: number): number {

--- a/src/core/auth/README.md
+++ b/src/core/auth/README.md
@@ -8,6 +8,9 @@ The boundary is intentionally small:
   deserialization, writes, private file permissions, summaries, and redaction.
 - `OpenAiOAuthService` owns the OpenAI OAuth browser flow, token exchange,
   refresh, account-id extraction, and platform-specific browser launching.
+- `ProviderCredentialCommandService` owns shared credential command semantics
+  such as status, OAuth login, and logout. Terminal and control-plane hosts may
+  call it, but they still own their own rendering and invocation flow.
 - Runtime and LLM services may ask auth for credentials, but auth should not
   own model policy, adapter selection, tool behavior, or UI formatting.
 

--- a/src/core/auth/command-service.ts
+++ b/src/core/auth/command-service.ts
@@ -1,0 +1,72 @@
+import type { LlmProvider } from '@/core/llm/types.js';
+import { OpenAiOAuthService } from './openai-oauth.js';
+import { ProviderCredentialRepository } from './provider-credentials.js';
+import type { OpenAiOAuthCredential } from './types.js';
+
+export type ProviderCredentialCommandOptions = {
+  storePath?: string;
+  openBrowser?: boolean;
+  openAiLogin?: () => Promise<OpenAiOAuthCredential>;
+  onAuthorizeUrl?: (url: string) => void;
+};
+
+/**
+ * Owns provider credential command semantics shared by terminal and API hosts.
+ *
+ * Core auth owns what status/login/logout mean for persisted credentials.
+ * Interfaces own how command progress is rendered and how users invoke these
+ * actions.
+ */
+export class ProviderCredentialCommandService {
+  static formatStatusMessage(storePath = ProviderCredentialRepository.resolveStorePath()): string {
+    const summaries = new ProviderCredentialRepository({ storePath }).listSummaries();
+    const lines = [`Auth store: ${storePath}`];
+
+    if (summaries.length === 0) {
+      return [...lines, 'Stored credentials: none'].join('\n');
+    }
+
+    lines.push('Stored credentials:');
+    for (const summary of summaries) {
+      const details = [
+        `type=${summary.type}`,
+        summary.label ? `label=${summary.label}` : undefined,
+        summary.accountId ? `account=${summary.accountId}` : undefined,
+        summary.expiresAt ? `expires=${new Date(summary.expiresAt).toISOString()}` : undefined,
+        summary.expired === true ? 'expired=true' : undefined,
+        `updated=${summary.updatedAt}`,
+      ].filter(Boolean);
+      lines.push(`- ${summary.provider}: ${details.join(' ')}`);
+    }
+    return lines.join('\n');
+  }
+
+  static async loginProviderWithOAuth(
+    provider: LlmProvider,
+    options: ProviderCredentialCommandOptions = {},
+  ): Promise<string> {
+    const storePath = options.storePath ?? ProviderCredentialRepository.resolveStorePath();
+    if (provider !== 'openai') {
+      throw new Error(`OAuth login is not available for ${provider}. Use API keys or supported provider credentials.`);
+    }
+
+    const credential = await (options.openAiLogin ?? (() => OpenAiOAuthService.runBrowserLogin({
+      openBrowser: options.openBrowser,
+      onAuthorizeUrl: options.onAuthorizeUrl,
+    })))();
+    new ProviderCredentialRepository({ storePath }).set(credential);
+
+    return [
+      'Stored OpenAI OAuth credential.',
+      credential.accountId ? `Account: ${credential.accountId}` : undefined,
+      `Expires: ${new Date(credential.expiresAt).toISOString()}`,
+    ].filter((line): line is string => Boolean(line)).join('\n');
+  }
+
+  static logoutProvider(provider: LlmProvider, storePath = ProviderCredentialRepository.resolveStorePath()): string {
+    const removed = new ProviderCredentialRepository({ storePath }).remove(provider);
+    return removed ?
+        `Removed stored ${provider} credential.`
+      : `No stored ${provider} credential found.`;
+  }
+}

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -1,5 +1,7 @@
 export { ProviderCredentialRepository } from './provider-credentials.js';
 export { OpenAiOAuthService } from './openai-oauth.js';
+export { ProviderCredentialCommandService } from './command-service.js';
+export type { ProviderCredentialCommandOptions } from './command-service.js';
 export type {
   OpenAiIdTokenClaims,
   OpenAiOAuthCredential,

--- a/src/server/services/control-plane/slash-command-execution-context-service.ts
+++ b/src/server/services/control-plane/slash-command-execution-context-service.ts
@@ -1,4 +1,4 @@
-import { ProviderCredentialRepository } from '@/core/auth/index.js';
+import { ProviderCredentialCommandService } from '@/core/auth/index.js';
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
 import type { ConversationEngineConfig } from '@/core/chat/engine/types.js';
 import type { ChatSession } from '@/core/chat/types.js';
@@ -6,7 +6,6 @@ import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/i
 import type { SlashCommandExecutionContext } from '@/core/commands/slash/modules/context.js';
 import type { SlashCommandHint } from '@/core/commands/slash/types.js';
 import { FileHeartbeatTaskService } from '@/core/heartbeat/index.js';
-import type { LlmProvider } from '@/core/llm/types.js';
 import { controlPlaneSessionRuntimeContextService } from './session-runtime-context-service.js';
 
 export type ControlPlaneSlashCommandExecutionContextArgs = Omit<ConversationEngineConfig, 'model'> & {
@@ -43,11 +42,11 @@ export class ControlPlaneSlashCommandExecutionContextService {
         credentialSource: () => runtimeContext.credentialSource,
       },
       auth: {
-        status: () => this.formatAuthStatus(args.credentialStorePath),
-        login: async (provider) => {
-          throw new Error(`OAuth login for ${provider} is only available through the terminal auth command.`);
-        },
-        logout: (provider) => this.logoutProvider(provider, args.credentialStorePath),
+        status: () => ProviderCredentialCommandService.formatStatusMessage(args.credentialStorePath),
+        login: (provider) => ProviderCredentialCommandService.loginProviderWithOAuth(provider, {
+          storePath: args.credentialStorePath,
+        }),
+        logout: (provider) => ProviderCredentialCommandService.logoutProvider(provider, args.credentialStorePath),
       },
       compaction: {
         compactActive: args.compactActive,
@@ -100,35 +99,6 @@ export class ControlPlaneSlashCommandExecutionContextService {
     return this.recentSessions(sessions).map((session, index) => (
       `${index + 1}. ${session.id} (${session.name}) - ${ChatSessionRecords.summarize(session)}`
     ));
-  }
-
-  private formatAuthStatus(storePath = ProviderCredentialRepository.resolveStorePath()): string {
-    const summaries = new ProviderCredentialRepository({ storePath }).listSummaries();
-    const lines = [`Auth store: ${storePath}`];
-    if (summaries.length === 0) {
-      return [...lines, 'Stored credentials: none'].join('\n');
-    }
-
-    return [
-      ...lines,
-      'Stored credentials:',
-      ...summaries.map((summary) => {
-        const details = [
-          `type=${summary.type}`,
-          summary.label ? `label=${summary.label}` : undefined,
-          summary.accountId ? `account=${summary.accountId}` : undefined,
-          summary.expiresAt ? `expires=${new Date(summary.expiresAt).toISOString()}` : undefined,
-          summary.expired === true ? 'expired=true' : undefined,
-          `updated=${summary.updatedAt}`,
-        ].filter(Boolean);
-        return `- ${summary.provider}: ${details.join(' ')}`;
-      }),
-    ].join('\n');
-  }
-
-  private logoutProvider(provider: LlmProvider, storePath = ProviderCredentialRepository.resolveStorePath()): string {
-    const removed = new ProviderCredentialRepository({ storePath }).remove(provider);
-    return removed ? `Removed stored ${provider} credential.` : `No stored ${provider} credential found.`;
   }
 
   private formatHelpMessage(hints: SlashCommandHint[]): string {


### PR DESCRIPTION
## Summary
- add shared prompt undo/redo state and wire Ctrl+Z, Ctrl+Shift+Z, and Ctrl+Y in cli-v2
- route control-plane /auth login through core auth command semantics instead of returning a terminal-only error
- confirm cli-v2 file mentions submit user-authored @path text without extra host notes

## Validation
- ./node_modules/.bin/vitest run src/__tests__/unit/client-shared/prompt-input-service.test.ts src/__tests__/unit/cli-v2/prompt-line-editor-service.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/integration/control-plane/session-lifecycle.test.ts
- yarn build
- git diff --check
- cli-v2 boundary grep for core/server/old-cli imports