### PR TITLE
Refactor cli-v2 session store workflows

### DIFF
--- a/src/cli-v2/state/README.md
+++ b/src/cli-v2/state/README.md
@@ -1,0 +1,48 @@
+# cli-v2 Session State
+
+This folder owns the terminal app model for one control-plane session view.
+It is intentionally a TUI orchestration layer: core services and the
+control-plane API own domain policy, while Ink components render a single
+snapshot and call user-intent methods.
+
+## Ownership
+
+- `control-plane-session-store.ts` is the public facade consumed by Ink. Keep it
+  small: construct workflow owners, expose `getSnapshot`/`subscribe`, and route
+  user intents.
+- `control-plane-session-state.ts` owns the canonical mutable render snapshot
+  and subscription mechanics. Renderable TUI facts belong in this one snapshot,
+  not in scattered workflow-local state.
+- `control-plane-session-loader.ts` owns workspace/session loading, selection,
+  runtime-context refresh, pending-approval refresh trigger, and event-stream
+  attachment ordering.
+- `control-plane-prompt-controller.ts` owns prompt intent routing and normal
+  prompt submission state transitions. Prompt parsing rules stay in
+  `client-shared`.
+- `control-plane-slash-command-controller.ts` owns slash command API
+  orchestration after execution. Slash command definitions, parsing, aliases,
+  and semantics stay in core/control-plane.
+- `control-plane-direct-shell-controller.ts` owns TUI direct-shell confirmation
+  state and direct-shell run submission. Shell policy and command execution stay
+  in core/control-plane.
+- `control-plane-approval-controller.ts` owns pending-approval mirroring and
+  resolution state. Approval policy remains server/core-owned.
+- `control-plane-run-controller.ts` owns cancellation state and run-state
+  polling fallback. The server remains the run source of truth.
+- `control-plane-live-event-reducer.ts` owns reduction of control-plane live
+  events into the TUI snapshot. Shared activity semantics stay in
+  `client-shared`.
+
+## Invariants
+
+- The TUI has one render-state source of truth: `ControlPlaneSessionState`.
+- Workflow controllers may keep private lifecycle mechanics only when those
+  facts are not render state, such as timers or stream buffers.
+- Do not import core, server, or old CLI modules from cli-v2. Consume
+  control-plane APIs and `client-shared` types/services.
+- Do not add a controller that only forwards calls. A controller must own real
+  workflow behavior: ordering, state transitions, lifecycle reset, event
+  reduction, or terminal UX coordination.
+- Do not duplicate domain policy in this folder. If a rule belongs to slash
+  commands, shell policy, model capabilities, approvals, or activity semantics,
+  move it to the owning core/control-plane/client-shared module instead.

--- a/src/cli-v2/state/control-plane-approval-controller.ts
+++ b/src/cli-v2/state/control-plane-approval-controller.ts
@@ -1,0 +1,62 @@
+import type {
+  ControlPlaneApprovalDecision,
+} from '@/client-shared/api/types.js';
+import type { ControlPlaneSessionApiService } from '../services/sessions/control-plane-session-api-service.js';
+import type { ControlPlaneSessionState } from './control-plane-session-state.js';
+
+type ControlPlaneApprovalControllerOptions = {
+  api: ControlPlaneSessionApiService;
+  state: ControlPlaneSessionState;
+  formatError: (error: unknown) => string;
+};
+
+/**
+ * Owns cli-v2 pending-approval state and resolution workflow.
+ *
+ * Core/control-plane owns approval policy and persistence. This controller only
+ * mirrors the pending approval into the TUI snapshot and records the local
+ * resolving state around a user's decision.
+ */
+export class ControlPlaneApprovalController {
+  constructor(private readonly options: ControlPlaneApprovalControllerOptions) {}
+
+  async refresh(sessionId: string): Promise<void> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const pendingApproval = await this.options.api.getPendingApproval(workspaceId, sessionId);
+    this.options.state.patch({ pendingApproval });
+  }
+
+  async resolve(decision: ControlPlaneApprovalDecision): Promise<void> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const sessionId = this.options.state.requireActiveSessionId();
+    this.options.state.patch({
+      approvalResolving: true,
+      error: undefined,
+      latestUpdate: {
+        label: 'Resolving approval',
+        tone: 'info',
+      },
+    });
+
+    try {
+      const result = await this.options.api.resolvePendingApproval(workspaceId, sessionId, decision);
+      if (!result.resolved) {
+        throw new Error('No pending approval found for this session.');
+      }
+      await this.refresh(sessionId);
+      this.options.state.patch({
+        approvalResolving: false,
+        latestUpdate: {
+          label: 'Approval resolved',
+          detail: decision.type,
+          tone: 'info',
+        },
+      });
+    } catch (error) {
+      this.options.state.patch({
+        approvalResolving: false,
+        error: this.options.formatError(error),
+      });
+    }
+  }
+}

--- a/src/cli-v2/state/control-plane-direct-shell-controller.ts
+++ b/src/cli-v2/state/control-plane-direct-shell-controller.ts
@@ -1,0 +1,145 @@
+import type { ControlPlaneSessionApiService } from '../services/sessions/control-plane-session-api-service.js';
+import type { AssistantStreamBufferService } from '../services/sessions/assistant-stream-buffer-service.js';
+import type { ControlPlaneSessionLoader } from './control-plane-session-loader.js';
+import type { ControlPlaneSessionState } from './control-plane-session-state.js';
+
+type ControlPlaneDirectShellControllerOptions = {
+  api: ControlPlaneSessionApiService;
+  state: ControlPlaneSessionState;
+  loader: ControlPlaneSessionLoader;
+  assistantStreamBuffer: AssistantStreamBufferService;
+  refreshSessions: () => Promise<unknown>;
+  refreshPendingApproval: (sessionId: string) => Promise<void>;
+  formatError: (error: unknown) => string;
+};
+
+/**
+ * Owns cli-v2 direct-shell interaction state.
+ *
+ * Core/control-plane owns shell policy and execution. This controller owns only
+ * the TUI workflow around that policy: empty-command rejection, local
+ * confirmation state, direct-shell run submission, and terminal activity
+ * snapshot transitions.
+ */
+export class ControlPlaneDirectShellController {
+  constructor(private readonly options: ControlPlaneDirectShellControllerOptions) {}
+
+  async submit(command: string): Promise<void> {
+    if (!command.trim()) {
+      this.options.state.patch({
+        error: 'Direct shell command cannot be empty.',
+      });
+      return;
+    }
+
+    if (this.options.state.getSnapshot().running) {
+      this.options.state.patch({
+        error: undefined,
+        latestUpdate: {
+          label: 'Direct shell blocked',
+          detail: 'wait for the current run to finish',
+          tone: 'warning',
+        },
+      });
+      return;
+    }
+
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const sessionId = this.options.state.requireActiveSessionId();
+    const preflight = await this.options.api.preflightDirectShell({ workspaceId, sessionId, command });
+    if (preflight.risk === 'blocked') {
+      this.options.state.patch({
+        error: preflight.reason ?? 'Direct shell command is blocked by shell policy.',
+      });
+      return;
+    }
+
+    if (preflight.risk === 'confirmRequired') {
+      this.options.state.patch({
+        pendingDirectShellConfirmation: preflight,
+        error: undefined,
+        latestUpdate: {
+          label: 'Confirm shell command',
+          detail: preflight.reason,
+          tone: 'warning',
+        },
+      });
+      return;
+    }
+
+    await this.startRun(command);
+  }
+
+  async resolveConfirmation(accepted: boolean): Promise<void> {
+    const pending = this.options.state.getSnapshot().pendingDirectShellConfirmation;
+    if (!pending) {
+      return;
+    }
+
+    this.options.state.patch({ pendingDirectShellConfirmation: undefined });
+    if (!accepted) {
+      this.options.state.patch({
+        latestUpdate: {
+          label: 'Direct shell cancelled',
+          detail: pending.command,
+          tone: 'info',
+        },
+      });
+      return;
+    }
+
+    await this.startRun(pending.command, true);
+  }
+
+  private async startRun(command: string, riskAccepted?: boolean): Promise<void> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const sessionId = this.options.state.requireActiveSessionId();
+    this.options.state.patch((current) => ({
+      submitting: true,
+      running: true,
+      error: undefined,
+      pendingDirectShellConfirmation: undefined,
+      activePlan: undefined,
+      currentActivity: {
+        label: 'Running shell',
+        startedAt: new Date().toISOString(),
+        tone: 'info',
+      },
+      liveStatus: current.streamConnected
+        ? 'Running direct shell command...'
+        : 'Running direct shell command... reconnecting live stream if needed.',
+      latestUpdate: {
+        label: 'Direct shell accepted',
+        detail: command,
+        tone: 'info',
+      },
+    }));
+
+    try {
+      const result = await this.options.api.runDirectShellAsync({ workspaceId, sessionId, command, riskAccepted });
+      this.options.assistantStreamBuffer.reset();
+      this.options.state.patch({
+        submitting: false,
+        running: 'accepted' in result,
+        latestUpdate: {
+          label: 'Direct shell accepted',
+          detail: 'accepted' in result ? result.runId : undefined,
+          tone: 'info',
+        },
+      });
+      await this.options.loader.refreshSession(sessionId, { silent: true });
+      await this.options.refreshSessions();
+      await this.options.refreshPendingApproval(sessionId);
+    } catch (error) {
+      this.options.state.patch({
+        error: this.options.formatError(error),
+        running: false,
+        submitting: false,
+        liveStatus: undefined,
+        currentActivity: undefined,
+      });
+      await this.options.loader.refreshSession(sessionId, { silent: true }).catch(() => undefined);
+      this.options.assistantStreamBuffer.reset();
+    }
+  }
+}

--- a/src/cli-v2/state/control-plane-live-event-reducer.ts
+++ b/src/cli-v2/state/control-plane-live-event-reducer.ts
@@ -1,0 +1,124 @@
+import { ClientSharedSessionActivityService } from '@/client-shared/services/session-activities/index.js';
+import { ClientSharedSessionMessageService } from '@/client-shared/services/session-messages/index.js';
+import type { ControlPlaneSessionEventEnvelope } from '@/client-shared/api/types.js';
+import { SessionActivityService } from '../services/activities/session-activity-service.js';
+import type { AssistantStreamBufferService, AssistantStreamUpdate } from '../services/sessions/assistant-stream-buffer-service.js';
+import type { ControlPlaneSessionLoader } from './control-plane-session-loader.js';
+import type { ControlPlaneSessionState } from './control-plane-session-state.js';
+
+type ControlPlaneLiveEventReducerOptions = {
+  state: ControlPlaneSessionState;
+  loader: ControlPlaneSessionLoader;
+  assistantStreamBuffer: AssistantStreamBufferService;
+  refreshSessions: () => Promise<unknown>;
+  refreshPendingApproval: (sessionId: string) => Promise<void>;
+};
+
+/**
+ * Owns cli-v2 reduction of control-plane live events into render state.
+ *
+ * Server events are the transport contract. Client-shared owns activity
+ * semantics. This reducer owns only terminal snapshot effects: streaming text,
+ * current activity, plan visibility, pending approval refresh triggers, and
+ * latest-update state.
+ */
+export class ControlPlaneLiveEventReducer {
+  constructor(private readonly options: ControlPlaneLiveEventReducerOptions) {}
+
+  applySessionEvent(workspaceId: string, event: ControlPlaneSessionEventEnvelope): void {
+    if (!this.options.state.isActiveSessionAddress(workspaceId, event.sessionId)) {
+      return;
+    }
+
+    if (event.type === 'waiting') {
+      this.options.state.patch({
+        liveStatus: 'Waiting for the session event stream...',
+        latestUpdate: {
+          label: 'Waiting for session events',
+          tone: 'info',
+        },
+      });
+      return;
+    }
+
+    if (event.type === 'session.updated' || event.type === 'session.queue.updated') {
+      void this.options.loader.refreshSession(event.sessionId, { silent: true });
+      return;
+    }
+
+    if (event.type === 'session.approval.updated') {
+      void this.options.refreshPendingApproval(event.sessionId);
+      return;
+    }
+
+    if (event.type !== 'session.event') {
+      return;
+    }
+
+    event.activities.forEach((activity) => {
+      ClientSharedSessionActivityService.applyActivity(activity, {
+        onAssistantStream: (streamActivity) => {
+          this.options.assistantStreamBuffer.push({
+            workspaceId,
+            sessionId: event.sessionId,
+            text: streamActivity.text,
+            done: streamActivity.done,
+          });
+        },
+        onRunStarted: (runActivity, liveStatus) => {
+          this.options.state.patch({
+            running: true,
+            liveStatus,
+            currentActivity: ClientSharedSessionActivityService.createThinkingStatus(runActivity.timestamp),
+            latestUpdate: SessionActivityService.resolveLatestUpdate(runActivity),
+          });
+        },
+        onRunFinished: (runActivity, liveStatus) => {
+          this.options.assistantStreamBuffer.flush();
+          this.options.state.patch({
+            running: false,
+            ...(liveStatus !== undefined ? { liveStatus } : {}),
+            currentActivity: undefined,
+            latestUpdate: SessionActivityService.resolveLatestUpdate(runActivity),
+          });
+          void this.options.loader.refreshSession(event.sessionId, { silent: true });
+          void this.options.refreshSessions();
+        },
+        onPendingApprovalChanged: () => {
+          void this.options.refreshPendingApproval(event.sessionId);
+        },
+        onPlanUpdated: (plan) => {
+          this.options.state.patch({ activePlan: plan });
+        },
+        onPlanCleared: () => {
+          this.options.state.patch({ activePlan: undefined });
+        },
+        onCurrentActivityChanged: (currentActivity) => {
+          this.options.state.patch({ currentActivity });
+        },
+        onLiveStatus: (statusActivity, liveStatus) => {
+          const latestUpdate = SessionActivityService.resolveLatestUpdate(statusActivity);
+          if (liveStatus === undefined && latestUpdate === undefined) {
+            return;
+          }
+
+          this.options.state.patch({
+            ...(liveStatus !== undefined ? { liveStatus } : {}),
+            ...(latestUpdate !== undefined ? { latestUpdate } : {}),
+          });
+        },
+      });
+    });
+  }
+
+  applyAssistantStreamUpdate(update: AssistantStreamUpdate): void {
+    this.options.state.patch((current) => ({
+      activeSession: ClientSharedSessionMessageService.upsertLiveAssistantMessage(
+        current.activeSession,
+        update.text,
+        update.done,
+      ),
+      ...(!update.done ? { liveStatus: 'Receiving assistant response...' } : {}),
+    }));
+  }
+}

--- a/src/cli-v2/state/control-plane-prompt-controller.ts
+++ b/src/cli-v2/state/control-plane-prompt-controller.ts
@@ -1,0 +1,149 @@
+import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
+import { ClientSharedSessionActivityService } from '@/client-shared/services/session-activities/index.js';
+import type { ControlPlaneSessionApiService } from '../services/sessions/control-plane-session-api-service.js';
+import type { AssistantStreamBufferService } from '../services/sessions/assistant-stream-buffer-service.js';
+import type { ControlPlaneDirectShellController } from './control-plane-direct-shell-controller.js';
+import type { ControlPlaneSessionLoader } from './control-plane-session-loader.js';
+import type { ControlPlaneSessionState } from './control-plane-session-state.js';
+import type { ControlPlaneSlashCommandController } from './control-plane-slash-command-controller.js';
+import { SlashCommandAutocompleteService } from '../services/slash-commands/index.js';
+
+type ControlPlanePromptControllerOptions = {
+  api: ControlPlaneSessionApiService;
+  state: ControlPlaneSessionState;
+  loader: ControlPlaneSessionLoader;
+  assistantStreamBuffer: AssistantStreamBufferService;
+  slashCommands: ControlPlaneSlashCommandController;
+  directShell: ControlPlaneDirectShellController;
+  refreshSessions: () => Promise<unknown>;
+  refreshPendingApproval: (sessionId: string) => Promise<void>;
+  formatError: (error: unknown) => string;
+};
+
+/**
+ * Owns cli-v2 prompt intent routing and normal prompt submission.
+ *
+ * Prompt parsing rules stay in client-shared. Slash and direct-shell workflows
+ * stay in their controllers. This controller owns the TUI-specific routing
+ * between those paths plus normal prompt queue/run-accepted state transitions.
+ */
+export class ControlPlanePromptController {
+  constructor(private readonly options: ControlPlanePromptControllerOptions) {}
+
+  async submitPrompt(prompt: string): Promise<void> {
+    const trimmed = prompt.trim();
+    if (!trimmed || this.options.state.getSnapshot().submitting) {
+      return;
+    }
+
+    if (SlashCommandAutocompleteService.isSlashDraft(trimmed)) {
+      await this.options.slashCommands.execute(trimmed);
+      return;
+    }
+
+    const directShell = ClientSharedPromptInputService.parseDirectShellDraft(trimmed);
+    if (directShell) {
+      await this.options.directShell.submit(directShell.command);
+      return;
+    }
+
+    await this.submitNormalPrompt(trimmed);
+  }
+
+  private async submitNormalPrompt(prompt: string): Promise<void> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const sessionId = this.options.state.requireActiveSessionId();
+    this.options.state.patch((current) => ({
+      submitting: true,
+      running: true,
+      error: undefined,
+      activePlan: undefined,
+      currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
+      liveStatus: current.streamConnected
+        ? 'Heddle is working...'
+        : 'Heddle is working... reconnecting live stream if needed.',
+      latestUpdate: {
+        label: 'Thinking',
+        detail: 'waiting for model or tool activity',
+        tone: 'info',
+      },
+    }));
+
+    try {
+      const result = await this.options.api.sendPromptAsync({
+        workspaceId,
+        sessionId,
+        prompt,
+      });
+      if ('queued' in result) {
+        this.options.state.patch({
+          submitting: false,
+          running: this.options.state.getSnapshot().running,
+          liveStatus: this.options.state.getSnapshot().running
+            ? this.options.state.getSnapshot().liveStatus
+            : 'Queued prompt will run when earlier work finishes.',
+          latestUpdate: {
+            label: 'Prompt queued',
+            detail: `position ${result.position}`,
+            tone: 'info',
+          },
+        });
+        await this.options.loader.refreshSession(sessionId, { silent: true });
+        await this.options.refreshSessions();
+        return;
+      }
+
+      this.options.assistantStreamBuffer.reset();
+      this.options.state.patch({
+        submitting: false,
+        running: true,
+        liveStatus: this.options.state.getSnapshot().streamConnected
+          ? 'Heddle is working...'
+          : 'Heddle is working... reconnecting live stream if needed.',
+        currentActivity: this.options.state.getSnapshot().currentActivity
+          ?? ClientSharedSessionActivityService.createThinkingStatus(),
+        latestUpdate: {
+          label: 'Run accepted',
+          detail: result.runId,
+          tone: 'info',
+        },
+      });
+      await this.options.loader.refreshSession(sessionId, { silent: true });
+      await this.options.refreshSessions();
+      await this.options.refreshPendingApproval(sessionId);
+    } catch (error) {
+      if (isRunAlreadyInProgressError(error, this.options.formatError)) {
+        this.options.state.patch({
+          error: undefined,
+          running: true,
+          submitting: false,
+          liveStatus: this.options.state.getSnapshot().streamConnected
+            ? 'A run is already in progress for this session.'
+            : 'A run is already in progress for this session. Reconnecting live stream if needed.',
+          currentActivity: this.options.state.getSnapshot().currentActivity
+            ?? ClientSharedSessionActivityService.createThinkingStatus(),
+          latestUpdate: {
+            label: 'Run already in progress',
+            detail: 'waiting for current run to finish',
+            tone: 'warning',
+          },
+        });
+        return;
+      }
+
+      this.options.state.patch({
+        error: this.options.formatError(error),
+        running: false,
+        submitting: false,
+        liveStatus: undefined,
+        currentActivity: undefined,
+      });
+      await this.options.loader.refreshSession(sessionId, { silent: true }).catch(() => undefined);
+      this.options.assistantStreamBuffer.reset();
+    }
+  }
+}
+
+function isRunAlreadyInProgressError(error: unknown, formatError: (error: unknown) => string): boolean {
+  return formatError(error).includes('A run is already in progress for this session.');
+}

--- a/src/cli-v2/state/control-plane-run-controller.ts
+++ b/src/cli-v2/state/control-plane-run-controller.ts
@@ -1,0 +1,126 @@
+import { SessionActivityService } from '../services/activities/session-activity-service.js';
+import type { SessionRunStatePollAddress } from '../services/sessions/session-run-state-poller-service.js';
+import type { ControlPlaneSessionApiService } from '../services/sessions/control-plane-session-api-service.js';
+import type { ControlPlaneSessionLoader } from './control-plane-session-loader.js';
+import type { ControlPlaneApprovalController } from './control-plane-approval-controller.js';
+import type { ControlPlaneSessionState } from './control-plane-session-state.js';
+
+type ControlPlaneRunControllerOptions = {
+  api: ControlPlaneSessionApiService;
+  state: ControlPlaneSessionState;
+  loader: ControlPlaneSessionLoader;
+  approvals: ControlPlaneApprovalController;
+  refreshSessions: () => Promise<unknown>;
+  formatError: (error: unknown) => string;
+};
+
+/**
+ * Owns cli-v2 run cancellation and polling fallback.
+ *
+ * The server remains the source of truth for active runs. This controller owns
+ * the TUI mirror: stop-request state, polling-based recovery when events lag,
+ * and final refresh once a run is no longer active.
+ */
+export class ControlPlaneRunController {
+  constructor(private readonly options: ControlPlaneRunControllerOptions) {}
+
+  async cancelRun(): Promise<void> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const sessionId = this.options.state.requireActiveSessionId();
+    this.options.state.patch({
+      cancelling: true,
+      error: undefined,
+      liveStatus: 'Stop requested. Waiting for the current step to settle...',
+      latestUpdate: {
+        label: 'Stop requested',
+        tone: 'warning',
+      },
+    });
+
+    try {
+      const result = await this.options.api.cancelRun(workspaceId, sessionId);
+      await this.options.approvals.refresh(sessionId);
+      const running = await this.options.api.getRunning(workspaceId, sessionId);
+      this.options.state.patch({
+        running: result.cancelled ? running.running : false,
+        cancelling: false,
+        liveStatus: result.cancelled && running.running ? this.options.state.getSnapshot().liveStatus : undefined,
+        currentActivity: result.cancelled && running.running ? this.options.state.getSnapshot().currentActivity : undefined,
+        latestUpdate: {
+          label: result.cancelled ? 'Stop request accepted' : 'No active run to stop',
+          tone: result.cancelled ? 'warning' : 'info',
+        },
+      });
+    } catch (error) {
+      this.options.state.patch({
+        error: this.options.formatError(error),
+        cancelling: false,
+        liveStatus: undefined,
+        currentActivity: undefined,
+      });
+    }
+  }
+
+  shouldPollRunState(): boolean {
+    const snapshot = this.options.state.getSnapshot();
+    return snapshot.running || snapshot.submitting || snapshot.cancelling;
+  }
+
+  resolveRunStatePollAddress(): SessionRunStatePollAddress | undefined {
+    const { workspaceId, activeSessionId } = this.options.state.getSnapshot();
+    return workspaceId && activeSessionId ? { workspaceId, sessionId: activeSessionId } : undefined;
+  }
+
+  async pollRunState({ workspaceId, sessionId }: SessionRunStatePollAddress): Promise<void> {
+    const runState = await this.options.api.getRunState(workspaceId, sessionId);
+    if (!this.options.state.isActiveSessionAddress(workspaceId, sessionId)) {
+      return;
+    }
+
+    const snapshot = this.options.state.getSnapshot();
+    this.options.state.patch({
+      pendingApproval: runState.pendingApproval,
+      running: runState.running,
+      runtimeContext: snapshot.runtimeContext
+        ? { ...snapshot.runtimeContext, running: runState.running }
+        : snapshot.runtimeContext,
+      cancelling: runState.running ? snapshot.cancelling : false,
+      latestUpdate: runState.pendingApproval
+        ? {
+          label: 'Approval requested',
+          detail: SessionActivityService.formatPendingApprovalLabel(runState.pendingApproval),
+          tone: 'warning',
+        }
+        : snapshot.latestUpdate,
+    });
+
+    if (runState.running) {
+      return;
+    }
+
+    if (this.options.state.getSnapshot().submitting) {
+      this.options.state.patch({
+        liveStatus: 'Waiting for run acceptance...',
+        latestUpdate: {
+          label: 'Run starting',
+          detail: 'waiting for server acceptance',
+          tone: 'info',
+        },
+      });
+      return;
+    }
+
+    await this.options.loader.refreshSession(sessionId, { silent: true });
+    await this.options.refreshSessions();
+    this.options.state.patch({
+      submitting: false,
+      liveStatus: undefined,
+      activePlan: undefined,
+      currentActivity: undefined,
+      latestUpdate: {
+        label: 'Run finished',
+        tone: 'success',
+      },
+    });
+  }
+}

--- a/src/cli-v2/state/control-plane-session-loader.ts
+++ b/src/cli-v2/state/control-plane-session-loader.ts
@@ -1,0 +1,103 @@
+import { ClientSharedSessionMessageService } from '@/client-shared/services/session-messages/index.js';
+import type {
+  ControlPlaneSessionView,
+} from '@/client-shared/api/types.js';
+import type {
+  ControlPlaneSessionApiService,
+  ControlPlaneSessionCreateInput,
+} from '../services/sessions/control-plane-session-api-service.js';
+import type { ControlPlaneSessionSubscriptionService } from '../services/sessions/control-plane-session-subscription-service.js';
+import type { AssistantStreamBufferService } from '../services/sessions/assistant-stream-buffer-service.js';
+import type { ControlPlaneSessionState } from './control-plane-session-state.js';
+
+type ControlPlaneSessionLoaderOptions = {
+  api: ControlPlaneSessionApiService;
+  state: ControlPlaneSessionState;
+  subscriptions: ControlPlaneSessionSubscriptionService;
+  assistantStreamBuffer: AssistantStreamBufferService;
+  onRefreshPendingApproval: (sessionId: string) => Promise<void>;
+  onError: (error: unknown) => string;
+};
+
+/**
+ * Owns cli-v2 workspace/session loading and selection lifecycle.
+ *
+ * This is not a generic API proxy: it owns the ordering that makes a selected
+ * session coherent for the TUI, including active-state reset, session detail
+ * fetch, runtime context fetch, run-state mirror, pending approval refresh, and
+ * event-stream subscription.
+ */
+export class ControlPlaneSessionLoader {
+  constructor(private readonly options: ControlPlaneSessionLoaderOptions) {}
+
+  async refreshSessions(): Promise<ControlPlaneSessionView[]> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const sessions = await this.options.api.listSessions(workspaceId);
+    this.options.state.patch({ sessions });
+    return sessions;
+  }
+
+  async createSession(input: ControlPlaneSessionCreateInput = {}): Promise<ControlPlaneSessionView> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const session = await this.options.api.createSession(workspaceId, input);
+    await this.refreshSessions();
+    return session;
+  }
+
+  async selectSession(sessionId: string): Promise<void> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    this.options.assistantStreamBuffer.reset();
+    this.options.state.patch({
+      activeSessionId: sessionId,
+      activeSession: null,
+      runtimeContext: undefined,
+      pendingApproval: null,
+      pendingDirectShellConfirmation: undefined,
+      liveStatus: undefined,
+      currentActivity: undefined,
+      activePlan: undefined,
+      latestUpdate: undefined,
+      error: undefined,
+      loading: true,
+      streamConnected: false,
+    });
+
+    try {
+      const session = await this.options.api.getSession(workspaceId, sessionId);
+      const runtimeContext = await this.options.api.getRuntimeContext(workspaceId, sessionId);
+      const running = await this.options.api.getRunning(workspaceId, sessionId);
+      this.options.state.patch({
+        activeSession: session,
+        runtimeContext,
+        running: running.running,
+        loading: false,
+      });
+      await this.options.onRefreshPendingApproval(sessionId);
+      this.options.subscriptions.subscribeToSessionEvents(workspaceId, sessionId);
+    } catch (error) {
+      this.options.state.patch({ error: this.options.onError(error), loading: false });
+    }
+  }
+
+  async refreshSession(sessionId: string, options: { silent?: boolean } = {}): Promise<void> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    if (!options.silent) {
+      this.options.state.patch({ loading: true });
+    }
+
+    try {
+      const next = await this.options.api.getSession(workspaceId, sessionId);
+      const runtimeContext = await this.options.api.getRuntimeContext(workspaceId, sessionId);
+      this.options.state.patch((current) => ({
+        activeSession: options.silent
+          ? ClientSharedSessionMessageService.mergeTransientMessages(current.activeSession, next)
+          : next,
+        runtimeContext,
+        loading: false,
+      }));
+    } catch (error) {
+      this.options.state.patch({ error: this.options.onError(error), loading: false });
+    }
+  }
+
+}

--- a/src/cli-v2/state/control-plane-session-state.ts
+++ b/src/cli-v2/state/control-plane-session-state.ts
@@ -1,0 +1,131 @@
+import type {
+  ClientSharedAgentActivityStatus,
+  ClientSharedSessionPlan,
+} from '@/client-shared/services/session-activities/index.js';
+import type { ControlPlaneProxyClient } from '@/client-shared/api/proxy.js';
+import type {
+  ControlPlaneApprovalDecision,
+  ControlPlaneModelOptions,
+  ControlPlanePendingApproval,
+  ControlPlaneSessionDirectShellPreflight,
+  ControlPlaneSessionDetail,
+  ControlPlaneSessionRuntimeContext,
+  ControlPlaneSessionView,
+  ControlPlaneSlashCommandCatalog,
+  ControlPlaneSlashCommandResult,
+} from '@/client-shared/api/types.js';
+import type { ControlPlaneSessionLatestUpdate } from '../services/activities/session-activity-service.js';
+
+export type ControlPlaneSessionStoreOptions = {
+  client: ControlPlaneProxyClient;
+  defaultModel?: string;
+  maxSteps?: number;
+  searchIgnoreDirs?: string[];
+  systemContext?: string;
+  apiKey?: string;
+  preferApiKey?: boolean;
+};
+
+export type ControlPlaneSessionStoreStartInput = {
+  workspaceId?: string;
+  sessionId?: string;
+};
+
+export type ControlPlaneSessionStoreSnapshot = {
+  workspaceId?: string;
+  sessions: ControlPlaneSessionView[];
+  activeSessionId?: string;
+  activeSession: ControlPlaneSessionDetail;
+  runtimeContext?: ControlPlaneSessionRuntimeContext;
+  modelOptions?: ControlPlaneModelOptions;
+  pendingApproval: ControlPlanePendingApproval;
+  pendingDirectShellConfirmation?: ControlPlaneSessionDirectShellPreflight;
+  loading: boolean;
+  submitting: boolean;
+  approvalResolving: boolean;
+  running: boolean;
+  cancelling: boolean;
+  streamConnected: boolean;
+  liveStatus?: string;
+  currentActivity?: ClientSharedAgentActivityStatus;
+  activePlan?: ClientSharedSessionPlan;
+  latestUpdate?: ControlPlaneSessionLatestUpdate;
+  slashCommandCatalog?: ControlPlaneSlashCommandCatalog;
+  commandResults: ControlPlaneSlashCommandResult[];
+  error?: string;
+};
+
+export type ControlPlaneSessionSnapshotPatch =
+  | Partial<ControlPlaneSessionStoreSnapshot>
+  | ((current: ControlPlaneSessionStoreSnapshot) => Partial<ControlPlaneSessionStoreSnapshot>);
+
+export const INITIAL_CONTROL_PLANE_SESSION_SNAPSHOT: ControlPlaneSessionStoreSnapshot = {
+  sessions: [],
+  activeSession: null,
+  runtimeContext: undefined,
+  modelOptions: undefined,
+  pendingApproval: null,
+  pendingDirectShellConfirmation: undefined,
+  loading: false,
+  submitting: false,
+  approvalResolving: false,
+  running: false,
+  cancelling: false,
+  streamConnected: false,
+  commandResults: [],
+};
+
+/**
+ * Owns the cli-v2 render snapshot and subscription mechanics.
+ *
+ * This class must stay generic: no API calls, no domain policy, no event
+ * interpretation. Workflow controllers produce patches; this state object is
+ * the single mutable source of truth consumed by Ink components.
+ */
+export class ControlPlaneSessionState {
+  private readonly listeners = new Set<() => void>();
+  private snapshotValue: ControlPlaneSessionStoreSnapshot = INITIAL_CONTROL_PLANE_SESSION_SNAPSHOT;
+
+  constructor(private readonly onChanged?: () => void) {}
+
+  getSnapshot = (): ControlPlaneSessionStoreSnapshot => this.snapshotValue;
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  patch(next: ControlPlaneSessionSnapshotPatch): void {
+    const patch = typeof next === 'function' ? next(this.snapshotValue) : next;
+    this.snapshotValue = {
+      ...this.snapshotValue,
+      ...patch,
+    };
+    this.onChanged?.();
+    this.listeners.forEach((listener) => listener());
+  }
+
+  requireWorkspaceId(): string {
+    const workspaceId = this.snapshotValue.workspaceId;
+    if (!workspaceId) {
+      throw new Error('Control-plane workspace is not loaded.');
+    }
+    return workspaceId;
+  }
+
+  requireActiveSessionId(): string {
+    const sessionId = this.snapshotValue.activeSessionId;
+    if (!sessionId) {
+      throw new Error('No active control-plane session is selected.');
+    }
+    return sessionId;
+  }
+
+  isActiveSessionAddress(workspaceId: string, sessionId: string): boolean {
+    return this.snapshotValue.workspaceId === workspaceId && this.snapshotValue.activeSessionId === sessionId;
+  }
+}
+
+export type { ControlPlaneApprovalDecision };

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -1,15 +1,3 @@
-import type { ControlPlaneProxyClient } from '@/client-shared/api/proxy.js';
-import { ClientSharedSessionActivityService } from '@/client-shared/services/session-activities/index.js';
-import type {
-  ClientSharedAgentActivityStatus,
-  ClientSharedSessionPlan,
-} from '@/client-shared/services/session-activities/index.js';
-import { ClientSharedSessionMessageService } from '@/client-shared/services/session-messages/index.js';
-import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
-import {
-  SessionActivityService,
-  type ControlPlaneSessionLatestUpdate,
-} from '../services/activities/session-activity-service.js';
 import {
   ControlPlaneSessionApiService,
   type ControlPlaneSessionCreateInput,
@@ -18,161 +6,172 @@ import { SlashCommandAutocompleteService } from '../services/slash-commands/inde
 import { ControlPlaneSessionSubscriptionService } from '../services/sessions/control-plane-session-subscription-service.js';
 import {
   AssistantStreamBufferService,
-  type AssistantStreamUpdate,
 } from '../services/sessions/assistant-stream-buffer-service.js';
 import {
   SessionRunStatePollerService,
-  type SessionRunStatePollAddress,
 } from '../services/sessions/session-run-state-poller-service.js';
+import {
+  ControlPlaneSessionState,
+  type ControlPlaneSessionStoreOptions,
+  type ControlPlaneSessionStoreSnapshot,
+  type ControlPlaneSessionStoreStartInput,
+} from './control-plane-session-state.js';
 import type {
   ControlPlaneApprovalDecision,
-  ControlPlaneModelOptions,
-  ControlPlanePendingApproval,
-  ControlPlaneSessionDirectShellPreflight,
-  ControlPlaneSessionDetail,
-  ControlPlaneSessionEventEnvelope,
-  ControlPlaneSessionRuntimeContext,
   ControlPlaneSessionView,
-  ControlPlaneSlashCommandCatalog,
   ControlPlaneSlashCommandHint,
-  ControlPlaneSlashCommandResult,
   ControlPlaneWorkspaceFileSuggestion,
 } from '@/client-shared/api/types.js';
+import { ControlPlaneSessionLoader } from './control-plane-session-loader.js';
+import { ControlPlaneDirectShellController } from './control-plane-direct-shell-controller.js';
+import { ControlPlaneSlashCommandController } from './control-plane-slash-command-controller.js';
+import { ControlPlanePromptController } from './control-plane-prompt-controller.js';
+import { ControlPlaneLiveEventReducer } from './control-plane-live-event-reducer.js';
+import { ControlPlaneApprovalController } from './control-plane-approval-controller.js';
+import { ControlPlaneRunController } from './control-plane-run-controller.js';
 
 const ASSISTANT_STREAM_RENDER_INTERVAL_MS = 75;
 const RUN_STATE_POLL_INTERVAL_MS = 750;
 
-export type ControlPlaneSessionStoreOptions = {
-  client: ControlPlaneProxyClient;
-  defaultModel?: string;
-  maxSteps?: number;
-  searchIgnoreDirs?: string[];
-  systemContext?: string;
-  apiKey?: string;
-  preferApiKey?: boolean;
-};
-
-export type ControlPlaneSessionStoreStartInput = {
-  workspaceId?: string;
-  sessionId?: string;
-};
-
-export type ControlPlaneSessionStoreSnapshot = {
-  workspaceId?: string;
-  sessions: ControlPlaneSessionView[];
-  activeSessionId?: string;
-  activeSession: ControlPlaneSessionDetail;
-  runtimeContext?: ControlPlaneSessionRuntimeContext;
-  modelOptions?: ControlPlaneModelOptions;
-  pendingApproval: ControlPlanePendingApproval;
-  pendingDirectShellConfirmation?: ControlPlaneSessionDirectShellPreflight;
-  loading: boolean;
-  submitting: boolean;
-  approvalResolving: boolean;
-  running: boolean;
-  cancelling: boolean;
-  streamConnected: boolean;
-  liveStatus?: string;
-  currentActivity?: ClientSharedAgentActivityStatus;
-  activePlan?: ClientSharedSessionPlan;
-  latestUpdate?: ControlPlaneSessionLatestUpdate;
-  slashCommandCatalog?: ControlPlaneSlashCommandCatalog;
-  commandResults: ControlPlaneSlashCommandResult[];
-  error?: string;
-};
-
-const INITIAL_SNAPSHOT: ControlPlaneSessionStoreSnapshot = {
-  sessions: [],
-  activeSession: null,
-  runtimeContext: undefined,
-  modelOptions: undefined,
-  pendingApproval: null,
-  pendingDirectShellConfirmation: undefined,
-  loading: false,
-  submitting: false,
-  approvalResolving: false,
-  running: false,
-  cancelling: false,
-  streamConnected: false,
-  commandResults: [],
-};
+export type {
+  ControlPlaneSessionStoreOptions,
+  ControlPlaneSessionStoreSnapshot,
+  ControlPlaneSessionStoreStartInput,
+} from './control-plane-session-state.js';
 
 /**
- * Owns cli-v2 control-plane session state over the shared tRPC API.
+ * Public facade for cli-v2 control-plane session state over the shared tRPC API.
  *
- * This is the non-React counterpart to web-v2's focused session hooks: it loads
- * the selected workspace/session, subscribes to live updates, keeps transient
- * conversation messages coherent, and exposes terminal intent methods.
- * Shared activity policy stays in client-shared; this store owns only cli-v2
- * state mutation and terminal workflow coordination.
+ * Keep this class thin by composition: workflow controllers own lifecycle and
+ * state-transition behavior, while this facade preserves the stable API that
+ * Ink components call. Shared activity/prompt policy stays in client-shared;
+ * core/control-plane remains the source of truth for domain behavior.
  */
 export class ControlPlaneSessionStore {
   private readonly api: ControlPlaneSessionApiService;
-  private readonly listeners = new Set<() => void>();
-  private snapshotValue: ControlPlaneSessionStoreSnapshot = INITIAL_SNAPSHOT;
+  private readonly state: ControlPlaneSessionState;
   private readonly subscriptions: ControlPlaneSessionSubscriptionService;
   private readonly assistantStreamBuffer: AssistantStreamBufferService;
   private readonly runStatePoller: SessionRunStatePollerService;
+  private readonly loader: ControlPlaneSessionLoader;
+  private readonly directShell: ControlPlaneDirectShellController;
+  private readonly slashCommands: ControlPlaneSlashCommandController;
+  private readonly prompts: ControlPlanePromptController;
+  private readonly liveEvents: ControlPlaneLiveEventReducer;
+  private readonly approvals: ControlPlaneApprovalController;
+  private readonly runs: ControlPlaneRunController;
 
   constructor(options: ControlPlaneSessionStoreOptions) {
     this.api = new ControlPlaneSessionApiService(options);
+    this.state = new ControlPlaneSessionState(() => this.runStatePoller.sync());
     this.subscriptions = new ControlPlaneSessionSubscriptionService({
       client: options.client,
       onSessionsUpdated: () => {
-        void this.refreshSessions().catch((error) => this.setSnapshot({ error: formatError(error) }));
+        void this.refreshSessions().catch((error) => this.state.patch({ error: formatError(error) }));
       },
-      onSessionEvent: (workspaceId, event) => this.applySessionEvent(workspaceId, event),
-      onSessionListError: (error) => this.setSnapshot({ error: error.message }),
+      onSessionEvent: (workspaceId, event) => this.liveEvents.applySessionEvent(workspaceId, event),
+      onSessionListError: (error) => this.state.patch({ error: error.message }),
       onSessionStreamError: (error) => {
-        this.setSnapshot({ streamConnected: false, liveStatus: error.message });
+        this.state.patch({ streamConnected: false, liveStatus: error.message });
       },
       onSessionStreamStarted: () => {
-        this.setSnapshot({ streamConnected: true });
+        this.state.patch({ streamConnected: true });
       },
       onSessionStreamComplete: () => {
-        this.setSnapshot({ streamConnected: false });
+        this.state.patch({ streamConnected: false });
       },
     });
     this.assistantStreamBuffer = new AssistantStreamBufferService({
       renderIntervalMs: ASSISTANT_STREAM_RENDER_INTERVAL_MS,
       canApply: (update) => (
-        this.isActiveSessionAddress(update.workspaceId, update.sessionId) &&
-        this.isRunAcceptingLiveAssistantStream()
+        this.state.isActiveSessionAddress(update.workspaceId, update.sessionId) &&
+        (this.state.getSnapshot().running || this.state.getSnapshot().submitting)
       ),
-      apply: (update) => this.applyAssistantStreamUpdate(update),
+      apply: (update) => this.liveEvents.applyAssistantStreamUpdate(update),
     });
     this.runStatePoller = new SessionRunStatePollerService({
       intervalMs: RUN_STATE_POLL_INTERVAL_MS,
-      getAddress: () => this.resolveRunStatePollAddress(),
-      isEnabled: () => this.shouldPollRunState(),
-      poll: (address) => this.pollRunState(address),
-      onError: (error) => this.setSnapshot({ error: formatError(error) }),
+      getAddress: () => this.runs.resolveRunStatePollAddress(),
+      isEnabled: () => this.runs.shouldPollRunState(),
+      poll: (address) => this.runs.pollRunState(address),
+      onError: (error) => this.state.patch({ error: formatError(error) }),
+    });
+    this.loader = new ControlPlaneSessionLoader({
+      api: this.api,
+      state: this.state,
+      subscriptions: this.subscriptions,
+      assistantStreamBuffer: this.assistantStreamBuffer,
+      onRefreshPendingApproval: (sessionId) => this.approvals.refresh(sessionId),
+      onError: formatError,
+    });
+    this.approvals = new ControlPlaneApprovalController({
+      api: this.api,
+      state: this.state,
+      formatError,
+    });
+    this.liveEvents = new ControlPlaneLiveEventReducer({
+      state: this.state,
+      loader: this.loader,
+      assistantStreamBuffer: this.assistantStreamBuffer,
+      refreshSessions: () => this.refreshSessions(),
+      refreshPendingApproval: (sessionId) => this.approvals.refresh(sessionId),
+    });
+    this.directShell = new ControlPlaneDirectShellController({
+      api: this.api,
+      state: this.state,
+      loader: this.loader,
+      assistantStreamBuffer: this.assistantStreamBuffer,
+      refreshSessions: () => this.refreshSessions(),
+      refreshPendingApproval: (sessionId) => this.approvals.refresh(sessionId),
+      formatError,
+    });
+    this.runs = new ControlPlaneRunController({
+      api: this.api,
+      state: this.state,
+      loader: this.loader,
+      approvals: this.approvals,
+      refreshSessions: () => this.refreshSessions(),
+      formatError,
+    });
+    this.slashCommands = new ControlPlaneSlashCommandController({
+      api: this.api,
+      state: this.state,
+      loader: this.loader,
+      formatError,
+    });
+    this.prompts = new ControlPlanePromptController({
+      api: this.api,
+      state: this.state,
+      loader: this.loader,
+      assistantStreamBuffer: this.assistantStreamBuffer,
+      slashCommands: this.slashCommands,
+      directShell: this.directShell,
+      refreshSessions: () => this.refreshSessions(),
+      refreshPendingApproval: (sessionId) => this.approvals.refresh(sessionId),
+      formatError,
     });
   }
 
-  getSnapshot = (): ControlPlaneSessionStoreSnapshot => this.snapshotValue;
+  getSnapshot = (): ControlPlaneSessionStoreSnapshot => this.state.getSnapshot();
 
   subscribe = (listener: () => void): (() => void) => {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
+    return this.state.subscribe(listener);
   };
 
   async start(input: ControlPlaneSessionStoreStartInput = {}): Promise<void> {
-    this.setSnapshot({ loading: true, error: undefined });
+    this.state.patch({ loading: true, error: undefined });
     try {
       const workspaceId = await this.api.resolveWorkspaceId(input.workspaceId);
       const modelOptions = await this.api.getModelOptions();
 
-      this.setSnapshot({ workspaceId, modelOptions });
+      this.state.patch({ workspaceId, modelOptions });
       await this.refreshSlashCommandCatalog(workspaceId);
       this.subscriptions.subscribeToSessionList(workspaceId);
       const sessions = await this.refreshSessions();
       const sessionId = input.sessionId ?? sessions[0]?.id ?? (await this.createSession()).id;
       await this.selectSession(sessionId);
     } catch (error) {
-      this.setSnapshot({ error: formatError(error), loading: false });
+      this.state.patch({ error: formatError(error), loading: false });
     }
   }
 
@@ -183,699 +182,63 @@ export class ControlPlaneSessionStore {
   }
 
   async refreshSessions(): Promise<ControlPlaneSessionView[]> {
-    const workspaceId = this.requireWorkspaceId();
-    const sessions = await this.api.listSessions(workspaceId);
-    this.setSnapshot({ sessions });
-    return sessions;
+    return this.loader.refreshSessions();
   }
 
   async searchWorkspaceFileMentions(query: string, limit = 20): Promise<ControlPlaneWorkspaceFileSuggestion[]> {
-    const workspaceId = this.requireWorkspaceId();
+    const workspaceId = this.state.requireWorkspaceId();
     const result = await this.api.searchWorkspaceFiles({ workspaceId, query, limit });
     return result.workspaceId === workspaceId ? result.files : [];
   }
 
   async createSession(input: ControlPlaneSessionCreateInput = {}): Promise<ControlPlaneSessionView> {
-    const workspaceId = this.requireWorkspaceId();
-    const session = await this.api.createSession(workspaceId, input);
-    await this.refreshSessions();
-    return session;
+    return this.loader.createSession(input);
   }
 
   async selectSession(sessionId: string): Promise<void> {
-    const workspaceId = this.requireWorkspaceId();
-    this.assistantStreamBuffer.reset();
-    this.setSnapshot({
-      activeSessionId: sessionId,
-      activeSession: null,
-      runtimeContext: undefined,
-      pendingApproval: null,
-      pendingDirectShellConfirmation: undefined,
-      liveStatus: undefined,
-      currentActivity: undefined,
-      activePlan: undefined,
-      latestUpdate: undefined,
-      error: undefined,
-      loading: true,
-      streamConnected: false,
-    });
-
-    try {
-      const session = await this.api.getSession(workspaceId, sessionId);
-      const runtimeContext = await this.api.getRuntimeContext(workspaceId, sessionId);
-      const running = await this.api.getRunning(workspaceId, sessionId);
-      this.setSnapshot({
-        activeSession: session,
-        runtimeContext,
-        running: running.running,
-        loading: false,
-      });
-      await this.refreshPendingApproval(sessionId);
-      this.subscriptions.subscribeToSessionEvents(workspaceId, sessionId);
-    } catch (error) {
-      this.setSnapshot({ error: formatError(error), loading: false });
-    }
+    await this.loader.selectSession(sessionId);
   }
 
   async submitPrompt(prompt: string): Promise<void> {
-    const trimmed = prompt.trim();
-    if (!trimmed || this.snapshotValue.submitting) {
-      return;
-    }
-
-    if (SlashCommandAutocompleteService.isSlashDraft(trimmed)) {
-      await this.executeSlashCommand(trimmed);
-      return;
-    }
-
-    const directShell = ClientSharedPromptInputService.parseDirectShellDraft(trimmed);
-    if (directShell) {
-      await this.executeDirectShell(directShell.command);
-      return;
-    }
-
-    const workspaceId = this.requireWorkspaceId();
-    const sessionId = this.requireActiveSessionId();
-    this.setSnapshot((current) => ({
-      submitting: true,
-      running: true,
-      error: undefined,
-      activePlan: undefined,
-      currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
-      liveStatus: current.streamConnected
-        ? 'Heddle is working...'
-        : 'Heddle is working... reconnecting live stream if needed.',
-      latestUpdate: {
-        label: 'Thinking',
-        detail: 'waiting for model or tool activity',
-        tone: 'info',
-      },
-    }));
-
-    try {
-      const result = await this.api.sendPromptAsync({
-        workspaceId,
-        sessionId,
-        prompt: trimmed,
-      });
-      if ('queued' in result) {
-        this.setSnapshot({
-          submitting: false,
-          running: this.snapshotValue.running,
-          liveStatus: this.snapshotValue.running
-            ? this.snapshotValue.liveStatus
-            : 'Queued prompt will run when earlier work finishes.',
-          latestUpdate: {
-            label: 'Prompt queued',
-            detail: `position ${result.position}`,
-            tone: 'info',
-          },
-        });
-        await this.refreshSession(sessionId, { silent: true });
-        await this.refreshSessions();
-        return;
-      }
-
-      this.assistantStreamBuffer.reset();
-      this.setSnapshot({
-        submitting: false,
-        running: true,
-        liveStatus: this.snapshotValue.streamConnected
-          ? 'Heddle is working...'
-          : 'Heddle is working... reconnecting live stream if needed.',
-        currentActivity: this.snapshotValue.currentActivity ?? ClientSharedSessionActivityService.createThinkingStatus(),
-        latestUpdate: {
-          label: 'Run accepted',
-          detail: result.runId,
-          tone: 'info',
-        },
-      });
-      await this.refreshSession(sessionId, { silent: true });
-      await this.refreshSessions();
-      await this.refreshPendingApproval(sessionId);
-    } catch (error) {
-      if (isRunAlreadyInProgressError(error)) {
-        this.setSnapshot({
-          error: undefined,
-          running: true,
-          submitting: false,
-          liveStatus: this.snapshotValue.streamConnected
-            ? 'A run is already in progress for this session.'
-            : 'A run is already in progress for this session. Reconnecting live stream if needed.',
-          currentActivity: this.snapshotValue.currentActivity ?? ClientSharedSessionActivityService.createThinkingStatus(),
-          latestUpdate: {
-            label: 'Run already in progress',
-            detail: 'waiting for current run to finish',
-            tone: 'warning',
-          },
-        });
-        return;
-      }
-
-      this.setSnapshot({
-        error: formatError(error),
-        running: false,
-        submitting: false,
-        liveStatus: undefined,
-        currentActivity: undefined,
-      });
-      await this.refreshSession(sessionId, { silent: true }).catch(() => undefined);
-      this.assistantStreamBuffer.reset();
-    }
+    await this.prompts.submitPrompt(prompt);
   }
 
   getSlashCommandHints(draft: string): ControlPlaneSlashCommandHint[] {
-    return SlashCommandAutocompleteService.filterHints(draft, this.snapshotValue.slashCommandCatalog?.hints ?? []);
+    return SlashCommandAutocompleteService.filterHints(draft, this.state.getSnapshot().slashCommandCatalog?.hints ?? []);
   }
 
   completeSlashCommandDraft(draft: string): string | undefined {
-    return SlashCommandAutocompleteService.complete(draft, this.snapshotValue.slashCommandCatalog?.hints ?? []);
+    return SlashCommandAutocompleteService.complete(draft, this.state.getSnapshot().slashCommandCatalog?.hints ?? []);
   }
 
   async selectModelFromPicker(modelId: string): Promise<void> {
-    await this.executeSlashCommand(`/model ${modelId}`);
+    await this.slashCommands.execute(`/model ${modelId}`);
   }
 
   async selectSessionFromPicker(sessionId: string): Promise<void> {
-    await this.executeSlashCommand(`/session switch ${sessionId}`);
+    await this.slashCommands.execute(`/session switch ${sessionId}`);
   }
 
   async selectReasoningFromPicker(reasoningEffort: string): Promise<void> {
-    await this.executeSlashCommand(reasoningEffort === 'default' ? '/reasoning default' : `/reasoning ${reasoningEffort}`);
+    await this.slashCommands.execute(reasoningEffort === 'default' ? '/reasoning default' : `/reasoning ${reasoningEffort}`);
   }
 
   async cancelRun(): Promise<void> {
-    const workspaceId = this.requireWorkspaceId();
-    const sessionId = this.requireActiveSessionId();
-    this.setSnapshot({
-      cancelling: true,
-      error: undefined,
-      liveStatus: 'Stop requested. Waiting for the current step to settle...',
-      latestUpdate: {
-        label: 'Stop requested',
-        tone: 'warning',
-      },
-    });
-
-    try {
-      const result = await this.api.cancelRun(workspaceId, sessionId);
-      await this.refreshPendingApproval(sessionId);
-      const running = await this.api.getRunning(workspaceId, sessionId);
-      this.setSnapshot({
-        running: result.cancelled ? running.running : false,
-        cancelling: false,
-        liveStatus: result.cancelled && running.running ? this.snapshotValue.liveStatus : undefined,
-        currentActivity: result.cancelled && running.running ? this.snapshotValue.currentActivity : undefined,
-        latestUpdate: {
-          label: result.cancelled ? 'Stop request accepted' : 'No active run to stop',
-          tone: result.cancelled ? 'warning' : 'info',
-        },
-      });
-    } catch (error) {
-      this.setSnapshot({
-        error: formatError(error),
-        cancelling: false,
-        liveStatus: undefined,
-        currentActivity: undefined,
-      });
-    }
+    await this.runs.cancelRun();
   }
 
   async resolvePendingApproval(decision: ControlPlaneApprovalDecision): Promise<void> {
-    const workspaceId = this.requireWorkspaceId();
-    const sessionId = this.requireActiveSessionId();
-    this.setSnapshot({
-      approvalResolving: true,
-      error: undefined,
-      latestUpdate: {
-        label: 'Resolving approval',
-        tone: 'info',
-      },
-    });
-
-    try {
-      const result = await this.api.resolvePendingApproval(workspaceId, sessionId, decision);
-      if (!result.resolved) {
-        throw new Error('No pending approval found for this session.');
-      }
-      await this.refreshPendingApproval(sessionId);
-      this.setSnapshot({
-        approvalResolving: false,
-        latestUpdate: {
-          label: 'Approval resolved',
-          detail: decision.type,
-          tone: 'info',
-        },
-      });
-    } catch (error) {
-      this.setSnapshot({
-        approvalResolving: false,
-        error: formatError(error),
-      });
-    }
-  }
-
-  private async refreshSession(sessionId: string, options: { silent?: boolean } = {}): Promise<void> {
-    const workspaceId = this.requireWorkspaceId();
-    if (!options.silent) {
-      this.setSnapshot({ loading: true });
-    }
-
-    try {
-      const next = await this.api.getSession(workspaceId, sessionId);
-      const runtimeContext = await this.api.getRuntimeContext(workspaceId, sessionId);
-      this.setSnapshot((current) => ({
-        activeSession: options.silent
-          ? ClientSharedSessionMessageService.mergeTransientMessages(current.activeSession, next)
-          : next,
-        runtimeContext,
-        loading: false,
-      }));
-    } catch (error) {
-      this.setSnapshot({ error: formatError(error), loading: false });
-    }
-  }
-
-  private async refreshPendingApproval(sessionId: string): Promise<void> {
-    const workspaceId = this.requireWorkspaceId();
-    const pendingApproval = await this.api.getPendingApproval(workspaceId, sessionId);
-    this.setSnapshot({ pendingApproval });
+    await this.approvals.resolve(decision);
   }
 
   private async refreshSlashCommandCatalog(workspaceId: string): Promise<void> {
     const slashCommandCatalog = await this.api.getSlashCommandCatalog(workspaceId);
-    this.setSnapshot({ slashCommandCatalog });
-  }
-
-  private async executeSlashCommand(command: string): Promise<void> {
-    if (this.snapshotValue.running) {
-      this.setSnapshot({
-        commandResults: this.appendCommandResult({
-          handled: true,
-          kind: 'message',
-          message: 'A run is already in progress. Wait for it to finish before running a slash command.',
-        }),
-      });
-      return;
-    }
-
-    const workspaceId = this.requireWorkspaceId();
-    const sessionId = this.requireActiveSessionId();
-    this.setSnapshot({ submitting: true, error: undefined });
-
-    try {
-      const result = await this.api.executeSlashCommand({ workspaceId, sessionId, command });
-      await this.applySlashCommandResult(workspaceId, result);
-    } catch (error) {
-      this.setSnapshot({ error: formatError(error) });
-    } finally {
-      this.setSnapshot({ submitting: false });
-    }
-  }
-
-  private async executeDirectShell(command: string): Promise<void> {
-    if (!command.trim()) {
-      this.setSnapshot({
-        error: 'Direct shell command cannot be empty.',
-      });
-      return;
-    }
-
-    if (this.snapshotValue.running) {
-      this.setSnapshot({
-        error: undefined,
-        latestUpdate: {
-          label: 'Direct shell blocked',
-          detail: 'wait for the current run to finish',
-          tone: 'warning',
-        },
-      });
-      return;
-    }
-
-    const workspaceId = this.requireWorkspaceId();
-    const sessionId = this.requireActiveSessionId();
-    const preflight = await this.api.preflightDirectShell({ workspaceId, sessionId, command });
-    if (preflight.risk === 'blocked') {
-      this.setSnapshot({
-        error: preflight.reason ?? 'Direct shell command is blocked by shell policy.',
-      });
-      return;
-    }
-
-    if (preflight.risk === 'confirmRequired') {
-      this.setSnapshot({
-        pendingDirectShellConfirmation: preflight,
-        error: undefined,
-        latestUpdate: {
-          label: 'Confirm shell command',
-          detail: preflight.reason,
-          tone: 'warning',
-        },
-      });
-      return;
-    }
-
-    await this.startDirectShellRun(command);
+    this.state.patch({ slashCommandCatalog });
   }
 
   async resolveDirectShellConfirmation(accepted: boolean): Promise<void> {
-    const pending = this.snapshotValue.pendingDirectShellConfirmation;
-    if (!pending) {
-      return;
-    }
-
-    this.setSnapshot({ pendingDirectShellConfirmation: undefined });
-    if (!accepted) {
-      this.setSnapshot({
-        latestUpdate: {
-          label: 'Direct shell cancelled',
-          detail: pending.command,
-          tone: 'info',
-        },
-      });
-      return;
-    }
-
-    await this.startDirectShellRun(pending.command, true);
+    await this.directShell.resolveConfirmation(accepted);
   }
-
-  private async startDirectShellRun(command: string, riskAccepted?: boolean): Promise<void> {
-    const workspaceId = this.requireWorkspaceId();
-    const sessionId = this.requireActiveSessionId();
-    this.setSnapshot((current) => ({
-      submitting: true,
-      running: true,
-      error: undefined,
-      pendingDirectShellConfirmation: undefined,
-      activePlan: undefined,
-      currentActivity: {
-        label: 'Running shell',
-        startedAt: new Date().toISOString(),
-        tone: 'info',
-      },
-      liveStatus: current.streamConnected
-        ? 'Running direct shell command...'
-        : 'Running direct shell command... reconnecting live stream if needed.',
-      latestUpdate: {
-        label: 'Direct shell accepted',
-        detail: command,
-        tone: 'info',
-      },
-    }));
-
-    try {
-      const result = await this.api.runDirectShellAsync({ workspaceId, sessionId, command, riskAccepted });
-      this.assistantStreamBuffer.reset();
-      this.setSnapshot({
-        submitting: false,
-        running: 'accepted' in result,
-        latestUpdate: {
-          label: 'Direct shell accepted',
-          detail: 'accepted' in result ? result.runId : undefined,
-          tone: 'info',
-        },
-      });
-      await this.refreshSession(sessionId, { silent: true });
-      await this.refreshSessions();
-      await this.refreshPendingApproval(sessionId);
-    } catch (error) {
-      this.setSnapshot({
-        error: formatError(error),
-        running: false,
-        submitting: false,
-        liveStatus: undefined,
-        currentActivity: undefined,
-      });
-      await this.refreshSession(sessionId, { silent: true }).catch(() => undefined);
-      this.assistantStreamBuffer.reset();
-    }
-  }
-
-  private async applySlashCommandResult(workspaceId: string, result: ControlPlaneSlashCommandResult): Promise<void> {
-    if (result.handled === false) {
-      return;
-    }
-
-    this.setSnapshot({
-      commandResults: this.appendCommandResult(result),
-    });
-
-    const resultSessionId = 'sessionId' in result ? result.sessionId : undefined;
-    if (resultSessionId && resultSessionId !== this.snapshotValue.activeSessionId) {
-      await this.refreshSessions();
-      await this.selectSession(resultSessionId);
-    } else if (this.snapshotValue.activeSessionId) {
-      const sessions = await this.refreshSessions();
-      if (sessions.some((session) => session.id === this.snapshotValue.activeSessionId)) {
-        await this.refreshSession(this.snapshotValue.activeSessionId, { silent: true });
-      } else {
-        await this.selectSession(sessions[0]?.id ?? (await this.createSession()).id);
-      }
-    }
-
-    if (result.kind === 'continue') {
-      const sessionId = resultSessionId ?? this.requireActiveSessionId();
-      await this.continueSession(workspaceId, sessionId);
-      return;
-    }
-
-    if (result.kind === 'execute') {
-      await this.submitAgentPrompt(result.prompt);
-    }
-  }
-
-  private async continueSession(workspaceId: string, sessionId: string): Promise<void> {
-    this.setSnapshot({
-      running: true,
-      activePlan: undefined,
-      currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
-      liveStatus: 'Heddle is continuing from the current transcript...',
-    });
-    await this.api.continueSession(workspaceId, sessionId);
-    await this.refreshSession(sessionId, { silent: true });
-    await this.refreshSessions();
-  }
-
-  private async submitAgentPrompt(prompt: string): Promise<void> {
-    const workspaceId = this.requireWorkspaceId();
-    const sessionId = this.requireActiveSessionId();
-    await this.api.sendPromptAsync({ workspaceId, sessionId, prompt });
-    this.setSnapshot({
-      running: true,
-      activePlan: undefined,
-      currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
-      liveStatus: this.snapshotValue.streamConnected
-        ? 'Heddle is working...'
-        : 'Heddle is working... reconnecting live stream if needed.',
-    });
-    await this.refreshSession(sessionId, { silent: true });
-    await this.refreshSessions();
-  }
-
-  private appendCommandResult(result: ControlPlaneSlashCommandResult): ControlPlaneSlashCommandResult[] {
-    return [...this.snapshotValue.commandResults, result].slice(-5);
-  }
-
-  private applySessionEvent(workspaceId: string, event: ControlPlaneSessionEventEnvelope): void {
-    if (!this.isActiveSessionAddress(workspaceId, event.sessionId)) {
-      return;
-    }
-
-    if (event.type === 'waiting') {
-      this.setSnapshot({
-        liveStatus: 'Waiting for the session event stream...',
-        latestUpdate: {
-          label: 'Waiting for session events',
-          tone: 'info',
-        },
-      });
-      return;
-    }
-
-    if (event.type === 'session.updated' || event.type === 'session.queue.updated') {
-      void this.refreshSession(event.sessionId, { silent: true });
-      return;
-    }
-
-    if (event.type === 'session.approval.updated') {
-      void this.refreshPendingApproval(event.sessionId);
-      return;
-    }
-
-    if (event.type !== 'session.event') {
-      return;
-    }
-
-    event.activities.forEach((activity) => {
-      ClientSharedSessionActivityService.applyActivity(activity, {
-        onAssistantStream: (streamActivity) => {
-          this.assistantStreamBuffer.push({
-            workspaceId,
-            sessionId: event.sessionId,
-            text: streamActivity.text,
-            done: streamActivity.done,
-          });
-        },
-        onRunStarted: (runActivity, liveStatus) => {
-          this.setSnapshot({
-            running: true,
-            liveStatus,
-            currentActivity: ClientSharedSessionActivityService.createThinkingStatus(runActivity.timestamp),
-            latestUpdate: SessionActivityService.resolveLatestUpdate(runActivity),
-          });
-        },
-        onRunFinished: (runActivity, liveStatus) => {
-          this.assistantStreamBuffer.flush();
-          this.setSnapshot({
-            running: false,
-            ...(liveStatus !== undefined ? { liveStatus } : {}),
-            currentActivity: undefined,
-            latestUpdate: SessionActivityService.resolveLatestUpdate(runActivity),
-          });
-          void this.refreshSession(event.sessionId, { silent: true });
-          void this.refreshSessions();
-        },
-        onPendingApprovalChanged: () => {
-          void this.refreshPendingApproval(event.sessionId);
-        },
-        onPlanUpdated: (plan) => {
-          this.setSnapshot({ activePlan: plan });
-        },
-        onPlanCleared: () => {
-          this.setSnapshot({ activePlan: undefined });
-        },
-        onCurrentActivityChanged: (currentActivity) => {
-          this.setSnapshot({ currentActivity });
-        },
-        onLiveStatus: (statusActivity, liveStatus) => {
-          const latestUpdate = SessionActivityService.resolveLatestUpdate(statusActivity);
-          if (liveStatus === undefined && latestUpdate === undefined) {
-            return;
-          }
-
-          this.setSnapshot({
-            ...(liveStatus !== undefined ? { liveStatus } : {}),
-            ...(latestUpdate !== undefined ? { latestUpdate } : {}),
-          });
-        },
-      });
-    });
-  }
-
-  private applyAssistantStreamUpdate(update: AssistantStreamUpdate): void {
-    this.setSnapshot((current) => ({
-      activeSession: ClientSharedSessionMessageService.upsertLiveAssistantMessage(
-        current.activeSession,
-        update.text,
-        update.done,
-      ),
-      ...(!update.done ? { liveStatus: 'Receiving assistant response...' } : {}),
-    }));
-  }
-
-  private isActiveSessionAddress(workspaceId: string, sessionId: string): boolean {
-    return this.snapshotValue.workspaceId === workspaceId && this.snapshotValue.activeSessionId === sessionId;
-  }
-
-  private isRunAcceptingLiveAssistantStream(): boolean {
-    return this.snapshotValue.running || this.snapshotValue.submitting;
-  }
-
-  private requireWorkspaceId(): string {
-    const workspaceId = this.snapshotValue.workspaceId;
-    if (!workspaceId) {
-      throw new Error('Control-plane workspace is not loaded.');
-    }
-    return workspaceId;
-  }
-
-  private requireActiveSessionId(): string {
-    const sessionId = this.snapshotValue.activeSessionId;
-    if (!sessionId) {
-      throw new Error('No active control-plane session is selected.');
-    }
-    return sessionId;
-  }
-
-  private setSnapshot(
-    next:
-      | Partial<ControlPlaneSessionStoreSnapshot>
-      | ((current: ControlPlaneSessionStoreSnapshot) => Partial<ControlPlaneSessionStoreSnapshot>),
-  ): void {
-    const patch = typeof next === 'function' ? next(this.snapshotValue) : next;
-    this.snapshotValue = {
-      ...this.snapshotValue,
-      ...patch,
-    };
-    this.runStatePoller.sync();
-    this.listeners.forEach((listener) => listener());
-  }
-
-  private shouldPollRunState(): boolean {
-    return this.snapshotValue.running || this.snapshotValue.submitting || this.snapshotValue.cancelling;
-  }
-
-  private resolveRunStatePollAddress(): SessionRunStatePollAddress | undefined {
-    const { workspaceId, activeSessionId } = this.snapshotValue;
-    return workspaceId && activeSessionId ? { workspaceId, sessionId: activeSessionId } : undefined;
-  }
-
-  private async pollRunState({ workspaceId, sessionId }: SessionRunStatePollAddress): Promise<void> {
-    const runState = await this.api.getRunState(workspaceId, sessionId);
-    if (!this.isActiveSessionAddress(workspaceId, sessionId)) {
-      return;
-    }
-
-    this.setSnapshot({
-      pendingApproval: runState.pendingApproval,
-      running: runState.running,
-      runtimeContext: this.snapshotValue.runtimeContext
-        ? { ...this.snapshotValue.runtimeContext, running: runState.running }
-        : this.snapshotValue.runtimeContext,
-      cancelling: runState.running ? this.snapshotValue.cancelling : false,
-      latestUpdate: runState.pendingApproval
-        ? {
-          label: 'Approval requested',
-          detail: SessionActivityService.formatPendingApprovalLabel(runState.pendingApproval),
-          tone: 'warning',
-        }
-        : this.snapshotValue.latestUpdate,
-    });
-
-    if (runState.running) {
-      return;
-    }
-
-    if (this.snapshotValue.submitting) {
-      this.setSnapshot({
-        liveStatus: 'Waiting for run acceptance...',
-        latestUpdate: {
-          label: 'Run starting',
-          detail: 'waiting for server acceptance',
-          tone: 'info',
-        },
-      });
-      return;
-    }
-
-    await this.refreshSession(sessionId, { silent: true });
-    await this.refreshSessions();
-    this.setSnapshot({
-      submitting: false,
-      liveStatus: undefined,
-      activePlan: undefined,
-      currentActivity: undefined,
-      latestUpdate: {
-        label: 'Run finished',
-        tone: 'success',
-      },
-    });
-  }
-}
-
-function isRunAlreadyInProgressError(error: unknown): boolean {
-  return formatError(error).includes('A run is already in progress for this session.');
 }
 
 function formatError(error: unknown): string {

--- a/src/cli-v2/state/control-plane-slash-command-controller.ts
+++ b/src/cli-v2/state/control-plane-slash-command-controller.ts
@@ -1,0 +1,116 @@
+import { ClientSharedSessionActivityService } from '@/client-shared/services/session-activities/index.js';
+import type { ControlPlaneSlashCommandResult } from '@/client-shared/api/types.js';
+import type { ControlPlaneSessionApiService } from '../services/sessions/control-plane-session-api-service.js';
+import type { ControlPlaneSessionLoader } from './control-plane-session-loader.js';
+import type { ControlPlaneSessionState } from './control-plane-session-state.js';
+
+type ControlPlaneSlashCommandControllerOptions = {
+  api: ControlPlaneSessionApiService;
+  state: ControlPlaneSessionState;
+  loader: ControlPlaneSessionLoader;
+  formatError: (error: unknown) => string;
+};
+
+/**
+ * Owns cli-v2 slash command execution workflow.
+ *
+ * Core/control-plane owns command modules, parsing, aliases, and result
+ * semantics. This controller owns only TUI orchestration after the API returns:
+ * command-result retention, session switching, refresh ordering, and follow-on
+ * continue/execute actions.
+ */
+export class ControlPlaneSlashCommandController {
+  constructor(private readonly options: ControlPlaneSlashCommandControllerOptions) {}
+
+  async execute(command: string): Promise<void> {
+    if (this.options.state.getSnapshot().running) {
+      this.options.state.patch({
+        commandResults: this.appendCommandResult({
+          handled: true,
+          kind: 'message',
+          message: 'A run is already in progress. Wait for it to finish before running a slash command.',
+        }),
+      });
+      return;
+    }
+
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const sessionId = this.options.state.requireActiveSessionId();
+    this.options.state.patch({ submitting: true, error: undefined });
+
+    try {
+      const result = await this.options.api.executeSlashCommand({ workspaceId, sessionId, command });
+      await this.applyResult(workspaceId, result);
+    } catch (error) {
+      this.options.state.patch({ error: this.options.formatError(error) });
+    } finally {
+      this.options.state.patch({ submitting: false });
+    }
+  }
+
+  private async applyResult(workspaceId: string, result: ControlPlaneSlashCommandResult): Promise<void> {
+    if (result.handled === false) {
+      return;
+    }
+
+    this.options.state.patch({
+      commandResults: this.appendCommandResult(result),
+    });
+
+    const resultSessionId = 'sessionId' in result ? result.sessionId : undefined;
+    const activeSessionId = this.options.state.getSnapshot().activeSessionId;
+    if (resultSessionId && resultSessionId !== activeSessionId) {
+      await this.options.loader.refreshSessions();
+      await this.options.loader.selectSession(resultSessionId);
+    } else if (activeSessionId) {
+      const sessions = await this.options.loader.refreshSessions();
+      if (sessions.some((session) => session.id === activeSessionId)) {
+        await this.options.loader.refreshSession(activeSessionId, { silent: true });
+      } else {
+        await this.options.loader.selectSession(sessions[0]?.id ?? (await this.options.loader.createSession()).id);
+      }
+    }
+
+    if (result.kind === 'continue') {
+      const sessionId = resultSessionId ?? this.options.state.requireActiveSessionId();
+      await this.continueSession(workspaceId, sessionId);
+      return;
+    }
+
+    if (result.kind === 'execute') {
+      await this.submitAgentPrompt(result.prompt);
+    }
+  }
+
+  private async continueSession(workspaceId: string, sessionId: string): Promise<void> {
+    this.options.state.patch({
+      running: true,
+      activePlan: undefined,
+      currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
+      liveStatus: 'Heddle is continuing from the current transcript...',
+    });
+    await this.options.api.continueSession(workspaceId, sessionId);
+    await this.options.loader.refreshSession(sessionId, { silent: true });
+    await this.options.loader.refreshSessions();
+  }
+
+  private async submitAgentPrompt(prompt: string): Promise<void> {
+    const workspaceId = this.options.state.requireWorkspaceId();
+    const sessionId = this.options.state.requireActiveSessionId();
+    await this.options.api.sendPromptAsync({ workspaceId, sessionId, prompt });
+    this.options.state.patch({
+      running: true,
+      activePlan: undefined,
+      currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
+      liveStatus: this.options.state.getSnapshot().streamConnected
+        ? 'Heddle is working...'
+        : 'Heddle is working... reconnecting live stream if needed.',
+    });
+    await this.options.loader.refreshSession(sessionId, { silent: true });
+    await this.options.loader.refreshSessions();
+  }
+
+  private appendCommandResult(result: ControlPlaneSlashCommandResult): ControlPlaneSlashCommandResult[] {
+    return [...this.options.state.getSnapshot().commandResults, result].slice(-5);
+  }
+}


### PR DESCRIPTION
## Summary
- split the cli-v2 control-plane session store into a small facade plus focused workflow owners for snapshot state, loading, prompt routing, slash commands, direct shell, approvals, run polling, and live events
- removed private one-line forwarding wrappers from the store facade; callback wiring now points at the owning service/controller directly
- documented the state-layer ownership rules and no-thin-wrapper invariants
- preserved the existing public store API used by Ink components while keeping domain policy in control-plane/client-shared/core owners

## Tests
- yarn typecheck
- yarn test src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/unit/cli-v2/prompt-activity.test.ts src/__tests__/unit/cli-v2/runtime-status.test.ts src/__tests__/unit/cli-v2/file-mention-picker.test.tsx
- yarn build
- rg -n "from ['\"](@/core|@/server|@/cli/chat)|from ['\"].*(core|server|cli/chat)" src/cli-v2
- rg -n "runShellCommand|shell-process|ConversationDirectShellService|ToolApprovalService" src/cli-v2 src/web-v2

## Manual regression surface
- cli-v2 startup, workspace/session loading, and switching sessions
- normal prompt submit, queued prompt submit during active run, and assistant stream rendering
- slash command execution, command result retention, and command-driven session switching/continue
- direct shell preflight, confirmation/cancel/run, and direct shell result activity
- pending approval refresh/resolution, run cancellation, and polling recovery when live events lag
- plan/current activity/latest activity rendering, runtime status bar, and file mention search