### PR TITLE
[codex] Wire autopilot profile config

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -12,7 +12,20 @@ Older workspaces with a root-level `heddle.config.json` still load for backward 
   "maxSteps": 100,
   "stateDir": ".heddle",
   "directShellApproval": "never",
-  "searchIgnoreDirs": [".git", "dist", "node_modules", ".heddle"]
+  "searchIgnoreDirs": [".git", "dist", "node_modules", ".heddle"],
+  "autopilot": {
+    "mode": "interactive",
+    "roots": [
+      {
+        "path": ".",
+        "access": "manual-only"
+      }
+    ],
+    "environments": {
+      "allow": ["local", "dev"],
+      "requireApproval": ["staging", "production", "unknown"]
+    }
+  }
 }
 ```
 
@@ -32,6 +45,30 @@ Configuration is applied in this order:
 - `directShellApproval`: whether explicit `!command` usage in chat still requires approval
 - `searchIgnoreDirs`: directories excluded from routine `search_files` calls
 - `agentContextPaths`: optional project instruction files injected into the system prompt. When omitted, Heddle loads the first non-empty file found in this order: `HEDDLE.md`, `AGENTS.md`, `CLAUDE.md`. Only one default file is loaded to preserve context space. If configured, Heddle uses the listed paths exactly, so advanced projects can opt into custom names or multiple files.
+- `autopilot`: optional approval autonomy profile. `mode: "interactive"` keeps
+  ordinary approval behavior. `mode: "autopilot"` lets matching tool calls run
+  without manual approval when the agent honestly declares a compatible policy
+  envelope and the runtime-computed facts match the configured roots,
+  capabilities, and environments. Hard-deny rules still block destructive
+  actions before remembered approvals.
+
+`autopilot.roots[].path` should be a project/workspace boundary, usually a git
+repository root or a folder with config such as `package.json`,
+`requirements.txt`, `pyproject.toml`, `Cargo.toml`, or `go.mod`. Use the
+narrowest project root involved, not individual file paths.
+
+`autopilot.roots[].access` accepts:
+
+- `read`: read-only claims can run unattended.
+- `write`: write-like claims may run unattended only when listed capabilities
+  allow them.
+- `autopilot`: the root is eligible for unattended work, still constrained by
+  capabilities.
+- `manual-only`: matching calls require manual approval.
+- `deny`: matching calls are denied before approval fallback.
+
+Common capabilities include `read`, `write`, `execute`, `simple-delete`,
+`many-file-edit`, `verification`, `formatting`, `dependency`, and `git-stage`.
 
 ## When To Use Config
 
@@ -42,6 +79,9 @@ Configuration is applied in this order:
 - you want predictable shell approval behavior in a shared workflow
 - your repository has directories that should stay out of routine search unless explicitly targeted
 - the project relies on custom instruction paths beyond the default `HEDDLE.md`, `AGENTS.md`, or `CLAUDE.md` discovery order
+- you want unattended local/dev coding work inside specific project roots while
+  keeping dangerous roots, production-like environments, and broad destructive
+  actions approval-gated or denied
 
 ## See Also
 

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -7,6 +7,7 @@ import { EngineConversationTurnService } from '@/core/chat/engine/turns/service.
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
 import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
 import * as agentLoopModule from '@/core/runtime/loop/index.js';
+import type { AutopilotProfile } from '@/core/approvals/index.js';
 import type { ToolApprovalPolicy } from '@/core/approvals/types.js';
 import type { RunResult, ToolCall, ToolDefinition } from '@/index.js';
 import { controlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
@@ -206,6 +207,79 @@ describe('control-plane session runtime integration', () => {
     ]);
     expect(detail?.lastContinuePrompt).toBe('inspect file with expanded mention contents');
     expect(continueResult.session?.lastContinuePrompt).toBe('inspect file with expanded mention contents');
+  });
+
+  it('passes config autopilot policy before remembered approval rules into control-plane turns', async () => {
+    const engineArgs = createControlPlaneSessionEngineArgs();
+    const autopilot: AutopilotProfile = {
+      mode: 'autopilot',
+      roots: [{
+        path: '.',
+        access: 'autopilot',
+        allow: ['read', 'write', 'execute', 'many-file-edit'],
+      }],
+      environments: {
+        allow: ['local', 'dev'],
+        requireApproval: ['staging', 'production', 'unknown'],
+      },
+    };
+    const session = controlPlaneChatSessionsController.createSession({
+      ...engineArgs,
+      suggestedName: 'Autopilot policy order test',
+      model: 'gpt-5.4',
+      autopilot,
+    });
+    const loopSpy = vi.spyOn(agentLoopModule.AgentLoopRuntimeService, 'run').mockResolvedValue(createLoopResult({
+      workspaceRoot: engineArgs.workspaceRoot,
+      prompt: 'Run safely.',
+      summary: 'Done.',
+    }) as never);
+
+    await controlPlaneChatSessionsController.submitPrompt({
+      ...engineArgs,
+      sessionId: session.id,
+      prompt: 'Run safely.',
+      autopilot,
+      leaseOwner: {
+        ownerKind: 'daemon',
+        ownerId: 'daemon-test',
+        clientLabel: 'control plane',
+      },
+    });
+
+    const firstPolicy = loopSpy.mock.calls[0]?.[0].approvalPolicies?.[0];
+    const decision = await firstPolicy?.({
+      workspaceRoot: engineArgs.workspaceRoot,
+      call: {
+        id: 'call-danger',
+        tool: 'run_shell_mutate',
+        input: {
+          command: 'rm -rf ~',
+          policy: {
+            operations: ['delete'],
+            intent: 'Delete home directory',
+            targetRoots: ['.'],
+            writeRoots: ['.'],
+            expectedEffects: ['delete many files'],
+            maxDestructiveScope: 'many-files',
+            environment: 'local',
+            confidence: 'high',
+          },
+        },
+      },
+      tool: {
+        name: 'run_shell_mutate',
+        description: 'Mutate shell',
+        requiresApproval: true,
+        parameters: { type: 'object' },
+        execute: async () => ({ ok: true }),
+      },
+    });
+
+    expect(decision).toEqual(expect.objectContaining({
+      type: 'deny',
+      reason: expect.stringContaining('root/home recursive deletion is blocked'),
+    }));
   });
 });
 

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -240,6 +240,7 @@ describe('control-plane session runtime integration', () => {
       sessionId: session.id,
       prompt: 'Run safely.',
       autopilot,
+      apiKey: 'test-openai-key',
       leaseOwner: {
         ownerKind: 'daemon',
         ownerId: 'daemon-test',

--- a/src/__tests__/unit/control-plane/control-plane-workspace.test.ts
+++ b/src/__tests__/unit/control-plane/control-plane-workspace.test.ts
@@ -1,0 +1,76 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createLogger } from '@/core/utils/logger.js';
+import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
+import type { HeddleServerContext } from '@/server/types.js';
+import { resolveControlPlaneRequestWorkspace } from '@/server/routes/trpc/control-plane-workspace.js';
+
+const silentLogger = createLogger({ level: 'silent', console: false });
+
+describe('resolveControlPlaneRequestWorkspace', () => {
+  it('loads workspace autopilot config into session engine args', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-control-plane-workspace-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    mkdirSync(stateRoot, { recursive: true });
+    writeFileSync(join(stateRoot, 'config.json'), `${JSON.stringify({
+      autopilot: {
+        mode: 'autopilot',
+        roots: [{
+          path: '.',
+          access: 'autopilot',
+          allow: ['read', 'write', 'execute'],
+        }],
+        environments: {
+          allow: ['local', 'dev'],
+          requireApproval: ['staging', 'production', 'unknown'],
+        },
+      },
+    })}\n`);
+    const workspace = createWorkspaceDescriptor({ workspaceRoot, stateRoot });
+
+    const resolved = resolveControlPlaneRequestWorkspace(createContext(workspace));
+
+    expect(resolved.sessionEngineArgs.autopilot).toEqual({
+      mode: 'autopilot',
+      roots: [{
+        path: '.',
+        access: 'autopilot',
+        allow: ['read', 'write', 'execute'],
+      }],
+      environments: {
+        allow: ['local', 'dev'],
+        requireApproval: ['staging', 'production', 'unknown'],
+      },
+    });
+  });
+});
+
+function createWorkspaceDescriptor(args: {
+  workspaceRoot: string;
+  stateRoot: string;
+}): WorkspaceDescriptor {
+  return {
+    id: 'workspace-1',
+    name: 'Workspace 1',
+    workspaceRoot: args.workspaceRoot,
+    repoRoots: [args.workspaceRoot],
+    stateRoot: args.stateRoot,
+    createdAt: '2026-06-08T00:00:00.000Z',
+    updatedAt: '2026-06-08T00:00:00.000Z',
+  };
+}
+
+function createContext(workspace: WorkspaceDescriptor): HeddleServerContext {
+  return {
+    workspaceRoot: workspace.workspaceRoot,
+    stateRoot: workspace.stateRoot,
+    preferApiKey: false,
+    activeWorkspaceId: workspace.id,
+    activeWorkspace: workspace,
+    workspaces: [workspace],
+    runtimeHost: null,
+    logger: silentLogger,
+  };
+}

--- a/src/__tests__/unit/core/project-config.test.ts
+++ b/src/__tests__/unit/core/project-config.test.ts
@@ -45,6 +45,18 @@ describe('ProjectConfigService', () => {
       directShellApproval: 'sometimes',
       searchIgnoreDirs: ['node_modules'],
       agentContextPaths: ['AGENTS.md'],
+      autopilot: {
+        mode: 'autopilot',
+        roots: [{
+          path: '.',
+          access: 'autopilot',
+          allow: ['read', 'write', 'execute'],
+        }],
+        environments: {
+          allow: ['local', 'dev'],
+          requireApproval: ['staging', 'production', 'unknown'],
+        },
+      },
       unknown: true,
     })}\n`);
 
@@ -53,6 +65,42 @@ describe('ProjectConfigService', () => {
       stateDir: '.state',
       searchIgnoreDirs: ['node_modules'],
       agentContextPaths: ['AGENTS.md'],
+      autopilot: {
+        mode: 'autopilot',
+        roots: [{
+          path: '.',
+          access: 'autopilot',
+          allow: ['read', 'write', 'execute'],
+        }],
+        environments: {
+          allow: ['local', 'dev'],
+          requireApproval: ['staging', 'production', 'unknown'],
+        },
+      },
+    });
+  });
+
+  it('ignores invalid autopilot profile config without rejecting other fields', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-project-config-'));
+    const initResult = ProjectConfigService.initialize(workspaceRoot);
+    writeFileSync(initResult.configPath, `${JSON.stringify({
+      model: 'gpt-5.4',
+      autopilot: {
+        mode: 'autopilot',
+        roots: [{
+          path: '.',
+          access: 'autopilot',
+          allow: ['rm-everything'],
+        }],
+        environments: {
+          allow: ['production'],
+          requireApproval: ['staging', 'production', 'unknown'],
+        },
+      },
+    })}\n`);
+
+    expect(ProjectConfigService.read(workspaceRoot)).toEqual({
+      model: 'gpt-5.4',
     });
   });
 

--- a/src/core/approvals/autonomy/README.md
+++ b/src/core/approvals/autonomy/README.md
@@ -217,8 +217,10 @@ policy hints together.
 
 ## Current Limits
 
-This service is the core policy foundation. Workspace/user profile loading,
-user-facing yolo controls, and postflight effect auditing are follow-up slices.
-The existing `AutonomyPostflightAudit` type reserves the downstream shape so the
-future implementation can record observed effects without inventing a second
-trace vocabulary.
+This service is the core policy foundation. Workspace config may provide an
+`autopilot` profile through `.heddle/config.json`; project-config validates the
+persisted shape, and control-plane request context passes the profile into this
+approval policy. User-facing yolo controls and postflight effect auditing remain
+follow-up slices. The existing `AutonomyPostflightAudit` type reserves the
+downstream shape so the future implementation can record observed effects
+without inventing a second trace vocabulary.

--- a/src/core/project-config/README.md
+++ b/src/core/project-config/README.md
@@ -10,6 +10,9 @@ The public adapter methods are intentionally small:
   returning only supported fields and `{}` when the file is missing or invalid.
 - `ProjectConfigService.initialize(workspaceRoot)` creates the default config
   template when absent and reports whether a file was created.
+- The optional `autopilot` field uses the approval autonomy profile schema from
+  `src/core/approvals/autonomy/`. Project config validates the persisted shape,
+  but approval semantics and policy decisions stay in the approvals domain.
 
 Terminal command adapters may call these methods directly. They should not
 duplicate config defaults, parse JSON themselves, reinterpret invalid values, or

--- a/src/core/project-config/service.ts
+++ b/src/core/project-config/service.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { z } from 'zod';
+import { AutopilotProfileSchema } from '@/core/approvals/autonomy/index.js';
 import type { ProjectConfig, ProjectConfigInitializeResult } from './types.js';
 
 const LOCAL_CONFIG_DIR_NAME = '.heddle';
@@ -24,6 +25,7 @@ const projectConfigSchema = z.object({
   directShellApproval: z.enum(['always', 'never']).optional().catch(undefined),
   searchIgnoreDirs: z.array(z.string()).optional().catch(undefined),
   agentContextPaths: z.array(z.string()).optional().catch(undefined),
+  autopilot: AutopilotProfileSchema.optional().catch(undefined),
 }).strip();
 
 /**

--- a/src/core/project-config/types.ts
+++ b/src/core/project-config/types.ts
@@ -1,3 +1,5 @@
+import type { AutopilotProfile } from '@/core/approvals/index.js';
+
 export type ProjectConfig = {
   model?: string;
   maxSteps?: number;
@@ -5,6 +7,7 @@ export type ProjectConfig = {
   directShellApproval?: 'always' | 'never';
   searchIgnoreDirs?: string[];
   agentContextPaths?: string[];
+  autopilot?: AutopilotProfile;
 };
 
 export type ProjectConfigInitializeResult =

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -19,6 +19,8 @@ import type { Logger } from 'pino';
 import {
   ToolApprovalPolicies,
   ToolApprovalService,
+  type AutopilotProfile,
+  type ToolApprovalPolicy,
   type ToolApprovalRequest,
   type ToolApprovalUserDecision,
 } from '@/core/approvals/index.js';
@@ -62,6 +64,7 @@ type ControlPlaneSessionReadArgs = Omit<ConversationEngineConfig, 'model' | 'wor
   model?: string;
   sessionStoragePath: string;
   workspaceId: string;
+  autopilot?: AutopilotProfile;
 };
 
 type CreateControlPlaneChatSessionArgs = ControlPlaneSessionReadArgs & {
@@ -132,7 +135,7 @@ export class ControlPlaneChatSessionsController {
   createSession(args: CreateControlPlaneChatSessionArgs): ChatSessionDetail {
     const { suggestedName, ...engineInput } = args;
     const model = this.resolveSessionCreationModel(args);
-    const engine = createConversationEngine({
+    const engine = this.createEngine({
       ...engineInput,
       model,
     });
@@ -721,17 +724,31 @@ export class ControlPlaneChatSessionsController {
   }
 
   private createEngine(args: ControlPlaneSessionReadArgs): ConversationEngine {
+    const { autopilot, ...engineArgs } = args;
     const approvalService = this.createApprovalService(args);
     return createConversationEngine({
-      ...args,
+      ...engineArgs,
       model: args.model ?? DEFAULT_OPENAI_MODEL,
-      approvalPolicies: [
-        ...(args.approvalPolicies ?? []),
-        ToolApprovalPolicies.rememberedProjectRule({
-          isApproved: (context) => approvalService.isApprovedByRememberedProjectRule(context),
-        }),
-      ],
+      approvalPolicies: this.createApprovalPolicies({
+        approvalPolicies: args.approvalPolicies,
+        autopilot,
+        approvalService,
+      }),
     });
+  }
+
+  private createApprovalPolicies(args: {
+    approvalPolicies?: ToolApprovalPolicy[];
+    autopilot?: AutopilotProfile;
+    approvalService: ToolApprovalService;
+  }): ToolApprovalPolicy[] {
+    return [
+      ...(args.autopilot ? [ToolApprovalPolicies.autopilot({ profile: args.autopilot })] : []),
+      ...(args.approvalPolicies ?? []),
+      ToolApprovalPolicies.rememberedProjectRule({
+        isApproved: (context) => args.approvalService.isApprovedByRememberedProjectRule(context),
+      }),
+    ];
   }
 
   private createEngineHost(args: ControlPlaneSessionReadArgs & ControlPlaneSessionAddress, publisher: ControlPlaneTurnPublisher): ConversationEngineHost {

--- a/src/server/routes/trpc/control-plane-workspace.ts
+++ b/src/server/routes/trpc/control-plane-workspace.ts
@@ -1,5 +1,7 @@
 import { resolve } from 'node:path';
 import type { Logger } from 'pino';
+import type { AutopilotProfile } from '@/core/approvals/index.js';
+import { ProjectConfigService } from '@/core/project-config/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { getWorkspaceOperationLogger } from '@/server/logging/workspace-operation-logger.js';
@@ -20,6 +22,7 @@ export type ControlPlaneRequestWorkspace = {
     sessionStoragePath: string;
     preferApiKey: boolean;
     workspaceId: string;
+    autopilot?: AutopilotProfile;
   };
 };
 
@@ -67,6 +70,7 @@ export function resolveControlPlaneRequestWorkspace(
   input?: WorkspaceScopedInput,
 ): ControlPlaneRequestWorkspace {
   const workspace = resolveWorkspaceDescriptor(ctx, input?.workspaceId);
+  const projectConfig = ProjectConfigService.read(workspace.workspaceRoot);
   const logger = getWorkspaceOperationLogger(workspace.stateRoot);
   return {
     workspace,
@@ -77,6 +81,7 @@ export function resolveControlPlaneRequestWorkspace(
       sessionStoragePath: resolve(workspace.stateRoot, 'chat-sessions.catalog.json'),
       preferApiKey: ctx.preferApiKey,
       workspaceId: workspace.id,
+      autopilot: projectConfig.autopilot,
     },
   };
 }


### PR DESCRIPTION
## Summary

Wires the merged autopilot approval foundation into workspace configuration so `.heddle/config.json` can provide an optional `autopilot` profile for control-plane runs.

## What changed

- Adds optional `autopilot` to `ProjectConfig` and validates it with the existing approval autonomy profile schema.
- Loads workspace config in control-plane request context and passes the profile into session engine args for all control-plane hosts.
- Converts the configured profile into `ToolApprovalPolicies.autopilot(...)` in the control-plane session controller.
- Orders configured autopilot policy before remembered approval rules so hard-deny decisions cannot be bypassed by saved approvals.
- Documents the new config field in the project config docs and autonomy README.

## Expected behavior

This slice makes autopilot usable by editing `.heddle/config.json`; it does not add a UI toggle yet. When `autopilot.mode` is `interactive`, normal approval behavior remains. When `autopilot.mode` is `autopilot`, matching local/dev tool calls can run without manual approval only when the agent declares a compatible policy envelope and the runtime-computed facts match the configured roots/capabilities/environments. Dangerous hard-deny patterns still deny before human approval or remembered approval fallback.

## Validation

- `./node_modules/.bin/vitest run src/__tests__/unit/core/project-config.test.ts src/__tests__/unit/control-plane/control-plane-workspace.test.ts src/__tests__/integration/control-plane/session-runtime.test.ts`
- `./node_modules/.bin/vitest run src/__tests__/unit/core/import-boundaries.test.ts`
- `yarn build`
- `git diff --check`