### PR TITLE
Fix session lease recovery heartbeat

### DIFF
--- a/docs/guides/runtime-host-model.md
+++ b/docs/guides/runtime-host-model.md
@@ -127,6 +127,10 @@ Heddle records a lightweight session lease while a session is being mutated. If
 another client tries to continue that same session while the lease is fresh, the
 run is blocked with a warning about concurrent mutation risk.
 
+Active control-plane runs refresh that lease on a short heartbeat. If the owner
+process dies and the heartbeat stops, the lease becomes stale quickly and a new
+run can reclaim the session without manual state-file edits.
+
 ## What `heddle ask` Does
 
 `ask` is a one-shot terminal command. It still exits after one prompt, but the

--- a/src/__tests__/unit/chat/chat-session-lease.test.ts
+++ b/src/__tests__/unit/chat/chat-session-lease.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { ChatSessionLeases } from '../../../core/chat/engine/sessions/leases/index.js';
+import {
+  ChatSessionLeases,
+  SESSION_LEASE_STALE_AFTER_MS,
+} from '../../../core/chat/engine/sessions/leases/index.js';
 import type { ChatSession } from '../../../core/chat/types.js';
 
 function createSession(): ChatSession {
@@ -30,10 +33,58 @@ describe('chat session leases', () => {
       ownerId: 'tui-123',
       clientLabel: 'terminal chat',
     });
-    expect(ChatSessionLeases.isFresh(leased.lease, { now: Date.parse('2026-04-21T01:05:00.000Z') })).toBe(true);
+    expect(ChatSessionLeases.isFresh(leased.lease, { now: Date.parse('2026-04-21T01:00:19.000Z') })).toBe(true);
+    expect(ChatSessionLeases.isFresh(leased.lease, { now: Date.parse('2026-04-21T01:00:21.000Z') })).toBe(false);
 
     const released = ChatSessionLeases.release(leased, { ownerId: 'tui-123' });
     expect(released.lease).toBeUndefined();
+  });
+
+  it('uses a short stale window for crashed control-plane recovery', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), {
+      ownerKind: 'daemon',
+      ownerId: 'embedded-chat-12345-1779894401584',
+      clientLabel: 'control plane',
+    }, {
+      now: Date.parse('2026-04-21T01:00:00.000Z'),
+    });
+
+    expect(ChatSessionLeases.conflict(leased, {
+      ownerKind: 'daemon',
+      ownerId: 'embedded-chat-99999-1779894500000',
+      clientLabel: 'control plane',
+    }, {
+      now: Date.parse('2026-04-21T01:00:00.000Z') + SESSION_LEASE_STALE_AFTER_MS - 1,
+    })).toContain('already active in control plane');
+
+    expect(ChatSessionLeases.conflict(leased, {
+      ownerKind: 'daemon',
+      ownerId: 'embedded-chat-99999-1779894500000',
+      clientLabel: 'control plane',
+    }, {
+      now: Date.parse('2026-04-21T01:00:00.000Z') + SESSION_LEASE_STALE_AFTER_MS + 1,
+    })).toBeUndefined();
+  });
+
+  it('refreshes lastSeenAt only for the matching owner', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), {
+      ownerKind: 'daemon',
+      ownerId: 'daemon-123',
+      clientLabel: 'control plane',
+    }, {
+      now: Date.parse('2026-04-21T01:00:00.000Z'),
+    });
+
+    const ignored = ChatSessionLeases.refresh(leased, { ownerId: 'daemon-other' }, {
+      now: Date.parse('2026-04-21T01:00:05.000Z'),
+    });
+    expect(ignored.lease?.lastSeenAt).toBe('2026-04-21T01:00:00.000Z');
+
+    const refreshed = ChatSessionLeases.refresh(leased, { ownerId: 'daemon-123' }, {
+      now: Date.parse('2026-04-21T01:00:05.000Z'),
+    });
+    expect(refreshed.lease?.lastSeenAt).toBe('2026-04-21T01:00:05.000Z');
+    expect(refreshed.lease?.acquiredAt).toBe('2026-04-21T01:00:00.000Z');
   });
 
   it('reports a conflict for a different fresh owner', () => {
@@ -50,7 +101,7 @@ describe('chat session leases', () => {
       ownerId: 'tui-123',
       clientLabel: 'terminal chat',
     }, {
-      now: Date.parse('2026-04-21T01:01:00.000Z'),
+      now: Date.parse('2026-04-21T01:00:10.000Z'),
     })).toContain('Continuing from multiple clients in the same session may corrupt the conversation.');
   });
 
@@ -126,7 +177,7 @@ describe('chat session leases', () => {
       ownerId: 'tui-123',
       clientLabel: 'terminal chat',
     }, {
-      now: Date.parse('2026-04-21T01:01:00.000Z'),
+      now: Date.parse('2026-04-21T01:00:10.000Z'),
       isProcessAlive: () => true,
     })).toContain('already active in terminal chat');
   });

--- a/src/__tests__/unit/control-plane/session-cancel.test.ts
+++ b/src/__tests__/unit/control-plane/session-cancel.test.ts
@@ -9,8 +9,9 @@ import type { ToolCall, ToolDefinition } from '@/core/types.js';
 import { ControlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
 import type {
   ControlPlaneSessionRunContext,
-  ControlPlaneSessionRunService,
 } from '@/server/services/control-plane/session-run-service.js';
+import { ControlPlaneSessionRunService } from '@/server/services/control-plane/session-run-service.js';
+import { SESSION_LEASE_REFRESH_INTERVAL_MS } from '@/core/chat/engine/sessions/leases/index.js';
 
 type ControllerInternals = {
   runService: ControlPlaneSessionRunService;
@@ -40,6 +41,78 @@ type ControllerInternals = {
 };
 
 describe('ControlPlaneChatSessionsController run cancellation', () => {
+  it('refreshes active runs until they settle', async () => {
+    vi.useFakeTimers();
+    const runService = new ControlPlaneSessionRunService();
+    const heartbeats: string[] = [];
+    let finishRun: (() => void) | undefined;
+
+    try {
+      const result = runService.startAndWait({
+        address: {
+          workspaceId: 'workspace-heartbeat',
+          sessionId: 'session-heartbeat',
+        },
+        onHeartbeat: (run) => {
+          heartbeats.push(run.runId);
+        },
+        execute: async () => await new Promise<void>((resolve) => {
+          finishRun = resolve;
+        }),
+      });
+
+      await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS - 1);
+      expect(heartbeats).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(heartbeats).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS);
+      expect(heartbeats).toHaveLength(2);
+
+      finishRun?.();
+      await result;
+
+      await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS);
+      expect(heartbeats).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('aborts active runs when heartbeat refresh fails', async () => {
+    vi.useFakeTimers();
+    const runService = new ControlPlaneSessionRunService();
+    let runAbortSignal: AbortSignal | undefined;
+    let finishRun: (() => void) | undefined;
+
+    try {
+      const result = runService.startAndWait({
+        address: {
+          workspaceId: 'workspace-heartbeat-failure',
+          sessionId: 'session-heartbeat-failure',
+        },
+        onHeartbeat: () => {
+          throw new Error('lease refresh failed');
+        },
+        execute: async (run) => {
+          runAbortSignal = run.controller.signal;
+          return await new Promise<void>((resolve) => {
+            finishRun = resolve;
+          });
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS);
+      expect(runAbortSignal?.aborted).toBe(true);
+
+      finishRun?.();
+      await result;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('aborts the active run and resolves pending approval as denied', () => {
     const controller = new ControlPlaneChatSessionsController();
     const internals = controller as unknown as ControllerInternals;

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -422,6 +422,9 @@ describe('createConversationEngine', () => {
       'Session session-1 is already active in terminal chat.',
     );
 
+    const refreshed = engine.sessions.refreshLease(session.id, owner);
+    expect(refreshed.lease?.ownerId).toBe('tui-test-client');
+
     const stillLeased = engine.sessions.releaseLease(session.id, { ownerId: 'daemon-1' });
     expect(stillLeased.lease?.ownerId).toBe('tui-test-client');
 

--- a/src/core/chat/engine/sessions/leases/index.ts
+++ b/src/core/chat/engine/sessions/leases/index.ts
@@ -1,2 +1,6 @@
-export { ChatSessionLeases } from './leases.js';
+export {
+  ChatSessionLeases,
+  SESSION_LEASE_REFRESH_INTERVAL_MS,
+  SESSION_LEASE_STALE_AFTER_MS,
+} from './leases.js';
 export type { ChatSessionLeaseConflictOptions, ChatSessionLeaseOwner } from './types.js';

--- a/src/core/chat/engine/sessions/leases/leases.ts
+++ b/src/core/chat/engine/sessions/leases/leases.ts
@@ -7,8 +7,10 @@
  */
 import type { ChatSession, ChatSessionLease } from '@/core/chat/types.js';
 import type { ChatSessionLeaseConflictOptions, ChatSessionLeaseOwner } from './types.js';
+import dayjs from 'dayjs';
 
-const DEFAULT_SESSION_LEASE_STALE_AFTER_MS = 15 * 60 * 1000;
+export const SESSION_LEASE_REFRESH_INTERVAL_MS = 5 * 1000;
+export const SESSION_LEASE_STALE_AFTER_MS = 20 * 1000;
 const LOCAL_PROCESS_LEASE_OWNER_PATTERN = /^(?:tui|ask|submit|daemon)-(\d+)(?:-\d+)?$/;
 
 export class ChatSessionLeases {
@@ -20,12 +22,12 @@ export class ChatSessionLeases {
       return false;
     }
 
-    const lastSeenAt = Date.parse(lease.lastSeenAt);
-    if (!Number.isFinite(lastSeenAt)) {
+    const lastSeenAt = dayjs(lease.lastSeenAt);
+    if (!lastSeenAt.isValid()) {
       return false;
     }
 
-    return (options?.now ?? Date.now()) - lastSeenAt <= (options?.staleAfterMs ?? DEFAULT_SESSION_LEASE_STALE_AFTER_MS);
+    return dayjs(options?.now ?? Date.now()).diff(lastSeenAt) <= (options?.staleAfterMs ?? SESSION_LEASE_STALE_AFTER_MS);
   }
 
   static isOwnedByDeadLocalProcess(
@@ -51,7 +53,7 @@ export class ChatSessionLeases {
     owner: ChatSessionLeaseOwner,
     options?: { now?: number },
   ): ChatSession {
-    const timestamp = new Date(options?.now ?? Date.now()).toISOString();
+    const timestamp = dayjs(options?.now ?? Date.now()).toISOString();
     return {
       ...session,
       lease: {
@@ -60,6 +62,24 @@ export class ChatSessionLeases {
         acquiredAt: session.lease?.ownerId === owner.ownerId ? session.lease.acquiredAt : timestamp,
         lastSeenAt: timestamp,
         clientLabel: owner.clientLabel,
+      },
+    };
+  }
+
+  static refresh(
+    session: ChatSession,
+    owner: Pick<ChatSessionLeaseOwner, 'ownerId'>,
+    options?: { now?: number },
+  ): ChatSession {
+    if (!session.lease || session.lease.ownerId !== owner.ownerId) {
+      return session;
+    }
+
+    return {
+      ...session,
+      lease: {
+        ...session.lease,
+        lastSeenAt: dayjs(options?.now ?? Date.now()).toISOString(),
       },
     };
   }

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -322,6 +322,10 @@ export class FileConversationSessionService implements ConversationSessionServic
     });
   }
 
+  refreshLease(id: string, owner: Pick<ChatSessionLeaseOwner, 'ownerId'>): ChatSession {
+    return this.updateRequiredSession(id, (session) => ChatSessionLeases.refresh(session, owner));
+  }
+
   releaseLease(id: string, owner: Pick<ChatSessionLeaseOwner, 'ownerId'>): ChatSession {
     return this.updateRequiredSession(id, (session) => ChatSessionLeases.release(session, owner));
   }

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -84,6 +84,7 @@ export type ConversationSessionService = {
   // Leases
   getLeaseConflict(id: string, owner: ChatSessionLeaseOwner): string | undefined;
   acquireLease(id: string, owner: ChatSessionLeaseOwner): ChatSession;
+  refreshLease(id: string, owner: Pick<ChatSessionLeaseOwner, 'ownerId'>): ChatSession;
   releaseLease(id: string, owner: Pick<ChatSessionLeaseOwner, 'ownerId'>): ChatSession;
 };
 

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -181,6 +181,9 @@ export class ControlPlaneChatSessionsController {
   async compactSession(args: CompactControlPlaneChatSessionArgs): Promise<ChatSessionDetail> {
     return await this.runService.startAndWait({
       address: args,
+      onHeartbeat: () => {
+        this.createEngine(args).sessions.refreshLease(args.sessionId, args.leaseOwner);
+      },
       execute: async () => {
         const { sessionId, force = true, leaseOwner, ...engineInput } = args;
         const sessions = this.createEngine(engineInput).sessions;
@@ -495,6 +498,9 @@ export class ControlPlaneChatSessionsController {
           leaseOwner: args.leaseOwner,
         });
       },
+      onHeartbeat: () => {
+        this.createEngine(args).sessions.refreshLease(args.sessionId, args.leaseOwner);
+      },
       execute: async (run: ControlPlaneSessionRunContext) => {
         const result = process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1'
           ? await this.runFakeBrowserIntegrationSessionPrompt(args)
@@ -525,6 +531,9 @@ export class ControlPlaneChatSessionsController {
   private buildContinuePromptRun(args: ContinueChatPromptArgs) {
     return {
       address: args,
+      onHeartbeat: () => {
+        this.createEngine(args).sessions.refreshLease(args.sessionId, args.leaseOwner);
+      },
       execute: async (run: ControlPlaneSessionRunContext) => {
         if (process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1') {
           const session = this.createEngine(args).sessions.require(args.sessionId);
@@ -557,6 +566,9 @@ export class ControlPlaneChatSessionsController {
   private buildDirectShellRun(args: SubmitDirectShellArgs) {
     return {
       address: args,
+      onHeartbeat: () => {
+        this.createEngine(args).sessions.refreshLease(args.sessionId, args.leaseOwner);
+      },
       execute: async (run: ControlPlaneSessionRunContext) => {
         const publisher = ControlPlaneChatSessionEventsController.createSessionEventPublisher({
           eventBus: this.sessionEventBus,

--- a/src/server/services/control-plane/session-run-service.ts
+++ b/src/server/services/control-plane/session-run-service.ts
@@ -3,6 +3,7 @@ import type {
   ToolApprovalRequest,
   ToolApprovalUserDecision,
 } from '@/core/approvals/index.js';
+import { SESSION_LEASE_REFRESH_INTERVAL_MS } from '@/core/chat/engine/sessions/leases/index.js';
 import type { ControlPlaneAcceptedSessionRun } from '@/server/control-plane-types.js';
 
 export type ControlPlaneSessionRunAddress = {
@@ -24,6 +25,7 @@ export type ControlPlaneSessionRunContext = {
 type StartControlPlaneSessionRunInput<Result> = {
   address: ControlPlaneSessionRunAddress;
   onAccepted?: (run: ControlPlaneSessionRunContext) => void;
+  onHeartbeat?: (run: ControlPlaneSessionRunContext) => void | Promise<void>;
   execute: (run: ControlPlaneSessionRunContext) => Promise<Result>;
   onError?: (error: unknown, run: ControlPlaneSessionRunContext) => void | Promise<void>;
   onSettled?: (run: ControlPlaneSessionRunContext) => void | Promise<void>;
@@ -58,6 +60,7 @@ export class ControlPlaneSessionRunService {
 
     let accepted = false;
     let acceptanceError: unknown;
+    let stopHeartbeat: (() => void) | undefined;
 
     const result = Promise.resolve()
       .then(() => {
@@ -74,6 +77,7 @@ export class ControlPlaneSessionRunService {
         throw error;
       })
       .finally(() => {
+        stopHeartbeat?.();
         this.pendingApprovals.delete(key);
         this.inFlightRuns.delete(key);
         if (accepted) {
@@ -86,6 +90,7 @@ export class ControlPlaneSessionRunService {
 
     try {
       input.onAccepted?.(run);
+      stopHeartbeat = this.startHeartbeat(run, input.onHeartbeat);
       accepted = true;
     } catch (error) {
       acceptanceError = error;
@@ -172,5 +177,35 @@ export class ControlPlaneSessionRunService {
 
   private static addressKey(address: ControlPlaneSessionRunAddress): string {
     return `${address.workspaceId}:${address.sessionId}`;
+  }
+
+  private startHeartbeat(
+    run: ControlPlaneSessionRunContext,
+    onHeartbeat: StartControlPlaneSessionRunInput<unknown>['onHeartbeat'],
+  ): (() => void) | undefined {
+    if (!onHeartbeat) {
+      return undefined;
+    }
+
+    let refreshing = false;
+    const timer = setInterval(() => {
+      if (refreshing || run.controller.signal.aborted) {
+        return;
+      }
+
+      refreshing = true;
+      Promise.resolve()
+        .then(() => onHeartbeat(run))
+        .catch(() => {
+          run.controller.abort();
+        })
+        .finally(() => {
+          refreshing = false;
+        });
+    }, SESSION_LEASE_REFRESH_INTERVAL_MS);
+
+    return () => {
+      clearInterval(timer);
+    };
   }
 }


### PR DESCRIPTION
## Summary
- shorten chat-session lease freshness to 20s and add a core-owned lease refresh operation
- refresh active control-plane run leases every 5s for prompt, continue, direct shell, and compaction runs
- abort active runs if lease refresh fails, and document quick stale-lease recovery

## Expected behavior
- A live run keeps its session lease fresh while it is mutating the session.
- If the embedded/server process dies mid-run, the lease stops refreshing and becomes reclaimable after roughly 20s instead of blocking for 15 minutes.
- Fresh leases from another active run still block unsafe concurrent mutation.

## Verification
- yarn test
- yarn build
- yarn lint