### PR TITLE
[codex] Add conversation activity timeline UI

### DIFF
--- a/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
+++ b/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
@@ -86,6 +86,49 @@ describe('cli-v2 ConversationPanel', () => {
     expect(view.container.textContent).toContain('const ok = true;');
     expect(view.container.textContent).not.toContain('```ts');
   });
+
+  it('renders persisted turn activities inline with the conversation', () => {
+    const view = render(
+      <ConversationPanel
+        session={createSessionDetail({
+          messages: [
+            { id: 'message-1', role: 'user', text: 'Update docs' },
+            { id: 'message-2', role: 'assistant', text: 'Done.' },
+          ],
+          turns: [
+            {
+              id: 'turn-1',
+              prompt: 'Update docs',
+              outcome: 'done',
+              summary: 'Updated docs',
+              steps: 2,
+              traceFile: '/tmp/trace.json',
+              events: [],
+              presentation: {
+                timelineItems: [
+                  {
+                    type: 'edit_diff',
+                    id: 'turn-1:edit:call-1',
+                    toolCallId: 'call-1',
+                    path: 'docs/index.md',
+                    action: 'replace',
+                    patch: '@@ -1 +1 @@\n-old\n+new',
+                    truncated: false,
+                  },
+                ],
+              },
+            },
+          ],
+        })}
+        runtimeContext={createRuntimeContext()}
+      />,
+    );
+
+    expect(view.container.textContent).toContain('Activity');
+    expect(view.container.textContent).toContain('Edit diff');
+    expect(view.container.textContent).toContain('docs/index.md');
+    expect(view.container.textContent).toContain('+new');
+  });
 });
 
 function createSessionDetail(

--- a/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
+++ b/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
@@ -31,7 +31,7 @@ describe('cli-v2 ConversationPanel', () => {
     expect(view.container.textContent).toContain('No provider credential detected.');
   });
 
-  it('renders queued user turns and direct shell results from the active session detail', () => {
+  it('renders user turns and direct shell results from the active session detail', () => {
     const view = render(
       <ConversationPanel
         session={createSessionDetail({
@@ -57,7 +57,8 @@ describe('cli-v2 ConversationPanel', () => {
       />,
     );
 
-    expect(view.container.textContent).toContain('You (queued)');
+    expect(view.container.textContent).toContain('You');
+    expect(view.container.textContent).not.toContain('You (queued)');
     expect(view.container.textContent).toContain('What changed?');
     expect(view.container.textContent).toContain('done shell git status --short');
     expect(view.container.textContent).toContain('local workspace inspection');
@@ -87,7 +88,7 @@ describe('cli-v2 ConversationPanel', () => {
     expect(view.container.textContent).not.toContain('```ts');
   });
 
-  it('renders persisted turn activities inline with the conversation', () => {
+  it('renders persisted turn activity groups collapsed by default', () => {
     const view = render(
       <ConversationPanel
         session={createSessionDetail({
@@ -125,6 +126,52 @@ describe('cli-v2 ConversationPanel', () => {
     );
 
     expect(view.container.textContent).toContain('Activity');
+    expect(view.container.textContent).toContain('Agent tool activities');
+    expect(view.container.textContent).toContain('1 item');
+    expect(view.container.textContent).toContain('press a to expand');
+    expect(view.container.textContent).not.toContain('docs/index.md');
+    expect(view.container.textContent).not.toContain('+new');
+  });
+
+  it('renders persisted turn activity details when expanded', () => {
+    const view = render(
+      <ConversationPanel
+        activityExpanded
+        session={createSessionDetail({
+          messages: [
+            { id: 'message-1', role: 'user', text: 'Update docs' },
+            { id: 'message-2', role: 'assistant', text: 'Done.' },
+          ],
+          turns: [
+            {
+              id: 'turn-1',
+              prompt: 'Update docs',
+              outcome: 'done',
+              summary: 'Updated docs',
+              steps: 2,
+              traceFile: '/tmp/trace.json',
+              events: [],
+              presentation: {
+                timelineItems: [
+                  {
+                    type: 'edit_diff',
+                    id: 'turn-1:edit:call-1',
+                    toolCallId: 'call-1',
+                    path: 'docs/index.md',
+                    action: 'replace',
+                    patch: '@@ -1 +1 @@\n-old\n+new',
+                    truncated: false,
+                  },
+                ],
+              },
+            },
+          ],
+        })}
+        runtimeContext={createRuntimeContext()}
+      />,
+    );
+
+    expect(view.container.textContent).toContain('press a to collapse');
     expect(view.container.textContent).toContain('Edit diff');
     expect(view.container.textContent).toContain('docs/index.md');
     expect(view.container.textContent).toContain('+new');

--- a/src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
@@ -78,9 +78,14 @@ describe('ClientSharedSessionTurnPresentationService', () => {
 
     expect(ClientSharedSessionTurnPresentationService.projectConversationTimeline(session).map((item) => item.id)).toEqual([
       'message-1',
-      'turn-1:edit:call-1',
+      'turn-1:activity-group',
       'message-2',
     ]);
+
+    const activityGroup = ClientSharedSessionTurnPresentationService
+      .projectConversationTimeline(session)
+      .find((item) => item.type === 'turn_activity_group');
+    expect(activityGroup?.activities).toHaveLength(1);
   });
 
   it('keeps unmatched turn activities visible at the end of the timeline', () => {
@@ -108,7 +113,7 @@ describe('ClientSharedSessionTurnPresentationService', () => {
 
     expect(ClientSharedSessionTurnPresentationService.projectConversationTimeline(session).map((item) => item.id)).toEqual([
       'message-1',
-      'turn-1:approval:call-1',
+      'turn-1:activity-group',
     ]);
   });
 });

--- a/src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
@@ -48,4 +48,98 @@ describe('ClientSharedSessionTurnPresentationService', () => {
       },
     ]);
   });
+
+  it('projects turn activities into the conversation timeline after the matching prompt', () => {
+    const session = createSessionDetail({
+      messages: [
+        { id: 'message-1', role: 'user', text: 'Update docs' },
+        { id: 'message-2', role: 'assistant', text: 'Done.' },
+      ],
+      turns: [
+        createTurn({
+          id: 'turn-1',
+          prompt: 'Update docs',
+          presentation: {
+            timelineItems: [
+              {
+                type: 'edit_diff',
+                id: 'turn-1:edit:call-1',
+                toolCallId: 'call-1',
+                path: 'docs/index.md',
+                action: 'replace',
+                patch: '@@ -1 +1 @@\n-old\n+new',
+                truncated: false,
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    expect(ClientSharedSessionTurnPresentationService.projectConversationTimeline(session).map((item) => item.id)).toEqual([
+      'message-1',
+      'turn-1:edit:call-1',
+      'message-2',
+    ]);
+  });
+
+  it('keeps unmatched turn activities visible at the end of the timeline', () => {
+    const session = createSessionDetail({
+      messages: [{ id: 'message-1', role: 'assistant', text: 'Done.' }],
+      turns: [
+        createTurn({
+          id: 'turn-1',
+          prompt: 'Update docs',
+          presentation: {
+            timelineItems: [
+              {
+                type: 'approval',
+                id: 'turn-1:approval:call-1',
+                toolCallId: 'call-1',
+                tool: 'run_shell_mutate',
+                summary: 'run_shell_mutate (npm run build)',
+                status: 'approved',
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    expect(ClientSharedSessionTurnPresentationService.projectConversationTimeline(session).map((item) => item.id)).toEqual([
+      'message-1',
+      'turn-1:approval:call-1',
+    ]);
+  });
 });
+
+function createSessionDetail(
+  overrides: Partial<NonNullable<ControlPlaneSessionDetail>> = {},
+): NonNullable<ControlPlaneSessionDetail> {
+  return {
+    id: 'session-1',
+    name: 'Session 1',
+    messageCount: 0,
+    turnCount: 0,
+    queuedPromptCount: 0,
+    messages: [],
+    queuedPrompts: [],
+    turns: [],
+    ...overrides,
+  };
+}
+
+function createTurn(
+  overrides: Partial<NonNullable<ControlPlaneSessionDetail>['turns'][number]> = {},
+): NonNullable<ControlPlaneSessionDetail>['turns'][number] {
+  return {
+    id: 'turn-1',
+    prompt: 'Update docs',
+    outcome: 'done',
+    summary: 'Updated docs',
+    steps: 2,
+    traceFile: '/tmp/trace.json',
+    events: [],
+    ...overrides,
+  };
+}

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -73,11 +73,13 @@ export function App({
         {snapshot.activeSession ? ` · ${snapshot.activeSession.name}` : ''}
       </Text>
       <ConversationPanel runtimeContext={snapshot.runtimeContext} session={snapshot.activeSession} />
-      <RecentEditDiffPanel
-        diffs={snapshot.recentEditDiffs}
-        review={recentEditDiffReview}
-        running={snapshot.running}
-      />
+      {snapshot.running ? (
+        <RecentEditDiffPanel
+          diffs={snapshot.recentEditDiffs}
+          review={recentEditDiffReview}
+          running={snapshot.running}
+        />
+      ) : null}
       <CommandResultPanel results={snapshot.commandResults} />
       {snapshot.pendingApproval ? (
         <ApprovalPanel

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -1,7 +1,7 @@
 // Keep this root component thin: wire top-level app state and render surfaces
 // only. Put feature behavior in cli-v2 hooks, services, or focused components
 // instead of growing App.tsx directly.
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { AgentPlanPanel } from './components/AgentPlanPanel.js';
@@ -17,7 +17,9 @@ import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
 import { useRecentEditDiffReview } from './hooks/useRecentEditDiffReview.js';
 import { PromptActivityService } from './services/activities/prompt-activity-service.js';
+import { ClientSharedSessionTurnPresentationService } from '@/client-shared/services/session-turn-presentation/index.js';
 import type { ControlPlaneApprovalDecision } from '@/client-shared/api/types.js';
+import type { PromptInputKey } from './components/PromptInput.js';
 import type {
   ControlPlaneSessionStore,
   ControlPlaneSessionStoreStartInput,
@@ -31,8 +33,12 @@ export function App({
   initialSelection?: ControlPlaneSessionStoreStartInput;
 }) {
   const startedRef = useRef(false);
+  const [activityExpanded, setActivityExpanded] = useState(false);
   const snapshot = useControlPlaneSessionStore(store);
   const recentEditDiffReview = useRecentEditDiffReview(snapshot.recentEditDiffs);
+  const hasConversationActivityGroups = ClientSharedSessionTurnPresentationService
+    .projectConversationTimeline(snapshot.activeSession)
+    .some((item) => item.type === 'turn_activity_group');
 
   useEffect(() => {
     if (startedRef.current) {
@@ -62,6 +68,26 @@ export function App({
     recentEditDiffReview.handleReviewKey(input, key);
   }, { isActive: recentEditDiffReview.mode === 'review' });
 
+  const handleComposerSpecialKey = useCallback((input: string, key: PromptInputKey, draft: string) => {
+    if (recentEditDiffReview.handlePromptSpecialKey(input, key, draft)) {
+      return true;
+    }
+
+    if (
+      !hasConversationActivityGroups ||
+      draft.length > 0 ||
+      key.ctrl ||
+      key.meta ||
+      key.super ||
+      input !== 'a'
+    ) {
+      return false;
+    }
+
+    setActivityExpanded((current) => !current);
+    return true;
+  }, [hasConversationActivityGroups, recentEditDiffReview]);
+
   return (
     <Box flexDirection="column" paddingX={1}>
       <Box marginBottom={1}>
@@ -72,7 +98,11 @@ export function App({
         {snapshot.workspaceId ? `Workspace ${snapshot.workspaceId}` : 'Loading workspace...'}
         {snapshot.activeSession ? ` · ${snapshot.activeSession.name}` : ''}
       </Text>
-      <ConversationPanel runtimeContext={snapshot.runtimeContext} session={snapshot.activeSession} />
+      <ConversationPanel
+        activityExpanded={activityExpanded}
+        runtimeContext={snapshot.runtimeContext}
+        session={snapshot.activeSession}
+      />
       {snapshot.running ? (
         <RecentEditDiffPanel
           diffs={snapshot.recentEditDiffs}
@@ -110,7 +140,7 @@ export function App({
         store={store}
         snapshot={snapshot}
         keyboardDisabled={recentEditDiffReview.mode === 'review'}
-        onSpecialKey={recentEditDiffReview.handlePromptSpecialKey}
+        onSpecialKey={handleComposerSpecialKey}
       />
       <RuntimeStatusBar snapshot={snapshot} />
     </Box>

--- a/src/cli-v2/components/ConversationPanel.tsx
+++ b/src/cli-v2/components/ConversationPanel.tsx
@@ -1,9 +1,13 @@
 import React, { memo } from 'react';
 import { Box, Text } from 'ink';
 import type { ControlPlaneSessionDetail, ControlPlaneSessionRuntimeContext } from '@/client-shared/api/types.js';
+import { ClientSharedSessionTurnPresentationService } from '@/client-shared/services/session-turn-presentation/index.js';
+import type { ClientSharedConversationTimelineItem } from '@/client-shared/services/session-turn-presentation/index.js';
 import { AssistantMarkdown } from './AssistantMarkdown.js';
+import { ConversationTurnActivityBlock } from './ConversationTurnActivityBlock.js';
 
 type ConversationMessage = NonNullable<ControlPlaneSessionDetail>['messages'][number];
+const MAX_VISIBLE_TIMELINE_ITEMS = 14;
 
 export const ConversationPanel = memo(function ConversationPanel({
   runtimeContext,
@@ -12,26 +16,60 @@ export const ConversationPanel = memo(function ConversationPanel({
   runtimeContext?: ControlPlaneSessionRuntimeContext;
   session: ControlPlaneSessionDetail;
 }) {
-  const messages = session?.messages.slice(-10) ?? [];
+  const timelineItems = ClientSharedSessionTurnPresentationService
+    .projectConversationTimeline(session)
+    .slice(-MAX_VISIBLE_TIMELINE_ITEMS);
   const showWelcome = Boolean(session && runtimeContext?.welcomeGuide && !session.messages.some((message) => message.role === 'user'));
 
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Text bold>Conversation</Text>
       <WelcomeGuideSlot show={showWelcome} runtimeContext={runtimeContext} />
-      <EmptyConversationSlot show={messages.length === 0 && !showWelcome} />
-      {messages.map((message, index) => (
-        <Box key={message.id} flexDirection="column" marginBottom={1}>
-          <Text dimColor>{resolveMessageLabel(message)}</Text>
-          <Box paddingLeft={2} flexDirection="column">
-            <MessageBody message={message} />
-          </Box>
-          <Text dimColor>{index === messages.length - 1 ? '└' : '└────────────────────────────────────────────────────────'}</Text>
-        </Box>
+      <EmptyConversationSlot show={timelineItems.length === 0 && !showWelcome} />
+      {timelineItems.map((item, index) => (
+        <ConversationTimelineItemView
+          key={item.id}
+          item={item}
+          last={index === timelineItems.length - 1}
+        />
       ))}
     </Box>
   );
 });
+
+function ConversationTimelineItemView({
+  item,
+  last,
+}: {
+  item: ClientSharedConversationTimelineItem;
+  last: boolean;
+}) {
+  if (item.type === 'turn_activity') {
+    return (
+      <Box flexDirection="column" marginBottom={1}>
+        <Text dimColor>┌ Activity</Text>
+        <Box paddingLeft={2} flexDirection="column">
+          <ConversationTurnActivityBlock item={item} />
+        </Box>
+        <TimelineFooter last={last} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text dimColor>{resolveMessageLabel(item.message)}</Text>
+      <Box paddingLeft={2} flexDirection="column">
+        <MessageBody message={item.message} />
+      </Box>
+      <TimelineFooter last={last} />
+    </Box>
+  );
+}
+
+function TimelineFooter({ last }: { last: boolean }) {
+  return <Text dimColor>{last ? '└' : '└────────────────────────────────────────────────────────'}</Text>;
+}
 
 function WelcomeGuideSlot({
   runtimeContext,

--- a/src/cli-v2/components/ConversationPanel.tsx
+++ b/src/cli-v2/components/ConversationPanel.tsx
@@ -10,9 +10,11 @@ type ConversationMessage = NonNullable<ControlPlaneSessionDetail>['messages'][nu
 const MAX_VISIBLE_TIMELINE_ITEMS = 14;
 
 export const ConversationPanel = memo(function ConversationPanel({
+  activityExpanded = false,
   runtimeContext,
   session,
 }: {
+  activityExpanded?: boolean;
   runtimeContext?: ControlPlaneSessionRuntimeContext;
   session: ControlPlaneSessionDetail;
 }) {
@@ -28,6 +30,7 @@ export const ConversationPanel = memo(function ConversationPanel({
       <EmptyConversationSlot show={timelineItems.length === 0 && !showWelcome} />
       {timelineItems.map((item, index) => (
         <ConversationTimelineItemView
+          activityExpanded={activityExpanded}
           key={item.id}
           item={item}
           last={index === timelineItems.length - 1}
@@ -38,18 +41,20 @@ export const ConversationPanel = memo(function ConversationPanel({
 });
 
 function ConversationTimelineItemView({
+  activityExpanded,
   item,
   last,
 }: {
+  activityExpanded: boolean;
   item: ClientSharedConversationTimelineItem;
   last: boolean;
 }) {
-  if (item.type === 'turn_activity') {
+  if (item.type === 'turn_activity_group') {
     return (
       <Box flexDirection="column" marginBottom={1}>
         <Text dimColor>┌ Activity</Text>
         <Box paddingLeft={2} flexDirection="column">
-          <ConversationTurnActivityBlock item={item} />
+          <ConversationTurnActivityBlock expanded={activityExpanded} item={item} />
         </Box>
         <TimelineFooter last={last} />
       </Box>
@@ -94,7 +99,7 @@ function resolveMessageLabel(message: ConversationMessage): string {
     return '┌ Heddle';
   }
 
-  return message.isPending ? '┌ You (queued)' : '┌ You';
+  return '┌ You';
 }
 
 function MessageBody({ message }: { message: ConversationMessage }) {

--- a/src/cli-v2/components/ConversationTurnActivityBlock.tsx
+++ b/src/cli-v2/components/ConversationTurnActivityBlock.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import type { ClientSharedConversationTimelineActivityItem } from '@/client-shared/services/session-turn-presentation/index.js';
+import type { ClientSharedConversationTimelineActivityGroupItem } from '@/client-shared/services/session-turn-presentation/index.js';
 import { DiffPatchBlock } from './DiffPatchBlock.js';
 
 const INLINE_DIFF_MAX_VISIBLE_LINES = 80;
+type ConversationTurnActivity = ClientSharedConversationTimelineActivityGroupItem['activities'][number];
 
 const approvalStatusColors: Record<string, string> = {
   approved: 'green',
@@ -21,65 +22,94 @@ const editActionLabels: Record<string, string> = {
 // Owns cli-v2 presentation for persisted turn activity blocks. The activity
 // facts come from core/API metadata; this component only chooses terminal
 // labels, colors, and inline diff limits.
-export function ConversationTurnActivityBlock({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
-  if (item.activity.type === 'approval') {
-    return <ApprovalActivityBlock item={item} />;
-  }
-
-  return <EditDiffActivityBlock item={item} />;
+export function ConversationTurnActivityBlock({
+  expanded,
+  item,
+}: {
+  expanded: boolean;
+  item: ClientSharedConversationTimelineActivityGroupItem;
+}) {
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text color="cyan">Agent tool activities</Text>
+        <Text dimColor> · {formatActivityCount(item.activities.length)}</Text>
+        <Text dimColor>{expanded ? ' · press a to collapse' : ' · press a to expand'}</Text>
+      </Text>
+      {expanded ? (
+        <Box flexDirection="column" marginTop={1} paddingLeft={2}>
+          {item.activities.map((activity) => (
+            <ActivityBlock key={activity.id} activity={activity} />
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
 }
 
-function ApprovalActivityBlock({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
-  if (item.activity.type !== 'approval') {
+function ActivityBlock({ activity }: { activity: ConversationTurnActivity }) {
+  if (activity.type === 'approval') {
+    return <ApprovalActivityBlock activity={activity} />;
+  }
+
+  return <EditDiffActivityBlock activity={activity} />;
+}
+
+function ApprovalActivityBlock({ activity }: { activity: ConversationTurnActivity }) {
+  if (activity.type !== 'approval') {
     return null;
   }
 
   return (
-    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
+    <Box flexDirection="column" marginBottom={1}>
       <Text>
         <Text bold>Approval</Text>
         <Text dimColor> · </Text>
-        <Text color={approvalStatusColors[item.activity.status]}>{item.activity.status}</Text>
-        <ActivityStep step={item.activity.step} />
+        <Text color={approvalStatusColors[activity.status]}>{activity.status}</Text>
+        <ActivityStep step={activity.step} />
       </Text>
       <Text>
         <Text dimColor>tool </Text>
-        <Text>{item.activity.tool}</Text>
+        <Text>{activity.tool}</Text>
       </Text>
-      <Text>{item.activity.summary}</Text>
-      {item.activity.command ? (
+      <Text>{activity.summary}</Text>
+      {activity.command ? (
         <Text>
           <Text dimColor>command </Text>
-          <Text>{item.activity.command}</Text>
+          <Text>{activity.command}</Text>
         </Text>
       ) : null}
-      {item.activity.reason ? <Text dimColor>{item.activity.reason}</Text> : null}
+      {activity.reason ? <Text dimColor>{activity.reason}</Text> : null}
     </Box>
   );
 }
 
-function EditDiffActivityBlock({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
-  if (item.activity.type !== 'edit_diff') {
+function EditDiffActivityBlock({ activity }: { activity: ConversationTurnActivity }) {
+  if (activity.type !== 'edit_diff') {
     return null;
   }
 
   return (
-    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
+    <Box flexDirection="column" marginBottom={1}>
       <Text>
         <Text bold>Edit diff</Text>
         <Text dimColor> · </Text>
-        <Text color="cyan">{item.activity.path}</Text>
-        <Text dimColor>{formatEditMeta(item.activity.action)}</Text>
-        <ActivityStep step={item.activity.step} />
+        <Text color="cyan">{activity.path}</Text>
+        <Text dimColor>{formatEditMeta(activity.action)}</Text>
+        <ActivityStep step={activity.step} />
       </Text>
       <DiffPatchBlock
-        id={item.activity.id}
+        id={activity.id}
         maxVisibleLines={INLINE_DIFF_MAX_VISIBLE_LINES}
-        patch={item.activity.patch ?? ''}
-        truncated={item.activity.truncated}
+        patch={activity.patch ?? ''}
+        truncated={activity.truncated}
       />
     </Box>
   );
+}
+
+function formatActivityCount(count: number): string {
+  return count === 1 ? '1 item' : `${count} items`;
 }
 
 function ActivityStep({ step }: { step?: number }) {

--- a/src/cli-v2/components/ConversationTurnActivityBlock.tsx
+++ b/src/cli-v2/components/ConversationTurnActivityBlock.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { ClientSharedConversationTimelineActivityItem } from '@/client-shared/services/session-turn-presentation/index.js';
+import { DiffPatchBlock } from './DiffPatchBlock.js';
+
+const INLINE_DIFF_MAX_VISIBLE_LINES = 80;
+
+const approvalStatusColors: Record<string, string> = {
+  approved: 'green',
+  denied: 'red',
+  requested: 'yellow',
+};
+
+const editActionLabels: Record<string, string> = {
+  create: 'created',
+  delete: 'deleted',
+  replace: 'edited',
+  update: 'edited',
+};
+
+// Owns cli-v2 presentation for persisted turn activity blocks. The activity
+// facts come from core/API metadata; this component only chooses terminal
+// labels, colors, and inline diff limits.
+export function ConversationTurnActivityBlock({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
+  if (item.activity.type === 'approval') {
+    return <ApprovalActivityBlock item={item} />;
+  }
+
+  return <EditDiffActivityBlock item={item} />;
+}
+
+function ApprovalActivityBlock({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
+  if (item.activity.type !== 'approval') {
+    return null;
+  }
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
+      <Text>
+        <Text bold>Approval</Text>
+        <Text dimColor> · </Text>
+        <Text color={approvalStatusColors[item.activity.status]}>{item.activity.status}</Text>
+        <ActivityStep step={item.activity.step} />
+      </Text>
+      <Text>
+        <Text dimColor>tool </Text>
+        <Text>{item.activity.tool}</Text>
+      </Text>
+      <Text>{item.activity.summary}</Text>
+      {item.activity.command ? (
+        <Text>
+          <Text dimColor>command </Text>
+          <Text>{item.activity.command}</Text>
+        </Text>
+      ) : null}
+      {item.activity.reason ? <Text dimColor>{item.activity.reason}</Text> : null}
+    </Box>
+  );
+}
+
+function EditDiffActivityBlock({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
+  if (item.activity.type !== 'edit_diff') {
+    return null;
+  }
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
+      <Text>
+        <Text bold>Edit diff</Text>
+        <Text dimColor> · </Text>
+        <Text color="cyan">{item.activity.path}</Text>
+        <Text dimColor>{formatEditMeta(item.activity.action)}</Text>
+        <ActivityStep step={item.activity.step} />
+      </Text>
+      <DiffPatchBlock
+        id={item.activity.id}
+        maxVisibleLines={INLINE_DIFF_MAX_VISIBLE_LINES}
+        patch={item.activity.patch ?? ''}
+        truncated={item.activity.truncated}
+      />
+    </Box>
+  );
+}
+
+function ActivityStep({ step }: { step?: number }) {
+  return typeof step === 'number' ? <Text dimColor> · step {step}</Text> : null;
+}
+
+function formatEditMeta(action: string | undefined): string {
+  if (!action) {
+    return '';
+  }
+
+  return ` · ${editActionLabels[action] ?? action}`;
+}

--- a/src/cli-v2/components/DiffPatchBlock.tsx
+++ b/src/cli-v2/components/DiffPatchBlock.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Text } from 'ink';
+
+const DEFAULT_MAX_VISIBLE_LINES = 120;
+const DEFAULT_MAX_LINE_LENGTH = 160;
+
+type DiffPatchBlockProps = {
+  id: string;
+  patch: string;
+  truncated?: boolean;
+  maxVisibleLines?: number;
+  maxLineLength?: number;
+};
+
+type RenderedDiff = {
+  lines: string[];
+  truncated: boolean;
+};
+
+// Owns terminal-safe unified diff rendering for cli-v2 surfaces. It does not
+// decide which diffs belong in conversation history or live review mode.
+export function DiffPatchBlock({
+  id,
+  maxLineLength = DEFAULT_MAX_LINE_LENGTH,
+  maxVisibleLines = DEFAULT_MAX_VISIBLE_LINES,
+  patch,
+  truncated = false,
+}: DiffPatchBlockProps) {
+  const rendered = preparePatchLines({ maxLineLength, maxVisibleLines, patch });
+
+  return (
+    <>
+      {rendered.lines.map((line, index) => (
+        <Text key={`${id}:${index}`} color={resolveDiffLineColor(line)} dimColor={isDiffHeaderLine(line)}>
+          {line}
+        </Text>
+      ))}
+      {truncated || rendered.truncated ? <Text color="yellow">Diff preview truncated.</Text> : null}
+    </>
+  );
+}
+
+function preparePatchLines({
+  maxLineLength,
+  maxVisibleLines,
+  patch,
+}: {
+  maxLineLength: number;
+  maxVisibleLines: number;
+  patch: string;
+}): RenderedDiff {
+  const rawLines = patch.split('\n');
+  const visibleLines = rawLines.slice(0, maxVisibleLines).map((line) => truncateLine(line, maxLineLength));
+  return {
+    lines: visibleLines,
+    truncated: rawLines.length > visibleLines.length,
+  };
+}
+
+function truncateLine(line: string, maxLineLength: number): string {
+  if (line.length <= maxLineLength) {
+    return line;
+  }
+
+  return `${line.slice(0, maxLineLength - 3)}...`;
+}
+
+function resolveDiffLineColor(line: string): string | undefined {
+  if (line.startsWith('@@')) {
+    return 'cyan';
+  }
+
+  if (line.startsWith('+') && !line.startsWith('+++')) {
+    return 'green';
+  }
+
+  if (line.startsWith('-') && !line.startsWith('---')) {
+    return 'red';
+  }
+
+  return undefined;
+}
+
+function isDiffHeaderLine(line: string): boolean {
+  return line.startsWith('diff --git') || line.startsWith('index ') || line.startsWith('---') || line.startsWith('+++');
+}

--- a/src/cli-v2/components/RecentEditDiffPanel.tsx
+++ b/src/cli-v2/components/RecentEditDiffPanel.tsx
@@ -3,9 +3,7 @@ import { Box, Text } from 'ink';
 import uniqBy from 'lodash/uniqBy.js';
 import type { ClientSharedRecentEditDiff } from '@/client-shared/services/session-activities/index.js';
 import type { RecentEditDiffReviewState } from '../hooks/useRecentEditDiffReview.js';
-
-const MAX_VISIBLE_LINES = 120;
-const MAX_LINE_LENGTH = 160;
+import { DiffPatchBlock } from './DiffPatchBlock.js';
 
 const actionLabels: Record<string, string> = {
   create: 'created',
@@ -18,11 +16,6 @@ type RecentEditDiffPanelProps = {
   diffs: ClientSharedRecentEditDiff[];
   review: RecentEditDiffReviewState;
   running: boolean;
-};
-
-type RenderedDiff = {
-  lines: string[];
-  truncated: boolean;
 };
 
 export function RecentEditDiffPanel({ diffs, review, running }: RecentEditDiffPanelProps) {
@@ -81,7 +74,7 @@ function RecentEditDiffReviewPanel({
           <Text color="cyan">{diff.path}</Text>
           <Text dimColor>{formatEditMeta(diff)}</Text>
         </Text>
-        {renderPatch(diff)}
+        <DiffPatchBlock id={diff.id} patch={diff.patch} truncated={diff.truncated} />
       </Box>
       <Text dimColor>j/k or arrows move · n/p file · esc back</Text>
     </Box>
@@ -98,55 +91,4 @@ function formatEditMeta(diff: ClientSharedRecentEditDiff): string {
   const action = diff.action ? actionLabels[diff.action] ?? diff.action : undefined;
   const step = typeof diff.step === 'number' ? `step ${diff.step}` : undefined;
   return [action, step].filter(Boolean).map((value) => ` · ${value}`).join('');
-}
-
-function renderPatch(diff: ClientSharedRecentEditDiff) {
-  const { lines, truncated } = preparePatchLines(diff.patch);
-  return (
-    <>
-      {lines.map((line, index) => (
-        <Text key={`${diff.id}:${index}`} color={resolveDiffLineColor(line)} dimColor={isDiffHeaderLine(line)}>
-          {line}
-        </Text>
-      ))}
-      {diff.truncated || truncated ? <Text color="yellow">Diff preview truncated.</Text> : null}
-    </>
-  );
-}
-
-function preparePatchLines(patch: string): RenderedDiff {
-  const rawLines = patch.split('\n');
-  const visibleLines = rawLines.slice(0, MAX_VISIBLE_LINES).map(truncateLine);
-  return {
-    lines: visibleLines,
-    truncated: rawLines.length > visibleLines.length,
-  };
-}
-
-function truncateLine(line: string): string {
-  if (line.length <= MAX_LINE_LENGTH) {
-    return line;
-  }
-
-  return `${line.slice(0, MAX_LINE_LENGTH - 3)}...`;
-}
-
-function resolveDiffLineColor(line: string): string | undefined {
-  if (line.startsWith('@@')) {
-    return 'cyan';
-  }
-
-  if (line.startsWith('+') && !line.startsWith('+++')) {
-    return 'green';
-  }
-
-  if (line.startsWith('-') && !line.startsWith('---')) {
-    return 'red';
-  }
-
-  return undefined;
-}
-
-function isDiffHeaderLine(line: string): boolean {
-  return line.startsWith('diff --git') || line.startsWith('index ') || line.startsWith('---') || line.startsWith('+++');
 }

--- a/src/client-shared/services/session-turn-presentation/index.ts
+++ b/src/client-shared/services/session-turn-presentation/index.ts
@@ -1,6 +1,6 @@
 export {
   ClientSharedSessionTurnPresentationService,
-  type ClientSharedConversationTimelineActivityItem,
+  type ClientSharedConversationTimelineActivityGroupItem,
   type ClientSharedConversationTimelineItem,
   type ClientSharedConversationTimelineMessageItem,
   type ClientSharedSessionTurnPresentationItem,

--- a/src/client-shared/services/session-turn-presentation/index.ts
+++ b/src/client-shared/services/session-turn-presentation/index.ts
@@ -1,4 +1,7 @@
 export {
   ClientSharedSessionTurnPresentationService,
+  type ClientSharedConversationTimelineActivityItem,
+  type ClientSharedConversationTimelineItem,
+  type ClientSharedConversationTimelineMessageItem,
   type ClientSharedSessionTurnPresentationItem,
 } from './session-turn-presentation-service.js';

--- a/src/client-shared/services/session-turn-presentation/session-turn-presentation-service.ts
+++ b/src/client-shared/services/session-turn-presentation/session-turn-presentation-service.ts
@@ -1,5 +1,6 @@
 import type {
   ControlPlaneSessionDetail,
+  ControlPlaneSessionMessage,
   ControlPlaneSessionTurn,
 } from '../../api/types.js';
 import type { ConversationTurnPresentationTimelineItem } from '@/core/chat/types.js';
@@ -11,6 +12,24 @@ export type ClientSharedSessionTurnPresentationItem = {
   activity: ConversationTurnPresentationTimelineItem;
 };
 
+export type ClientSharedConversationTimelineMessageItem = {
+  type: 'message';
+  id: string;
+  message: ControlPlaneSessionMessage;
+};
+
+export type ClientSharedConversationTimelineActivityItem = {
+  type: 'turn_activity';
+  id: string;
+  turnId: string;
+  turnPrompt: string;
+  activity: ConversationTurnPresentationTimelineItem;
+};
+
+export type ClientSharedConversationTimelineItem =
+  | ClientSharedConversationTimelineMessageItem
+  | ClientSharedConversationTimelineActivityItem;
+
 /**
  * Owns frontend-neutral projection of persisted turn presentation metadata.
  *
@@ -20,6 +39,49 @@ export type ClientSharedSessionTurnPresentationItem = {
  * host-specific layout, keyboard shortcuts, or collapse state.
  */
 export class ClientSharedSessionTurnPresentationService {
+  static projectConversationTimeline(
+    session: ControlPlaneSessionDetail | undefined | null,
+  ): ClientSharedConversationTimelineItem[] {
+    if (!session) {
+      return [];
+    }
+
+    const placedTurnIds = new Set<string>();
+    const timeline = session.messages.flatMap((message) => {
+      const messageItem: ClientSharedConversationTimelineMessageItem = {
+        type: 'message',
+        id: message.id,
+        message,
+      };
+
+      if (message.role !== 'user') {
+        return [messageItem];
+      }
+
+      const turn = ClientSharedSessionTurnPresentationService.findUnplacedTurnForPrompt({
+        turns: session.turns,
+        placedTurnIds,
+        prompt: message.text,
+      });
+      if (!turn) {
+        return [messageItem];
+      }
+
+      placedTurnIds.add(turn.id);
+      return [
+        messageItem,
+        ...ClientSharedSessionTurnPresentationService.projectConversationActivityItems(turn),
+      ];
+    });
+
+    return [
+      ...timeline,
+      ...session.turns
+        .filter((turn) => !placedTurnIds.has(turn.id))
+        .flatMap((turn) => ClientSharedSessionTurnPresentationService.projectConversationActivityItems(turn)),
+    ];
+  }
+
   static projectTurnActivities(
     session: ControlPlaneSessionDetail | undefined | null,
   ): ClientSharedSessionTurnPresentationItem[] {
@@ -35,5 +97,24 @@ export class ClientSharedSessionTurnPresentationService {
       turnPrompt: turn.prompt,
       activity,
     })) ?? [];
+  }
+
+  private static projectConversationActivityItems(turn: ControlPlaneSessionTurn): ClientSharedConversationTimelineActivityItem[] {
+    return ClientSharedSessionTurnPresentationService.projectTurnActivityItems(turn).map((item) => ({
+      ...item,
+      type: 'turn_activity' as const,
+    }));
+  }
+
+  private static findUnplacedTurnForPrompt({
+    placedTurnIds,
+    prompt,
+    turns,
+  }: {
+    placedTurnIds: Set<string>;
+    prompt: string;
+    turns: ControlPlaneSessionTurn[];
+  }): ControlPlaneSessionTurn | undefined {
+    return turns.find((turn) => !placedTurnIds.has(turn.id) && turn.prompt.trim() === prompt.trim());
   }
 }

--- a/src/client-shared/services/session-turn-presentation/session-turn-presentation-service.ts
+++ b/src/client-shared/services/session-turn-presentation/session-turn-presentation-service.ts
@@ -18,17 +18,17 @@ export type ClientSharedConversationTimelineMessageItem = {
   message: ControlPlaneSessionMessage;
 };
 
-export type ClientSharedConversationTimelineActivityItem = {
-  type: 'turn_activity';
+export type ClientSharedConversationTimelineActivityGroupItem = {
+  type: 'turn_activity_group';
   id: string;
   turnId: string;
   turnPrompt: string;
-  activity: ConversationTurnPresentationTimelineItem;
+  activities: ConversationTurnPresentationTimelineItem[];
 };
 
 export type ClientSharedConversationTimelineItem =
   | ClientSharedConversationTimelineMessageItem
-  | ClientSharedConversationTimelineActivityItem;
+  | ClientSharedConversationTimelineActivityGroupItem;
 
 /**
  * Owns frontend-neutral projection of persisted turn presentation metadata.
@@ -70,7 +70,7 @@ export class ClientSharedSessionTurnPresentationService {
       placedTurnIds.add(turn.id);
       return [
         messageItem,
-        ...ClientSharedSessionTurnPresentationService.projectConversationActivityItems(turn),
+        ...ClientSharedSessionTurnPresentationService.projectConversationActivityGroup(turn),
       ];
     });
 
@@ -78,7 +78,7 @@ export class ClientSharedSessionTurnPresentationService {
       ...timeline,
       ...session.turns
         .filter((turn) => !placedTurnIds.has(turn.id))
-        .flatMap((turn) => ClientSharedSessionTurnPresentationService.projectConversationActivityItems(turn)),
+        .flatMap((turn) => ClientSharedSessionTurnPresentationService.projectConversationActivityGroup(turn)),
     ];
   }
 
@@ -99,11 +99,19 @@ export class ClientSharedSessionTurnPresentationService {
     })) ?? [];
   }
 
-  private static projectConversationActivityItems(turn: ControlPlaneSessionTurn): ClientSharedConversationTimelineActivityItem[] {
-    return ClientSharedSessionTurnPresentationService.projectTurnActivityItems(turn).map((item) => ({
-      ...item,
-      type: 'turn_activity' as const,
-    }));
+  private static projectConversationActivityGroup(turn: ControlPlaneSessionTurn): ClientSharedConversationTimelineActivityGroupItem[] {
+    const activities = turn.presentation?.timelineItems ?? [];
+    if (activities.length === 0) {
+      return [];
+    }
+
+    return [{
+      type: 'turn_activity_group',
+      id: `${turn.id}:activity-group`,
+      turnId: turn.id,
+      turnPrompt: turn.prompt,
+      activities,
+    }];
   }
 
   private static findUnplacedTurnForPrompt({

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -13,11 +13,13 @@ import type {
   ClientSharedAgentActivityStatus,
   ClientSharedSessionLatestUpdate,
 } from '@/client-shared/services/session-activities';
+import { ClientSharedSessionTurnPresentationService } from '@/client-shared/services/session-turn-presentation';
 import { AgentActivityStatus } from './AgentActivityStatus';
 import { AgentPlanPanel } from './AgentPlanPanel';
 import { ApprovalPanel } from './ApprovalPanel';
 import { ConversationComposer } from './ConversationComposer';
 import { ConversationMessage } from './ConversationMessage';
+import { ConversationTurnActivity } from './ConversationTurnActivity';
 import { ConversationWelcomePanel } from './ConversationWelcomePanel';
 import { DirectShellConfirmDialog } from './DirectShellConfirmDialog';
 import { QueuedPromptStrip } from './QueuedPromptStrip';
@@ -91,6 +93,7 @@ export function ConversationThread({
 }: ConversationThreadProps) {
   const hasUserMessage = session?.messages.some((message) => message.role === 'user') ?? false;
   const showWelcome = Boolean(runtimeContext?.welcomeGuide && !hasUserMessage && !submitting);
+  const conversationTimeline = ClientSharedSessionTurnPresentationService.projectConversationTimeline(session);
   const conversationAutoScroll = useConversationAutoScroll({
     liveStatus,
     messages: session?.messages ?? [],
@@ -144,8 +147,12 @@ export function ConversationThread({
           {showWelcome && runtimeContext?.welcomeGuide ? (
             <ConversationWelcomePanel welcomeGuide={runtimeContext.welcomeGuide} />
           ) : null}
-          {session.messages.map((message) => (
-            <ConversationMessage key={message.id} message={message} />
+          {conversationTimeline.map((item) => (
+            item.type === 'message' ? (
+              <ConversationMessage key={item.id} message={item.message} />
+            ) : (
+              <ConversationTurnActivity key={item.id} item={item} />
+            )
           ))}
         </div>
       </div>

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -19,7 +19,7 @@ import { AgentPlanPanel } from './AgentPlanPanel';
 import { ApprovalPanel } from './ApprovalPanel';
 import { ConversationComposer } from './ConversationComposer';
 import { ConversationMessage } from './ConversationMessage';
-import { ConversationTurnActivity } from './ConversationTurnActivity';
+import { ConversationTurnActivityGroup } from './ConversationTurnActivity';
 import { ConversationWelcomePanel } from './ConversationWelcomePanel';
 import { DirectShellConfirmDialog } from './DirectShellConfirmDialog';
 import { QueuedPromptStrip } from './QueuedPromptStrip';
@@ -151,7 +151,7 @@ export function ConversationThread({
             item.type === 'message' ? (
               <ConversationMessage key={item.id} message={item.message} />
             ) : (
-              <ConversationTurnActivity key={item.id} item={item} />
+              <ConversationTurnActivityGroup key={item.id} item={item} />
             )
           ))}
         </div>

--- a/src/web-v2/components/conversation/ConversationTurnActivity.tsx
+++ b/src/web-v2/components/conversation/ConversationTurnActivity.tsx
@@ -1,7 +1,8 @@
 import { memo } from 'react';
-import type { ClientSharedConversationTimelineActivityItem } from '@/client-shared/services/session-turn-presentation';
+import type { ClientSharedConversationTimelineActivityGroupItem } from '@/client-shared/services/session-turn-presentation';
 
 const MAX_DIFF_LINES = 120;
+type ConversationTurnActivity = ClientSharedConversationTimelineActivityGroupItem['activities'][number];
 
 const approvalLabels: Record<string, string> = {
   approved: 'Approved',
@@ -16,67 +17,85 @@ const editActionLabels: Record<string, string> = {
   update: 'Edited',
 };
 
-export const ConversationTurnActivity = memo(function ConversationTurnActivity({
+export const ConversationTurnActivityGroup = memo(function ConversationTurnActivityGroup({
   item,
 }: {
-  item: ClientSharedConversationTimelineActivityItem;
+  item: ClientSharedConversationTimelineActivityGroupItem;
 }) {
-  if (item.activity.type === 'approval') {
-    return <ApprovalActivity item={item} />;
-  }
-
-  return <EditDiffActivity item={item} />;
+  return (
+    <article className="v2-message-row v2-message-row-assistant" data-message-role="assistant">
+      <details className="v2-turn-activity-group">
+        <summary className="v2-turn-activity-summary-row">
+          <span className="v2-turn-activity-title">Agent tool activities</span>
+          <span className="v2-turn-activity-meta">{formatActivityCount(item.activities.length)}</span>
+        </summary>
+        <div className="v2-turn-activity-details">
+          {item.activities.map((activity) => (
+            <ActivityDetail key={activity.id} activity={activity} />
+          ))}
+        </div>
+      </details>
+    </article>
+  );
 });
 
-function ApprovalActivity({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
-  if (item.activity.type !== 'approval') {
+function ActivityDetail({ activity }: { activity: ConversationTurnActivity }) {
+  if (activity.type === 'approval') {
+    return <ApprovalActivity activity={activity} />;
+  }
+
+  return <EditDiffActivity activity={activity} />;
+}
+
+function ApprovalActivity({ activity }: { activity: ConversationTurnActivity }) {
+  if (activity.type !== 'approval') {
     return null;
   }
 
   return (
-    <article className="v2-message-row v2-message-row-assistant" data-message-role="assistant">
-      <section className="v2-turn-activity-card" data-activity-type="approval" data-activity-status={item.activity.status}>
-        <header className="v2-turn-activity-header">
-          <span className="v2-turn-activity-title">{approvalLabels[item.activity.status]}</span>
-          <span className="v2-turn-activity-meta">{item.activity.tool}</span>
-        </header>
-        <p className="v2-turn-activity-summary">{item.activity.summary}</p>
-        {item.activity.command ? <pre className="v2-turn-activity-command">{item.activity.command}</pre> : null}
-        {item.activity.reason ? <p className="v2-turn-activity-muted">{item.activity.reason}</p> : null}
-      </section>
-    </article>
+    <section className="v2-turn-activity-detail" data-activity-type="approval" data-activity-status={activity.status}>
+      <header className="v2-turn-activity-header">
+        <span className="v2-turn-activity-title">{approvalLabels[activity.status]}</span>
+        <span className="v2-turn-activity-meta">{activity.tool}</span>
+      </header>
+      <p className="v2-turn-activity-copy">{activity.summary}</p>
+      {activity.command ? <pre className="v2-turn-activity-command">{activity.command}</pre> : null}
+      {activity.reason ? <p className="v2-turn-activity-muted">{activity.reason}</p> : null}
+    </section>
   );
 }
 
-function EditDiffActivity({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
-  if (item.activity.type !== 'edit_diff') {
+function EditDiffActivity({ activity }: { activity: ConversationTurnActivity }) {
+  if (activity.type !== 'edit_diff') {
     return null;
   }
 
-  const lines = item.activity.patch.split('\n');
+  const lines = activity.patch.split('\n');
   const visibleLines = lines.slice(0, MAX_DIFF_LINES);
-  const truncated = item.activity.truncated || lines.length > visibleLines.length;
+  const truncated = activity.truncated || lines.length > visibleLines.length;
 
   return (
-    <article className="v2-message-row v2-message-row-assistant" data-message-role="assistant">
-      <section className="v2-turn-activity-card" data-activity-type="edit-diff">
-        <header className="v2-turn-activity-header">
-          <span className="v2-turn-activity-title">Edit diff</span>
-          <span className="v2-turn-activity-meta">{formatEditMeta(item.activity.action)}</span>
-        </header>
-        <div className="v2-turn-activity-path">{item.activity.path}</div>
-        <pre className="v2-turn-activity-diff" aria-label={`Diff for ${item.activity.path}`}>
-          {visibleLines.map((line, index) => (
-            <span key={`${item.activity.id}:${index}`} className={resolveDiffLineClass(line)}>
-              {line || ' '}
-              {'\n'}
-            </span>
-          ))}
-        </pre>
-        {truncated ? <p className="v2-turn-activity-muted">Diff preview truncated.</p> : null}
-      </section>
-    </article>
+    <section className="v2-turn-activity-detail" data-activity-type="edit-diff">
+      <header className="v2-turn-activity-header">
+        <span className="v2-turn-activity-title">Edit diff</span>
+        <span className="v2-turn-activity-meta">{formatEditMeta(activity.action)}</span>
+      </header>
+      <div className="v2-turn-activity-path">{activity.path}</div>
+      <pre className="v2-turn-activity-diff" aria-label={`Diff for ${activity.path}`}>
+        {visibleLines.map((line, index) => (
+          <span key={`${activity.id}:${index}`} className={resolveDiffLineClass(line)}>
+            {line || ' '}
+            {'\n'}
+          </span>
+        ))}
+      </pre>
+      {truncated ? <p className="v2-turn-activity-muted">Diff preview truncated.</p> : null}
+    </section>
   );
+}
+
+function formatActivityCount(count: number): string {
+  return count === 1 ? '1 item' : `${count} items`;
 }
 
 function formatEditMeta(action: string | undefined): string {

--- a/src/web-v2/components/conversation/ConversationTurnActivity.tsx
+++ b/src/web-v2/components/conversation/ConversationTurnActivity.tsx
@@ -1,0 +1,104 @@
+import { memo } from 'react';
+import type { ClientSharedConversationTimelineActivityItem } from '@/client-shared/services/session-turn-presentation';
+
+const MAX_DIFF_LINES = 120;
+
+const approvalLabels: Record<string, string> = {
+  approved: 'Approved',
+  denied: 'Denied',
+  requested: 'Approval requested',
+};
+
+const editActionLabels: Record<string, string> = {
+  create: 'Created',
+  delete: 'Deleted',
+  replace: 'Edited',
+  update: 'Edited',
+};
+
+export const ConversationTurnActivity = memo(function ConversationTurnActivity({
+  item,
+}: {
+  item: ClientSharedConversationTimelineActivityItem;
+}) {
+  if (item.activity.type === 'approval') {
+    return <ApprovalActivity item={item} />;
+  }
+
+  return <EditDiffActivity item={item} />;
+});
+
+function ApprovalActivity({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
+  if (item.activity.type !== 'approval') {
+    return null;
+  }
+
+  return (
+    <article className="v2-message-row v2-message-row-assistant" data-message-role="assistant">
+      <section className="v2-turn-activity-card" data-activity-type="approval" data-activity-status={item.activity.status}>
+        <header className="v2-turn-activity-header">
+          <span className="v2-turn-activity-title">{approvalLabels[item.activity.status]}</span>
+          <span className="v2-turn-activity-meta">{item.activity.tool}</span>
+        </header>
+        <p className="v2-turn-activity-summary">{item.activity.summary}</p>
+        {item.activity.command ? <pre className="v2-turn-activity-command">{item.activity.command}</pre> : null}
+        {item.activity.reason ? <p className="v2-turn-activity-muted">{item.activity.reason}</p> : null}
+      </section>
+    </article>
+  );
+}
+
+function EditDiffActivity({ item }: { item: ClientSharedConversationTimelineActivityItem }) {
+  if (item.activity.type !== 'edit_diff') {
+    return null;
+  }
+
+  const lines = item.activity.patch.split('\n');
+  const visibleLines = lines.slice(0, MAX_DIFF_LINES);
+  const truncated = item.activity.truncated || lines.length > visibleLines.length;
+
+  return (
+    <article className="v2-message-row v2-message-row-assistant" data-message-role="assistant">
+      <section className="v2-turn-activity-card" data-activity-type="edit-diff">
+        <header className="v2-turn-activity-header">
+          <span className="v2-turn-activity-title">Edit diff</span>
+          <span className="v2-turn-activity-meta">{formatEditMeta(item.activity.action)}</span>
+        </header>
+        <div className="v2-turn-activity-path">{item.activity.path}</div>
+        <pre className="v2-turn-activity-diff" aria-label={`Diff for ${item.activity.path}`}>
+          {visibleLines.map((line, index) => (
+            <span key={`${item.activity.id}:${index}`} className={resolveDiffLineClass(line)}>
+              {line || ' '}
+              {'\n'}
+            </span>
+          ))}
+        </pre>
+        {truncated ? <p className="v2-turn-activity-muted">Diff preview truncated.</p> : null}
+      </section>
+    </article>
+  );
+}
+
+function formatEditMeta(action: string | undefined): string {
+  if (!action) {
+    return '';
+  }
+
+  return editActionLabels[action] ?? action;
+}
+
+function resolveDiffLineClass(line: string): string {
+  if (line.startsWith('@@')) {
+    return 'v2-turn-activity-diff-line v2-turn-activity-diff-line-hunk';
+  }
+
+  if (line.startsWith('+') && !line.startsWith('+++')) {
+    return 'v2-turn-activity-diff-line v2-turn-activity-diff-line-added';
+  }
+
+  if (line.startsWith('-') && !line.startsWith('---')) {
+    return 'v2-turn-activity-diff-line v2-turn-activity-diff-line-removed';
+  }
+
+  return 'v2-turn-activity-diff-line';
+}

--- a/src/web-v2/styles/conversation.css
+++ b/src/web-v2/styles/conversation.css
@@ -36,26 +36,67 @@
     color: color-mix(in oklab, var(--color-foreground) 94%, transparent);
   }
 
-  .v2-turn-activity-card {
+  .v2-turn-activity-group {
     width: min(100%, 46rem);
     min-width: 0;
-    border: 1px solid color-mix(in oklab, var(--color-border) 72%, transparent);
     border-radius: var(--radius-lg);
-    background: color-mix(in oklab, var(--color-muted) 42%, var(--color-background));
-    padding: 0.85rem;
+    background: color-mix(in oklab, var(--color-muted) 32%, var(--color-background));
     color: color-mix(in oklab, var(--color-foreground) 92%, transparent);
   }
 
-  .v2-turn-activity-card[data-activity-status="approved"] {
-    border-color: color-mix(in oklab, hsl(145 72% 52%) 34%, var(--color-border));
+  .v2-turn-activity-summary-row {
+    display: flex;
+    min-width: 0;
+    cursor: pointer;
+    list-style: none;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border-radius: var(--radius-lg);
+    border: 1px solid color-mix(in oklab, var(--color-border) 58%, transparent);
+    padding: 0.65rem 0.75rem;
   }
 
-  .v2-turn-activity-card[data-activity-status="denied"] {
-    border-color: color-mix(in oklab, var(--color-destructive) 46%, var(--color-border));
+  .v2-turn-activity-summary-row::-webkit-details-marker {
+    display: none;
   }
 
-  .v2-turn-activity-card[data-activity-status="requested"] {
-    border-color: color-mix(in oklab, var(--color-warning, hsl(45 92% 70%)) 42%, var(--color-border));
+  .v2-turn-activity-summary-row::before {
+    content: "›";
+    color: var(--color-muted-foreground);
+    font-size: 0.9rem;
+    line-height: 1;
+    transition: transform 120ms ease;
+  }
+
+  .v2-turn-activity-group[open] .v2-turn-activity-summary-row::before {
+    transform: rotate(90deg);
+  }
+
+  .v2-turn-activity-details {
+    display: grid;
+    gap: 0.7rem;
+    padding: 0.75rem 0 0;
+  }
+
+  .v2-turn-activity-detail {
+    min-width: 0;
+    border-radius: var(--radius-md);
+    border: 1px solid color-mix(in oklab, var(--color-border) 48%, transparent);
+    background: color-mix(in oklab, var(--color-background) 74%, var(--color-muted));
+    padding: 0.75rem;
+  }
+
+  .v2-turn-activity-detail[data-activity-status="approved"] {
+    border-color: color-mix(in oklab, hsl(145 42% 48%) 22%, var(--color-border));
+  }
+
+  .v2-turn-activity-detail[data-activity-status="denied"] {
+    border-color: color-mix(in oklab, var(--color-destructive) 32%, var(--color-border));
+  }
+
+  .v2-turn-activity-detail[data-activity-status="requested"] {
+    border-color: color-mix(in oklab, var(--color-warning, hsl(45 92% 70%)) 28%, var(--color-border));
   }
 
   .v2-turn-activity-header {
@@ -81,7 +122,7 @@
     line-height: 1.45;
   }
 
-  .v2-turn-activity-summary {
+  .v2-turn-activity-copy {
     margin: 0;
     font-size: 0.8125rem;
     line-height: 1.45;

--- a/src/web-v2/styles/conversation.css
+++ b/src/web-v2/styles/conversation.css
@@ -39,22 +39,18 @@
   .v2-turn-activity-group {
     width: min(100%, 46rem);
     min-width: 0;
-    border-radius: var(--radius-lg);
-    background: color-mix(in oklab, var(--color-muted) 32%, var(--color-background));
     color: color-mix(in oklab, var(--color-foreground) 92%, transparent);
   }
 
   .v2-turn-activity-summary-row {
-    display: flex;
+    display: inline-flex;
     min-width: 0;
     cursor: pointer;
     list-style: none;
     align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    border-radius: var(--radius-lg);
-    border: 1px solid color-mix(in oklab, var(--color-border) 58%, transparent);
-    padding: 0.65rem 0.75rem;
+    gap: 0.45rem;
+    color: var(--color-muted-foreground);
+    padding: 0;
   }
 
   .v2-turn-activity-summary-row::-webkit-details-marker {
@@ -76,7 +72,7 @@
   .v2-turn-activity-details {
     display: grid;
     gap: 0.7rem;
-    padding: 0.75rem 0 0;
+    padding: 0.75rem 0 0 1.25rem;
   }
 
   .v2-turn-activity-detail {

--- a/src/web-v2/styles/conversation.css
+++ b/src/web-v2/styles/conversation.css
@@ -36,6 +36,105 @@
     color: color-mix(in oklab, var(--color-foreground) 94%, transparent);
   }
 
+  .v2-turn-activity-card {
+    width: min(100%, 46rem);
+    min-width: 0;
+    border: 1px solid color-mix(in oklab, var(--color-border) 72%, transparent);
+    border-radius: var(--radius-lg);
+    background: color-mix(in oklab, var(--color-muted) 42%, var(--color-background));
+    padding: 0.85rem;
+    color: color-mix(in oklab, var(--color-foreground) 92%, transparent);
+  }
+
+  .v2-turn-activity-card[data-activity-status="approved"] {
+    border-color: color-mix(in oklab, hsl(145 72% 52%) 34%, var(--color-border));
+  }
+
+  .v2-turn-activity-card[data-activity-status="denied"] {
+    border-color: color-mix(in oklab, var(--color-destructive) 46%, var(--color-border));
+  }
+
+  .v2-turn-activity-card[data-activity-status="requested"] {
+    border-color: color-mix(in oklab, var(--color-warning, hsl(45 92% 70%)) 42%, var(--color-border));
+  }
+
+  .v2-turn-activity-header {
+    display: flex;
+    min-width: 0;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.45rem;
+  }
+
+  .v2-turn-activity-title {
+    color: var(--color-foreground);
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.35;
+  }
+
+  .v2-turn-activity-meta,
+  .v2-turn-activity-muted {
+    color: var(--color-muted-foreground);
+    font-size: 0.75rem;
+    line-height: 1.45;
+  }
+
+  .v2-turn-activity-summary {
+    margin: 0;
+    font-size: 0.8125rem;
+    line-height: 1.45;
+  }
+
+  .v2-turn-activity-command,
+  .v2-turn-activity-diff {
+    overflow: auto;
+    margin-top: 0.55rem;
+    border-radius: var(--radius-md);
+    background: color-mix(in oklab, var(--color-background) 88%, black);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.45;
+  }
+
+  .v2-turn-activity-command {
+    margin-bottom: 0;
+    padding: 0.55rem 0.65rem;
+    white-space: pre-wrap;
+  }
+
+  .v2-turn-activity-path {
+    margin-top: 0.2rem;
+    color: color-mix(in oklab, hsl(190 90% 70%) 82%, var(--color-foreground));
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+  }
+
+  .v2-turn-activity-diff {
+    margin-bottom: 0;
+    padding: 0.65rem;
+    white-space: pre;
+  }
+
+  .v2-turn-activity-diff-line {
+    color: color-mix(in oklab, var(--color-foreground) 82%, transparent);
+  }
+
+  .v2-turn-activity-diff-line-hunk {
+    color: color-mix(in oklab, hsl(190 90% 70%) 84%, var(--color-foreground));
+  }
+
+  .v2-turn-activity-diff-line-added {
+    color: color-mix(in oklab, hsl(145 72% 58%) 84%, var(--color-foreground));
+  }
+
+  .v2-turn-activity-diff-line-removed {
+    color: color-mix(in oklab, var(--color-destructive) 72%, var(--color-foreground));
+  }
+
   .v2-assistant-markdown {
     max-width: 100%;
     min-width: 0;


### PR DESCRIPTION
## What changed
- Adds a shared client-side conversation timeline projection that places persisted turn activities after the matching user prompt.
- Renders approval and edit-diff activity blocks inline in the TUI conversation view.
- Renders the same persisted turn activities inline in the web-v2 conversation thread.
- Keeps the old TUI recent edit review affordance active only while a run is still running, so completed diffs move into the conversation journal instead of lingering as a separate block.
- Reuses one TUI diff patch renderer for live review and inline activity blocks.

## Expected behavior
- After a completed turn with file edits or approvals, the conversation reads as: user prompt, tool/activity block, assistant response.
- Web users see these activity blocks inside the scrollable conversation thread.
- TUI users see activity blocks in the latest conversation window; the live recent-edit review shortcut remains available during active runs.
- No core trace parsing or transcript mutation is added in UI code; core still owns persisted activity facts, client-shared owns projection, and each interface owns rendering.

## Verification
- yarn test src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts src/__tests__/unit/cli-v2/conversation-panel.test.tsx src/__tests__/unit/cli-v2/recent-edit-diff-review.test.tsx
- yarn typecheck
- yarn lint
- yarn build
