### PR TITLE
Add model response retry policy

### DIFF
--- a/examples/programmatic-loop.ts
+++ b/examples/programmatic-loop.ts
@@ -107,6 +107,8 @@ function formatTraceEvent(event: TraceEvent): string {
       return `[trace] run.started goal=${JSON.stringify(shorten(event.goal))}`;
     case 'assistant.turn':
       return `[trace] assistant.turn step=${event.step} tools=${event.requestedTools ? event.toolCalls?.map((call) => call.tool).join(',') || 'yes' : 'none'} content=${JSON.stringify(shorten(event.content))}`;
+    case 'model.retry':
+      return `[trace] model.retry step=${event.step} reason=${event.reason} attempt=${event.attempt}/${event.maxAttempts} retryAfterMs=${event.retryAfterMs} message=${JSON.stringify(shorten(event.message))}`;
     case 'host.warning':
       return `[trace] host.warning step=${event.step} code=${event.code} message=${JSON.stringify(shorten(event.message))}`;
     case 'tool.approval_requested':
@@ -133,6 +135,8 @@ function formatTraceEvent(event: TraceEvent): string {
       return `[trace] cyberloop.annotation step=${event.step} frame=${event.frameKind} drift=${event.driftLevel}`;
     case 'run.finished':
       return `[trace] run.finished step=${event.step} outcome=${event.outcome} summary=${JSON.stringify(shorten(event.summary))}`;
+    default:
+      return event;
   }
 }
 

--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -10,6 +10,17 @@ import { createLogger } from '../../../core/utils/logger.js';
 
 const silentLogger = createLogger({ level: 'silent', console: false });
 
+async function runWithRetryTimers(run: () => Promise<Awaited<ReturnType<typeof AgentRunService.run>>>) {
+  vi.useFakeTimers();
+  try {
+    const promise = run();
+    await vi.runAllTimersAsync();
+    return await promise;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 describe('AgentRunService.run', () => {
   it('executes tool calls, appends tool output, and finishes with a final answer', async () => {
     const seenMessages: ChatMessage[][] = [];
@@ -90,10 +101,12 @@ describe('AgentRunService.run', () => {
     });
   });
 
-  it('records an error outcome when the LLM chat throws a non-abort error', async () => {
+  it('records an error outcome when the LLM chat throws a non-retryable error', async () => {
+    let calls = 0;
     const fakeLlm: LlmAdapter = {
       async chat(): Promise<LlmResponse> {
-        throw new Error('boom');
+        calls += 1;
+        throw Object.assign(new Error('Unauthorized'), { status: 401 });
       },
     };
 
@@ -106,8 +119,118 @@ describe('AgentRunService.run', () => {
     });
 
     expect(result.outcome).toBe('error');
-    expect(result.summary).toBe('LLM error: boom');
+    expect(result.summary).toBe('LLM error: Unauthorized');
+    expect(calls).toBe(1);
     expect(result.trace.some((event) => event.type === 'run.finished')).toBe(true);
+  });
+
+  it('retries transient LLM transport errors before returning the assistant response', async () => {
+    let calls = 0;
+    const fakeLlm: LlmAdapter = {
+      async chat(): Promise<LlmResponse> {
+        calls += 1;
+
+        if (calls < 3) {
+          throw Object.assign(new Error('fetch failed'), { status: 503 });
+        }
+
+        return {
+          content: 'Recovered after reconnecting.',
+        };
+      },
+    };
+
+    const result = await runWithRetryTimers(() => AgentRunService.run({
+      goal: 'Handle provider disconnects.',
+      llm: fakeLlm,
+      tools: [],
+      maxSteps: 1,
+      logger: silentLogger,
+    }));
+
+    expect(result.outcome).toBe('done');
+    expect(result.summary).toBe('Recovered after reconnecting.');
+    expect(calls).toBe(3);
+    expect(result.trace.filter((event) => event.type === 'model.retry')).toEqual([
+      expect.objectContaining({
+        type: 'model.retry',
+        reason: 'transport_error',
+        attempt: 1,
+        maxAttempts: 5,
+        message: 'fetch failed',
+      }),
+      expect.objectContaining({
+        type: 'model.retry',
+        reason: 'transport_error',
+        attempt: 2,
+        maxAttempts: 5,
+        message: 'fetch failed',
+      }),
+    ]);
+  });
+
+  it('retries empty final model responses before returning an error', async () => {
+    let calls = 0;
+    const fakeLlm: LlmAdapter = {
+      async chat(): Promise<LlmResponse> {
+        calls += 1;
+        return {};
+      },
+    };
+
+    const result = await runWithRetryTimers(() => AgentRunService.run({
+      goal: 'Finish with useful text.',
+      llm: fakeLlm,
+      tools: [],
+      maxSteps: 1,
+      logger: silentLogger,
+    }));
+
+    expect(result.outcome).toBe('error');
+    expect(result.summary).toBe('Model returned an empty response after 3 attempts');
+    expect(calls).toBe(3);
+    expect(result.trace.filter((event) => event.type === 'model.retry')).toHaveLength(2);
+  });
+
+  it('does not retry a valid tool-call response without assistant text', async () => {
+    let calls = 0;
+    const fakeLlm: LlmAdapter = {
+      async chat(messages): Promise<LlmResponse> {
+        calls += 1;
+
+        if (messages.some((message) => message.role === 'tool')) {
+          return {
+            content: 'Done after tool use.',
+          };
+        }
+
+        return {
+          toolCalls: [{ id: 'call-1', tool: 'list_files', input: { path: '.' } }],
+        };
+      },
+    };
+
+    const listFilesTool: ToolDefinition = {
+      name: 'list_files',
+      description: 'Lists files in a directory',
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        return { ok: true, output: 'README.md\nsrc/' };
+      },
+    };
+
+    const result = await AgentRunService.run({
+      goal: 'Inspect this repo.',
+      llm: fakeLlm,
+      tools: [listFilesTool],
+      maxSteps: 3,
+      logger: silentLogger,
+    });
+
+    expect(result.outcome).toBe('done');
+    expect(result.summary).toBe('Done after tool use.');
+    expect(calls).toBe(2);
+    expect(result.trace.filter((event) => event.type === 'model.retry')).toHaveLength(0);
   });
 
   it('records assistant rationale on tool turns when the model provides text with tool calls', async () => {

--- a/src/core/agent/model/index.ts
+++ b/src/core/agent/model/index.ts
@@ -1,4 +1,5 @@
 export { AgentModelTurnService } from './model-turn-service.js';
+export { AgentModelTurnRetryService } from './model-turn-retry-service.js';
 export type {
   AccumulateAgentUsageArgs,
   AgentModelTurnResult,

--- a/src/core/agent/model/model-turn-retry-service.ts
+++ b/src/core/agent/model/model-turn-retry-service.ts
@@ -1,0 +1,146 @@
+import get from 'lodash/get.js';
+import includes from 'lodash/includes.js';
+import isNumber from 'lodash/isNumber.js';
+import isString from 'lodash/isString.js';
+import type { LlmResponse } from '@/core/llm/types.js';
+
+export type AgentModelTurnRetryReason = 'transport_error' | 'empty_response';
+
+export type AgentModelTurnRetryDecision = {
+  retryable: boolean;
+  reason?: AgentModelTurnRetryReason;
+  maxAttempts: number;
+  message: string;
+};
+
+export type AgentModelTurnRetryFailure =
+  | { kind: 'error'; error: unknown }
+  | { kind: 'response'; response: LlmResponse };
+
+const TRANSPORT_RETRY_ATTEMPTS = 5;
+const EMPTY_RESPONSE_RETRY_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 500;
+const RETRY_MAX_DELAY_MS = 4_000;
+
+const RETRYABLE_STATUS_CODES = new Set([408, 409, 425, 429, 500, 502, 503, 504]);
+const NON_RETRYABLE_STATUS_CODES = new Set([400, 401, 403, 404, 422]);
+
+const RETRYABLE_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'UND_ERR_SOCKET',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+]);
+
+const RETRYABLE_MESSAGE_PATTERNS = [
+  'fetch failed',
+  'network',
+  'socket hang up',
+  'connection reset',
+  'connection refused',
+  'connection terminated',
+  'connection closed',
+  'stream terminated',
+  'terminated',
+  'timeout',
+  'timed out',
+  'disconnect',
+  'disconnected',
+  'temporarily unavailable',
+  'rate limit',
+];
+
+/**
+ * Owns retry classification and delay policy for a single model turn.
+ *
+ * The agent loop retries only the provider/model request. It never replays tool
+ * calls or complete runs, because those effects belong to later loop phases.
+ */
+export class AgentModelTurnRetryService {
+  static resolve(failure: AgentModelTurnRetryFailure): AgentModelTurnRetryDecision {
+    if (failure.kind === 'response') {
+      return AgentModelTurnRetryService.resolveResponse(failure.response);
+    }
+
+    return AgentModelTurnRetryService.resolveError(failure.error);
+  }
+
+  static nextDelayMs(attempt: number): number {
+    return Math.min(RETRY_BASE_DELAY_MS * 2 ** Math.max(attempt - 1, 0), RETRY_MAX_DELAY_MS);
+  }
+
+  private static resolveResponse(response: LlmResponse): AgentModelTurnRetryDecision {
+    if (response.content || (response.toolCalls?.length ?? 0) > 0) {
+      return { retryable: false, maxAttempts: 1, message: 'Model response is usable.' };
+    }
+
+    return {
+      retryable: true,
+      reason: 'empty_response',
+      maxAttempts: EMPTY_RESPONSE_RETRY_ATTEMPTS,
+      message: 'Model returned an empty response',
+    };
+  }
+
+  private static resolveError(error: unknown): AgentModelTurnRetryDecision {
+    const message = AgentModelTurnRetryService.formatErrorMessage(error);
+    const status = AgentModelTurnRetryService.readStatusCode(error);
+
+    if (status !== undefined && NON_RETRYABLE_STATUS_CODES.has(status)) {
+      return { retryable: false, maxAttempts: 1, message };
+    }
+
+    if (status !== undefined && RETRYABLE_STATUS_CODES.has(status)) {
+      return {
+        retryable: true,
+        reason: 'transport_error',
+        maxAttempts: TRANSPORT_RETRY_ATTEMPTS,
+        message,
+      };
+    }
+
+    if (AgentModelTurnRetryService.hasRetryableErrorCode(error) || AgentModelTurnRetryService.hasRetryableMessage(message)) {
+      return {
+        retryable: true,
+        reason: 'transport_error',
+        maxAttempts: TRANSPORT_RETRY_ATTEMPTS,
+        message,
+      };
+    }
+
+    return { retryable: false, maxAttempts: 1, message };
+  }
+
+  private static readStatusCode(error: unknown): number | undefined {
+    const status = get(error, 'status') ?? get(error, 'statusCode') ?? get(error, 'response.status');
+    if (isNumber(status)) {
+      return status;
+    }
+
+    if (isString(status)) {
+      const parsed = Number.parseInt(status, 10);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }
+
+    return undefined;
+  }
+
+  private static hasRetryableErrorCode(error: unknown): boolean {
+    const code = get(error, 'code') ?? get(error, 'cause.code');
+    return isString(code) && RETRYABLE_ERROR_CODES.has(code);
+  }
+
+  private static hasRetryableMessage(message: string): boolean {
+    const normalized = message.toLowerCase();
+    return RETRYABLE_MESSAGE_PATTERNS.some((pattern) => includes(normalized, pattern));
+  }
+
+  private static formatErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/src/core/agent/model/model-turn-service.ts
+++ b/src/core/agent/model/model-turn-service.ts
@@ -1,9 +1,11 @@
+import { setTimeout as sleep } from 'node:timers/promises';
 import type { LlmStreamEvent, LlmUsage } from '@/core/llm/types.js';
 import { HeddleEventType } from '@/core/event-types.js';
 import { isAbortError } from '@/core/agent/utils/index.js';
 import { STREAM_UPDATE_INTERVAL_MS } from '../constants.js';
 import { AgentRunFinisher } from '../finish/index.js';
 import type { AccumulateAgentUsageArgs, AgentModelTurnResult, RequestAgentModelTurnArgs } from './types.js';
+import { AgentModelTurnRetryService } from './model-turn-retry-service.js';
 
 /**
  * Owns one LLM request/stream step inside an agent run.
@@ -15,31 +17,96 @@ export class AgentModelTurnService {
       return AgentRunFinisher.finishInterrupted(context, 'Agent run interrupted before LLM call');
     }
 
-    try {
-      const streamState = {
-        content: '',
-        reasoningSummary: '',
-        lastStreamEmitAt: 0,
-      };
-      const response = await context.llm.chat(
-        context.messages,
-        context.registry.list(),
-        context.abortSignal,
-        (event: LlmStreamEvent) => AgentModelTurnService.handleStreamEvent({ context, event, streamState }),
-      );
-      context.state.usage = AgentModelTurnService.accumulateUsage({
-        current: context.state.usage,
-        next: response.usage,
-      });
-      return response;
-    } catch (error) {
-      if (isAbortError(error) || context.abortSignal?.aborted || context.shouldStop?.()) {
-        return AgentRunFinisher.finishInterrupted(context, 'Agent run interrupted during LLM call');
-      }
+    return AgentModelTurnService.requestWithRetries(args);
+  }
 
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      context.log.error({ step: context.state.step, error: errorMessage }, 'LLM call failed');
-      return AgentRunFinisher.finish(context, 'error', `LLM error: ${errorMessage}`);
+  private static async requestWithRetries(args: RequestAgentModelTurnArgs): Promise<AgentModelTurnResult> {
+    const { context } = args;
+    let attempt = 1;
+
+    while (true) {
+      try {
+        const response = await AgentModelTurnService.requestOnce(args);
+        context.state.usage = AgentModelTurnService.accumulateUsage({
+          current: context.state.usage,
+          next: response.usage,
+        });
+
+        const retry = AgentModelTurnRetryService.resolve({ kind: 'response', response });
+        if (!retry.retryable || attempt >= retry.maxAttempts) {
+          return retry.retryable
+            ? AgentRunFinisher.finish(context, 'error', `${retry.message} after ${attempt} attempts`)
+            : response;
+        }
+
+        await AgentModelTurnService.recordRetryAndWait({ context, attempt, retry });
+        attempt += 1;
+      } catch (error) {
+        if (isAbortError(error) || context.abortSignal?.aborted || context.shouldStop?.()) {
+          return AgentRunFinisher.finishInterrupted(context, 'Agent run interrupted during LLM call');
+        }
+
+        const retry = AgentModelTurnRetryService.resolve({ kind: 'error', error });
+        if (!retry.retryable || attempt >= retry.maxAttempts) {
+          context.log.error({ step: context.state.step, error: retry.message, attempts: attempt }, 'LLM call failed');
+          return AgentRunFinisher.finish(
+            context,
+            'error',
+            attempt > 1 ? `LLM error after ${attempt} attempts: ${retry.message}` : `LLM error: ${retry.message}`,
+          );
+        }
+
+        await AgentModelTurnService.recordRetryAndWait({ context, attempt, retry });
+        attempt += 1;
+      }
+    }
+  }
+
+  private static async requestOnce(args: RequestAgentModelTurnArgs) {
+    const { context } = args;
+    const streamState = {
+      content: '',
+      reasoningSummary: '',
+      lastStreamEmitAt: 0,
+    };
+
+    return context.llm.chat(
+      context.messages,
+      context.registry.list(),
+      context.abortSignal,
+      (event: LlmStreamEvent) => AgentModelTurnService.handleStreamEvent({ context, event, streamState }),
+    );
+  }
+
+  private static async recordRetryAndWait(args: {
+    context: RequestAgentModelTurnArgs['context'];
+    attempt: number;
+    retry: ReturnType<typeof AgentModelTurnRetryService.resolve>;
+  }): Promise<void> {
+    const { context, attempt, retry } = args;
+    const retryAfterMs = AgentModelTurnRetryService.nextDelayMs(attempt);
+
+    context.live.trace({
+      type: HeddleEventType.modelRetry,
+      reason: retry.reason ?? 'transport_error',
+      attempt,
+      maxAttempts: retry.maxAttempts,
+      retryAfterMs,
+      message: retry.message,
+      step: context.state.step,
+      timestamp: context.now(),
+    });
+    context.log.warn(
+      { step: context.state.step, attempt, maxAttempts: retry.maxAttempts, retryAfterMs, reason: retry.reason, message: retry.message },
+      'Retrying LLM call',
+    );
+
+    try {
+      await sleep(retryAfterMs, undefined, { signal: context.abortSignal });
+    } catch (error) {
+      if (isAbortError(error) || context.abortSignal?.aborted) {
+        throw error;
+      }
     }
   }
 

--- a/src/core/event-types.ts
+++ b/src/core/event-types.ts
@@ -8,6 +8,7 @@ export const HeddleEventType = {
   runStarted: 'run.started',
   assistantTurn: 'assistant.turn',
   assistantStream: 'assistant.stream',
+  modelRetry: 'model.retry',
   hostWarning: 'host.warning',
   toolApprovalRequested: 'tool.approval_requested',
   toolApprovalResolved: 'tool.approval_resolved',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -73,6 +73,16 @@ export type TraceEvent =
       timestamp: string;
     }
   | {
+      type: typeof HeddleEventType.modelRetry;
+      reason: 'transport_error' | 'empty_response';
+      attempt: number;
+      maxAttempts: number;
+      retryAfterMs: number;
+      message: string;
+      step: number;
+      timestamp: string;
+    }
+  | {
       type: typeof HeddleEventType.hostWarning;
       code: 'actionless_completion';
       message: string;


### PR DESCRIPTION
## Summary
- add a core-owned model turn retry policy for transient provider/network failures and empty model responses
- record model.retry trace events so retries are observable without making UI surfaces own retry semantics
- preserve tool-call responses without assistant text as valid, so retries do not replay tools or full runs

## Expected behavior
- transient backend/provider disconnects, 5xx/429-style failures, and common network errors retry the current model request up to 5 attempts
- empty model responses retry up to 3 attempts before failing with a clearer summary
- non-retryable errors like auth/invalid request still fail immediately
- tool calls are not replayed by retry policy; retries happen only before a model turn returns usable content or tool calls

## Verification
- yarn test src/__tests__/integration/core/run-agent.test.ts
- yarn build
- yarn lint