### PR TITLE
Fix TUI prompt input render performance

### DIFF
--- a/src/__tests__/unit/cli-v2/prompt-input.test.ts
+++ b/src/__tests__/unit/cli-v2/prompt-input.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildPromptRenderLines,
   resolvePromptInputRenderWidth,
+  shouldKeepOptimisticPromptInputState,
 } from '@/cli-v2/components/PromptInput.js';
 
 describe('cli-v2 PromptInput helpers', () => {
@@ -66,5 +67,29 @@ describe('cli-v2 PromptInput helpers', () => {
         hasCursor: true,
       },
     ]);
+  });
+
+  it('keeps newer optimistic input when an older parent echo arrives', () => {
+    expect(shouldKeepOptimisticPromptInputState({
+      current: { value: 'abc', cursor: 3 },
+      incoming: { value: 'ab', cursor: 2 },
+      pending: { value: 'abc', cursor: 3 },
+    })).toBe(true);
+  });
+
+  it('accepts parent state once it catches up with the optimistic input', () => {
+    expect(shouldKeepOptimisticPromptInputState({
+      current: { value: 'abc', cursor: 3 },
+      incoming: { value: 'abc', cursor: 3 },
+      pending: { value: 'abc', cursor: 3 },
+    })).toBe(false);
+  });
+
+  it('accepts external parent updates after optimistic input is cleared', () => {
+    expect(shouldKeepOptimisticPromptInputState({
+      current: { value: 'abc', cursor: 3 },
+      incoming: { value: '', cursor: 0 },
+      pending: undefined,
+    })).toBe(false);
   });
 });

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -5,27 +5,17 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
 import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { AgentPlanPanel } from './components/AgentPlanPanel.js';
+import { ComposerPanel } from './components/ComposerPanel.js';
 import { CommandResultPanel } from './components/CommandResultPanel.js';
 import { ConversationPanel } from './components/ConversationPanel.js';
 import { DirectShellConfirmationPanel } from './components/DirectShellConfirmationPanel.js';
-import { DirectShellModeHintPanel } from './components/DirectShellModeHintPanel.js';
-import { FileMentionPickerPanel } from './components/FileMentionPickerPanel.js';
-import { ModelPickerPanel } from './components/ModelPickerPanel.js';
-import { PromptInput } from './components/PromptInput.js';
 import { PromptStatusPanel } from './components/PromptStatusPanel.js';
 import { QueuedPromptPanel } from './components/QueuedPromptPanel.js';
 import { RecentEditDiffPanel } from './components/RecentEditDiffPanel.js';
-import { ReasoningEffortPickerPanel } from './components/ReasoningEffortPickerPanel.js';
 import { RunControls } from './components/RunControls.js';
 import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
-import { SessionPickerPanel } from './components/SessionPickerPanel.js';
-import { SlashCommandHintPanel } from './components/SlashCommandHintPanel.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
-import { useFileMentionPicker } from './hooks/useFileMentionPicker.js';
-import { usePromptPickers } from './hooks/usePromptPickers.js';
-import { usePromptDraft } from './hooks/usePromptDraft.js';
 import { PromptActivityService } from './services/activities/prompt-activity-service.js';
-import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
 import type { ControlPlaneApprovalDecision } from '@/client-shared/api/types.js';
 import type {
   ControlPlaneSessionStore,
@@ -41,41 +31,6 @@ export function App({
 }) {
   const startedRef = useRef(false);
   const snapshot = useControlPlaneSessionStore(store);
-  const {
-    draft,
-    cursor,
-    setDraft,
-    setDraftState,
-    clearDraft,
-    recordSubmittedPrompt,
-    navigateHistory,
-    undoPromptEdit,
-    redoPromptEdit,
-  } = usePromptDraft();
-  const submitDisabled = snapshot.loading || snapshot.submitting || Boolean(snapshot.pendingDirectShellConfirmation);
-  const inputDisabled = snapshot.loading || Boolean(snapshot.pendingDirectShellConfirmation) || Boolean(snapshot.pendingApproval);
-  const slashCommandHints = store.getSlashCommandHints(draft);
-  const directShellDraft = ClientSharedPromptInputService.parseDirectShellDraft(draft);
-  const pickers = usePromptPickers({
-    draft,
-    snapshot,
-    clearDraft,
-    onSelectModel: (model) => {
-      void store.selectModelFromPicker(model);
-    },
-    onSelectReasoning: (reasoningEffort) => {
-      void store.selectReasoningFromPicker(reasoningEffort);
-    },
-    onSelectSession: (sessionId) => {
-      void store.selectSessionFromPicker(sessionId);
-    },
-  });
-  const fileMentions = useFileMentionPicker({
-    draft,
-    setDraft,
-    snapshot,
-    store,
-  });
 
   useEffect(() => {
     if (startedRef.current) {
@@ -88,33 +43,6 @@ export function App({
       store.dispose();
     };
   }, [initialSelection, store]);
-
-  const submitPrompt = useCallback((value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return;
-    }
-
-    if (submitDisabled) {
-      return;
-    }
-
-    if (pickers.submitSelection()) {
-      return;
-    }
-
-    clearDraft();
-    if (!trimmed.startsWith('/')) {
-      recordSubmittedPrompt(trimmed);
-    }
-    void store.submitPrompt(value);
-  }, [
-    clearDraft,
-    pickers,
-    recordSubmittedPrompt,
-    store,
-    submitDisabled,
-  ]);
 
   const resolveApproval = useCallback((decision: ControlPlaneApprovalDecision) => {
     void store.resolvePendingApproval(decision);
@@ -160,79 +88,13 @@ export function App({
         onCancel={cancelRun}
       />
       <AgentPlanPanel plan={snapshot.activePlan} />
-      {pickers.model.query !== undefined ? (
-        <ModelPickerPanel
-          query={pickers.model.query}
-          models={pickers.model.items}
-          activeModel={snapshot.runtimeContext?.model}
-          highlightedIndex={pickers.model.highlightedIndex}
-        />
-      ) : null}
-      {pickers.reasoning.query !== undefined ? (
-        <ReasoningEffortPickerPanel
-          query={pickers.reasoning.query}
-          options={pickers.reasoning.items}
-          activeReasoningEffort={snapshot.runtimeContext?.reasoningEffort}
-          highlightedIndex={pickers.reasoning.highlightedIndex}
-        />
-      ) : null}
-      {pickers.session.query !== undefined ? (
-        <SessionPickerPanel
-          query={pickers.session.query}
-          sessions={pickers.session.items}
-          activeSessionId={snapshot.activeSessionId}
-          highlightedIndex={pickers.session.highlightedIndex}
-        />
-      ) : null}
-      {fileMentions.visible ? (
-        <FileMentionPickerPanel
-          query={fileMentions.query}
-          suggestions={fileMentions.suggestions}
-          highlightedIndex={fileMentions.highlightedIndex}
-          loading={fileMentions.loading}
-          error={fileMentions.error}
-        />
-      ) : null}
-      {!pickers.visible && !fileMentions.visible ? <SlashCommandHintPanel hints={slashCommandHints} /> : null}
       <PromptStatusPanel
         currentActivity={snapshot.currentActivity}
         latestActivity={PromptActivityService.build(snapshot)}
       />
       <QueuedPromptPanel session={snapshot.activeSession} />
-      {directShellDraft && !snapshot.pendingDirectShellConfirmation ? (
-        <DirectShellModeHintPanel command={directShellDraft.command} />
-      ) : null}
-      <PromptInput
-        disabled={inputDisabled}
-        submitDisabled={submitDisabled}
-        placeholder={resolvePromptPlaceholder(snapshot)}
-        value={draft}
-        cursor={cursor}
-        onChange={setDraftState}
-        onSubmit={submitPrompt}
-        onComplete={(value) => store.completeSlashCommandDraft(value)}
-        onHistory={navigateHistory}
-        onUndo={undoPromptEdit}
-        onRedo={redoPromptEdit}
-        onSpecialKey={(input, key) => fileMentions.handleSpecialKey(input, key) || pickers.handleSpecialKey(input, key)}
-      />
+      <ComposerPanel store={store} snapshot={snapshot} />
       <RuntimeStatusBar snapshot={snapshot} />
     </Box>
   );
-}
-
-function resolvePromptPlaceholder(snapshot: ReturnType<typeof useControlPlaneSessionStore>): string {
-  if (snapshot.loading) {
-    return 'Loading session...';
-  }
-
-  if (snapshot.pendingApproval) {
-    return 'Waiting for approval';
-  }
-
-  if (snapshot.running) {
-    return 'Queue a follow-up';
-  }
-
-  return 'Type a prompt';
 }

--- a/src/cli-v2/components/ComposerPanel.tsx
+++ b/src/cli-v2/components/ComposerPanel.tsx
@@ -1,0 +1,169 @@
+import React, { useCallback } from 'react';
+import { DirectShellModeHintPanel } from './DirectShellModeHintPanel.js';
+import { FileMentionPickerPanel } from './FileMentionPickerPanel.js';
+import { ModelPickerPanel } from './ModelPickerPanel.js';
+import { PromptInput } from './PromptInput.js';
+import { ReasoningEffortPickerPanel } from './ReasoningEffortPickerPanel.js';
+import { SessionPickerPanel } from './SessionPickerPanel.js';
+import { SlashCommandHintPanel } from './SlashCommandHintPanel.js';
+import { useFileMentionPicker } from '../hooks/useFileMentionPicker.js';
+import { usePromptDraft } from '../hooks/usePromptDraft.js';
+import { usePromptPickers } from '../hooks/usePromptPickers.js';
+import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
+import type {
+  ControlPlaneSessionStore,
+  ControlPlaneSessionStoreSnapshot,
+} from '../state/control-plane-session-store.js';
+
+type ComposerPanelProps = {
+  store: ControlPlaneSessionStore;
+  snapshot: ControlPlaneSessionStoreSnapshot;
+};
+
+/**
+ * Owns the terminal composer interaction boundary.
+ *
+ * Prompt drafts, history, completions, and picker input are TUI-local state.
+ * Keeping them here prevents each keystroke from invalidating the transcript,
+ * markdown renderer, diff review panel, and other expensive session surfaces.
+ * Domain behavior still belongs to the control-plane API/store.
+ */
+export const ComposerPanel = React.memo(function ComposerPanel({
+  store,
+  snapshot,
+}: ComposerPanelProps) {
+  const {
+    draft,
+    cursor,
+    setDraft,
+    setDraftState,
+    clearDraft,
+    recordSubmittedPrompt,
+    navigateHistory,
+    undoPromptEdit,
+    redoPromptEdit,
+  } = usePromptDraft();
+  const submitDisabled = snapshot.loading || snapshot.submitting || Boolean(snapshot.pendingDirectShellConfirmation);
+  const inputDisabled = snapshot.loading || Boolean(snapshot.pendingDirectShellConfirmation) || Boolean(snapshot.pendingApproval);
+  const slashCommandHints = store.getSlashCommandHints(draft);
+  const directShellDraft = ClientSharedPromptInputService.parseDirectShellDraft(draft);
+  const pickers = usePromptPickers({
+    draft,
+    snapshot,
+    clearDraft,
+    onSelectModel: (model) => {
+      void store.selectModelFromPicker(model);
+    },
+    onSelectReasoning: (reasoningEffort) => {
+      void store.selectReasoningFromPicker(reasoningEffort);
+    },
+    onSelectSession: (sessionId) => {
+      void store.selectSessionFromPicker(sessionId);
+    },
+  });
+  const fileMentions = useFileMentionPicker({
+    draft,
+    setDraft,
+    snapshot,
+    store,
+  });
+
+  const submitPrompt = useCallback((value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    if (submitDisabled) {
+      return;
+    }
+
+    if (pickers.submitSelection()) {
+      return;
+    }
+
+    clearDraft();
+    if (!trimmed.startsWith('/')) {
+      recordSubmittedPrompt(trimmed);
+    }
+    void store.submitPrompt(value);
+  }, [
+    clearDraft,
+    pickers,
+    recordSubmittedPrompt,
+    store,
+    submitDisabled,
+  ]);
+
+  return (
+    <>
+      {pickers.model.query !== undefined ? (
+        <ModelPickerPanel
+          query={pickers.model.query}
+          models={pickers.model.items}
+          activeModel={snapshot.runtimeContext?.model}
+          highlightedIndex={pickers.model.highlightedIndex}
+        />
+      ) : null}
+      {pickers.reasoning.query !== undefined ? (
+        <ReasoningEffortPickerPanel
+          query={pickers.reasoning.query}
+          options={pickers.reasoning.items}
+          activeReasoningEffort={snapshot.runtimeContext?.reasoningEffort}
+          highlightedIndex={pickers.reasoning.highlightedIndex}
+        />
+      ) : null}
+      {pickers.session.query !== undefined ? (
+        <SessionPickerPanel
+          query={pickers.session.query}
+          sessions={pickers.session.items}
+          activeSessionId={snapshot.activeSessionId}
+          highlightedIndex={pickers.session.highlightedIndex}
+        />
+      ) : null}
+      {fileMentions.visible ? (
+        <FileMentionPickerPanel
+          query={fileMentions.query}
+          suggestions={fileMentions.suggestions}
+          highlightedIndex={fileMentions.highlightedIndex}
+          loading={fileMentions.loading}
+          error={fileMentions.error}
+        />
+      ) : null}
+      {!pickers.visible && !fileMentions.visible ? <SlashCommandHintPanel hints={slashCommandHints} /> : null}
+      {directShellDraft && !snapshot.pendingDirectShellConfirmation ? (
+        <DirectShellModeHintPanel command={directShellDraft.command} />
+      ) : null}
+      <PromptInput
+        disabled={inputDisabled}
+        submitDisabled={submitDisabled}
+        placeholder={resolvePromptPlaceholder(snapshot)}
+        value={draft}
+        cursor={cursor}
+        onChange={setDraftState}
+        onSubmit={submitPrompt}
+        onComplete={(value) => store.completeSlashCommandDraft(value)}
+        onHistory={navigateHistory}
+        onUndo={undoPromptEdit}
+        onRedo={redoPromptEdit}
+        onSpecialKey={(input, key) => fileMentions.handleSpecialKey(input, key) || pickers.handleSpecialKey(input, key)}
+      />
+    </>
+  );
+});
+
+function resolvePromptPlaceholder(snapshot: ControlPlaneSessionStoreSnapshot): string {
+  if (snapshot.loading) {
+    return 'Loading session...';
+  }
+
+  if (snapshot.pendingApproval) {
+    return 'Waiting for approval';
+  }
+
+  if (snapshot.running) {
+    return 'Queue a follow-up';
+  }
+
+  return 'Type a prompt';
+}

--- a/src/cli-v2/components/PromptInput.tsx
+++ b/src/cli-v2/components/PromptInput.tsx
@@ -61,6 +61,7 @@ export function PromptInput({
   const separator = repeatSeparator((stdout.columns ?? 0) - 2);
   const valueRef = useRef(value);
   const cursorRef = useRef(cursor);
+  const pendingLocalStateRef = useRef<ClientSharedPromptDraftState | undefined>(undefined);
   const renderWidth = resolvePromptInputRenderWidth(stdout.columns);
   const lines = useMemo(
     () => buildPromptRenderLines(value, cursor, MAX_VISIBLE_INPUT_LINES, renderWidth),
@@ -68,18 +69,28 @@ export function PromptInput({
   );
 
   useEffect(() => {
-    valueRef.current = value;
-  }, [value]);
+    const incoming = normalizePromptInputState({ value, cursor });
+    const current = normalizePromptInputState({
+      value: valueRef.current,
+      cursor: cursorRef.current,
+    });
 
-  useEffect(() => {
-    cursorRef.current = ClientSharedPromptInputService.clampCursor(valueRef.current, cursor);
-  }, [cursor]);
+    if (shouldKeepOptimisticPromptInputState({
+      current,
+      incoming,
+      pending: pendingLocalStateRef.current,
+    })) {
+      return;
+    }
+
+    pendingLocalStateRef.current = undefined;
+    valueRef.current = incoming.value;
+    cursorRef.current = incoming.cursor;
+  }, [cursor, value]);
 
   const applyState = useCallback((nextState: ClientSharedPromptDraftState) => {
-    const normalized = {
-      value: nextState.value,
-      cursor: ClientSharedPromptInputService.clampCursor(nextState.value, nextState.cursor),
-    };
+    const normalized = normalizePromptInputState(nextState);
+    pendingLocalStateRef.current = normalized;
     valueRef.current = normalized.value;
     cursorRef.current = normalized.cursor;
     onChange(normalized);
@@ -91,6 +102,7 @@ export function PromptInput({
     }
 
     if (onSpecialKey?.(input, key)) {
+      pendingLocalStateRef.current = undefined;
       return;
     }
 
@@ -109,7 +121,12 @@ export function PromptInput({
 
     if (command.kind === 'submit') {
       if (!submitDisabled) {
-        onSubmit(valueRef.current);
+        const submittedValue = valueRef.current;
+        const cleared = normalizePromptInputState({ value: '', cursor: 0 });
+        pendingLocalStateRef.current = cleared;
+        valueRef.current = cleared.value;
+        cursorRef.current = cleared.cursor;
+        onSubmit(submittedValue);
       }
       return;
     }
@@ -121,17 +138,20 @@ export function PromptInput({
 
     if (command.kind === 'history') {
       if (ClientSharedPromptInputService.canNavigateHistory(command.direction, current)) {
+        pendingLocalStateRef.current = undefined;
         onHistory?.(command.direction);
       }
       return;
     }
 
     if (command.kind === 'undo') {
+      pendingLocalStateRef.current = undefined;
       onUndo?.();
       return;
     }
 
     if (command.kind === 'redo') {
+      pendingLocalStateRef.current = undefined;
       onRedo?.();
       return;
     }
@@ -170,6 +190,37 @@ export function PromptInput({
       </Box>
     </Box>
   );
+}
+
+export function shouldKeepOptimisticPromptInputState({
+  current,
+  incoming,
+  pending,
+}: {
+  current: ClientSharedPromptDraftState;
+  incoming: ClientSharedPromptDraftState;
+  pending?: ClientSharedPromptDraftState;
+}): boolean {
+  if (!pending) {
+    return false;
+  }
+
+  if (isSamePromptInputState(incoming, pending)) {
+    return false;
+  }
+
+  return isSamePromptInputState(current, pending);
+}
+
+function normalizePromptInputState(state: ClientSharedPromptDraftState): ClientSharedPromptDraftState {
+  return {
+    value: state.value,
+    cursor: ClientSharedPromptInputService.clampCursor(state.value, state.cursor),
+  };
+}
+
+function isSamePromptInputState(left: ClientSharedPromptDraftState, right: ClientSharedPromptDraftState): boolean {
+  return left.value === right.value && left.cursor === right.cursor;
 }
 
 export type PromptRenderLine = {


### PR DESCRIPTION
## Summary
- isolates the cli-v2 composer so prompt keystrokes do not re-render the full transcript/diff tree
- keeps PromptInput local optimistic draft state from being overwritten by stale parent echoes, which was causing typed characters to disappear
- preserves intentional external updates for submit clear, history, undo/redo, and special-key flows

## Verification
- yarn -s test:unit src/__tests__/unit/cli-v2/prompt-input.test.ts
- yarn -s typecheck
- yarn lint
- yarn build