### PR TITLE
[codex] Add TUI recent edit diff panel

### DIFF
--- a/src/__tests__/unit/client-shared/session-activity-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-activity-service.test.ts
@@ -120,6 +120,84 @@ describe('ClientSharedSessionActivityService', () => {
     expect(effects).toEqual(['Implement']);
   });
 
+  it('projects recent edit diffs from successful edit_file completions', () => {
+    const diffs: string[] = [];
+
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'tool.completed',
+      tool: 'edit_file',
+      toolCallId: 'call-1',
+      result: {
+        ok: true,
+        output: {
+          path: 'src/example.ts',
+          action: 'replace',
+          diff: {
+            diff: [
+              '--- a/src/example.ts',
+              '+++ b/src/example.ts',
+              '@@ -1 +1 @@',
+              '-old',
+              '+new',
+            ].join('\n'),
+            truncated: false,
+          },
+        },
+      },
+      durationMs: 4,
+      step: 3,
+      runId: 'run-1',
+      source: 'agent-loop',
+      timestamp: '2026-06-03T00:00:00.000Z',
+    } as ControlPlaneSessionActivity, {
+      onRecentEditDiff: (diff) => diffs.push(`${diff.id}:${diff.path}:${diff.action}:${diff.step}:${diff.patch}`),
+    });
+
+    expect(diffs).toEqual([
+      `run-1:call-1:src/example.ts:replace:3:${[
+        '--- a/src/example.ts',
+        '+++ b/src/example.ts',
+        '@@ -1 +1 @@',
+        '-old',
+        '+new',
+      ].join('\n')}`,
+    ]);
+  });
+
+  it('does not project recent edit diffs from shell or failed edit_file completions', () => {
+    const diffs: string[] = [];
+
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'tool.completed',
+      tool: 'run_shell',
+      toolCallId: 'call-1',
+      result: { ok: true },
+      durationMs: 4,
+      step: 1,
+      runId: 'run-1',
+      source: 'agent-loop',
+      timestamp: '2026-06-03T00:00:00.000Z',
+    } as ControlPlaneSessionActivity, {
+      onRecentEditDiff: (diff) => diffs.push(diff.path),
+    });
+
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'tool.completed',
+      tool: 'edit_file',
+      toolCallId: 'call-2',
+      result: { ok: false },
+      durationMs: 4,
+      step: 2,
+      runId: 'run-1',
+      source: 'agent-loop',
+      timestamp: '2026-06-03T00:00:01.000Z',
+    } as ControlPlaneSessionActivity, {
+      onRecentEditDiff: (diff) => diffs.push(diff.path),
+    });
+
+    expect(diffs).toEqual([]);
+  });
+
   it('uses derived tool labels when the API provides them', () => {
     expect(ClientSharedSessionActivityService.formatToolLabel({
       type: 'tool.approval_requested',

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -14,6 +14,7 @@ import { ModelPickerPanel } from './components/ModelPickerPanel.js';
 import { PromptInput } from './components/PromptInput.js';
 import { PromptStatusPanel } from './components/PromptStatusPanel.js';
 import { QueuedPromptPanel } from './components/QueuedPromptPanel.js';
+import { RecentEditDiffPanel } from './components/RecentEditDiffPanel.js';
 import { ReasoningEffortPickerPanel } from './components/ReasoningEffortPickerPanel.js';
 import { RunControls } from './components/RunControls.js';
 import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
@@ -138,6 +139,7 @@ export function App({
         {snapshot.activeSession ? ` · ${snapshot.activeSession.name}` : ''}
       </Text>
       <ConversationPanel runtimeContext={snapshot.runtimeContext} session={snapshot.activeSession} />
+      <RecentEditDiffPanel diffs={snapshot.recentEditDiffs} />
       <CommandResultPanel results={snapshot.commandResults} />
       {snapshot.pendingApproval ? (
         <ApprovalPanel

--- a/src/cli-v2/components/RecentEditDiffPanel.tsx
+++ b/src/cli-v2/components/RecentEditDiffPanel.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { ClientSharedRecentEditDiff } from '@/client-shared/services/session-activities/index.js';
+
+const MAX_VISIBLE_DIFFS = 3;
+const MAX_VISIBLE_LINES = 120;
+const MAX_LINE_LENGTH = 160;
+
+const actionLabels: Record<string, string> = {
+  create: 'created',
+  delete: 'deleted',
+  replace: 'edited',
+  update: 'edited',
+};
+
+type RecentEditDiffPanelProps = {
+  diffs: ClientSharedRecentEditDiff[];
+};
+
+type RenderedDiff = {
+  lines: string[];
+  truncated: boolean;
+};
+
+export function RecentEditDiffPanel({ diffs }: RecentEditDiffPanelProps) {
+  const visibleDiffs = diffs.slice(-MAX_VISIBLE_DIFFS);
+  if (visibleDiffs.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} marginTop={1}>
+      <Text bold>Recent edits</Text>
+      {visibleDiffs.map((diff) => (
+        <Box key={diff.id} flexDirection="column" marginTop={1}>
+          <Text>
+            <Text color="cyan">{diff.path}</Text>
+            <Text dimColor>{formatEditMeta(diff)}</Text>
+          </Text>
+          {renderPatch(diff)}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function formatEditMeta(diff: ClientSharedRecentEditDiff): string {
+  const action = diff.action ? actionLabels[diff.action] ?? diff.action : undefined;
+  const step = typeof diff.step === 'number' ? `step ${diff.step}` : undefined;
+  return [action, step].filter(Boolean).map((value) => ` · ${value}`).join('');
+}
+
+function renderPatch(diff: ClientSharedRecentEditDiff) {
+  const { lines, truncated } = preparePatchLines(diff.patch);
+  return (
+    <>
+      {lines.map((line, index) => (
+        <Text key={`${diff.id}:${index}`} color={resolveDiffLineColor(line)} dimColor={isDiffHeaderLine(line)}>
+          {line}
+        </Text>
+      ))}
+      {diff.truncated || truncated ? <Text color="yellow">Diff preview truncated.</Text> : null}
+    </>
+  );
+}
+
+function preparePatchLines(patch: string): RenderedDiff {
+  const rawLines = patch.split('\n');
+  const visibleLines = rawLines.slice(0, MAX_VISIBLE_LINES).map(truncateLine);
+  return {
+    lines: visibleLines,
+    truncated: rawLines.length > visibleLines.length,
+  };
+}
+
+function truncateLine(line: string): string {
+  if (line.length <= MAX_LINE_LENGTH) {
+    return line;
+  }
+
+  return `${line.slice(0, MAX_LINE_LENGTH - 3)}...`;
+}
+
+function resolveDiffLineColor(line: string): string | undefined {
+  if (line.startsWith('@@')) {
+    return 'cyan';
+  }
+
+  if (line.startsWith('+') && !line.startsWith('+++')) {
+    return 'green';
+  }
+
+  if (line.startsWith('-') && !line.startsWith('---')) {
+    return 'red';
+  }
+
+  return undefined;
+}
+
+function isDiffHeaderLine(line: string): boolean {
+  return line.startsWith('diff --git') || line.startsWith('index ') || line.startsWith('---') || line.startsWith('+++');
+}

--- a/src/cli-v2/state/control-plane-live-event-reducer.ts
+++ b/src/cli-v2/state/control-plane-live-event-reducer.ts
@@ -14,6 +14,8 @@ type ControlPlaneLiveEventReducerOptions = {
   refreshPendingApproval: (sessionId: string) => Promise<void>;
 };
 
+const MAX_RECENT_EDIT_DIFFS = 5;
+
 /**
  * Owns cli-v2 reduction of control-plane live events into render state.
  *
@@ -70,8 +72,17 @@ export class ControlPlaneLiveEventReducer {
             running: true,
             liveStatus,
             currentActivity: ClientSharedSessionActivityService.createThinkingStatus(runActivity.timestamp),
+            recentEditDiffs: [],
             latestUpdate: SessionActivityService.resolveLatestUpdate(runActivity),
           });
+        },
+        onRecentEditDiff: (diff) => {
+          this.options.state.patch((current) => ({
+            recentEditDiffs: [
+              ...current.recentEditDiffs.filter((candidate) => candidate.id !== diff.id),
+              diff,
+            ].slice(-MAX_RECENT_EDIT_DIFFS),
+          }));
         },
         onRunFinished: (runActivity, liveStatus) => {
           this.options.assistantStreamBuffer.flush();

--- a/src/cli-v2/state/control-plane-session-loader.ts
+++ b/src/cli-v2/state/control-plane-session-loader.ts
@@ -56,6 +56,7 @@ export class ControlPlaneSessionLoader {
       liveStatus: undefined,
       currentActivity: undefined,
       activePlan: undefined,
+      recentEditDiffs: [],
       latestUpdate: undefined,
       error: undefined,
       loading: true,

--- a/src/cli-v2/state/control-plane-session-state.ts
+++ b/src/cli-v2/state/control-plane-session-state.ts
@@ -1,5 +1,6 @@
 import type {
   ClientSharedAgentActivityStatus,
+  ClientSharedRecentEditDiff,
   ClientSharedSessionPlan,
 } from '@/client-shared/services/session-activities/index.js';
 import type { ControlPlaneProxyClient } from '@/client-shared/api/proxy.js';
@@ -49,6 +50,7 @@ export type ControlPlaneSessionStoreSnapshot = {
   liveStatus?: string;
   currentActivity?: ClientSharedAgentActivityStatus;
   activePlan?: ClientSharedSessionPlan;
+  recentEditDiffs: ClientSharedRecentEditDiff[];
   latestUpdate?: ControlPlaneSessionLatestUpdate;
   slashCommandCatalog?: ControlPlaneSlashCommandCatalog;
   commandResults: ControlPlaneSlashCommandResult[];
@@ -72,6 +74,7 @@ export const INITIAL_CONTROL_PLANE_SESSION_SNAPSHOT: ControlPlaneSessionStoreSna
   running: false,
   cancelling: false,
   streamConnected: false,
+  recentEditDiffs: [],
   commandResults: [],
 };
 

--- a/src/client-shared/services/session-activities/index.ts
+++ b/src/client-shared/services/session-activities/index.ts
@@ -1,6 +1,7 @@
 export {
   ClientSharedSessionActivityService,
   type ClientSharedAgentActivityStatus,
+  type ClientSharedRecentEditDiff,
   type ClientSharedSessionActivity,
   type ClientSharedSessionLatestUpdate,
   type ClientSharedSessionPlan,

--- a/src/client-shared/services/session-activities/session-activity-service.ts
+++ b/src/client-shared/services/session-activities/session-activity-service.ts
@@ -4,6 +4,9 @@ import type {
 } from '../../api/types.js';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration.js';
+import isBoolean from 'lodash/isBoolean.js';
+import isPlainObject from 'lodash/isPlainObject.js';
+import isString from 'lodash/isString.js';
 
 dayjs.extend(duration);
 
@@ -18,6 +21,17 @@ export type ClientSharedSessionLatestUpdate = {
   label: string;
   detail?: string;
   tone: 'info' | 'success' | 'warning' | 'error';
+};
+export type ClientSharedRecentEditDiff = {
+  id: string;
+  runId: string;
+  step?: number;
+  toolCallId: string;
+  path: string;
+  action?: string;
+  patch: string;
+  truncated: boolean;
+  timestamp: string;
 };
 
 type SessionActivityStatusHandlers = {
@@ -45,6 +59,7 @@ export type ClientSharedSessionActivityEffects = {
   onAssistantStream?: (activity: ActivityOf<'assistant.stream'>, liveStatus: string | undefined) => void;
   onRunStarted?: (activity: ActivityOf<'loop.started'> | ActivityOf<'direct_shell.started'>, liveStatus: string | undefined) => void;
   onRunFinished?: (activity: ActivityOf<'loop.finished'> | ActivityOf<'direct_shell.completed'>, liveStatus: string | undefined) => void;
+  onRecentEditDiff?: (diff: ClientSharedRecentEditDiff, activity: ActivityOf<'tool.completed'>) => void;
   onPlanUpdated?: (activity: ClientSharedSessionPlan) => void;
   onPlanCleared?: () => void;
   onLiveStatus?: (activity: ClientSharedSessionActivity, liveStatus: string | undefined) => void;
@@ -95,6 +110,10 @@ export class ClientSharedSessionActivityService {
     'tool.completed': (activity, effects) => {
       effects.onCurrentActivityChanged?.(ClientSharedSessionActivityService.createThinkingStatus(activity.timestamp));
       ClientSharedSessionActivityService.applyLiveStatus(activity, effects);
+      const recentEditDiff = ClientSharedSessionActivityService.projectRecentEditDiff(activity);
+      if (recentEditDiff) {
+        effects.onRecentEditDiff?.(recentEditDiff, activity);
+      }
       effects.onWorkspaceChanged?.(activity);
     },
     'plan.updated': (activity, effects) => {
@@ -241,6 +260,41 @@ export class ClientSharedSessionActivityService {
       (activity: ClientSharedSessionActivity) => ClientSharedSessionLatestUpdate | undefined
     ) | undefined;
     return handler?.(activity);
+  }
+
+  static projectRecentEditDiff(activity: ActivityOf<'tool.completed'>): ClientSharedRecentEditDiff | undefined {
+    if (activity.tool !== 'edit_file' || activity.result?.ok !== true) {
+      return undefined;
+    }
+
+    const output = isPlainObject(activity.result.output)
+      ? activity.result.output as Record<string, unknown>
+      : undefined;
+    const diff = output && isPlainObject(output.diff)
+      ? output.diff as Record<string, unknown>
+      : undefined;
+    if (!output || !diff) {
+      return undefined;
+    }
+
+    const path = output && isString(output.path) && output.path.length > 0 ? output.path : undefined;
+    const patch = diff && isString(diff.diff) && diff.diff.length > 0 ? diff.diff : undefined;
+    if (!path || !patch) {
+      return undefined;
+    }
+
+    const action = isString(output.action) && output.action.length > 0 ? output.action : undefined;
+    return {
+      id: `${activity.runId}:${activity.toolCallId}`,
+      runId: activity.runId,
+      ...(typeof activity.step === 'number' ? { step: activity.step } : {}),
+      toolCallId: activity.toolCallId,
+      path,
+      ...(action ? { action } : {}),
+      patch,
+      truncated: isBoolean(diff.truncated) ? diff.truncated : false,
+      timestamp: activity.timestamp,
+    };
   }
 
   private static formatLiveStatus(activity: ClientSharedSessionActivity): string | undefined {


### PR DESCRIPTION
## Summary

- project successful `edit_file` completions into a shared `ClientSharedRecentEditDiff` client contract
- store recent edit diffs in the cli-v2 session snapshot and clear them on new runs/session switches
- render a bounded TUI `Recent edits` panel with colored diff hunks for the files the agent just touched

## Behavior change

The web UI continues to show the full workspace diff review panel.

The TUI now shows recent diffs from successful `edit_file` tool completions in the active session. This uses live tool activity facts, not current Git workspace state, so the panel is scoped to files the agent just touched through `edit_file`. Shell mutations still refresh workspace state but are not attributed as exact recent edit diffs.

## Boundary notes

- `client-shared` owns the neutral projection from control-plane session activity to recent edit diff data.
- `cli-v2` owns terminal snapshot lifecycle and Ink rendering.
- No cli-v2 imports from core/server/legacy cli were added.

## Verification

- `yarn test:unit src/__tests__/unit/client-shared/session-activity-service.test.ts`
- `yarn typecheck`
- `yarn lint`
- `git diff --check`
