### PR TITLE
[codex] Harden browser click and close safety

### DIFF
--- a/src/__tests__/unit/core/browser-policy.test.ts
+++ b/src/__tests__/unit/core/browser-policy.test.ts
@@ -65,6 +65,22 @@ describe('BrowserPolicyService', () => {
     });
   });
 
+  it('requires approval for click targets without known destinations', () => {
+    const policy = new BrowserPolicyService({ allowedDomains: ['wikipedia.org'] });
+
+    expect(policy.evaluateClick({
+      ref: 'el_1',
+      role: 'button',
+      name: 'Open menu',
+      text: 'Open menu',
+      tagName: 'button',
+    })).toMatchObject({
+      status: 'approvalRequired',
+      risk: 'medium',
+      reason: expect.stringContaining('does not expose a browser navigation URL'),
+    });
+  });
+
   it('classifies forbidden click text before off-domain navigation', () => {
     const policy = new BrowserPolicyService({ allowedDomains: ['wikipedia.org'] });
 

--- a/src/__tests__/unit/core/browser-session.test.ts
+++ b/src/__tests__/unit/core/browser-session.test.ts
@@ -8,6 +8,7 @@ import {
   BrowserSessionService,
   type BrowserActionEvidenceEvent,
   type BrowserDriver,
+  type BrowserDriverClickOptions,
   type BrowserDriverFactory,
   type BrowserDriverLaunchOptions,
   type BrowserDriverSnapshotOptions,
@@ -74,6 +75,32 @@ describe('BrowserSessionService', () => {
         path: expect.stringContaining('after-click.png'),
       },
     });
+  });
+
+  it('revokes snapshot refs after a click changes the page', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'heddle-browser-session-revoke-refs-'));
+    const driver = new FakeBrowserDriver();
+    const session = new BrowserSessionService({
+      profile: {
+        profileId: 'test',
+        userDataDir: join(dir, 'profile'),
+        headless: true,
+      },
+      policy: {
+        allowedDomains: ['wikipedia.org'],
+      },
+      evidenceDir: join(dir, 'run'),
+    }, new FakeBrowserDriverFactory(driver));
+
+    await session.open({ url: 'https://en.wikipedia.org/wiki/Browser_automation' });
+    await session.snapshot();
+    await expect(session.click({ ref: 'el_1' })).resolves.toMatchObject({ status: 'allowed' });
+
+    await expect(session.click({ ref: 'el_1' })).resolves.toMatchObject({
+      status: 'blocked',
+      reason: 'Unknown browser snapshot ref: el_1',
+    });
+    expect(driver.clickedRefs).toEqual(['el_1']);
   });
 
   it('blocks forbidden click refs before the driver executes them', async () => {
@@ -154,6 +181,60 @@ describe('BrowserSessionService', () => {
     expect(driver.clickedRefs).toEqual([]);
   });
 
+  it('requires approval for click refs without known destinations before the driver executes them', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'heddle-browser-session-unknown-click-'));
+    const driver = new FakeBrowserDriver();
+    const session = new BrowserSessionService({
+      profile: {
+        profileId: 'test',
+        userDataDir: join(dir, 'profile'),
+        headless: true,
+      },
+      policy: {
+        allowedDomains: ['wikipedia.org'],
+      },
+      evidenceDir: join(dir, 'run'),
+    }, new FakeBrowserDriverFactory(driver));
+
+    await session.open({ url: 'https://en.wikipedia.org/wiki/Browser_automation' });
+    await session.snapshot();
+    const result = await session.click({ ref: 'el_4' });
+
+    expect(result).toMatchObject({
+      status: 'approvalRequired',
+      reason: expect.stringContaining('does not expose a browser navigation URL'),
+    });
+    expect(driver.clickedRefs).toEqual([]);
+  });
+
+  it('blocks off-domain navigation triggered by an allowlisted click ref', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'heddle-browser-session-redirect-'));
+    const driver = new FakeBrowserDriver();
+    const session = new BrowserSessionService({
+      profile: {
+        profileId: 'test',
+        userDataDir: join(dir, 'profile'),
+        headless: true,
+      },
+      policy: {
+        allowedDomains: ['wikipedia.org'],
+      },
+      evidenceDir: join(dir, 'run'),
+    }, new FakeBrowserDriverFactory(driver));
+
+    await session.open({ url: 'https://en.wikipedia.org/wiki/Browser_automation' });
+    await session.snapshot();
+    const result = await session.click({ ref: 'el_5' });
+
+    expect(result).toMatchObject({
+      status: 'approvalRequired',
+      url: 'https://example.com/redirect',
+      reason: expect.stringContaining('outside the browser domain allowlist'),
+    });
+    expect(driver.clickedRefs).toEqual([]);
+    expect(driver.currentUrl()).toBe('https://en.wikipedia.org/wiki/Browser_automation');
+  });
+
   it('passes the snapshot max element cap to the browser driver', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'heddle-browser-session-cap-'));
     const driver = new FakeBrowserDriver();
@@ -223,13 +304,32 @@ class FakeBrowserDriver implements BrowserDriver {
           href: 'https://example.com/source',
           tagName: 'a',
         },
+        {
+          ref: 'el_4',
+          role: 'button',
+          name: 'Open menu',
+          text: 'Open menu',
+          tagName: 'button',
+        },
+        {
+          ref: 'el_5',
+          role: 'link',
+          name: 'Safe redirect',
+          href: 'https://en.wikipedia.org/wiki/Safe_redirect',
+          tagName: 'a',
+        },
       ],
     };
   }
 
-  async click(ref: string): Promise<string> {
+  async click(ref: string, options: BrowserDriverClickOptions = {}): Promise<string> {
+    const nextUrl = ref === 'el_5' ? 'https://example.com/redirect' : 'https://en.wikipedia.org/wiki/History';
+    if (!(options.canNavigateTo?.(nextUrl) ?? true)) {
+      throw new Error('navigation blocked by browser guard');
+    }
+
     this.clickedRefs.push(ref);
-    this.url = 'https://en.wikipedia.org/wiki/History';
+    this.url = nextUrl;
     return this.url;
   }
 

--- a/src/__tests__/unit/tools/browser-research-toolkit.test.ts
+++ b/src/__tests__/unit/tools/browser-research-toolkit.test.ts
@@ -122,6 +122,25 @@ describe('createBrowserResearchToolkit', () => {
     await fresh.tools.browser_close.execute({});
   });
 
+  it('releases profile locks when browser_close throws during driver shutdown', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-browser-toolkit-close-throw-'));
+    const failing = await createTools({
+      stateRoot,
+      driver: new ThrowingCloseBrowserDriver(),
+    });
+
+    await failing.tools.browser_open.execute({ url: 'https://en.wikipedia.org/wiki/Browser_automation' });
+    await expect(failing.tools.browser_close.execute({}))
+      .rejects
+      .toThrow('driver close failed');
+
+    const fresh = await createTools({ stateRoot });
+    await expect(fresh.tools.browser_open.execute({ url: 'https://en.wikipedia.org/wiki/Browser_automation' }))
+      .resolves
+      .toMatchObject({ ok: true });
+    await fresh.tools.browser_close.execute({});
+  });
+
   it('composes as an opt-in toolkit without duplicate names', async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-browser-toolkit-compose-'));
     const toolkit = createBrowserResearchToolkit({
@@ -235,5 +254,11 @@ class FakeBrowserDriver implements BrowserDriver {
 class ThrowingOpenBrowserDriver extends FakeBrowserDriver {
   override async open(_url: string): Promise<string> {
     throw new Error('driver open failed');
+  }
+}
+
+class ThrowingCloseBrowserDriver extends FakeBrowserDriver {
+  override async close(): Promise<void> {
+    throw new Error('driver close failed');
   }
 }

--- a/src/core/browser/playwright/driver.ts
+++ b/src/core/browser/playwright/driver.ts
@@ -1,9 +1,10 @@
 import { createRequire } from 'node:module';
 
-import type { chromium, BrowserContext, Locator, Page } from 'playwright';
+import type { chromium, BrowserContext, Locator, Page, Route } from 'playwright';
 
 import type {
   BrowserDriver,
+  BrowserDriverClickOptions,
   BrowserDriverFactory,
   BrowserDriverLaunchOptions,
   BrowserDriverSnapshotOptions,
@@ -93,14 +94,20 @@ class PlaywrightBrowserDriver implements BrowserDriver {
     };
   }
 
-  async click(ref: string): Promise<string> {
+  async click(ref: string, options: BrowserDriverClickOptions = {}): Promise<string> {
     const locator = this.refs.get(ref);
     if (!locator) {
       throw new Error(`Unknown browser snapshot ref: ${ref}`);
     }
 
-    await locator.click();
-    await this.page.waitForLoadState('domcontentloaded').catch(() => undefined);
+    const routeHandler = this.createNavigationGuard(options);
+    await this.page.route('**/*', routeHandler);
+    try {
+      await locator.click();
+      await this.page.waitForLoadState('domcontentloaded').catch(() => undefined);
+    } finally {
+      await this.page.unroute('**/*', routeHandler).catch(() => undefined);
+    }
     return this.page.url();
   }
 
@@ -114,6 +121,23 @@ class PlaywrightBrowserDriver implements BrowserDriver {
 
   currentUrl(): string | undefined {
     return this.page.url();
+  }
+
+  private createNavigationGuard(options: BrowserDriverClickOptions): (route: Route) => Promise<void> {
+    return async (route) => {
+      const request = route.request();
+      if (!request.isNavigationRequest() || !options.canNavigateTo) {
+        await route.continue();
+        return;
+      }
+
+      if (options.canNavigateTo(request.url())) {
+        await route.continue();
+        return;
+      }
+
+      await route.abort('blockedbyclient');
+    };
   }
 
   private async snapshotElement(locator: Locator, index: number): Promise<BrowserSnapshotElement | undefined> {

--- a/src/core/browser/playwright/driver.ts
+++ b/src/core/browser/playwright/driver.ts
@@ -131,13 +131,24 @@ class PlaywrightBrowserDriver implements BrowserDriver {
         return;
       }
 
-      if (options.canNavigateTo(request.url())) {
-        await route.continue();
+      if (!options.canNavigateTo(request.url())) {
+        await route.abort('blockedbyclient');
         return;
       }
 
-      await route.abort('blockedbyclient');
+      const finalUrl = await this.resolveFinalNavigationUrl(route);
+      if (!options.canNavigateTo(finalUrl)) {
+        await route.abort('blockedbyclient');
+        return;
+      }
+
+      await route.continue();
     };
+  }
+
+  private async resolveFinalNavigationUrl(route: Route): Promise<string> {
+    const response = await route.fetch({ maxRedirects: 20 });
+    return response.url();
   }
 
   private async snapshotElement(locator: Locator, index: number): Promise<BrowserSnapshotElement | undefined> {

--- a/src/core/browser/policy/service.ts
+++ b/src/core/browser/policy/service.ts
@@ -62,7 +62,21 @@ export class BrowserPolicyService {
       };
     }
 
-    const hrefDecision = element.href ? this.evaluateNavigation(element.href) : { status: 'allowed' as const };
+    if (!element.href) {
+      return this.config.requireApprovalForOffDomainNavigation ?? true
+        ? {
+          status: 'approvalRequired',
+          risk: 'medium',
+          reason: 'Click target does not expose a browser navigation URL before execution.',
+        }
+        : {
+          status: 'blocked',
+          risk: 'medium',
+          reason: 'Click target does not expose a browser navigation URL before execution.',
+        };
+    }
+
+    const hrefDecision = this.evaluateNavigation(element.href);
     if (hrefDecision.status !== 'allowed') {
       return hrefDecision;
     }

--- a/src/core/browser/sessions/service.ts
+++ b/src/core/browser/sessions/service.ts
@@ -129,25 +129,58 @@ export class BrowserSessionService {
 
     const decision = this.policy.evaluateClick(element);
     if (decision.status !== 'allowed') {
-      await this.record({
-        id: actionId,
-        timestamp,
-        action: 'click',
-        status: decision.status,
-        reason: decision.reason,
-        url: this.currentUrl(),
-        detail: { ref: input.ref, target: this.evidenceTarget(element) },
-      });
-      return {
-        status: decision.status,
+      return await this.completePolicyDeniedClick({
         actionId,
         timestamp,
+        ref: input.ref,
+        element,
+        decision,
         url: this.currentUrl(),
-        reason: decision.reason,
-      };
+      });
     }
 
-    const finalUrl = await (await this.getDriver()).click(input.ref);
+    let blockedNavigation: { url: string; decision: ReturnType<BrowserPolicyService['evaluateNavigation']> } | undefined;
+    let finalUrl: string;
+    try {
+      finalUrl = await (await this.getDriver()).click(input.ref, {
+        canNavigateTo: (url) => {
+          const navigationDecision = this.policy.evaluateNavigation(url);
+          if (navigationDecision.status === 'allowed') {
+            return true;
+          }
+
+          blockedNavigation = { url, decision: navigationDecision };
+          return false;
+        },
+      });
+    } catch (error) {
+      this.latestSnapshot = undefined;
+      if (blockedNavigation) {
+        return await this.completePolicyDeniedClick({
+          actionId,
+          timestamp,
+          ref: input.ref,
+          element,
+          decision: blockedNavigation.decision,
+          url: blockedNavigation.url,
+        });
+      }
+
+      throw error;
+    }
+    this.latestSnapshot = undefined;
+
+    if (blockedNavigation) {
+      return await this.completePolicyDeniedClick({
+        actionId,
+        timestamp,
+        ref: input.ref,
+        element,
+        decision: blockedNavigation.decision,
+        url: blockedNavigation.url,
+      });
+    }
+
     const finalDecision = this.policy.evaluateNavigation(finalUrl);
     await this.record({
       id: actionId,
@@ -166,6 +199,32 @@ export class BrowserSessionService {
       url: finalUrl,
       reason: finalDecision.reason,
       data: { finalUrl },
+    };
+  }
+
+  private async completePolicyDeniedClick(args: {
+    actionId: string;
+    timestamp: string;
+    ref: string;
+    element: BrowserSnapshot['elements'][number];
+    decision: ReturnType<BrowserPolicyService['evaluateNavigation']>;
+    url?: string;
+  }): Promise<BrowserActionResult<{ finalUrl: string }>> {
+    await this.record({
+      id: args.actionId,
+      timestamp: args.timestamp,
+      action: 'click',
+      status: args.decision.status,
+      reason: args.decision.reason,
+      url: args.url,
+      detail: { ref: args.ref, target: this.evidenceTarget(args.element) },
+    });
+    return {
+      status: args.decision.status,
+      actionId: args.actionId,
+      timestamp: args.timestamp,
+      url: args.url,
+      reason: args.decision.reason,
     };
   }
 

--- a/src/core/browser/types.ts
+++ b/src/core/browser/types.ts
@@ -94,10 +94,14 @@ export interface BrowserDriverSnapshotResult {
   elements: BrowserSnapshotElement[];
 }
 
+export interface BrowserDriverClickOptions {
+  canNavigateTo?: (url: string) => boolean;
+}
+
 export interface BrowserDriver {
   open(url: string): Promise<string>;
   snapshot(options: BrowserDriverSnapshotOptions): Promise<BrowserDriverSnapshotResult>;
-  click(ref: string): Promise<string>;
+  click(ref: string, options?: BrowserDriverClickOptions): Promise<string>;
   screenshot(path: string): Promise<void>;
   close(): Promise<void>;
   currentUrl(): string | undefined;

--- a/src/core/tools/toolkits/browser-research/toolkit.ts
+++ b/src/core/tools/toolkits/browser-research/toolkit.ts
@@ -291,12 +291,14 @@ async function getBrowserSession(
 }
 
 async function closeBrowserState(state: BrowserRuntimeState): Promise<Awaited<ReturnType<BrowserSessionService['close']>> | undefined> {
-  const result = await state.session?.close();
-  state.lease?.release();
-  state.session = undefined;
-  state.lease = undefined;
-  state.opened = false;
-  return result;
+  try {
+    return await state.session?.close();
+  } finally {
+    state.lease?.release();
+    state.session = undefined;
+    state.lease = undefined;
+    state.opened = false;
+  }
 }
 
 function createSessionConfig(


### PR DESCRIPTION
## Summary
- revoke browser snapshot refs after executed clicks so stale refs cannot be reused after navigation or DOM changes
- require approval for click targets without known destinations and guard Playwright navigation requests before off-domain navigation completes
- release browser profile locks in a finally block even when browser_close driver shutdown rejects

## Validation
- yarn test:unit src/__tests__/unit/core/browser-policy.test.ts src/__tests__/unit/core/browser-session.test.ts src/__tests__/unit/tools/browser-research-toolkit.test.ts src/__tests__/unit/core/browser-profile.test.ts
- yarn typecheck
- yarn example:browser-research-toolkit:headless
- git diff --check