### PR TITLE
Add turn presentation metadata

### DIFF
--- a/src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { ClientSharedSessionTurnPresentationService } from '@/client-shared/services/session-turn-presentation/index.js';
+import type { ControlPlaneSessionDetail } from '@/client-shared/api/types.js';
+
+describe('ClientSharedSessionTurnPresentationService', () => {
+  it('projects persisted turn activities with turn context', () => {
+    const session = {
+      id: 'session-1',
+      name: 'Session 1',
+      messageCount: 0,
+      turnCount: 1,
+      queuedPromptCount: 0,
+      messages: [],
+      queuedPrompts: [],
+      turns: [
+        {
+          id: 'turn-1',
+          prompt: 'Update docs',
+          outcome: 'done',
+          summary: 'Updated docs',
+          steps: 2,
+          traceFile: '/tmp/trace.json',
+          events: [],
+          presentation: {
+            timelineItems: [
+              {
+                type: 'approval',
+                id: 'turn-1:approval:call-1',
+                toolCallId: 'call-1',
+                tool: 'run_shell_mutate',
+                summary: 'run_shell_mutate (npm run build)',
+                status: 'approved',
+                command: 'npm run build',
+                timestamp: '2026-06-05T01:00:00.000Z',
+              },
+            ],
+          },
+        },
+      ],
+    } satisfies ControlPlaneSessionDetail;
+
+    expect(ClientSharedSessionTurnPresentationService.projectTurnActivities(session)).toEqual([
+      {
+        id: 'turn-1:approval:call-1',
+        turnId: 'turn-1',
+        turnPrompt: 'Update docs',
+        activity: session.turns[0]?.presentation?.timelineItems[0],
+      },
+    ]);
+  });
+});

--- a/src/__tests__/unit/core/conversation-turn-presentation.test.ts
+++ b/src/__tests__/unit/core/conversation-turn-presentation.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { HeddleEventType } from '@/core/event-types.js';
+import { ConversationTurnPresentationService } from '@/core/chat/engine/turns/presentation/index.js';
+import type { TraceEvent } from '@/core/types.js';
+
+describe('ConversationTurnPresentationService', () => {
+  it('projects approvals and edit diffs from completed turn traces', () => {
+    const trace: TraceEvent[] = [
+      {
+        type: HeddleEventType.toolApprovalRequested,
+        call: {
+          id: 'approval-1',
+          tool: 'run_shell_mutate',
+          input: { command: 'npm run build' },
+        },
+        step: 1,
+        timestamp: '2026-06-05T01:00:00.000Z',
+      },
+      {
+        type: HeddleEventType.toolApprovalResolved,
+        call: {
+          id: 'approval-1',
+          tool: 'run_shell_mutate',
+          input: { command: 'npm run build' },
+        },
+        approved: true,
+        reason: 'approved once',
+        step: 1,
+        timestamp: '2026-06-05T01:00:01.000Z',
+      },
+      {
+        type: HeddleEventType.toolCompleted,
+        call: {
+          id: 'edit-1',
+          tool: 'edit_file',
+          input: { path: 'src/example.ts' },
+        },
+        result: {
+          ok: true,
+          output: {
+            path: 'src/example.ts',
+            action: 'replaced',
+            diff: {
+              diff: [
+                '--- a/src/example.ts',
+                '+++ b/src/example.ts',
+                '@@ -1 +1 @@',
+                '-old',
+                '+new',
+              ].join('\n'),
+              truncated: false,
+            },
+          },
+        },
+        step: 2,
+        timestamp: '2026-06-05T01:00:02.000Z',
+      },
+    ];
+
+    expect(ConversationTurnPresentationService.project({ turnId: 'turn-1', trace })).toEqual({
+      timelineItems: [
+        {
+          type: 'approval',
+          id: 'turn-1:approval:approval-1',
+          toolCallId: 'approval-1',
+          tool: 'run_shell_mutate',
+          summary: 'run_shell_mutate (npm run build)',
+          status: 'approved',
+          command: 'npm run build',
+          reason: 'approved once',
+          step: 1,
+          timestamp: '2026-06-05T01:00:01.000Z',
+        },
+        {
+          type: 'edit_diff',
+          id: 'turn-1:edit-diff:edit-1',
+          toolCallId: 'edit-1',
+          path: 'src/example.ts',
+          action: 'replaced',
+          patch: [
+            '--- a/src/example.ts',
+            '+++ b/src/example.ts',
+            '@@ -1 +1 @@',
+            '-old',
+            '+new',
+          ].join('\n'),
+          truncated: false,
+          step: 2,
+          timestamp: '2026-06-05T01:00:02.000Z',
+        },
+      ],
+    });
+  });
+
+  it('drops non-presentation traces and invalid stored presentation values', () => {
+    const trace: TraceEvent[] = [
+      {
+        type: HeddleEventType.runFinished,
+        outcome: 'done',
+        summary: 'Done',
+        step: 1,
+        timestamp: '2026-06-05T01:00:00.000Z',
+      },
+    ];
+
+    expect(ConversationTurnPresentationService.project({ turnId: 'turn-1', trace })).toBeUndefined();
+    expect(ConversationTurnPresentationService.read({ timelineItems: [{ type: 'unknown' }] })).toBeUndefined();
+  });
+});

--- a/src/client-shared/api/types.ts
+++ b/src/client-shared/api/types.ts
@@ -19,6 +19,7 @@ export type ControlPlaneHeartbeatEventEnvelope = AsyncIterableValue<RouterOutput
 export type ControlPlaneSessionMessage = NonNullable<ControlPlaneSessionDetail>['messages'][number];
 export type ControlPlaneSessionRuntimeContext = RouterOutputs['controlPlane']['sessionRuntimeContext'];
 export type ControlPlanePendingApproval = RouterOutputs['controlPlane']['sessionPendingApproval'];
+export type ControlPlaneSessionTurn = NonNullable<ControlPlaneSessionDetail>['turns'][number];
 export type ControlPlaneApprovalDecision = RouterInputs['controlPlane']['sessionResolveApproval']['decision'];
 export type ControlPlaneSessionSendPromptResult = RouterOutputs['controlPlane']['sessionSendPrompt'];
 export type ControlPlaneSessionSendPromptAsyncResult = RouterOutputs['controlPlane']['sessionSendPromptAsync'];

--- a/src/client-shared/services/session-turn-presentation/index.ts
+++ b/src/client-shared/services/session-turn-presentation/index.ts
@@ -1,0 +1,4 @@
+export {
+  ClientSharedSessionTurnPresentationService,
+  type ClientSharedSessionTurnPresentationItem,
+} from './session-turn-presentation-service.js';

--- a/src/client-shared/services/session-turn-presentation/session-turn-presentation-service.ts
+++ b/src/client-shared/services/session-turn-presentation/session-turn-presentation-service.ts
@@ -1,0 +1,39 @@
+import type {
+  ControlPlaneSessionDetail,
+  ControlPlaneSessionTurn,
+} from '../../api/types.js';
+import type { ConversationTurnPresentationTimelineItem } from '@/core/chat/types.js';
+
+export type ClientSharedSessionTurnPresentationItem = {
+  id: string;
+  turnId: string;
+  turnPrompt: string;
+  activity: ConversationTurnPresentationTimelineItem;
+};
+
+/**
+ * Owns frontend-neutral projection of persisted turn presentation metadata.
+ *
+ * Core owns which tool facts become durable turn presentation metadata. This
+ * service owns the shared client-side shape that web-v2 and cli-v2 can render
+ * differently. It does not parse raw traces, inspect tool payloads, or decide
+ * host-specific layout, keyboard shortcuts, or collapse state.
+ */
+export class ClientSharedSessionTurnPresentationService {
+  static projectTurnActivities(
+    session: ControlPlaneSessionDetail | undefined | null,
+  ): ClientSharedSessionTurnPresentationItem[] {
+    return session?.turns.flatMap((turn) => (
+      ClientSharedSessionTurnPresentationService.projectTurnActivityItems(turn)
+    )) ?? [];
+  }
+
+  static projectTurnActivityItems(turn: ControlPlaneSessionTurn): ClientSharedSessionTurnPresentationItem[] {
+    return turn.presentation?.timelineItems.map((activity) => ({
+      id: activity.id,
+      turnId: turn.id,
+      turnPrompt: turn.prompt,
+      activity,
+    })) ?? [];
+  }
+}

--- a/src/core/chat/engine/sessions/records/records.ts
+++ b/src/core/chat/engine/sessions/records/records.ts
@@ -8,6 +8,7 @@
 import { truncate } from '@/core/utils/text.js';
 import type { ChatSession, ConversationLine } from '@/core/chat/types.js';
 import { TraceSummaryService } from '@/core/observability/index.js';
+import { ConversationTurnPresentationService } from '@/core/chat/engine/turns/presentation/index.js';
 import { ConversationLines } from './conversation-lines.js';
 import type {
   ApplyCompactedChatSessionHistoryInput,
@@ -64,6 +65,10 @@ export class ChatSessionRecords {
         typeof input.traceSummarizerRegistry?.summarizeTrace === 'function'
           ? input.traceSummarizerRegistry.summarizeTrace(input.result.trace)
           : TraceSummaryService.default().summarizeTrace(input.result.trace),
+      presentation: ConversationTurnPresentationService.project({
+        turnId: input.id,
+        trace: input.result.trace,
+      }),
     };
   }
 

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -6,6 +6,7 @@
  */
 import { z } from 'zod';
 import { ConversationDirectShellLineResultSchema } from '@/core/chat/engine/direct-shell/result-schema.js';
+import { ConversationTurnPresentationSchema } from '@/core/chat/engine/turns/presentation/index.js';
 
 const ReasoningEffortSchema = z.enum(['low', 'medium', 'high', 'ultrahigh']);
 const ChatSessionRetentionSchema = z.enum(['reusable', 'one_off']);
@@ -74,6 +75,10 @@ const TurnSummarySchema = z.object({
   steps: z.number().describe('Number of assistant loop steps executed in the turn.'),
   traceFile: z.string().describe('Path to the persisted trace file for this turn.'),
   events: z.array(z.string()).describe('Compact event summaries extracted from the turn trace.'),
+  presentation: ConversationTurnPresentationSchema
+    .describe('Compact non-transcript tool activity metadata for conversation timeline presentation.')
+    .optional()
+    .catch(undefined),
 });
 
 const TurnSummariesSchema = z.array(z.unknown())

--- a/src/core/chat/engine/turns/presentation/index.ts
+++ b/src/core/chat/engine/turns/presentation/index.ts
@@ -1,0 +1,5 @@
+export { ConversationTurnPresentationService } from './turn-presentation-service.js';
+export {
+  ConversationTurnPresentationSchema,
+  ConversationTurnPresentationTimelineItemSchema,
+} from './schema.js';

--- a/src/core/chat/engine/turns/presentation/schema.ts
+++ b/src/core/chat/engine/turns/presentation/schema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+const TurnPresentationBaseTimelineItemSchema = z.object({
+  id: z.string(),
+  toolCallId: z.string(),
+  step: z.number().optional(),
+  timestamp: z.string(),
+});
+
+const TurnApprovalTimelineItemSchema = TurnPresentationBaseTimelineItemSchema.extend({
+  type: z.literal('approval'),
+  tool: z.string(),
+  summary: z.string(),
+  status: z.enum(['requested', 'approved', 'denied']),
+  command: z.string().optional(),
+  reason: z.string().optional(),
+});
+
+const TurnEditDiffTimelineItemSchema = TurnPresentationBaseTimelineItemSchema.extend({
+  type: z.literal('edit_diff'),
+  path: z.string(),
+  action: z.string().optional(),
+  patch: z.string(),
+  truncated: z.boolean(),
+});
+
+export const ConversationTurnPresentationTimelineItemSchema = z.union([
+  TurnApprovalTimelineItemSchema,
+  TurnEditDiffTimelineItemSchema,
+]);
+
+export const ConversationTurnPresentationSchema = z.object({
+  timelineItems: z.array(ConversationTurnPresentationTimelineItemSchema),
+});

--- a/src/core/chat/engine/turns/presentation/turn-presentation-service.ts
+++ b/src/core/chat/engine/turns/presentation/turn-presentation-service.ts
@@ -1,0 +1,134 @@
+/**
+ * Owns durable presentation metadata extracted from a completed turn trace.
+ *
+ * This is not model transcript history and it is not host UI rendering. Core
+ * owns this compact, stable activity contract so terminal and browser clients
+ * can reconstruct the same conversation-adjacent tool activity without parsing
+ * raw trace files or duplicating tool payload semantics.
+ */
+import dayjs from 'dayjs';
+import compact from 'lodash/compact.js';
+import isPlainObject from 'lodash/isPlainObject.js';
+import isString from 'lodash/isString.js';
+import orderBy from 'lodash/orderBy.js';
+import { HeddleEventType } from '@/core/event-types.js';
+import type { TraceEvent, ToolCall } from '@/core/types.js';
+import { ToolActivitySummarizer } from '@/core/live/index.js';
+import type {
+  ConversationTurnApprovalTimelineItem,
+  ConversationTurnEditDiffTimelineItem,
+  ConversationTurnPresentation,
+  ConversationTurnPresentationTimelineItem,
+} from '@/core/chat/types.js';
+import { ConversationTurnPresentationSchema } from './schema.js';
+
+type ProjectTurnPresentationInput = {
+  turnId: string;
+  trace: TraceEvent[];
+};
+
+export class ConversationTurnPresentationService {
+  static project(input: ProjectTurnPresentationInput): ConversationTurnPresentation | undefined {
+    const requestedApprovals = input.trace
+      .filter((event): event is Extract<TraceEvent, { type: typeof HeddleEventType.toolApprovalRequested }> => (
+        event.type === HeddleEventType.toolApprovalRequested
+      ));
+    const approvalResolutions = new Map(input.trace
+      .filter((event): event is Extract<TraceEvent, { type: typeof HeddleEventType.toolApprovalResolved }> => (
+        event.type === HeddleEventType.toolApprovalResolved
+      ))
+      .map((event) => [event.call.id, event]));
+    const approvals = requestedApprovals.map((event) => (
+      ConversationTurnPresentationService.projectApproval(input.turnId, event, approvalResolutions.get(event.call.id))
+    ));
+    const editDiffs = compact(input.trace.map((event) => (
+      event.type === HeddleEventType.toolCompleted
+        ? ConversationTurnPresentationService.projectEditDiff(input.turnId, event)
+        : undefined
+    )));
+    const timelineItems = ConversationTurnPresentationService.sortTimelineItems([...approvals, ...editDiffs]);
+
+    return timelineItems.length > 0 ? { timelineItems } : undefined;
+  }
+
+  static read(raw: unknown): ConversationTurnPresentation | undefined {
+    const parsed = ConversationTurnPresentationSchema.safeParse(raw);
+    return parsed.success ? parsed.data : undefined;
+  }
+
+  private static projectApproval(
+    turnId: string,
+    event: Extract<TraceEvent, { type: typeof HeddleEventType.toolApprovalRequested }>,
+    resolution: Extract<TraceEvent, { type: typeof HeddleEventType.toolApprovalResolved }> | undefined,
+  ): ConversationTurnApprovalTimelineItem {
+    const command = ConversationTurnPresentationService.readCommandOrPath(event.call);
+    return {
+      type: 'approval',
+      id: `${turnId}:approval:${event.call.id}`,
+      toolCallId: event.call.id,
+      tool: event.call.tool,
+      summary: ToolActivitySummarizer.summarizeCall(event.call),
+      status:
+        resolution ? (resolution.approved ? 'approved' : 'denied')
+        : 'requested',
+      ...(command ? { command } : {}),
+      ...(resolution?.reason ? { reason: resolution.reason } : {}),
+      step: event.step,
+      timestamp: resolution?.timestamp ?? event.timestamp,
+    };
+  }
+
+  private static projectEditDiff(
+    turnId: string,
+    event: Extract<TraceEvent, { type: typeof HeddleEventType.toolCompleted }>,
+  ): ConversationTurnEditDiffTimelineItem | undefined {
+    if (event.call.tool !== 'edit_file' || event.result.ok !== true || !isPlainObject(event.result.output)) {
+      return undefined;
+    }
+
+    const output = event.result.output as Record<string, unknown>;
+    const diff = isPlainObject(output.diff) ? output.diff as Record<string, unknown> : undefined;
+    const path = ConversationTurnPresentationService.readNonEmptyString(output.path);
+    const patch = ConversationTurnPresentationService.readNonEmptyString(diff?.diff);
+    if (!path || !patch) {
+      return undefined;
+    }
+
+    const action = ConversationTurnPresentationService.readNonEmptyString(output.action);
+    return {
+      type: 'edit_diff',
+      id: `${turnId}:edit-diff:${event.call.id}`,
+      toolCallId: event.call.id,
+      path,
+      ...(action ? { action } : {}),
+      patch,
+      truncated: diff?.truncated === true,
+      step: event.step,
+      timestamp: event.timestamp,
+    };
+  }
+
+  private static sortTimelineItems(
+    timelineItems: ConversationTurnPresentationTimelineItem[],
+  ): ConversationTurnPresentationTimelineItem[] {
+    return orderBy(timelineItems, [
+      (item) => dayjs(item.timestamp).valueOf(),
+      (item) => item.step ?? Number.MAX_SAFE_INTEGER,
+      'id',
+    ], ['asc', 'asc', 'asc']);
+  }
+
+  private static readCommandOrPath(call: ToolCall): string | undefined {
+    if (!isPlainObject(call.input)) {
+      return undefined;
+    }
+
+    const input = call.input as Record<string, unknown>;
+    return ConversationTurnPresentationService.readNonEmptyString(input.command)
+      ?? ConversationTurnPresentationService.readNonEmptyString(input.path);
+  }
+
+  private static readNonEmptyString(value: unknown): string | undefined {
+    return isString(value) && value.trim().length > 0 ? value.trim() : undefined;
+  }
+}

--- a/src/core/chat/types.ts
+++ b/src/core/chat/types.ts
@@ -11,6 +11,40 @@ export type TurnSummary = {
   steps: number;
   traceFile: string;
   events: string[];
+  presentation?: ConversationTurnPresentation;
+};
+
+export type ConversationTurnPresentation = {
+  timelineItems: ConversationTurnPresentationTimelineItem[];
+};
+
+export type ConversationTurnPresentationTimelineItem =
+  | ConversationTurnApprovalTimelineItem
+  | ConversationTurnEditDiffTimelineItem;
+
+export type ConversationTurnApprovalTimelineItem = {
+  type: 'approval';
+  id: string;
+  toolCallId: string;
+  tool: string;
+  summary: string;
+  status: 'requested' | 'approved' | 'denied';
+  command?: string;
+  reason?: string;
+  step?: number;
+  timestamp: string;
+};
+
+export type ConversationTurnEditDiffTimelineItem = {
+  type: 'edit_diff';
+  id: string;
+  toolCallId: string;
+  path: string;
+  action?: string;
+  patch: string;
+  truncated: boolean;
+  step?: number;
+  timestamp: string;
 };
 
 export type ConversationLine = {

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -6,7 +6,12 @@ import type { ReviewDiffFile } from '@/core/review/index.js';
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { ReasoningEffortOption } from '@/core/llm/models/index.js';
 import type { ReasoningEffort } from '@/core/llm/types.js';
-import type { ChatSessionRetention, ConversationDirectShellLineResult, QueuedConversationPrompt } from '@/core/chat/types.js';
+import type {
+  ChatSessionRetention,
+  ConversationDirectShellLineResult,
+  ConversationTurnPresentation,
+  QueuedConversationPrompt,
+} from '@/core/chat/types.js';
 import type { ConversationActivity } from '@/core/live/index.js';
 
 export type ChatSessionView = {
@@ -80,6 +85,7 @@ export type ChatTurnView = {
   steps: number;
   traceFile: string;
   events: string[];
+  presentation?: ConversationTurnPresentation;
 };
 
 export type CommandEvidenceView = {

--- a/src/server/controllers/trpc/control-plane/chat-session-presenter.ts
+++ b/src/server/controllers/trpc/control-plane/chat-session-presenter.ts
@@ -1,6 +1,7 @@
 import type { ChatSession, ConversationDirectShellLineResult } from '@/core/chat/types.js';
 import type { ReasoningEffort } from '@/core/llm/types.js';
 import { ConversationDirectShellLineResultSchema } from '@/core/chat/engine/direct-shell/result-schema.js';
+import { ConversationTurnPresentationService } from '@/core/chat/engine/turns/presentation/index.js';
 import type {
   ChatSessionDetail,
   ChatSessionMessage,
@@ -232,6 +233,7 @@ export class ControlPlaneChatSessionPresenter {
       steps,
       traceFile,
       events,
+      presentation: ConversationTurnPresentationService.read(candidate.presentation),
     }];
   }
 


### PR DESCRIPTION
## Summary
- add core-owned turn presentation metadata for approval and edit-file diff activity
- persist the optional presentation contract on completed turn summaries and expose it through the control-plane session API
- add a client-shared projector so web-v2 and cli-v2 can consume the same per-turn activity facts without parsing traces

## Expected behavior
- New completed turns that request tool approvals or complete edit_file calls now store compact presentation metadata under turn.presentation.
- Older sessions without presentation metadata remain readable.
- Browser and TUI can later render approval/diff activity inside the conversation timeline from the same shared API contract instead of reconstructing from raw trace files independently.

## Verification
- npx vitest run src/__tests__/unit/core/conversation-turn-presentation.test.ts src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
- yarn test src/__tests__/unit/core/conversation-turn-presentation.test.ts src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
- yarn typecheck
- yarn lint
- yarn build