### PR TITLE
[codex] Add autopilot approval policy foundation

### DIFF
--- a/examples/programmatic-loop.ts
+++ b/examples/programmatic-loop.ts
@@ -111,6 +111,10 @@ function formatTraceEvent(event: TraceEvent): string {
       return `[trace] model.retry step=${event.step} reason=${event.reason} attempt=${event.attempt}/${event.maxAttempts} retryAfterMs=${event.retryAfterMs} message=${JSON.stringify(shorten(event.message))}`;
     case 'host.warning':
       return `[trace] host.warning step=${event.step} code=${event.code} message=${JSON.stringify(shorten(event.message))}`;
+    case 'autonomy.decision':
+      return `[trace] autonomy.decision step=${event.step} tool=${event.evaluation.call.tool} decision=${event.evaluation.decision.type} reason=${JSON.stringify(shorten(event.evaluation.decision.reason))}`;
+    case 'autonomy.postflight':
+      return `[trace] autonomy.postflight step=${event.step} tool=${event.audit.call.tool} decision=${event.audit.decision} reason=${JSON.stringify(shorten(event.audit.reason ?? ''))}`;
     case 'tool.approval_requested':
       return `[trace] tool.approval_requested step=${event.step} tool=${event.call.tool}`;
     case 'tool.approval_resolved':

--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
 import { AgentRunService } from '../../../core/agent/index.js';
 import type { AgentRunEvent } from '../../../core/agent/index.js';
+import { ToolApprovalPolicies, type AutopilotProfile } from '../../../core/approvals/index.js';
 import type { ChatMessage, LlmAdapter, LlmResponse } from '../../../core/llm/types.js';
 import type { ToolDefinition } from '../../../core/types.js';
 import { createLogger } from '../../../core/utils/logger.js';
@@ -829,6 +830,97 @@ describe('AgentRunService.run', () => {
       },
       step: 1,
       timestamp: expect.any(String),
+    }));
+  });
+
+  it('records autonomy decision traces when autopilot denies before human approval', async () => {
+    const approveToolCall = vi.fn(async () => ({ approved: true, reason: 'should not be requested' }));
+    const fakeLlm: LlmAdapter = {
+      async chat(messages): Promise<LlmResponse> {
+        if (messages.some((message) => message.role === 'tool')) {
+          return { content: 'The destructive command was blocked by autopilot.' };
+        }
+
+        return {
+          toolCalls: [{
+            id: 'call-1',
+            tool: 'run_shell_mutate',
+            input: {
+              command: 'rm -rf ~',
+              policy: {
+                operations: ['delete'],
+                intent: 'cleanup temporary files',
+                targetRoots: ['.'],
+                expectedEffects: ['cleanup temporary files'],
+                maxDestructiveScope: 'single-file',
+                environment: 'local',
+                confidence: 'high',
+              },
+            },
+          }],
+        };
+      },
+    };
+    const profile: AutopilotProfile = {
+      mode: 'autopilot',
+      roots: [{
+        path: '.',
+        access: 'autopilot',
+        allow: ['read', 'write', 'execute', 'simple-delete'],
+      }],
+      environments: {
+        allow: ['local', 'dev'],
+        requireApproval: ['staging', 'production', 'unknown'],
+      },
+    };
+    const mutateTool: ToolDefinition = {
+      name: 'run_shell_mutate',
+      description: 'Runs a bounded workspace mutation command',
+      requiresApproval: true,
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        return { ok: true, output: 'should not run' };
+      },
+    };
+
+    const result = await AgentRunService.run({
+      goal: 'Clean up temporary files.',
+      llm: fakeLlm,
+      tools: [mutateTool],
+      maxSteps: 3,
+      logger: silentLogger,
+      approvalPolicies: [ToolApprovalPolicies.autopilot({ profile })],
+      approveToolCall,
+      workspaceRoot: '/workspace/current',
+    });
+
+    expect(result.outcome).toBe('done');
+    expect(approveToolCall).not.toHaveBeenCalled();
+    expect(result.trace.map((event) => event.type)).toContain('autonomy.decision');
+    expect(result.trace.map((event) => event.type)).not.toContain('tool.approval_requested');
+    expect(result.trace).toContainEqual(expect.objectContaining({
+      type: 'autonomy.decision',
+      evaluation: expect.objectContaining({
+        decision: expect.objectContaining({
+          type: 'deny',
+          reason: 'root/home recursive deletion is blocked',
+        }),
+        envelope: expect.objectContaining({
+          operations: ['delete'],
+          intent: 'cleanup temporary files',
+        }),
+        facts: expect.objectContaining({
+          command: 'rm -rf ~',
+          hardDenyReasons: ['root/home recursive deletion is blocked'],
+        }),
+      }),
+    }));
+    expect(result.trace).toContainEqual(expect.objectContaining({
+      type: 'tool.completed',
+      result: expect.objectContaining({
+        ok: false,
+        error: 'Approval denied for run_shell_mutate: root/home recursive deletion is blocked',
+      }),
     }));
   });
 

--- a/src/__tests__/unit/core/approval-policy-chain.test.ts
+++ b/src/__tests__/unit/core/approval-policy-chain.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   ToolApprovalPolicies,
   ToolApprovalService,
+  type AutopilotProfile,
 } from '@/core/approvals/index.js';
 import { ProjectApprovalRuleCodec } from '@/core/approvals/remembered-rules/index.js';
 import type { ToolApprovalPolicyContext } from '@/core/approvals/types.js';
@@ -166,6 +167,104 @@ describe('approval policy chain', () => {
       approved: false,
       reason: 'Command not allowed. This command appears catastrophically destructive (home/root/disk-level) and is blocked even in approval-gated mutate mode.',
     });
+  });
+
+  it('lets autopilot satisfy an earlier approval request when the declared envelope is allowed', async () => {
+    const service = new ToolApprovalService();
+    const human = vi.fn(async () => ({ approved: false, reason: 'should not request human approval' }));
+    const profile: AutopilotProfile = {
+      mode: 'autopilot',
+      roots: [{
+        path: '.',
+        access: 'autopilot',
+        allow: ['read', 'write', 'execute', 'verification'],
+      }],
+      environments: {
+        allow: ['local', 'dev'],
+        requireApproval: ['staging', 'production', 'unknown'],
+      },
+    };
+
+    await expect(service.resolve({
+      policies: [
+        ...ToolApprovalPolicies.default(),
+        ToolApprovalPolicies.autopilot({ profile }),
+      ],
+      context: context({
+        call: {
+          id: 'call-test',
+          tool: 'run_shell_mutate',
+          input: {
+            command: 'yarn test',
+            policy: {
+              operations: ['execute'],
+              intent: 'run local tests',
+              targetRoots: ['.'],
+              expectedEffects: ['run test suite'],
+              environment: 'local',
+              confidence: 'high',
+            },
+          },
+        },
+      }),
+      requestHumanApproval: human,
+    })).resolves.toEqual(expect.objectContaining({
+      approved: true,
+      reason: 'allowed by autopilot profile and declared policy envelope',
+      autonomyEvaluation: expect.objectContaining({
+        decision: expect.objectContaining({ type: 'allow' }),
+      }),
+    }));
+    expect(human).not.toHaveBeenCalled();
+  });
+
+  it('lets autopilot deny unsafe commands without falling through to human approval', async () => {
+    const service = new ToolApprovalService();
+    const human = vi.fn(async () => ({ approved: true, reason: 'should not request human approval' }));
+    const profile: AutopilotProfile = {
+      mode: 'autopilot',
+      roots: [{
+        path: '.',
+        access: 'autopilot',
+        allow: ['read', 'write', 'execute'],
+      }],
+      environments: {
+        allow: ['local', 'dev'],
+        requireApproval: ['staging', 'production', 'unknown'],
+      },
+    };
+
+    await expect(service.resolve({
+      policies: [
+        ...ToolApprovalPolicies.default(),
+        ToolApprovalPolicies.autopilot({ profile }),
+      ],
+      context: context({
+        call: {
+          id: 'call-rm',
+          tool: 'run_shell_mutate',
+          input: {
+            command: 'rm -rf ~',
+            policy: {
+              operations: ['delete'],
+              intent: 'cleanup',
+              targetRoots: ['.'],
+              expectedEffects: ['cleanup'],
+              environment: 'local',
+              confidence: 'high',
+            },
+          },
+        },
+      }),
+      requestHumanApproval: human,
+    })).resolves.toEqual(expect.objectContaining({
+      approved: false,
+      reason: 'root/home recursive deletion is blocked',
+      autonomyEvaluation: expect.objectContaining({
+        decision: expect.objectContaining({ type: 'deny' }),
+      }),
+    }));
+    expect(human).not.toHaveBeenCalled();
   });
 
   it('lets remembered outside-workspace read_file approvals satisfy request policies before human approval', async () => {

--- a/src/__tests__/unit/core/autonomy-policy-service.test.ts
+++ b/src/__tests__/unit/core/autonomy-policy-service.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import { AutonomyPolicyService, type AutopilotProfile } from '@/core/approvals/index.js';
+import type { ToolApprovalPolicyContext } from '@/core/approvals/types.js';
+
+const profile: AutopilotProfile = {
+  mode: 'autopilot',
+  roots: [
+    {
+      path: '.',
+      access: 'autopilot',
+      allow: ['read', 'write', 'execute', 'simple-delete', 'many-file-edit', 'verification', 'formatting', 'git-stage'],
+    },
+    {
+      path: '../sibling-repo',
+      access: 'autopilot',
+      allow: ['read', 'write', 'execute', 'many-file-edit'],
+    },
+    {
+      path: '../manual',
+      access: 'manual-only',
+    },
+    {
+      path: '../denied',
+      access: 'deny',
+    },
+  ],
+  environments: {
+    allow: ['local', 'dev'],
+    requireApproval: ['staging', 'production', 'unknown'],
+  },
+};
+
+function context(overrides: Partial<ToolApprovalPolicyContext> = {}): ToolApprovalPolicyContext {
+  return {
+    call: {
+      id: 'call-1',
+      tool: 'run_shell_mutate',
+      input: {
+        command: 'node scripts/update-sibling.js',
+        policy: {
+          operations: ['read', 'write', 'execute'],
+          intent: 'update generated imports in sibling repo',
+          targetRoots: ['../sibling-repo'],
+          expectedEffects: ['rewrite generated import paths'],
+          maxDestructiveScope: 'many-files',
+          environment: 'local',
+          confidence: 'high',
+        },
+      },
+    },
+    tool: {
+      name: 'run_shell_mutate',
+      description: 'mutates workspace',
+      requiresApproval: true,
+      parameters: {},
+      execute: async () => ({ ok: true }),
+    },
+    workspaceRoot: '/workspace/current',
+    ...overrides,
+  };
+}
+
+describe('AutonomyPolicyService', () => {
+  it('allows unknown shell when the declared envelope fits configured autopilot roots', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context(),
+      profile,
+    });
+
+    expect(evaluation.decision).toEqual(expect.objectContaining({
+      type: 'allow',
+      reason: 'allowed by autopilot profile and declared policy envelope',
+    }));
+    expect(evaluation.envelope?.operations).toEqual(['read', 'write', 'execute']);
+    expect(evaluation.facts.claimedWriteRoots).toEqual(['/workspace/sibling-repo']);
+  });
+
+  it('requests approval when an approval-gated tool is missing an envelope', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-1',
+          tool: 'run_shell_mutate',
+          input: { command: 'node scripts/update-sibling.js' },
+        },
+      }),
+      profile,
+    });
+
+    expect(evaluation.decision).toEqual(expect.objectContaining({
+      type: 'request',
+      reason: 'tool call needs a declared policy envelope',
+    }));
+  });
+
+  it('denies hard-denied roots even when the envelope claims low risk', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-edit',
+          tool: 'edit_file',
+          input: {
+            path: '../denied/secrets.txt',
+            content: 'secret',
+            createIfMissing: true,
+            policy: {
+              operations: ['read'],
+              intent: 'inspect current workspace',
+              targetRoots: ['.'],
+              expectedEffects: ['read only'],
+              environment: 'local',
+              confidence: 'high',
+            },
+          },
+        },
+        tool: {
+          name: 'edit_file',
+          description: 'edits files',
+          requiresApproval: true,
+          parameters: {},
+          execute: async () => ({ ok: true }),
+        },
+      }),
+      profile,
+    });
+
+    expect(evaluation.decision.type).toBe('deny');
+    expect(evaluation.facts.hardDenyReasons).toContain('root is hard-denied by autopilot policy: /workspace/denied/secrets.txt');
+  });
+
+  it('requests approval for manual-only roots and production environments', () => {
+    const manual = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-edit',
+          tool: 'edit_file',
+          input: {
+            path: '../manual/file.txt',
+            content: 'ok',
+            createIfMissing: true,
+            policy: {
+              operations: ['write'],
+              intent: 'write manual root',
+              targetRoots: ['../manual'],
+              expectedEffects: ['write file'],
+              environment: 'local',
+              confidence: 'high',
+            },
+          },
+        },
+        tool: {
+          name: 'edit_file',
+          description: 'edits files',
+          requiresApproval: true,
+          parameters: {},
+          execute: async () => ({ ok: true }),
+        },
+      }),
+      profile,
+    });
+    expect(manual.decision).toEqual(expect.objectContaining({
+      type: 'request',
+      reason: expect.stringContaining('root requires manual approval'),
+    }));
+
+    const production = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-shell',
+          tool: 'run_shell_mutate',
+          input: {
+            command: 'node scripts/update-sibling.js',
+            policy: {
+              operations: ['execute'],
+              intent: 'run production-like command',
+              targetRoots: ['.'],
+              expectedEffects: ['execute script'],
+              environment: 'production',
+              confidence: 'high',
+            },
+          },
+        },
+      }),
+      profile,
+    });
+    expect(production.decision).toEqual(expect.objectContaining({
+      type: 'request',
+      reason: 'environment is not allowed for unattended execution',
+    }));
+  });
+
+  it('denies deterministic catastrophic shell commands regardless of envelope', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-rm',
+          tool: 'run_shell_mutate',
+          input: {
+            command: 'rm -rf ~',
+            policy: {
+              operations: ['delete'],
+              intent: 'cleanup temporary files',
+              targetRoots: ['.'],
+              expectedEffects: ['cleanup'],
+              maxDestructiveScope: 'single-file',
+              environment: 'local',
+              confidence: 'high',
+            },
+          },
+        },
+      }),
+      profile,
+    });
+
+    expect(evaluation.decision.type).toBe('deny');
+    expect(evaluation.facts.hardDenyReasons).toContain('root/home recursive deletion is blocked');
+  });
+});

--- a/src/__tests__/unit/tools/tool-policy-envelope.test.ts
+++ b/src/__tests__/unit/tools/tool-policy-envelope.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ToolExecutionService, ToolPolicyEnvelopeSchemaService, ToolRegistry } from '@/core/tools/index.js';
+import type { ToolDefinition } from '@/core/types.js';
+
+function tool(overrides: Partial<ToolDefinition> = {}): ToolDefinition {
+  return {
+    name: 'test_tool',
+    description: 'test tool',
+    parameters: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        path: { type: 'string' },
+      },
+      required: ['path'],
+    },
+    execute: async () => ({ ok: true }),
+    ...overrides,
+  };
+}
+
+describe('tool policy envelope', () => {
+  it('adds optional policy to object-shaped tool schemas', () => {
+    const parameters = ToolPolicyEnvelopeSchemaService.addToParameters(tool().parameters);
+
+    expect(parameters).toEqual(expect.objectContaining({
+      properties: expect.objectContaining({
+        path: { type: 'string' },
+        policy: expect.objectContaining({
+          type: 'object',
+          required: ['operations', 'intent', 'targetRoots', 'expectedEffects', 'environment', 'confidence'],
+        }),
+      }),
+      required: ['path'],
+    }));
+  });
+
+  it('leaves non-object schemas and existing policy fields unchanged', () => {
+    const nonObject = { type: 'string' };
+    expect(ToolPolicyEnvelopeSchemaService.addToParameters(nonObject)).toBe(nonObject);
+
+    const withPolicy = {
+      type: 'object',
+      properties: {
+        policy: { type: 'string' },
+      },
+    };
+    expect(ToolPolicyEnvelopeSchemaService.addToParameters(withPolicy)).toBe(withPolicy);
+  });
+
+  it('keeps executable tools raw while listing model-visible augmented tools', () => {
+    const executable = tool();
+    const registry = new ToolRegistry([executable]);
+
+    expect(registry.get('test_tool')).toBe(executable);
+    expect(registry.list()[0]?.parameters).toEqual(expect.objectContaining({
+      properties: expect.objectContaining({
+        policy: expect.any(Object),
+      }),
+    }));
+  });
+
+  it('strips policy envelope before tool execution', async () => {
+    const execute = vi.fn(async () => ({ ok: true, output: 'ok' }));
+    const registry = new ToolRegistry([tool({ execute })]);
+
+    await expect(ToolExecutionService.execute(registry, {
+      id: 'call-1',
+      tool: 'test_tool',
+      input: {
+        path: 'README.md',
+        policy: {
+          operations: ['read'],
+          intent: 'inspect README',
+          targetRoots: ['.'],
+          expectedEffects: ['read README'],
+          environment: 'local',
+          confidence: 'high',
+        },
+      },
+    })).resolves.toEqual({ ok: true, output: 'ok' });
+
+    expect(execute).toHaveBeenCalledWith({ path: 'README.md' });
+  });
+
+  it('rejects invalid policy envelope before execution', async () => {
+    const execute = vi.fn(async () => ({ ok: true }));
+    const registry = new ToolRegistry([tool({ execute })]);
+
+    await expect(ToolExecutionService.execute(registry, {
+      id: 'call-1',
+      tool: 'test_tool',
+      input: {
+        path: 'README.md',
+        policy: { operations: [] },
+      },
+    })).resolves.toEqual(expect.objectContaining({
+      ok: false,
+      error: expect.stringContaining('Invalid tool policy envelope'),
+    }));
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/agent/tools/tool-dispatcher.ts
+++ b/src/core/agent/tools/tool-dispatcher.ts
@@ -1,6 +1,6 @@
 import type { Logger } from 'pino';
 import type { ToolApprovalPolicy } from '@/core/approvals/types.js';
-import { ToolApprovalPolicies, ToolApprovalService } from '@/core/approvals/index.js';
+import { AutonomyTraceService, ToolApprovalPolicies, ToolApprovalService } from '@/core/approvals/index.js';
 import { HeddleEventType } from '@/core/event-types.js';
 import { ToolActivitySummarizer } from '@/core/live/index.js';
 import { ToolExecutionService, type ToolRegistry } from '@/core/tools/index.js';
@@ -81,6 +81,13 @@ export class AgentToolDispatcher {
         return humanDecision;
       } : undefined,
     });
+    if (approval.autonomyEvaluation) {
+      live.trace(AutonomyTraceService.decision({
+        evaluation: approval.autonomyEvaluation,
+        step,
+        timestamp: now(),
+      }));
+    }
     if (approval.approved) {
       return undefined;
     }

--- a/src/core/approvals/README.md
+++ b/src/core/approvals/README.md
@@ -25,6 +25,7 @@ Approval behavior currently exists in these places:
 - `src/core/agent/tools/tool-dispatcher.ts`
 - `src/core/approvals/service.ts`
 - `src/core/approvals/policies.ts`
+- `src/core/approvals/autonomy/`
 - `src/core/approvals/remembered-rules/`
 - `src/cli-v2/components/ApprovalPanel.tsx`
 - `src/server/controllers/trpc/control-plane/chat-sessions-controller.ts`
@@ -37,7 +38,11 @@ Approval behavior currently exists in these places:
   request-to-human approval resolution, approval request view construction,
   edit previews, and remembered project approval rule application.
 - `policies.ts`: `ToolApprovalPolicies` built-in tool, workspace-boundary,
-  remembered-rule, and human-surface policy constructors.
+  remembered-rule, autonomy, and human-surface policy constructors.
+- `autonomy/`: autopilot profile normalization, tool policy evaluation,
+  computed policy facts, and autonomy trace event construction. This subdomain
+  owns approval decisions for long-running agent mode, not tool execution or
+  host presentation.
 - `remembered-rules/`: project approval rule service, repository, codec,
   schemas, and types. The repository is an internal storage boundary for
   `ToolApprovalService`; host/controller code must not import it directly.
@@ -156,6 +161,9 @@ state from event fragments.
 
 - Add a runtime approval rule by passing `approvalPolicies` into `AgentRunService.run`,
   `AgentLoopRuntimeService.run`, `HeartbeatRunnerAgent.run`, or `createConversationEngine(...).turns`.
+- Add autopilot behavior in `autonomy/` and expose it through
+  `ToolApprovalPolicies.autopilot(...)`. Do not duplicate the policy envelope
+  shape in host, trace, or tool execution layers.
 - Add host UI by instantiating `ToolApprovalService` in the host controller and
   passing its request payload to the host presentation layer.
 - Add remembered approval storage by extending `ToolApprovalService` and the
@@ -171,11 +179,15 @@ state from event fragments.
   in `ProjectApprovalRuleCodec` and Zod schemas.
 - To change approval trace behavior, update trace/event tests and host projection
   tests.
+- To change autopilot policy semantics, update `autonomy/` service tests and
+  keep trace events wrapping the domain `AutonomyEvaluation` /
+  `AutonomyPostflightAudit` shapes instead of redefining trace-only copies.
 
 ## Tests
 
 - `src/__tests__/unit/core/project-approval-rules.test.ts`
 - `src/__tests__/unit/core/approval-policy-chain.test.ts`
+- `src/__tests__/unit/core/autonomy-policy-service.test.ts`
 - `src/__tests__/integration/core/run-agent.test.ts`
 - `src/__tests__/integration/tools/tools.test.ts`
 

--- a/src/core/approvals/autonomy/README.md
+++ b/src/core/approvals/autonomy/README.md
@@ -2,6 +2,16 @@
 
 This domain owns Heddle's autopilot approval policy semantics.
 
+Autonomy is the approval layer for long-running agent work. Its job is to let
+the agent keep moving without asking for every tool call while still enforcing
+basic runtime-owned safety boundaries. It is not a sandbox and it is not a
+replacement for deterministic tool validation. It combines:
+
+- user-configured policy roots;
+- the agent's declared intent envelope;
+- runtime-computed facts from the tool call; and
+- hard-deny rules for destructive operations that should never run unattended.
+
 ## Owns
 
 - Normalized autopilot root profiles.
@@ -23,3 +33,192 @@ This domain owns Heddle's autopilot approval policy semantics.
 The agent's envelope is a claim. The autonomy policy uses it as the declared
 scope contract for ambiguous tools, but deterministic hard-deny rules and
 configured root policy remain runtime-owned.
+
+The harness must not fully trust the claim, but it also must not block every
+free-form shell command only because static parsing is incomplete. For shell
+commands and scripts, the envelope is the agent's explicit contract about the
+intended operation class, roots, environment, destructive scope, and confidence.
+Autonomy evaluates that contract against configured roots and hard-deny facts.
+
+## Example Profile
+
+Profiles are intentionally small. A profile answers: which roots may run
+unattended, which capabilities are allowed there, which roots must remain
+manual, and which environments may proceed without approval.
+
+```ts
+const profile: AutopilotProfile = {
+  mode: 'autopilot',
+  roots: [
+    {
+      path: '.', // current Heddle checkout, resolved relative to workspace root
+      access: 'autopilot',
+      allow: [
+        'read',
+        'write',
+        'execute',
+        'simple-delete',
+        'many-file-edit',
+        'verification',
+        'formatting',
+        'dependency',
+        'git-stage',
+      ],
+    },
+    {
+      path: '../heddle-workspace-notes',
+      access: 'autopilot',
+      allow: ['read', 'write', 'simple-delete', 'many-file-edit'],
+    },
+    {
+      path: '~',
+      access: 'manual-only',
+    },
+    {
+      path: '/Volumes',
+      access: 'deny',
+    },
+  ],
+  environments: {
+    allow: ['local', 'dev'],
+    requireApproval: ['staging', 'production', 'unknown'],
+  },
+};
+```
+
+Access levels:
+
+- `read`: only read claims can run unattended.
+- `write`: write-like claims may run unattended only when the listed
+  capabilities allow them.
+- `autopilot`: the root is eligible for unattended work, still constrained by
+  capabilities.
+- `manual-only`: matching calls request approval.
+- `deny`: matching calls are denied before approval fallback.
+
+Capabilities are intentionally coarse. They are policy vocabulary, not a full
+filesystem permission system. For example, `simple-delete` can allow a
+single-file delete, while `many-file-edit` is required for broad replacements or
+many-file deletion/edit scopes.
+
+## Agent Intent Envelope
+
+Every agent-callable tool can expose the same optional `policy` field through
+`src/core/tools/policy-envelope`. Tool-specific input remains owned by the tool;
+the envelope is shared product vocabulary for autonomy and trace.
+
+```ts
+type ToolPolicyEnvelope = {
+  operations: Array<'read' | 'write' | 'delete' | 'move' | 'execute' | 'git' | 'network' | 'unknown'>;
+  intent: string;
+  targetRoots: string[];
+  readRoots?: string[];
+  writeRoots?: string[];
+  expectedEffects: string[];
+  maxDestructiveScope?: 'none' | 'single-file' | 'generated-files' | 'many-files';
+  environment: 'local' | 'dev' | 'staging' | 'production' | 'unknown';
+  confidence: 'high' | 'medium' | 'low';
+};
+```
+
+`operations` is an array on purpose. Real coding work often combines actions:
+running a formatter can be `execute` plus `write`; a broad migration script may
+be `execute` plus `write`; a cleanup may be `delete` plus `git`. Forcing the
+agent to collapse the call into one operation makes the declaration less useful
+and slows the agent down.
+
+Example shell mutation claim:
+
+```json
+{
+  "command": "node scripts/rewrite-imports.js ../heddle-workspace-notes",
+  "policy": {
+    "operations": ["execute", "write"],
+    "intent": "Run a local migration script that rewrites note imports in the sibling notes repo.",
+    "targetRoots": ["../heddle-workspace-notes"],
+    "writeRoots": ["../heddle-workspace-notes"],
+    "expectedEffects": ["many markdown files may be updated"],
+    "maxDestructiveScope": "many-files",
+    "environment": "local",
+    "confidence": "medium"
+  }
+}
+```
+
+The shell command is still free-form. The policy does not try to prove every
+effect from static parsing. Instead, it checks whether the declared roots,
+operation classes, destructive scope, environment, and hard-deny facts are
+compatible with the profile.
+
+## Decision Flow
+
+`AutonomyPolicyService.evaluate(...)` produces one `AutonomyEvaluation`.
+Downstream trace and approval code should pass that shape through directly
+instead of redefining similar fields.
+
+```text
+Tool call with optional policy envelope
+  -> ToolPolicyEnvelopeInputService.extract(...)
+  -> AutopilotProfileService.normalize(...)
+  -> AutonomyPolicyService.computeFacts(...)
+  -> AutonomyPolicyService.decide(...)
+  -> ToolApprovalPolicies.autopilot(...)
+  -> allow | request approval | deny
+  -> AutonomyTraceService.decision(...) records the same AutonomyEvaluation
+```
+
+The service currently computes:
+
+- declared operations, read roots, and write roots;
+- known tool targets such as `path`, `from`, and `to`;
+- root decisions for each claimed or known target;
+- hard-deny reasons from root policy and dangerous command patterns;
+- approval reasons for unconfigured roots, manual-only roots, insufficient
+  capabilities, non-local environments, network claims, and low-confidence or
+  unknown claims;
+- policy hints that explain how the user could tune the profile after a block.
+
+Decision rules:
+
+- `deny`: hard-denied root, root/home recursive delete, workspace-wide
+  recursive delete, wildcard recursive delete, privilege escalation, hard git
+  reset, force push, disk formatting, device writes, or `terraform destroy`.
+- `request`: missing envelope for approval-gated mutating tools,
+  `unknown`/low-confidence intent, disallowed environment, manual-only root,
+  unconfigured root, missing capability, or network operation.
+- `allow`: profile is in `autopilot` mode, the envelope is specific enough, all
+  roots are configured, capabilities match, environment is allowed, and no
+  hard-deny or approval reason is present.
+
+## Trace Contract
+
+Autonomy trace exists so later sessions can understand why a long-running agent
+was blocked and how policy should be adjusted. Trace events should wrap the
+domain object:
+
+- `autonomy.decision` contains `AutonomyEvaluation`;
+- `autonomy.postflight` contains `AutonomyPostflightAudit`.
+
+Do not create a trace-only shape that renames the same fields. If another layer
+needs less data for display, project it at the presentation boundary. The core
+trace should keep the agent envelope, computed facts, decision, reason, and
+policy hints together.
+
+## Maintenance Rules
+
+- Add policy logic in `AutonomyPolicyService`, not in hosts or tool
+  implementations.
+- Add profile normalization/default behavior in `AutopilotProfileService`.
+- Add or change the shared envelope only in `src/core/tools/policy-envelope/`.
+- Keep tool execution using stripped tool input; the `policy` field is intent
+  metadata, not part of the tool's business input.
+- Keep trace shapes consistent with the domain types.
+- Add service tests for policy changes before wiring UI/config behavior.
+
+## Current Limits
+
+This service is the core policy foundation. Workspace/user profile loading,
+user-facing yolo controls, and postflight effect auditing are follow-up slices.
+The existing `AutonomyPostflightAudit` type reserves the downstream shape so the
+future implementation can record observed effects without inventing a second
+trace vocabulary.

--- a/src/core/approvals/autonomy/README.md
+++ b/src/core/approvals/autonomy/README.md
@@ -1,0 +1,25 @@
+# Approval Autonomy
+
+This domain owns Heddle's autopilot approval policy semantics.
+
+## Owns
+
+- Normalized autopilot root profiles.
+- Agent-declared policy envelope evaluation.
+- Runtime-computed autonomy facts.
+- Allow/request/deny decisions for unattended tool calls.
+- Policy hints that help future sessions tune config after a blocked run.
+
+## Does Not Own
+
+- Tool schema injection or envelope extraction. That belongs to
+  `src/core/tools/policy-envelope`.
+- Tool execution.
+- Pending approval UI or browser/TUI presentation.
+- Remembered project approval storage.
+
+## Boundary Rule
+
+The agent's envelope is a claim. The autonomy policy uses it as the declared
+scope contract for ambiguous tools, but deterministic hard-deny rules and
+configured root policy remain runtime-owned.

--- a/src/core/approvals/autonomy/index.ts
+++ b/src/core/approvals/autonomy/index.ts
@@ -1,0 +1,23 @@
+export { AutopilotProfileService, DEFAULT_INTERACTIVE_AUTOPILOT_PROFILE } from './profile-service.js';
+export { AutonomyPolicyService } from './policy-service.js';
+export { AutonomyTraceService } from './trace-service.js';
+export {
+  AutopilotCapabilitySchema,
+  AutopilotProfileSchema,
+  AutopilotRootAccessSchema,
+  AutopilotRootPolicySchema,
+} from './schemas.js';
+export type {
+  AutonomyEvaluation,
+  AutonomyPolicyHint,
+  AutonomyPostflightAudit,
+  AutopilotCapability,
+  AutopilotDecision,
+  AutopilotProfile,
+  AutopilotRootAccess,
+  AutopilotRootPolicy,
+  NormalizedAutopilotProfile,
+  NormalizedAutopilotRootPolicy,
+  ToolPolicyFacts,
+  ToolPolicyRootDecision,
+} from './types.js';

--- a/src/core/approvals/autonomy/policy-service.ts
+++ b/src/core/approvals/autonomy/policy-service.ts
@@ -1,0 +1,427 @@
+import { resolve } from 'node:path';
+import type { ToolApprovalPolicyContext, ToolApprovalPolicyDecision } from '../types.js';
+import { ToolPolicyEnvelopeInputService, type ToolPolicyEnvelope, type ToolPolicyOperation } from '@/core/tools/index.js';
+import type {
+  AutonomyEvaluation,
+  AutonomyPolicyHint,
+  AutopilotCapability,
+  AutopilotDecision,
+  AutopilotProfile,
+  NormalizedAutopilotProfile,
+  ToolPolicyFacts,
+  ToolPolicyRootDecision,
+} from './types.js';
+import { AutopilotProfileService } from './profile-service.js';
+
+const ENVELOPE_REQUIRED_TOOLS = new Set(['run_shell_mutate', 'edit_file', 'delete_file', 'move_file']);
+const MUTATING_OPERATIONS = new Set<ToolPolicyOperation>(['write', 'delete', 'move', 'execute', 'git', 'network', 'unknown']);
+
+/**
+ * Owns autopilot allow/request/deny decisions from a profile plus tool facts.
+ */
+export class AutonomyPolicyService {
+  static evaluate(args: {
+    context: ToolApprovalPolicyContext;
+    profile: AutopilotProfile;
+  }): AutonomyEvaluation {
+    const workspaceRoot = resolve(args.context.workspaceRoot ?? process.cwd());
+    const profile = AutopilotProfileService.normalize({
+      profile: args.profile,
+      workspaceRoot,
+    });
+    const extraction = ToolPolicyEnvelopeInputService.extract(args.context.call.input);
+    const envelope = extraction.envelope;
+    const facts = AutonomyPolicyService.computeFacts({
+      context: args.context,
+      envelope,
+      profile,
+      workspaceRoot,
+      extractionError: extraction.error,
+      toolInput: extraction.toolInput,
+    });
+    const policyHints = AutonomyPolicyService.createPolicyHints(facts);
+    const decision = AutonomyPolicyService.decide({
+      context: args.context,
+      envelope,
+      facts,
+      profile,
+    });
+
+    return {
+      call: args.context.call,
+      profileMode: profile.mode,
+      envelope,
+      facts,
+      decision,
+      policyHints,
+    };
+  }
+
+  static toApprovalDecision(evaluation: AutonomyEvaluation): ToolApprovalPolicyDecision | undefined {
+    if (evaluation.profileMode !== 'autopilot') {
+      return undefined;
+    }
+
+    return {
+      type: evaluation.decision.type,
+      reason: evaluation.decision.reason,
+      autonomyEvaluation: evaluation,
+    };
+  }
+
+  private static decide(args: {
+    context: ToolApprovalPolicyContext;
+    envelope?: ToolPolicyEnvelope;
+    facts: ToolPolicyFacts;
+    profile: NormalizedAutopilotProfile;
+  }): AutopilotDecision {
+    const { context, envelope, facts, profile } = args;
+
+    if (profile.mode !== 'autopilot') {
+      return { type: 'request', reason: 'interactive approval mode', facts };
+    }
+
+    if (facts.hardDenyReasons.length > 0) {
+      return { type: 'deny', reason: facts.hardDenyReasons.join('; '), facts };
+    }
+
+    if (AutonomyPolicyService.requiresPolicyEnvelope(context) && !envelope) {
+      return { type: 'request', reason: 'tool call needs a declared policy envelope', facts };
+    }
+
+    if (!envelope) {
+      return { type: 'allow', reason: 'autopilot profile does not require an envelope for this tool', facts };
+    }
+
+    if (envelope.confidence === 'low' || envelope.operations.includes('unknown')) {
+      return { type: 'request', reason: 'policy envelope is not specific enough for autopilot', facts };
+    }
+
+    if (!profile.environments.allow.includes(envelope.environment as 'local' | 'dev')) {
+      return { type: 'request', reason: 'environment is not allowed for unattended execution', facts };
+    }
+
+    if (facts.approvalReasons.length > 0) {
+      return { type: 'request', reason: facts.approvalReasons.join('; '), facts };
+    }
+
+    return { type: 'allow', reason: 'allowed by autopilot profile and declared policy envelope', facts };
+  }
+
+  private static computeFacts(args: {
+    context: ToolApprovalPolicyContext;
+    envelope?: ToolPolicyEnvelope;
+    profile: NormalizedAutopilotProfile;
+    workspaceRoot: string;
+    extractionError?: string;
+    toolInput: unknown;
+  }): ToolPolicyFacts {
+    const command = AutonomyPolicyService.getShellCommand(args.context.call.tool, args.toolInput);
+    const resolvedKnownTargets = AutonomyPolicyService.resolveKnownTargets({
+      tool: args.context.call.tool,
+      input: args.toolInput,
+      workspaceRoot: args.workspaceRoot,
+    });
+    const operations = args.envelope?.operations ?? AutonomyPolicyService.inferOperations(args.context);
+    const claimedReadRoots = AutonomyPolicyService.resolveEnvelopeRoots({
+      roots: args.envelope?.readRoots ?? args.envelope?.targetRoots ?? [],
+      workspaceRoot: args.workspaceRoot,
+    });
+    const claimedWriteRoots = AutonomyPolicyService.resolveEnvelopeRoots({
+      roots: AutonomyPolicyService.resolveDeclaredWriteRoots(args.envelope),
+      workspaceRoot: args.workspaceRoot,
+    });
+    const rootsToEvaluate = [...claimedReadRoots, ...claimedWriteRoots, ...resolvedKnownTargets];
+    const rootDecisions = AutonomyPolicyService.resolveRootDecisions({
+      roots: rootsToEvaluate,
+      profile: args.profile,
+    });
+    const hardDenyReasons = [
+      ...AutonomyPolicyService.resolveHardDenyReasons({ command, rootDecisions }),
+      ...(args.extractionError ? [args.extractionError] : []),
+    ];
+    const approvalReasons = AutonomyPolicyService.resolveApprovalReasons({
+      envelope: args.envelope,
+      operations,
+      rootDecisions,
+      profile: args.profile,
+      context: args.context,
+    });
+
+    return {
+      tool: args.context.call.tool,
+      operations,
+      command,
+      cwd: args.workspaceRoot,
+      claimedReadRoots,
+      claimedWriteRoots,
+      resolvedKnownTargets,
+      rootDecisions,
+      hardDenyReasons,
+      approvalReasons,
+      claimMismatches: [],
+    };
+  }
+
+  private static requiresPolicyEnvelope(context: ToolApprovalPolicyContext): boolean {
+    return Boolean(context.tool.requiresApproval) || ENVELOPE_REQUIRED_TOOLS.has(context.call.tool);
+  }
+
+  private static inferOperations(context: ToolApprovalPolicyContext): ToolPolicyOperation[] {
+    if (context.call.tool === 'read_file' || context.call.tool === 'list_files' || context.call.tool === 'search_files') {
+      return ['read'];
+    }
+
+    if (context.call.tool === 'delete_file') {
+      return ['delete'];
+    }
+
+    if (context.call.tool === 'move_file') {
+      return ['move'];
+    }
+
+    if (context.call.tool === 'edit_file') {
+      return ['write'];
+    }
+
+    if (context.call.tool === 'run_shell_mutate') {
+      return ['execute'];
+    }
+
+    return context.tool.requiresApproval ? ['unknown'] : ['read'];
+  }
+
+  private static resolveDeclaredWriteRoots(envelope: ToolPolicyEnvelope | undefined): string[] {
+    if (!envelope) {
+      return [];
+    }
+
+    if (envelope.writeRoots) {
+      return envelope.writeRoots;
+    }
+
+    return envelope.operations.some((operation) => MUTATING_OPERATIONS.has(operation))
+      ? envelope.targetRoots
+      : [];
+  }
+
+  private static resolveEnvelopeRoots(args: {
+    roots: string[];
+    workspaceRoot: string;
+  }): string[] {
+    return args.roots.map((root) => resolve(args.workspaceRoot, root));
+  }
+
+  private static resolveKnownTargets(args: {
+    tool: string;
+    input: unknown;
+    workspaceRoot: string;
+  }): string[] {
+    const input = args.input;
+    if (!isRecord(input)) {
+      return [];
+    }
+
+    const pathValues = ['path', 'from', 'to']
+      .map((key) => input[key])
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+
+    return pathValues.map((pathValue) => resolve(args.workspaceRoot, pathValue));
+  }
+
+  private static resolveRootDecisions(args: {
+    roots: string[];
+    profile: NormalizedAutopilotProfile;
+  }): ToolPolicyRootDecision[] {
+    const uniqueRoots = [...new Set(args.roots)];
+    return uniqueRoots.map((root) => {
+      const policy = AutopilotProfileService.findRootPolicy({
+        profile: args.profile,
+        target: root,
+      });
+
+      return policy
+        ? { root, access: policy.access, matchedPolicyPath: policy.path }
+        : { root, access: 'unconfigured' };
+    });
+  }
+
+  private static resolveHardDenyReasons(args: {
+    command?: string;
+    rootDecisions: ToolPolicyRootDecision[];
+  }): string[] {
+    return [
+      ...AutonomyPolicyService.resolveCommandHardDenyReasons(args.command),
+      ...args.rootDecisions
+        .filter((decision) => decision.access === 'deny')
+        .map((decision) => `root is hard-denied by autopilot policy: ${decision.root}`),
+    ];
+  }
+
+  private static resolveCommandHardDenyReasons(command: string | undefined): string[] {
+    if (!command) {
+      return [];
+    }
+
+    const normalized = command.trim().toLowerCase().replace(/\s+/g, ' ');
+    const patterns = [
+      { pattern: /(?:^|[;&|])\s*rm\s+-rf\s+(?:\/|~|\$home)(?:\s|$)/, reason: 'root/home recursive deletion is blocked' },
+      { pattern: /(?:^|[;&|])\s*rm\s+-rf\s+\.(?:\s|$)/, reason: 'workspace-wide recursive deletion is blocked' },
+      { pattern: /(?:^|[;&|])\s*rm\s+-rf\s+\*(?:\s|$)/, reason: 'wildcard recursive deletion is blocked' },
+      { pattern: /(?:^|[;&|])\s*sudo\b/, reason: 'sudo is blocked in autopilot' },
+      { pattern: /(?:^|[;&|])\s*(?:su|doas)\b/, reason: 'privilege escalation is blocked in autopilot' },
+      { pattern: /(?:^|[;&|])\s*git\s+reset\s+--hard\b/, reason: 'git history/worktree reset is blocked in autopilot' },
+      { pattern: /(?:^|[;&|])\s*git\s+push\b.*\s--force(?:\s|$)/, reason: 'git force push is blocked in autopilot' },
+      { pattern: /(?:^|[;&|])\s*mkfs(?:\.[^\s]+)?\b/, reason: 'disk formatting is blocked in autopilot' },
+      { pattern: /(?:^|[;&|])\s*dd\b.*\bof=\/dev\//, reason: 'device writes are blocked in autopilot' },
+      { pattern: /(?:^|[;&|])\s*terraform\s+destroy\b/, reason: 'terraform destroy is blocked in autopilot' },
+    ];
+
+    return patterns
+      .filter(({ pattern }) => pattern.test(normalized))
+      .map(({ reason }) => reason);
+  }
+
+  private static resolveApprovalReasons(args: {
+    envelope?: ToolPolicyEnvelope;
+    operations: ToolPolicyOperation[];
+    rootDecisions: ToolPolicyRootDecision[];
+    profile: NormalizedAutopilotProfile;
+    context: ToolApprovalPolicyContext;
+  }): string[] {
+    if (!args.envelope) {
+      return [];
+    }
+    const envelope = args.envelope;
+
+    return [
+      ...args.rootDecisions.flatMap((decision) => AutonomyPolicyService.rootApprovalReasons({
+        decision,
+        operations: args.operations,
+        envelope,
+        profile: args.profile,
+      })),
+      ...(args.operations.includes('network') ? ['network operations require approval in initial autopilot policy'] : []),
+    ];
+  }
+
+  private static rootApprovalReasons(args: {
+    decision: ToolPolicyRootDecision;
+    operations: ToolPolicyOperation[];
+    envelope: ToolPolicyEnvelope;
+    profile: NormalizedAutopilotProfile;
+  }): string[] {
+    if (args.decision.access === 'unconfigured') {
+      return [`root is not configured for autopilot: ${args.decision.root}`];
+    }
+
+    if (args.decision.access === 'manual-only') {
+      return [`root requires manual approval: ${args.decision.root}`];
+    }
+
+    const policy = AutopilotProfileService.findRootPolicy({
+      profile: args.profile,
+      target: args.decision.root,
+    });
+    if (!policy) {
+      return [`root is not configured for autopilot: ${args.decision.root}`];
+    }
+
+    return AutonomyPolicyService.requiredCapabilities(args.operations, args.envelope)
+      .filter((capability) => !AutonomyPolicyService.rootAllowsCapability(policy.allow ?? [], policy.access, capability))
+      .map((capability) => `root does not allow ${capability}: ${args.decision.root}`);
+  }
+
+  private static requiredCapabilities(
+    operations: ToolPolicyOperation[],
+    envelope: ToolPolicyEnvelope,
+  ): AutopilotCapability[] {
+    const capabilities = operations.flatMap((operation): AutopilotCapability[] => {
+      if (operation === 'read') {
+        return ['read'];
+      }
+      if (operation === 'write' || operation === 'move') {
+        return envelope.maxDestructiveScope === 'many-files' ? ['write', 'many-file-edit'] : ['write'];
+      }
+      if (operation === 'delete') {
+        return envelope.maxDestructiveScope === 'many-files' ? ['many-file-edit'] : ['simple-delete'];
+      }
+      if (operation === 'execute') {
+        return ['execute'];
+      }
+      if (operation === 'git') {
+        return ['git-stage'];
+      }
+      return [];
+    });
+
+    return [...new Set(capabilities)];
+  }
+
+  private static rootAllowsCapability(
+    allow: AutopilotCapability[],
+    access: ToolPolicyRootDecision['access'],
+    capability: AutopilotCapability,
+  ): boolean {
+    if (access === 'read') {
+      return capability === 'read';
+    }
+
+    if (access !== 'write' && access !== 'autopilot') {
+      return false;
+    }
+
+    return allow.includes(capability);
+  }
+
+  private static createPolicyHints(facts: ToolPolicyFacts): AutonomyPolicyHint[] {
+    return [
+      ...facts.rootDecisions.flatMap((decision): AutonomyPolicyHint[] => {
+        if (decision.access === 'unconfigured') {
+          return [{
+            kind: 'allow-root',
+            message: `Add an autopilot root policy for ${decision.root} if this scope should run unattended.`,
+            candidateConfig: {
+              path: decision.root,
+              access: 'autopilot',
+              allow: ['read', 'write', 'execute'],
+            },
+          }];
+        }
+
+        if (decision.access === 'manual-only') {
+          return [{
+            kind: 'manual-only-root',
+            message: `${decision.root} is manual-only. Move it to autopilot only if unattended work is expected there.`,
+          }];
+        }
+
+        if (decision.access === 'deny') {
+          return [{
+            kind: 'deny-root',
+            message: `${decision.root} is hard-denied and should stay blocked unless the root policy is intentionally changed.`,
+          }];
+        }
+
+        return [];
+      }),
+      ...facts.hardDenyReasons.map((reason): AutonomyPolicyHint => ({
+        kind: 'hard-deny-pattern',
+        message: reason,
+      })),
+    ];
+  }
+
+  private static getShellCommand(tool: string, input: unknown): string | undefined {
+    if (tool !== 'run_shell_mutate' || !isRecord(input)) {
+      return undefined;
+    }
+
+    const command = input.command;
+    return typeof command === 'string' && command.trim() ? command : undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/core/approvals/autonomy/profile-service.ts
+++ b/src/core/approvals/autonomy/profile-service.ts
@@ -1,0 +1,63 @@
+import { isAbsolute, relative, resolve } from 'node:path';
+import type {
+  AutopilotProfile,
+  AutopilotRootPolicy,
+  NormalizedAutopilotProfile,
+  NormalizedAutopilotRootPolicy,
+} from './types.js';
+
+export const DEFAULT_INTERACTIVE_AUTOPILOT_PROFILE: NormalizedAutopilotProfile = {
+  mode: 'interactive',
+  roots: [],
+  environments: {
+    allow: ['local', 'dev'],
+    requireApproval: ['staging', 'production', 'unknown'],
+  },
+};
+
+/**
+ * Normalizes configured roots once at the approval/autonomy boundary.
+ */
+export class AutopilotProfileService {
+  static normalize(args: {
+    profile?: AutopilotProfile;
+    workspaceRoot: string;
+  }): NormalizedAutopilotProfile {
+    if (!args.profile) {
+      return DEFAULT_INTERACTIVE_AUTOPILOT_PROFILE;
+    }
+
+    return {
+      ...args.profile,
+      roots: args.profile.roots.map((root) => AutopilotProfileService.normalizeRoot({
+        root,
+        workspaceRoot: args.workspaceRoot,
+      })),
+    };
+  }
+
+  static findRootPolicy(args: {
+    profile: NormalizedAutopilotProfile;
+    target: string;
+  }): NormalizedAutopilotRootPolicy | undefined {
+    const resolvedTarget = resolve(args.target);
+    return args.profile.roots
+      .filter((root) => AutopilotProfileService.isInsideRoot(resolvedTarget, root.path))
+      .sort((left, right) => right.path.length - left.path.length)[0];
+  }
+
+  static isInsideRoot(target: string, root: string): boolean {
+    const relativeTarget = relative(resolve(root), resolve(target));
+    return relativeTarget === '' || (!relativeTarget.startsWith('..') && !isAbsolute(relativeTarget));
+  }
+
+  private static normalizeRoot(args: {
+    root: AutopilotRootPolicy;
+    workspaceRoot: string;
+  }): NormalizedAutopilotRootPolicy {
+    return {
+      ...args.root,
+      path: resolve(args.workspaceRoot, args.root.path),
+    };
+  }
+}

--- a/src/core/approvals/autonomy/schemas.ts
+++ b/src/core/approvals/autonomy/schemas.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const AutopilotRootAccessSchema = z.enum(['read', 'write', 'autopilot', 'manual-only', 'deny']);
+
+export const AutopilotCapabilitySchema = z.enum([
+  'read',
+  'write',
+  'execute',
+  'simple-delete',
+  'many-file-edit',
+  'verification',
+  'formatting',
+  'dependency',
+  'git-stage',
+]);
+
+export const AutopilotRootPolicySchema = z.object({
+  path: z.string().min(1),
+  access: AutopilotRootAccessSchema,
+  allow: z.array(AutopilotCapabilitySchema).optional(),
+}).strip();
+
+export const AutopilotProfileSchema = z.object({
+  mode: z.enum(['interactive', 'autopilot']),
+  roots: z.array(AutopilotRootPolicySchema),
+  environments: z.object({
+    allow: z.array(z.enum(['local', 'dev'])),
+    requireApproval: z.array(z.enum(['staging', 'production', 'unknown'])),
+  }).strip(),
+}).strip();

--- a/src/core/approvals/autonomy/trace-service.ts
+++ b/src/core/approvals/autonomy/trace-service.ts
@@ -1,0 +1,34 @@
+import { HeddleEventType } from '@/core/event-types.js';
+import type { TraceEvent } from '@/core/types.js';
+import type { AutonomyEvaluation, AutonomyPostflightAudit } from './types.js';
+
+/**
+ * Wraps autonomy domain objects in trace-owned event metadata.
+ */
+export class AutonomyTraceService {
+  static decision(args: {
+    evaluation: AutonomyEvaluation;
+    step: number;
+    timestamp: string;
+  }): TraceEvent {
+    return {
+      type: HeddleEventType.autonomyDecision,
+      evaluation: args.evaluation,
+      step: args.step,
+      timestamp: args.timestamp,
+    };
+  }
+
+  static postflight(args: {
+    audit: AutonomyPostflightAudit;
+    step: number;
+    timestamp: string;
+  }): TraceEvent {
+    return {
+      type: HeddleEventType.autonomyPostflight,
+      audit: args.audit,
+      step: args.step,
+      timestamp: args.timestamp,
+    };
+  }
+}

--- a/src/core/approvals/autonomy/types.ts
+++ b/src/core/approvals/autonomy/types.ts
@@ -1,0 +1,91 @@
+import type { ToolCall } from '@/core/types.js';
+import type { ToolPolicyEnvelope, ToolPolicyOperation } from '@/core/tools/index.js';
+
+export type AutopilotRootAccess = 'read' | 'write' | 'autopilot' | 'manual-only' | 'deny';
+
+export type AutopilotCapability =
+  | 'read'
+  | 'write'
+  | 'execute'
+  | 'simple-delete'
+  | 'many-file-edit'
+  | 'verification'
+  | 'formatting'
+  | 'dependency'
+  | 'git-stage';
+
+export type AutopilotRootPolicy = {
+  path: string;
+  access: AutopilotRootAccess;
+  allow?: AutopilotCapability[];
+};
+
+export type AutopilotProfile = {
+  mode: 'interactive' | 'autopilot';
+  roots: AutopilotRootPolicy[];
+  environments: {
+    allow: Array<'local' | 'dev'>;
+    requireApproval: Array<'staging' | 'production' | 'unknown'>;
+  };
+};
+
+export type NormalizedAutopilotRootPolicy = AutopilotRootPolicy & {
+  path: string;
+};
+
+export type NormalizedAutopilotProfile = AutopilotProfile & {
+  roots: NormalizedAutopilotRootPolicy[];
+};
+
+export type ToolPolicyRootDecision = {
+  root: string;
+  access: AutopilotRootAccess | 'unconfigured';
+  matchedPolicyPath?: string;
+};
+
+export type ToolPolicyFacts = {
+  tool: string;
+  operations: ToolPolicyOperation[];
+  command?: string;
+  cwd?: string;
+  claimedReadRoots: string[];
+  claimedWriteRoots: string[];
+  resolvedKnownTargets: string[];
+  rootDecisions: ToolPolicyRootDecision[];
+  hardDenyReasons: string[];
+  approvalReasons: string[];
+  claimMismatches: string[];
+};
+
+export type AutopilotDecision =
+  | { type: 'allow'; reason: string; facts: ToolPolicyFacts }
+  | { type: 'request'; reason: string; facts: ToolPolicyFacts }
+  | { type: 'deny'; reason: string; facts: ToolPolicyFacts };
+
+export type AutonomyPolicyHint = {
+  kind: 'allow-root' | 'deny-root' | 'manual-only-root' | 'allow-capability' | 'hard-deny-pattern' | 'environment';
+  message: string;
+  candidateConfig?: unknown;
+};
+
+export type AutonomyEvaluation = {
+  call: ToolCall;
+  profileMode: AutopilotProfile['mode'];
+  envelope?: ToolPolicyEnvelope;
+  facts: ToolPolicyFacts;
+  decision: AutopilotDecision;
+  policyHints: AutonomyPolicyHint[];
+};
+
+export type AutonomyPostflightAudit = {
+  call: ToolCall;
+  envelope?: ToolPolicyEnvelope;
+  observedEffects: {
+    changedPaths: string[];
+    changedRoots: string[];
+    exceededDeclaredRoots: string[];
+    gitHistoryChanged: boolean;
+  };
+  decision: 'continue' | 'stop';
+  reason?: string;
+};

--- a/src/core/approvals/index.ts
+++ b/src/core/approvals/index.ts
@@ -1,6 +1,26 @@
 export { ToolApprovalPolicies } from './policies.js';
 export { ToolApprovalService } from './service.js';
+export {
+  AutonomyPolicyService,
+  AutonomyTraceService,
+  AutopilotProfileService,
+  DEFAULT_INTERACTIVE_AUTOPILOT_PROFILE,
+} from './autonomy/index.js';
 export type { ToolApprovalServiceOptions } from './service.js';
+export type {
+  AutonomyEvaluation,
+  AutonomyPolicyHint,
+  AutonomyPostflightAudit,
+  AutopilotCapability,
+  AutopilotDecision,
+  AutopilotProfile,
+  AutopilotRootAccess,
+  AutopilotRootPolicy,
+  NormalizedAutopilotProfile,
+  NormalizedAutopilotRootPolicy,
+  ToolPolicyFacts,
+  ToolPolicyRootDecision,
+} from './autonomy/index.js';
 export type {
   EvaluateToolApprovalPoliciesArgs,
   RequestToolApprovalThroughServiceArgs,

--- a/src/core/approvals/policies.ts
+++ b/src/core/approvals/policies.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_MUTATE_RULES,
 } from '@/core/tools/toolkits/shell-process/shell-policy.js';
 import type { ToolApprovalPolicy, ToolApprovalPolicyContext, ToolApprovalSurface } from './types.js';
+import { AutonomyPolicyService, type AutopilotProfile } from './autonomy/index.js';
 
 /**
  * Owns reusable approval policy constructors and the default policy chain.
@@ -69,6 +70,16 @@ export class ToolApprovalPolicies {
         ? { type: 'deny', reason: policy.error }
         : { type: 'allow', reason: policy.reason };
     };
+  }
+
+  static autopilot(args: { profile: AutopilotProfile }): ToolApprovalPolicy {
+    return (context) =>
+      AutonomyPolicyService.toApprovalDecision(
+        AutonomyPolicyService.evaluate({
+          context,
+          profile: args.profile,
+        }),
+      );
   }
 
   static isOutsideWorkspaceInspectionCall(args: {

--- a/src/core/approvals/service.ts
+++ b/src/core/approvals/service.ts
@@ -14,6 +14,7 @@ import {
 } from './remembered-rules/index.js';
 import { previewEditFileInput } from '@/core/tools/toolkits/coding-files/edit-file.js';
 import { ToolActivitySummarizer } from '@/core/live/index.js';
+import { ToolPolicyEnvelopeInputService } from '@/core/tools/index.js';
 import type { ToolApprovalPolicyContext } from './types.js';
 
 export type ToolApprovalServiceOptions = {
@@ -45,6 +46,7 @@ export class ToolApprovalService {
 
   async resolve(args: ResolveToolApprovalArgs): Promise<ToolApprovalDecision> {
     let requestReason: string | undefined;
+    let autonomyEvaluation: ToolApprovalDecision['autonomyEvaluation'];
 
     for (const policy of args.policies) {
       const decision = await policy(args.context);
@@ -52,12 +54,14 @@ export class ToolApprovalService {
         continue;
       }
 
+      autonomyEvaluation ??= decision.autonomyEvaluation;
+
       if (decision.type === 'deny') {
-        return { approved: false, reason: decision.reason };
+        return ToolApprovalService.withAutonomyEvaluation({ approved: false, reason: decision.reason }, autonomyEvaluation);
       }
 
       if (decision.type === 'allow') {
-        return { approved: true, reason: decision.reason };
+        return ToolApprovalService.withAutonomyEvaluation({ approved: true, reason: decision.reason }, autonomyEvaluation);
       }
 
       requestReason ??= decision.reason;
@@ -69,12 +73,15 @@ export class ToolApprovalService {
 
     if (!args.requestHumanApproval) {
       return {
-        approved: false,
-        reason: `No approval handler configured for ${args.context.call.tool}${requestReason ? `: ${requestReason}` : ''}`,
+        ...ToolApprovalService.withAutonomyEvaluation({
+          approved: false,
+          reason: `No approval handler configured for ${args.context.call.tool}${requestReason ? `: ${requestReason}` : ''}`,
+        }, autonomyEvaluation),
       };
     }
 
-    return args.requestHumanApproval(args.context, requestReason);
+    const decision = await args.requestHumanApproval(args.context, requestReason);
+    return ToolApprovalService.withAutonomyEvaluation(decision, autonomyEvaluation);
   }
 
   async requestHumanApproval(args: RequestToolApprovalThroughServiceArgs): Promise<ToolApprovalDecision> {
@@ -92,18 +99,23 @@ export class ToolApprovalService {
   }
 
   async createRequest(args: ToolApprovalPolicyContext & { reason?: string }): Promise<ToolApprovalRequest> {
-    const rememberedRule = ProjectApprovalRules.createForCall(args.call);
+    const input = ToolPolicyEnvelopeInputService.extract(args.call.input).toolInput;
+    const call = {
+      ...args.call,
+      input,
+    };
+    const rememberedRule = ProjectApprovalRules.createForCall(call);
     const editPreview =
       args.call.tool === 'edit_file'
-        ? await previewEditFileInput(args.call.input, this.options.workspaceRoot)
+        ? await previewEditFileInput(input, this.options.workspaceRoot)
         : undefined;
 
     return {
       tool: args.tool.name,
       callId: args.call.id,
-      input: args.call.input,
+      input,
       requestedAt: (this.options.now ?? (() => new Date()))().toISOString(),
-      summary: ToolActivitySummarizer.summarizeCall(args.call),
+      summary: ToolActivitySummarizer.summarizeCall(call),
       reason: args.reason,
       editPreview,
       rememberProjectApproval: rememberedRule
@@ -174,5 +186,12 @@ export class ToolApprovalService {
     return this.options.projectApprovalRulesFile
       ? new FileProjectApprovalRuleRepository(this.options.projectApprovalRulesFile)
       : undefined;
+  }
+
+  private static withAutonomyEvaluation(
+    decision: ToolApprovalDecision,
+    autonomyEvaluation: ToolApprovalDecision['autonomyEvaluation'],
+  ): ToolApprovalDecision {
+    return autonomyEvaluation ? { ...decision, autonomyEvaluation } : decision;
   }
 }

--- a/src/core/approvals/types.ts
+++ b/src/core/approvals/types.ts
@@ -1,8 +1,9 @@
 import type { ToolCall, ToolDefinition } from '@/core/types.js';
 import type { EditFilePreview } from '@/core/tools/toolkits/coding-files/edit-file.js';
 import type { ProjectApprovalRule } from './remembered-rules/index.js';
+import type { AutonomyEvaluation } from './autonomy/index.js';
 
-export type ToolApprovalDecision = { approved: boolean; reason?: string };
+export type ToolApprovalDecision = { approved: boolean; reason?: string; autonomyEvaluation?: AutonomyEvaluation };
 
 export type ToolApprovalUserDecision =
   | { type: 'approve'; reason?: string }
@@ -10,9 +11,9 @@ export type ToolApprovalUserDecision =
   | { type: 'approve_and_remember_project'; reason?: string };
 
 export type ToolApprovalPolicyDecision =
-  | { type: 'allow'; reason?: string }
-  | { type: 'deny'; reason?: string }
-  | { type: 'request'; reason?: string };
+  | { type: 'allow'; reason?: string; autonomyEvaluation?: AutonomyEvaluation }
+  | { type: 'deny'; reason?: string; autonomyEvaluation?: AutonomyEvaluation }
+  | { type: 'request'; reason?: string; autonomyEvaluation?: AutonomyEvaluation };
 
 export type ToolApprovalPolicyContext = {
   call: ToolCall;

--- a/src/core/event-types.ts
+++ b/src/core/event-types.ts
@@ -10,6 +10,8 @@ export const HeddleEventType = {
   assistantStream: 'assistant.stream',
   modelRetry: 'model.retry',
   hostWarning: 'host.warning',
+  autonomyDecision: 'autonomy.decision',
+  autonomyPostflight: 'autonomy.postflight',
   toolApprovalRequested: 'tool.approval_requested',
   toolApprovalResolved: 'tool.approval_resolved',
   toolFallback: 'tool.fallback',

--- a/src/core/tools/README.md
+++ b/src/core/tools/README.md
@@ -11,6 +11,7 @@ workspace.
   tool names.
 - Tool registry creation and duplicate-name protection at execution time.
 - Tool execution wrapper and timeout behavior.
+- Shared tool policy-envelope schema injection and input stripping.
 - Coding file tools under `toolkits/coding-files/`.
 - Knowledge and memory-surface tools under `toolkits/knowledge/`.
 - External context tools under `toolkits/external-context/`.
@@ -23,6 +24,8 @@ workspace.
 - Default runtime bundle policy. That lives in `src/core/runtime`.
 - Human approval policy and remembered approvals. Those live in
   `src/core/approvals`.
+- Autopilot policy decisions. The tools domain exposes and strips the shared
+  policy envelope, but `src/core/approvals/autonomy/` evaluates it.
 - Host UI for tool calls or results.
 - Memory maintenance domain rules beyond the knowledge-tool interfaces.
 
@@ -31,6 +34,9 @@ workspace.
 - `index.ts`: public class-based boundary for registry, execution, and bundle
   composition.
 - `toolkit.ts`: shared toolkit types plus `ToolBundleComposer` guardrails.
+- `policy-envelope/`: shared `ToolPolicyEnvelope` contract, model-visible
+  schema injection, and execution-time stripping/validation. Tool-specific
+  input remains owned by the individual tool.
 - `toolkits/coding-files/`: file/search/edit tool implementations plus shared
   edit-core behavior.
 - `toolkits/knowledge/`: memory notes, memory checkpoint, and durable knowledge
@@ -48,9 +54,13 @@ workspace.
 
 - `ToolRegistry`: duplicate-checked registry for the tools in one run.
 - `ToolExecutionService`: executes one tool call against a registry with
-  timeout/error normalization.
+  timeout/error normalization. It removes the shared policy envelope before
+  calling the tool implementation.
 - `ToolBundleComposer`: toolkit composition API used by runtime default-tool
   assembly.
+- `policy-envelope/*`: the cross-tool declaration shape used by approval
+  policy and trace. Downstream services should consume this shape directly
+  instead of creating near-duplicate DTOs.
 - `toolkits/coding-files/*`: coding file tools.
 - `toolkits/knowledge/*`: knowledge and memory-surface tools.
 - `toolkits/external-context/*`: web and image tools.
@@ -69,6 +79,8 @@ workspace.
   family, policy, or composition responsibility.
 - Attach approval policy through approval/toolkit registration rather than
   embedding host approval UI in tool implementations.
+- Extend the shared `ToolPolicyEnvelope` only when all tool families can use
+  the field consistently. Tool-specific arguments stay in each tool schema.
 
 ## Common Changes
 
@@ -88,6 +100,8 @@ workspace.
   approval-rule compatibility tests.
 - To change a tool output shape, update trace/review projection tests if hosts
   depend on that output.
+- To change the model-visible policy declaration, update `policy-envelope/`
+  tests plus approval/autonomy tests that evaluate the declared intent.
 
 ## Tests
 
@@ -95,6 +109,7 @@ workspace.
 - `src/__tests__/integration/core/agent-loop.test.ts`
 - `src/__tests__/integration/memory/memory-integration.test.ts`
 - `src/__tests__/unit/tools/run-shell.command.test.ts`
+- `src/__tests__/unit/tools/tool-policy-envelope.test.ts`
 - toolkit/default-tool guardrail tests near runtime or tools integration suites
 
 ## Notes For Coding Agents

--- a/src/core/tools/execute-tool.ts
+++ b/src/core/tools/execute-tool.ts
@@ -1,5 +1,6 @@
 import type { ToolCall, ToolResult } from '@/core/types.js';
 import type { ToolRegistry } from './registry.js';
+import { ToolPolicyEnvelopeInputService } from './policy-envelope/index.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -21,8 +22,16 @@ export class ToolExecutionService {
     }
 
     try {
+      const extraction = ToolPolicyEnvelopeInputService.extract(call.input);
+      if (extraction.error) {
+        return {
+          ok: false,
+          error: extraction.error,
+        };
+      }
+
       const result = await Promise.race([
-        tool.execute(call.input),
+        tool.execute(extraction.toolInput),
         new Promise<ToolResult>((_, reject) =>
           setTimeout(() => reject(new Error(`Tool "${call.tool}" timed out after ${timeoutMs}ms`)), timeoutMs),
         ),

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -2,3 +2,14 @@ export { ToolExecutionService } from './execute-tool.js';
 export { ToolRegistry } from './registry.js';
 export { ToolBundleComposer } from './toolkit.js';
 export type { ToolToolkit, ToolToolkitContext } from './toolkit.js';
+export {
+  ToolPolicyEnvelopeInputService,
+  ToolPolicyEnvelopeSchemaService,
+} from './policy-envelope/index.js';
+export type {
+  ToolPolicyConfidence,
+  ToolPolicyEnvelope,
+  ToolPolicyEnvelopeExtraction,
+  ToolPolicyEnvironment,
+  ToolPolicyOperation,
+} from './policy-envelope/index.js';

--- a/src/core/tools/policy-envelope/README.md
+++ b/src/core/tools/policy-envelope/README.md
@@ -52,13 +52,22 @@ Field meanings:
   This is an array because real work often combines actions, such as
   `execute + write` for a migration script.
 - `intent`: short natural-language explanation of why the tool call exists.
-- `targetRoots`: broad roots involved in the work.
-- `readRoots`: optional narrower read roots when read and write scopes differ.
-- `writeRoots`: optional narrower write roots when the call mutates files.
+- `targetRoots`: project/workspace roots involved in the work.
+- `readRoots`: optional narrower project/workspace roots when read and write
+  scopes differ.
+- `writeRoots`: optional narrower project/workspace roots when the call mutates
+  files.
 - `expectedEffects`: concise effect claims useful for approval UI and trace.
 - `maxDestructiveScope`: expected upper bound of destructive change.
 - `environment`: where the operation is expected to act.
 - `confidence`: how certain the agent is that the declaration is complete.
+
+A root is a project/workspace boundary, usually a git repository root or a
+folder with project config such as `package.json`, `requirements.txt`,
+`pyproject.toml`, `Cargo.toml`, `go.mod`, or similar. Agents should use the
+narrowest project root involved, not an individual file path. For example,
+reading `src/core/tools/registry.ts` should normally claim `targetRoots: ["."]`,
+not `targetRoots: ["src/core/tools/registry.ts"]`.
 
 ## Example Tool Inputs
 

--- a/src/core/tools/policy-envelope/README.md
+++ b/src/core/tools/policy-envelope/README.md
@@ -30,6 +30,12 @@ vocabulary for "what I am trying to do" while each tool keeps its own business
 arguments. The tools domain exposes and removes the envelope; approvals decide
 whether the claim is allowed.
 
+The agent should use the envelope to honestly declare the purpose and expected
+impact surface of the operation: operation categories, target roots, read/write
+roots, expected effects, environment, destructive scope, and confidence. The
+harness combines that declaration with runtime environment facts and configured
+policy before deciding whether to allow, request approval, or deny the action.
+
 ## Envelope Shape
 
 ```ts

--- a/src/core/tools/policy-envelope/README.md
+++ b/src/core/tools/policy-envelope/README.md
@@ -24,3 +24,139 @@ low-friction intent contract without duplicating schema fragments.
 
 Agents report intent through this envelope. The runtime may use it as a policy
 claim, but it must not treat it as verified fact.
+
+The envelope is deliberately shared across tools. It gives the agent one stable
+vocabulary for "what I am trying to do" while each tool keeps its own business
+arguments. The tools domain exposes and removes the envelope; approvals decide
+whether the claim is allowed.
+
+## Envelope Shape
+
+```ts
+type ToolPolicyEnvelope = {
+  operations: Array<'read' | 'write' | 'delete' | 'move' | 'execute' | 'git' | 'network' | 'unknown'>;
+  intent: string;
+  targetRoots: string[];
+  readRoots?: string[];
+  writeRoots?: string[];
+  expectedEffects: string[];
+  maxDestructiveScope?: 'none' | 'single-file' | 'generated-files' | 'many-files';
+  environment: 'local' | 'dev' | 'staging' | 'production' | 'unknown';
+  confidence: 'high' | 'medium' | 'low';
+};
+```
+
+Field meanings:
+
+- `operations`: all operation classes the agent expects the call to perform.
+  This is an array because real work often combines actions, such as
+  `execute + write` for a migration script.
+- `intent`: short natural-language explanation of why the tool call exists.
+- `targetRoots`: broad roots involved in the work.
+- `readRoots`: optional narrower read roots when read and write scopes differ.
+- `writeRoots`: optional narrower write roots when the call mutates files.
+- `expectedEffects`: concise effect claims useful for approval UI and trace.
+- `maxDestructiveScope`: expected upper bound of destructive change.
+- `environment`: where the operation is expected to act.
+- `confidence`: how certain the agent is that the declaration is complete.
+
+## Example Tool Inputs
+
+Read-only inspection can declare only read intent:
+
+```json
+{
+  "path": "src/core/tools/registry.ts",
+  "policy": {
+    "operations": ["read"],
+    "intent": "Inspect the tool registry before wiring policy envelope support.",
+    "targetRoots": ["."],
+    "readRoots": ["."],
+    "expectedEffects": ["no files changed"],
+    "maxDestructiveScope": "none",
+    "environment": "local",
+    "confidence": "high"
+  }
+}
+```
+
+A free-form shell mutation can declare multiple operations and a sibling repo
+scope without forcing the tool schema to understand the shell command:
+
+```json
+{
+  "command": "node scripts/rewrite-imports.js ../heddle-workspace-notes",
+  "policy": {
+    "operations": ["execute", "write"],
+    "intent": "Run a local migration script that updates markdown import paths in the sibling notes repo.",
+    "targetRoots": ["../heddle-workspace-notes"],
+    "readRoots": ["../heddle-workspace-notes"],
+    "writeRoots": ["../heddle-workspace-notes"],
+    "expectedEffects": ["many markdown files may be edited"],
+    "maxDestructiveScope": "many-files",
+    "environment": "local",
+    "confidence": "medium"
+  }
+}
+```
+
+A cleanup can describe delete plus git effects together:
+
+```json
+{
+  "command": "rm generated/*.tmp && git add generated",
+  "policy": {
+    "operations": ["delete", "git"],
+    "intent": "Remove generated temporary files and stage the generated folder.",
+    "targetRoots": ["generated"],
+    "writeRoots": ["generated"],
+    "expectedEffects": ["generated temporary files deleted", "generated folder staged"],
+    "maxDestructiveScope": "generated-files",
+    "environment": "local",
+    "confidence": "medium"
+  }
+}
+```
+
+## Runtime Flow
+
+The model sees augmented schemas from `ToolRegistry.list()`. The executable
+tool definitions returned by `ToolRegistry.get(...)` stay unchanged.
+
+```text
+ToolRegistry.list()
+  -> ToolPolicyEnvelopeSchemaService.addToTool(...)
+  -> model sees optional policy field
+
+ToolExecutionService.execute(...)
+  -> ToolPolicyEnvelopeInputService.extract(...)
+  -> validate and remove policy
+  -> execute raw tool with stripped business input
+```
+
+Approval code also extracts the envelope before building previews and approval
+requests. Tool implementations should not receive or inspect `policy`; it is
+intent metadata for approval, trace, and future postflight auditing.
+
+## Relationship To Autonomy
+
+`src/core/approvals/autonomy/` consumes this shape directly. It compares the
+agent's declared intent with configured roots, known tool targets, command
+hard-deny patterns, and environment policy. Trace records the same domain
+objects that include this envelope.
+
+Do not create a second "trace envelope" or "approval envelope" with the same
+fields. If a consumer needs less data, project from this type at that consumer's
+presentation boundary.
+
+## Maintenance Rules
+
+- Keep the envelope optional so ordinary tools remain lightweight.
+- Add fields only when they are useful across tool families, not for one tool's
+  private needs.
+- Keep tool-specific validation in the toolkit that owns the tool.
+- Keep approval decisions in `src/core/approvals`, not here.
+- Keep extraction centralized in `ToolPolicyEnvelopeInputService` so tools,
+  approvals, and tests agree on the stripped input shape.
+- Update `src/__tests__/unit/tools/tool-policy-envelope.test.ts` when changing
+  schema injection, validation, or stripping behavior.

--- a/src/core/tools/policy-envelope/README.md
+++ b/src/core/tools/policy-envelope/README.md
@@ -1,0 +1,26 @@
+# Tool Policy Envelope
+
+This domain owns the shared model-facing policy envelope that can be attached
+to tool calls. Toolkits own their business input schemas; this domain owns the
+common `policy` field so every environment-touching tool can expose the same
+low-friction intent contract without duplicating schema fragments.
+
+## Owns
+
+- The shared `ToolPolicyEnvelope` type.
+- The JSON-schema fragment for the `policy` field.
+- Central schema augmentation for object-shaped tool parameters.
+- Input extraction that separates the envelope from tool business input before
+  execution.
+
+## Does Not Own
+
+- Approval policy decisions. Those belong to `src/core/approvals`.
+- Tool-specific input interpretation. Those belong to the relevant toolkit.
+- Trace persistence. Trace events consume the same domain objects but do not
+  define this shape.
+
+## Boundary Rule
+
+Agents report intent through this envelope. The runtime may use it as a policy
+claim, but it must not treat it as verified fact.

--- a/src/core/tools/policy-envelope/index.ts
+++ b/src/core/tools/policy-envelope/index.ts
@@ -1,0 +1,9 @@
+export { ToolPolicyEnvelopeInputService } from './input-service.js';
+export { ToolPolicyEnvelopeSchemaService } from './schema-service.js';
+export type {
+  ToolPolicyConfidence,
+  ToolPolicyEnvelope,
+  ToolPolicyEnvelopeExtraction,
+  ToolPolicyEnvironment,
+  ToolPolicyOperation,
+} from './types.js';

--- a/src/core/tools/policy-envelope/index.ts
+++ b/src/core/tools/policy-envelope/index.ts
@@ -1,7 +1,14 @@
 export { ToolPolicyEnvelopeInputService } from './input-service.js';
 export { ToolPolicyEnvelopeSchemaService } from './schema-service.js';
+export {
+  TOOL_POLICY_CONFIDENCE_LEVELS,
+  TOOL_POLICY_DESTRUCTIVE_SCOPES,
+  TOOL_POLICY_ENVIRONMENTS,
+  TOOL_POLICY_OPERATIONS,
+} from './types.js';
 export type {
   ToolPolicyConfidence,
+  ToolPolicyDestructiveScope,
   ToolPolicyEnvelope,
   ToolPolicyEnvelopeExtraction,
   ToolPolicyEnvironment,

--- a/src/core/tools/policy-envelope/input-service.ts
+++ b/src/core/tools/policy-envelope/input-service.ts
@@ -4,20 +4,54 @@ import {
   TOOL_POLICY_DESTRUCTIVE_SCOPES,
   TOOL_POLICY_ENVIRONMENTS,
   TOOL_POLICY_OPERATIONS,
+  type ToolPolicyEnvelope,
   type ToolPolicyEnvelopeExtraction,
 } from './types.js';
 
 const ToolPolicyEnvelopeSchema = z.object({
-  operations: z.array(z.enum(TOOL_POLICY_OPERATIONS)).min(1),
-  intent: z.string().min(1),
-  targetRoots: z.array(z.string()).min(1),
-  readRoots: z.array(z.string()).optional(),
-  writeRoots: z.array(z.string()).optional(),
-  expectedEffects: z.array(z.string()),
-  maxDestructiveScope: z.enum(TOOL_POLICY_DESTRUCTIVE_SCOPES).optional(),
-  environment: z.enum(TOOL_POLICY_ENVIRONMENTS),
-  confidence: z.enum(TOOL_POLICY_CONFIDENCE_LEVELS),
-}).strip();
+  operations: z.array(z.enum(TOOL_POLICY_OPERATIONS)).min(1).describe(
+    'Operation categories the agent claims this tool call may perform. Multiple values are valid because one call can combine execution, writes, deletes, git, or network effects.',
+  ),
+  intent: z.string().min(1).describe(
+    'Human-readable purpose for the tool call. Used for approval/debugging context, not for deterministic verification.',
+  ),
+  targetRoots: z.array(z.string()).min(1).describe(
+    'Project/workspace roots involved in the call. These should be project boundaries such as repo roots or config-bearing folders, not individual file paths.',
+  ),
+  readRoots: z.array(z.string()).optional().describe(
+    'Optional project/workspace roots the agent claims the call may read when read scope differs from targetRoots.',
+  ),
+  writeRoots: z.array(z.string()).optional().describe(
+    'Optional project/workspace roots the agent claims the call may mutate when write/delete/move scope differs from targetRoots.',
+  ),
+  expectedEffects: z.array(z.string()).describe(
+    'Short effect claims for trace review and policy tuning, such as files edited, generated files deleted, or git staging performed.',
+  ),
+  maxDestructiveScope: z.enum(TOOL_POLICY_DESTRUCTIVE_SCOPES).optional().describe(
+    'Largest destructive impact the agent expects from this call. This is a declared upper bound used by autonomy policy.',
+  ),
+  environment: z.enum(TOOL_POLICY_ENVIRONMENTS).describe(
+    'Environment the agent believes the call targets. Autonomy policy uses this to distinguish local/dev work from staging, production, or unknown targets.',
+  ),
+  confidence: z.enum(TOOL_POLICY_CONFIDENCE_LEVELS).describe(
+    'Agent confidence that the envelope completely describes the purpose and impact surface of the call.',
+  ),
+}).strip().describe(
+  'Developer-facing validator for the shared ToolPolicyEnvelope shape. It validates the agent declaration before approval/autonomy policy consumes it, then strips the envelope from tool business input.',
+);
+
+type AssertExactSchemaShape<Actual, Expected> = Actual extends Expected
+  ? Expected extends Actual
+    ? true
+    : never
+  : never;
+
+const toolPolicyEnvelopeSchemaConformsToDeclaredShape: AssertExactSchemaShape<
+  z.infer<typeof ToolPolicyEnvelopeSchema>,
+  ToolPolicyEnvelope
+> = true;
+
+void toolPolicyEnvelopeSchemaConformsToDeclaredShape;
 
 /**
  * Separates the shared policy envelope from tool-owned business input.

--- a/src/core/tools/policy-envelope/input-service.ts
+++ b/src/core/tools/policy-envelope/input-service.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import type { ToolPolicyEnvelopeExtraction } from './types.js';
+
+const ToolPolicyEnvelopeSchema = z.object({
+  operations: z.array(z.enum(['read', 'write', 'delete', 'move', 'execute', 'git', 'network', 'unknown'])).min(1),
+  intent: z.string().min(1),
+  targetRoots: z.array(z.string()).min(1),
+  readRoots: z.array(z.string()).optional(),
+  writeRoots: z.array(z.string()).optional(),
+  expectedEffects: z.array(z.string()),
+  maxDestructiveScope: z.enum(['none', 'single-file', 'generated-files', 'many-files']).optional(),
+  environment: z.enum(['local', 'dev', 'staging', 'production', 'unknown']),
+  confidence: z.enum(['high', 'medium', 'low']),
+}).strip();
+
+/**
+ * Separates the shared policy envelope from tool-owned business input.
+ */
+export class ToolPolicyEnvelopeInputService {
+  static extract(input: unknown): ToolPolicyEnvelopeExtraction {
+    if (!isRecord(input) || !Object.prototype.hasOwnProperty.call(input, 'policy')) {
+      return { toolInput: input };
+    }
+
+    const { policy: rawPolicy, ...toolInput } = input;
+    if (rawPolicy === undefined) {
+      return { toolInput };
+    }
+
+    const parsed = ToolPolicyEnvelopeSchema.safeParse(rawPolicy);
+    if (!parsed.success) {
+      return {
+        toolInput,
+        error: `Invalid tool policy envelope: ${parsed.error.issues.map((issue) => issue.message).join('; ')}`,
+      };
+    }
+
+    return {
+      envelope: parsed.data,
+      toolInput,
+    };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/core/tools/policy-envelope/input-service.ts
+++ b/src/core/tools/policy-envelope/input-service.ts
@@ -1,16 +1,22 @@
 import { z } from 'zod';
-import type { ToolPolicyEnvelopeExtraction } from './types.js';
+import {
+  TOOL_POLICY_CONFIDENCE_LEVELS,
+  TOOL_POLICY_DESTRUCTIVE_SCOPES,
+  TOOL_POLICY_ENVIRONMENTS,
+  TOOL_POLICY_OPERATIONS,
+  type ToolPolicyEnvelopeExtraction,
+} from './types.js';
 
 const ToolPolicyEnvelopeSchema = z.object({
-  operations: z.array(z.enum(['read', 'write', 'delete', 'move', 'execute', 'git', 'network', 'unknown'])).min(1),
+  operations: z.array(z.enum(TOOL_POLICY_OPERATIONS)).min(1),
   intent: z.string().min(1),
   targetRoots: z.array(z.string()).min(1),
   readRoots: z.array(z.string()).optional(),
   writeRoots: z.array(z.string()).optional(),
   expectedEffects: z.array(z.string()),
-  maxDestructiveScope: z.enum(['none', 'single-file', 'generated-files', 'many-files']).optional(),
-  environment: z.enum(['local', 'dev', 'staging', 'production', 'unknown']),
-  confidence: z.enum(['high', 'medium', 'low']),
+  maxDestructiveScope: z.enum(TOOL_POLICY_DESTRUCTIVE_SCOPES).optional(),
+  environment: z.enum(TOOL_POLICY_ENVIRONMENTS),
+  confidence: z.enum(TOOL_POLICY_CONFIDENCE_LEVELS),
 }).strip();
 
 /**

--- a/src/core/tools/policy-envelope/schema-service.ts
+++ b/src/core/tools/policy-envelope/schema-service.ts
@@ -13,7 +13,7 @@ const POLICY_ENVELOPE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   description:
-    'Optional agent-declared intent envelope for approval/autopilot policy. This is a claim, not runtime-verified fact.',
+    'Optional agent-declared intent envelope for approval/autopilot policy. Use this to honestly declare the purpose, operation categories, expected impact surface, target roots, environment, and confidence for this tool call. The harness treats this as a claim, combines it with runtime environment facts and configured policy, then decides whether to allow, request approval, or deny the action.',
   properties: {
     operations: {
       type: 'array',

--- a/src/core/tools/policy-envelope/schema-service.ts
+++ b/src/core/tools/policy-envelope/schema-service.ts
@@ -1,0 +1,94 @@
+import type { ToolDefinition } from '@/core/types.js';
+
+const POLICY_ENVELOPE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  description:
+    'Optional agent-declared intent envelope for approval/autopilot policy. This is a claim, not runtime-verified fact.',
+  properties: {
+    operations: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'string',
+        enum: ['read', 'write', 'delete', 'move', 'execute', 'git', 'network', 'unknown'],
+      },
+      description: 'Operation categories the agent expects this tool call to perform. Use multiple values when appropriate.',
+    },
+    intent: {
+      type: 'string',
+      description: 'Short natural-language statement of what the agent intends this tool call to accomplish.',
+    },
+    targetRoots: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Filesystem or environment roots the agent expects this call to touch.',
+    },
+    readRoots: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Roots the agent expects this call may read.',
+    },
+    writeRoots: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Roots the agent expects this call may write, delete, move, or otherwise mutate.',
+    },
+    expectedEffects: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Concise expected effects, useful for later trace review and policy tuning.',
+    },
+    maxDestructiveScope: {
+      type: 'string',
+      enum: ['none', 'single-file', 'generated-files', 'many-files'],
+      description: 'Largest destructive effect the agent expects.',
+    },
+    environment: {
+      type: 'string',
+      enum: ['local', 'dev', 'staging', 'production', 'unknown'],
+      description: 'Environment the agent believes this call targets.',
+    },
+    confidence: {
+      type: 'string',
+      enum: ['high', 'medium', 'low'],
+      description: 'Confidence in the declared envelope.',
+    },
+  },
+  required: ['operations', 'intent', 'targetRoots', 'expectedEffects', 'environment', 'confidence'],
+};
+
+/**
+ * Adds the shared optional policy envelope to model-visible object schemas.
+ */
+export class ToolPolicyEnvelopeSchemaService {
+  static addToTool(tool: ToolDefinition): ToolDefinition {
+    return {
+      ...tool,
+      parameters: ToolPolicyEnvelopeSchemaService.addToParameters(tool.parameters),
+    };
+  }
+
+  static addToParameters(parameters: Record<string, unknown>): Record<string, unknown> {
+    if (parameters.type !== 'object') {
+      return parameters;
+    }
+
+    const properties = isRecord(parameters.properties) ? parameters.properties : {};
+    if (Object.prototype.hasOwnProperty.call(properties, 'policy')) {
+      return parameters;
+    }
+
+    return {
+      ...parameters,
+      properties: {
+        ...properties,
+        policy: POLICY_ENVELOPE_SCHEMA,
+      },
+    };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/core/tools/policy-envelope/schema-service.ts
+++ b/src/core/tools/policy-envelope/schema-service.ts
@@ -1,4 +1,10 @@
 import type { ToolDefinition } from '@/core/types.js';
+import {
+  TOOL_POLICY_CONFIDENCE_LEVELS,
+  TOOL_POLICY_DESTRUCTIVE_SCOPES,
+  TOOL_POLICY_ENVIRONMENTS,
+  TOOL_POLICY_OPERATIONS,
+} from './types.js';
 
 const POLICY_ENVELOPE_SCHEMA = {
   type: 'object',
@@ -11,7 +17,7 @@ const POLICY_ENVELOPE_SCHEMA = {
       minItems: 1,
       items: {
         type: 'string',
-        enum: ['read', 'write', 'delete', 'move', 'execute', 'git', 'network', 'unknown'],
+        enum: [...TOOL_POLICY_OPERATIONS],
       },
       description: 'Operation categories the agent expects this tool call to perform. Use multiple values when appropriate.',
     },
@@ -41,17 +47,17 @@ const POLICY_ENVELOPE_SCHEMA = {
     },
     maxDestructiveScope: {
       type: 'string',
-      enum: ['none', 'single-file', 'generated-files', 'many-files'],
+      enum: [...TOOL_POLICY_DESTRUCTIVE_SCOPES],
       description: 'Largest destructive effect the agent expects.',
     },
     environment: {
       type: 'string',
-      enum: ['local', 'dev', 'staging', 'production', 'unknown'],
+      enum: [...TOOL_POLICY_ENVIRONMENTS],
       description: 'Environment the agent believes this call targets.',
     },
     confidence: {
       type: 'string',
-      enum: ['high', 'medium', 'low'],
+      enum: [...TOOL_POLICY_CONFIDENCE_LEVELS],
       description: 'Confidence in the declared envelope.',
     },
   },

--- a/src/core/tools/policy-envelope/schema-service.ts
+++ b/src/core/tools/policy-envelope/schema-service.ts
@@ -6,6 +6,9 @@ import {
   TOOL_POLICY_OPERATIONS,
 } from './types.js';
 
+const ROOT_DESCRIPTION =
+  'A root is a project/workspace boundary, usually a git repository root or a folder with project config such as package.json, requirements.txt, pyproject.toml, Cargo.toml, go.mod, or similar. Use the narrowest project root involved, not an individual file path.';
+
 const POLICY_ENVELOPE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -28,17 +31,17 @@ const POLICY_ENVELOPE_SCHEMA = {
     targetRoots: {
       type: 'array',
       items: { type: 'string' },
-      description: 'Filesystem or environment roots the agent expects this call to touch.',
+      description: `Project/workspace roots the agent expects this call to touch. ${ROOT_DESCRIPTION}`,
     },
     readRoots: {
       type: 'array',
       items: { type: 'string' },
-      description: 'Roots the agent expects this call may read.',
+      description: `Project/workspace roots the agent expects this call may read. ${ROOT_DESCRIPTION}`,
     },
     writeRoots: {
       type: 'array',
       items: { type: 'string' },
-      description: 'Roots the agent expects this call may write, delete, move, or otherwise mutate.',
+      description: `Project/workspace roots the agent expects this call may write, delete, move, or otherwise mutate. ${ROOT_DESCRIPTION}`,
     },
     expectedEffects: {
       type: 'array',

--- a/src/core/tools/policy-envelope/types.ts
+++ b/src/core/tools/policy-envelope/types.ts
@@ -1,0 +1,36 @@
+export type ToolPolicyOperation =
+  | 'read'
+  | 'write'
+  | 'delete'
+  | 'move'
+  | 'execute'
+  | 'git'
+  | 'network'
+  | 'unknown';
+
+export type ToolPolicyEnvironment =
+  | 'local'
+  | 'dev'
+  | 'staging'
+  | 'production'
+  | 'unknown';
+
+export type ToolPolicyConfidence = 'high' | 'medium' | 'low';
+
+export type ToolPolicyEnvelope = {
+  operations: ToolPolicyOperation[];
+  intent: string;
+  targetRoots: string[];
+  readRoots?: string[];
+  writeRoots?: string[];
+  expectedEffects: string[];
+  maxDestructiveScope?: 'none' | 'single-file' | 'generated-files' | 'many-files';
+  environment: ToolPolicyEnvironment;
+  confidence: ToolPolicyConfidence;
+};
+
+export type ToolPolicyEnvelopeExtraction = {
+  envelope?: ToolPolicyEnvelope;
+  toolInput: unknown;
+  error?: string;
+};

--- a/src/core/tools/policy-envelope/types.ts
+++ b/src/core/tools/policy-envelope/types.ts
@@ -1,21 +1,12 @@
-export type ToolPolicyOperation =
-  | 'read'
-  | 'write'
-  | 'delete'
-  | 'move'
-  | 'execute'
-  | 'git'
-  | 'network'
-  | 'unknown';
+export const TOOL_POLICY_OPERATIONS = ['read', 'write', 'delete', 'move', 'execute', 'git', 'network', 'unknown'] as const;
+export const TOOL_POLICY_DESTRUCTIVE_SCOPES = ['none', 'single-file', 'generated-files', 'many-files'] as const;
+export const TOOL_POLICY_ENVIRONMENTS = ['local', 'dev', 'staging', 'production', 'unknown'] as const;
+export const TOOL_POLICY_CONFIDENCE_LEVELS = ['high', 'medium', 'low'] as const;
 
-export type ToolPolicyEnvironment =
-  | 'local'
-  | 'dev'
-  | 'staging'
-  | 'production'
-  | 'unknown';
-
-export type ToolPolicyConfidence = 'high' | 'medium' | 'low';
+export type ToolPolicyOperation = (typeof TOOL_POLICY_OPERATIONS)[number];
+export type ToolPolicyDestructiveScope = (typeof TOOL_POLICY_DESTRUCTIVE_SCOPES)[number];
+export type ToolPolicyEnvironment = (typeof TOOL_POLICY_ENVIRONMENTS)[number];
+export type ToolPolicyConfidence = (typeof TOOL_POLICY_CONFIDENCE_LEVELS)[number];
 
 export type ToolPolicyEnvelope = {
   operations: ToolPolicyOperation[];
@@ -24,7 +15,7 @@ export type ToolPolicyEnvelope = {
   readRoots?: string[];
   writeRoots?: string[];
   expectedEffects: string[];
-  maxDestructiveScope?: 'none' | 'single-file' | 'generated-files' | 'many-files';
+  maxDestructiveScope?: ToolPolicyDestructiveScope;
   environment: ToolPolicyEnvironment;
   confidence: ToolPolicyConfidence;
 };

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from '@/core/types.js';
+import { ToolPolicyEnvelopeSchemaService } from './policy-envelope/index.js';
 
 /**
  * Registry for the executable tool set available to one agent run.
@@ -20,7 +21,7 @@ export class ToolRegistry {
   }
 
   list(): ToolDefinition[] {
-    return [...this.toolMap.values()];
+    return [...this.toolMap.values()].map((tool) => ToolPolicyEnvelopeSchemaService.addToTool(tool));
   }
 
   names(): string[] {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,7 @@
 
 import type { ChatMessage, LlmUsage } from './llm/types.js';
 import { HeddleEventType } from './event-types.js';
+import type { AutonomyEvaluation, AutonomyPostflightAudit } from './approvals/autonomy/index.js';
 
 /**
  * Input to the agent loop.
@@ -87,6 +88,18 @@ export type TraceEvent =
       code: 'actionless_completion';
       message: string;
       details?: Record<string, unknown>;
+      step: number;
+      timestamp: string;
+    }
+  | {
+      type: typeof HeddleEventType.autonomyDecision;
+      evaluation: AutonomyEvaluation;
+      step: number;
+      timestamp: string;
+    }
+  | {
+      type: typeof HeddleEventType.autonomyPostflight;
+      audit: AutonomyPostflightAudit;
       step: number;
       timestamp: string;
     }


### PR DESCRIPTION
## Summary

Adds the first autopilot approval-policy foundation for long-running Heddle agent runs. The change introduces a shared tool policy envelope, an approvals-owned autonomy policy service, durable autonomy decision trace events, and focused tests around policy decisions and tool execution stripping.

## What changed

- Adds `src/core/tools/policy-envelope/` for the shared agent-declared intent shape, schema injection, validation, and stripping before tool execution.
- Adds `src/core/approvals/autonomy/` for autopilot profiles, computed facts, policy decisions, and trace helpers.
- Wires `ToolApprovalPolicies.autopilot(...)` into the existing ordered approval policy chain.
- Records `autonomy.decision` trace events using the same domain `AutonomyEvaluation` shape instead of a duplicate trace DTO.
- Updates approval/tool READMEs so the ownership boundary is explicit.

## Validation

- `yarn build`
- `yarn test src/__tests__/unit/tools/tool-policy-envelope.test.ts src/__tests__/unit/core/autonomy-policy-service.test.ts src/__tests__/unit/core/approval-policy-chain.test.ts src/__tests__/integration/core/run-agent.test.ts`
- `git diff --check`

## Notes

This PR intentionally stops at the reusable foundation. Workspace/user config loading and richer postflight effect auditing should land as follow-up slices.