### PR TITLE
[codex] Fix TUI local command shortcuts

### DIFF
--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -305,6 +305,23 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('records local TUI command messages without calling slash command execution', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    store.showLocalCommandMessage('No recent edit diffs are available to review.');
+
+    expect(store.getSnapshot().commandResults.at(-1)).toEqual({
+      handled: true,
+      kind: 'message',
+      message: 'No recent edit diffs are available to review.',
+    });
+    expect(store.getSnapshot().commandResultExpanded).toBe(true);
+    expect(fixture.calls.slashCommandExecuteMutate).not.toHaveBeenCalled();
+    store.dispose();
+  });
+
   it('collapses command results when a live run-start event arrives', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });

--- a/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
+++ b/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
@@ -128,7 +128,7 @@ describe('cli-v2 ConversationPanel', () => {
     expect(view.container.textContent).toContain('Activity');
     expect(view.container.textContent).toContain('Agent tool activities');
     expect(view.container.textContent).toContain('1 item');
-    expect(view.container.textContent).toContain('press a to expand');
+    expect(view.container.textContent).toContain('/a to expand');
     expect(view.container.textContent).not.toContain('docs/index.md');
     expect(view.container.textContent).not.toContain('+new');
   });
@@ -171,7 +171,7 @@ describe('cli-v2 ConversationPanel', () => {
       />,
     );
 
-    expect(view.container.textContent).toContain('press a to collapse');
+    expect(view.container.textContent).toContain('/a to collapse');
     expect(view.container.textContent).toContain('Edit diff');
     expect(view.container.textContent).toContain('docs/index.md');
     expect(view.container.textContent).toContain('+new');

--- a/src/__tests__/unit/cli-v2/recent-edit-diff-review.test.tsx
+++ b/src/__tests__/unit/cli-v2/recent-edit-diff-review.test.tsx
@@ -21,7 +21,7 @@ describe('cli-v2 recent edit diff review', () => {
 
     expect(view.container.textContent).toContain('Recent edits: 2 edits across 2 files');
     expect(view.container.textContent).toContain('run done');
-    expect(view.container.textContent).toContain('press d to review');
+    expect(view.container.textContent).toContain('type /d to review');
     expect(view.container.textContent).not.toContain('@@ -1,2 +1,2 @@');
   });
 
@@ -63,16 +63,13 @@ describe('cli-v2 recent edit diff review', () => {
     expect(view.container.textContent).not.toContain('src/file-1.ts');
   });
 
-  it('opens from an empty prompt and ignores normal draft text', () => {
+  it('opens only through explicit review mode actions', () => {
     const { result } = renderHook(() => useRecentEditDiffReview(createDiffs(1)));
 
-    act(() => {
-      expect(result.current.handlePromptSpecialKey('d', {}, 'draft')).toBe(false);
-    });
     expect(result.current.mode).toBe('summary');
 
     act(() => {
-      expect(result.current.handlePromptSpecialKey('d', {}, '')).toBe(true);
+      result.current.open();
     });
     expect(result.current.mode).toBe('review');
   });

--- a/src/__tests__/unit/cli-v2/tui-local-slash-command-service.test.ts
+++ b/src/__tests__/unit/cli-v2/tui-local-slash-command-service.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TuiLocalSlashCommandService } from '@/cli-v2/services/slash-commands/index.js';
+
+describe('TuiLocalSlashCommandService', () => {
+  it('exposes terminal presentation commands consistently', () => {
+    expect(TuiLocalSlashCommandService.hints()).toEqual([
+      { command: '/a', description: 'toggle terminal activity details' },
+      { command: '/activity', description: 'toggle terminal activity details' },
+      { command: '/d', description: 'open terminal diff review' },
+      { command: '/diff', description: 'open terminal diff review' },
+      { command: '/c', description: 'toggle terminal command output' },
+      { command: '/commands', description: 'toggle terminal command output' },
+    ]);
+  });
+
+  it('executes aliases without falling through to control-plane slash commands', () => {
+    const activity = vi.fn();
+    const diff = vi.fn();
+    const commandResults = vi.fn();
+
+    expect(TuiLocalSlashCommandService.execute('/a', { activity, diff, commandResults })).toBe(true);
+    expect(TuiLocalSlashCommandService.execute('/DIFF', { activity, diff, commandResults })).toBe(true);
+    expect(TuiLocalSlashCommandService.execute(' /commands ', { activity, diff, commandResults })).toBe(true);
+    expect(TuiLocalSlashCommandService.execute('/model', { activity, diff, commandResults })).toBe(false);
+
+    expect(activity).toHaveBeenCalledTimes(1);
+    expect(diff).toHaveBeenCalledTimes(1);
+    expect(commandResults).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -1,7 +1,7 @@
 // Keep this root component thin: wire top-level app state and render surfaces
 // only. Put feature behavior in cli-v2 hooks, services, or focused components
 // instead of growing App.tsx directly.
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { AgentPlanPanel } from './components/AgentPlanPanel.js';
@@ -17,9 +17,9 @@ import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
 import { useRecentEditDiffReview } from './hooks/useRecentEditDiffReview.js';
 import { PromptActivityService } from './services/activities/prompt-activity-service.js';
+import { TuiLocalSlashCommandService } from './services/slash-commands/index.js';
 import { ClientSharedSessionTurnPresentationService } from '@/client-shared/services/session-turn-presentation/index.js';
 import type { ControlPlaneApprovalDecision } from '@/client-shared/api/types.js';
-import type { PromptInputKey } from './components/PromptInput.js';
 import type {
   ControlPlaneSessionStore,
   ControlPlaneSessionStoreStartInput,
@@ -69,27 +69,39 @@ export function App({
     recentEditDiffReview.handleReviewKey(input, key);
   }, { isActive: recentEditDiffReview.mode === 'review' });
 
-  const handleComposerSpecialKey = useCallback((input: string, key: PromptInputKey, draft: string) => {
-    if (recentEditDiffReview.handlePromptSpecialKey(input, key, draft)) {
-      return true;
-    }
+  const localSlashCommandHandlers = useMemo(() => ({
+    activity: () => {
+      if (!hasConversationActivityGroups) {
+        store.showLocalCommandMessage('No agent tool activities are available to expand.');
+        return;
+      }
 
-    if (draft.length > 0 || key.ctrl || key.meta || key.super) {
-      return false;
-    }
+      setActivityExpanded((current) => !current);
+    },
+    commandResults: () => {
+      if (!hasCommandResults) {
+        store.showLocalCommandMessage('No command output is available to expand.');
+        return;
+      }
 
-    const handlers: Record<string, (() => void) | undefined> = {
-      a: hasConversationActivityGroups ? () => setActivityExpanded((current) => !current) : undefined,
-      c: hasCommandResults ? () => store.toggleCommandResultExpanded() : undefined,
-    };
-    const handler = handlers[input];
-    if (!handler) {
-      return false;
-    }
+      store.toggleCommandResultExpanded();
+    },
+    diff: () => {
+      if (!recentEditDiffReview.hasDiffs) {
+        store.showLocalCommandMessage('No recent edit diffs are available to review.');
+        return;
+      }
 
-    handler();
-    return true;
-  }, [hasCommandResults, hasConversationActivityGroups, recentEditDiffReview, store]);
+      recentEditDiffReview.open();
+    },
+  }), [hasCommandResults, hasConversationActivityGroups, recentEditDiffReview, store]);
+  const localSlashCommandHints = useMemo(
+    () => TuiLocalSlashCommandService.hints(),
+    [],
+  );
+  const executeLocalSlashCommand = useCallback((command: string) => (
+    TuiLocalSlashCommandService.execute(command, localSlashCommandHandlers)
+  ), [localSlashCommandHandlers]);
 
   return (
     <Box flexDirection="column" paddingX={1}>
@@ -146,7 +158,8 @@ export function App({
         store={store}
         snapshot={snapshot}
         keyboardDisabled={recentEditDiffReview.mode === 'review'}
-        onSpecialKey={handleComposerSpecialKey}
+        localSlashCommandHints={localSlashCommandHints}
+        onLocalSlashCommand={executeLocalSlashCommand}
       />
       <RuntimeStatusBar snapshot={snapshot} />
     </Box>

--- a/src/cli-v2/README.md
+++ b/src/cli-v2/README.md
@@ -27,6 +27,13 @@
 - `services/`: TUI-specific domain services used by hooks and components.
   Services are not hooks; they centralize terminal-only logic behind clear
   class boundaries.
+- TUI-local slash-style commands such as `/a`, `/d`, and `/c` may live under
+  `services/slash-commands` only when their entire effect is Ink-local
+  presentation state, such as expanding a terminal disclosure row or opening a
+  focused terminal review panel. Put commands in core/control-plane slash
+  modules when they affect shared session/runtime/model/auth/heartbeat/
+  compaction/workspace behavior, or when web-v2 and programmatic hosts should
+  observe the same command semantics.
 - `components/`: terminal rendering components.
 - `main.ts`: public terminal bootstrap and command routing.
 - `index.tsx`: interactive TUI entrypoint that receives a tRPC URL from

--- a/src/cli-v2/components/CommandResultPanel.tsx
+++ b/src/cli-v2/components/CommandResultPanel.tsx
@@ -22,7 +22,7 @@ export function CommandResultPanel({
     <Box flexDirection="column" marginTop={1}>
       <Text>
         <Text color="green">Command</Text>
-        <Text dimColor> · press c to collapse</Text>
+        <Text dimColor> · /c to collapse</Text>
       </Text>
       {visibleResults.map((result, index) => (
         <Box key={index} flexDirection="column" marginTop={index === 0 ? 0 : 1}>
@@ -47,7 +47,7 @@ function CollapsedCommandResult({
       <Text>
         <Text color="green">Command</Text>
         <Text dimColor> · {summarizeResult(result)}</Text>
-        <Text dimColor> · press c to expand</Text>
+        <Text dimColor> · /c to expand</Text>
       </Text>
     </Box>
   );

--- a/src/cli-v2/components/ComposerPanel.tsx
+++ b/src/cli-v2/components/ComposerPanel.tsx
@@ -10,16 +10,20 @@ import { useFileMentionPicker } from '../hooks/useFileMentionPicker.js';
 import { usePromptDraft } from '../hooks/usePromptDraft.js';
 import { usePromptPickers } from '../hooks/usePromptPickers.js';
 import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input/index.js';
+import { SlashCommandAutocompleteService } from '../services/slash-commands/index.js';
 import type {
   ControlPlaneSessionStore,
   ControlPlaneSessionStoreSnapshot,
 } from '../state/control-plane-session-store.js';
+import type { ControlPlaneSlashCommandHint } from '@/client-shared/api/types.js';
 import type { PromptInputKey } from './PromptInput.js';
 
 type ComposerPanelProps = {
   store: ControlPlaneSessionStore;
   snapshot: ControlPlaneSessionStoreSnapshot;
   keyboardDisabled?: boolean;
+  localSlashCommandHints?: ControlPlaneSlashCommandHint[];
+  onLocalSlashCommand?: (command: string) => boolean;
   onSpecialKey?: (input: string, key: PromptInputKey, draft: string) => boolean;
 };
 
@@ -35,6 +39,8 @@ export const ComposerPanel = React.memo(function ComposerPanel({
   store,
   snapshot,
   keyboardDisabled = false,
+  localSlashCommandHints = [],
+  onLocalSlashCommand,
   onSpecialKey,
 }: ComposerPanelProps) {
   const {
@@ -50,7 +56,10 @@ export const ComposerPanel = React.memo(function ComposerPanel({
   } = usePromptDraft();
   const submitDisabled = snapshot.loading || snapshot.submitting || Boolean(snapshot.pendingDirectShellConfirmation);
   const inputDisabled = snapshot.loading || Boolean(snapshot.pendingDirectShellConfirmation) || Boolean(snapshot.pendingApproval);
-  const slashCommandHints = store.getSlashCommandHints(draft);
+  const slashCommandHints = [
+    ...SlashCommandAutocompleteService.filterHints(draft, localSlashCommandHints),
+    ...store.getSlashCommandHints(draft),
+  ];
   const directShellDraft = ClientSharedPromptInputService.parseDirectShellDraft(draft);
   const pickers = usePromptPickers({
     draft,
@@ -88,12 +97,17 @@ export const ComposerPanel = React.memo(function ComposerPanel({
     }
 
     clearDraft();
+    if (onLocalSlashCommand?.(trimmed)) {
+      return;
+    }
+
     if (!trimmed.startsWith('/')) {
       recordSubmittedPrompt(trimmed);
     }
     void store.submitPrompt(value);
   }, [
     clearDraft,
+    onLocalSlashCommand,
     pickers,
     recordSubmittedPrompt,
     store,
@@ -147,7 +161,12 @@ export const ComposerPanel = React.memo(function ComposerPanel({
         cursor={cursor}
         onChange={setDraftState}
         onSubmit={submitPrompt}
-        onComplete={(value) => store.completeSlashCommandDraft(value)}
+        onComplete={(value) => (
+          SlashCommandAutocompleteService.complete(value, [
+            ...SlashCommandAutocompleteService.filterHints(value, localSlashCommandHints),
+            ...store.getSlashCommandHints(value),
+          ]) ?? store.completeSlashCommandDraft(value)
+        )}
         onHistory={navigateHistory}
         onUndo={undoPromptEdit}
         onRedo={redoPromptEdit}

--- a/src/cli-v2/components/ConversationTurnActivityBlock.tsx
+++ b/src/cli-v2/components/ConversationTurnActivityBlock.tsx
@@ -34,7 +34,7 @@ export function ConversationTurnActivityBlock({
       <Text>
         <Text color="cyan">Agent tool activities</Text>
         <Text dimColor> · {formatActivityCount(item.activities.length)}</Text>
-        <Text dimColor>{expanded ? ' · press a to collapse' : ' · press a to expand'}</Text>
+        <Text dimColor>{expanded ? ' · /a to collapse' : ' · /a to expand'}</Text>
       </Text>
       {expanded ? (
         <Box flexDirection="column" marginTop={1} paddingLeft={2}>

--- a/src/cli-v2/components/RecentEditDiffPanel.tsx
+++ b/src/cli-v2/components/RecentEditDiffPanel.tsx
@@ -42,8 +42,8 @@ function RecentEditDiffSummary({
       <Text dimColor>Recent edits: </Text>
       <Text>{formatDiffScope(diffs)}</Text>
       <Text dimColor>{running ? ' · run active' : ' · run done'}</Text>
-      <Text dimColor> · press </Text>
-      <Text color="cyan">d</Text>
+      <Text dimColor> · type </Text>
+      <Text color="cyan">/d</Text>
       <Text dimColor> to review</Text>
     </Box>
   );

--- a/src/cli-v2/hooks/useRecentEditDiffReview.ts
+++ b/src/cli-v2/hooks/useRecentEditDiffReview.ts
@@ -13,7 +13,6 @@ export type RecentEditDiffReviewState = {
   close: () => void;
   next: () => void;
   previous: () => void;
-  handlePromptSpecialKey: (input: string, key: PromptInputKey, draft: string) => boolean;
   handleReviewKey: (input: string, key: PromptInputKey) => boolean;
 };
 
@@ -69,19 +68,6 @@ export function useRecentEditDiffReview(diffs: ClientSharedRecentEditDiff[]): Re
     move(-1);
   }, [move]);
 
-  const handlePromptSpecialKey = useCallback((input: string, key: PromptInputKey, draft: string) => {
-    if (!hasDiffs || mode === 'review' || key.ctrl || key.meta || key.super || draft.length > 0) {
-      return false;
-    }
-
-    if (input !== 'd') {
-      return false;
-    }
-
-    open();
-    return true;
-  }, [hasDiffs, mode, open]);
-
   const handleReviewKey = useCallback((input: string, key: PromptInputKey) => {
     if (mode !== 'review') {
       return false;
@@ -114,12 +100,10 @@ export function useRecentEditDiffReview(diffs: ClientSharedRecentEditDiff[]): Re
     close,
     next,
     previous,
-    handlePromptSpecialKey,
     handleReviewKey,
   }), [
     close,
     diffs,
-    handlePromptSpecialKey,
     handleReviewKey,
     hasDiffs,
     mode,

--- a/src/cli-v2/services/README.md
+++ b/src/cli-v2/services/README.md
@@ -33,5 +33,11 @@ Current domains:
   API runtime defaults, subscriptions, and run-state polling that are specific
   to Ink rendering and cli-v2 store coordination.
 - `slash-commands/`: local hint filtering and tab completion over
-  control-plane-provided slash command metadata.
+  control-plane-provided slash command metadata, plus TUI-local slash-style
+  commands whose entire effect is terminal presentation state. Keep commands
+  here only when they operate on Ink-local UI state such as disclosure expansion,
+  focused terminal review mode, or terminal-only result visibility. Put commands
+  in core/control-plane slash modules when they affect shared session, runtime,
+  model, auth, heartbeat, compaction, or workspace behavior, or when another
+  host should observe the same command semantics.
 - `status/`: terminal status-bar formatting over control-plane runtime context.

--- a/src/cli-v2/services/slash-commands/index.ts
+++ b/src/cli-v2/services/slash-commands/index.ts
@@ -1,1 +1,5 @@
 export { SlashCommandAutocompleteService } from './slash-command-autocomplete-service.js';
+export {
+  TuiLocalSlashCommandService,
+  type TuiLocalSlashCommandHandlers,
+} from './tui-local-slash-command-service.js';

--- a/src/cli-v2/services/slash-commands/tui-local-slash-command-service.ts
+++ b/src/cli-v2/services/slash-commands/tui-local-slash-command-service.ts
@@ -1,0 +1,66 @@
+import type { ControlPlaneSlashCommandHint } from '@/client-shared/api/types.js';
+
+export type TuiLocalSlashCommandAction = 'activity' | 'diff' | 'commandResults';
+
+export type TuiLocalSlashCommandHandlers = Record<TuiLocalSlashCommandAction, () => void>;
+
+type TuiLocalSlashCommandDefinition = {
+  action: TuiLocalSlashCommandAction;
+  commands: string[];
+  description: string;
+};
+
+/**
+ * Owns slash-style commands whose entire effect is cli-v2 terminal presentation.
+ *
+ * Put a command here only when it operates on Ink-local UI state that another
+ * host cannot observe or rely on: expanding a disclosure row, opening a focused
+ * terminal review panel, or toggling a terminal-only result view. These commands
+ * may reuse slash syntax for discoverability, but they are not shared command
+ * semantics and must not require a control-plane API call to complete.
+ *
+ * Put a command in the core/control-plane slash registry when it affects shared
+ * session, runtime, model, auth, heartbeat, compaction, or workspace behavior,
+ * or when web-v2/programmatic hosts should see the same command and result.
+ * If a future command needs both shared effects and TUI presentation changes,
+ * keep the shared operation in core/control-plane and let cli-v2 react to the
+ * returned state instead of moving core policy into this service.
+ */
+export class TuiLocalSlashCommandService {
+  private static readonly definitions: TuiLocalSlashCommandDefinition[] = [
+    {
+      action: 'activity',
+      commands: ['/a', '/activity'],
+      description: 'toggle terminal activity details',
+    },
+    {
+      action: 'diff',
+      commands: ['/d', '/diff'],
+      description: 'open terminal diff review',
+    },
+    {
+      action: 'commandResults',
+      commands: ['/c', '/commands'],
+      description: 'toggle terminal command output',
+    },
+  ];
+
+  static hints(): ControlPlaneSlashCommandHint[] {
+    return TuiLocalSlashCommandService.definitions.flatMap((definition) => (
+      definition.commands.map((command) => ({ command, description: definition.description }))
+    ));
+  }
+
+  static execute(command: string, handlers: TuiLocalSlashCommandHandlers): boolean {
+    const normalized = command.trim().toLowerCase();
+    const definition = TuiLocalSlashCommandService.definitions
+      .find((candidate) => candidate.commands.includes(normalized));
+
+    if (!definition) {
+      return false;
+    }
+
+    handlers[definition.action]();
+    return true;
+  }
+}

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -239,6 +239,16 @@ export class ControlPlaneSessionStore {
     }));
   }
 
+  showLocalCommandMessage(message: string): void {
+    this.state.patch((current) => ({
+      commandResults: [
+        ...current.commandResults,
+        { handled: true, kind: 'message', message } as const,
+      ].slice(-5),
+      commandResultExpanded: true,
+    }));
+  }
+
   private async refreshSlashCommandCatalog(workspaceId: string): Promise<void> {
     const slashCommandCatalog = await this.api.getSlashCommandCatalog(workspaceId);
     this.state.patch({ slashCommandCatalog });


### PR DESCRIPTION
## Summary

- move TUI-only activity, diff-review, and command-output toggles to slash-style local commands
- add short aliases `/a`, `/d`, and `/c` alongside `/activity`, `/diff`, and `/commands`
- remove bare printable-letter composer shortcuts so `a`, `d`, and `c` type normally in prompts
- document that these commands belong in `cli-v2` because they only change terminal presentation state

## Why

The composer called special-key handlers before normal text insertion, so an empty prompt could swallow ordinary first characters like `a` or `d`. These toggles are terminal display state, not shared session or runtime semantics, so routing them through the core/control-plane slash-command registry would put the behavior in the wrong layer.

Approval prompts keep their `[a] approve` and `[d] deny` behavior because prompt input is blocked while approval mode owns the keyboard.

## Verification

- `yarn test src/__tests__/unit/cli-v2/tui-local-slash-command-service.test.ts src/__tests__/unit/cli-v2/recent-edit-diff-review.test.tsx src/__tests__/unit/cli-v2/conversation-panel.test.tsx src/__tests__/unit/cli-v2/control-plane-session-store.test.ts`
- `yarn typecheck`
- `yarn lint`
- `yarn build`
