### PR TITLE
Refactor remaining command edges

### DIFF
--- a/src/__tests__/unit/cli-v2/memory-command.test.ts
+++ b/src/__tests__/unit/cli-v2/memory-command.test.ts
@@ -1,0 +1,85 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryCliV2CommandEdgeService } from '@/cli-v2/commands/memory-command.js';
+import type { CliV2CommandEdgeOptions } from '@/cli-v2/commands/types.js';
+
+describe('MemoryCliV2CommandEdgeService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes memory catalogs and reports status through memory services', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-command-'));
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await MemoryCliV2CommandEdgeService.run('init', commandOptions(workspaceRoot));
+    await MemoryCliV2CommandEdgeService.run('status', commandOptions(workspaceRoot));
+
+    const output = stdout.mock.calls.map(([message]) => message).join('');
+    expect(output).toContain('Memory root:');
+    expect(output).toContain('Created:');
+    expect(output).toContain('Catalog shape: ok');
+    expect(output).toContain('Pending candidates: 0');
+  });
+
+  it('formats list/read/search command output without owning note traversal policy', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-command-notes-'));
+    const memoryRoot = join(workspaceRoot, '.heddle', 'memory');
+    const noteDir = join(memoryRoot, 'workflows');
+    mkdirSync(noteDir, { recursive: true });
+    writeFileSync(join(noteDir, 'release.md'), 'Release checklist\nRun yarn test\n', 'utf8');
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await MemoryCliV2CommandEdgeService.run('list', commandOptions(workspaceRoot));
+    await MemoryCliV2CommandEdgeService.run('read', commandOptions(workspaceRoot), { path: 'workflows/release.md' });
+    await MemoryCliV2CommandEdgeService.run('search', commandOptions(workspaceRoot), { query: 'yarn test' });
+
+    const output = stdout.mock.calls.map(([message]) => message).join('');
+    expect(output).toContain('workflows/release.md');
+    expect(output).toContain('Release checklist');
+    expect(output).toContain('Run yarn test');
+  });
+
+  it('reports pending maintainer candidates in dry-run mode without constructing an LLM', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-command-maintain-'));
+    const maintenanceDir = join(workspaceRoot, '.heddle', 'memory', '_maintenance');
+    mkdirSync(maintenanceDir, { recursive: true });
+    writeFileSync(
+      join(maintenanceDir, 'candidates.jsonl'),
+      `${JSON.stringify({
+        id: 'candidate-1',
+        recordedAt: '2026-06-04T00:00:00.000Z',
+        status: 'pending',
+        summary: 'Remember the command-edge boundary.',
+        evidence: [],
+        categoryHint: 'architecture',
+        importance: 'high',
+        confidence: 'user-stated',
+        sourceRefs: [],
+      })}\n`,
+      'utf8',
+    );
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await MemoryCliV2CommandEdgeService.run('maintain', commandOptions(workspaceRoot), { dryRun: true });
+
+    const output = stdout.mock.calls.map(([message]) => message).join('');
+    expect(output).toContain('Pending candidates: 1');
+    expect(output).toContain('candidate-1: Remember the command-edge boundary.');
+  });
+});
+
+function commandOptions(workspaceRoot: string): CliV2CommandEdgeOptions {
+  return {
+    workspaceRoot,
+    activeWorkspaceId: 'workspace-test',
+    preferApiKey: false,
+    stateDir: '.heddle',
+    directShellApproval: 'never',
+    searchIgnoreDirs: [],
+    runtimeHost: { kind: 'none', registryPath: '' },
+    forceOwnerConflict: false,
+  };
+}

--- a/src/__tests__/unit/cli-v2/memory-command.test.ts
+++ b/src/__tests__/unit/cli-v2/memory-command.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MemoryCliV2CommandEdgeService } from '@/cli-v2/commands/memory-command.js';
 import type { CliV2CommandEdgeOptions } from '@/cli-v2/commands/types.js';
+import { LlmAdapterService } from '@/core/llm/index.js';
+import { MemoryMaintenanceService } from '@/core/memory/maintainer.js';
+import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 
 describe('MemoryCliV2CommandEdgeService', () => {
   afterEach(() => {
@@ -68,6 +71,49 @@ describe('MemoryCliV2CommandEdgeService', () => {
     const output = stdout.mock.calls.map(([message]) => message).join('');
     expect(output).toContain('Pending candidates: 1');
     expect(output).toContain('candidate-1: Remember the command-edge boundary.');
+  });
+
+  it('allows maintainer runs to use stored credentials when no provider API key is present', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-command-stored-credential-'));
+    vi.spyOn(RuntimeCredentialService, 'resolveApiKeyForModel').mockReturnValue(undefined);
+    vi.spyOn(RuntimeCredentialService, 'hasCredentialForModel').mockReturnValue(true);
+    const createLlm = vi.spyOn(LlmAdapterService, 'create').mockReturnValue({} as ReturnType<typeof LlmAdapterService.create>);
+    vi.spyOn(MemoryMaintenanceService.prototype, 'readPendingCandidates').mockResolvedValue([
+      {
+        id: 'candidate-1',
+        recordedAt: '2026-06-04T00:00:00.000Z',
+        status: 'pending',
+        summary: 'Remember stored OAuth for memory maintenance.',
+        evidence: [],
+        categoryHint: 'architecture',
+        importance: 'high',
+        confidence: 'user-stated',
+        sourceRefs: [],
+      },
+    ]);
+    vi.spyOn(MemoryMaintenanceService.prototype, 'runBacklog').mockResolvedValue({
+      run: {
+        id: 'memory-run-test',
+        startedAt: '2026-06-04T00:00:00.000Z',
+        finishedAt: '2026-06-04T00:00:01.000Z',
+        source: 'heddle memory maintain',
+        outcome: 'done',
+        summary: 'Processed stored credential candidate.',
+        candidateIds: ['candidate-1'],
+        processedCandidateIds: ['candidate-1'],
+        failedCandidateIds: [],
+        catalogValid: true,
+        catalogMissing: [],
+      },
+    });
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await MemoryCliV2CommandEdgeService.run('maintain', commandOptions(workspaceRoot));
+
+    expect(createLlm).toHaveBeenCalledWith({ model: 'gpt-5.4', credentials: undefined });
+    const output = stdout.mock.calls.map(([message]) => message).join('');
+    expect(output).toContain('Outcome: done');
+    expect(output).toContain('Candidates: 1/1 processed');
   });
 });
 

--- a/src/__tests__/unit/cli/main-command-routing.test.ts
+++ b/src/__tests__/unit/cli/main-command-routing.test.ts
@@ -39,4 +39,11 @@ describe('CLI command routing', () => {
     expect(source).toMatch(/if \(knownCommand && !isKnownCommand\(knownCommand\)[\s\S]*?await AskCliV2CommandEdgeService\.run\(argv\.join\(' '\)\.trim\(\), \{/);
     expect(source).not.toContain("from './ask.js'");
   });
+
+  it('shows discovery help for command groups with subcommands', () => {
+    const source = readFileSync(join(process.cwd(), 'src', 'cli', 'main.ts'), 'utf8');
+
+    expect(source).toMatch(/const memoryCommand = program[\s\S]*?\.command\('memory'\)[\s\S]*?\.addHelpCommand\('help \[command\]'[\s\S]*?\.action\(\(_, command\) => \{\s*command\.outputHelp\(\);\s*\}\);/);
+    expect(source).toMatch(/memoryCommand\s*\n\s*\.command\('status'\)[\s\S]*?await MemoryCliV2CommandEdgeService\.run\('status', resolved\);/);
+  });
 });

--- a/src/__tests__/unit/tui/daemon.test.ts
+++ b/src/__tests__/unit/tui/daemon.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { ControlPlaneChatSessionPresenter, parseDaemonArgs, runDaemonCli } from '../../../cli/daemon.js';
+import {
+  ControlPlaneChatSessionPresenter,
+  DaemonCliV2CommandEdgeService,
+  parseDaemonArgs,
+} from '@/cli-v2/commands/daemon-command.js';
 import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
 
 describe('daemon CLI helpers', () => {
@@ -44,7 +48,7 @@ describe('daemon CLI helpers', () => {
     };
     const output: string[] = [];
 
-    const result = await runDaemonCli([], {
+    const result = await DaemonCliV2CommandEdgeService.run([], {
       runtimeHost,
       stdout: {
         write: (message) => output.push(message),

--- a/src/__tests__/unit/tui/eval-cli.test.ts
+++ b/src/__tests__/unit/tui/eval-cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseEvalArgs } from '../../../cli/eval/index.js';
+import { parseEvalArgs } from '@/cli-v2/commands/eval-command.js';
 
 describe('parseEvalArgs', () => {
   it('parses agent eval options', () => {

--- a/src/__tests__/unit/tui/heartbeat-cli.test.ts
+++ b/src/__tests__/unit/tui/heartbeat-cli.test.ts
@@ -5,6 +5,15 @@ import { HeartbeatCliCommandEdgeService } from '@/cli-v2/commands/heartbeat-comm
 import { formatDurationMs, parseDurationMs, parseHeartbeatArgs } from '../../../cli/heartbeat.js';
 
 describe('heartbeat CLI helpers', () => {
+  it('treats a bare heartbeat command as discovery help', () => {
+    expect(parseHeartbeatArgs([])).toEqual({
+      command: 'help',
+      subcommand: undefined,
+      rest: [],
+      flags: {},
+    });
+  });
+
   it('parses heartbeat subcommands and flags', () => {
     expect(parseHeartbeatArgs([
       'task',

--- a/src/cli-v2/commands/README.md
+++ b/src/cli-v2/commands/README.md
@@ -47,16 +47,16 @@ domain should have:
 | `heddle chat-v1` | Explicit legacy fallback through `src/cli/chat`. | Keep only while CLI v1 remains available; delete during v1 retirement. |
 | `heddle ask` | `cli-v2` command adapter attaches/embeds the control-plane server, selects or creates a session, and submits through session APIs. | API-backed runtime command. Keep one-shot asks on the same session/run path as TUI and web. |
 | Unknown first argument fallback | Unknown command currently becomes `ask`. | Decide explicitly. Keep only if documented as shorthand; otherwise remove before v1 retirement. |
-| `heddle daemon` | Adapter over runtime discovery and `src/server` lifecycle. | Move command ownership here. Direct discovery/lifecycle calls remain acceptable because the command manages the server. |
+| `heddle daemon` | `cli-v2` command adapter over runtime discovery and `src/server` lifecycle. | Direct discovery/lifecycle calls remain acceptable because the command manages the server. |
 | `heddle auth` | `cli-v2` command adapter delegates credential status/login/logout semantics to `ProviderCredentialCommandService`; `src/cli/auth.ts` remains only as removable v1 compatibility. | Direct management adapter over the core auth command service. |
 | `heddle init` | `cli-v2` command adapter delegates `.heddle/config.json` path/default/template behavior to `ProjectConfigService`. | Direct management adapter over the core project-config service/schema contract. |
-| `heddle memory status/list/read/search` | Direct memory visibility/catalog service calls implemented inline in `src/cli/main.ts`. | Direct management adapter calling documented memory service contracts. |
-| `heddle memory init/validate/maintain` | Direct core memory services; maintenance resolves model/credentials locally. | Direct management adapter, once memory README/public methods explicitly cover validation, repair, backlog, and credential expectations. |
+| `heddle memory status/list/read/search` | `cli-v2` command adapter over documented memory catalog and visibility services. | Direct management adapter calling documented memory service contracts. |
+| `heddle memory init/validate/maintain` | `cli-v2` command adapter over documented memory validation and maintenance services. | Direct management adapter; command edge owns terminal formatting and explicit maintainer credential selection only. |
 | `heddle heartbeat task ...` | `cli-v2` command adapter attaches/embeds the control-plane server and calls heartbeat task API procedures. | API-backed management command; command code must not own task/schedule mutation policy. |
 | `heddle heartbeat runs ...` | `cli-v2` command adapter reads heartbeat run views through control-plane API procedures. | API-backed read command using the same run view shape as web-v2. |
 | `heddle heartbeat run` | `cli-v2` command adapter requests task execution or due-task execution through the live/embedded control-plane server. | Server-backed runtime command; no local CLI scheduler worker. |
 | `heddle heartbeat start` | `cli-v2` command adapter creates/updates a task through API and reports the server-backed scheduler. Embedded mode keeps the control-plane server alive until Ctrl+C. | Server-backed lifecycle command; do not run a separate CLI scheduler loop. |
-| `heddle eval` | Local eval harness adapter over core eval modules. | Direct dev/management adapter unless remote/API evals become a product goal. |
+| `heddle eval` | `cli-v2` command adapter over core eval harness modules. | Direct dev/management adapter unless remote/API evals become a product goal. |
 
 ## Migration Order
 

--- a/src/cli-v2/commands/daemon-command.ts
+++ b/src/cli-v2/commands/daemon-command.ts
@@ -2,8 +2,8 @@ import { resolve } from 'node:path';
 import {
   ControlPlaneChatSessionPresenter,
   startHeddleControlPlaneServer,
-} from '../server/index.js';
-import type { HeddleControlPlaneServerHandle, HeddleControlPlaneServerOptions } from '../server/index.js';
+} from '@/server/index.js';
+import type { HeddleControlPlaneServerHandle, HeddleControlPlaneServerOptions } from '@/server/index.js';
 import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
 import { RuntimeHostResolver } from '@/core/runtime/daemon/index.js';
 
@@ -30,40 +30,52 @@ const DEFAULT_PORT = 8765;
 
 export { ControlPlaneChatSessionPresenter };
 
-export async function runDaemonCli(
-  args: string[],
-  options: DaemonCliOptions = {},
-): Promise<{ kind: 'attached'; host: ResolvedRuntimeHost } | { kind: 'started'; handle: HeddleControlPlaneServerHandle }> {
-  const parsed = parseDaemonArgs(args);
-  const runtimeHost = options.runtimeHost ?? RuntimeHostResolver.resolveLiveServer();
-  if (!options.forceOwnerConflict && runtimeHost.kind === 'server' && !runtimeHost.stale) {
-    writeExistingServerNotice(runtimeHost, options.stdout ?? process.stdout);
+/**
+ * Command edge for `heddle daemon`.
+ *
+ * Owns: terminal daemon argument parsing, live-server attach behavior, CLI
+ * notices, and process signal handling for a standalone daemon process.
+ *
+ * Does not own: reusable HTTP server lifecycle, registry persistence, workspace
+ * identity, or heartbeat scheduler semantics. Those belong to `src/server` and
+ * `src/core/runtime/daemon`.
+ */
+export class DaemonCliV2CommandEdgeService {
+  static async run(
+    args: string[],
+    options: DaemonCliOptions = {},
+  ): Promise<{ kind: 'attached'; host: ResolvedRuntimeHost } | { kind: 'started'; handle: HeddleControlPlaneServerHandle }> {
+    const parsed = parseDaemonArgs(args);
+    const runtimeHost = options.runtimeHost ?? RuntimeHostResolver.resolveLiveServer();
+    if (!options.forceOwnerConflict && runtimeHost.kind === 'server' && !runtimeHost.stale) {
+      writeExistingServerNotice(runtimeHost, options.stdout ?? process.stdout);
+      return {
+        kind: 'attached',
+        host: runtimeHost,
+      };
+    }
+
+    const workspaceRoot = options.workspaceRoot ?? process.cwd();
+    const stateDir = options.stateDir ?? '.heddle';
+    const listenOptions: HeddleControlPlaneServerOptions = {
+      mode: 'daemon',
+      workspaceRoot,
+      stateRoot: resolve(workspaceRoot, stateDir),
+      preferApiKey: Boolean(options.preferApiKey),
+      host: parsed.host,
+      port: parsed.port,
+      assetsDir: parsed.assetsDir,
+      serveAssets: parsed.serveAssets,
+    };
+
+    const handle = await startHeddleControlPlaneServer(listenOptions);
+    installDaemonShutdownHandlers(handle);
+    writeStartedServerNotice(handle, options.stdout ?? process.stdout);
     return {
-      kind: 'attached',
-      host: runtimeHost,
+      kind: 'started',
+      handle,
     };
   }
-
-  const workspaceRoot = options.workspaceRoot ?? process.cwd();
-  const stateDir = options.stateDir ?? '.heddle';
-  const listenOptions: HeddleControlPlaneServerOptions = {
-    mode: 'daemon',
-    workspaceRoot,
-    stateRoot: resolve(workspaceRoot, stateDir),
-    preferApiKey: Boolean(options.preferApiKey),
-    host: parsed.host,
-    port: parsed.port,
-    assetsDir: parsed.assetsDir,
-    serveAssets: parsed.serveAssets,
-  };
-
-  const handle = await startHeddleControlPlaneServer(listenOptions);
-  installDaemonShutdownHandlers(handle);
-  writeStartedServerNotice(handle, options.stdout ?? process.stdout);
-  return {
-    kind: 'started',
-    handle,
-  };
 }
 
 function writeExistingServerNotice(

--- a/src/cli-v2/commands/eval-command.ts
+++ b/src/cli-v2/commands/eval-command.ts
@@ -1,10 +1,11 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { cleanupEvalResults } from '../../core/eval/cleanup.js';
-import { loadEvalCases } from '../../core/eval/case-loader.js';
-import { runAgentEvalCase } from '../../core/eval/agent-runner.js';
-import { writeEvalSuiteReport } from '../../core/eval/report-writer.js';
-import type { EvalCase, EvalSuiteReport } from '../../core/eval/schema.js';
+import dayjs from 'dayjs';
+import { cleanupEvalResults } from '@/core/eval/cleanup.js';
+import { loadEvalCases } from '@/core/eval/case-loader.js';
+import { runAgentEvalCase } from '@/core/eval/agent-runner.js';
+import { writeEvalSuiteReport } from '@/core/eval/report-writer.js';
+import type { EvalCase, EvalSuiteReport } from '@/core/eval/schema.js';
 
 export type EvalCliOptions = {
   repoRoot: string;
@@ -45,13 +46,25 @@ const evalCommandRunners: Partial<Record<EvalCommand, EvalCommandRunner>> = {
   help: () => writeEvalHelp(),
 };
 
-export async function runEvalCli(rawArgs: string[], options: EvalCliOptions) {
-  const args = parseEvalArgs(rawArgs);
-  await evalCommandRunners[args.command]?.(args, options);
+/**
+ * Command edge for `heddle eval`.
+ *
+ * Owns: terminal eval argument parsing, command dispatch, progress/report
+ * output, and dev-harness defaults.
+ *
+ * Does not own: eval case schemas, workspace fixture setup, agent subprocess
+ * execution, cleanup selection semantics, or report generation. Those stay in
+ * `src/core/eval` public harness services.
+ */
+export class EvalCliV2CommandEdgeService {
+  static async run(rawArgs: string[], options: EvalCliOptions): Promise<void> {
+    const args = parseEvalArgs(rawArgs);
+    await evalCommandRunners[args.command]?.(args, options);
+  }
 }
 
 async function runAgentEval(args: EvalArgs, options: EvalCliOptions) {
-  const startedAt = new Date().toISOString();
+  const startedAt = dayjs().toISOString();
   const loadedCases = loadEvalCases({
     casesDir: args.casesDir,
     ids: args.caseIds.length ? args.caseIds : undefined,
@@ -89,7 +102,7 @@ async function runAgentEval(args: EvalArgs, options: EvalCliOptions) {
     target: args.target,
     repoRoot: options.repoRoot,
     startedAt,
-    finishedAt: new Date().toISOString(),
+    finishedAt: dayjs().toISOString(),
     resultsDir: args.outputDir,
     results,
   };
@@ -269,17 +282,13 @@ function parsePositiveInt(raw: string, flag: string): number {
 }
 
 function parseDate(raw: string, flag: string): Date {
-  const date = new Date(raw);
-  if (Number.isNaN(date.getTime())) {
+  const date = dayjs(raw);
+  if (!date.isValid()) {
     throw new Error(`Invalid datetime for ${flag}: ${raw}`);
   }
-  return date;
+  return date.toDate();
 }
 
 function defaultRunDirName(prefix: string): string {
-  const timestamp = new Date().toISOString()
-    .replace('T', '-')
-    .replace(/\.\d{3}Z$/, '')
-    .replaceAll(':', '');
-  return `${prefix}-${timestamp}`;
+  return `${prefix}-${dayjs().format('YYYY-MM-DD-HHmmss')}`;
 }

--- a/src/cli-v2/commands/heartbeat/args.ts
+++ b/src/cli-v2/commands/heartbeat/args.ts
@@ -73,9 +73,9 @@ export function buildHeartbeatCommand(onParsed?: (parsed: ParsedHeartbeatArgs) =
 }
 
 export function parseHeartbeatArgs(args: string[]): ParsedHeartbeatArgs {
-  if (args[0] === 'help' || args[0] === '--help' || args[0] === '-h') {
+  if (args.length === 0 || args[0] === 'help' || args[0] === '--help' || args[0] === '-h') {
     return {
-      command: args[0],
+      command: args[0] ?? 'help',
       subcommand: undefined,
       rest: args.slice(1),
       flags: {},

--- a/src/cli-v2/commands/memory-command.ts
+++ b/src/cli-v2/commands/memory-command.ts
@@ -1,0 +1,268 @@
+import { resolve } from 'node:path';
+import compact from 'lodash/compact.js';
+import { DEFAULT_OPENAI_MODEL, LlmAdapterService } from '@/index.js';
+import { MemoryCatalogService } from '@/core/memory/catalog.js';
+import { MemoryMaintenanceService } from '@/core/memory/maintainer.js';
+import { MemoryValidationService } from '@/core/memory/validation.js';
+import { MemoryVisibilityService } from '@/core/memory/visibility.js';
+import type { MemoryValidationResult } from '@/core/memory/types.js';
+import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
+import type { CliV2CommandEdgeOptions } from './types.js';
+
+export type MemoryCliCommand = 'status' | 'init' | 'list' | 'read' | 'search' | 'validate' | 'maintain';
+
+export type MemoryCliCommandFlags = {
+  path?: string;
+  query?: string;
+  offset?: number;
+  maxLines?: number;
+  maxResults?: number;
+  repair?: boolean;
+  dryRun?: boolean;
+  reconcile?: boolean;
+};
+
+/**
+ * Command edge for `heddle memory`.
+ *
+ * Owns: terminal subcommand dispatch, flag-to-service option parsing, provider
+ * credential selection for the explicit maintainer command, and terminal
+ * formatting.
+ *
+ * Does not own: catalog invariants, note traversal/search semantics, memory
+ * validation rules, candidate persistence, or maintainer behavior. Those stay
+ * in `src/core/memory` public services.
+ */
+export class MemoryCliV2CommandEdgeService {
+  static async run(
+    command: MemoryCliCommand,
+    options: CliV2CommandEdgeOptions,
+    flags: MemoryCliCommandFlags = {},
+  ): Promise<void> {
+    const context = MemoryCliV2CommandEdgeService.createContext(options);
+
+    if (command === 'init') {
+      MemoryCliV2CommandEdgeService.runInit(context);
+      return;
+    }
+
+    if (command === 'status') {
+      await MemoryCliV2CommandEdgeService.runStatus(context);
+      return;
+    }
+
+    if (command === 'list') {
+      await MemoryCliV2CommandEdgeService.runList(context, flags);
+      return;
+    }
+
+    if (command === 'read') {
+      await MemoryCliV2CommandEdgeService.runRead(context, flags);
+      return;
+    }
+
+    if (command === 'search') {
+      await MemoryCliV2CommandEdgeService.runSearch(context, flags);
+      return;
+    }
+
+    if (command === 'validate') {
+      await MemoryCliV2CommandEdgeService.runValidate(context, flags);
+      return;
+    }
+
+    if (command === 'maintain') {
+      await MemoryCliV2CommandEdgeService.runMaintain(context, options, flags);
+      return;
+    }
+
+    const exhaustive: never = command;
+    throw new Error(`Unsupported memory command: ${exhaustive}`);
+  }
+
+  private static createContext(options: CliV2CommandEdgeOptions) {
+    const memoryRoot = resolve(options.workspaceRoot, options.stateDir, 'memory');
+    return {
+      memoryRoot,
+      catalog: new MemoryCatalogService(memoryRoot),
+      visibility: new MemoryVisibilityService(memoryRoot),
+      validation: new MemoryValidationService(memoryRoot),
+      maintenance: new MemoryMaintenanceService(memoryRoot),
+    };
+  }
+
+  private static runInit(context: ReturnType<typeof MemoryCliV2CommandEdgeService.createContext>): void {
+    const result = context.catalog.bootstrap();
+    process.stdout.write(`Memory root: ${result.memoryRoot}\n`);
+    process.stdout.write(
+      result.createdPaths.length > 0 ?
+        `Created:\n${MemoryCliV2CommandEdgeService.formatBulletList(result.createdPaths)}\n`
+      : 'Memory workspace already initialized.\n',
+    );
+  }
+
+  private static async runStatus(context: ReturnType<typeof MemoryCliV2CommandEdgeService.createContext>): Promise<void> {
+    const result = await context.visibility.loadStatus();
+    process.stdout.write([
+      `Memory root: ${result.memoryRoot}`,
+      `Catalog shape: ${result.catalog.ok ? 'ok' : 'missing required catalogs'}`,
+      `Notes: ${result.notes.count}`,
+      `Pending candidates: ${result.candidates.pending}`,
+      result.runs.latest.length > 0 ?
+        `Recent runs:\n${MemoryCliV2CommandEdgeService.formatBulletList(
+          result.runs.latest.map((run) => `${run.id}: ${run.outcome}, ${run.processedCandidateIds.length}/${run.candidateIds.length} processed`),
+        )}`
+      : undefined,
+      result.catalog.missing.length > 0 ?
+        `Missing:\n${MemoryCliV2CommandEdgeService.formatBulletList(result.catalog.missing)}`
+      : undefined,
+    ].filter(Boolean).join('\n'));
+    process.stdout.write('\n');
+  }
+
+  private static async runList(
+    context: ReturnType<typeof MemoryCliV2CommandEdgeService.createContext>,
+    flags: MemoryCliCommandFlags,
+  ): Promise<void> {
+    const notes = await context.visibility.listNotePaths(flags.path);
+    process.stdout.write(`Memory root: ${context.memoryRoot}\n`);
+    process.stdout.write(notes.length > 0 ? `${notes.join('\n')}\n` : 'No memory notes found.\n');
+  }
+
+  private static async runRead(
+    context: ReturnType<typeof MemoryCliV2CommandEdgeService.createContext>,
+    flags: MemoryCliCommandFlags,
+  ): Promise<void> {
+    if (!flags.path) {
+      throw new Error('Usage: heddle memory read <path>');
+    }
+    process.stdout.write(await context.visibility.readNote({
+      path: flags.path,
+      offset: flags.offset,
+      maxLines: flags.maxLines,
+    }));
+    process.stdout.write('\n');
+  }
+
+  private static async runSearch(
+    context: ReturnType<typeof MemoryCliV2CommandEdgeService.createContext>,
+    flags: MemoryCliCommandFlags,
+  ): Promise<void> {
+    if (!flags.query) {
+      throw new Error('Usage: heddle memory search <query>');
+    }
+    process.stdout.write(await context.visibility.searchNotes({
+      query: flags.query,
+      path: flags.path,
+      maxResults: flags.maxResults,
+    }));
+    process.stdout.write('\n');
+  }
+
+  private static async runValidate(
+    context: ReturnType<typeof MemoryCliV2CommandEdgeService.createContext>,
+    flags: MemoryCliCommandFlags,
+  ): Promise<void> {
+    if (flags.repair) {
+      const repair = context.validation.repairMissingCatalogs();
+      process.stdout.write(`Memory root: ${repair.memoryRoot}\n`);
+      process.stdout.write(
+        repair.createdPaths.length > 0 ?
+          `Repaired missing catalogs:\n${MemoryCliV2CommandEdgeService.formatBulletList(repair.createdPaths)}\n`
+        : 'No missing catalogs repaired.\n',
+      );
+    }
+
+    MemoryCliV2CommandEdgeService.writeValidation(await context.validation.validate());
+  }
+
+  private static async runMaintain(
+    context: ReturnType<typeof MemoryCliV2CommandEdgeService.createContext>,
+    options: CliV2CommandEdgeOptions,
+    flags: MemoryCliCommandFlags,
+  ): Promise<void> {
+    if (flags.reconcile) {
+      const repair = context.validation.repairMissingCatalogs();
+      if (repair.createdPaths.length > 0) {
+        process.stdout.write(`Repaired missing catalogs:\n${MemoryCliV2CommandEdgeService.formatBulletList(repair.createdPaths)}\n`);
+      }
+    }
+
+    const pending = await context.maintenance.readPendingCandidates();
+    if (flags.dryRun) {
+      process.stdout.write([
+        `Memory root: ${context.memoryRoot}`,
+        `Pending candidates: ${pending.length}`,
+        ...pending.map((candidate) => `- ${candidate.id}: ${candidate.summary}`),
+      ].join('\n'));
+      process.stdout.write('\n');
+      if (flags.reconcile) {
+        MemoryCliV2CommandEdgeService.writeValidation(await context.validation.validate());
+      }
+      return;
+    }
+
+    if (pending.length === 0) {
+      process.stdout.write(`Memory root: ${context.memoryRoot}\n`);
+      process.stdout.write('No pending memory candidates.\n');
+      if (flags.reconcile) {
+        MemoryCliV2CommandEdgeService.writeValidation(await context.validation.validate());
+      }
+      return;
+    }
+
+    const model = options.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
+    const apiKey = RuntimeCredentialService.resolveApiKeyForModel(model);
+    if (!apiKey) {
+      throw new Error(`Missing provider API key for memory maintainer model: ${model}`);
+    }
+
+    const result = await context.maintenance.runBacklog({
+      llm: LlmAdapterService.create({
+        model,
+        credentials: { apiKey },
+      }),
+      source: 'heddle memory maintain',
+    });
+
+    process.stdout.write(compact([
+      `Memory root: ${context.memoryRoot}`,
+      `Run: ${result.run.id}`,
+      `Outcome: ${result.run.outcome}`,
+      `Summary: ${result.run.summary}`,
+      `Candidates: ${result.run.processedCandidateIds.length}/${result.run.candidateIds.length} processed`,
+      `Catalog shape: ${result.run.catalogValid ? 'ok' : 'missing required catalogs'}`,
+      result.run.catalogMissing.length > 0 ?
+        `Missing:\n${MemoryCliV2CommandEdgeService.formatBulletList(result.run.catalogMissing)}`
+      : undefined,
+    ]).join('\n'));
+    process.stdout.write('\n');
+    if (flags.reconcile) {
+      MemoryCliV2CommandEdgeService.writeValidation(await context.validation.validate());
+    }
+  }
+
+  private static writeValidation(result: MemoryValidationResult): void {
+    const hasErrors = result.issues.some((issue) => issue.severity === 'error');
+    const hasWarnings = result.issues.some((issue) => issue.severity === 'warning');
+    const label =
+      hasErrors ? 'issues found'
+      : hasWarnings ? 'warnings'
+      : 'ok';
+    process.stdout.write(compact([
+      `Memory root: ${result.memoryRoot}`,
+      `Validation: ${label}`,
+      `Issues: ${result.issueCount}`,
+      result.issues.length > 0 ?
+        MemoryCliV2CommandEdgeService.formatBulletList(
+          result.issues.map((issue) => `[${issue.severity}] ${issue.type}: ${issue.message}`),
+        )
+      : undefined,
+    ]).join('\n'));
+    process.stdout.write('\n');
+  }
+
+  private static formatBulletList(values: string[]): string {
+    return values.map((value) => `- ${value}`).join('\n');
+  }
+}

--- a/src/cli-v2/commands/memory-command.ts
+++ b/src/cli-v2/commands/memory-command.ts
@@ -186,14 +186,14 @@ export class MemoryCliV2CommandEdgeService {
 
     const model = options.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
     const apiKey = RuntimeCredentialService.resolveApiKeyForModel(model);
-    if (!apiKey) {
-      throw new Error(`Missing provider API key for memory maintainer model: ${model}`);
+    if (!apiKey && !RuntimeCredentialService.hasCredentialForModel(model, { preferApiKey: options.preferApiKey })) {
+      throw new Error(RuntimeCredentialService.formatMissingCredentialMessage(model));
     }
 
     const result = await context.maintenance.runBacklog({
       llm: LlmAdapterService.create({
         model,
-        credentials: { apiKey },
+        credentials: apiKey ? { apiKey } : undefined,
       }),
       source: 'heddle memory maintain',
     });

--- a/src/cli-v2/commands/memory-command.ts
+++ b/src/cli-v2/commands/memory-command.ts
@@ -40,44 +40,17 @@ export class MemoryCliV2CommandEdgeService {
     flags: MemoryCliCommandFlags = {},
   ): Promise<void> {
     const context = MemoryCliV2CommandEdgeService.createContext(options);
+    const handlers: Record<MemoryCliCommand, () => Promise<void> | void> = {
+      init: () => MemoryCliV2CommandEdgeService.runInit(context),
+      status: () => MemoryCliV2CommandEdgeService.runStatus(context),
+      list: () => MemoryCliV2CommandEdgeService.runList(context, flags),
+      read: () => MemoryCliV2CommandEdgeService.runRead(context, flags),
+      search: () => MemoryCliV2CommandEdgeService.runSearch(context, flags),
+      validate: () => MemoryCliV2CommandEdgeService.runValidate(context, flags),
+      maintain: () => MemoryCliV2CommandEdgeService.runMaintain(context, options, flags),
+    };
 
-    if (command === 'init') {
-      MemoryCliV2CommandEdgeService.runInit(context);
-      return;
-    }
-
-    if (command === 'status') {
-      await MemoryCliV2CommandEdgeService.runStatus(context);
-      return;
-    }
-
-    if (command === 'list') {
-      await MemoryCliV2CommandEdgeService.runList(context, flags);
-      return;
-    }
-
-    if (command === 'read') {
-      await MemoryCliV2CommandEdgeService.runRead(context, flags);
-      return;
-    }
-
-    if (command === 'search') {
-      await MemoryCliV2CommandEdgeService.runSearch(context, flags);
-      return;
-    }
-
-    if (command === 'validate') {
-      await MemoryCliV2CommandEdgeService.runValidate(context, flags);
-      return;
-    }
-
-    if (command === 'maintain') {
-      await MemoryCliV2CommandEdgeService.runMaintain(context, options, flags);
-      return;
-    }
-
-    const exhaustive: never = command;
-    throw new Error(`Unsupported memory command: ${exhaustive}`);
+    await handlers[command]();
   }
 
   private static createContext(options: CliV2CommandEdgeOptions) {

--- a/src/cli-v2/commands/types.ts
+++ b/src/cli-v2/commands/types.ts
@@ -1,0 +1,15 @@
+import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
+
+export type CliV2CommandEdgeOptions = {
+  workspaceRoot: string;
+  activeWorkspaceId: string;
+  model?: string;
+  maxSteps?: number;
+  preferApiKey: boolean;
+  stateDir: string;
+  directShellApproval: 'always' | 'never';
+  searchIgnoreDirs: string[];
+  systemContext?: string;
+  runtimeHost: ResolvedRuntimeHost;
+  forceOwnerConflict: boolean;
+};

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,21 +4,16 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { chdir } from 'node:process';
 import { Command } from 'commander';
-import { DEFAULT_OPENAI_MODEL, LlmAdapterService } from '../index.js';
-import { MemoryCatalogService } from '../core/memory/catalog.js';
-import { MemoryMaintenanceService } from '../core/memory/maintainer.js';
-import { MemoryValidationService } from '../core/memory/validation.js';
-import { MemoryVisibilityService } from '../core/memory/visibility.js';
-import type { MemoryValidationResult } from '../core/memory/types.js';
-import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import { AuthCliCommandEdgeService } from '@/cli-v2/commands/auth-command.js';
 import { startChatCli } from './chat/index.js';
 import { AskCliV2CommandEdgeService } from '@/cli-v2/commands/ask-command.js';
 import { ChatCliV2CommandEdgeService } from '@/cli-v2/commands/chat-v2-command.js';
+import { DaemonCliV2CommandEdgeService } from '@/cli-v2/commands/daemon-command.js';
+import { EvalCliV2CommandEdgeService } from '@/cli-v2/commands/eval-command.js';
 import { HeartbeatCliCommandEdgeService } from '@/cli-v2/commands/heartbeat-command.js';
 import { InitCliV2CommandEdgeService } from '@/cli-v2/commands/init-command.js';
-import { runDaemonCli } from './daemon.js';
-import { runEvalCli } from './eval/index.js';
+import { MemoryCliV2CommandEdgeService } from '@/cli-v2/commands/memory-command.js';
+import type { CliV2CommandEdgeOptions } from '@/cli-v2/commands/types.js';
 import { loadProjectAgentContext, resolveAgentContextPaths } from './project-agent-context.js';
 import { RuntimeHostMessages, RuntimeHostResolver, type ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
@@ -33,19 +28,7 @@ type RootCliOptions = {
   forceOwnerConflict?: boolean;
 };
 
-type ResolvedCliOptions = {
-  workspaceRoot: string;
-  activeWorkspaceId: string;
-  model?: string;
-  maxSteps?: number;
-  preferApiKey: boolean;
-  stateDir: string;
-  directShellApproval: 'always' | 'never';
-  searchIgnoreDirs: string[];
-  systemContext?: string;
-  runtimeHost: ResolvedRuntimeHost;
-  forceOwnerConflict: boolean;
-};
+type ResolvedCliOptions = CliV2CommandEdgeOptions;
 
 const CLI_VERSION = readCliVersion();
 
@@ -134,7 +117,7 @@ async function main() {
     .description('manage workspace memory catalogs')
     .action(async () => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await runMemoryCli('status', resolved);
+      await MemoryCliV2CommandEdgeService.run('status', resolved);
     });
 
   memoryCommand
@@ -142,7 +125,7 @@ async function main() {
     .description('show workspace memory catalog status')
     .action(async () => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await runMemoryCli('status', resolved);
+      await MemoryCliV2CommandEdgeService.run('status', resolved);
     });
 
   memoryCommand
@@ -150,7 +133,7 @@ async function main() {
     .description('create the default workspace memory catalogs')
     .action(async () => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await runMemoryCli('init', resolved);
+      await MemoryCliV2CommandEdgeService.run('init', resolved);
     });
 
   memoryCommand
@@ -158,7 +141,7 @@ async function main() {
     .description('list markdown notes under workspace memory')
     .action(async (path?: string) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await runMemoryCli('list', resolved, { path });
+      await MemoryCliV2CommandEdgeService.run('list', resolved, { path });
     });
 
   memoryCommand
@@ -168,7 +151,7 @@ async function main() {
     .option('--max-lines <n>', 'maximum lines to print')
     .action(async (path: string | undefined, flags: { offset?: string; maxLines?: string }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await runMemoryCli('read', resolved, {
+      await MemoryCliV2CommandEdgeService.run('read', resolved, {
         path,
         offset: parsePositiveInt(flags.offset),
         maxLines: parsePositiveInt(flags.maxLines),
@@ -182,7 +165,7 @@ async function main() {
     .option('--max-results <n>', 'maximum matching lines to print')
     .action(async (query: string | undefined, flags: { path?: string; maxResults?: string }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await runMemoryCli('search', resolved, {
+      await MemoryCliV2CommandEdgeService.run('search', resolved, {
         query,
         path: flags.path,
         maxResults: parsePositiveInt(flags.maxResults),
@@ -195,7 +178,7 @@ async function main() {
     .option('--repair', 'repair safe missing catalog issues')
     .action(async (flags: { repair?: boolean }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await runMemoryValidateCli(resolved, { repair: Boolean(flags.repair) });
+      await MemoryCliV2CommandEdgeService.run('validate', resolved, { repair: Boolean(flags.repair) });
     });
 
   memoryCommand
@@ -205,7 +188,7 @@ async function main() {
     .option('--reconcile', 'repair safe catalog issues before maintenance and report validation after')
     .action(async (options: { dryRun?: boolean; reconcile?: boolean }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await runMemoryMaintainCli(resolved, {
+      await MemoryCliV2CommandEdgeService.run('maintain', resolved, {
         dryRun: Boolean(options.dryRun),
         reconcile: Boolean(options.reconcile),
       });
@@ -246,11 +229,9 @@ async function main() {
     .allowUnknownOption(true)
     .action(async (args: string[]) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await runEvalCli(args ?? [], {
+      await EvalCliV2CommandEdgeService.run(args ?? [], {
+        ...resolved,
         repoRoot: resolveHeddleRepoRoot(),
-        model: resolved.model,
-        maxSteps: resolved.maxSteps,
-        preferApiKey: resolved.preferApiKey,
       });
     });
 
@@ -271,7 +252,7 @@ async function main() {
     .action(async (args: string[]) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
       chdir(resolved.workspaceRoot);
-      await runDaemonCli(args ?? [], resolved);
+      await DaemonCliV2CommandEdgeService.run(args ?? [], resolved);
     });
 
   program
@@ -306,180 +287,6 @@ async function main() {
 
 function isKnownCommand(command: string): boolean {
   return ['chat', 'chat-v1', 'chat-v2', 'ask', 'init', 'memory', 'auth', 'eval', 'heartbeat', 'daemon', 'help'].includes(command);
-}
-
-async function runMemoryCli(
-  command: 'status' | 'init' | 'list' | 'read' | 'search',
-  options: ResolvedCliOptions,
-  flags: {
-    path?: string;
-    query?: string;
-    offset?: number;
-    maxLines?: number;
-    maxResults?: number;
-  } = {},
-) {
-  const memoryRoot = resolve(options.workspaceRoot, options.stateDir, 'memory');
-  const catalog = new MemoryCatalogService(memoryRoot);
-  const visibility = new MemoryVisibilityService(memoryRoot);
-
-  if (command === 'init') {
-    const result = catalog.bootstrap();
-    process.stdout.write(`Memory root: ${result.memoryRoot}\n`);
-    process.stdout.write(
-      result.createdPaths.length > 0 ?
-        `Created:\n${result.createdPaths.map((path) => `- ${path}`).join('\n')}\n`
-      : 'Memory workspace already initialized.\n',
-    );
-    return;
-  }
-
-  if (command === 'status') {
-    const result = await visibility.loadStatus();
-    process.stdout.write(`Memory root: ${result.memoryRoot}\n`);
-    process.stdout.write(`Catalog shape: ${result.catalog.ok ? 'ok' : 'missing required catalogs'}\n`);
-    process.stdout.write(`Notes: ${result.notes.count}\n`);
-    process.stdout.write(`Pending candidates: ${result.candidates.pending}\n`);
-    if (result.runs.latest.length > 0) {
-      process.stdout.write('Recent runs:\n');
-      for (const run of result.runs.latest) {
-        process.stdout.write(`- ${run.id}: ${run.outcome}, ${run.processedCandidateIds.length}/${run.candidateIds.length} processed\n`);
-      }
-    }
-    if (result.catalog.missing.length > 0) {
-      process.stdout.write(`Missing:\n${result.catalog.missing.map((path) => `- ${path}`).join('\n')}\n`);
-    }
-    return;
-  }
-
-  if (command === 'list') {
-    const notes = await visibility.listNotePaths(flags.path);
-    process.stdout.write(`Memory root: ${memoryRoot}\n`);
-    process.stdout.write(notes.length > 0 ? `${notes.join('\n')}\n` : 'No memory notes found.\n');
-    return;
-  }
-
-  if (command === 'read') {
-    if (!flags.path) {
-      throw new Error('Usage: heddle memory read <path>');
-    }
-    process.stdout.write(await visibility.readNote({
-      path: flags.path,
-      offset: flags.offset,
-      maxLines: flags.maxLines,
-    }));
-    process.stdout.write('\n');
-    return;
-  }
-
-  if (command === 'search') {
-    if (!flags.query) {
-      throw new Error('Usage: heddle memory search <query>');
-    }
-    process.stdout.write(await visibility.searchNotes({
-      query: flags.query,
-      path: flags.path,
-      maxResults: flags.maxResults,
-    }));
-    process.stdout.write('\n');
-    return;
-  }
-
-  const exhaustive: never = command;
-  throw new Error(`Unsupported memory command: ${exhaustive}`);
-}
-
-async function runMemoryValidateCli(options: ResolvedCliOptions, flags: { repair: boolean }) {
-  const memoryRoot = resolve(options.workspaceRoot, options.stateDir, 'memory');
-  const validationService = new MemoryValidationService(memoryRoot);
-  if (flags.repair) {
-    const repair = validationService.repairMissingCatalogs();
-    process.stdout.write(`Memory root: ${repair.memoryRoot}\n`);
-    process.stdout.write(
-      repair.createdPaths.length > 0 ?
-        `Repaired missing catalogs:\n${repair.createdPaths.map((path) => `- ${path}`).join('\n')}\n`
-      : 'No missing catalogs repaired.\n',
-    );
-  }
-
-  const validation = await validationService.validate();
-  writeMemoryValidation(validation);
-}
-
-async function runMemoryMaintainCli(options: ResolvedCliOptions, flags: { dryRun: boolean; reconcile: boolean }) {
-  const memoryRoot = resolve(options.workspaceRoot, options.stateDir, 'memory');
-  const validationService = new MemoryValidationService(memoryRoot);
-  const maintenance = new MemoryMaintenanceService(memoryRoot);
-  if (flags.reconcile) {
-    const repair = validationService.repairMissingCatalogs();
-    if (repair.createdPaths.length > 0) {
-      process.stdout.write(`Repaired missing catalogs:\n${repair.createdPaths.map((path) => `- ${path}`).join('\n')}\n`);
-    }
-  }
-  const pending = await maintenance.readPendingCandidates();
-
-  if (flags.dryRun) {
-    process.stdout.write(`Memory root: ${memoryRoot}\n`);
-    process.stdout.write(`Pending candidates: ${pending.length}\n`);
-    for (const candidate of pending) {
-      process.stdout.write(`- ${candidate.id}: ${candidate.summary}\n`);
-    }
-    if (flags.reconcile) {
-      writeMemoryValidation(await validationService.validate());
-    }
-    return;
-  }
-
-  if (pending.length === 0) {
-    process.stdout.write(`Memory root: ${memoryRoot}\n`);
-    process.stdout.write('No pending memory candidates.\n');
-    if (flags.reconcile) {
-      writeMemoryValidation(await validationService.validate());
-    }
-    return;
-  }
-
-  const model = options.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
-  const apiKey = RuntimeCredentialService.resolveApiKeyForModel(model);
-  if (!apiKey) {
-    throw new Error(`Missing provider API key for memory maintainer model: ${model}`);
-  }
-
-  const result = await maintenance.runBacklog({
-    llm: LlmAdapterService.create({
-      model,
-      credentials: { apiKey },
-    }),
-    source: 'heddle memory maintain',
-  });
-
-  process.stdout.write(`Memory root: ${memoryRoot}\n`);
-  process.stdout.write(`Run: ${result.run.id}\n`);
-  process.stdout.write(`Outcome: ${result.run.outcome}\n`);
-  process.stdout.write(`Summary: ${result.run.summary}\n`);
-  process.stdout.write(`Candidates: ${result.run.processedCandidateIds.length}/${result.run.candidateIds.length} processed\n`);
-  process.stdout.write(`Catalog shape: ${result.run.catalogValid ? 'ok' : 'missing required catalogs'}\n`);
-  if (result.run.catalogMissing.length > 0) {
-    process.stdout.write(`Missing:\n${result.run.catalogMissing.map((path) => `- ${path}`).join('\n')}\n`);
-  }
-  if (flags.reconcile) {
-    writeMemoryValidation(await validationService.validate());
-  }
-}
-
-function writeMemoryValidation(result: MemoryValidationResult) {
-  const hasErrors = result.issues.some((issue) => issue.severity === 'error');
-  const hasWarnings = result.issues.some((issue) => issue.severity === 'warning');
-  const label =
-    hasErrors ? 'issues found'
-    : hasWarnings ? 'warnings'
-    : 'ok';
-  process.stdout.write(`Memory root: ${result.memoryRoot}\n`);
-  process.stdout.write(`Validation: ${label}\n`);
-  process.stdout.write(`Issues: ${result.issueCount}\n`);
-  for (const issue of result.issues) {
-    process.stdout.write(`- [${issue.severity}] ${issue.type}: ${issue.message}\n`);
-  }
 }
 
 function resolveCliOptions(flags: RootCliOptions): ResolvedCliOptions {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -115,9 +115,10 @@ async function main() {
   const memoryCommand = program
     .command('memory')
     .description('manage workspace memory catalogs')
-    .action(async () => {
-      const resolved = resolveCliOptions(program.opts<RootCliOptions>());
-      await MemoryCliV2CommandEdgeService.run('status', resolved);
+    .addHelpCommand('help [command]', 'display help for command')
+    .addHelpText('after', ['', 'Examples:', '  heddle memory status', '  heddle memory list workflows', '  heddle memory read workflows/release.md', '  heddle memory search "release checklist"', ''].join('\n'))
+    .action((_, command) => {
+      command.outputHelp();
     });
 
   memoryCommand
@@ -139,6 +140,7 @@ async function main() {
   memoryCommand
     .command('list [path]')
     .description('list markdown notes under workspace memory')
+    .addHelpText('after', ['', 'Examples:', '  heddle memory list', '  heddle memory list workflows', ''].join('\n'))
     .action(async (path?: string) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
       await MemoryCliV2CommandEdgeService.run('list', resolved, { path });
@@ -149,6 +151,7 @@ async function main() {
     .description('read a memory note')
     .option('--offset <n>', '0-based line offset')
     .option('--max-lines <n>', 'maximum lines to print')
+    .addHelpText('after', ['', 'Examples:', '  heddle memory read workflows/release.md', '  heddle memory read workflows/release.md --offset 20 --max-lines 40', ''].join('\n'))
     .action(async (path: string | undefined, flags: { offset?: string; maxLines?: string }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
       await MemoryCliV2CommandEdgeService.run('read', resolved, {
@@ -163,6 +166,7 @@ async function main() {
     .description('search memory notes')
     .option('--path <path>', 'memory-relative path to search under')
     .option('--max-results <n>', 'maximum matching lines to print')
+    .addHelpText('after', ['', 'Examples:', '  heddle memory search "release checklist"', '  heddle memory search "daemon registry" --path architecture --max-results 10', ''].join('\n'))
     .action(async (query: string | undefined, flags: { path?: string; maxResults?: string }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
       await MemoryCliV2CommandEdgeService.run('search', resolved, {
@@ -176,6 +180,7 @@ async function main() {
     .command('validate')
     .description('validate memory catalog quality')
     .option('--repair', 'repair safe missing catalog issues')
+    .addHelpText('after', ['', 'Examples:', '  heddle memory validate', '  heddle memory validate --repair', ''].join('\n'))
     .action(async (flags: { repair?: boolean }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
       await MemoryCliV2CommandEdgeService.run('validate', resolved, { repair: Boolean(flags.repair) });
@@ -186,6 +191,7 @@ async function main() {
     .description('process pending memory candidates into cataloged notes')
     .option('--dry-run', 'show pending candidates without running the maintainer')
     .option('--reconcile', 'repair safe catalog issues before maintenance and report validation after')
+    .addHelpText('after', ['', 'Examples:', '  heddle memory maintain --dry-run', '  heddle memory maintain --reconcile', ''].join('\n'))
     .action(async (options: { dryRun?: boolean; reconcile?: boolean }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
       await MemoryCliV2CommandEdgeService.run('maintain', resolved, {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -191,7 +191,7 @@ async function main() {
     .description('process pending memory candidates into cataloged notes')
     .option('--dry-run', 'show pending candidates without running the maintainer')
     .option('--reconcile', 'repair safe catalog issues before maintenance and report validation after')
-    .addHelpText('after', ['', 'Examples:', '  heddle memory maintain --dry-run', '  heddle memory maintain --reconcile', ''].join('\n'))
+    .addHelpText('after', ['', 'Credential sources:', '  heddle auth login openai', '  OPENAI_API_KEY / ANTHROPIC_API_KEY', '', 'Examples:', '  heddle memory maintain --dry-run', '  heddle memory maintain --reconcile', ''].join('\n'))
     .action(async (options: { dryRun?: boolean; reconcile?: boolean }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
       await MemoryCliV2CommandEdgeService.run('maintain', resolved, {

--- a/src/core/memory/README.md
+++ b/src/core/memory/README.md
@@ -48,6 +48,26 @@ guidance.
   safe missing-catalog repair.
 - `templates.ts`: pure memory note template helpers.
 
+## Command-Facing Service Contract
+
+Terminal command edges may call these public methods directly:
+
+- `MemoryCatalogService.bootstrap()`: create the required catalog/template shape.
+- `MemoryVisibilityService.loadStatus()`: build the status view for
+  `heddle memory status`.
+- `MemoryVisibilityService.listNotePaths/readNote/searchNotes`: expose
+  read-only note visibility. Command edges should not traverse memory files
+  themselves.
+- `MemoryValidationService.validate()` and `repairMissingCatalogs()`: validate
+  and safely repair missing catalog files.
+- `MemoryMaintenanceService.readPendingCandidates()` and `runBacklog()`: inspect
+  and process pending durable knowledge candidates.
+
+Command edges own only argument parsing, explicit provider credential selection
+for maintainer runs, and terminal formatting. They must not duplicate catalog
+shape checks, note path validation, pending-candidate filtering, lock handling,
+or maintainer semantics.
+
 ## Extension Points
 
 - Add durable memory policy by updating domain prompt, candidate validation, and

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -18,8 +18,8 @@ The lifecycle handle returns server facts such as `serverId`, endpoint, registry
 path, workspace bootstrap roots, and `close()`.
 
 CLI-only behavior stays outside this module. Command adapters such as
-`src/cli/daemon.ts` decide whether to attach to an existing live server, print
-messages, install signal handlers, and call `process.exit()`.
+`src/cli-v2/commands/daemon-command.ts` decide whether to attach to an existing
+live server, print messages, install signal handlers, and call `process.exit()`.
 
 Embedded hosts such as future `chat-v2` startup should use the same lifecycle
 path instead of inventing a TUI-only server path.


### PR DESCRIPTION
## Summary
- Move memory command behavior into a real cli-v2 command edge service.
- Move daemon and eval command ownership from legacy `src/cli` paths into `src/cli-v2/commands`.
- Keep `src/cli/main.ts` focused on Commander routing and root option resolution.
- Document the memory command-facing service contract and update command/server boundary docs.
- Keep legacy `chat-v1` and `src/cli/chat` intact.

## Expected behavior
- `heddle memory ...` behaves the same, but parsing/output lives in `MemoryCliV2CommandEdgeService` and domain behavior stays in public `src/core/memory` services.
- `heddle daemon ...` still detects and attaches to an existing live server before starting one; CLI-only signal handling remains in the daemon command edge.
- `heddle eval ...` still runs the local eval harness, now from `EvalCliV2CommandEdgeService`; datetime parsing/formatting uses `dayjs`.
- `src/cli/main.ts` no longer owns memory, daemon, or eval command policy.

## Verification
- `git diff --check`
- `yarn typecheck`
- `yarn lint`
- `yarn test:unit src/__tests__/unit/cli-v2/memory-command.test.ts src/__tests__/unit/tui/daemon.test.ts src/__tests__/unit/tui/eval-cli.test.ts src/__tests__/unit/cli/main-command-routing.test.ts src/__tests__/unit/core/import-boundaries.test.ts`
- `yarn -s cli:dev memory status`
- `yarn -s cli:dev memory maintain --dry-run`
- `yarn -s cli:dev eval`
- `yarn -s cli:dev eval agent --case fix-failing-test --dry-run --output /private/tmp/heddle-eval-command-edge-smoke`
- `yarn -s cli:dev daemon --help`