### PR TITLE
Refactor runtime registry ownership

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "eslint .",
     "lint": "yarn eslint",
     "release:context": "node scripts/release-context.mjs",
-    "build": "yarn clean && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && yarn client:build",
+    "build": "yarn clean && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && node scripts/mark-bin-executable.mjs && yarn client:build",
     "client:build": "tsc -p src/web-v2/tsconfig.json --noEmit && vite build --config src/web-v2/vite.config.ts",
     "client:dev": "vite --config src/web-v2/vite.config.ts",
     "client:build:v1": "tsc -p src/web/tsconfig.json --noEmit && vite build --config src/web/vite.config.ts",

--- a/scripts/mark-bin-executable.mjs
+++ b/scripts/mark-bin-executable.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { chmodSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const binPaths = [
+  'dist/src/cli/main.js',
+];
+
+for (const binPath of binPaths) {
+  const absolutePath = resolve(repoRoot, binPath);
+  if (!existsSync(absolutePath)) {
+    throw new Error(`Missing built bin entrypoint: ${binPath}`);
+  }
+  chmodSync(absolutePath, 0o755);
+}

--- a/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
+++ b/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
@@ -96,7 +96,8 @@ test('navigates primary and settings routes without hash routing', async ({ page
 });
 
 test('shows task run workbench and run details', async ({ page }) => {
-  await trpc.controlPlane.workspaceSetActive.mutate({ workspaceId: 'default' });
+  const state = await trpc.controlPlane.state.query();
+  await trpc.controlPlane.workspaceSetActive.mutate({ workspaceId: state.activeWorkspaceId });
   await page.goto('/tasks');
   const taskList = page.getByRole('region', { name: 'Tasks' });
 

--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -8,7 +8,7 @@ import { ConversationCompactionService } from '@/core/chat/engine/compaction/ind
 import { createConversationEngine } from '@/core/chat/engine/conversation-engine.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import { AgentLoopRuntimeService } from '@/core/runtime/loop/index.js';
-import { DEFAULT_WORKSPACE_ID, RuntimeWorkspaceService, type WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
+import { RuntimeWorkspaceService, type WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
 import type { HeddleServerContext } from '@/server/types.js';
 
@@ -41,14 +41,14 @@ describe('control-plane session lifecycle API', () => {
   });
 
   it('scopes lifecycle mutations to the requested workspace', async () => {
-    const { caller, secondaryWorkspace, createEngineForWorkspace } = createControlPlaneCaller();
-    const defaultEngine = createEngineForWorkspace(DEFAULT_WORKSPACE_ID);
+    const { caller, activeWorkspace, secondaryWorkspace, createEngineForWorkspace } = createControlPlaneCaller();
+    const defaultEngine = createEngineForWorkspace(activeWorkspace.id);
     const secondaryEngine = createEngineForWorkspace(secondaryWorkspace.id);
     defaultEngine.sessions.create({
       id: 'same-session-id',
       name: 'Default workspace session',
       apiKeyPresent: true,
-      workspaceId: DEFAULT_WORKSPACE_ID,
+      workspaceId: activeWorkspace.id,
     });
     secondaryEngine.sessions.create({
       id: 'same-session-id',
@@ -63,7 +63,7 @@ describe('control-plane session lifecycle API', () => {
       name: 'Renamed secondary session',
     });
 
-    await expect(caller.session({ workspaceId: DEFAULT_WORKSPACE_ID, id: 'same-session-id' })).resolves.toMatchObject({
+    await expect(caller.session({ workspaceId: activeWorkspace.id, id: 'same-session-id' })).resolves.toMatchObject({
       id: 'same-session-id',
       name: 'Default workspace session',
     });
@@ -87,12 +87,12 @@ describe('control-plane session lifecycle API', () => {
   });
 
   it('resets session transcript state through the API', async () => {
-    const { caller, engine } = createControlPlaneCaller();
+    const { caller, engine, activeWorkspace } = createControlPlaneCaller();
     const session = engine.sessions.create({
       id: 'session-reset-api',
       name: 'Reset API session',
       apiKeyPresent: true,
-      workspaceId: DEFAULT_WORKSPACE_ID,
+      workspaceId: activeWorkspace.id,
     });
     engine.sessions.appendMessage(session.id, {
       id: 'local-user-message',
@@ -113,12 +113,12 @@ describe('control-plane session lifecycle API', () => {
   });
 
   it('runs direct shell through the control-plane session API', async () => {
-    const { caller, engine } = createControlPlaneCaller();
+    const { caller, engine, activeWorkspace } = createControlPlaneCaller();
     const session = engine.sessions.create({
       id: 'direct-shell-api',
       name: 'Direct shell API session',
       apiKeyPresent: true,
-      workspaceId: DEFAULT_WORKSPACE_ID,
+      workspaceId: activeWorkspace.id,
     });
 
     await expect(caller.sessionDirectShellAsync({
@@ -147,12 +147,12 @@ describe('control-plane session lifecycle API', () => {
   });
 
   it('preflights direct shell risk before interfaces ask for confirmation', async () => {
-    const { caller, engine } = createControlPlaneCaller();
+    const { caller, engine, activeWorkspace } = createControlPlaneCaller();
     const session = engine.sessions.create({
       id: 'direct-shell-preflight-api',
       name: 'Direct shell preflight API session',
       apiKeyPresent: true,
-      workspaceId: DEFAULT_WORKSPACE_ID,
+      workspaceId: activeWorkspace.id,
     });
 
     await expect(caller.sessionDirectShellPreflight({
@@ -175,12 +175,12 @@ describe('control-plane session lifecycle API', () => {
   });
 
   it('blocks destructive lifecycle mutations while another client owns the session lease', async () => {
-    const { caller, engine } = createControlPlaneCaller();
+    const { caller, engine, activeWorkspace } = createControlPlaneCaller();
     const session = engine.sessions.create({
       id: 'leased-session-api',
       name: 'Leased API session',
       apiKeyPresent: true,
-      workspaceId: DEFAULT_WORKSPACE_ID,
+      workspaceId: activeWorkspace.id,
     });
     engine.sessions.acquireLease(session.id, EXTERNAL_TUI_LEASE_OWNER);
 
@@ -199,12 +199,12 @@ describe('control-plane session lifecycle API', () => {
   });
 
   it('compacts a session through the API without requiring clients to call compaction services', async () => {
-    const { caller, engine } = createControlPlaneCaller();
+    const { caller, engine, activeWorkspace } = createControlPlaneCaller();
     const session = engine.sessions.create({
       id: 'session-compact-api',
       name: 'Compact API session',
       apiKeyPresent: true,
-      workspaceId: DEFAULT_WORKSPACE_ID,
+      workspaceId: activeWorkspace.id,
     });
     engine.sessions.update(session.id, (current) => ({
       ...current,
@@ -227,12 +227,12 @@ describe('control-plane session lifecycle API', () => {
   });
 
   it('restores prior compaction state when manual compaction fails', async () => {
-    const { caller, engine } = createControlPlaneCaller();
+    const { caller, engine, activeWorkspace } = createControlPlaneCaller();
     const session = engine.sessions.create({
       id: 'session-compact-failure-api',
       name: 'Compact failure API session',
       apiKeyPresent: true,
-      workspaceId: DEFAULT_WORKSPACE_ID,
+      workspaceId: activeWorkspace.id,
     });
     const priorContext = {
       estimatedHistoryTokens: 42,
@@ -324,7 +324,7 @@ describe('control-plane session lifecycle API', () => {
   });
 
   it('returns selected-session runtime context for commands and status surfaces', async () => {
-    const { caller } = createControlPlaneCaller();
+    const { caller, activeWorkspace } = createControlPlaneCaller();
     const session = await caller.sessionCreate({ name: 'Runtime context session', model: 'gpt-5.4' });
     await caller.sessionSettingsUpdate({
       id: session.id,
@@ -335,7 +335,7 @@ describe('control-plane session lifecycle API', () => {
     await expect(caller.sessionRuntimeContext({
       sessionId: session.id,
     })).resolves.toMatchObject({
-      workspaceId: DEFAULT_WORKSPACE_ID,
+      workspaceId: activeWorkspace.id,
       sessionId: session.id,
       sessionName: 'Runtime context session',
       model: 'gpt-5.4',
@@ -385,7 +385,7 @@ describe('control-plane session lifecycle API', () => {
     vi.useFakeTimers();
     vi.stubEnv('HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT', '1');
     try {
-      const { caller } = createControlPlaneCaller();
+      const { caller, activeWorkspace } = createControlPlaneCaller();
       const session = await caller.sessionCreate({ name: 'Async submit session' });
 
       const accepted = await caller.sessionSendPromptAsync({
@@ -396,7 +396,7 @@ describe('control-plane session lifecycle API', () => {
       expect(accepted).toMatchObject({
         accepted: true,
         sessionId: session.id,
-        workspaceId: DEFAULT_WORKSPACE_ID,
+        workspaceId: activeWorkspace.id,
       });
       await expect(caller.sessionRunState({ id: session.id })).resolves.toMatchObject({
         running: true,
@@ -553,10 +553,10 @@ function createControlPlaneCaller() {
     name: 'Secondary workspace',
     setActive: false,
   });
-  const activeWorkspace = resolved.workspaces.find((workspace) => workspace.id === DEFAULT_WORKSPACE_ID);
+  const activeWorkspace = resolved.workspaces.find((workspace) => workspace.id === resolved.activeWorkspaceId);
   const secondaryWorkspace = resolved.workspaces.find((workspace) => workspace.id === 'workspace-secondary');
   if (!activeWorkspace) {
-    throw new Error('expected default workspace');
+    throw new Error('expected active workspace');
   }
   if (!secondaryWorkspace) {
     throw new Error('expected secondary workspace');
@@ -584,6 +584,7 @@ function createControlPlaneCaller() {
   return {
     caller: controlPlaneRouter.createCaller(context),
     engine: createEngineForWorkspace(activeWorkspace.id),
+    activeWorkspace,
     secondaryWorkspace,
     createEngineForWorkspace,
   };

--- a/src/__tests__/integration/control-plane/workspace-catalog.test.ts
+++ b/src/__tests__/integration/control-plane/workspace-catalog.test.ts
@@ -4,7 +4,6 @@ import { join } from 'node:path';
 import pino from 'pino';
 import { describe, expect, it } from 'vitest';
 import {
-  DEFAULT_WORKSPACE_ID,
   FileWorkspaceRepository,
   RuntimeWorkspaceService,
 } from '@/core/runtime/workspaces/index.js';
@@ -23,18 +22,19 @@ describe('workspace catalog', () => {
     expect(existsSync(catalogPath)).toBe(true);
     expect(catalog).toMatchObject({
       version: 1,
-      activeWorkspaceId: DEFAULT_WORKSPACE_ID,
+      activeWorkspaceId: catalog.workspaces[0]?.id,
     });
+    expect(catalog.activeWorkspaceId).toMatch(/^workspace-/);
     expect(catalog.workspaces).toHaveLength(1);
     expect(catalog.workspaces[0]).toMatchObject({
-      id: DEFAULT_WORKSPACE_ID,
+      id: catalog.activeWorkspaceId,
       workspaceRoot,
       repoRoots: [workspaceRoot],
       stateRoot,
     });
 
     const saved = JSON.parse(readFileSync(catalogPath, 'utf8')) as typeof catalog;
-    expect(saved.activeWorkspaceId).toBe(DEFAULT_WORKSPACE_ID);
+    expect(saved.activeWorkspaceId).toBe(catalog.activeWorkspaceId);
     expect(saved.workspaces[0]?.workspaceRoot).toBe(workspaceRoot);
   });
 
@@ -56,19 +56,18 @@ describe('workspace catalog', () => {
       workspaces: catalog.workspaces,
       runtimeHost: {
         mode: 'daemon',
-        ownerId: 'embedded-test',
+        serverId: 'embedded-test',
         registryPath,
         endpoint: { host: '127.0.0.1', port: 0 },
         startedAt: '2026-04-26T00:00:00.000Z',
-        workspaceOwner: null,
       },
       logger: pino({ level: 'silent' }),
     });
 
     const state = await caller.state();
-    expect(state.activeWorkspaceId).toBe(DEFAULT_WORKSPACE_ID);
+    expect(state.activeWorkspaceId).toBe(activeWorkspace.id);
     expect(state.workspace).toMatchObject({
-      id: DEFAULT_WORKSPACE_ID,
+      id: activeWorkspace.id,
       workspaceRoot,
       stateRoot,
     });
@@ -102,7 +101,7 @@ describe('workspace catalog', () => {
     });
 
     expect(created.workspaces).toHaveLength(2);
-    expect(created.activeWorkspaceId).toBe(DEFAULT_WORKSPACE_ID);
+    expect(created.activeWorkspaceId).toBe(created.workspaces[0]?.id);
 
     const switched = RuntimeWorkspaceService.setActive({
       workspaceRoot,
@@ -122,12 +121,16 @@ describe('workspace catalog', () => {
   it('can rename a workspace', () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-workspace-rename-'));
     const stateRoot = join(workspaceRoot, '.heddle');
-    RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
+    const catalog = RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
+    const activeWorkspace = catalog.workspaces[0];
+    if (!activeWorkspace) {
+      throw new Error('expected active workspace');
+    }
 
     const renamed = RuntimeWorkspaceService.rename({
       workspaceRoot,
       stateRoot,
-      workspaceId: DEFAULT_WORKSPACE_ID,
+      workspaceId: activeWorkspace.id,
       name: 'Primary workspace',
     });
 
@@ -153,11 +156,10 @@ describe('workspace catalog', () => {
       workspaces: catalog.workspaces,
       runtimeHost: {
         mode: 'daemon',
-        ownerId: 'daemon-test',
+        serverId: 'daemon-test',
         registryPath,
         endpoint: { host: '127.0.0.1', port: 8765 },
         startedAt: '2026-04-26T00:00:00.000Z',
-        workspaceOwner: null,
       },
       logger: pino({ level: 'silent' }),
     });
@@ -167,18 +169,18 @@ describe('workspace catalog', () => {
       workspaceRoot: join(workspaceRoot, 'second'),
       setActive: true,
     });
-    expect(created.activeWorkspaceId).not.toBe(DEFAULT_WORKSPACE_ID);
+    expect(created.activeWorkspaceId).not.toBe(activeWorkspace.id);
     expect(created.workspace).toMatchObject({
       name: 'Second workspace',
       workspaceRoot: join(workspaceRoot, 'second'),
       stateRoot: join(workspaceRoot, 'second', '.heddle'),
     });
 
-    const switched = await caller.workspaceSetActive({ workspaceId: DEFAULT_WORKSPACE_ID });
-    expect(switched.activeWorkspaceId).toBe(DEFAULT_WORKSPACE_ID);
-    expect(switched.workspace.id).toBe(DEFAULT_WORKSPACE_ID);
+    const switched = await caller.workspaceSetActive({ workspaceId: activeWorkspace.id });
+    expect(switched.activeWorkspaceId).toBe(activeWorkspace.id);
+    expect(switched.workspace.id).toBe(activeWorkspace.id);
 
-    const renamed = await caller.workspaceRename({ workspaceId: DEFAULT_WORKSPACE_ID, name: 'Renamed default' });
+    const renamed = await caller.workspaceRename({ workspaceId: activeWorkspace.id, name: 'Renamed default' });
     expect(renamed.workspace.name).toBe('Renamed default');
 
     const registeredStateRoots = RuntimeDaemonRegistryService.read(registryPath).workspaces.map((record) => record.workspace.stateRoot);
@@ -189,6 +191,7 @@ describe('workspace catalog', () => {
   it('routes session APIs through the requested workspace state root without switching active workspace', async () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-workspace-session-routing-'));
     const stateRoot = join(workspaceRoot, '.heddle');
+    const registryPath = FileDaemonRegistryRepository.resolvePath(mkdtempSync(join(tmpdir(), 'heddle-workspace-session-routing-home-')));
     RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
     const resolved = RuntimeWorkspaceService.createDescriptor({
       workspaceRoot,
@@ -198,7 +201,7 @@ describe('workspace catalog', () => {
       setActive: false,
       nextId: 'workspace-2',
     });
-    const activeWorkspace = resolved.workspaces.find((workspace) => workspace.id === DEFAULT_WORKSPACE_ID);
+    const activeWorkspace = resolved.workspaces.find((workspace) => workspace.id === resolved.activeWorkspaceId);
     const secondWorkspace = resolved.workspaces.find((workspace) => workspace.id === 'workspace-2');
     if (!activeWorkspace || !secondWorkspace) {
       throw new Error('expected both workspaces');
@@ -225,7 +228,13 @@ describe('workspace catalog', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: resolved.workspaces,
-      runtimeHost: null,
+      runtimeHost: {
+        mode: 'daemon',
+        serverId: 'daemon-test',
+        registryPath,
+        endpoint: { host: '127.0.0.1', port: 8765 },
+        startedAt: '2026-04-26T00:00:00.000Z',
+      },
       logger: pino({ level: 'silent' }),
     });
 
@@ -281,7 +290,7 @@ describe('workspace catalog', () => {
       setActive: false,
       nextId: 'workspace-2',
     });
-    const activeWorkspace = resolved.workspaces.find((workspace) => workspace.id === DEFAULT_WORKSPACE_ID);
+    const activeWorkspace = resolved.workspaces.find((workspace) => workspace.id === resolved.activeWorkspaceId);
     const secondWorkspace = resolved.workspaces.find((workspace) => workspace.id === 'workspace-2');
     if (!activeWorkspace || !secondWorkspace) {
       throw new Error('expected both workspaces');
@@ -329,7 +338,7 @@ describe('workspace catalog', () => {
       activeWorkspaceId: 'workspace-2',
       workspaces: [
         {
-          id: DEFAULT_WORKSPACE_ID,
+          id: 'default',
           name: 'Default workspace',
           workspaceRoot,
           repoRoots: [workspaceRoot],
@@ -407,11 +416,10 @@ describe('workspace catalog', () => {
       workspaces: catalog.workspaces,
       runtimeHost: {
         mode: 'daemon',
-        ownerId: 'daemon-test',
+        serverId: 'daemon-test',
         registryPath,
         endpoint: { host: '127.0.0.1', port: 8765 },
         startedAt: '2026-04-26T00:00:00.000Z',
-        workspaceOwner: null,
       },
       logger: pino({ level: 'silent' }),
     });

--- a/src/__tests__/integration/server/daemon-registry.test.ts
+++ b/src/__tests__/integration/server/daemon-registry.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -6,82 +6,70 @@ import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/co
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 
 describe('daemon registry', () => {
-  it('registers daemon ownership for workspace catalog entries', () => {
+  it('records a live control-plane server independently from known workspaces', () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-daemon-registry-'));
     const stateRoot = join(workspaceRoot, '.heddle');
     const registryPath = FileDaemonRegistryRepository.resolvePath(mkdtempSync(join(tmpdir(), 'heddle-daemon-registry-home-')));
     const catalog = RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
 
-    const registry = RuntimeDaemonRegistryService.upsertWorkspaceRegistration({
+    RuntimeDaemonRegistryService.registerKnownWorkspaces({ registryPath, workspaces: catalog.workspaces });
+    const registry = RuntimeDaemonRegistryService.registerLiveServer({
       registryPath,
-      workspaces: catalog.workspaces,
-      owner: {
-        ownerId: 'daemon-1',
+      server: {
+        serverId: 'server-1',
         mode: 'daemon',
         host: '127.0.0.1',
         port: 8765,
         pid: 1234,
         startedAt: '2026-04-21T00:00:00.000Z',
-        workspaceRoot,
-        stateRoot,
       },
     });
 
-    expect(registry.workspaces).toHaveLength(1);
-    expect(registry.workspaces[0]).toMatchObject({
-      workspace: {
-        id: 'default',
-        workspaceRoot,
-      },
-      owner: {
-        ownerId: 'daemon-1',
-        host: '127.0.0.1',
-        port: 8765,
-        workspaceRoot,
-        stateRoot,
-      },
+    expect(registry.server).toMatchObject({
+      serverId: 'server-1',
+      host: '127.0.0.1',
+      port: 8765,
     });
-
-    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, 'default')?.owner?.ownerId).toBe('daemon-1');
+    expect(registry.workspaces).toEqual([
+      expect.objectContaining({
+        workspace: expect.objectContaining({
+          id: catalog.activeWorkspaceId,
+          workspaceRoot,
+        }),
+      }),
+    ]);
+    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, catalog.activeWorkspaceId)?.workspace.workspaceRoot).toBe(workspaceRoot);
   });
 
-  it('clears ownership only for the matching daemon owner', () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-daemon-clear-'));
-    const stateRoot = join(workspaceRoot, '.heddle');
+  it('clears only the matching live control-plane server', () => {
     const registryPath = FileDaemonRegistryRepository.resolvePath(mkdtempSync(join(tmpdir(), 'heddle-daemon-clear-home-')));
-    const catalog = RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
 
-    RuntimeDaemonRegistryService.upsertWorkspaceRegistration({
+    RuntimeDaemonRegistryService.registerLiveServer({
       registryPath,
-      workspaces: catalog.workspaces,
-      owner: {
-        ownerId: 'daemon-1',
+      server: {
+        serverId: 'server-1',
         mode: 'daemon',
         host: '127.0.0.1',
         port: 8765,
         pid: 1234,
         startedAt: '2026-04-21T00:00:00.000Z',
-        workspaceRoot,
-        stateRoot,
       },
     });
 
-    RuntimeDaemonRegistryService.clearWorkspaceRegistration({
+    RuntimeDaemonRegistryService.clearLiveServer({
       registryPath,
-      workspaceIds: ['default'],
-      ownerId: 'daemon-2',
+      serverId: 'server-2',
     });
-    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, 'default')?.owner?.ownerId).toBe('daemon-1');
+    expect(RuntimeDaemonRegistryService.read(registryPath).server?.serverId).toBe('server-1');
 
-    RuntimeDaemonRegistryService.clearWorkspaceRegistration({
+    RuntimeDaemonRegistryService.clearLiveServer({
       registryPath,
-      workspaceIds: ['default'],
-      ownerId: 'daemon-1',
+      serverId: 'server-1',
     });
-    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, 'default')?.owner).toBeUndefined();
+    expect(RuntimeDaemonRegistryService.read(registryPath).server).toBeUndefined();
   });
 
-  it('keeps default-id workspaces distinct by state root', () => {
+  it('keeps generated workspace ids distinct across registered roots', () => {
     const firstRoot = mkdtempSync(join(tmpdir(), 'heddle-daemon-registry-first-'));
     const secondRoot = mkdtempSync(join(tmpdir(), 'heddle-daemon-registry-second-'));
     const registryPath = FileDaemonRegistryRepository.resolvePath(mkdtempSync(join(tmpdir(), 'heddle-daemon-registry-global-home-')));
@@ -92,7 +80,43 @@ describe('daemon registry', () => {
     const registry = RuntimeDaemonRegistryService.registerKnownWorkspaces({ registryPath, workspaces: secondCatalog.workspaces });
 
     expect(registry.workspaces).toHaveLength(2);
-    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, 'default', join(firstRoot, '.heddle'))?.workspace.workspaceRoot).toBe(firstRoot);
-    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, 'default', join(secondRoot, '.heddle'))?.workspace.workspaceRoot).toBe(secondRoot);
+    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, firstCatalog.activeWorkspaceId)?.workspace.workspaceRoot).toBe(firstRoot);
+    expect(RuntimeDaemonRegistryService.readWorkspaceRegistration(registryPath, secondCatalog.activeWorkspaceId)?.workspace.workspaceRoot).toBe(secondRoot);
+  });
+
+  it('normalizes legacy workspace-owner records into a top-level live server', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-daemon-registry-legacy-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const registryPath = FileDaemonRegistryRepository.resolvePath(mkdtempSync(join(tmpdir(), 'heddle-daemon-registry-legacy-home-')));
+    const catalog = RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
+
+    writeFileSync(registryPath, `${JSON.stringify({
+      version: 1,
+      updatedAt: '2026-04-21T00:00:30.000Z',
+      workspaces: [{
+        workspace: catalog.workspaces[0],
+        owner: {
+          ownerId: 'legacy-owner',
+          mode: 'daemon',
+          host: '127.0.0.1',
+          port: 8765,
+          pid: 1234,
+          startedAt: '2026-04-21T00:00:00.000Z',
+          lastSeenAt: '2026-04-21T00:00:30.000Z',
+        },
+        updatedAt: '2026-04-21T00:00:30.000Z',
+      }],
+    }, null, 2)}\n`, 'utf8');
+
+    const registry = RuntimeDaemonRegistryService.read(registryPath);
+
+    expect(registry.server).toMatchObject({
+      serverId: 'legacy-owner',
+      mode: 'daemon',
+      host: '127.0.0.1',
+      port: 8765,
+    });
+    expect(readFileSync(registryPath, 'utf8')).toContain('owner');
+    expect(RuntimeDaemonRegistryService.registerKnownWorkspaces({ registryPath, workspaces: catalog.workspaces }).workspaces[0]).not.toHaveProperty('owner');
   });
 });

--- a/src/__tests__/integration/server/runtime-hosts.test.ts
+++ b/src/__tests__/integration/server/runtime-hosts.test.ts
@@ -8,92 +8,72 @@ import {
   RuntimeHostMessages,
   RuntimeHostResolver,
 } from '@/core/runtime/daemon/index.js';
-import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 
 describe('runtime host discovery', () => {
-  it('returns none when no daemon owner exists for the workspace', () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-runtime-host-none-'));
-    const stateRoot = join(workspaceRoot, '.heddle');
+  it('returns none when no live control-plane server exists', () => {
     const registryPath = FileDaemonRegistryRepository.resolvePath(mkdtempSync(join(tmpdir(), 'heddle-runtime-host-none-home-')));
 
-    RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
-    const resolved = RuntimeHostResolver.resolveWorkspaceHost({ workspaceRoot, stateRoot, registryPath });
+    const resolved = RuntimeHostResolver.resolveLiveServer({ registryPath });
 
     expect(resolved).toMatchObject({
       kind: 'none',
-      workspaceId: 'default',
+      registryPath,
     });
   });
 
-  it('returns active daemon ownership when the registry owner is fresh', () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-runtime-host-daemon-'));
-    const stateRoot = join(workspaceRoot, '.heddle');
+  it('returns the live control-plane server when the registry heartbeat is fresh', () => {
     const registryPath = FileDaemonRegistryRepository.resolvePath(mkdtempSync(join(tmpdir(), 'heddle-runtime-host-home-')));
-    const catalog = RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
 
-    RuntimeDaemonRegistryService.upsertWorkspaceRegistration({
+    RuntimeDaemonRegistryService.registerLiveServer({
       registryPath,
-      workspaces: catalog.workspaces,
-      owner: {
-        ownerId: 'daemon-1',
+      server: {
+        serverId: 'server-1',
         mode: 'daemon',
         host: '127.0.0.1',
         port: 8765,
         pid: 42,
         startedAt: '2026-04-21T00:00:00.000Z',
         lastSeenAt: '2026-04-21T00:00:30.000Z',
-        workspaceRoot,
-        stateRoot,
       },
     });
 
-    const resolved = RuntimeHostResolver.resolveWorkspaceHost({
-      workspaceRoot,
-      stateRoot,
+    const resolved = RuntimeHostResolver.resolveLiveServer({
       registryPath,
       now: Date.parse('2026-04-21T00:00:45.000Z'),
       isPidAlive: () => true,
     });
 
     expect(resolved).toMatchObject({
-      kind: 'daemon',
-      ownerId: 'daemon-1',
+      kind: 'server',
+      serverId: 'server-1',
       endpoint: {
         host: '127.0.0.1',
         port: 8765,
       },
       stale: false,
     });
-    expect(RuntimeHostMessages.formatNotice('chat', resolved)).toContain('Embedded chat still works here');
+    expect(RuntimeHostMessages.formatNotice('chat', resolved)).toContain('live control-plane server');
     expect(RuntimeHostMessages.embeddedCommandConflict('chat', resolved)).toContain('Refusing embedded `chat`');
     expect(RuntimeHostMessages.daemonStartConflict(resolved)).toContain('Refusing to start a second daemon');
   });
 
-  it('marks daemon ownership stale when lastSeenAt is too old', () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-runtime-host-stale-'));
-    const stateRoot = join(workspaceRoot, '.heddle');
+  it('marks the live server stale when lastSeenAt is too old', () => {
     const registryPath = FileDaemonRegistryRepository.resolvePath(mkdtempSync(join(tmpdir(), 'heddle-runtime-host-stale-home-')));
-    const catalog = RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
 
-    RuntimeDaemonRegistryService.upsertWorkspaceRegistration({
+    RuntimeDaemonRegistryService.registerLiveServer({
       registryPath,
-      workspaces: catalog.workspaces,
-      owner: {
-        ownerId: 'daemon-1',
+      server: {
+        serverId: 'server-1',
         mode: 'daemon',
         host: '127.0.0.1',
         port: 8765,
         pid: 42,
         startedAt: '2026-04-21T00:00:00.000Z',
         lastSeenAt: '2026-04-21T00:00:00.000Z',
-        workspaceRoot,
-        stateRoot,
       },
     });
 
-    const resolved = RuntimeHostResolver.resolveWorkspaceHost({
-      workspaceRoot,
-      stateRoot,
+    const resolved = RuntimeHostResolver.resolveLiveServer({
       registryPath,
       now: Date.parse('2026-04-21T00:01:00.000Z'),
       staleAfterMs: 10_000,
@@ -101,7 +81,7 @@ describe('runtime host discovery', () => {
     });
 
     expect(resolved).toMatchObject({
-      kind: 'daemon',
+      kind: 'server',
       stale: true,
     });
     expect(RuntimeHostMessages.formatNotice('ask', resolved)).toBeUndefined();
@@ -109,38 +89,30 @@ describe('runtime host discovery', () => {
     expect(RuntimeHostMessages.daemonStartConflict(resolved)).toBeUndefined();
   });
 
-  it('marks daemon ownership stale when the recorded daemon pid is gone', () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-runtime-host-dead-pid-'));
-    const stateRoot = join(workspaceRoot, '.heddle');
+  it('marks the live server stale when the recorded pid is gone', () => {
     const registryPath = FileDaemonRegistryRepository.resolvePath(mkdtempSync(join(tmpdir(), 'heddle-runtime-host-dead-pid-home-')));
-    const catalog = RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
 
-    RuntimeDaemonRegistryService.upsertWorkspaceRegistration({
+    RuntimeDaemonRegistryService.registerLiveServer({
       registryPath,
-      workspaces: catalog.workspaces,
-      owner: {
-        ownerId: 'daemon-1',
+      server: {
+        serverId: 'server-1',
         mode: 'daemon',
         host: '127.0.0.1',
         port: 8765,
         pid: 4242,
         startedAt: '2026-04-21T00:00:00.000Z',
         lastSeenAt: '2026-04-21T00:00:30.000Z',
-        workspaceRoot,
-        stateRoot,
       },
     });
 
-    const resolved = RuntimeHostResolver.resolveWorkspaceHost({
-      workspaceRoot,
-      stateRoot,
+    const resolved = RuntimeHostResolver.resolveLiveServer({
       registryPath,
       now: Date.parse('2026-04-21T00:00:31.000Z'),
       isPidAlive: () => false,
     });
 
     expect(resolved).toMatchObject({
-      kind: 'daemon',
+      kind: 'server',
       stale: true,
     });
     expect(RuntimeHostMessages.daemonStartConflict(resolved)).toBeUndefined();

--- a/src/__tests__/integration/tui/ask-cli.test.ts
+++ b/src/__tests__/integration/tui/ask-cli.test.ts
@@ -9,6 +9,7 @@ import { FileChatSessionRepository } from '../../../core/chat/engine/sessions/re
 import type { ChatSession } from '../../../core/chat/types.js';
 import * as agentLoopModule from '@/core/runtime/loop/index.js';
 import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
+import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 import type { RunResult } from '../../../index.js';
 import { createHeddleServerApp } from '../../../server/app.js';
 
@@ -108,7 +109,10 @@ describe('AskCliHost.run', () => {
     expect(session?.history).toEqual(result.transcript);
     expect(session?.turns).toHaveLength(1);
     expect(session?.lastContinuePrompt).toBe('inspect the repository');
-    expect(session?.workspaceId).toBe('default');
+    expect(session?.workspaceId).toBe(RuntimeWorkspaceService.resolveContext({
+      workspaceRoot,
+      stateRoot: join(workspaceRoot, '.heddle'),
+    }).activeWorkspace.id);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`Session: ${catalog[0]!.id}`));
   });
 
@@ -329,10 +333,10 @@ describe('AskCliHost.run', () => {
     await onceListening(server);
     const address = server.address() as AddressInfo;
     const runtimeHost: ResolvedRuntimeHost = {
-      kind: 'daemon',
+      kind: 'server',
       registryPath: join(workspaceRoot, 'daemon-registry.json'),
-      workspaceId: 'default',
-      ownerId: 'daemon-owner',
+      serverId: 'daemon-owner',
+      mode: 'daemon',
       endpoint: { host: '127.0.0.1', port: address.port },
       startedAt: '2026-04-21T00:00:00.000Z',
       lastSeenAt: '2026-04-21T00:00:00.000Z',
@@ -391,10 +395,10 @@ describe('AskCliHost.run', () => {
     await onceListening(server);
     const address = server.address() as AddressInfo;
     const runtimeHost: ResolvedRuntimeHost = {
-      kind: 'daemon',
+      kind: 'server',
       registryPath: join(workspaceRoot, 'daemon-registry.json'),
-      workspaceId: 'default',
-      ownerId: 'daemon-owner',
+      serverId: 'daemon-owner',
+      mode: 'daemon',
       endpoint: { host: '127.0.0.1', port: address.port },
       startedAt: '2026-04-21T00:00:00.000Z',
       lastSeenAt: '2026-04-21T00:00:00.000Z',

--- a/src/__tests__/integration/web/control-plane-screens.test.tsx
+++ b/src/__tests__/integration/web/control-plane-screens.test.tsx
@@ -209,11 +209,10 @@ function createControlPlaneState(): ControlPlaneState {
     ],
     runtimeHost: {
       mode: 'daemon',
-      ownerId: 'owner-1',
+      serverId: 'server-1',
       registryPath: '/Users/example/.heddle/daemon.json',
       endpoint: { host: '127.0.0.1', port: 4873 },
       startedAt: '2026-04-02T00:00:00.000Z',
-      workspaceOwner: { ownerId: 'owner-1', workspaceRoot: '/Users/example/primary', stateRoot: '/Users/example/primary/.heddle', lastSeenAt: '2026-04-02T00:10:00.000Z' },
     },
     sessions: [
       createSession('session-one', 'gpt-5.4', 3),

--- a/src/__tests__/unit/control-plane/control-plane-host-surface.test.ts
+++ b/src/__tests__/unit/control-plane/control-plane-host-surface.test.ts
@@ -1,12 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { projectRuntimeHostSurface } from '../../../web/features/control-plane/host-surface.js';
 import type { ControlPlaneState } from '@/server/control-plane-types.js';
 
 describe('projectRuntimeHostSurface', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it('returns local control-plane state when no runtime host is loaded', () => {
     expect(projectRuntimeHostSurface(baseState())).toMatchObject({
       state: 'local',
@@ -15,64 +11,21 @@ describe('projectRuntimeHostSurface', () => {
     });
   });
 
-  it('returns attached state when daemon owner heartbeat is fresh', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-04-21T12:00:30.000Z'));
-
+  it('returns attached state when runtime host metadata is loaded', () => {
     expect(projectRuntimeHostSurface(baseState({
       runtimeHost: {
         mode: 'daemon',
-        ownerId: 'daemon-1',
+        serverId: 'server-1',
         registryPath: '/tmp/registry.json',
         endpoint: { host: '127.0.0.1', port: 8765 },
         startedAt: '2026-04-21T12:00:00.000Z',
-        workspaceOwner: {
-          ownerId: 'daemon-1',
-          mode: 'daemon',
-          host: '127.0.0.1',
-          port: 8765,
-          pid: 123,
-          startedAt: '2026-04-21T12:00:00.000Z',
-          lastSeenAt: '2026-04-21T12:00:10.000Z',
-          workspaceRoot: '/workspace',
-          stateRoot: '/workspace/.heddle',
-        },
       },
     }))).toMatchObject({
       state: 'attached',
-      label: 'Attached to daemon',
+      label: 'Attached to control-plane server',
       tone: 'secondary',
       endpoint: '127.0.0.1:8765',
-    });
-  });
-
-  it('returns stale state when daemon owner heartbeat is too old', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-04-21T12:02:00.000Z'));
-
-    expect(projectRuntimeHostSurface(baseState({
-      runtimeHost: {
-        mode: 'daemon',
-        ownerId: 'daemon-1',
-        registryPath: '/tmp/registry.json',
-        endpoint: { host: '127.0.0.1', port: 8765 },
-        startedAt: '2026-04-21T12:00:00.000Z',
-        workspaceOwner: {
-          ownerId: 'daemon-1',
-          mode: 'daemon',
-          host: '127.0.0.1',
-          port: 8765,
-          pid: 123,
-          startedAt: '2026-04-21T12:00:00.000Z',
-          lastSeenAt: '2026-04-21T12:00:10.000Z',
-          workspaceRoot: '/workspace',
-          stateRoot: '/workspace/.heddle',
-        },
-      },
-    }))).toMatchObject({
-      state: 'stale',
-      label: 'Daemon unreachable',
-      tone: 'destructive',
+      serverId: 'server-1',
     });
   });
 });

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -12,6 +12,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import dayjs from 'dayjs';
 import {
   DEFAULT_OPENAI_MODEL,
   type ToolCall,
@@ -56,7 +57,8 @@ type RunDaemonBackedAskOptions = {
   targetSessionId?: string;
   latestSession?: boolean;
   createSessionName?: string;
-  runtimeHost: Extract<ResolvedRuntimeHost, { kind: 'daemon' }>;
+  workspaceId: string;
+  runtimeHost: Extract<ResolvedRuntimeHost, { kind: 'server' }>;
 };
 
 export class AskCliHost {
@@ -82,8 +84,14 @@ export class AskCliHost {
     if (sessionModeCount > 1) {
       throw new Error('Choose only one of --session, --latest, or --new-session for heddle ask.');
     }
+    // v1 compatibility only: daemon-backed `heddle ask` has no interactive workspace picker,
+    // so it must send the cwd-derived workspace id explicitly until v1 commands are removed.
+    const activeWorkspace = RuntimeWorkspaceService.resolveContext({
+      workspaceRoot,
+      stateRoot,
+    }).activeWorkspace;
 
-    if (options.runtimeHost?.kind === 'daemon' && !options.runtimeHost.stale) {
+    if (options.runtimeHost?.kind === 'server' && !options.runtimeHost.stale) {
       await AskCliHost.runDaemonBackedAsk({
         goal,
         model,
@@ -95,6 +103,7 @@ export class AskCliHost {
         targetSessionId: options.sessionId,
         latestSession: options.latestSession,
         createSessionName: options.createSessionName,
+        workspaceId: activeWorkspace.id,
         runtimeHost: options.runtimeHost,
       });
       return;
@@ -183,9 +192,10 @@ export class AskCliHost {
 
     const sessionId =
       options.targetSessionId
-      ?? (options.latestSession ? await AskCliHost.resolveLatestRemoteSessionId(client) : undefined)
+      ?? (options.latestSession ? await AskCliHost.resolveLatestRemoteSessionId(client, options.workspaceId) : undefined)
       ?? await AskCliHost.createRemoteSession(client, {
-        name: options.createSessionName?.trim() || `Ask ${new Date().toISOString()}`,
+        workspaceId: options.workspaceId,
+        name: options.createSessionName?.trim() || `Ask ${dayjs().toISOString()}`,
         model: options.model,
         retention: options.createSessionName === undefined ? 'one_off' : 'reusable',
         apiKeyPresent: RuntimeCredentialService.hasCredentialForModel(options.model, {
@@ -196,6 +206,7 @@ export class AskCliHost {
       });
 
     const result = await client.controlPlane.sessionSendPrompt.mutate({
+      workspaceId: options.workspaceId,
       sessionId,
       prompt: options.goal,
       maxSteps: options.maxSteps,
@@ -216,8 +227,8 @@ export class AskCliHost {
     });
   }
 
-  private static async resolveLatestRemoteSessionId(client: ReturnType<typeof createDaemonControlPlaneClient>): Promise<string> {
-    const result = await client.controlPlane.sessions.query();
+  private static async resolveLatestRemoteSessionId(client: ReturnType<typeof createDaemonControlPlaneClient>, workspaceId: string): Promise<string> {
+    const result = await client.controlPlane.sessions.query({ workspaceId });
     const latest = result.sessions[0];
     if (!latest) {
       throw new Error('No saved chat sessions are available yet. Use --new-session to create one first.');
@@ -227,9 +238,10 @@ export class AskCliHost {
 
   private static async createRemoteSession(
     client: ReturnType<typeof createDaemonControlPlaneClient>,
-    input: { name?: string; model: string; retention?: ChatSessionRetention; apiKeyPresent: boolean },
+    input: { workspaceId: string; name?: string; model: string; retention?: ChatSessionRetention; apiKeyPresent: boolean },
   ): Promise<string> {
     const created = await client.controlPlane.sessionCreate.mutate({
+      workspaceId: input.workspaceId,
       name: input.name,
       model: input.model,
       retention: input.retention,

--- a/src/cli/chat/components/RuntimeHostInterstitial.tsx
+++ b/src/cli/chat/components/RuntimeHostInterstitial.tsx
@@ -5,7 +5,7 @@ import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
 export function RuntimeHostInterstitial({
   runtimeHost,
 }: {
-  runtimeHost: Extract<ResolvedRuntimeHost, { kind: 'daemon' }>;
+  runtimeHost: Extract<ResolvedRuntimeHost, { kind: 'server' }>;
 }) {
   const { exit } = useApp();
   const endpoint = `http://${runtimeHost.endpoint.host}:${runtimeHost.endpoint.port}`;
@@ -29,15 +29,14 @@ export function RuntimeHostInterstitial({
 
   return (
     <Box flexDirection="column" paddingX={1} paddingY={1}>
-      <Text bold>Workspace owned by daemon</Text>
+      <Text bold>Control-plane server is already running</Text>
       <Box marginTop={1} flexDirection="column">
-        <Text>This workspace already has a live Heddle daemon owner.</Text>
-        <Text>Interactive chat stays blocked here so one workspace does not get two competing runtime owners.</Text>
+        <Text>Heddle already has a live local control-plane server.</Text>
+        <Text>Interactive chat stays blocked here so this process does not create a competing runtime owner.</Text>
       </Box>
       <Box marginTop={1} flexDirection="column">
-        <Text>workspace={runtimeHost.workspaceId}</Text>
-        <Text>daemon={endpoint}</Text>
-        <Text>owner={runtimeHost.ownerId}</Text>
+        <Text>server={endpoint}</Text>
+        <Text>serverId={runtimeHost.serverId}</Text>
       </Box>
       <Box marginTop={1} flexDirection="column">
         <Text bold>Actions</Text>

--- a/src/cli/chat/hooks/useChatStatusSummary.ts
+++ b/src/cli/chat/hooks/useChatStatusSummary.ts
@@ -87,8 +87,8 @@ export function useChatStatusSummary(args: {
       : args.isMemoryUpdating ? 'Memory maintenance is running in the background • Enter sends • Ctrl+C exits'
       : 'Enter sends • Tab completes slash commands • /help shows commands • !command runs shell • Ctrl+C exits';
     const runtimeHostWarning =
-      args.runtimeHostWarningSource?.kind === 'daemon' && !args.runtimeHostWarningSource.stale ?
-        `Daemon is also attached to this workspace at http://${args.runtimeHostWarningSource.endpoint.host}:${args.runtimeHostWarningSource.endpoint.port}. Different sessions are fine; avoid writing to the same session from multiple clients.`
+      args.runtimeHostWarningSource?.kind === 'server' && !args.runtimeHostWarningSource.stale ?
+        `Control-plane server is running at http://${args.runtimeHostWarningSource.endpoint.host}:${args.runtimeHostWarningSource.endpoint.port}. Different sessions are fine; avoid writing to the same session from multiple clients.`
       : undefined;
     const activityLines = args.liveEvents
       .slice(-4)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -42,6 +42,7 @@ type HeddleProjectConfig = {
 
 type ResolvedCliOptions = {
   workspaceRoot: string;
+  activeWorkspaceId: string;
   model?: string;
   maxSteps?: number;
   preferApiKey: boolean;
@@ -87,13 +88,13 @@ async function main() {
     .action(async () => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
       chdir(resolved.workspaceRoot);
-      if (resolved.runtimeHost.kind !== 'daemon' || resolved.forceOwnerConflict) {
+      if (resolved.runtimeHost.kind !== 'server' || resolved.forceOwnerConflict) {
         throw new Error('chat-v2 requires a running Heddle daemon because it only consumes the shared control-plane API.');
       }
       writeRuntimeHostNotice('chat-v2', resolved.runtimeHost);
       startChatCliV2({
         trpcUrl: `http://${resolved.runtimeHost.endpoint.host}:${resolved.runtimeHost.endpoint.port}/trpc`,
-        workspaceId: resolved.runtimeHost.workspaceId,
+        workspaceId: resolved.activeWorkspaceId,
         model: resolved.model,
         maxSteps: resolved.maxSteps,
         searchIgnoreDirs: resolved.searchIgnoreDirs,
@@ -509,6 +510,7 @@ function resolveCliOptions(flags: RootCliOptions): ResolvedCliOptions {
   });
   return {
     workspaceRoot,
+    activeWorkspaceId: workspaceContext.activeWorkspaceId,
     model: flags.model ?? projectConfig.model,
     maxSteps: parsePositiveInt(flags.maxSteps) ?? projectConfig.maxSteps,
     preferApiKey: Boolean(flags.preferApiKey),
@@ -519,10 +521,7 @@ function resolveCliOptions(flags: RootCliOptions): ResolvedCliOptions {
       workspaceRoot,
       resolveAgentContextPaths(workspaceRoot, projectConfig.agentContextPaths)
     ),
-    runtimeHost: RuntimeHostResolver.resolveWorkspaceHost({
-      workspaceRoot,
-      stateRoot,
-    }),
+    runtimeHost: RuntimeHostResolver.resolveLiveServer(),
     forceOwnerConflict: Boolean(flags.forceOwnerConflict),
   };
 }

--- a/src/cli/remote/control-plane-client.ts
+++ b/src/cli/remote/control-plane-client.ts
@@ -1,7 +1,7 @@
 import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
 import { ClientSharedProxyApiService } from '@/client-shared/api/proxy.js';
 
-export function createDaemonControlPlaneClient(host: Extract<ResolvedRuntimeHost, { kind: 'daemon' }>) {
+export function createDaemonControlPlaneClient(host: Extract<ResolvedRuntimeHost, { kind: 'server' }>) {
   return ClientSharedProxyApiService.createClient({
     url: `http://${host.endpoint.host}:${host.endpoint.port}/trpc`,
   });

--- a/src/core/runtime/daemon/README.md
+++ b/src/core/runtime/daemon/README.md
@@ -1,8 +1,14 @@
 # Runtime Daemon
 
-Owns runtime-host discovery through the daemon registry. The registry service
-records known workspaces and live daemon ownership; the host resolver turns that
-registry state into the active runtime-owner view used by CLI and server hosts.
+Owns local control-plane server discovery through the global daemon registry.
+The registry service records two distinct facts:
+
+- the one live local control-plane server, when one is registered
+- known workspace descriptors that clients may target by request
+
+Workspace records are catalog/identity facts. They must not imply server
+ownership. Server liveness is top-level process state so TUI, web, daemon, and
+future embedded hosts can all discover the same machine-level control plane.
 
 Call `RuntimeDaemonRegistryService`, `RuntimeHostResolver`, and
 `RuntimeHostMessages` directly. File I/O stays inside

--- a/src/core/runtime/daemon/host-resolver.ts
+++ b/src/core/runtime/daemon/host-resolver.ts
@@ -1,53 +1,46 @@
 /**
  * Runtime host resolver.
  *
- * Resolves whether the current workspace has a live daemon owner. This is
- * daemon-discovery policy, not CLI/web presentation.
+ * Resolves whether this machine already has a live local control-plane server.
+ * This is server-discovery policy, not workspace selection or presentation.
  */
+import dayjs from 'dayjs';
 import { FileDaemonRegistryRepository } from './registry-repository.js';
 import { RuntimeDaemonRegistryService } from './registry-service.js';
 import type { ResolvedRuntimeHost, ResolveRuntimeHostInput } from './types.js';
-import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 
 const DEFAULT_STALE_AFTER_MS = 45_000;
 
 export class RuntimeHostResolver {
-  static resolveWorkspaceHost(input: ResolveRuntimeHostInput): ResolvedRuntimeHost {
-    const workspace = RuntimeWorkspaceService.resolveContext(input).activeWorkspace;
+  static resolveLiveServer(input: ResolveRuntimeHostInput = {}): ResolvedRuntimeHost {
     const registryPath = input.registryPath ?? FileDaemonRegistryRepository.resolvePath();
-    const registration = RuntimeDaemonRegistryService.readWorkspaceRegistration(
-      registryPath,
-      workspace.id,
-      workspace.stateRoot,
-    );
-    const owner = registration?.owner;
+    const server = RuntimeDaemonRegistryService.read(registryPath).server;
 
-    if (!owner) {
+    if (!server) {
       return {
         kind: 'none',
         registryPath,
-        workspaceId: workspace.id,
       };
     }
 
-    const now = input.now ?? Date.now();
-    const lastSeenAt = Date.parse(owner.lastSeenAt);
-    const ageMs = Number.isFinite(lastSeenAt) ? Math.max(0, now - lastSeenAt) : Number.POSITIVE_INFINITY;
+    const now = dayjs(input.now);
+    const lastSeenAt = dayjs(server.lastSeenAt);
+    const ageMs = lastSeenAt.isValid() ? Math.max(0, now.diff(lastSeenAt)) : Number.POSITIVE_INFINITY;
     const staleByAge = ageMs > (input.staleAfterMs ?? DEFAULT_STALE_AFTER_MS);
-    const pidAlive = owner.pid > 0 ? (input.isPidAlive ?? RuntimeHostResolver.isPidAlive)(owner.pid) : true;
+    const pidAlive = server.pid > 0 ? (input.isPidAlive ?? RuntimeHostResolver.isPidAlive)(server.pid) : true;
     const stale = staleByAge || !pidAlive;
 
     return {
-      kind: 'daemon',
+      kind: 'server',
       registryPath,
-      workspaceId: workspace.id,
-      ownerId: owner.ownerId,
+      serverId: server.serverId,
+      mode: server.mode,
       endpoint: {
-        host: owner.host,
-        port: owner.port,
+        host: server.host,
+        port: server.port,
       },
-      startedAt: owner.startedAt,
-      lastSeenAt: owner.lastSeenAt,
+      startedAt: server.startedAt,
+      lastSeenAt: server.lastSeenAt,
       stale,
       ageMs,
     };

--- a/src/core/runtime/daemon/index.ts
+++ b/src/core/runtime/daemon/index.ts
@@ -3,12 +3,12 @@ export { RuntimeHostMessages } from './messages.js';
 export { FileDaemonRegistryRepository } from './registry-repository.js';
 export { RuntimeDaemonRegistryService } from './registry-service.js';
 export type {
-  ClearDaemonWorkspaceRegistrationInput,
-  DaemonOwnerRecord,
+  ClearControlPlaneServerInput,
+  ControlPlaneServerRecord,
   DaemonRegistry,
   RegisteredWorkspaceRecord,
+  RegisterControlPlaneServerInput,
   RegisterKnownWorkspacesInput,
   ResolvedRuntimeHost,
   ResolveRuntimeHostInput,
-  UpsertDaemonWorkspaceRegistrationInput,
 } from './types.js';

--- a/src/core/runtime/daemon/messages.ts
+++ b/src/core/runtime/daemon/messages.ts
@@ -1,55 +1,54 @@
 /**
  * Runtime host message formatter.
  *
- * Keeps daemon-owner notices and conflict text together so host adapters do not
- * each invent slightly different wording for the same runtime-owner state.
+ * Keeps live control-plane server notices and conflict text together so host
+ * adapters do not each invent slightly different wording for the same runtime
+ * state.
  */
 import type { ResolvedRuntimeHost } from './types.js';
 
 export class RuntimeHostMessages {
   static formatNotice(command: string, host: ResolvedRuntimeHost): string | undefined {
-    if (host.kind !== 'daemon' || host.stale) {
+    if (host.kind !== 'server' || host.stale) {
       return undefined;
     }
 
     if (command === 'chat') {
       return [
-        'Heddle notice: a live daemon is attached to this workspace.',
-        `daemon=http://${host.endpoint.host}:${host.endpoint.port}`,
-        `workspace=${host.workspaceId}`,
+        'Heddle notice: a live control-plane server is running.',
+        `server=http://${host.endpoint.host}:${host.endpoint.port}`,
         'Embedded chat still works here; avoid writing to the same session from multiple clients.',
       ].join(' ');
     }
 
     return [
-      `Heddle notice: workspace is currently owned by a daemon for \`${command}\`.`,
-      `daemon=http://${host.endpoint.host}:${host.endpoint.port}`,
-      `workspace=${host.workspaceId}`,
+      `Heddle notice: a live control-plane server is running for \`${command}\`.`,
+      `server=http://${host.endpoint.host}:${host.endpoint.port}`,
     ].join(' ');
   }
 
   static embeddedCommandConflict(command: string, host: ResolvedRuntimeHost): string | undefined {
-    if (host.kind !== 'daemon' || host.stale) {
+    if (host.kind !== 'server' || host.stale) {
       return undefined;
     }
 
     return [
-      `Workspace ${host.workspaceId} is currently owned by a live Heddle daemon.`,
+      'A live Heddle control-plane server is already running.',
       `Refusing embedded \`${command}\` to avoid conflicting runtime owners.`,
-      `daemon=http://${host.endpoint.host}:${host.endpoint.port}`,
+      `server=http://${host.endpoint.host}:${host.endpoint.port}`,
       'Use the daemon-backed control plane, stop the daemon, or rerun with `--force-owner-conflict`.',
     ].join(' ');
   }
 
   static daemonStartConflict(host: ResolvedRuntimeHost): string | undefined {
-    if (host.kind !== 'daemon' || host.stale) {
+    if (host.kind !== 'server' || host.stale) {
       return undefined;
     }
 
     return [
-      `Workspace ${host.workspaceId} is already owned by a live Heddle daemon.`,
+      'A live Heddle control-plane server is already running.',
       'Refusing to start a second daemon.',
-      `daemon=http://${host.endpoint.host}:${host.endpoint.port}`,
+      `server=http://${host.endpoint.host}:${host.endpoint.port}`,
       'Stop the existing daemon first or rerun with `--force-owner-conflict`.',
     ].join(' ');
   }

--- a/src/core/runtime/daemon/registry-service.ts
+++ b/src/core/runtime/daemon/registry-service.ts
@@ -1,19 +1,21 @@
 /**
  * Runtime daemon registry service.
  *
- * Owns the domain behavior for recording known workspaces, claiming daemon
- * ownership, clearing daemon ownership, and resolving workspace registrations.
+ * Owns the domain behavior for recording known workspaces and the one live
+ * local control-plane server. Workspace records are identity/catalog facts;
+ * server liveness is top-level process state and must not be stored as
+ * workspace ownership.
  */
 import { resolve } from 'node:path';
 import { DaemonRegistryReadSchema } from './schemas.js';
 import { FileDaemonRegistryRepository } from './registry-repository.js';
 import type {
-  ClearDaemonWorkspaceRegistrationInput,
-  DaemonOwnerRecord,
+  ClearControlPlaneServerInput,
+  ControlPlaneServerRecord,
   DaemonRegistry,
+  RegisterControlPlaneServerInput,
   RegisteredWorkspaceRecord,
   RegisterKnownWorkspacesInput,
-  UpsertDaemonWorkspaceRegistrationInput,
 } from './types.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 
@@ -23,52 +25,31 @@ export class RuntimeDaemonRegistryService {
     return RuntimeDaemonRegistryService.normalizeRegistry(repository.readRaw());
   }
 
-  static upsertWorkspaceRegistration(input: UpsertDaemonWorkspaceRegistrationInput): DaemonRegistry {
+  static registerLiveServer(input: RegisterControlPlaneServerInput): DaemonRegistry {
     const registry = RuntimeDaemonRegistryService.read(input.registryPath);
-    const now = input.owner.lastSeenAt ?? new Date().toISOString();
-    const nextRecords = RuntimeDaemonRegistryService.toRecordMap(registry.workspaces);
-
-    for (const workspace of input.workspaces) {
-      nextRecords.set(RuntimeDaemonRegistryService.workspaceRecordKey(workspace), {
-        workspace,
-        owner: {
-          ...input.owner,
-          lastSeenAt: now,
-        },
-        updatedAt: now,
-      });
-    }
+    const now = input.server.lastSeenAt ?? new Date().toISOString();
 
     return RuntimeDaemonRegistryService.saveNext(input.registryPath, {
       version: 1,
       updatedAt: now,
-      workspaces: Array.from(nextRecords.values()),
+      server: {
+        ...input.server,
+        lastSeenAt: now,
+      },
+      workspaces: registry.workspaces,
     });
   }
 
-  static clearWorkspaceRegistration(input: ClearDaemonWorkspaceRegistrationInput): DaemonRegistry {
+  static clearLiveServer(input: ClearControlPlaneServerInput): DaemonRegistry {
     const registry = RuntimeDaemonRegistryService.read(input.registryPath);
-    const targetIds = new Set(input.workspaceIds);
-    const targetStateRoots = new Set((input.stateRoots ?? []).map((stateRoot) => resolve(stateRoot)));
     const now = new Date().toISOString();
+    const server = registry.server?.serverId === input.serverId ? undefined : registry.server;
 
     return RuntimeDaemonRegistryService.saveNext(input.registryPath, {
       version: 1,
       updatedAt: now,
-      workspaces: registry.workspaces.map((record) => {
-        const matchesWorkspace =
-          targetIds.has(record.workspace.id)
-          || targetStateRoots.has(resolve(record.workspace.stateRoot));
-        if (!matchesWorkspace || record.owner?.ownerId !== input.ownerId) {
-          return record;
-        }
-
-        return {
-          ...record,
-          owner: undefined,
-          updatedAt: now,
-        };
-      }),
+      server,
+      workspaces: registry.workspaces,
     });
   }
 
@@ -93,10 +74,8 @@ export class RuntimeDaemonRegistryService {
     const nextRecords = RuntimeDaemonRegistryService.toRecordMap(registry.workspaces);
 
     for (const workspace of input.workspaces) {
-      const existing = nextRecords.get(RuntimeDaemonRegistryService.workspaceRecordKey(workspace));
       nextRecords.set(RuntimeDaemonRegistryService.workspaceRecordKey(workspace), {
         workspace,
-        owner: existing?.owner,
         updatedAt: now,
       });
     }
@@ -104,6 +83,7 @@ export class RuntimeDaemonRegistryService {
     return RuntimeDaemonRegistryService.saveNext(registryPath, {
       version: 1,
       updatedAt: now,
+      server: registry.server,
       workspaces: Array.from(nextRecords.values()),
     });
   }
@@ -134,6 +114,8 @@ export class RuntimeDaemonRegistryService {
     return {
       version: 1,
       updatedAt: parsed.data.updatedAt?.trim() || new Date().toISOString(),
+      server: RuntimeDaemonRegistryService.normalizeServer(parsed.data.server)
+        ?? RuntimeDaemonRegistryService.normalizeLegacyServer(parsed.data.workspaces ?? []),
       workspaces: (parsed.data.workspaces ?? []).flatMap((record) => (
         record.workspace ? [RuntimeDaemonRegistryService.normalizeWorkspaceRecord(record)] : []
       )),
@@ -142,32 +124,54 @@ export class RuntimeDaemonRegistryService {
 
   private static normalizeWorkspaceRecord(record: {
     workspace?: Partial<WorkspaceDescriptor>;
-    owner?: Partial<DaemonOwnerRecord>;
     updatedAt?: string;
   }): RegisteredWorkspaceRecord {
     return {
       workspace: record.workspace as WorkspaceDescriptor,
-      owner: RuntimeDaemonRegistryService.normalizeOwner(record.owner),
       updatedAt: record.updatedAt?.trim() || new Date().toISOString(),
     };
   }
 
-  private static normalizeOwner(owner: Partial<DaemonOwnerRecord> | undefined): DaemonOwnerRecord | undefined {
-    if (!owner?.ownerId || !owner.host || typeof owner.port !== 'number' || !owner.startedAt || !owner.lastSeenAt) {
+  private static normalizeServer(server: Partial<ControlPlaneServerRecord> | undefined): ControlPlaneServerRecord | undefined {
+    if (!server?.serverId || !server.mode || !server.host || typeof server.port !== 'number' || !server.startedAt || !server.lastSeenAt) {
       return undefined;
     }
 
     return {
-      ownerId: owner.ownerId,
-      mode: 'daemon',
-      host: owner.host,
-      port: owner.port,
-      pid: typeof owner.pid === 'number' ? owner.pid : 0,
-      startedAt: owner.startedAt,
-      lastSeenAt: owner.lastSeenAt,
-      workspaceRoot: owner.workspaceRoot ?? '',
-      stateRoot: owner.stateRoot ?? '',
+      serverId: server.serverId,
+      mode: server.mode,
+      host: server.host,
+      port: server.port,
+      pid: typeof server.pid === 'number' ? server.pid : 0,
+      startedAt: server.startedAt,
+      lastSeenAt: server.lastSeenAt,
     };
+  }
+
+  private static normalizeLegacyServer(records: Array<{
+    owner?: {
+      ownerId?: string;
+      mode?: 'daemon';
+      host?: string;
+      port?: number;
+      pid?: number;
+      startedAt?: string;
+      lastSeenAt?: string;
+    };
+  }>): ControlPlaneServerRecord | undefined {
+    return records
+      .map((record) => record.owner)
+      .filter((owner): owner is NonNullable<typeof owner> => Boolean(owner))
+      .sort((left, right) => (right.lastSeenAt ?? '').localeCompare(left.lastSeenAt ?? ''))
+      .flatMap((owner) => RuntimeDaemonRegistryService.normalizeServer({
+        serverId: owner.ownerId,
+        mode: 'daemon',
+        host: owner.host,
+        port: owner.port,
+        pid: owner.pid,
+        startedAt: owner.startedAt,
+        lastSeenAt: owner.lastSeenAt,
+      }) ?? [])[0];
   }
 
   private static toRecordMap(records: RegisteredWorkspaceRecord[]): Map<string, RegisteredWorkspaceRecord> {

--- a/src/core/runtime/daemon/schemas.ts
+++ b/src/core/runtime/daemon/schemas.ts
@@ -1,39 +1,48 @@
 /**
  * Zod schemas for daemon registry persistence.
  *
- * This file is the JSON contract for `.heddle/daemon-registry.json`, which
- * lets hosts discover live daemon owners for known workspaces.
+ * This file is the JSON contract for the global daemon registry. The registry
+ * owns live control-plane server discovery and known workspace records; a
+ * workspace record must not imply server ownership.
  */
 import { z } from 'zod';
 import { WorkspaceDescriptorSchema } from '@/core/runtime/workspaces/schemas.js';
 
-export const DaemonOwnerRecordSchema = z.object({
-  ownerId: z.string().describe('Unique daemon owner identifier for this registration.'),
-  mode: z.literal('daemon').describe('Runtime owner mode. Currently only daemon owners are persisted here.'),
-  host: z.string().describe('HTTP host where the daemon control plane listens.'),
-  port: z.number().describe('HTTP port where the daemon control plane listens.'),
-  pid: z.number().describe('Local process id for stale-owner detection.'),
-  startedAt: z.string().describe('Timestamp when this daemon owner started.'),
-  lastSeenAt: z.string().describe('Timestamp when this daemon owner last refreshed its registration.'),
-  workspaceRoot: z.string().describe('Filesystem workspace root used by this daemon owner.'),
-  stateRoot: z.string().describe('Heddle state root used by this daemon owner.'),
+export const ControlPlaneServerRecordSchema = z.object({
+  serverId: z.string().describe('Unique local control-plane server identifier.'),
+  mode: z.enum(['daemon', 'embedded-chat']).describe('Runtime server mode.'),
+  host: z.string().describe('HTTP host where the control plane listens.'),
+  port: z.number().describe('HTTP port where the control plane listens.'),
+  pid: z.number().describe('Local process id for stale-server detection.'),
+  startedAt: z.string().describe('Timestamp when this server started.'),
+  lastSeenAt: z.string().describe('Timestamp when this server last refreshed its registry heartbeat.'),
 });
 
 export const RegisteredWorkspaceRecordSchema = z.object({
   workspace: WorkspaceDescriptorSchema.describe('Workspace descriptor known to the daemon registry.'),
-  owner: DaemonOwnerRecordSchema.optional().catch(undefined)
-    .describe('Live daemon owner for this workspace when one is registered.'),
   updatedAt: z.string().describe('Timestamp when this registry record was last changed.'),
 });
 
 export const DaemonRegistrySchema = z.object({
   version: z.literal(1).describe('Daemon registry format version.'),
   updatedAt: z.string().describe('Timestamp when this registry was last written.'),
-  workspaces: z.array(RegisteredWorkspaceRecordSchema).describe('Known workspace records and optional daemon owners.'),
+  server: ControlPlaneServerRecordSchema.optional().describe('Live local control-plane server, when one is registered.'),
+  workspaces: z.array(RegisteredWorkspaceRecordSchema).describe('Known workspace records.'),
 });
 
 export const DaemonRegistryReadSchema = z.object({
   version: z.literal(1).optional().catch(1),
   updatedAt: z.string().optional().catch(undefined),
-  workspaces: z.array(RegisteredWorkspaceRecordSchema.partial()).optional().catch(undefined),
+  server: ControlPlaneServerRecordSchema.partial().optional().catch(undefined),
+  workspaces: z.array(RegisteredWorkspaceRecordSchema.partial().extend({
+    owner: z.object({
+      ownerId: z.string().optional(),
+      mode: z.literal('daemon').optional(),
+      host: z.string().optional(),
+      port: z.number().optional(),
+      pid: z.number().optional(),
+      startedAt: z.string().optional(),
+      lastSeenAt: z.string().optional(),
+    }).optional().catch(undefined),
+  })).optional().catch(undefined),
 });

--- a/src/core/runtime/daemon/types.ts
+++ b/src/core/runtime/daemon/types.ts
@@ -1,40 +1,35 @@
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 
-export type DaemonOwnerRecord = {
-  ownerId: string;
-  mode: 'daemon';
+export type ControlPlaneServerRecord = {
+  serverId: string;
+  mode: 'daemon' | 'embedded-chat';
   host: string;
   port: number;
   pid: number;
   startedAt: string;
   lastSeenAt: string;
-  workspaceRoot: string;
-  stateRoot: string;
 };
 
 export type RegisteredWorkspaceRecord = {
   workspace: WorkspaceDescriptor;
-  owner?: DaemonOwnerRecord;
   updatedAt: string;
 };
 
 export type DaemonRegistry = {
   version: 1;
   updatedAt: string;
+  server?: ControlPlaneServerRecord;
   workspaces: RegisteredWorkspaceRecord[];
 };
 
-export type UpsertDaemonWorkspaceRegistrationInput = {
+export type RegisterControlPlaneServerInput = {
   registryPath: string;
-  workspaces: WorkspaceDescriptor[];
-  owner: Omit<DaemonOwnerRecord, 'lastSeenAt'> & { lastSeenAt?: string };
+  server: Omit<ControlPlaneServerRecord, 'lastSeenAt'> & { lastSeenAt?: string };
 };
 
-export type ClearDaemonWorkspaceRegistrationInput = {
+export type ClearControlPlaneServerInput = {
   registryPath: string;
-  workspaceIds: string[];
-  stateRoots?: string[];
-  ownerId: string;
+  serverId: string;
 };
 
 export type RegisterKnownWorkspacesInput = {
@@ -43,8 +38,6 @@ export type RegisterKnownWorkspacesInput = {
 };
 
 export type ResolveRuntimeHostInput = {
-  workspaceRoot: string;
-  stateRoot: string;
   registryPath?: string;
   now?: number;
   staleAfterMs?: number;
@@ -55,13 +48,12 @@ export type ResolvedRuntimeHost =
   | {
       kind: 'none';
       registryPath: string;
-      workspaceId: string;
     }
   | {
-      kind: 'daemon';
+      kind: 'server';
       registryPath: string;
-      workspaceId: string;
-      ownerId: string;
+      serverId: string;
+      mode: ControlPlaneServerRecord['mode'];
       endpoint: {
         host: string;
         port: number;

--- a/src/core/runtime/workspaces/index.ts
+++ b/src/core/runtime/workspaces/index.ts
@@ -9,4 +9,3 @@ export type {
   WorkspaceDescriptor,
   WorkspaceRootConfig,
 } from './types.js';
-export { DEFAULT_WORKSPACE_ID } from './types.js';

--- a/src/core/runtime/workspaces/service.ts
+++ b/src/core/runtime/workspaces/service.ts
@@ -5,11 +5,12 @@
  * normalization, active workspace selection, creation, and renaming. Host code
  * should call this service instead of touching workspace catalog files.
  */
+import { createHash, randomUUID } from 'node:crypto';
 import { basename, dirname, join, resolve } from 'node:path';
 import { FileWorkspaceRepository } from './repository.js';
 import { WorkspaceCatalogReadSchema } from './schemas.js';
 import {
-  DEFAULT_WORKSPACE_ID,
+  LEGACY_DEFAULT_WORKSPACE_ID,
   type CreateWorkspaceDescriptorInput,
   type RenameWorkspaceDescriptorInput,
   type ResolvedWorkspaceContext,
@@ -113,7 +114,7 @@ export class RuntimeWorkspaceService {
         input.repoRoots.map((root) => resolve(root))
       : [workspaceRoot];
     const nextWorkspace: WorkspaceDescriptor = {
-      id: input.nextId ?? `workspace-${Date.now()}`,
+      id: input.nextId ?? RuntimeWorkspaceService.createWorkspaceId(),
       name: input.name.trim() || RuntimeWorkspaceService.deriveDefaultWorkspaceName(workspaceRoot),
       workspaceRoot,
       repoRoots,
@@ -144,12 +145,13 @@ export class RuntimeWorkspaceService {
 
   private static createDefaultCatalog(config: WorkspaceRootConfig): WorkspaceCatalog {
     const now = new Date().toISOString();
+    const workspaceId = RuntimeWorkspaceService.createWorkspaceId(config.stateRoot);
     return {
       version: 1,
-      activeWorkspaceId: DEFAULT_WORKSPACE_ID,
+      activeWorkspaceId: workspaceId,
       workspaces: [
         {
-          id: DEFAULT_WORKSPACE_ID,
+          id: workspaceId,
           name: RuntimeWorkspaceService.deriveDefaultWorkspaceName(config.workspaceRoot),
           workspaceRoot: config.workspaceRoot,
           repoRoots: [config.workspaceRoot],
@@ -180,7 +182,10 @@ export class RuntimeWorkspaceService {
     const workspaces =
       parsed.data.workspaces && parsed.data.workspaces.length > 0 ?
         parsed.data.workspaces.map((workspace, index) => RuntimeWorkspaceService.normalizeDescriptor(workspace, {
-          fallbackId: index === 0 ? DEFAULT_WORKSPACE_ID : `workspace-${index + 1}`,
+          fallbackId:
+            index === 0 ?
+              RuntimeWorkspaceService.createWorkspaceId(args.stateRoot)
+            : RuntimeWorkspaceService.createWorkspaceId(workspace.stateRoot ?? `${args.stateRoot}:${index}`),
           workspaceRoot: args.workspaceRoot,
           stateRoot: args.stateRoot,
         }))
@@ -188,7 +193,7 @@ export class RuntimeWorkspaceService {
     const activeWorkspaceId =
       parsed.data.activeWorkspaceId && workspaces.some((workspace) => workspace.id === parsed.data.activeWorkspaceId) ?
         parsed.data.activeWorkspaceId
-      : workspaces[0]?.id ?? DEFAULT_WORKSPACE_ID;
+      : workspaces[0]?.id ?? fallback.activeWorkspaceId;
 
     return {
       version: 1,
@@ -217,7 +222,7 @@ export class RuntimeWorkspaceService {
       : [workspaceRoot];
 
     return {
-      id: workspace.id?.trim() || options.fallbackId,
+      id: RuntimeWorkspaceService.normalizeWorkspaceId(workspace.id, options.fallbackId, stateRoot),
       name: workspace.name?.trim() || RuntimeWorkspaceService.deriveDefaultWorkspaceName(workspaceRoot),
       workspaceRoot,
       repoRoots,
@@ -225,5 +230,22 @@ export class RuntimeWorkspaceService {
       createdAt: workspace.createdAt ?? now,
       updatedAt: workspace.updatedAt ?? now,
     };
+  }
+
+  private static normalizeWorkspaceId(id: string | undefined, fallbackId: string, stateRoot: string): string {
+    const trimmed = id?.trim();
+    if (!trimmed || trimmed === LEGACY_DEFAULT_WORKSPACE_ID) {
+      // Backward compatibility only: migrate old local `default` ids into stable,
+      // state-root-derived ids so one daemon can safely serve multiple workspaces.
+      return fallbackId || RuntimeWorkspaceService.createWorkspaceId(stateRoot);
+    }
+    return trimmed;
+  }
+
+  private static createWorkspaceId(seed?: string): string {
+    if (!seed) {
+      return `workspace-${randomUUID()}`;
+    }
+    return `workspace-${createHash('sha256').update(resolve(seed)).digest('hex').slice(0, 16)}`;
   }
 }

--- a/src/core/runtime/workspaces/types.ts
+++ b/src/core/runtime/workspaces/types.ts
@@ -1,4 +1,6 @@
-export const DEFAULT_WORKSPACE_ID = 'default';
+// Backward compatibility only: older workspace catalogs used this local id.
+// RuntimeWorkspaceService migrates it to a globally unique workspace id on read.
+export const LEGACY_DEFAULT_WORKSPACE_ID = 'default';
 
 export type WorkspaceDescriptor = {
   id: string;

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -1,4 +1,4 @@
-import type { DaemonOwnerRecord } from '@/core/runtime/daemon/index.js';
+import type { ControlPlaneServerRecord } from '@/core/runtime/daemon/index.js';
 import type { HeartbeatDecision, HeartbeatRunView, HeartbeatTaskStatus, HeartbeatTaskView } from '@/core/heartbeat/index.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import type { MemoryStatusView } from '@/core/memory/types.js';
@@ -296,15 +296,14 @@ export type ControlPlaneState = {
   workspaces: WorkspaceDescriptor[];
   knownWorkspaces: WorkspaceDescriptor[];
   runtimeHost: {
-    mode: 'daemon';
-    ownerId: string;
+    mode: ControlPlaneServerRecord['mode'];
+    serverId: string;
     registryPath: string;
     endpoint: {
       host: string;
       port: number;
     };
     startedAt: string;
-    workspaceOwner: DaemonOwnerRecord | null;
   } | null;
   sessions: ChatSessionView[];
   heartbeat: {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -29,43 +29,38 @@ export async function listenHeddleDaemon(options: HeddleServerListenOptions): Pr
   }
   const logger = options.logger ?? createServerLogger({ stateRoot: options.stateRoot });
   const registryPath = options.daemonRegistryPath ?? FileDaemonRegistryRepository.resolvePath();
-  const ownerId = `daemon-${process.pid}-${Date.now()}`;
+  const serverId = `daemon-${process.pid}-${Date.now()}`;
   const startedAt = new Date().toISOString();
-  const registerDaemon = (lastSeenAt?: string) => {
+  const registerDaemonServer = (lastSeenAt?: string) => {
     const workspaceContext = RuntimeWorkspaceService.resolveContext({
       workspaceRoot: options.workspaceRoot,
       stateRoot: options.stateRoot,
     });
-    RuntimeDaemonRegistryService.upsertWorkspaceRegistration({
+    RuntimeDaemonRegistryService.registerKnownWorkspaces({
       registryPath,
       workspaces: workspaceContext.workspaces,
-      owner: {
-        ownerId,
+    });
+    RuntimeDaemonRegistryService.registerLiveServer({
+      registryPath,
+      server: {
+        serverId,
         mode: 'daemon',
         host: options.host,
         port: options.port,
         pid: process.pid,
         startedAt,
         lastSeenAt,
-        workspaceRoot: options.workspaceRoot,
-        stateRoot: options.stateRoot,
       },
     });
   };
   const unregisterDaemon = () => {
-    const workspaceContext = RuntimeWorkspaceService.resolveContext({
-      workspaceRoot: options.workspaceRoot,
-      stateRoot: options.stateRoot,
-    });
-    RuntimeDaemonRegistryService.clearWorkspaceRegistration({
+    RuntimeDaemonRegistryService.clearLiveServer({
       registryPath,
-      workspaceIds: workspaceContext.workspaces.map((workspace) => workspace.id),
-      stateRoots: workspaceContext.workspaces.map((workspace) => workspace.stateRoot),
-      ownerId,
+      serverId,
     });
   };
 
-  registerDaemon(startedAt);
+  registerDaemonServer(startedAt);
   const heartbeatSchedulerHost = new HeddleHeartbeatSchedulerHost({
     workspaceRoot: options.workspaceRoot,
     stateRoot: options.stateRoot,
@@ -90,7 +85,7 @@ export async function listenHeddleDaemon(options: HeddleServerListenOptions): Pr
     logger,
     runtimeHost: {
       mode: 'daemon',
-      ownerId,
+      serverId,
       registryPath,
       endpoint: {
         host: options.host,
@@ -112,7 +107,7 @@ export async function listenHeddleDaemon(options: HeddleServerListenOptions): Pr
 
   const heartbeat = setInterval(() => {
     try {
-      registerDaemon();
+      registerDaemonServer();
       heartbeatSchedulerHost.sync();
     } catch (error) {
       logger.warn({ error }, 'Failed to refresh daemon registry heartbeat');
@@ -165,7 +160,7 @@ export async function listenHeddleDaemon(options: HeddleServerListenOptions): Pr
         assetsDir,
         serveAssets,
         registryPath,
-        ownerId,
+        serverId,
       }, 'Heddle server started');
       process.stdout.write(`Heddle server listening at http://${options.host}:${options.port}\n`);
       process.stdout.write(`workspace=${options.workspaceRoot}\n`);

--- a/src/server/routes/trpc/control-plane-workspace.ts
+++ b/src/server/routes/trpc/control-plane-workspace.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
 import type { Logger } from 'pino';
+import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { getWorkspaceOperationLogger } from '@/server/logging/workspace-operation-logger.js';
 import type { HeddleServerContext } from '@/server/types.js';
@@ -85,7 +86,12 @@ function resolveWorkspaceDescriptor(ctx: HeddleServerContext, workspaceId: strin
     return ctx.activeWorkspace;
   }
 
-  const workspace = ctx.workspaces.find((candidate) => candidate.id === workspaceId);
+  const workspace =
+    ctx.workspaces.find((candidate) => candidate.id === workspaceId)
+    ?? RuntimeDaemonRegistryService.readWorkspaceRegistration(
+      ctx.runtimeHost?.registryPath ?? FileDaemonRegistryRepository.resolvePath(),
+      workspaceId,
+    )?.workspace;
   if (!workspace) {
     throw new Error(`Workspace not found: ${workspaceId}`);
   }

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -556,7 +556,7 @@ function buildSubmitPromptArgs(ctx: ControlPlaneWorkspaceContext, input: Session
 function resolveControlPlaneLeaseOwner(ctx: Pick<HeddleServerContext, 'runtimeHost'>): ChatSessionLeaseOwner {
   return {
     ownerKind: 'daemon',
-    ownerId: ctx.runtimeHost?.ownerId ?? `daemon-${process.pid}`,
+    ownerId: ctx.runtimeHost?.serverId ?? `daemon-${process.pid}`,
     clientLabel: 'control plane',
   };
 }

--- a/src/server/routes/trpc/trpc.ts
+++ b/src/server/routes/trpc/trpc.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
-import { RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 import { appRouter } from '../../router.js';
 import type { HeddleRuntimeHostDescriptor, HeddleServerContext } from '../../types.js';
@@ -19,14 +18,6 @@ export function createTrpcExpressRouter(options: CreateTrpcExpressRouterOptions)
         workspaceRoot: options.workspaceRoot,
         stateRoot: options.stateRoot,
       });
-      const workspaceOwner =
-        options.runtimeHost ?
-          RuntimeDaemonRegistryService.readWorkspaceRegistration(
-            options.runtimeHost.registryPath,
-            workspaceContext.activeWorkspaceId,
-            workspaceContext.activeWorkspace.stateRoot,
-          )?.owner ?? null
-        : null;
       return {
         workspaceRoot: options.workspaceRoot,
         stateRoot: options.stateRoot,
@@ -34,13 +25,7 @@ export function createTrpcExpressRouter(options: CreateTrpcExpressRouterOptions)
         activeWorkspaceId: workspaceContext.activeWorkspaceId,
         activeWorkspace: workspaceContext.activeWorkspace,
         workspaces: workspaceContext.workspaces,
-        runtimeHost:
-          options.runtimeHost ?
-            {
-              ...options.runtimeHost,
-              workspaceOwner,
-            }
-          : null,
+        runtimeHost: options.runtimeHost ?? null,
         logger: options.logger,
       };
     },

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,5 +1,5 @@
 import type { Logger } from 'pino';
-import type { DaemonOwnerRecord } from '@/core/runtime/daemon/index.js';
+import type { ControlPlaneServerRecord } from '@/core/runtime/daemon/index.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 
 export type HeddleServerOptions = {
@@ -19,8 +19,8 @@ export type HeddleServerListenOptions = HeddleServerOptions & {
 };
 
 export type HeddleRuntimeHostDescriptor = {
-  mode: 'daemon';
-  ownerId: string;
+  mode: ControlPlaneServerRecord['mode'];
+  serverId: string;
   registryPath: string;
   endpoint: {
     host: string;
@@ -29,9 +29,7 @@ export type HeddleRuntimeHostDescriptor = {
   startedAt: string;
 };
 
-export type HeddleRuntimeHostInfo = HeddleRuntimeHostDescriptor & {
-  workspaceOwner: DaemonOwnerRecord | null;
-};
+export type HeddleRuntimeHostInfo = HeddleRuntimeHostDescriptor;
 
 export type HeddleServerContext = {
   workspaceRoot: string;

--- a/src/web/features/control-plane/components/common.tsx
+++ b/src/web/features/control-plane/components/common.tsx
@@ -118,11 +118,11 @@ export function RuntimeHostStrip({
         </div>
         {onRefresh ? <Button type="button" variant="outline" size="sm" onClick={onRefresh}>Refresh state</Button> : null}
       </div>
-      {host.endpoint || host.ownerId || host.lastSeenAt ?
+      {host.endpoint || host.serverId || host.startedAt ?
         <div className="flex min-w-0 flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
           {host.endpoint ? <span>endpoint={host.endpoint}</span> : null}
-          {host.ownerId ? <span>owner={host.ownerId}</span> : null}
-          {host.lastSeenAt ? <span>last seen={new Date(host.lastSeenAt).toLocaleTimeString()}</span> : null}
+          {host.serverId ? <span>server={host.serverId}</span> : null}
+          {host.startedAt ? <span>started={new Date(host.startedAt).toLocaleTimeString()}</span> : null}
         </div>
       : null}
     </section>
@@ -135,8 +135,8 @@ function RuntimeHostInfoContent({ host }: { host: RuntimeHostSurface }) {
       <strong>{host.label}</strong>
       <p>{host.detail}</p>
       {host.endpoint ? <p>endpoint={host.endpoint}</p> : null}
-      {host.ownerId ? <p>owner={host.ownerId}</p> : null}
-      {host.lastSeenAt ? <p>last seen={new Date(host.lastSeenAt).toLocaleTimeString()}</p> : null}
+      {host.serverId ? <p>server={host.serverId}</p> : null}
+      {host.startedAt ? <p>started={new Date(host.startedAt).toLocaleTimeString()}</p> : null}
     </div>
   );
 }

--- a/src/web/features/control-plane/host-surface.ts
+++ b/src/web/features/control-plane/host-surface.ts
@@ -1,16 +1,14 @@
 import type { ControlPlaneState } from '../../lib/api';
 
-const STALE_AFTER_MS = 45_000;
-
 export type RuntimeHostSurface = {
-  state: 'attached' | 'stale' | 'local';
+  state: 'attached' | 'local';
   label: string;
   badgeLabel: string;
   detail: string;
-  tone: 'secondary' | 'outline' | 'destructive';
+  tone: 'secondary' | 'outline';
   endpoint?: string;
-  ownerId?: string;
-  lastSeenAt?: string;
+  serverId?: string;
+  startedAt?: string;
 };
 
 export function projectRuntimeHostSurface(state?: ControlPlaneState): RuntimeHostSurface {
@@ -19,49 +17,21 @@ export function projectRuntimeHostSurface(state?: ControlPlaneState): RuntimeHos
       state: 'local',
       label: 'Local control plane',
       badgeLabel: 'Local',
-      detail: 'No daemon ownership metadata is loaded in this control-plane session.',
+      detail: 'No live server metadata is loaded in this control-plane session.',
       tone: 'outline',
     };
   }
 
-  const lastSeenAt = state.runtimeHost.workspaceOwner?.lastSeenAt;
-  const stale = isStale(lastSeenAt);
   const endpoint = `${state.runtimeHost.endpoint.host}:${state.runtimeHost.endpoint.port}`;
-
-  if (stale) {
-    return {
-      state: 'stale',
-      label: 'Daemon unreachable',
-      badgeLabel: 'Stale daemon',
-      detail: lastSeenAt ?
-        `The last daemon heartbeat is stale for ${state.workspace.name}. Refresh state or restart the daemon before trusting live runtime status.`
-      : `The daemon owner for ${state.workspace.name} is not reporting a recent heartbeat.`,
-      tone: 'destructive',
-      endpoint,
-      ownerId: state.runtimeHost.ownerId,
-      lastSeenAt,
-    };
-  }
 
   return {
     state: 'attached',
-    label: 'Attached to daemon',
-    badgeLabel: 'Daemon',
-    detail: `Sessions and tasks are reading daemon-owned runtime state for ${state.workspace.name}.`,
+    label: 'Attached to control-plane server',
+    badgeLabel: 'Server',
+    detail: `Sessions and tasks are using the live control-plane server for ${state.workspace.name}.`,
     tone: 'secondary',
     endpoint,
-    ownerId: state.runtimeHost.ownerId,
-    lastSeenAt,
+    serverId: state.runtimeHost.serverId,
+    startedAt: state.runtimeHost.startedAt,
   };
-}
-
-function isStale(lastSeenAt: string | undefined): boolean {
-  if (!lastSeenAt) {
-    return false;
-  }
-  const parsed = Date.parse(lastSeenAt);
-  if (!Number.isFinite(parsed)) {
-    return false;
-  }
-  return Date.now() - parsed > STALE_AFTER_MS;
 }

--- a/src/web/features/control-plane/screens/OverviewScreen.tsx
+++ b/src/web/features/control-plane/screens/OverviewScreen.tsx
@@ -65,8 +65,8 @@ export function OverviewScreen({
               <MetaRow label="Endpoint">
                 {state.runtimeHost.endpoint.host}:{state.runtimeHost.endpoint.port}
               </MetaRow>
-              <MetaRow label="Owner">{state.runtimeHost.ownerId}</MetaRow>
-              <MetaRow label="Last seen">{state.runtimeHost.workspaceOwner?.lastSeenAt ?? 'unknown'}</MetaRow>
+              <MetaRow label="Server">{state.runtimeHost.serverId}</MetaRow>
+              <MetaRow label="Started">{state.runtimeHost.startedAt}</MetaRow>
               <MetaRow label="Registry">{state.runtimeHost.registryPath}</MetaRow>
             </dl>
           : <p className="mt-4 text-sm text-muted-foreground">Daemon metadata is not loaded in this control-plane session.</p>}


### PR DESCRIPTION
## Summary
- Move the daemon registry from workspace-owner records to a top-level live control-plane server plus known workspace records
- Change runtime host discovery to resolve the live local server directly, independent of workspace ownership
- Make workspace catalog ids globally unique: new default workspaces use a stable state-root-derived `workspace-*` id, and legacy `default` catalog ids are migrated on read
- Teach request-scoped workspace resolution to find registered workspaces by `workspaceId`, so one live server can handle clients from different workspaces
- Keep v1 `heddle ask` changes minimal: daemon-backed ask now sends the cwd-derived workspace id explicitly, with inline comments marking the v1-only compatibility path
- Fix packaged CLI linking by marking the built bin entrypoint executable during `yarn build`

## How to test
- Run focused registry, workspace, and ask coverage:
  `./node_modules/.bin/vitest run src/__tests__/integration/control-plane/workspace-catalog.test.ts src/__tests__/integration/control-plane/session-lifecycle.test.ts src/__tests__/integration/server/daemon-registry.test.ts src/__tests__/integration/server/runtime-hosts.test.ts src/__tests__/integration/tui/ask-cli.test.ts`
- Run build/typecheck:
  `yarn build`
- Run web-v2 browser integration in an environment that can launch Chromium:
  `yarn test:browser-integration:v2`
- Verify local link packaging after build:
  `npm link`, then run the linked bin or `/Users/roackb2/.asdf/installs/nodejs/22.21.1/bin/heddle --version`

## Manual verification focus
- Start daemon and inspect `~/.heddle/daemon-registry.json`: it should contain a top-level `server`; the current Heddle workspace should be registered with a generated `workspace-*` id rather than `default`
- Confirm old registry records can still be read, but new/current workspace records do not rely on the local `default` id
- Confirm daemon-backed `heddle ask` sends the cwd-derived workspace id with session list/create/prompt calls
- Confirm `chat-v2` still passes its active workspace id separately from the resolved live server endpoint
- Confirm bare `heddle` still starts the current default chat path until the final cli-v2 default switch PR
