### PR TITLE
Fix slash command timeout handling

### DIFF
--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -10,6 +10,8 @@ import type {
   ControlPlaneSessionView,
   ControlPlaneSessionsEventEnvelope,
 } from '../../../client-shared/api/types.js';
+import { createControlPlaneRequestContext } from '../../../client-shared/api/links.js';
+import { SLASH_COMMAND_REQUEST_TIMEOUT_MS } from '../../../cli-v2/services/sessions/control-plane-session-api-service.js';
 import { ControlPlaneSessionStore } from '../../../cli-v2/state/control-plane-session-store.js';
 
 describe('ControlPlaneSessionStore', () => {
@@ -246,22 +248,22 @@ describe('ControlPlaneSessionStore', () => {
       workspaceId: 'workspace-1',
       sessionId: 'session-1',
       command: '/model gpt-5.4-mini',
-    });
+    }, slashCommandRequestOptions());
     expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenNthCalledWith(2, {
       workspaceId: 'workspace-1',
       sessionId: 'session-1',
       command: '/reasoning medium',
-    });
+    }, slashCommandRequestOptions());
     expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenNthCalledWith(3, {
       workspaceId: 'workspace-1',
       sessionId: 'session-1',
       command: '/reasoning default',
-    });
+    }, slashCommandRequestOptions());
     expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenNthCalledWith(4, {
       workspaceId: 'workspace-1',
       sessionId: 'session-1',
       command: '/session switch session-2',
-    });
+    }, slashCommandRequestOptions());
     expect(fixture.calls.sessionSendPromptAsyncMutate).not.toHaveBeenCalled();
     store.dispose();
   });
@@ -277,7 +279,7 @@ describe('ControlPlaneSessionStore', () => {
       workspaceId: 'workspace-1',
       sessionId: 'session-1',
       command: '/model',
-    });
+    }, slashCommandRequestOptions());
     expect(fixture.calls.sessionSendPromptAsyncMutate).not.toHaveBeenCalled();
     expect(store.getSnapshot().commandResults.at(-1)).toEqual({
       handled: true,
@@ -349,6 +351,30 @@ describe('ControlPlaneSessionStore', () => {
       kind: 'message',
       message: 'Unknown command: /nope. Use the slash command hints to inspect available commands.',
     });
+    store.dispose();
+  });
+
+  it('surfaces slash command timeout details in prompt and command-result UI state', async () => {
+    const fixture = createClientFixture();
+    fixture.calls.slashCommandExecuteMutate.mockRejectedValueOnce(
+      new Error('Control-plane request "controlPlane.slashCommandExecute" timed out after 300000ms.'),
+    );
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    await store.submitPrompt('/compact');
+
+    expect(store.getSnapshot().error).toBe(
+      'Slash command "/compact" timed out waiting for the control plane. '
+      + 'Control-plane request "controlPlane.slashCommandExecute" timed out after 300000ms. '
+      + 'Server-side work may still finish; watch the activity/status line for follow-up updates.',
+    );
+    expect(store.getSnapshot().commandResults.at(-1)).toMatchObject({
+      handled: true,
+      kind: 'message',
+      message: store.getSnapshot().error,
+    });
+    expect(store.getSnapshot().commandResultExpanded).toBe(true);
     store.dispose();
   });
 
@@ -902,6 +928,14 @@ function createPendingApproval(): NonNullable<ControlPlanePendingApproval> {
     input: { command: 'touch queued.txt' },
     requestedAt: new Date().toISOString(),
     summary: 'run shell command',
+  };
+}
+
+function slashCommandRequestOptions() {
+  return {
+    context: createControlPlaneRequestContext({
+      timeoutMs: SLASH_COMMAND_REQUEST_TIMEOUT_MS,
+    }),
   };
 }
 

--- a/src/__tests__/unit/client-shared/api-links.test.ts
+++ b/src/__tests__/unit/client-shared/api-links.test.ts
@@ -48,7 +48,7 @@ describe('control-plane API links', () => {
 
   it('times out tRPC operations at the default request budget', async () => {
     vi.useFakeTimers();
-    const request = runNeverCompletingOperation({
+    const request = waitForHungQueryThroughTimeoutLink({
       defaultTimeoutMs: 25,
       context: {},
     });
@@ -61,7 +61,7 @@ describe('control-plane API links', () => {
   it('uses per-operation timeout context when provided', async () => {
     vi.useFakeTimers();
     let settled = false;
-    const request = runNeverCompletingOperation({
+    const request = waitForHungQueryThroughTimeoutLink({
       defaultTimeoutMs: 25,
       context: createControlPlaneRequestContext({ timeoutMs: 75 }),
     }).finally(() => {
@@ -80,7 +80,7 @@ describe('control-plane API links', () => {
   it('does not time out subscription operations', async () => {
     vi.useFakeTimers();
     let error: unknown;
-    const subscription = createNeverCompletingOperation({
+    const subscription = createHungOperationThroughTimeoutLink({
       defaultTimeoutMs: 25,
       context: {},
       type: 'subscription',
@@ -96,21 +96,26 @@ describe('control-plane API links', () => {
   });
 });
 
-function runNeverCompletingOperation({
+// Simulates a query whose server response never arrives so the test can verify
+// the client-side timeout link without relying on a real control-plane server.
+function waitForHungQueryThroughTimeoutLink({
   context,
   defaultTimeoutMs,
 }: {
   context: Record<string, unknown>;
   defaultTimeoutMs: number;
 }) {
-  return observableToPromise(createNeverCompletingOperation({
+  return observableToPromise(createHungOperationThroughTimeoutLink({
     context,
     defaultTimeoutMs,
     type: 'query',
   }));
 }
 
-function createNeverCompletingOperation({
+// Builds a tRPC operation that never emits or completes. Request operations
+// should be timed out by the link; subscriptions should remain open because
+// live event streams are expected to be long-lived.
+function createHungOperationThroughTimeoutLink({
   context,
   defaultTimeoutMs,
   type,

--- a/src/__tests__/unit/client-shared/api-links.test.ts
+++ b/src/__tests__/unit/client-shared/api-links.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createControlPlaneRequestFetch } from '@/client-shared/api/links';
+import { observable, observableToPromise } from '@trpc/server/observable';
+import {
+  createControlPlaneRequestContext,
+  createControlPlaneRequestFetch,
+  createControlPlaneRequestTimeoutLink,
+} from '@/client-shared/api/links';
 
 describe('control-plane API links', () => {
   afterEach(() => {
@@ -40,4 +45,56 @@ describe('control-plane API links', () => {
 
     await expect(request).rejects.toThrow('Caller cancelled request.');
   });
+
+  it('times out tRPC operations at the default request budget', async () => {
+    vi.useFakeTimers();
+    const request = runNeverCompletingOperation({
+      defaultTimeoutMs: 25,
+      context: {},
+    });
+    const assertion = expect(request).rejects.toThrow('Control-plane request "controlPlane.state" timed out after 25ms.');
+
+    await vi.advanceTimersByTimeAsync(25);
+    await assertion;
+  });
+
+  it('uses per-operation timeout context when provided', async () => {
+    vi.useFakeTimers();
+    let settled = false;
+    const request = runNeverCompletingOperation({
+      defaultTimeoutMs: 25,
+      context: createControlPlaneRequestContext({ timeoutMs: 75 }),
+    }).finally(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    const assertion = expect(request).rejects.toThrow('Control-plane request "controlPlane.state" timed out after 75ms.');
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+  });
 });
+
+function runNeverCompletingOperation({
+  context,
+  defaultTimeoutMs,
+}: {
+  context: Record<string, unknown>;
+  defaultTimeoutMs: number;
+}) {
+  const link = createControlPlaneRequestTimeoutLink({ defaultTimeoutMs })({});
+  return observableToPromise(link({
+    op: {
+      id: 1,
+      type: 'query',
+      path: 'controlPlane.state',
+      input: undefined,
+      context,
+      signal: undefined,
+    },
+    next: () => observable(() => undefined),
+  }));
+}

--- a/src/__tests__/unit/client-shared/api-links.test.ts
+++ b/src/__tests__/unit/client-shared/api-links.test.ts
@@ -76,6 +76,24 @@ describe('control-plane API links', () => {
     await vi.advanceTimersByTimeAsync(50);
     await assertion;
   });
+
+  it('does not time out subscription operations', async () => {
+    vi.useFakeTimers();
+    let error: unknown;
+    const subscription = createNeverCompletingOperation({
+      defaultTimeoutMs: 25,
+      context: {},
+      type: 'subscription',
+    }).subscribe({
+      error: (caught) => {
+        error = caught;
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(error).toBeUndefined();
+    subscription.unsubscribe();
+  });
 });
 
 function runNeverCompletingOperation({
@@ -85,16 +103,32 @@ function runNeverCompletingOperation({
   context: Record<string, unknown>;
   defaultTimeoutMs: number;
 }) {
+  return observableToPromise(createNeverCompletingOperation({
+    context,
+    defaultTimeoutMs,
+    type: 'query',
+  }));
+}
+
+function createNeverCompletingOperation({
+  context,
+  defaultTimeoutMs,
+  type,
+}: {
+  context: Record<string, unknown>;
+  defaultTimeoutMs: number;
+  type: 'query' | 'mutation' | 'subscription';
+}) {
   const link = createControlPlaneRequestTimeoutLink({ defaultTimeoutMs })({});
-  return observableToPromise(link({
+  return link({
     op: {
       id: 1,
-      type: 'query',
+      type,
       path: 'controlPlane.state',
       input: undefined,
       context,
       signal: undefined,
     },
     next: () => observable(() => undefined),
-  }));
+  });
 }

--- a/src/__tests__/unit/core/chat-turn-persistence.test.ts
+++ b/src/__tests__/unit/core/chat-turn-persistence.test.ts
@@ -1,8 +1,9 @@
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConversationTurnArtifacts, ConversationTurnPersistenceService } from '../../../core/chat/engine/turns/persistence/index.js';
+import { ConversationCompactionService } from '../../../core/chat/engine/compaction/index.js';
 import { FileChatSessionRepository } from '../../../core/chat/engine/sessions/repository/index.js';
 import { TraceSummaryService } from '@/core/observability/index.js';
 import type { AgentLoopResult } from '@/core/runtime/loop/index.js';
@@ -10,6 +11,10 @@ import type { ChatSession } from '../../../core/chat/types.js';
 import type { RunResult } from '../../../core/types.js';
 
 describe('chat turn persistence', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('uses a supplied trace summarizer registry for persisted turn events', async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-turn-persistence-'));
     const session = createSession();
@@ -48,6 +53,49 @@ describe('chat turn persistence', () => {
     });
 
     expect(artifacts.turn.events).toEqual(['custom summary for read_file']);
+  });
+
+  it('forces final compaction after context-window overload failures', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-turn-persistence-context-overload-'));
+    const session = createSession();
+    const result: RunResult = {
+      outcome: 'error',
+      summary: 'Your input exceeds the context window of this model. Please adjust your input and try again.',
+      trace: [],
+      transcript: [
+        { role: 'user', content: 'Large prompt' },
+        { role: 'assistant', content: 'Large prior response' },
+        { role: 'user', content: 'Retry' },
+      ],
+    };
+    const compact = vi.spyOn(ConversationCompactionService, 'compact').mockResolvedValueOnce({
+      history: result.transcript,
+      context: {
+        estimatedHistoryTokens: 3,
+      },
+      archive: {
+        archives: [],
+      },
+    });
+
+    const artifacts = await ConversationTurnArtifacts.build({
+      result,
+      prompt: 'Retry',
+      session,
+      model: 'gpt-5.5',
+      stateRoot,
+      traceDir: join(stateRoot, 'traces'),
+      toolNames: [],
+      historyForTokenEstimate: result.transcript,
+      summarizer: {},
+      createTurnId: () => 'turn-1',
+    });
+
+    expect(compact).toHaveBeenCalledWith(expect.objectContaining({
+      force: true,
+      history: result.transcript,
+    }));
+    expect(artifacts.summary).toContain('automatically compact earlier history');
   });
 
   it('persists the completed turn back to session storage', async () => {

--- a/src/__tests__/unit/core/conversation-turn-failure-messages.test.ts
+++ b/src/__tests__/unit/core/conversation-turn-failure-messages.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { ConversationTurnFailureMessages } from '@/core/chat/engine/turns/failure/index.js';
 
 describe('ConversationTurnFailureMessages', () => {
+  it('adds automatic compaction guidance for context-window overloads', () => {
+    const message = 'Your input exceeds the context window of this model. Please adjust your input and try again.';
+    const formatted = ConversationTurnFailureMessages.format(
+      message,
+      { model: 'gpt-5.5', estimatedHistoryTokens: 201163 },
+    );
+
+    expect(formatted).toContain('exceeded the model context window');
+    expect(formatted).toContain('201,163 tokens');
+    expect(formatted).toContain('automatically compact earlier history');
+    expect(ConversationTurnFailureMessages.shouldForceCompactionAfterFailure(message)).toBe(true);
+  });
+
   it('adds manual compaction guidance for likely input-size TPM failures', () => {
     const formatted = ConversationTurnFailureMessages.format(
       `429 {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your organization's rate limit of 30,000 input tokens per minute. Please reduce the prompt length or the maximum tokens requested."}}`,
@@ -11,6 +24,7 @@ describe('ConversationTurnFailureMessages', () => {
     expect(formatted).toContain('input-token-per-minute limit');
     expect(formatted).toContain('18,234 tokens');
     expect(formatted).toContain('/compact, /clear, or /session new');
+    expect(ConversationTurnFailureMessages.shouldForceCompactionAfterFailure(formatted)).toBe(false);
   });
 
   it('distinguishes OpenAI quota exhaustion from prompt-size issues', () => {

--- a/src/cli-v2/services/sessions/control-plane-session-api-service.ts
+++ b/src/cli-v2/services/sessions/control-plane-session-api-service.ts
@@ -1,4 +1,5 @@
 import type { ControlPlaneProxyClient } from '@/client-shared/api/proxy.js';
+import { createControlPlaneRequestContext } from '@/client-shared/api/links.js';
 import type {
   ControlPlaneApprovalDecision,
   RouterInputs,
@@ -11,6 +12,8 @@ type SessionDirectShellPreflightInput = RouterInputs['controlPlane']['sessionDir
 type SessionDirectShellAsyncInput = RouterInputs['controlPlane']['sessionDirectShellAsync'];
 type SlashCommandExecuteInput = RouterInputs['controlPlane']['slashCommandExecute'];
 type WorkspaceFileSearchInput = RouterInputs['controlPlane']['workspaceFileSearch'];
+
+export const SLASH_COMMAND_REQUEST_TIMEOUT_MS = 5 * 60_000;
 
 export type ControlPlaneSessionApiServiceOptions = {
   client: ControlPlaneProxyClient;
@@ -138,7 +141,11 @@ export class ControlPlaneSessionApiService {
   }
 
   async executeSlashCommand(input: Pick<SlashCommandExecuteInput, 'workspaceId' | 'sessionId' | 'command'>) {
-    return this.client.controlPlane.slashCommandExecute.mutate(input);
+    return this.client.controlPlane.slashCommandExecute.mutate(input, {
+      context: createControlPlaneRequestContext({
+        timeoutMs: SLASH_COMMAND_REQUEST_TIMEOUT_MS,
+      }),
+    });
   }
 
   async continueSession(workspaceId: string, sessionId: string) {

--- a/src/cli-v2/state/control-plane-slash-command-controller.ts
+++ b/src/cli-v2/state/control-plane-slash-command-controller.ts
@@ -43,7 +43,16 @@ export class ControlPlaneSlashCommandController {
       const result = await this.options.api.executeSlashCommand({ workspaceId, sessionId, command });
       await this.applyResult(workspaceId, result);
     } catch (error) {
-      this.options.state.patch({ error: this.options.formatError(error) });
+      const message = this.formatSlashCommandError(command, error);
+      this.options.state.patch({
+        error: message,
+        commandResults: this.appendCommandResult({
+          handled: true,
+          kind: 'message',
+          message,
+        }),
+        commandResultExpanded: true,
+      });
     } finally {
       this.options.state.patch({ submitting: false });
     }
@@ -116,5 +125,18 @@ export class ControlPlaneSlashCommandController {
 
   private appendCommandResult(result: ControlPlaneSlashCommandResult): ControlPlaneSlashCommandResult[] {
     return [...this.options.state.getSnapshot().commandResults, result].slice(-5);
+  }
+
+  private formatSlashCommandError(command: string, error: unknown): string {
+    const message = this.options.formatError(error);
+    if (!message.includes('timed out')) {
+      return `Slash command "${command}" failed. ${message}`;
+    }
+
+    return [
+      `Slash command "${command}" timed out waiting for the control plane.`,
+      message,
+      'Server-side work may still finish; watch the activity/status line for follow-up updates.',
+    ].join(' ');
   }
 }

--- a/src/client-shared/api/links.ts
+++ b/src/client-shared/api/links.ts
@@ -3,8 +3,12 @@ import {
   httpLink,
   httpSubscriptionLink,
   splitLink,
+  TRPCClientError,
+  type Operation,
+  type OperationContext,
   type TRPCLink,
 } from '@trpc/client';
+import { observable } from '@trpc/server/observable';
 import type { EventSource } from 'eventsource';
 import type { AppRouter } from '@/server/router.js';
 
@@ -16,6 +20,7 @@ export type CreateControlPlaneTrpcLinksOptions = {
 };
 
 const DEFAULT_CONTROL_PLANE_REQUEST_TIMEOUT_MS = 30_000;
+export const CONTROL_PLANE_REQUEST_TIMEOUT_CONTEXT_KEY = 'requestTimeoutMs';
 
 /**
  * Shared tRPC link service for frontend API consumers.
@@ -30,10 +35,10 @@ export class ClientSharedApiLinkService {
     eventSource,
     requestTimeoutMs = DEFAULT_CONTROL_PLANE_REQUEST_TIMEOUT_MS,
   }: CreateControlPlaneTrpcLinksOptions): TRPCLink<AppRouter>[] {
-    const fetch = createControlPlaneRequestFetch({ timeoutMs: requestTimeoutMs });
-    const requestLink = batch ? httpBatchLink({ url, fetch }) : httpLink({ url, fetch });
+    const requestLink = batch ? httpBatchLink({ url }) : httpLink({ url });
 
     return [
+      createControlPlaneRequestTimeoutLink({ defaultTimeoutMs: requestTimeoutMs }),
       splitLink({
         condition: (operation) => operation.type === 'subscription',
         true: httpSubscriptionLink({ url, EventSource: eventSource }),
@@ -41,6 +46,58 @@ export class ClientSharedApiLinkService {
       }),
     ];
   }
+}
+
+export function createControlPlaneRequestContext({
+  timeoutMs,
+}: {
+  timeoutMs: number;
+}): OperationContext {
+  return {
+    [CONTROL_PLANE_REQUEST_TIMEOUT_CONTEXT_KEY]: timeoutMs,
+  };
+}
+
+export function createControlPlaneRequestTimeoutLink({
+  defaultTimeoutMs = DEFAULT_CONTROL_PLANE_REQUEST_TIMEOUT_MS,
+}: {
+  defaultTimeoutMs?: number;
+} = {}): TRPCLink<AppRouter> {
+  return () => ({ op, next }) => observable((observer) => {
+    const timeoutMs = resolveControlPlaneRequestTimeoutMs(op, defaultTimeoutMs);
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return next(op).subscribe(observer);
+    }
+
+    const timeoutId = setTimeout(() => {
+      subscription.unsubscribe();
+      observer.error(TRPCClientError.from(new Error(`Control-plane request "${op.path}" timed out after ${timeoutMs}ms.`)));
+    }, timeoutMs);
+    const subscription = next(op).subscribe({
+      next: (value) => observer.next(value),
+      error: (error) => {
+        clearTimeout(timeoutId);
+        observer.error(error);
+      },
+      complete: () => {
+        clearTimeout(timeoutId);
+        observer.complete();
+      },
+    });
+
+    return () => {
+      clearTimeout(timeoutId);
+      subscription.unsubscribe();
+    };
+  });
+}
+
+function resolveControlPlaneRequestTimeoutMs(
+  op: Operation,
+  defaultTimeoutMs: number,
+): number {
+  const candidate = op.context[CONTROL_PLANE_REQUEST_TIMEOUT_CONTEXT_KEY];
+  return typeof candidate === 'number' ? candidate : defaultTimeoutMs;
 }
 
 export function createControlPlaneRequestFetch({

--- a/src/client-shared/api/links.ts
+++ b/src/client-shared/api/links.ts
@@ -41,6 +41,9 @@ export class ClientSharedApiLinkService {
       splitLink({
         condition: (operation) => operation.type === 'subscription',
         true: httpSubscriptionLink({ url, EventSource: eventSource }),
+        // Only request/response operations use the timeout link. Subscriptions
+        // are long-lived event streams, so timing them out would disconnect live
+        // session updates even when the control plane is healthy.
         false: [
           createControlPlaneRequestTimeoutLink({ defaultTimeoutMs: requestTimeoutMs }),
           requestLink,
@@ -50,6 +53,8 @@ export class ClientSharedApiLinkService {
   }
 }
 
+// Per-operation timeout override for intentionally long request/response calls
+// such as slash commands that may compact or summarize a large conversation.
 export function createControlPlaneRequestContext({
   timeoutMs,
 }: {
@@ -60,12 +65,17 @@ export function createControlPlaneRequestContext({
   };
 }
 
+// Applies a client-side timeout to finite control-plane requests. This is kept
+// as a tRPC link so every shared API consumer gets the same timeout behavior
+// without duplicating host-specific fetch or command handling.
 export function createControlPlaneRequestTimeoutLink({
   defaultTimeoutMs = DEFAULT_CONTROL_PLANE_REQUEST_TIMEOUT_MS,
 }: {
   defaultTimeoutMs?: number;
 } = {}): TRPCLink<AppRouter> {
   return () => ({ op, next }) => observable((observer) => {
+    // Defensive guard: this link should only be installed on the request branch,
+    // but subscriptions must never inherit finite request timeouts.
     if (op.type === 'subscription') {
       return next(op).subscribe(observer);
     }
@@ -98,6 +108,8 @@ export function createControlPlaneRequestTimeoutLink({
   });
 }
 
+// Reads the operation override set by createControlPlaneRequestContext and
+// falls back to the shared default resolved at link creation time.
 function resolveControlPlaneRequestTimeoutMs(
   op: Operation,
   defaultTimeoutMs: number,
@@ -106,6 +118,9 @@ function resolveControlPlaneRequestTimeoutMs(
   return typeof candidate === 'number' ? candidate : defaultTimeoutMs;
 }
 
+// Fetch-level timeout for request transports that need AbortSignal support.
+// It preserves upstream cancellation reasons so tRPC/client callers can still
+// distinguish caller cancellation from a control-plane timeout.
 export function createControlPlaneRequestFetch({
   fetchImpl = globalThis.fetch,
   timeoutMs = DEFAULT_CONTROL_PLANE_REQUEST_TIMEOUT_MS,

--- a/src/client-shared/api/links.ts
+++ b/src/client-shared/api/links.ts
@@ -38,11 +38,13 @@ export class ClientSharedApiLinkService {
     const requestLink = batch ? httpBatchLink({ url }) : httpLink({ url });
 
     return [
-      createControlPlaneRequestTimeoutLink({ defaultTimeoutMs: requestTimeoutMs }),
       splitLink({
         condition: (operation) => operation.type === 'subscription',
         true: httpSubscriptionLink({ url, EventSource: eventSource }),
-        false: requestLink,
+        false: [
+          createControlPlaneRequestTimeoutLink({ defaultTimeoutMs: requestTimeoutMs }),
+          requestLink,
+        ],
       }),
     ];
   }
@@ -64,6 +66,10 @@ export function createControlPlaneRequestTimeoutLink({
   defaultTimeoutMs?: number;
 } = {}): TRPCLink<AppRouter> {
   return () => ({ op, next }) => observable((observer) => {
+    if (op.type === 'subscription') {
+      return next(op).subscribe(observer);
+    }
+
     const timeoutMs = resolveControlPlaneRequestTimeoutMs(op, defaultTimeoutMs);
     if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
       return next(op).subscribe(observer);

--- a/src/core/chat/engine/turns/failure/failure-message-formatter.ts
+++ b/src/core/chat/engine/turns/failure/failure-message-formatter.ts
@@ -5,6 +5,14 @@ import type { ConversationTurnFailureHintOptions } from './types.js';
  */
 export class ConversationTurnFailureMessages {
   static format(message: string, options: ConversationTurnFailureHintOptions): string {
+    if (ConversationTurnFailureMessages.looksLikeContextWindowOverload(message)) {
+      const sizeHint =
+        typeof options.estimatedHistoryTokens === 'number' ?
+          ` Current session history is estimated at about ${options.estimatedHistoryTokens.toLocaleString()} tokens before the next request.`
+        : '';
+      return `${message}\n\nThis failed because the current prompt plus session history exceeded the model context window.${sizeHint} Heddle will automatically compact earlier history for the next retry.`;
+    }
+
     if (ConversationTurnFailureMessages.looksLikeAnthropicInputRateLimit(message)) {
       const sizeHint =
         typeof options.estimatedHistoryTokens === 'number' ?
@@ -18,6 +26,23 @@ export class ConversationTurnFailureMessages {
     }
 
     return message;
+  }
+
+  static shouldForceCompactionAfterFailure(message: string): boolean {
+    return ConversationTurnFailureMessages.looksLikeContextWindowOverload(message);
+  }
+
+  private static looksLikeContextWindowOverload(message: string): boolean {
+    const normalized = message.toLowerCase();
+    return [
+      'exceeds the context window',
+      'exceeded the context window',
+      'context window exceeded',
+      'context length exceeded',
+      'maximum context length',
+      'prompt is too long',
+      'input is too long',
+    ].some((phrase) => normalized.includes(phrase));
   }
 
   private static looksLikeAnthropicInputRateLimit(message: string): boolean {

--- a/src/core/chat/engine/turns/persistence/turn-artifacts.ts
+++ b/src/core/chat/engine/turns/persistence/turn-artifacts.ts
@@ -27,6 +27,7 @@ export class ConversationTurnArtifacts {
       runtime: compactionRuntime,
       session: args.session,
       request: compactionRequest,
+      force: ConversationTurnFailureMessages.shouldForceCompactionAfterFailure(args.result.summary),
       summarizer: args.summarizer,
       onStatusChange: (event) => args.onCompactionStatus?.(event, sourceHistory),
     });


### PR DESCRIPTION
## Summary
- move control-plane request timeout enforcement into a shared tRPC link that can honor per-operation timeout context
- give cli-v2 slash command execution a 5 minute request budget so /compact does not falsely fail after 30 seconds
- surface slash command failures in both the prompt error line and command-result panel with command-specific context
- force final-turn compaction automatically when a failed model call clearly reports context-window/context-length overload

## Verification
- yarn lint
- yarn build
- yarn test src/__tests__/unit/client-shared/api-links.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/unit/core/conversation-turn-failure-messages.test.ts src/__tests__/unit/core/chat-turn-persistence.test.ts