### PR TITLE
Improve TUI diff review flow

### DIFF
--- a/src/__tests__/unit/cli-v2/recent-edit-diff-review.test.tsx
+++ b/src/__tests__/unit/cli-v2/recent-edit-diff-review.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act, render, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RecentEditDiffPanel } from '@/cli-v2/components/RecentEditDiffPanel.js';
+import { useRecentEditDiffReview } from '@/cli-v2/hooks/useRecentEditDiffReview.js';
+import type { ClientSharedRecentEditDiff } from '@/client-shared/services/session-activities/index.js';
+
+describe('cli-v2 recent edit diff review', () => {
+  it('shows a compact review summary by default', () => {
+    const diffs = createDiffs(2);
+    const { result } = renderHook(() => useRecentEditDiffReview(diffs));
+    const view = render(
+      <RecentEditDiffPanel
+        diffs={diffs}
+        review={result.current}
+        running={false}
+      />,
+    );
+
+    expect(view.container.textContent).toContain('Recent edits: 2 edits across 2 files');
+    expect(view.container.textContent).toContain('run done');
+    expect(view.container.textContent).toContain('press d to review');
+    expect(view.container.textContent).not.toContain('@@ -1,2 +1,2 @@');
+  });
+
+  it('summarizes repeated edits without overstating changed files', () => {
+    const diffs = createDiffs(2).map((diff) => ({ ...diff, path: 'src/shared.ts' }));
+    const { result } = renderHook(() => useRecentEditDiffReview(diffs));
+    const view = render(
+      <RecentEditDiffPanel
+        diffs={diffs}
+        review={result.current}
+        running={false}
+      />,
+    );
+
+    expect(view.container.textContent).toContain('2 edits across 1 file');
+  });
+
+  it('renders one selected file in review mode', () => {
+    const diffs = createDiffs(2);
+    const { result } = renderHook(() => useRecentEditDiffReview(diffs));
+
+    act(() => {
+      result.current.open();
+      result.current.next();
+    });
+
+    const view = render(
+      <RecentEditDiffPanel
+        diffs={diffs}
+        review={result.current}
+        running
+      />,
+    );
+
+    expect(view.container.textContent).toContain('Diff review');
+    expect(view.container.textContent).toContain('[2/2] src/file-2.ts');
+    expect(view.container.textContent).toContain('@@ -1,2 +1,2 @@');
+    expect(view.container.textContent).toContain('+const value2 = true;');
+    expect(view.container.textContent).not.toContain('src/file-1.ts');
+  });
+
+  it('opens from an empty prompt and ignores normal draft text', () => {
+    const { result } = renderHook(() => useRecentEditDiffReview(createDiffs(1)));
+
+    act(() => {
+      expect(result.current.handlePromptSpecialKey('d', {}, 'draft')).toBe(false);
+    });
+    expect(result.current.mode).toBe('summary');
+
+    act(() => {
+      expect(result.current.handlePromptSpecialKey('d', {}, '')).toBe(true);
+    });
+    expect(result.current.mode).toBe('review');
+  });
+
+  it('moves through files and closes from review keyboard input', () => {
+    const { result } = renderHook(() => useRecentEditDiffReview(createDiffs(3)));
+
+    act(() => {
+      result.current.open();
+    });
+
+    act(() => {
+      expect(result.current.handleReviewKey('n', {})).toBe(true);
+    });
+    expect(result.current.selectedIndex).toBe(1);
+
+    act(() => {
+      expect(result.current.handleReviewKey('k', {})).toBe(true);
+    });
+    expect(result.current.selectedIndex).toBe(0);
+
+    act(() => {
+      expect(result.current.handleReviewKey('', { escape: true })).toBe(true);
+    });
+    expect(result.current.mode).toBe('summary');
+  });
+});
+
+function createDiffs(count: number): ClientSharedRecentEditDiff[] {
+  return Array.from({ length: count }, (_, index) => {
+    const number = index + 1;
+    return {
+      id: `run-1:tool-${number}`,
+      runId: 'run-1',
+      step: number,
+      toolCallId: `tool-${number}`,
+      path: `src/file-${number}.ts`,
+      action: 'replace',
+      patch: [
+        '@@ -1,2 +1,2 @@',
+        `-const value${number} = false;`,
+        `+const value${number} = true;`,
+      ].join('\n'),
+      truncated: false,
+      timestamp: '2026-06-05T00:00:00.000Z',
+    };
+  });
+}

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -2,7 +2,7 @@
 // only. Put feature behavior in cli-v2 hooks, services, or focused components
 // instead of growing App.tsx directly.
 import React, { useCallback, useEffect, useRef } from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { AgentPlanPanel } from './components/AgentPlanPanel.js';
 import { ComposerPanel } from './components/ComposerPanel.js';
@@ -15,6 +15,7 @@ import { RecentEditDiffPanel } from './components/RecentEditDiffPanel.js';
 import { RunControls } from './components/RunControls.js';
 import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
+import { useRecentEditDiffReview } from './hooks/useRecentEditDiffReview.js';
 import { PromptActivityService } from './services/activities/prompt-activity-service.js';
 import type { ControlPlaneApprovalDecision } from '@/client-shared/api/types.js';
 import type {
@@ -31,6 +32,7 @@ export function App({
 }) {
   const startedRef = useRef(false);
   const snapshot = useControlPlaneSessionStore(store);
+  const recentEditDiffReview = useRecentEditDiffReview(snapshot.recentEditDiffs);
 
   useEffect(() => {
     if (startedRef.current) {
@@ -56,6 +58,10 @@ export function App({
     void store.cancelRun();
   }, [store]);
 
+  useInput((input, key) => {
+    recentEditDiffReview.handleReviewKey(input, key);
+  }, { isActive: recentEditDiffReview.mode === 'review' });
+
   return (
     <Box flexDirection="column" paddingX={1}>
       <Box marginBottom={1}>
@@ -67,7 +73,11 @@ export function App({
         {snapshot.activeSession ? ` · ${snapshot.activeSession.name}` : ''}
       </Text>
       <ConversationPanel runtimeContext={snapshot.runtimeContext} session={snapshot.activeSession} />
-      <RecentEditDiffPanel diffs={snapshot.recentEditDiffs} />
+      <RecentEditDiffPanel
+        diffs={snapshot.recentEditDiffs}
+        review={recentEditDiffReview}
+        running={snapshot.running}
+      />
       <CommandResultPanel results={snapshot.commandResults} />
       {snapshot.pendingApproval ? (
         <ApprovalPanel
@@ -85,6 +95,7 @@ export function App({
       <RunControls
         running={snapshot.running}
         cancelling={snapshot.cancelling}
+        keyboardDisabled={recentEditDiffReview.mode === 'review'}
         onCancel={cancelRun}
       />
       <AgentPlanPanel plan={snapshot.activePlan} />
@@ -93,7 +104,12 @@ export function App({
         latestActivity={PromptActivityService.build(snapshot)}
       />
       <QueuedPromptPanel session={snapshot.activeSession} />
-      <ComposerPanel store={store} snapshot={snapshot} />
+      <ComposerPanel
+        store={store}
+        snapshot={snapshot}
+        keyboardDisabled={recentEditDiffReview.mode === 'review'}
+        onSpecialKey={recentEditDiffReview.handlePromptSpecialKey}
+      />
       <RuntimeStatusBar snapshot={snapshot} />
     </Box>
   );

--- a/src/cli-v2/components/ComposerPanel.tsx
+++ b/src/cli-v2/components/ComposerPanel.tsx
@@ -14,10 +14,13 @@ import type {
   ControlPlaneSessionStore,
   ControlPlaneSessionStoreSnapshot,
 } from '../state/control-plane-session-store.js';
+import type { PromptInputKey } from './PromptInput.js';
 
 type ComposerPanelProps = {
   store: ControlPlaneSessionStore;
   snapshot: ControlPlaneSessionStoreSnapshot;
+  keyboardDisabled?: boolean;
+  onSpecialKey?: (input: string, key: PromptInputKey, draft: string) => boolean;
 };
 
 /**
@@ -31,6 +34,8 @@ type ComposerPanelProps = {
 export const ComposerPanel = React.memo(function ComposerPanel({
   store,
   snapshot,
+  keyboardDisabled = false,
+  onSpecialKey,
 }: ComposerPanelProps) {
   const {
     draft,
@@ -135,8 +140,8 @@ export const ComposerPanel = React.memo(function ComposerPanel({
         <DirectShellModeHintPanel command={directShellDraft.command} />
       ) : null}
       <PromptInput
-        disabled={inputDisabled}
-        submitDisabled={submitDisabled}
+        disabled={inputDisabled || keyboardDisabled}
+        submitDisabled={submitDisabled || keyboardDisabled}
         placeholder={resolvePromptPlaceholder(snapshot)}
         value={draft}
         cursor={cursor}
@@ -146,7 +151,11 @@ export const ComposerPanel = React.memo(function ComposerPanel({
         onHistory={navigateHistory}
         onUndo={undoPromptEdit}
         onRedo={redoPromptEdit}
-        onSpecialKey={(input, key) => fileMentions.handleSpecialKey(input, key) || pickers.handleSpecialKey(input, key)}
+        onSpecialKey={(input, key) => (
+          onSpecialKey?.(input, key, draft) ||
+          fileMentions.handleSpecialKey(input, key) ||
+          pickers.handleSpecialKey(input, key)
+        )}
       />
     </>
   );

--- a/src/cli-v2/components/RecentEditDiffPanel.tsx
+++ b/src/cli-v2/components/RecentEditDiffPanel.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Box, Text } from 'ink';
+import uniqBy from 'lodash/uniqBy.js';
 import type { ClientSharedRecentEditDiff } from '@/client-shared/services/session-activities/index.js';
+import type { RecentEditDiffReviewState } from '../hooks/useRecentEditDiffReview.js';
 
-const MAX_VISIBLE_DIFFS = 3;
 const MAX_VISIBLE_LINES = 120;
 const MAX_LINE_LENGTH = 160;
 
@@ -15,6 +16,8 @@ const actionLabels: Record<string, string> = {
 
 type RecentEditDiffPanelProps = {
   diffs: ClientSharedRecentEditDiff[];
+  review: RecentEditDiffReviewState;
+  running: boolean;
 };
 
 type RenderedDiff = {
@@ -22,26 +25,73 @@ type RenderedDiff = {
   truncated: boolean;
 };
 
-export function RecentEditDiffPanel({ diffs }: RecentEditDiffPanelProps) {
-  const visibleDiffs = diffs.slice(-MAX_VISIBLE_DIFFS);
-  if (visibleDiffs.length === 0) {
+export function RecentEditDiffPanel({ diffs, review, running }: RecentEditDiffPanelProps) {
+  if (diffs.length === 0) {
+    return null;
+  }
+
+  if (review.mode === 'review' && review.selectedDiff) {
+    return <RecentEditDiffReviewPanel diffs={diffs} review={review} />;
+  }
+
+  return <RecentEditDiffSummary diffs={diffs} running={running} />;
+}
+
+function RecentEditDiffSummary({
+  diffs,
+  running,
+}: {
+  diffs: ClientSharedRecentEditDiff[];
+  running: boolean;
+}) {
+  return (
+    <Box marginTop={1}>
+      <Text dimColor>Recent edits: </Text>
+      <Text>{formatDiffScope(diffs)}</Text>
+      <Text dimColor>{running ? ' · run active' : ' · run done'}</Text>
+      <Text dimColor> · press </Text>
+      <Text color="cyan">d</Text>
+      <Text dimColor> to review</Text>
+    </Box>
+  );
+}
+
+function RecentEditDiffReviewPanel({
+  diffs,
+  review,
+}: {
+  diffs: ClientSharedRecentEditDiff[];
+  review: RecentEditDiffReviewState;
+}) {
+  const diff = review.selectedDiff;
+  if (!diff) {
     return null;
   }
 
   return (
     <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} marginTop={1}>
-      <Text bold>Recent edits</Text>
-      {visibleDiffs.map((diff) => (
-        <Box key={diff.id} flexDirection="column" marginTop={1}>
-          <Text>
-            <Text color="cyan">{diff.path}</Text>
-            <Text dimColor>{formatEditMeta(diff)}</Text>
-          </Text>
-          {renderPatch(diff)}
-        </Box>
-      ))}
+      <Text>
+        <Text bold>Diff review</Text>
+        <Text dimColor> · {formatDiffScope(diffs)}</Text>
+        <Text dimColor> · Esc close</Text>
+      </Text>
+      <Box flexDirection="column" marginTop={1}>
+        <Text>
+          <Text dimColor>[{review.selectedIndex + 1}/{diffs.length}] </Text>
+          <Text color="cyan">{diff.path}</Text>
+          <Text dimColor>{formatEditMeta(diff)}</Text>
+        </Text>
+        {renderPatch(diff)}
+      </Box>
+      <Text dimColor>j/k or arrows move · n/p file · esc back</Text>
     </Box>
   );
+}
+
+function formatDiffScope(diffs: ClientSharedRecentEditDiff[]): string {
+  const editCount = diffs.length;
+  const fileCount = uniqBy(diffs, 'path').length;
+  return `${editCount} ${editCount === 1 ? 'edit' : 'edits'} across ${fileCount} ${fileCount === 1 ? 'file' : 'files'}`;
 }
 
 function formatEditMeta(diff: ClientSharedRecentEditDiff): string {

--- a/src/cli-v2/components/RunControls.tsx
+++ b/src/cli-v2/components/RunControls.tsx
@@ -3,17 +3,18 @@ import { Box, Text, useInput } from 'ink';
 type RunControlsProps = {
   running: boolean;
   cancelling: boolean;
+  keyboardDisabled?: boolean;
   onCancel: () => void;
 };
 
-export function RunControls({ running, cancelling, onCancel }: RunControlsProps) {
+export function RunControls({ running, cancelling, keyboardDisabled = false, onCancel }: RunControlsProps) {
   useInput((_input, key) => {
     if (!running || cancelling || !key.escape) {
       return;
     }
 
     onCancel();
-  }, { isActive: running && !cancelling });
+  }, { isActive: running && !cancelling && !keyboardDisabled });
 
   if (running || cancelling) {
     return (

--- a/src/cli-v2/hooks/useRecentEditDiffReview.ts
+++ b/src/cli-v2/hooks/useRecentEditDiffReview.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ClientSharedRecentEditDiff } from '@/client-shared/services/session-activities/index.js';
+import type { PromptInputKey } from '../components/PromptInput.js';
+
+export type RecentEditDiffReviewMode = 'summary' | 'review';
+
+export type RecentEditDiffReviewState = {
+  mode: RecentEditDiffReviewMode;
+  selectedIndex: number;
+  selectedDiff?: ClientSharedRecentEditDiff;
+  hasDiffs: boolean;
+  open: () => void;
+  close: () => void;
+  next: () => void;
+  previous: () => void;
+  handlePromptSpecialKey: (input: string, key: PromptInputKey, draft: string) => boolean;
+  handleReviewKey: (input: string, key: PromptInputKey) => boolean;
+};
+
+/**
+ * Owns TUI-only diff review state.
+ *
+ * The control-plane API owns recent-edit diff facts. This hook owns only the
+ * terminal interaction model: summary vs focused review mode and keyboard
+ * navigation across already-projected diffs.
+ */
+export function useRecentEditDiffReview(diffs: ClientSharedRecentEditDiff[]): RecentEditDiffReviewState {
+  const [mode, setMode] = useState<RecentEditDiffReviewMode>('summary');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const hasDiffs = diffs.length > 0;
+
+  useEffect(() => {
+    if (!hasDiffs) {
+      setMode('summary');
+      setSelectedIndex(0);
+      return;
+    }
+
+    setSelectedIndex((current) => Math.min(current, diffs.length - 1));
+  }, [diffs.length, hasDiffs]);
+
+  const move = useCallback((direction: 1 | -1) => {
+    setSelectedIndex((current) => {
+      if (!hasDiffs) {
+        return 0;
+      }
+
+      return (current + direction + diffs.length) % diffs.length;
+    });
+  }, [diffs.length, hasDiffs]);
+
+  const open = useCallback(() => {
+    if (!hasDiffs) {
+      return;
+    }
+
+    setMode('review');
+  }, [hasDiffs]);
+
+  const close = useCallback(() => {
+    setMode('summary');
+  }, []);
+
+  const next = useCallback(() => {
+    move(1);
+  }, [move]);
+
+  const previous = useCallback(() => {
+    move(-1);
+  }, [move]);
+
+  const handlePromptSpecialKey = useCallback((input: string, key: PromptInputKey, draft: string) => {
+    if (!hasDiffs || mode === 'review' || key.ctrl || key.meta || key.super || draft.length > 0) {
+      return false;
+    }
+
+    if (input !== 'd') {
+      return false;
+    }
+
+    open();
+    return true;
+  }, [hasDiffs, mode, open]);
+
+  const handleReviewKey = useCallback((input: string, key: PromptInputKey) => {
+    if (mode !== 'review') {
+      return false;
+    }
+
+    if (key.escape) {
+      close();
+      return true;
+    }
+
+    if (key.downArrow || input === 'j' || input === 'n') {
+      next();
+      return true;
+    }
+
+    if (key.upArrow || input === 'k' || input === 'p') {
+      previous();
+      return true;
+    }
+
+    return true;
+  }, [close, mode, next, previous]);
+
+  return useMemo(() => ({
+    mode,
+    selectedIndex,
+    selectedDiff: diffs[selectedIndex],
+    hasDiffs,
+    open,
+    close,
+    next,
+    previous,
+    handlePromptSpecialKey,
+    handleReviewKey,
+  }), [
+    close,
+    diffs,
+    handlePromptSpecialKey,
+    handleReviewKey,
+    hasDiffs,
+    mode,
+    next,
+    open,
+    previous,
+    selectedIndex,
+  ]);
+}


### PR DESCRIPTION
## Summary

- Collapse recent edit diffs into a compact summary by default so a finished run is easier to read.
- Add a TUI-local diff review mode opened with `d` from an empty prompt, showing one recent edit at a time.
- Add keyboard navigation for review mode and prevent `Esc` from cancelling a running job while review mode owns focus.

## Expected behavior

- When recent edit diffs exist, the TUI shows a one-line summary like `Recent edits: 2 edits across 1 file - run done - press d to review`.
- Pressing `d` from an empty prompt opens focused diff review mode.
- Review mode shows one edit at a time with `j/k`, arrow keys, or `n/p` for navigation and `Esc` to return.
- Typing `d` inside a non-empty prompt remains normal text.
- Server/core behavior is unchanged; this is TUI presentation state over existing recent-edit diff facts.

## Verification

- `yarn -s test:unit src/__tests__/unit/cli-v2/recent-edit-diff-review.test.tsx`
- `yarn lint`
- `yarn build`
- `yarn test`
