### PR TITLE
Add browser automation capability skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ Official website: [heddleagent.com](https://heddleagent.com)
 
 > **Terminal UI v2 is now the default.** Run `heddle` or `heddle chat` to use the API-backed terminal experience. Messages, run events, and agent response streams now flow through the shared control-plane path, so terminal, browser, and mobile clients can follow the same work at the same time for smoother cross-device workflows.
 
+## Agenda
+
+- [See Heddle In Action](#see-heddle-in-action)
+- [Why Try Heddle](#why-try-heddle)
+- [What Heddle Does](#what-heddle-does)
+- [Programmatic Use Layers](#programmatic-use-layers)
+- [See Heddle](#see-heddle)
+- [2-Minute Try-It Path](#2-minute-try-it-path)
+- [Major Features](#major-features)
+- [Install](#install)
+- [Requirements](#requirements)
+- [Documentation](#documentation)
+- [Project Status](#project-status)
+- [Development](#development)
+
 ## See Heddle In Action
 
 Terminal, browser, and mobile surfaces can observe the same live session at once:
@@ -35,6 +50,7 @@ It is a good fit if you want:
 - a terminal-first coding agent that works in a real repository
 - an agent that learns durable project knowledge while working with you, using inspectable local memory
 - standard Agent Skills support for opt-in reusable workflows and tool-use instructions
+- opt-in Browser Automation for rendered page inspection and user-requested web workflows
 - explicit traces, approvals, and reviewable workflow artifacts
 - a browser control plane for local oversight, workspace switching, and session review
 - a path from interactive use to programmatic and scheduled agent workflows
@@ -52,6 +68,7 @@ At a high level, Heddle helps with:
 - switching between local workspaces from the browser control plane
 - learning durable facts, preferences, and workflows from real usage
 - enabling workspace-approved Agent Skills so the agent can load specialized instructions only when needed
+- enabling Browser Automation when an agent should inspect, screenshot, or operate real web pages
 - exposing more operator visibility than a black-box chat tool
 
 If you want a terminal-first coding agent with local state, review traces, workspace memory, and a path toward longer-running workflows, that is the problem Heddle is trying to solve.
@@ -260,6 +277,10 @@ activation from chat:
 /skills disable <name>
 ```
 
+Heddle also ships built-in skills for Heddle-owned capabilities. Capability
+settings can activate those built-ins without asking users to install separate
+skill files.
+
 Only active skills are shown to the agent. Heddle initially exposes a compact
 catalog with each active skill's name and description, then the agent can call
 `read_agent_skill` to fetch the full `SKILL.md` body when a skill is relevant.
@@ -271,6 +292,67 @@ policy or tool safety checks, so users remain responsible for which project or
 user skills they enable.
 
 More: [Agent Skills guide](docs/guides/agent-skills.md)
+
+### Browser Automation
+
+Browser Automation is an opt-in capability for tasks where the agent should see
+or operate real web pages instead of relying only on code inspection, tests, or
+plain web search.
+
+Use it when you want Heddle to:
+
+- visually inspect a frontend after local UI changes
+- capture page snapshots or screenshots as evidence
+- interact with a website the user asked it to browse
+- compare visible product/listing pages
+- use rendered DOM state that is not available from static files or APIs
+
+Browser Automation is off by default. Enable it from Settings -> Browser
+Automation or chat:
+
+```text
+/browser
+/browser enable
+/browser disable
+```
+
+Enabling Browser Automation activates Heddle's package-owned
+`browser-automation` Agent Skill and adds these tools to future default agent
+turns:
+
+```text
+browser_open
+browser_snapshot
+browser_click
+browser_screenshot
+browser_close
+```
+
+The built-in skill teaches the agent when browser automation is appropriate and
+when `web_search` is only useful for discovering a starting URL. Browser policy
+still remains authoritative: unsafe actions, off-domain navigation, and
+ambiguous JavaScript-only clicks can be blocked or require approval.
+
+#### Current Browser Automation Behavior
+
+- if no explicit domain allowlist is configured, the first `browser_open` URL
+  establishes the same-domain browsing boundary for that browser session
+- snapshots return scoped refs for safe `browser_click` calls
+- screenshots and browser evidence are stored under Heddle state
+- logged-in sites require a persistent browser profile with a valid session
+
+#### Browser Automation Next Steps
+
+- add profile management in Settings, including selected profile, Chrome
+  channel, headless/headed mode, and profile path visibility
+- add an "open profile for login" flow so users can prepare logged-in sessions
+  manually before agents reuse them
+- add form-safe browser tools such as `browser_type`, `browser_fill`, and
+  `browser_press`
+- surface browser evidence and screenshots in the control plane
+- design a live browser preview path, likely screenshot/CDP screencast based
+  rather than embedding Playwright's native headed window
+- add richer policy and approval flows for harmless same-origin UI clicks
 
 ### MCP integrations
 
@@ -483,6 +565,7 @@ npx -p @roackb2/heddle -p cyberloop heddle
 - [Control plane](docs/guides/control-plane.md)
 - [Heartbeat](docs/guides/heartbeat.md)
 - [Agent Skills](docs/guides/agent-skills.md)
+- Browser Automation: see the Browser Automation section above
 - [MCP integrations](docs/reference/mcp.md)
 - [Knowledge persistence](docs/guides/knowledge-persistence.md)
 - [Semantic drift](docs/guides/semantic-drift.md)
@@ -506,6 +589,7 @@ Current strengths include:
 - terminal-first coding and repository workflows
 - autonomous, catalog-backed workspace memory that helps the agent learn from normal usage
 - standard Agent Skills support with workspace-level activation and progressive disclosure
+- opt-in Browser Automation with browser snapshots, screenshots, policy checks, and a published next-step agenda
 - explicit traces, approval previews, diff review, and local workspace state
 - browser-based oversight and workspace switching through the control plane
 - local-first heartbeat primitives for scheduled agent work

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,87 +2,161 @@
 
 [English](README.md) | [繁體中文](README.zh-TW.md)
 
-Heddle 是一個開源、本地優先、可追蹤的 coding agent harness、runtime 與 CLI，目標是讓 AI coding agent 能在真實程式碼倉庫中工作，同時保留會話、記憶、審批、traces、驗證證據與操作可見性。
+Heddle 是一個開源的 AI coding agent runtime，也是 terminal-first 的 workspace，目標是支援真實專案工作。
 
 官方網站：[heddleagent.com](https://heddleagent.com)
 
-> **說明：** 這份繁體中文 README 用於快速介紹 Heddle。最新、最完整的技術細節仍以英文 README、官方文件與實際程式碼為準。
+> **Terminal UI v2 已是預設介面。** 執行 `heddle` 或 `heddle chat` 會使用 API-backed 的 terminal experience。訊息、run events 與 agent response streams 現在都會走 shared control-plane path，因此 terminal、browser 與 mobile clients 可以同時跟進同一份工作，讓跨裝置工作流程更順。
 
-> **Terminal UI v2 已是預設介面。** 執行 `heddle` 或 `heddle chat` 會開啟 API-backed 的終端介面。訊息、run events 與 agent 回應串流會走共用的 control-plane path，因此 terminal、browser 與 mobile client 可以同時追蹤同一個工作流程。
+## Agenda
 
-## Heddle 解決什麼問題
-
-Heddle 是為了「真實專案工作」設計的 coding agent runtime，而不是一次性 prompt wrapper。
-
-它適合這類情境：
-
-- 在陌生 repo 中快速理解架構、entrypoints、build/test 指令
-- 讓 agent 在本地 workspace 裡讀檔、搜尋、修改程式碼或文件
-- 對 shell command、file mutation 等敏感操作保持清楚審批流程
-- 將多步驟工作保存在 session 中，之後可以繼續，不必每次從零開始
-- 透過 traces、diff review、verification command evidence 檢查 agent 做了什麼
-- 讓 agent 累積可審查的 workspace memory，而不是每次重新探索同樣脈絡
-- 啟用標準 Agent Skills，讓 agent 只在需要時讀取可重用 workflow instructions
-- 設定 MCP servers，讓 agent 透過 Heddle approval 與 trace path 使用外部生態系工具
-- 用 browser control plane 查看 sessions、current diffs、tasks、settings 與 memory 狀態
-- 透過 heartbeat tasks 執行有界線的週期性或背景 agent 工作
-
-用白話說：Heddle 是給想要 AI coding assistant 真正進入本地專案工作、但又不想把專案交給黑盒自動化的人。
-
-## 為什麼試試 Heddle
-
-Heddle 適合你，如果你想要：
-
-- terminal-first 的 coding agent，可以直接在真實 repo 裡工作
-- local-first 的狀態管理，sessions、traces、memory 都存在專案的 `.heddle/` 之下
-- 標準 Agent Skills 支援，可以用 workspace activation 控制哪些 skills 會提供給 agent
-- MCP integrations，可以接上 Notion、Anytype、GitHub 或其他 user-configured MCP servers
-- 明確的審批、traces、diff review 與 verification evidence
-- browser control plane，用來做本地 oversight、workspace switching、session review
-- 從互動式使用延伸到 programmatic use 與 scheduled/heartbeat workflows 的路徑
-
-如果你只需要非常簡單的一次性問答工具，且不在意 sessions、memory、traces、審批或 operator control，那 Heddle 可能不是最合適的工具。
+- [看 Heddle 實際運作](#看-heddle-實際運作)
+- [為什麼試試 Heddle](#為什麼試試-heddle)
+- [Heddle 能做什麼](#heddle-能做什麼)
+- [Programmatic Use Layers](#programmatic-use-layers)
+- [介面展示](#介面展示)
+- [兩分鐘快速開始](#兩分鐘快速開始)
+- [主要功能](#主要功能)
+- [安裝](#安裝)
+- [需求](#需求)
+- [文件](#文件)
+- [專案狀態](#專案狀態)
+- [開發](#開發)
 
 ## 看 Heddle 實際運作
 
-Terminal、browser 與 mobile 可以同時觀察同一個 live session：
+Terminal、browser 與 mobile surfaces 可以同時觀察同一個 live session：
 
 ![Heddle streams the same session across terminal, browser, and mobile](docs/images/heddle-cross-device-stream.gif)
 
-在 control plane 中審核與批准敏感操作，同時保持 agent run 可見：
+在 control plane 中 review 與 approve sensitive actions，同時讓 agent run 持續可見：
 
 ![Heddle request approval flow in the browser control plane](docs/images/heddle-request-approval.gif)
 
-在 browser 或 mobile 中檢查 workspace diff，而同一個 conversation 仍持續進行：
+同一個 conversation 繼續進行時，也可以從 browser 與 mobile 檢查 workspace diffs：
 
 ![Heddle diff review across browser and mobile](docs/images/heddle-diff-view.gif)
 
+Heddle 是為這類 workflow 設計：agent 需要檢查 live repository、做有邊界的修改、驗證結果、跨 sessions 保持 continuity，並且讓 operator 能看清楚它正在做什麼。Heddle 支援 OpenAI 與 Anthropic models，會把 local workspace state 存在 `.heddle/`，包含 terminal chat experience 與 browser control plane，能在工作時學習 durable workspace knowledge，也提供 file diffs、commands、approvals 與 traces 的 review path。
+
+白話來說：Heddle 適合想要 AI coding assistant 真正進入專案工作、逐漸學會每個 project 的 operating knowledge、能在 local workspaces 之間切換，而且保持可檢查、不像黑盒的人。
+
+## 為什麼試試 Heddle
+
+Heddle 是給想要超越一次性 coding chat wrapper 或 stateless AI code assistant 的人。
+
+如果你想要以下能力，Heddle 會很適合：
+
+- terminal-first 的 coding agent，可以在真實 repository 裡工作
+- agent 能在工作時學習 durable project knowledge，並使用可檢查的 local memory
+- 標準 Agent Skills 支援，可用於 opt-in reusable workflows 與 tool-use instructions
+- opt-in Browser Automation，可用於 rendered page inspection 與使用者要求的網站工作流程
+- 明確 traces、approvals 與可 review 的 workflow artifacts
+- browser control plane，可用於 local oversight、workspace switching 與 session review
+- 從 interactive use 延伸到 programmatic 與 scheduled agent workflows 的路徑
+
+如果你只想要非常簡單的一次性 prompt runner，而且不在意 sessions、persistence、observability 或 operator control，那 Heddle 可能不是最適合的工具。
+
+## Heddle 能做什麼
+
+概略來說，Heddle 可以協助：
+
+- 理解陌生 repositories
+- 在真實 workspace 裡修改 code 或 docs
+- 執行 bounded verification，例如 builds、tests 與 repo review
+- 讓多步驟工作跨 sessions 延續，而不是每次重新開始
+- 從 browser control plane 在 local workspaces 之間切換
+- 從真實使用中學習 durable facts、preferences 與 workflows
+- 啟用 workspace-approved Agent Skills，讓 agent 只在需要時載入 specialized instructions
+- 啟用 Browser Automation，讓 agent 在需要時檢查、截圖或操作真實網頁
+- 提供比黑盒 chat tool 更多 operator visibility
+
+如果你想要一個 terminal-first coding agent，具有 local state、review traces、workspace memory，並且能往 longer-running workflows 發展，那就是 Heddle 想解決的問題。
+
+## Programmatic Use Layers
+
+Heddle 目前有兩個主要 programmatic layers：
+
+- `createConversationEngine`：alpha API，用於 persisted multi-turn sessions，包含 session storage、compaction、approvals、traces、semantic activity，以及 custom frontends 或 local hosts
+- `AgentLoopRuntimeService.run(...)`：較低階的 single-run execution loop，適合不需要 persisted chat 或 session behavior 的 hosts
+
+Advanced hosts 也可以重用較低階 class APIs，例如 `ToolRegistry`、`ToolExecutionService`、`TraceRecorder`、`TraceConsoleFormatter` 與 `ReviewDiffParser`，在明確需要 custom runtime 或 review surfaces 時自行組裝。
+
+如果你想使用 programmatic surface，請從 [Programmatic use guide](docs/guides/programmatic-use.md) 開始。
+
+給 contributors 的 compact architecture map 在 [Core Layering](docs/architecture/core-layering.md) 與 [Chat Layering](docs/architecture/chat-layering.md)。
+
+## 介面展示
+
+### Terminal coding workflow
+
+Heddle 在 terminal 中顯示 live progress、tool activity、plans 與 review output：
+
+![Heddle terminal coding workflow](docs/images/terminal-active-run.png)
+
+Heddle 可以 inspect files、用 ignore-aware fallbacks 搜尋、解釋 code、做 edits、以正確 approval model 執行 shell commands，並跨多輪完成任務。Terminal chat 會用 tool activity、dim `Thinking:` progress text、real-time assistant markdown，以及更清楚的 repeated command/search approval prompts 讓 long-running turns 保持可見。
+
+### Terminal change review
+
+Terminal chat/dev workflow 顯示 file edits、inline diff output，以及 verification-oriented follow-through：
+
+![Heddle terminal change review](docs/images/terminal-change-review.png)
+
+### Browser control plane overview
+
+預設 local control plane 是由 `heddle daemon` 提供的 web-v2 browser client。它是 coding sessions、workspace state、current changes、heartbeat tasks 與 settings 的 oversight surface：
+
+![Heddle web-v2 control plane](docs/images/control-plane-v2.png)
+
+web-v2 client 包含：
+
+- `Sessions`：saved conversations、live assistant streaming、tool progress、approvals 與 current workspace diff review。
+- `Composer controls`：model 與 reasoning settings、semantic drift controls、`@file` mentions，以及會保存為 local paths 給 `view_image` 使用的 image attachments。
+- `Workspace switching`：sidebar workspace selection，以及 `Settings > Workspace` 中註冊、重新命名與切換 local projects。
+- `Tasks`：heartbeat task creation、edit、enable/disable、run、resume、delete、live run state 與 saved run records。
+- `Settings`：language preferences、workspace management、memory status，以及 catalog health、note counts、pending candidates 與 latest maintenance run。
+- `Mobile`：針對 session list、conversation workbench、task detail、settings 與 diff review 的 focused panels。
+
+Task workbench 涵蓋 recurring heartbeat tasks、live run state 與 run result review：
+
+![Heddle web-v2 heartbeat task workbench](docs/images/control-plane-v2-heartbeat-task.png)
+
+同一個 control plane 支援 mobile layouts，session list、workbench 與 diff preview 都會以 focused panels 呈現：
+
+<p>
+  <img src="docs/images/control-plane-v2-session-list.PNG" alt="Heddle web-v2 mobile session list" width="220">
+  <img src="docs/images/control-plane-v2-workbench.PNG" alt="Heddle web-v2 mobile workbench" width="220">
+  <img src="docs/images/control-plane-v2-diff-view.PNG" alt="Heddle web-v2 mobile diff preview" width="220">
+</p>
+
 ## 兩分鐘快速開始
 
-### 1. 安裝 Heddle
+1. 安裝 Heddle：
 
 ```bash
 npm install -g @roackb2/heddle
 ```
 
-也可以不用全域安裝，直接用：
+2. 設定 provider access。
 
-```bash
-npx @roackb2/heddle
-```
-
-### 2. 設定 provider access
-
-OpenAI 可以使用你自己的 ChatGPT / Codex account 登入：
+OpenAI 可以用你自己的 ChatGPT/Codex account 登入：
 
 ```bash
 heddle auth login openai
 ```
 
-或使用 OpenAI Platform API key：
+或使用 Platform API key：
 
 ```bash
 export OPENAI_API_KEY=your_key_here
+```
+
+如果你同時保留 OpenAI OAuth credential 與 API key 方便測試，可以明確讓本次 run 偏好 API key：
+
+```bash
+heddle --prefer-api-key
+heddle --prefer-api-key ask "Summarize this repository"
+heddle --prefer-api-key daemon
 ```
 
 Anthropic 使用 API key：
@@ -91,105 +165,103 @@ Anthropic 使用 API key：
 export ANTHROPIC_API_KEY=your_key_here
 ```
 
-如果你同時有 OpenAI OAuth credential 與 API key，可以用 `--prefer-api-key` 指定本次 run 優先使用 API key：
+OpenAI account sign-in 是 experimental、由使用者自行選擇的 transport。它不是 OpenAI 官方支援；Heddle 與 OpenAI 沒有從屬、背書或贊助關係。使用 OpenAI 服務仍需遵守 OpenAI 的 terms 與 policies。
 
-```bash
-heddle --prefer-api-key
-heddle --prefer-api-key ask "Summarize this repository"
-heddle --prefer-api-key daemon
-```
-
-OpenAI account sign-in 是 experimental、由使用者自行選擇的 transport。它不是 OpenAI 官方支援；Heddle 與 OpenAI 沒有從屬、背書或贊助關係。使用 OpenAI 服務仍需遵守 OpenAI 的條款與政策。
-
-### 3. 進入你想讓 Heddle 工作的 repo
+3. 進入任何你想 inspect 的 repository：
 
 ```bash
 cd /path/to/project
 ```
 
-### 4. 開始 terminal chat
+4. 開始 chat：
 
 ```bash
 heddle
 ```
 
-可以試試這個 prompt：
+5. 試試這個 prompt：
 
 ```text
 Summarize this repository, show me the main build/test commands, and point out the likely entrypoints.
 ```
 
-### 5. 開啟 browser control plane（可選）
+6. 如果你也想使用 browser oversight UI：
 
 ```bash
 heddle daemon
 ```
 
-Daemon 預設會啟動本地 browser control plane。你可以在那裡查看 `Sessions`、`Tasks`、`Settings`，並檢查 active workspace、saved sessions、current diffs、memory status，或切換到另一個本地 project。
+從 daemon output 打開 browser control plane。你可以在那裡使用 `Sessions`、`Tasks` 與 `Settings` 檢查 active workspace、continue saved sessions、review changes、inspect memory status，或切換到另一個 local project。
 
-### 6. 一次性 ask 模式
-
-如果你想要一次性 CLI run，而不是互動式 chat：
+如果你偏好一次性的 CLI run，而不是 interactive chat，可以用：
 
 ```bash
 heddle ask "Summarize this repository"
 ```
 
-`ask` 會在一個 prompt 後結束，但仍會把 run 存成 `.heddle/` 底下的一個 saved session，讓 traces、memory maintenance 與後續 review 能共用同一套 persisted conversation path。
+`ask` 仍會在一個 prompt 後結束，但它現在會把 run 記錄成 `.heddle/` 下的一個 one-off saved session，所以 traces、memory maintenance 與後續 inspection 會使用和 normal sessions 相同的 persisted conversation path。
+
+Terminal chat footer 與 control-plane session composer 都會顯示 selected model 的 active auth source，所以你可以知道 session 正在使用 OpenAI account sign-in、API-key mode，或是缺少 credentials。
+
+### Try The Learning Loop
+
+當 Heddle 學會 reusable preference 並在之後套用時，它會更有用。你可以在 chat 裡教它一個 ticket format：
+
+```text
+Whenever I ask you to create a ticket, use these sections: problem statement, proposed approach, considered alternatives, conclusion.
+```
+
+然後開一個 fresh session 並詢問：
+
+```text
+Create a ticket for maintaining doc consistency after feature updates.
+```
+
+Heddle 應該會從 local memory catalog 找回這個 preference，並用指定結構產出 ticket。你可以用以下指令檢查它學到了什麼：
+
+```bash
+heddle memory status
+heddle memory list
+heddle memory search ticket
+```
 
 ## 主要功能
 
-### Terminal chat
+### Terminal chat for real coding work
 
-Heddle 的主要使用方式是在 repo 裡執行：
+Heddle 的主要使用方式是在 repository 中進行 interactive chat：
 
 ```bash
 heddle
 ```
 
-Terminal chat 可以：
+在這裡，Heddle 可以 inspect files、explain code、make edits、用正確 approval model 執行 shell commands，並跨多輪完成任務。
 
-- 檢查目錄與檔案
-- 搜尋 repo，並尊重 ignore 規則
-- 解釋程式碼與架構
-- 修改程式碼或文件
-- 執行 shell command，必要時要求 operator approval
-- 在多輪對話中持續完成同一個任務
-- 顯示 thinking、tool activity、plans、approval waits 與 assistant stream
+這是核心功能。如果你只把 Heddle 當成 terminal 裡的 coding agent 使用，這就是你最需要關心的部分。
 
-常用 chat commands 包含：
+Terminal composer 支援 multiline prompts、prompt undo/redo、prompt history navigation、用 `/model set` 選 model，以及用 `/reasoning set` 選 reasoning effort。Run 進行中，Heddle 會 streaming visible activity，讓你看見它是在 thinking、searching、calling tools、updating a plan，還是 waiting for approval。
 
-```text
-/model
-/model set <query>
-/reasoning
-/reasoning set <query>
-/skills
-/skills enable <name>
-/skills disable <name>
-/session list
-/session choose <query>
-/session new [name]
-/session switch <id>
-/session continue <id>
-/continue
-/compact
-/drift
-!<command>
-```
+更多：[Chat and sessions guide](docs/guides/chat-and-sessions.md)
+
+### Terminal UI v2 is the default
+
+預設 terminal chat 現在是 API-backed 的 `cli-v2` experience。從 project 中執行 `heddle` 或 `heddle chat` 就能開始。
+
+v2 terminal UI 使用和 browser UI 相同的 local control-plane API，不會直接碰 core services。對使用者來說，目標是在所有 interfaces 中保持同一套 behavior model。Saved conversation、selected model、reasoning setting、approval state 與 live run status 應該不管從 terminal、browser control plane，或另一台連到同一 local control-plane server 的裝置看，都會是一致的。Messages、tool events、approval waits 與 streamed agent responses 會透過 shared session event path 傳遞，因此多個 devices 可以同時 observe 與 continue 同一份工作，而不是等待某個 surface 完成或 refresh。
+
+對 contributors 來說，目標是更乾淨的 implementation path：TUI-specific rendering 與 keyboard behavior 留在 `cli-v2`，shared semantics 留在 core 與 server-owned control-plane APIs，future advanced features 可以建立在 maintainable API-first foundation 上，而不是在每個 interface 裡重複 command/session logic。
+
+### Project instructions
+
+Heddle 啟動時可以載入短的 project instruction file，讓 fresh session 一開始就知道 repository operating context。預設會依序讀取第一個非空檔案：`HEDDLE.md`、`AGENTS.md`、`CLAUDE.md`。
+
+為了保留 context space，預設只讀一個 default file。如果 project 需要不同路徑，或明確想讀多個 files，可以在 `.heddle/config.json` 設定 `agentContextPaths`。
+
+更多：[Project config](docs/reference/config.md)
 
 ### Agent Skills
 
-Heddle 支援標準 Agent Skills folder 格式，讓你把可重用 workflow instructions 放在 `SKILL.md`，不必每次 prompt 都重新貼一大段說明。
-
-常見路徑：
-
-```text
-.agents/skills/<name>/SKILL.md
-~/.agents/skills/<name>/SKILL.md
-```
-
-在 chat 裡可以用 slash commands 管理 workspace activation：
+Heddle 支援標準 Agent Skills folder format，可用於 reusable、opt-in agent workflows。把 project skills 放在 `.agents/skills/<name>/SKILL.md`，或把 user skills 放在 `~/.agents/skills/<name>/SKILL.md`，再從 chat 管理 workspace activation：
 
 ```text
 /skills
@@ -197,17 +269,67 @@ Heddle 支援標準 Agent Skills folder 格式，讓你把可重用 workflow ins
 /skills disable <name>
 ```
 
-只有 active skills 會提供給 agent。Heddle 會先把 active skills 的 name 與 description 放進 compact catalog；agent 只有在判斷某個 skill 相關時，才會用 `read_agent_skill` 讀取完整 `SKILL.md` 或其中 linked resources。Activation state 只存在 `.heddle/skills/activation.json`，skill definitions 仍留在原本資料夾。
+Heddle 也會內建一些 Heddle-owned capabilities 的 skills。Capability settings 可以啟用這些 built-ins，不需要使用者另外安裝 skill files。
 
-Skills 是 instructions，不是 permissions。啟用 skill 不會繞過 Heddle 的 approval policy、tool safety checks、browser policy 或 workspace permissions。使用者需要自行確認放進 `.agents/skills` 或 `~/.agents/skills` 的 skills 是否可信。
+只有 active skills 會提供給 agent。Heddle 一開始只會把每個 active skill 的 name 與 description 放進 compact catalog；agent 判斷某個 skill 相關時，才會呼叫 `read_agent_skill` 讀取完整 `SKILL.md` body。Activation state 存在 `.heddle/skills/activation.json`；skill definitions 仍留在原本 folders。
 
-更多細節請看英文文件：[Agent Skills guide](docs/guides/agent-skills.md)。
+Skills 是 instructions，不是 permissions。它們不會繞過 Heddle 的 approval policy 或 tool safety checks，所以使用者仍需自行負責啟用哪些 project 或 user skills。
+
+更多：[Agent Skills guide](docs/guides/agent-skills.md)
+
+### Browser Automation
+
+Browser Automation 是一個 opt-in capability，適合 agent 需要看見或操作真實網頁，而不是只依賴 code inspection、tests 或 plain web search 的任務。
+
+適合在這些情境啟用：
+
+- frontend UI 修改後，需要 visual inspection
+- 需要擷取 page snapshots 或 screenshots 作為 evidence
+- 使用者要求 agent 瀏覽或操作某個網站
+- 需要比較可見的商品頁、listing 或搜尋結果
+- 任務依賴 rendered DOM state，而不是 static files 或 APIs 就能回答
+
+Browser Automation 預設關閉。你可以從 Settings -> Browser Automation，或在 chat 中使用以下指令啟用：
+
+```text
+/browser
+/browser enable
+/browser disable
+```
+
+啟用 Browser Automation 會啟用 Heddle package-owned 的 `browser-automation` Agent Skill，並讓未來 default agent turns 可以使用：
+
+```text
+browser_open
+browser_snapshot
+browser_click
+browser_screenshot
+browser_close
+```
+
+內建 skill 會教 agent 什麼時候適合使用 browser automation，以及什麼時候 `web_search` 只適合用來尋找起始 URL。Browser policy 仍然是最終邊界：unsafe actions、off-domain navigation、模糊的 JavaScript-only clicks 都可能被 block 或要求 approval。
+
+#### Browser Automation 目前行為
+
+- 如果沒有明確設定 domain allowlist，第一個 `browser_open` URL 會成為該 browser session 的 same-domain browsing boundary
+- snapshots 會回傳 scoped refs，供安全的 `browser_click` 使用
+- screenshots 與 browser evidence 會存放在 Heddle state 底下
+- 需要登入狀態的網站仍然需要 persistent browser profile 與有效 session
+
+#### Browser Automation 下一步
+
+- 在 Settings 加入 profile management，包括 selected profile、Chrome channel、headless/headed mode、profile path visibility
+- 加入「open profile for login」流程，讓使用者可以手動準備 logged-in sessions，再讓 agent 重用
+- 加入 form-safe browser tools，例如 `browser_type`、`browser_fill`、`browser_press`
+- 在 control plane 顯示 browser evidence 與 screenshots
+- 設計 live browser preview，方向比較可能是 screenshot/CDP screencast，而不是嵌入 Playwright native headed window
+- 加入更細緻的 policy 與 approval flows，支援 harmless same-origin UI clicks
 
 ### MCP integrations
 
 Heddle 可以連接使用者設定的 Model Context Protocol servers，讓 agent 透過 Heddle 的 approval 與 trace path 使用 Notion、Anytype、GitHub 或其他 MCP 生態系工具。
 
-你可以在 Settings -> MCP 貼上標準 `mcpServers` JSON document，也可以直接編輯 `.heddle/mcp.json`，或在 chat 中用 `/mcp config` 打開這個檔案。Server config 與 workspace activation 是分開的：儲存 config 之後，仍然需要明確 enable 並 refresh server，未來 agent turns 才能看到 cached tools。
+你可以在 Settings -> MCP 貼上標準 `mcpServers` JSON document，也可以直接編輯 `.heddle/mcp.json`，或在 chat 中用 `/mcp config` 打開這個檔案。Server config 與 workspace activation 是分開的：儲存 config 後，仍然需要明確 enable 並 refresh server，未來 agent turns 才能看到 cached tools。
 
 ```text
 /mcp
@@ -217,84 +339,101 @@ Heddle 可以連接使用者設定的 Model Context Protocol servers，讓 agent
 /mcp disable <server>
 ```
 
-刷新已啟用的 server 會把 tool catalog cache 到 `.heddle/mcp/`。未來 agent turns 可以用 `mcp_list_tools` 檢視 MCP tools，並透過 approval-gated MCP tool adapters 呼叫它們。
+刷新已啟用 server 會把 tool catalog cache 到 `.heddle/mcp/`。未來 agent turns 可以用 `mcp_list_tools` inspect MCP tools，並透過 approval-gated MCP tool adapters 呼叫它們。
 
-更多細節請看英文文件：[MCP integrations](docs/reference/mcp.md)。
+更多：[MCP integrations](docs/reference/mcp.md)
 
-### Sessions 與 continuity
+### Sessions and continuity
 
-Heddle 會把 saved sessions 存在 `.heddle/` 之下，讓較長的工作不必每次重新開始。
+Heddle 會把 saved sessions 存在 `.heddle/`，讓較長工作不必每次重新開始。目前版本把 session catalog 存在 `.heddle/chat-sessions.catalog.json`，per-session bodies 存在 `.heddle/chat-sessions/`。這表示你可以回到中斷的 task、繼續之前的 debugging thread，或跨 runs 保留 project-specific context。
 
-目前 session storage 格式是：
+如果你在做真實的 multi-step work，而不是 one-shot prompts，這點會很重要。
 
-```text
-.heddle/chat-sessions.catalog.json
-.heddle/chat-sessions/<session-id>.json
-```
+常用 session commands 包含：
 
-這代表你可以：
+- `/session list`
+- `/session switch <id>`
+- `/continue`
+- `/compact`
+- `/model set`
+- `/reasoning set`
 
-- 回到中斷的 task
-- 繼續之前的 debugging thread
-- 保留 project-specific context
-- 透過 `/compact` 或自動 compaction 管理長對話
-- 在 terminal 與 browser control plane 之間查看同一組 session record
+更多：[Chat and sessions guide](docs/guides/chat-and-sessions.md)
 
-### Workspace memory
+### Knowledge Persistence: Heddle Learns While It Works
 
-Heddle 可以在 `.heddle/memory/` 底下維護 durable workspace knowledge。
+Heddle 可以在工作時學習 durable project knowledge。
 
-適合放進 memory 的內容包括：
+當 agent 注意到 reusable information，例如 preferred ticket format、canonical verification command、operational convention、recurring repo quirk，或 stable workflow pattern，它可以記錄 memory candidate，並讓 dedicated maintainer path 把這些 knowledge 整理成 `.heddle/memory/` 底下 cataloged markdown notes。
 
-- 架構與服務邊界
-- canonical build/test/release commands
-- repo convention 與 workflow rule
-- 使用者或團隊偏好，例如 ticket 格式、review 風格
-- 已完成實作或調查後的穩定發現
+目標是 practical recall：future sessions 應該知道從哪裡找，而不是每次重新探索相同 context。Heddle 透過 explicit catalogs、readable local notes、maintenance logs 與 memory visibility commands 完成這件事，而不是依賴 opaque retrieval。
 
-Memory 是可審查的 markdown catalog，不是黑盒向量資料庫。Heddle 可以在正常工作中記錄 memory candidates，再由 bounded maintainer path 把候選內容整理進 cataloged notes。
+Learning loop 是刻意具體化的：
 
-常用 memory commands：
+- 在正常工作中注意 durable facts 與 preferences
+- 不打斷使用者就記錄 memory candidates
+- 透過 maintainer path 把 candidates 整理進 cataloged markdown
+- 讓 future sessions 透過 explicit discovery paths 找回 context
+- 讓 users 用 `heddle memory status/list/read/search/validate` audit memory
 
-```bash
-heddle memory status
-heddle memory list
-heddle memory read <path>
-heddle memory search <query>
-heddle memory validate
-heddle memory maintain --dry-run
-```
+你可以在真實 project 上嘗試：告訴 Heddle 一個 durable preference，或讓它發現 stable workflow detail，然後開一個 fresh session，看它透過 memory catalog 找回 context。
 
-### Browser control plane
+例如，先告訴 Heddle 你偏好的 ticket template，再在新 session 中請它產 ticket。重點不只是存一份 note，而是讓 future work 從你已經教過 agent 的 operating knowledge 開始。
 
-執行：
+更多：[Knowledge persistence](docs/guides/knowledge-persistence.md)
+
+### Control plane and workspaces
+
+Control plane 是 Heddle 的 local browser UI：
 
 ```bash
 heddle daemon
 ```
 
-即可啟動本地 browser control plane。它是 Heddle 的 oversight surface，用來查看：
+它會啟動 local server，讓你：
 
-- `Sessions`：saved conversations、assistant streaming、tool progress、approvals、current workspace diff review
-- `Composer controls`：model、reasoning、drift controls、`@file` mentions、image attachments
-- `Workspace switching`：註冊、重新命名、切換本地 projects
-- `Tasks`：heartbeat task 的建立、編輯、啟用/停用、run、resume、delete、live run state 與 saved run records
-- `Settings`：workspace management、memory status、catalog health、pending candidates
-- `Mobile`：針對手機與平板的 session list、workbench、diff review 等 focused views
+- 查看 saved sessions
+- 觀察 active runs
+- review current workspace changes
+- 切換 registered workspaces
+- 檢查 memory status
+- 管理 heartbeat tasks
 
-預設 daemon 使用同一個 local control-plane server path。Terminal、browser 與 mobile client 都可以透過這條 path 共享 session events、approval state、workspace review 與 heartbeat records。
+Control plane 的目標不是取代 IDE，而是提供 agent work 的 operator view。
 
-### Heartbeat tasks
+更多：[Control plane](docs/guides/control-plane.md)
 
-Heartbeat tasks 是有界線的週期性或背景 agent 工作。它可以：
+### Runtime host model
 
-- 載入 durable task 與 checkpoint
-- 在 budget 內讓 agent 做有限工作
-- checkpoint 新狀態
-- 儲存 run record
-- 回傳 decision：`continue`、`pause`、`complete` 或 `escalate`
+Heddle 的核心不只是 CLI。它也可以被當成 runtime host foundation。
 
-常用指令：
+Host model 把幾個 concerns 拆開：
+
+- conversation/session persistence
+- model/provider resolution
+- tools and approvals
+- trace recording
+- memory maintenance
+- UI/control-plane presentation
+
+這讓未來可以建立不同 agent surfaces，而不需要重寫整個 runtime。
+
+更多：[Runtime host model](docs/guides/runtime-host-model.md)
+
+### Heartbeat
+
+Heartbeat 是 Heddle 對 recurring 或 long-running bounded agent work 的模型。
+
+Heartbeat task 可以：
+
+- 週期性執行
+- reuse checkpoint state
+- 在 budget 內做一小段 work
+- 決定 pause、continue、complete 或 escalate
+
+這不是 hidden daemon magic；它是 explicit local state 與 scheduler-friendly APIs 的組合。
+
+常用 commands：
 
 ```bash
 heddle heartbeat start --every 30m --task "Check for safe repository maintenance work"
@@ -303,19 +442,13 @@ heddle heartbeat run --task repo-gardener
 heddle heartbeat runs show latest --task repo-gardener
 ```
 
-Heartbeat task state 是 local-first 的；adding a task 只是儲存 scheduler state，不代表安裝了一個隱藏的 OS background service。
+更多：[Heartbeat](docs/guides/heartbeat.md)
 
-### Semantic drift（可選）
+### Semantic drift
 
-Heddle 可以搭配 optional `cyberloop` package 顯示 agent 回應是否偏離最近 conversation trajectory。
+Heddle 可以選擇性顯示 semantic drift telemetry，協助你觀察 agent run 是否開始偏離目前 task。
 
-```bash
-npm install -g cyberloop
-```
-
-Drift telemetry 是 observe-only，而且預設關閉。啟用時需要 OpenAI Platform API-key mode 來做 embeddings；OpenAI account sign-in 不用於 drift embeddings。
-
-在 chat 中可以使用：
+在 chat 中：
 
 ```text
 /drift
@@ -323,42 +456,144 @@ Drift telemetry 是 observe-only，而且預設關閉。啟用時需要 OpenAI P
 /drift off
 ```
 
-## Programmatic use
+Footer 會顯示：
 
-Heddle 也提供可被其他 host 使用的 runtime layers：
+- `drift=off`
+- `drift=stable`
+- `drift=medium`
+- `drift=high`
 
-- `createConversationEngine`：alpha API，用於 persisted multi-turn sessions、session storage、compaction、approvals、traces、semantic activity 與 custom frontends/local hosts
-- `AgentLoopRuntimeService.run(...)`：較低階的 single-run execution loop，適合不需要 persisted chat/session behavior 的 host
-- Heartbeat APIs：用於 scheduled/background runner cycles
+這是 observability feature，不是 magic correctness guarantee。它的目標是幫助 operator 注意到 run 可能開始偏離最近方向。
 
-如果你想把 Heddle 當成 programmatic runtime 使用，請從英文文件開始：
+如果你只是想找 coding agent，day one 不需要在意這個功能。如果你關心 agent observability 與 runtime behavior，它是 Heddle 比較有特色的功能之一。
 
-- [Programmatic use guide](docs/guides/programmatic-use.md)
+更多：[Semantic drift](docs/guides/semantic-drift.md)
+
+### Programmatic runtime APIs
+
+Heddle 不只是 CLI。npm package 也 expose runtime primitives，例如 `createConversationEngine`、`AgentLoopRuntimeService.run(...)`、`HeartbeatRunnerAgent.run`、`HeartbeatSchedulerService.runDueTasks` 與 `FileHeartbeatTaskService`，讓其他 hosts 可以建立在它之上。
+
+這是給想建立自己的 agent hosts、schedulers 或 control surfaces 的人，而不只是使用 packaged CLI。
+
+更多：[Programmatic use](docs/guides/programmatic-use.md)
+
+## 安裝
+
+全域安裝：
+
+```bash
+npm install -g @roackb2/heddle
+```
+
+不全域安裝也可以執行：
+
+```bash
+npx @roackb2/heddle
+```
+
+安裝後的 CLI command 是 `heddle`。
+
+## 需求
+
+- Node.js 20+
+- 至少要能存取一個 supported provider：
+  - 透過 `heddle auth login openai` 使用 OpenAI account sign-in，或設定 `OPENAI_API_KEY`
+  - Anthropic models 使用 `ANTHROPIC_API_KEY`
+
+Heddle 刻意不支援 Anthropic consumer subscription OAuth。除非 Anthropic 提供 approved third-party auth route，否則請使用 Anthropic API-key access。
+
+## Optional CyberLoop Integration
+
+如果你想在 chat 中使用 semantic drift telemetry，請在和 Heddle 相同的 environment 安裝 `cyberloop`：
+
+```bash
+npm install -g cyberloop
+# or for project-local usage
+npm install cyberloop
+```
+
+如果不想全域安裝，也可以一次性使用：
+
+```bash
+npx -p @roackb2/heddle -p cyberloop heddle
+```
+
+## 文件
+
+### 從這裡開始
+
+- [Documentation hub](docs/README.md)
 - [Runtime host model](docs/guides/runtime-host-model.md)
-- [Capabilities and tools](docs/reference/capabilities.md)
+- [Chat and sessions guide](docs/guides/chat-and-sessions.md)
+- [CLI reference](docs/reference/cli.md)
 
-## Project instructions
+### Feature guides
 
-Heddle 啟動時會嘗試讀取專案指令檔，讓新 session 一開始就知道 repo 的操作規則。預設優先順序：
+- [Runtime host model](docs/guides/runtime-host-model.md)
+- [Control plane](docs/guides/control-plane.md)
+- [Control plane](docs/guides/control-plane.md)
+- [Heartbeat](docs/guides/heartbeat.md)
+- [Agent Skills](docs/guides/agent-skills.md)
+- Browser Automation：請看上方 Browser Automation section
+- [MCP integrations](docs/reference/mcp.md)
+- [Knowledge persistence](docs/guides/knowledge-persistence.md)
+- [Semantic drift](docs/guides/semantic-drift.md)
+- [Programmatic use](docs/guides/programmatic-use.md)
 
-1. `HEDDLE.md`
-2. `AGENTS.md`
-3. `CLAUDE.md`
+### Contributors
 
-預設只讀第一個非空檔案，以節省 context。如果專案需要不同路徑或多個 instruction files，可以在 `.heddle/config.json` 設定 `agentContextPaths`。
+- [Agent context](docs/agent-context.md)
+- [Project posture](docs/project-posture.md)
+- [Development and contributing](docs/guides/development.md)
+- [Release convention](docs/releases/README.md)
+- [Framework Vision](docs/strategy/framework-vision.md)
+- [Coding Agent Roadmap](docs/strategy/coding-agent-roadmap.md)
 
-## 更多資源
+## 專案狀態
 
-- 官方網站：[heddleagent.com](https://heddleagent.com)
-- npm package：[@roackb2/heddle](https://www.npmjs.com/package/@roackb2/heddle)
-- GitHub Issues：[roackb2/heddle/issues](https://github.com/roackb2/heddle/issues)
-- 英文文件入口：[docs/README.md](docs/README.md)
-- CLI reference：[docs/reference/cli.md](docs/reference/cli.md)
-- Chat and sessions：[docs/guides/chat-and-sessions.md](docs/guides/chat-and-sessions.md)
-- Agent Skills：[docs/guides/agent-skills.md](docs/guides/agent-skills.md)
-- MCP integrations：[docs/reference/mcp.md](docs/reference/mcp.md)
-- Control plane：[docs/guides/control-plane.md](docs/guides/control-plane.md)
+Heddle 已經能用於真實 coding-agent workflows，但仍在持續演進。
+
+目前強項包括：
+
+- terminal-first coding 與 repository workflows
+- autonomous、catalog-backed workspace memory，能讓 agent 從正常使用中學習
+- 標準 Agent Skills 支援，包含 workspace-level activation 與 progressive disclosure
+- opt-in Browser Automation，包含 browser snapshots、screenshots、policy checks 與公開 next-step agenda
+- explicit traces、approval previews、diff review 與 local workspace state
+- 透過 control plane 進行 browser-based oversight 與 workspace switching
+- local-first heartbeat primitives，可用於 scheduled agent work
+- practical programmatic hooks，可用於 custom hosts
+
+目前限制包括：
+
+- browser control plane 對 file review 仍是 read-only；還不是 editable IDE-like diff environment
+- 某些 advanced workflows 在 source 與 examples 中比 polished product UX 更完整
+- 隨著 runtime 成熟，project surface 仍在變動
+
+## 開發
+
+如果你想開發 Heddle 本身：
+
+```bash
+yarn install
+yarn build
+yarn test
+```
+
+常見 entrypoints：
+
+- `src/cli-v2/`：目前預設 terminal UI
+- `src/server/`：local control-plane API
+- `src/web-v2/`：browser control-plane client
+- `src/core/chat/engine/`：persisted conversation/session engine
+- `src/core/runtime/`：programmatic runtime host layer
+- `src/core/tools/`：built-in tools and toolkits
+- `src/core/memory/`：workspace memory system
+- `src/core/heartbeat/`：heartbeat task/run services
+- `docs/`：user 與 contributor documentation
+
+請先閱讀 [Agent context](docs/agent-context.md) 與 [Project posture](docs/project-posture.md)，再進行 non-trivial changes。
 
 ## 授權
 
-Heddle 使用 MIT License。
+MIT

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -7,11 +7,15 @@ Skills are discovered from:
 
 - project skills under `.agents/skills/<name>/SKILL.md`
 - user skills under `~/.agents/skills/<name>/SKILL.md`
-- package-provided built-in skill roots when a host registers them
+- Heddle built-in skills shipped with the package
 
 Project skills take precedence over user skills with the same name. Heddle only
 stores workspace activation state under `.heddle/skills/activation.json`; it
 does not copy skill definitions into Heddle state.
+
+Built-in skills are Heddle-owned instructions for common capabilities. They are
+visible in the same catalog as project and user skills, but they are still not
+active by default.
 
 ## Skill Format
 
@@ -60,6 +64,29 @@ Use the terminal slash commands inside `heddle` or `heddle chat`:
 - `Missing definitions`: activation records whose `SKILL.md` no longer exists
 
 Only active skills are shown to the agent during a run.
+
+Browser Automation also has a capability-specific shortcut:
+
+```text
+/browser
+/browser enable
+/browser disable
+```
+
+`/browser enable` activates Heddle's built-in `browser-automation` skill and
+adds browser tools to future default agent turns in the current workspace. The
+equivalent web path is Settings -> Browser Automation.
+
+The browser skill teaches the agent when browser automation is useful: visual
+inspection for frontend work, user-requested website interaction, web research,
+shopping comparison, and tasks where rendered browser state matters. It also
+reminds the agent that logged-in sites require a selected browser profile with a
+valid session; without one, only public or non-session pages should be assumed
+reachable.
+
+If an agent needs a starting URL, it may use `web_search` to discover the
+target page, but it should switch to `browser_open` and `browser_snapshot` when
+the user asked for browser interaction or rendered page evidence.
 
 ## What The Agent Sees
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -55,6 +55,7 @@ Current runtime features include:
 - Agent Skills discovery from `.agents/skills/<name>/SKILL.md` and `~/.agents/skills/<name>/SKILL.md`
 - workspace-level skill activation through `/skills`, `/skills enable <name>`, and `/skills disable <name>`
 - progressive skill disclosure through the `read_agent_skill` tool for active skills only
+- built-in Browser Automation guidance through `/browser`, `/browser enable`, `/browser disable`, and Settings -> Browser Automation
 - MCP server config and management through `/mcp`, `/mcp config`, `/mcp enable <server>`, `/mcp disable <server>`, and `/mcp refresh <server>`
 - cached MCP tool access through `mcp_list_tools`, `mcp_call_tool`, and namespaced tools such as `mcp__server__tool`
 - remembered per-project approvals for repeated commands and edits, with clearer previews before approval
@@ -85,6 +86,7 @@ Beyond terminal chat, Heddle includes:
 - Heddle is a coding/workspace agent runtime, not a general-purpose autonomous system.
 - Knowledge persistence uses explicit local catalogs and maintainer runs, so users can audit what Heddle learned instead of relying on opaque retrieval.
 - Agent Skills are instructions, not permissions. Enabling a skill does not bypass Heddle's approval policy, tool safety checks, browser policy, or workspace permissions.
+- Browser Automation is off by default. Enabling it activates Heddle's built-in browser guidance and adds browser tools to future default turns. Browser profiles and policy still remain authoritative; without an explicit domain allowlist, the first opened URL establishes the same-domain browsing boundary.
 - MCP server declarations are integrations, not trust grants. Local stdio servers run commands with the user's OS permissions, and MCP tool calls still go through Heddle approvals and traces.
 - The control plane review view is read-only. Current changes are Git-backed, while historical turn evidence is trace-backed; it is not yet an editable IDE-grade diff surface or live file watcher.
 - The image workflow is intentionally lightweight: terminal users can provide a local image path, and browser uploads are saved back to local workspace state as readable image paths. In both cases, Heddle decides whether inspection is needed through `view_image`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -121,6 +121,9 @@ Inside `heddle` / `heddle chat`, the most-used local commands are:
 - `/skills`: list discovered Agent Skills and activation status for this workspace
 - `/skills enable <name>`: enable one Agent Skill for future turns in this workspace
 - `/skills disable <name>`: disable one active Agent Skill for future turns in this workspace
+- `/browser`: show Browser Automation status for this workspace
+- `/browser enable`: enable built-in Browser Automation guidance and browser tools for future default turns in this workspace
+- `/browser disable`: disable built-in Browser Automation guidance and browser tools for future default turns in this workspace
 
 Prompt editing supports `Shift+Enter` for newlines, `Ctrl+Z`/`Ctrl+Y` for undo/redo, and `Up`/`Down` for submitted prompt history when the cursor is on the first or last logical line.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "eslint .",
     "lint": "yarn eslint",
     "release:context": "node scripts/release-context.mjs",
-    "build": "yarn clean && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && node scripts/mark-bin-executable.mjs && yarn client:build",
+    "build": "yarn clean && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && node scripts/copy-built-in-skill-assets.mjs && node scripts/mark-bin-executable.mjs && yarn client:build",
     "client:build": "tsc -p src/web-v2/tsconfig.json --noEmit && vite build --config src/web-v2/vite.config.ts",
     "client:dev": "vite --config src/web-v2/vite.config.ts",
     "client:build:v2": "tsc -p src/web-v2/tsconfig.json --noEmit && vite build --config src/web-v2/vite.config.ts",

--- a/scripts/copy-built-in-skill-assets.mjs
+++ b/scripts/copy-built-in-skill-assets.mjs
@@ -1,0 +1,12 @@
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const assets = [
+  'src/core/skills/browser-automation.skill.yaml',
+];
+
+for (const asset of assets) {
+  const target = join('dist', asset);
+  mkdirSync(dirname(target), { recursive: true });
+  copyFileSync(asset, target);
+}

--- a/src/__tests__/unit/core/agent-skills.test.ts
+++ b/src/__tests__/unit/core/agent-skills.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { AgentSkillService, FileAgentSkillActivationRepository } from '@/core/skills/index.js';
+import { AgentSkillService, BROWSER_AUTOMATION_SKILL_NAME, FileAgentSkillActivationRepository } from '@/core/skills/index.js';
 import { createReadAgentSkillTool } from '@/core/tools/toolkits/agent-skills/index.js';
 
 describe('AgentSkillService', () => {
@@ -37,7 +37,7 @@ description: Summarize local notes.
 `,
     );
 
-    const service = new AgentSkillService({ workspaceRoot, homeDir });
+    const service = new AgentSkillService({ workspaceRoot, homeDir, builtInSkills: [] });
     const catalog = await service.loadCatalog();
 
     expect(catalog.issues).toEqual([]);
@@ -79,7 +79,7 @@ Use the [browser checklist](references/browser-checklist.md) before checkout flo
 `,
     );
 
-    const service = new AgentSkillService({ workspaceRoot, homeDir: join(root, 'home') });
+    const service = new AgentSkillService({ workspaceRoot, homeDir: join(root, 'home'), builtInSkills: [] });
     const result = await service.readSkill('browser-research');
 
     expect(result).toMatchObject({
@@ -110,7 +110,7 @@ Use [checklist](./references/browser-checklist.md), ignore [external](https://ex
 `,
     );
 
-    const service = new AgentSkillService({ workspaceRoot, homeDir: join(root, 'home') });
+    const service = new AgentSkillService({ workspaceRoot, homeDir: join(root, 'home'), builtInSkills: [] });
     const catalog = await service.loadCatalog();
     const prompt = service.formatCatalogPrompt(catalog);
     const result = await service.readSkill('browser-research');
@@ -142,6 +142,7 @@ extra-field: not-standard
     const catalog = await new AgentSkillService({
       workspaceRoot,
       homeDir: join(root, 'home'),
+      builtInSkills: [],
     }).loadCatalog();
 
     expect(catalog.skills).toEqual([]);
@@ -177,7 +178,7 @@ description: User-level research skill.
 `,
     );
 
-    const catalog = await new AgentSkillService({ workspaceRoot, homeDir }).loadCatalog();
+    const catalog = await new AgentSkillService({ workspaceRoot, homeDir, builtInSkills: [] }).loadCatalog();
 
     expect(catalog.skills).toEqual([
       expect.objectContaining({
@@ -218,6 +219,7 @@ name: Invalid Skill
 
     const catalog = await new AgentSkillService({
       workspaceRoot,
+      builtInSkills: [],
       homeDir: join(root, 'home'),
     }).loadCatalog();
 
@@ -262,6 +264,7 @@ description: Summarize local notes.
     const service = new AgentSkillService({
       workspaceRoot,
       homeDir: join(root, 'home'),
+      builtInSkills: [],
       activationStore,
     });
 
@@ -311,6 +314,7 @@ description: Summarize local notes.
     const service = new AgentSkillService({
       workspaceRoot,
       homeDir: join(root, 'home'),
+      builtInSkills: [],
       activationStore,
     });
 
@@ -361,6 +365,7 @@ description: Research web pages through a browser.
     const service = new AgentSkillService({
       workspaceRoot,
       homeDir: join(root, 'home'),
+      builtInSkills: [],
       activationStore: new FileAgentSkillActivationRepository({ stateRoot }),
     });
     const tool = createReadAgentSkillTool({ workspaceRoot, stateRoot });
@@ -431,6 +436,104 @@ Use [browser checklist](references/browser-checklist.md) before making claims.
       ok: false,
       reason: 'skill_not_active',
       name: 'missing-skill',
+    });
+  });
+
+  it('discovers the built-in browser automation skill without activating it by default', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-agent-skill-built-in-'));
+    const workspaceRoot = join(root, 'workspace');
+    const activationStore = new FileAgentSkillActivationRepository({
+      stateRoot: join(workspaceRoot, '.heddle'),
+    });
+    const service = new AgentSkillService({
+      workspaceRoot,
+      homeDir: join(root, 'home'),
+      activationStore,
+    });
+
+    await expect(service.loadCatalog()).resolves.toMatchObject({
+      skills: [
+        expect.objectContaining({
+          name: BROWSER_AUTOMATION_SKILL_NAME,
+          source: 'built-in',
+          description: expect.stringContaining('use a browser'),
+        }),
+      ],
+      issues: [],
+    });
+    await expect(service.loadActivatedCatalog()).resolves.toMatchObject({
+      skills: [],
+      issues: [],
+    });
+
+    await service.activateSkill(BROWSER_AUTOMATION_SKILL_NAME, new Date('2026-06-09T00:00:00.000Z'));
+    await expect(service.readActivatedSkill(BROWSER_AUTOMATION_SKILL_NAME)).resolves.toMatchObject({
+      skill: {
+        name: BROWSER_AUTOMATION_SKILL_NAME,
+        source: 'built-in',
+      },
+      body: expect.stringContaining('## When To Use It'),
+    });
+  });
+
+  it('reads an activated built-in skill by stored source and path when a project skill shadows the name', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-agent-skill-shadowed-built-in-'));
+    const workspaceRoot = join(root, 'workspace');
+    const activationStore = new FileAgentSkillActivationRepository({
+      stateRoot: join(workspaceRoot, '.heddle'),
+    });
+    await writeSkill(
+      join(workspaceRoot, '.agents', 'skills', BROWSER_AUTOMATION_SKILL_NAME),
+      `---
+name: ${BROWSER_AUTOMATION_SKILL_NAME}
+description: Shadowed project skill
+---
+# Shadowed
+
+Do not use browser automation.
+`,
+    );
+    const service = new AgentSkillService({
+      workspaceRoot,
+      homeDir: join(root, 'home'),
+      activationStore,
+    });
+
+    await expect(service.loadCatalog()).resolves.toMatchObject({
+      skills: [
+        expect.objectContaining({
+          name: BROWSER_AUTOMATION_SKILL_NAME,
+          source: 'project',
+        }),
+      ],
+      issues: [
+        expect.objectContaining({ code: 'duplicate_skill' }),
+      ],
+    });
+
+    await expect(service.activateBuiltInSkill(BROWSER_AUTOMATION_SKILL_NAME, new Date('2026-06-09T00:00:00.000Z')))
+      .resolves
+      .toMatchObject({
+        ok: true,
+        record: {
+          name: BROWSER_AUTOMATION_SKILL_NAME,
+          source: 'built-in',
+        },
+      });
+    await expect(service.loadActivatedCatalog()).resolves.toMatchObject({
+      skills: [
+        expect.objectContaining({
+          name: BROWSER_AUTOMATION_SKILL_NAME,
+          source: 'built-in',
+        }),
+      ],
+    });
+    await expect(service.readActivatedSkill(BROWSER_AUTOMATION_SKILL_NAME)).resolves.toMatchObject({
+      skill: {
+        name: BROWSER_AUTOMATION_SKILL_NAME,
+        source: 'built-in',
+      },
+      body: expect.stringContaining('Use browser automation when'),
     });
   });
 });

--- a/src/__tests__/unit/core/browser-automation-capability.test.ts
+++ b/src/__tests__/unit/core/browser-automation-capability.test.ts
@@ -1,0 +1,119 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { BrowserAutomationCapabilityService } from '@/core/browser/index.js';
+import { BROWSER_AUTOMATION_SKILL_NAME, FileAgentSkillActivationRepository } from '@/core/skills/index.js';
+
+describe('BrowserAutomationCapabilityService', () => {
+  it('keeps Browser Automation disabled until the workspace enables it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-browser-automation-'));
+    const workspaceRoot = join(root, 'workspace');
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const service = new BrowserAutomationCapabilityService({ workspaceRoot, stateRoot });
+
+    await expect(service.overview()).resolves.toMatchObject({
+      enabled: false,
+      skillName: BROWSER_AUTOMATION_SKILL_NAME,
+      skill: expect.objectContaining({
+        name: BROWSER_AUTOMATION_SKILL_NAME,
+        status: 'available',
+      }),
+    });
+    expect(new FileAgentSkillActivationRepository({ stateRoot }).read().skills).toEqual({});
+  });
+
+  it('enables and disables the built-in browser automation skill through workspace activation state', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-browser-automation-enable-'));
+    const workspaceRoot = join(root, 'workspace');
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const service = new BrowserAutomationCapabilityService({ workspaceRoot, stateRoot });
+
+    await expect(service.setEnabled(true)).resolves.toMatchObject({
+      ok: true,
+      overview: {
+        enabled: true,
+        skill: expect.objectContaining({
+          name: BROWSER_AUTOMATION_SKILL_NAME,
+          status: 'active',
+        }),
+      },
+    });
+    expect(new FileAgentSkillActivationRepository({ stateRoot }).read().skills[BROWSER_AUTOMATION_SKILL_NAME]).toMatchObject({
+      name: BROWSER_AUTOMATION_SKILL_NAME,
+      source: 'built-in',
+      status: 'active',
+    });
+
+    await expect(service.setEnabled(false)).resolves.toMatchObject({
+      ok: true,
+      overview: {
+        enabled: false,
+        skill: expect.objectContaining({
+          name: BROWSER_AUTOMATION_SKILL_NAME,
+          status: 'disabled',
+        }),
+      },
+    });
+  });
+
+  it('uses Heddle built-in browser automation even when a project skill shadows the name', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-browser-automation-shadow-'));
+    const workspaceRoot = join(root, 'workspace');
+    const stateRoot = join(workspaceRoot, '.heddle');
+    await writeProjectSkill({
+      workspaceRoot,
+      name: BROWSER_AUTOMATION_SKILL_NAME,
+      content: [
+        '---',
+        `name: ${BROWSER_AUTOMATION_SKILL_NAME}`,
+        'description: Shadowed project skill',
+        '---',
+        '',
+        'Do not use Heddle browser tools.',
+      ].join('\n'),
+    });
+
+    const service = new BrowserAutomationCapabilityService({ workspaceRoot, stateRoot });
+
+    await expect(service.overview()).resolves.toMatchObject({
+      enabled: false,
+      skill: expect.objectContaining({
+        catalogEntry: expect.objectContaining({
+          name: BROWSER_AUTOMATION_SKILL_NAME,
+          source: 'built-in',
+        }),
+        status: 'available',
+      }),
+    });
+    await expect(service.setEnabled(true)).resolves.toMatchObject({
+      ok: true,
+      overview: {
+        enabled: true,
+        skill: expect.objectContaining({
+          catalogEntry: expect.objectContaining({
+            source: 'built-in',
+          }),
+        }),
+      },
+    });
+
+    expect(new FileAgentSkillActivationRepository({ stateRoot }).read().skills[BROWSER_AUTOMATION_SKILL_NAME]).toMatchObject({
+      name: BROWSER_AUTOMATION_SKILL_NAME,
+      source: 'built-in',
+      status: 'active',
+    });
+    expect(BrowserAutomationCapabilityService.isEnabled({ stateRoot })).toBe(true);
+  });
+});
+
+async function writeProjectSkill(args: {
+  workspaceRoot: string;
+  name: string;
+  content: string;
+}): Promise<void> {
+  const skillRoot = join(args.workspaceRoot, '.agents', 'skills', args.name);
+  await mkdir(skillRoot, { recursive: true });
+  await writeFile(join(skillRoot, 'SKILL.md'), `${args.content}\n`, 'utf8');
+}

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -9,6 +9,7 @@ import { ConversationTurnPreflightService } from '../../../core/chat/engine/turn
 import { ConversationTurnContextBuilder } from '../../../core/chat/engine/turns/context/index.js';
 import { ConversationTurnRuntimeResolver } from '../../../core/chat/engine/turns/runtime/index.js';
 import { DEFAULT_OPENAI_MODEL } from '../../../core/config.js';
+import { BROWSER_AUTOMATION_SKILL_NAME, FileAgentSkillActivationRepository } from '../../../core/skills/index.js';
 
 describe('chat turn preparation modules', () => {
   afterEach(() => {
@@ -208,6 +209,48 @@ describe('chat turn preparation modules', () => {
       ownerKind: 'ask',
       clientLabel: 'another Heddle client',
     });
+  });
+
+  it('adds browser tools to future turns when Browser Automation is enabled', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-browser-automation-'));
+    const stateRoot = join(root, '.heddle');
+    const sessionStoragePath = join(stateRoot, 'chat-sessions.catalog.json');
+    const session = ChatSessionRecords.create({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.4',
+    });
+    new FileChatSessionRepository({ sessionStoragePath: sessionStoragePath }).save([session]);
+    new FileAgentSkillActivationRepository({ stateRoot }).write({
+      version: 1,
+      skills: {
+        [BROWSER_AUTOMATION_SKILL_NAME]: {
+          name: BROWSER_AUTOMATION_SKILL_NAME,
+          status: 'active',
+          source: 'built-in',
+          skillFilePath: 'heddle://built-in-skills/browser-automation/SKILL.md',
+          activatedAt: '2026-06-09T00:00:00.000Z',
+          updatedAt: '2026-06-09T00:00:00.000Z',
+        },
+      },
+    });
+
+    const context = ConversationTurnContextBuilder.build({
+      workspaceRoot: root,
+      stateRoot,
+      sessionStoragePath,
+      sessionId: 'session-1',
+      apiKey: 'explicit-key',
+    });
+
+    expect(context.toolNames).toEqual(expect.arrayContaining([
+      'browser_open',
+      'browser_snapshot',
+      'browser_click',
+      'browser_screenshot',
+      'browser_close',
+    ]));
   });
 
   it('persists the preflight compaction-running context for the leased session', () => {

--- a/src/__tests__/unit/core/slash-commands.test.ts
+++ b/src/__tests__/unit/core/slash-commands.test.ts
@@ -1,12 +1,14 @@
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { SlashCommandAutocomplete } from '../../../core/commands/slash/autocomplete.js';
+import { browserStatusMessage } from '../../../core/commands/slash/modules/browser/browser-commands.js';
 import { createMcpSlashCommandModule, listMcpMessage } from '../../../core/commands/slash/modules/mcp/mcp-commands.js';
 import type { SlashCommandExecutionContext } from '../../../core/commands/slash/modules/context.js';
 import { listSkillsMessage } from '../../../core/commands/slash/modules/skills/skills-commands.js';
 import { SlashCommandParser } from '../../../core/commands/slash/parser.js';
 import { SlashCommandRegistry } from '../../../core/commands/slash/registry.js';
 import type { AgentSkillActivationView } from '../../../core/skills/index.js';
+import type { BrowserAutomationOverview } from '../../../core/browser/index.js';
 import type { McpOverview } from '../../../core/mcp/index.js';
 import type { SlashCommand, SlashCommandModule } from '../../../core/commands/slash/types.js';
 
@@ -180,6 +182,46 @@ describe('MCP slash command output', () => {
       handled: true,
       kind: 'message',
       message: 'Opened MCP config: /workspace/.heddle/mcp.json',
+    });
+  });
+});
+
+describe('Browser Automation slash command output', () => {
+  it('reports capability status and activation commands', async () => {
+    const overview: BrowserAutomationOverview = {
+      enabled: false,
+      skillName: 'browser-automation',
+      activationStorePath: '/workspace/.heddle/skills/activation.json',
+      skill: {
+        name: 'browser-automation',
+        status: 'available',
+      },
+      profileRequirement: 'Logged-in sites require a selected profile.',
+      toolAvailability: 'Browser tools remain host-controlled.',
+    };
+
+    await expect(browserStatusMessage({
+      browserAutomation: {
+        overview: async () => overview,
+        setEnabled: vi.fn(),
+      },
+    })).resolves.toEqual({
+      handled: true,
+      kind: 'message',
+      message: [
+        'Browser Automation',
+        'status=disabled',
+        'skill=browser-automation',
+        'skillStatus=available',
+        'activationStore=/workspace/.heddle/skills/activation.json',
+        '',
+        'Logged-in sites require a selected profile.',
+        'Browser tools remain host-controlled.',
+        '',
+        'Commands',
+        '  /browser enable',
+        '  /browser disable',
+      ].join('\n'),
     });
   });
 });

--- a/src/__tests__/unit/tools/browser-research-toolkit.test.ts
+++ b/src/__tests__/unit/tools/browser-research-toolkit.test.ts
@@ -81,6 +81,27 @@ describe('createBrowserResearchToolkit', () => {
     expect(driver.clickedRefs).toEqual([]);
   });
 
+  it('uses the first opened URL as the browsing boundary when no explicit allowlist is configured', async () => {
+    const { tools, driver } = await createTools({ allowedDomains: [] });
+
+    await expect(tools.browser_open.execute({ url: 'https://en.wikipedia.org/wiki/Browser_automation' }))
+      .resolves
+      .toMatchObject({ ok: true });
+
+    await tools.browser_snapshot.execute({});
+    await expect(tools.browser_click.execute({ ref: 'el_2' }))
+      .resolves
+      .toMatchObject({
+        ok: false,
+        error: expect.stringContaining('outside the browser domain allowlist'),
+        output: {
+          status: 'approvalRequired',
+        },
+      });
+
+    expect(driver.clickedRefs).toEqual([]);
+  });
+
   it('captures screenshots and releases profile locks on close', async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-browser-toolkit-close-'));
     const first = await createTools({ stateRoot });
@@ -168,13 +189,14 @@ describe('createBrowserResearchToolkit', () => {
 async function createTools(options: {
   stateRoot?: string;
   driver?: BrowserDriver;
+  allowedDomains?: string[];
 } = {}) {
   const stateRoot = options.stateRoot ?? (await mkdtemp(join(tmpdir(), 'heddle-browser-toolkit-')));
   const driver = options.driver ?? new FakeBrowserDriver();
   const tools = Object.fromEntries(
     createBrowserResearchToolkit({
       stateRoot,
-      allowedDomains: ['wikipedia.org'],
+      allowedDomains: options.allowedDomains ?? ['wikipedia.org'],
       driverFactory: new FakeBrowserDriverFactory(driver),
       headless: true,
     }).createTools(context(stateRoot)).map((tool) => [tool.name, tool]),

--- a/src/client-shared/api/types.ts
+++ b/src/client-shared/api/types.ts
@@ -44,6 +44,7 @@ export type ControlPlaneHeartbeatRunView = ControlPlaneHeartbeatTask['runs'][num
 export type ControlPlaneHeartbeatRun = RouterOutputs['controlPlane']['heartbeatRun'];
 export type ControlPlaneHeartbeatTaskRunNow = RouterOutputs['controlPlane']['heartbeatTaskRunNow'];
 export type ControlPlaneMemoryStatus = RouterOutputs['controlPlane']['memoryStatus'];
+export type ControlPlaneBrowserAutomation = RouterOutputs['controlPlane']['browserAutomation'];
 export type ControlPlaneSkills = RouterOutputs['controlPlane']['skills'];
 export type ControlPlaneSkillActivationView = ControlPlaneSkills['skills'][number];
 export type ControlPlaneMcpServers = RouterOutputs['controlPlane']['mcpServers'];

--- a/src/core/browser/automation/README.md
+++ b/src/core/browser/automation/README.md
@@ -1,0 +1,60 @@
+# Browser Automation Capability
+
+This folder owns the user-facing Browser Automation switch.
+
+Browser automation has two separate concerns:
+
+- **Instruction activation**: whether future agent turns see the built-in
+  `browser-automation` Agent Skill catalog entry and can read the full skill.
+- **Default tool availability**: whether future default agent turns include the
+  `browser_*` tool bundle.
+- **Browser execution**: profiles, domain allowlists, evidence, policy, and
+  Playwright driver behavior.
+
+This service owns the first two concerns. It enables or disables the
+workspace-scoped built-in skill by using `AgentSkillService`, and runtime tool
+assembly checks the same activation state before injecting the browser toolkit.
+It does not configure domains, select profiles, or weaken browser policy.
+
+Browser Automation is a host-owned capability, so it must resolve the packaged
+built-in skill directly. Project or user Agent Skills named `browser-automation`
+remain ordinary skills; they must not shadow the capability switch or the
+guidance future browser-tool runs receive.
+
+## User Mental Model
+
+Users see Browser Automation as a capability they can turn on for a workspace.
+When it is on, Heddle teaches the agent when browser automation is appropriate:
+visual inspection for frontend work, user-requested website automation, web
+research, and workflows where rendered browser state matters. Future default
+agent turns also receive `browser_open`, `browser_snapshot`, `browser_click`,
+`browser_screenshot`, and `browser_close`.
+
+If no explicit domain allowlist is configured, the first successful
+`browser_open` URL establishes the same-domain browsing boundary for that
+browser session. This lets a user enable useful browser work without granting an
+unrestricted cross-site browser.
+
+Logged-in websites still require a browser profile with a valid session. If no
+session-backed profile is selected by the browser host/toolkit, agents should
+assume only public pages are reachable.
+
+## Boundaries
+
+Owned here:
+
+- Browser Automation enabled/disabled overview.
+- Delegating activation to the built-in `browser-automation` Agent Skill.
+- Exposing a shared activation check for default runtime tool assembly.
+- Shared status vocabulary for slash commands and web settings.
+
+Not owned here:
+
+- Browser driver lifecycle, snapshots, evidence, and policy.
+- Domain allowlists and forbidden browser actions.
+- Profile creation, profile selection, or session validation.
+- Web or terminal rendering details.
+
+Future slices that add profile/domain settings should extend `src/core/browser`
+policy/profile services rather than storing those settings in the skills
+activation file.

--- a/src/core/browser/automation/index.ts
+++ b/src/core/browser/automation/index.ts
@@ -1,0 +1,6 @@
+export { BrowserAutomationCapabilityService } from './service.js';
+export type {
+  BrowserAutomationOverview,
+  BrowserAutomationServiceOptions,
+  BrowserAutomationSetEnabledResult,
+} from './types.js';

--- a/src/core/browser/automation/service.ts
+++ b/src/core/browser/automation/service.ts
@@ -1,0 +1,91 @@
+import {
+  AgentSkillService,
+  BROWSER_AUTOMATION_SKILL_FILE_PATH,
+  BROWSER_AUTOMATION_SKILL_NAME,
+  FileAgentSkillActivationRepository,
+} from '@/core/skills/index.js';
+import type { BrowserAutomationOverview, BrowserAutomationServiceOptions, BrowserAutomationSetEnabledResult } from './types.js';
+
+/**
+ * Owns the user-facing Browser Automation capability switch.
+ *
+ * The current capability switch intentionally persists only Agent Skill
+ * activation. Browser execution policy and profile selection remain owned by
+ * the browser domain/toolkit so enabling this capability does not silently
+ * expand runtime permissions.
+ */
+export class BrowserAutomationCapabilityService {
+  private readonly workspaceRoot: string;
+  private readonly stateRoot: string;
+  private readonly activationStore: FileAgentSkillActivationRepository;
+  private readonly skills: AgentSkillService;
+
+  static isEnabled(options: { stateRoot: string }): boolean {
+    const record = new FileAgentSkillActivationRepository({ stateRoot: options.stateRoot })
+      .read()
+      .skills[BROWSER_AUTOMATION_SKILL_NAME];
+
+    return record?.status === 'active'
+      && record.source === 'built-in'
+      && record.skillFilePath === BROWSER_AUTOMATION_SKILL_FILE_PATH;
+  }
+
+  constructor(options: BrowserAutomationServiceOptions) {
+    this.workspaceRoot = options.workspaceRoot;
+    this.stateRoot = options.stateRoot;
+    this.activationStore = new FileAgentSkillActivationRepository({ stateRoot: this.stateRoot });
+    this.skills = new AgentSkillService({
+      workspaceRoot: this.workspaceRoot,
+      activationStore: this.activationStore,
+    });
+  }
+
+  async overview(): Promise<BrowserAutomationOverview> {
+    const skill = this.skills.getBuiltInActivationView(BROWSER_AUTOMATION_SKILL_NAME);
+
+    return {
+      enabled: skill?.status === 'active',
+      skillName: BROWSER_AUTOMATION_SKILL_NAME,
+      activationStorePath: FileAgentSkillActivationRepository.resolvePath(this.stateRoot),
+      skill,
+      profileRequirement:
+        'Logged-in sites require a browser profile with a valid session. Without one, agents should assume only public pages are available.',
+      toolAvailability:
+        'When enabled, future default agent turns include browser tools. If no explicit domain allowlist is configured, the first opened URL establishes the same-domain browsing boundary.',
+    };
+  }
+
+  async setEnabled(enabled: boolean): Promise<BrowserAutomationSetEnabledResult> {
+    if (enabled) {
+      const activation = await this.skills.activateBuiltInSkill(BROWSER_AUTOMATION_SKILL_NAME);
+      if (!activation.ok) {
+        return {
+          ok: false,
+          reason: 'skill_not_found',
+          overview: await this.overview(),
+        };
+      }
+
+      return {
+        ok: true,
+        activation,
+        overview: await this.overview(),
+      };
+    }
+
+    const overview = await this.overview();
+    if (overview.enabled) {
+      const activation = await this.skills.disableSkill(BROWSER_AUTOMATION_SKILL_NAME);
+      return {
+        ok: true,
+        activation,
+        overview: await this.overview(),
+      };
+    }
+
+    return {
+      ok: true,
+      overview,
+    };
+  }
+}

--- a/src/core/browser/automation/types.ts
+++ b/src/core/browser/automation/types.ts
@@ -1,0 +1,30 @@
+import type {
+  AgentSkillActivationResult,
+  AgentSkillActivationView,
+} from '@/core/skills/index.js';
+
+export type BrowserAutomationOverview = {
+  enabled: boolean;
+  skillName: string;
+  activationStorePath: string;
+  skill?: AgentSkillActivationView;
+  profileRequirement: string;
+  toolAvailability: string;
+};
+
+export type BrowserAutomationSetEnabledResult =
+  | {
+      ok: true;
+      overview: BrowserAutomationOverview;
+      activation?: AgentSkillActivationResult;
+    }
+  | {
+      ok: false;
+      reason: 'skill_not_found';
+      overview: BrowserAutomationOverview;
+    };
+
+export type BrowserAutomationServiceOptions = {
+  workspaceRoot: string;
+  stateRoot: string;
+};

--- a/src/core/browser/index.ts
+++ b/src/core/browser/index.ts
@@ -1,3 +1,8 @@
+export { BrowserAutomationCapabilityService } from './automation/index.js';
+export type {
+  BrowserAutomationOverview,
+  BrowserAutomationSetEnabledResult,
+} from './automation/index.js';
 export { BrowserEvidenceService } from './evidence/index.js';
 export { BrowserPolicyService, DEFAULT_FORBIDDEN_BROWSER_ACTION_TEXT } from './policy/index.js';
 export { BrowserProfileService } from './profiles/index.js';

--- a/src/core/commands/slash/modules/browser/browser-commands.ts
+++ b/src/core/commands/slash/modules/browser/browser-commands.ts
@@ -1,0 +1,83 @@
+import { SlashCommandParser } from '../../parser.js';
+import type { SlashCommandResult } from '../../result-types.js';
+import type { SlashCommandModule } from '../../types.js';
+import type { SlashCommandExecutionContext } from '../context.js';
+import { slashMessageResult } from '../results.js';
+
+export function createBrowserSlashCommandModule(): SlashCommandModule<SlashCommandResult, SlashCommandExecutionContext> {
+  return {
+    id: 'browser',
+    hints: [
+      { command: '/browser', description: 'show Browser Automation status' },
+      { command: '/browser enable', description: 'enable Browser Automation guidance and browser tools for this workspace' },
+      { command: '/browser disable', description: 'disable Browser Automation guidance and browser tools for this workspace' },
+    ],
+    commands: [
+      {
+        id: 'browser.status',
+        syntax: '/browser',
+        description: 'show Browser Automation status',
+        match: SlashCommandParser.matchesAnyExact(['/browser', '/browser status']),
+        run: (context) => browserStatusMessage(context),
+      },
+      {
+        id: 'browser.enable',
+        syntax: '/browser enable',
+        description: 'enable Browser Automation guidance and browser tools for this workspace',
+        match: SlashCommandParser.matchesExact('/browser enable'),
+        run: (context) => setBrowserAutomationMessage(context, true),
+      },
+      {
+        id: 'browser.disable',
+        syntax: '/browser disable',
+        description: 'disable Browser Automation guidance and browser tools for this workspace',
+        match: SlashCommandParser.matchesExact('/browser disable'),
+        run: (context) => setBrowserAutomationMessage(context, false),
+      },
+    ],
+  };
+}
+
+export async function browserStatusMessage(
+  context: Pick<SlashCommandExecutionContext, 'browserAutomation'>,
+): Promise<SlashCommandResult> {
+  const overview = await context.browserAutomation.overview();
+  return slashMessageResult(formatBrowserAutomationStatus(overview));
+}
+
+async function setBrowserAutomationMessage(
+  context: Pick<SlashCommandExecutionContext, 'browserAutomation'>,
+  enabled: boolean,
+): Promise<SlashCommandResult> {
+  const result = await context.browserAutomation.setEnabled(enabled);
+  if (!result.ok) {
+    return slashMessageResult(`Browser Automation built-in skill was not found: ${result.overview.skillName}`);
+  }
+
+  return slashMessageResult([
+    enabled
+      ? 'Browser Automation guidance and browser tools are enabled for future default agent turns in this workspace.'
+      : 'Browser Automation guidance and browser tools are disabled for future default agent turns in this workspace.',
+    '',
+    formatBrowserAutomationStatus(result.overview),
+  ].join('\n'));
+}
+
+function formatBrowserAutomationStatus(
+  overview: Awaited<ReturnType<SlashCommandExecutionContext['browserAutomation']['overview']>>,
+): string {
+  return [
+    'Browser Automation',
+    `status=${overview.enabled ? 'enabled' : 'disabled'}`,
+    `skill=${overview.skillName}`,
+    `skillStatus=${overview.skill?.status ?? 'missing'}`,
+    `activationStore=${overview.activationStorePath}`,
+    '',
+    overview.profileRequirement,
+    overview.toolAvailability,
+    '',
+    'Commands',
+    '  /browser enable',
+    '  /browser disable',
+  ].join('\n');
+}

--- a/src/core/commands/slash/modules/context.ts
+++ b/src/core/commands/slash/modules/context.ts
@@ -1,5 +1,9 @@
 import type { ChatSession } from '../../../chat/types.js';
 import type { AutonomyPermissionMode } from '../../../approvals/index.js';
+import type {
+  BrowserAutomationOverview,
+  BrowserAutomationSetEnabledResult,
+} from '../../../browser/index.js';
 import type { LlmProvider, ReasoningEffort } from '../../../llm/types.js';
 import type { ProviderCredentialSource } from '../../../runtime/credentials/index.js';
 import type {
@@ -57,6 +61,10 @@ export type SlashCommandExecutionContext = {
     listTasks: () => Promise<HeartbeatTask[]>;
     listRunRecords: (options?: { taskId?: string; limit?: number }) => Promise<HeartbeatTaskRunRecordEntry[]>;
     loadRunRecord: (id: string) => Promise<HeartbeatTaskRunRecordEntry | undefined>;
+  };
+  browserAutomation: {
+    overview: () => Promise<BrowserAutomationOverview>;
+    setEnabled: (enabled: boolean) => Promise<BrowserAutomationSetEnabledResult>;
   };
   skills: {
     list: () => Promise<AgentSkillActivationView[]>;

--- a/src/core/commands/slash/modules/core-command-modules.ts
+++ b/src/core/commands/slash/modules/core-command-modules.ts
@@ -2,6 +2,7 @@ import type { SlashCommandModule } from '../types.js';
 import type { SlashCommandResult } from '../result-types.js';
 import type { SlashCommandExecutionContext } from './context.js';
 import { createAuthSlashCommandModule } from './auth/auth-commands.js';
+import { createBrowserSlashCommandModule } from './browser/browser-commands.js';
 import { createCompactionSlashCommandModule } from './compaction/compaction-commands.js';
 import { createDriftSlashCommandModule } from './drift/drift-commands.js';
 import { createHeartbeatSlashCommandModule } from './heartbeat/heartbeat-commands.js';
@@ -26,6 +27,7 @@ export function createCoreSlashCommandModules(): SlashCommandModule<
     createPermissionsSlashCommandModule(),
     createSessionSlashCommandModule(),
     createHeartbeatSlashCommandModule(),
+    createBrowserSlashCommandModule(),
     createSkillsSlashCommandModule(),
     createMcpSlashCommandModule(),
   ];

--- a/src/core/runtime/tools/service.ts
+++ b/src/core/runtime/tools/service.ts
@@ -1,5 +1,7 @@
 import { join, resolve } from 'node:path';
+import { BrowserAutomationCapabilityService } from '@/core/browser/index.js';
 import { agentSkillsToolkit } from '@/core/tools/toolkits/agent-skills/toolkit.js';
+import { createBrowserResearchToolkit } from '@/core/tools/toolkits/browser-research/index.js';
 import { codingAwarenessToolkit } from '@/core/tools/toolkits/coding-awareness/toolkit.js';
 import { codingFilesToolkit } from '@/core/tools/toolkits/coding-files/toolkit.js';
 import { externalContextToolkit } from '@/core/tools/toolkits/external-context/toolkit.js';
@@ -24,7 +26,11 @@ export class RuntimeToolService {
     const memoryMode = options.memoryMode ?? 'read-and-record';
 
     return ToolBundleComposer.compose({
-      toolkits: this.createDefaultToolkits({ includePlanTool: options.includePlanTool }),
+      toolkits: this.createDefaultToolkits({
+        includePlanTool: options.includePlanTool,
+        browserAutomationEnabled: BrowserAutomationCapabilityService.isEnabled({ stateRoot }),
+        stateRoot,
+      }),
       context: {
         workspaceRoot,
         stateRoot,
@@ -41,7 +47,20 @@ export class RuntimeToolService {
 
   private static createDefaultToolkits(args: {
     includePlanTool?: boolean;
+    browserAutomationEnabled: boolean;
+    stateRoot: string;
   }): ToolToolkit[] {
+    const browserToolkits = args.browserAutomationEnabled
+      ? [
+        createBrowserResearchToolkit({
+          stateRoot: args.stateRoot,
+          allowedDomains: [],
+          profileId: 'browser-automation',
+          maxElementsPerSnapshot: 80,
+        }),
+      ]
+      : [];
+
     return [
       agentSkillsToolkit,
       codingAwarenessToolkit,
@@ -49,6 +68,7 @@ export class RuntimeToolService {
       externalContextToolkit,
       knowledgeToolkit,
       mcpToolkit,
+      ...browserToolkits,
       this.createDefaultInternalToolkit({ includePlanTool: args.includePlanTool }),
       shellProcessToolkit,
     ];

--- a/src/core/skills/README.md
+++ b/src/core/skills/README.md
@@ -6,7 +6,8 @@ Skills ecosystem.
 ## Responsibilities
 
 - discover skill folders from project `.agents/skills`, user
-  `~/.agents/skills`, and package-provided built-in skill roots;
+  `~/.agents/skills`, package-provided built-in skill definitions, and optional
+  built-in skill roots;
 - parse and validate `SKILL.md` frontmatter with Heddle-owned semantics backed
   by the mature `yaml` parser;
 - expose only catalog metadata for initial agent context;
@@ -15,6 +16,8 @@ Skills ecosystem.
   after the skill body has linked to them;
 - persist workspace-level activation status under Heddle state without copying
   skill definitions.
+- resolve active skills by the stored source and file path, not only by name, so
+  an activation record keeps pointing at the skill the user actually enabled.
 
 ## Boundaries
 
@@ -29,8 +32,16 @@ Skills ecosystem.
 - TUI activation is exposed through core slash commands (`/skills`,
   `/skills enable <name>`, `/skills disable <name>`) consumed by the existing
   control-plane slash command path.
+- Web activation is exposed through control-plane settings pages that call the
+  same `AgentSkillService` methods.
 
-Settings-page management is intentionally left to the web surface.
+Capability-specific settings may delegate to this domain for activation while
+owning their own user mental model. For example, Browser Automation enables the
+built-in `browser-automation` skill through `BrowserAutomationCapabilityService`;
+runtime tool assembly then checks that capability state before adding browser
+tools to default turns. Capability-owned built-ins should use
+`activateBuiltInSkill()` so project or user skills with the same name cannot
+shadow host-controlled guidance.
 
 ## How Skills Work
 
@@ -42,8 +53,12 @@ A skill is a directory with a `SKILL.md` file:
 ```
 
 `AgentSkillService.loadCatalog()` discovers project, user, and built-in skill
-roots, reads only `SKILL.md` frontmatter, validates supported fields, and
+definitions, reads only catalog frontmatter, validates supported fields, and
 returns a catalog. It does not expose the markdown body during catalog load.
+
+Built-in skills are code/package-owned definitions parsed into the same
+`SKILL.md` shape at runtime. Their editable source can live as package assets,
+but they are not copied into workspace state.
 
 Supported frontmatter fields are:
 
@@ -57,6 +72,13 @@ Supported frontmatter fields are:
 Project skills have precedence over user skills with the same name. Duplicate
 lower-precedence skills are reported as catalog issues instead of replacing the
 first entry.
+
+Precedence is:
+
+1. project skills
+2. user skills
+3. optional built-in skill roots
+4. package-provided built-in skills
 
 ## Activation Model
 
@@ -105,6 +127,8 @@ Terminal users manage workspace activation through core slash commands:
 /skills
 /skills enable browser-research
 /skills disable browser-research
+/browser enable
+/browser disable
 ```
 
 `/skills` lists activation views in sections:
@@ -114,8 +138,9 @@ Terminal users manage workspace activation through core slash commands:
 - `Disabled`: previously enabled and then disabled
 - `Missing definitions`: activation records whose original `SKILL.md` is gone
 
-The web settings page does not manage Agent Skills yet. Until that exists, the
-TUI slash commands are the user-facing activation path.
+The web Settings -> Skills page manages generic Agent Skills. Settings ->
+Browser Automation manages the built-in browser automation capability and uses
+the same activation store under the hood.
 
 ## What The Agent Sees Before Loading A Skill
 

--- a/src/core/skills/browser-automation.skill.yaml
+++ b/src/core/skills/browser-automation.skill.yaml
@@ -1,0 +1,61 @@
+name: browser-automation
+description: Use when the user asks to use a browser, interact with web pages, search within a site or product catalog, compare shopping listings, or visually inspect rendered frontend UI.
+allowed-tools: browser_open browser_snapshot browser_click browser_screenshot browser_close
+metadata:
+  owner: heddle
+  capability: browser-automation
+body: |-
+  # Browser Automation
+
+  Use browser automation when the user's task benefits from seeing or operating a real web page. When the user explicitly asks whether you can use a browser, asks you to browse/search a site, or asks you to interact with a website, prefer browser tools over plain web search.
+
+  ## When To Use It
+
+  Use browser automation when:
+
+  - the user explicitly asks you to use a browser or browse/search a website for them;
+  - the user asks you to interact with a website, compare products, inspect listings, gather evidence from pages, or automate a web workflow;
+  - the user is developing web pages and visual inspection would reveal layout, spacing, overflow, rendering, or interaction issues that are hard to locate with unit or integration tests alone;
+  - a frontend change needs a screenshot or page snapshot to verify what actually rendered;
+  - the task depends on browser-only state such as rendered DOM, client-side navigation, visible controls, or accessibility tree structure.
+
+  Do not use browser automation when code inspection, static analysis, unit tests, integration tests, or API calls are enough to answer the task.
+
+  ## Browser Tools vs Web Search
+
+  Web search is useful for finding a current URL or reference page. It is not a substitute for browser automation when the user asked you to use a browser, inspect rendered UI, interact with a page, compare visible product listings, or collect page-state evidence.
+
+  If you need a starting URL, use web_search only to discover the target page, then continue with browser_open and browser_snapshot.
+
+  ## Session And Profile Assumptions
+
+  If the task depends on logged-in state, first check whether the browser automation host has a selected profile with a valid session for the target site. Without a valid session-backed profile, assume only public or non-session pages are reachable.
+
+  Do not enter credentials or ask the browser to bypass login walls. Ask the user to select or prepare a suitable profile when logged-in access is required.
+
+  ## Operating Loop
+
+  1. Open the target URL with browser_open.
+  2. Capture browser_snapshot before making claims or choosing click targets.
+  3. Use only refs from the latest snapshot.
+  4. After any click that may navigate or change the DOM, capture a new snapshot before further clicks.
+  5. Use browser_screenshot when visual evidence is needed for layout, styling, or rendered state.
+  6. Close the browser session when the browser task is finished.
+
+  Never reuse snapshot refs after navigation. Browser refs are page-state scoped evidence, not stable selectors.
+
+  ## Safety Boundaries
+
+  Respect domain allowlists and browser policy. Stop before checkout, purchase, irreversible submission, account mutation, credential entry, payment, booking, messaging, upload, or destructive actions unless the user explicitly approves a future Heddle workflow that supports that action safely.
+
+  If browser policy blocks navigation or a click, report the blocked action and the reason instead of trying to route around it.
+
+  ## Reporting Results
+
+  Summarize browser work with:
+
+  - current URL;
+  - visible page title or heading;
+  - relevant observed text or controls;
+  - screenshots or evidence paths when captured;
+  - uncertainty, missing session state, blocked policy decisions, or unavailable pages.

--- a/src/core/skills/built-ins.ts
+++ b/src/core/skills/built-ins.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from 'node:fs';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import type { AgentSkillBuiltInDefinition } from './types.js';
+
+export const BROWSER_AUTOMATION_SKILL_NAME = 'browser-automation';
+
+export const BROWSER_AUTOMATION_SKILL_ROOT = `heddle://built-in-skills/${BROWSER_AUTOMATION_SKILL_NAME}`;
+export const BROWSER_AUTOMATION_SKILL_FILE_PATH = `${BROWSER_AUTOMATION_SKILL_ROOT}/SKILL.md`;
+const BROWSER_AUTOMATION_SKILL_YAML = new URL('./browser-automation.skill.yaml', import.meta.url);
+
+export const DEFAULT_BUILT_IN_AGENT_SKILLS: AgentSkillBuiltInDefinition[] = [
+  readBuiltInSkillYaml({
+    skillRootPath: BROWSER_AUTOMATION_SKILL_ROOT,
+    skillFilePath: BROWSER_AUTOMATION_SKILL_FILE_PATH,
+    yamlUrl: BROWSER_AUTOMATION_SKILL_YAML,
+  }),
+];
+
+function readBuiltInSkillYaml(args: {
+  skillRootPath: string;
+  skillFilePath: string;
+  yamlUrl: URL;
+}): AgentSkillBuiltInDefinition {
+  const parsed = parseYaml(readFileSync(args.yamlUrl, 'utf8')) as unknown;
+  if (!isBuiltInSkillYaml(parsed)) {
+    throw new Error(`Invalid built-in Agent Skill YAML: ${args.yamlUrl.toString()}`);
+  }
+
+  // Built-in skills live as YAML assets for maintainability, while the skills
+  // domain continues to consume standard SKILL.md frontmatter content.
+  const frontmatter = stringifyYaml(Object.fromEntries([
+    ['name', parsed.name],
+    ['description', parsed.description],
+    ['license', parsed.license],
+    ['compatibility', parsed.compatibility],
+    ['allowed-tools', parsed['allowed-tools']],
+    ['metadata', parsed.metadata],
+  ].filter((entry): entry is [string, string | Record<string, string>] => entry[1] !== undefined))).trimEnd();
+
+  return {
+    skillRootPath: args.skillRootPath,
+    skillFilePath: args.skillFilePath,
+    content: [
+      '---',
+      frontmatter,
+      '---',
+      parsed.body,
+    ].join('\n'),
+    resources: parsed.resources,
+  };
+}
+
+function isBuiltInSkillYaml(raw: unknown): raw is {
+  name: string;
+  description: string;
+  license?: string;
+  compatibility?: string;
+  'allowed-tools'?: string;
+  metadata?: Record<string, string>;
+  resources?: Record<string, string>;
+  body: string;
+} {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return false;
+  }
+
+  const value = raw as Record<string, unknown>;
+  return typeof value.name === 'string'
+    && typeof value.description === 'string'
+    && typeof value.body === 'string'
+    && optionalRecord(value.metadata)
+    && optionalRecord(value.resources)
+    && ['license', 'compatibility', 'allowed-tools'].every((key) => (
+      value[key] === undefined || typeof value[key] === 'string'
+    ));
+}
+
+function optionalRecord(value: unknown): value is Record<string, string> | undefined {
+  return value === undefined || (
+    Boolean(value)
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && Object.values(value as Record<string, unknown>).every((entry) => typeof entry === 'string')
+  );
+}

--- a/src/core/skills/index.ts
+++ b/src/core/skills/index.ts
@@ -1,6 +1,12 @@
 export { FileAgentSkillActivationRepository } from './activation-repository.js';
 export { AgentSkillsRuntimeContextService } from './runtime-context.js';
 export { AgentSkillService } from './service.js';
+export {
+  BROWSER_AUTOMATION_SKILL_FILE_PATH,
+  BROWSER_AUTOMATION_SKILL_NAME,
+  BROWSER_AUTOMATION_SKILL_ROOT,
+  DEFAULT_BUILT_IN_AGENT_SKILLS,
+} from './built-ins.js';
 export type { AppendAgentSkillsSystemContextOptions } from './runtime-context.js';
 export type {
   AgentSkillActivationRecord,
@@ -11,6 +17,7 @@ export type {
   AgentSkillActivationStorePort,
   AgentSkillActivationOverview,
   AgentSkillActivationView,
+  AgentSkillBuiltInDefinition,
   AgentSkillActivationViewStatus,
   AgentSkillCatalog,
   AgentSkillCatalogEntry,

--- a/src/core/skills/service.ts
+++ b/src/core/skills/service.ts
@@ -12,12 +12,14 @@ import type {
   AgentSkillActivationResult,
   AgentSkillActivationStorePort,
   AgentSkillActivationView,
+  AgentSkillBuiltInDefinition,
   AgentSkillReadResult,
   AgentSkillResourceReadResult,
   AgentSkillRoot,
   AgentSkillServiceOptions,
   AgentSkillSourceKind,
 } from './types.js';
+import { DEFAULT_BUILT_IN_AGENT_SKILLS } from './built-ins.js';
 
 const SKILL_FILE_NAMES = ['SKILL.md', 'skill.md'] as const;
 
@@ -32,6 +34,7 @@ export class AgentSkillService {
   private readonly workspaceRoot: string;
   private readonly cwd: string;
   private readonly homeDir: string;
+  private readonly builtInSkills: AgentSkillBuiltInDefinition[];
   private readonly builtInSkillRoots: string[];
   private readonly activationStore?: AgentSkillActivationStorePort;
 
@@ -39,6 +42,7 @@ export class AgentSkillService {
     this.workspaceRoot = resolve(options.workspaceRoot);
     this.cwd = resolve(options.cwd ?? options.workspaceRoot);
     this.homeDir = resolve(options.homeDir ?? homedir());
+    this.builtInSkills = options.builtInSkills ?? DEFAULT_BUILT_IN_AGENT_SKILLS;
     this.builtInSkillRoots = (options.builtInSkillRoots ?? []).map((root) => resolve(root));
     this.activationStore = options.activationStore;
   }
@@ -47,8 +51,15 @@ export class AgentSkillService {
     const rootResults = await Promise.all(
       this.listSkillRoots().map((root) => this.readRootCatalog(root)),
     );
-    const rawEntries = rootResults.flatMap((result) => result.entries);
-    const issues = rootResults.flatMap((result) => result.issues);
+    const builtInResult = this.readBuiltInCatalog();
+    const rawEntries = [
+      ...rootResults.flatMap((result) => result.entries),
+      ...builtInResult.entries,
+    ];
+    const issues = [
+      ...rootResults.flatMap((result) => result.issues),
+      ...builtInResult.issues,
+    ];
     const entriesByName = new Map<string, AgentSkillCatalogEntry>();
 
     for (const entry of rawEntries) {
@@ -78,23 +89,18 @@ export class AgentSkillService {
       return null;
     }
 
-    const content = await readFile(skill.skillFilePath, 'utf8');
-    const parsed = AgentSkillParser.parse(content);
-
-    return {
-      skill,
-      body: parsed.body,
-      resources: AgentSkillParser.extractResourceLinks(parsed.body),
-    };
+    return await this.readSkillEntry(skill);
   }
 
   async readActivatedSkill(name: string): Promise<AgentSkillReadResult | null> {
-    const activatedCatalog = await this.loadActivatedCatalog();
-    if (!activatedCatalog.skills.some((skill) => skill.name === name)) {
+    const record = this.readActivationStore().skills[name];
+    if (!record || record.status !== 'active') {
       return null;
     }
 
-    return await this.readSkill(name);
+    const catalog = await this.loadCatalog();
+    const skill = this.resolveActivationRecordCatalogEntry(record, catalog);
+    return skill ? await this.readSkillEntry(skill) : null;
   }
 
   async readActivatedSkillResource(name: string, resource: string): Promise<AgentSkillResourceReadResult | null> {
@@ -105,6 +111,16 @@ export class AgentSkillService {
 
     if (!skill || !resolvedResource) {
       return null;
+    }
+
+    const builtInSkill = this.findBuiltInSkill(skill.skill.skillFilePath);
+    if (builtInSkill) {
+      const content = builtInSkill.resources?.[resolvedResource.path];
+      return content === undefined ? null : {
+        skill: skill.skill,
+        resource: resolvedResource,
+        content,
+      };
     }
 
     const resourcePath = resolve(skill.skill.skillRootPath, resolvedResource.path);
@@ -121,16 +137,97 @@ export class AgentSkillService {
 
   async loadActivatedCatalog(): Promise<AgentSkillCatalog> {
     const catalog = await this.loadCatalog();
-    const activeSkillNames = new Set(
-      Object.values(this.activationStore?.read().skills ?? {})
-        .filter((record) => record.status === 'active')
-        .map((record) => record.name),
-    );
+    const activeSkills = Object.values(this.activationStore?.read().skills ?? {})
+      .filter((record) => record.status === 'active')
+      .flatMap((record) => {
+        const skill = this.resolveActivationRecordCatalogEntry(record, catalog);
+        return skill ? [skill] : [];
+      });
 
     return {
-      skills: catalog.skills.filter((skill) => activeSkillNames.has(skill.name)),
+      skills: activeSkills,
       issues: catalog.issues,
     };
+  }
+
+  getBuiltInActivationView(name: string): AgentSkillActivationView | undefined {
+    const skill = this.findBuiltInCatalogEntry(name);
+    if (!skill) {
+      return undefined;
+    }
+
+    const record = this.readActivationStore().skills[name];
+    const activeRecord = record?.source === 'built-in' && record.skillFilePath === skill.skillFilePath
+      ? record
+      : undefined;
+
+    return {
+      name,
+      status: activeRecord?.status ?? 'available',
+      catalogEntry: skill,
+      record: activeRecord,
+    };
+  }
+
+  async activateBuiltInSkill(name: string, now = new Date()): Promise<AgentSkillActivationResult> {
+    const skill = this.findBuiltInCatalogEntry(name);
+    if (!skill) {
+      return {
+        ok: false,
+        reason: 'skill_not_found',
+        name,
+      };
+    }
+
+    const timestamp = now.toISOString();
+    const store = this.readActivationStore();
+    const existing = store.skills[name];
+    const existingBuiltIn = existing?.source === skill.source && existing.skillFilePath === skill.skillFilePath
+      ? existing
+      : undefined;
+    const record: AgentSkillActivationRecord = {
+      name: skill.name,
+      source: skill.source,
+      skillFilePath: skill.skillFilePath,
+      status: 'active',
+      activatedAt: existingBuiltIn?.activatedAt ?? timestamp,
+      updatedAt: timestamp,
+    };
+
+    store.skills[name] = record;
+    this.writeActivationStore(store);
+
+    return {
+      ok: true,
+      record,
+    };
+  }
+
+  private async readSkillEntry(skill: AgentSkillCatalogEntry): Promise<AgentSkillReadResult> {
+    const content = this.findBuiltInSkill(skill.skillFilePath)?.content
+      ?? await readFile(skill.skillFilePath, 'utf8');
+    const parsed = AgentSkillParser.parse(content);
+
+    return {
+      skill,
+      body: parsed.body,
+      resources: AgentSkillParser.extractResourceLinks(parsed.body),
+    };
+  }
+
+  private resolveActivationRecordCatalogEntry(
+    record: AgentSkillActivationRecord,
+    catalog: AgentSkillCatalog,
+  ): AgentSkillCatalogEntry | undefined {
+    return catalog.skills.find((skill) => (
+      skill.name === record.name
+      && skill.source === record.source
+      && skill.skillFilePath === record.skillFilePath
+    )) ?? (
+      record.source === 'built-in'
+        ? this.findBuiltInCatalogEntry(record.name, record.skillFilePath)
+        : undefined
+    );
   }
 
   async listActivationViews(): Promise<AgentSkillActivationView[]> {
@@ -146,7 +243,6 @@ export class AgentSkillService {
   }
 
   private buildActivationViews(catalog: AgentSkillCatalog): AgentSkillActivationView[] {
-    const entriesByName = new Map(catalog.skills.map((skill) => [skill.name, skill]));
     const records = Object.values(this.activationStore?.read().skills ?? {});
     const viewsByName = new Map<string, AgentSkillActivationView>();
 
@@ -159,10 +255,11 @@ export class AgentSkillService {
     }
 
     for (const record of records) {
+      const skill = this.resolveActivationRecordCatalogEntry(record, catalog);
       viewsByName.set(record.name, {
         name: record.name,
-        status: entriesByName.has(record.name) ? record.status : 'missing',
-        catalogEntry: entriesByName.get(record.name),
+        status: skill ? record.status : 'missing',
+        catalogEntry: skill,
         record,
       });
     }
@@ -284,6 +381,50 @@ export class AgentSkillService {
       entries: skillResults.flatMap((result) => result.entry ? [result.entry] : []),
       issues: [...skillDirs.issues, ...skillResults.flatMap((result) => result.issues)],
     };
+  }
+
+  private readBuiltInCatalog(): {
+    entries: AgentSkillCatalogEntry[];
+    issues: AgentSkillCatalogIssue[];
+  } {
+    const results = this.builtInSkills.map((skill) => {
+      try {
+        return {
+          entry: AgentSkillParser.toCatalogEntry({
+            content: skill.content,
+            skillFilePath: skill.skillFilePath,
+            skillRootPath: skill.skillRootPath,
+            source: 'built-in',
+          }),
+          issue: undefined,
+        };
+      } catch (error) {
+        return {
+          entry: undefined,
+          issue: {
+            code: 'invalid_skill' as const,
+            path: skill.skillFilePath,
+            message: errorMessage(error),
+          },
+        };
+      }
+    });
+
+    return {
+      entries: results.flatMap((result) => result.entry ? [result.entry] : []),
+      issues: results.flatMap((result) => result.issue ? [result.issue] : []),
+    };
+  }
+
+  private findBuiltInSkill(skillFilePath: string): AgentSkillBuiltInDefinition | undefined {
+    return this.builtInSkills.find((skill) => skill.skillFilePath === skillFilePath);
+  }
+
+  private findBuiltInCatalogEntry(name: string, skillFilePath?: string): AgentSkillCatalogEntry | undefined {
+    return this.readBuiltInCatalog().entries.find((skill) => (
+      skill.name === name
+      && (skillFilePath === undefined || skill.skillFilePath === skillFilePath)
+    ));
   }
 
   private async readSkillDirectories(root: AgentSkillRoot): Promise<{

--- a/src/core/skills/types.ts
+++ b/src/core/skills/types.ts
@@ -12,6 +12,13 @@ export type AgentSkillRoot = {
   path: string;
 };
 
+export type AgentSkillBuiltInDefinition = {
+  skillRootPath: string;
+  skillFilePath: string;
+  content: string;
+  resources?: Record<string, string>;
+};
+
 export type AgentSkillCatalogEntry = {
   name: string;
   description: string;
@@ -98,6 +105,7 @@ export type AgentSkillServiceOptions = {
   workspaceRoot: string;
   cwd?: string;
   homeDir?: string;
+  builtInSkills?: AgentSkillBuiltInDefinition[];
   builtInSkillRoots?: string[];
   activationStore?: AgentSkillActivationStorePort;
 };

--- a/src/core/tools/toolkits/browser-research/README.md
+++ b/src/core/tools/toolkits/browser-research/README.md
@@ -2,8 +2,9 @@
 
 This toolkit exposes the experimental browser domain as opt-in agent tools.
 
-It is not part of `RuntimeToolService.createDefaultAgentTools(...)`. Hosts must
-include `createBrowserResearchToolkit(...)` deliberately when they want a
+It is opt-in. `RuntimeToolService.createDefaultAgentTools(...)` includes it only
+when the workspace Browser Automation capability is enabled. Other hosts can
+still include `createBrowserResearchToolkit(...)` deliberately when they want a
 research-only browser run.
 
 The package root may export this toolkit without forcing browser automation onto
@@ -24,7 +25,7 @@ can still import Heddle normally, and browser hosts may either install
 - Browser execution, profile locks, policy, snapshots, or evidence persistence.
   Those stay in `src/core/browser`.
 - Approval UI or pending approval coordination.
-- Default runtime tool composition.
+- The Browser Automation capability switch and default runtime tool composition.
 - Form typing, transactions, checkout, payment, booking, messaging, uploads, or
   downloads.
 
@@ -39,6 +40,10 @@ can still import Heddle normally, and browser hosts may either install
 
 If browser policy blocks or requires approval for an action, the tool returns a
 failed tool result instead of executing the browser driver action.
+
+When `allowedDomains` is empty, `browser_open` derives the session allowlist
+from the first opened URL. Subsequent clicks remain same-domain unless a host
+provides a broader explicit allowlist.
 
 ## Example
 

--- a/src/core/tools/toolkits/browser-research/toolkit.ts
+++ b/src/core/tools/toolkits/browser-research/toolkit.ts
@@ -71,14 +71,14 @@ function createBrowserOpenTool(
   return {
     name: 'browser_open',
     description:
-      'Open an allowlisted URL in the experimental Heddle-owned browser research profile. Use this before browser_snapshot, browser_click, or browser_screenshot. Input example: { "url": "https://en.wikipedia.org/wiki/Browser_automation" }.',
+      'Open a URL in the Heddle-owned browser research profile. Use this before browser_snapshot, browser_click, or browser_screenshot. If no explicit domain allowlist is configured, the first opened URL establishes the same-domain browsing boundary. Input example: { "url": "https://en.wikipedia.org/wiki/Browser_automation" }.',
     parameters: {
       type: 'object',
       additionalProperties: false,
       properties: {
         url: {
           type: 'string',
-          description: 'The URL to open. The browser policy allowlist must permit the domain.',
+          description: 'The URL to open. Browser policy must permit the domain, or the session must be configured to derive its boundary from the first URL.',
         },
       },
       required: ['url'],
@@ -116,7 +116,7 @@ async function openBrowserSession(
   state: BrowserRuntimeState,
   url: string,
 ): Promise<Awaited<ReturnType<BrowserSessionService['open']>>> {
-  const session = await getBrowserSession(options, state);
+  const session = await getBrowserSession(options, state, url);
 
   try {
     const result = await session.open({ url });
@@ -271,6 +271,7 @@ function createBrowserCloseTool(state: BrowserRuntimeState): ToolDefinition {
 async function getBrowserSession(
   options: BrowserResearchToolkitOptions,
   state: BrowserRuntimeState,
+  initialUrl?: string,
 ): Promise<BrowserSessionService> {
   if (state.session) {
     return state.session;
@@ -284,7 +285,7 @@ async function getBrowserSession(
   });
   state.lease = lease;
   state.session = new BrowserSessionService(
-    createSessionConfig(options, lease.profile),
+    createSessionConfig(options, lease.profile, initialUrl),
     options.driverFactory ?? new PlaywrightBrowserDriverFactory(),
   );
   return state.session;
@@ -304,19 +305,35 @@ async function closeBrowserState(state: BrowserRuntimeState): Promise<Awaited<Re
 function createSessionConfig(
   options: BrowserResearchToolkitOptions,
   profile: BrowserProfileConfig,
+  initialUrl?: string,
 ): BrowserSessionConfig {
   return {
     profile,
-    policy: createPolicyConfig(options),
+    policy: createPolicyConfig(options, initialUrl),
     evidenceDir: join(options.evidenceRoot ?? join(options.stateRoot, 'browser-runs'), `run-${Date.now()}`),
   };
 }
 
-function createPolicyConfig(options: BrowserResearchToolkitOptions): BrowserPolicyConfig {
+function createPolicyConfig(options: BrowserResearchToolkitOptions, initialUrl?: string): BrowserPolicyConfig {
   return {
-    allowedDomains: options.allowedDomains,
+    allowedDomains: options.allowedDomains.length > 0
+      ? options.allowedDomains
+      : initialAllowedDomains(initialUrl),
     maxElementsPerSnapshot: options.maxElementsPerSnapshot,
   };
+}
+
+function initialAllowedDomains(initialUrl: string | undefined): string[] {
+  if (!initialUrl) {
+    return [];
+  }
+
+  try {
+    const hostname = new URL(initialUrl).hostname.toLowerCase();
+    return hostname.startsWith('www.') ? [hostname.slice(4), hostname] : [hostname];
+  } catch {
+    return [];
+  }
 }
 
 function requireOpenedSession(

--- a/src/server/controllers/trpc/control-plane/browser-automation.ts
+++ b/src/server/controllers/trpc/control-plane/browser-automation.ts
@@ -1,0 +1,18 @@
+import { BrowserAutomationCapabilityService } from '@/core/browser/index.js';
+
+export class ControlPlaneBrowserAutomationController {
+  static async overview(workspaceRoot: string, stateRoot: string) {
+    return await ControlPlaneBrowserAutomationController.service(workspaceRoot, stateRoot).overview();
+  }
+
+  static async setEnabled(workspaceRoot: string, stateRoot: string, enabled: boolean) {
+    return await ControlPlaneBrowserAutomationController.service(workspaceRoot, stateRoot).setEnabled(enabled);
+  }
+
+  private static service(workspaceRoot: string, stateRoot: string): BrowserAutomationCapabilityService {
+    return new BrowserAutomationCapabilityService({
+      workspaceRoot,
+      stateRoot,
+    });
+  }
+}

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -15,6 +15,7 @@ import { ControlPlaneHeartbeatController } from '@/server/controllers/trpc/contr
 import { controlPlaneHeartbeatEventsController } from '@/server/controllers/trpc/control-plane/heartbeat-events.js';
 import { ControlPlaneMemoryController } from '@/server/controllers/trpc/control-plane/memory.js';
 import { ControlPlaneMcpController } from '@/server/controllers/trpc/control-plane/mcp.js';
+import { ControlPlaneBrowserAutomationController } from '@/server/controllers/trpc/control-plane/browser-automation.js';
 import { ControlPlaneLayoutSnapshotsController } from '@/server/controllers/trpc/control-plane/layout-snapshots.js';
 import { ControlPlaneWorkspaceFilesController } from '@/server/controllers/trpc/control-plane/workspace-files.js';
 import { ControlPlaneWorkspaceDiffController } from '@/server/controllers/trpc/control-plane/workspace-diff.js';
@@ -26,6 +27,7 @@ import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/co
 import { controlPlaneWorkspaceProcedure, type ControlPlaneWorkspaceContext } from './control-plane-workspace.js';
 import {
   agentAskInputSchema,
+  browserAutomationInputSchema,
   createSessionInputSchema,
   fileSearchInputSchema,
   heartbeatRunInputSchema,
@@ -437,6 +439,14 @@ export const controlPlaneRouter = router({
   skillDisable: controlPlaneWorkspaceProcedure.input(skillInputSchema).mutation(async ({ ctx, input }) => {
     const { workspace } = ctx.requestWorkspace;
     return await ControlPlaneSkillsController.disable(workspace.workspaceRoot, workspace.stateRoot, input.name);
+  }),
+  browserAutomation: controlPlaneWorkspaceProcedure.query(async ({ ctx }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return await ControlPlaneBrowserAutomationController.overview(workspace.workspaceRoot, workspace.stateRoot);
+  }),
+  browserAutomationSetEnabled: controlPlaneWorkspaceProcedure.input(browserAutomationInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return await ControlPlaneBrowserAutomationController.setEnabled(workspace.workspaceRoot, workspace.stateRoot, input.enabled);
   }),
   mcpServers: controlPlaneWorkspaceProcedure.query(async ({ ctx }) => {
     const { workspace } = ctx.requestWorkspace;

--- a/src/server/routes/trpc/schema.ts
+++ b/src/server/routes/trpc/schema.ts
@@ -241,6 +241,11 @@ export const skillInputSchema = z.object({
   name: z.string().min(1),
 });
 
+export const browserAutomationInputSchema = z.object({
+  workspaceId: z.string().min(1).optional(),
+  enabled: z.boolean(),
+});
+
 export const mcpServerInputSchema = z.object({
   workspaceId: z.string().min(1).optional(),
   serverId: z.string().min(1),

--- a/src/server/services/control-plane/slash-command-execution-context-service.ts
+++ b/src/server/services/control-plane/slash-command-execution-context-service.ts
@@ -7,6 +7,7 @@ import type { ChatSession } from '@/core/chat/types.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import type { SlashCommandExecutionContext } from '@/core/commands/slash/modules/context.js';
 import type { SlashCommandHint } from '@/core/commands/slash/types.js';
+import { BrowserAutomationCapabilityService } from '@/core/browser/index.js';
 import { FileHeartbeatTaskService } from '@/core/heartbeat/index.js';
 import { McpService } from '@/core/mcp/index.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
@@ -33,6 +34,10 @@ export class ControlPlaneSlashCommandExecutionContextService {
     const resolved = controlPlaneSessionRuntimeContextService.resolve(args);
     const { runtimeContext, sessions } = resolved;
     const heartbeatTasks = new FileHeartbeatTaskService({ stateRoot: args.stateRoot });
+    const browserAutomation = new BrowserAutomationCapabilityService({
+      workspaceRoot: args.workspaceRoot,
+      stateRoot: args.stateRoot,
+    });
     const skills = new AgentSkillService({
       workspaceRoot: args.workspaceRoot,
       activationStore: new FileAgentSkillActivationRepository({ stateRoot: args.stateRoot }),
@@ -116,6 +121,10 @@ export class ControlPlaneSlashCommandExecutionContextService {
         listTasks: async () => await heartbeatTasks.listTasks(),
         listRunRecords: async (options) => await heartbeatTasks.listRunRecords(options),
         loadRunRecord: async (id) => await heartbeatTasks.loadRunRecord(id),
+      },
+      browserAutomation: {
+        overview: async () => await browserAutomation.overview(),
+        setEnabled: async (enabled) => await browserAutomation.setEnabled(enabled),
       },
       skills: {
         list: async () => await skills.listActivationViews(),

--- a/src/web-v2/components/settings/BrowserAutomationSettingsView.tsx
+++ b/src/web-v2/components/settings/BrowserAutomationSettingsView.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react';
+import type { ControlPlaneBrowserAutomation } from '@web/api/client';
+import { Switch } from '@web/components/ui/switch';
+import { useI18n } from '@web/i18n';
+import { cn } from '@web/lib/utils';
+
+export interface BrowserAutomationSettingsViewProps {
+  browserAutomation?: ControlPlaneBrowserAutomation;
+  loading: boolean;
+  error?: string;
+  updating: boolean;
+  onSetEnabled: (enabled: boolean) => Promise<void>;
+}
+
+export function BrowserAutomationSettingsView({
+  browserAutomation,
+  loading,
+  error,
+  updating,
+  onSetEnabled,
+}: BrowserAutomationSettingsViewProps) {
+  const { t } = useI18n();
+  const [actionError, setActionError] = useState<string | undefined>();
+
+  async function setEnabled(enabled: boolean) {
+    try {
+      setActionError(undefined);
+      await onSetEnabled(enabled);
+    } catch (nextError) {
+      setActionError(nextError instanceof Error ? nextError.message : String(nextError));
+    }
+  }
+
+  if (loading && !browserAutomation) {
+    return <BrowserAutomationEmpty title={t('browserAutomationSettings.loadingTitle')} body={t('browserAutomationSettings.loadingBody')} />;
+  }
+
+  if (error && !browserAutomation) {
+    return <BrowserAutomationEmpty title={t('browserAutomationSettings.errorTitle')} body={error} />;
+  }
+
+  const enabled = browserAutomation?.enabled ?? false;
+  const skillStatus = browserAutomation?.skill?.status ?? 'missing';
+
+  return (
+    <div className="v2-scrollbar-hidden h-full min-w-0 overflow-auto">
+      <div className="v2-settings-page mx-auto flex w-full max-w-4xl flex-col gap-6 px-8 py-8">
+        <section className="min-w-0">
+          <div className="mb-3 flex min-w-0 flex-wrap items-end justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="v2-type-section-label text-muted-foreground">{t('browserAutomationSettings.overviewTitle')}</h2>
+              <p className="v2-type-panel-subtitle mt-1 text-pretty text-muted-foreground">
+                {browserAutomation?.activationStorePath ?? t('browserAutomationSettings.noActivationStore')}
+              </p>
+            </div>
+            <BrowserAutomationStatusPill enabled={enabled} />
+          </div>
+
+          <div className="v2-settings-group">
+            <div className="v2-settings-row">
+              <div className="min-w-0">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <p className="v2-type-body-strong min-w-0 truncate text-foreground">{t('browserAutomationSettings.switchTitle')}</p>
+                  <span className="v2-type-caption shrink-0 rounded-sm border border-border bg-muted/20 px-1.5 py-0.5 text-muted-foreground">
+                    {browserAutomation?.skillName ?? 'browser-automation'}
+                  </span>
+                </div>
+                <p className="v2-type-panel-subtitle mt-1 max-w-2xl text-pretty text-muted-foreground">
+                  {t('browserAutomationSettings.switchDetail')}
+                </p>
+              </div>
+              <div className="flex min-w-0 items-center justify-end gap-3">
+                <span className="v2-type-caption text-muted-foreground">
+                  {updating ? t('browserAutomationSettings.updating') : enabled ? t('browserAutomationSettings.disableAction') : t('browserAutomationSettings.enableAction')}
+                </span>
+                <Switch
+                  aria-label={enabled ? t('browserAutomationSettings.disableAction') : t('browserAutomationSettings.enableAction')}
+                  checked={enabled}
+                  disabled={updating || skillStatus === 'missing'}
+                  onCheckedChange={(checked) => void setEnabled(checked)}
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {actionError ? <BrowserAutomationAlert message={actionError} /> : null}
+
+        <section className="min-w-0">
+          <h2 className="v2-type-section-label mb-3 text-muted-foreground">{t('browserAutomationSettings.detailsTitle')}</h2>
+          <div className="v2-settings-group">
+            <BrowserAutomationDetailRow
+              label={t('browserAutomationSettings.skillStatusLabel')}
+              value={skillStatus}
+            />
+            <BrowserAutomationDetailRow
+              label={t('browserAutomationSettings.profileLabel')}
+              value={browserAutomation?.profileRequirement ?? t('browserAutomationSettings.profileFallback')}
+            />
+            <BrowserAutomationDetailRow
+              label={t('browserAutomationSettings.toolsLabel')}
+              value={browserAutomation?.toolAvailability ?? t('browserAutomationSettings.toolsFallback')}
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function BrowserAutomationStatusPill({ enabled }: { enabled: boolean }) {
+  const { t } = useI18n();
+  return (
+    <span
+      className={cn(
+        'v2-type-caption shrink-0 rounded-md border px-2.5 py-1 tabular-nums',
+        enabled
+          ? 'border-primary/45 bg-primary/10 text-foreground'
+          : 'border-border bg-muted/20 text-muted-foreground',
+      )}
+    >
+      {enabled ? t('browserAutomationSettings.enabled') : t('browserAutomationSettings.disabled')}
+    </span>
+  );
+}
+
+function BrowserAutomationDetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="v2-settings-row">
+      <div className="min-w-0">
+        <p className="v2-type-caption text-muted-foreground">{label}</p>
+        <p className="v2-type-panel-subtitle mt-1 text-pretty text-foreground">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function BrowserAutomationAlert({ message }: { message: string }) {
+  return (
+    <div className="rounded-md border border-destructive/45 bg-destructive/10 px-3 py-2">
+      <p className="v2-type-caption text-pretty text-destructive">{message}</p>
+    </div>
+  );
+}
+
+function BrowserAutomationEmpty({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="flex h-full min-h-0 items-center justify-center px-6">
+      <div className="max-w-sm text-center">
+        <p className="v2-type-body-strong text-foreground">{title}</p>
+        <p className="v2-type-panel-subtitle mt-1 text-pretty text-muted-foreground">{body}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/web-v2/components/settings/index.ts
+++ b/src/web-v2/components/settings/index.ts
@@ -1,3 +1,5 @@
+export { BrowserAutomationSettingsView } from './BrowserAutomationSettingsView';
+export type { BrowserAutomationSettingsViewProps } from './BrowserAutomationSettingsView';
 export { GeneralSettingsView } from './GeneralSettingsView';
 export { LanguageSelect } from './LanguageSelect';
 export { MemorySettingsView } from './MemorySettingsView';

--- a/src/web-v2/hooks/useControlPlaneAppState.ts
+++ b/src/web-v2/hooks/useControlPlaneAppState.ts
@@ -30,6 +30,7 @@ export function useControlPlaneAppState() {
   const workspaceSetActiveMutation = trpcReact.controlPlane.workspaceSetActive.useMutation();
   const skillActivateMutation = trpcReact.controlPlane.skillActivate.useMutation();
   const skillDisableMutation = trpcReact.controlPlane.skillDisable.useMutation();
+  const browserAutomationSetEnabledMutation = trpcReact.controlPlane.browserAutomationSetEnabled.useMutation();
   const mcpServerEnableMutation = trpcReact.controlPlane.mcpServerEnable.useMutation();
   const mcpServerDisableMutation = trpcReact.controlPlane.mcpServerDisable.useMutation();
   const mcpServerRefreshMutation = trpcReact.controlPlane.mcpServerRefresh.useMutation();
@@ -44,6 +45,9 @@ export function useControlPlaneAppState() {
   });
   const skillsQuery = trpcReact.controlPlane.skills.useQuery(sidebar.workspaceId ? { workspaceId: sidebar.workspaceId } : undefined, {
     enabled: navigation.settingsOpen && navigation.activeSettingsSectionId === 'skills',
+  });
+  const browserAutomationQuery = trpcReact.controlPlane.browserAutomation.useQuery(sidebar.workspaceId ? { workspaceId: sidebar.workspaceId } : undefined, {
+    enabled: navigation.settingsOpen && navigation.activeSettingsSectionId === 'browserAutomation',
   });
   const mcpQuery = trpcReact.controlPlane.mcpServers.useQuery(sidebar.workspaceId ? { workspaceId: sidebar.workspaceId } : undefined, {
     enabled: navigation.settingsOpen && navigation.activeSettingsSectionId === 'mcp',
@@ -123,6 +127,18 @@ export function useControlPlaneAppState() {
     await utils.controlPlane.skills.invalidate(sidebar.workspaceId ? { workspaceId: sidebar.workspaceId } : undefined);
   }
 
+  async function setBrowserAutomationEnabled(enabled: boolean) {
+    const input = sidebar.workspaceId ? { workspaceId: sidebar.workspaceId, enabled } : { enabled };
+    const result = await browserAutomationSetEnabledMutation.mutateAsync(input);
+    if (!result.ok) {
+      throw new Error(`Browser Automation skill not found: ${result.overview.skillName}`);
+    }
+    await Promise.all([
+      utils.controlPlane.browserAutomation.invalidate(sidebar.workspaceId ? { workspaceId: sidebar.workspaceId } : undefined),
+      utils.controlPlane.skills.invalidate(sidebar.workspaceId ? { workspaceId: sidebar.workspaceId } : undefined),
+    ]);
+  }
+
   async function setMcpServerEnabled(serverId: string, enabled: boolean) {
     const input = sidebar.workspaceId ? { workspaceId: sidebar.workspaceId, serverId } : { serverId };
     if (enabled) {
@@ -178,6 +194,13 @@ export function useControlPlaneAppState() {
         status: memoryStatusQuery.data ?? stateMemoryStatus,
         loading: memoryStatusQuery.isLoading || sidebar.stateQuery.isLoading,
         error: memoryStatusQuery.error instanceof Error ? memoryStatusQuery.error.message : undefined,
+      },
+      browserAutomationSettingsView: {
+        browserAutomation: browserAutomationQuery.data,
+        loading: browserAutomationQuery.isLoading || sidebar.stateQuery.isLoading,
+        error: browserAutomationQuery.error instanceof Error ? browserAutomationQuery.error.message : undefined,
+        updating: browserAutomationSetEnabledMutation.isPending,
+        onSetEnabled: setBrowserAutomationEnabled,
       },
       skillsSettingsView: {
         skills: skillsQuery.data,

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -189,11 +189,32 @@
     "workspaceSwitcher": "Workspace"
   },
   "settings": {
+    "browserAutomation": "Browser Automation",
     "general": "General",
     "memory": "Memory Status",
     "mcp": "MCP",
     "skills": "Skills",
     "workspaces": "Workspace"
+  },
+  "browserAutomationSettings": {
+    "detailsTitle": "Runtime notes",
+    "disableAction": "Disable",
+    "disabled": "disabled",
+    "enableAction": "Enable",
+    "enabled": "enabled",
+    "errorTitle": "Browser Automation unavailable",
+    "loadingBody": "Reading Browser Automation settings for the active workspace.",
+    "loadingTitle": "Loading Browser Automation",
+    "noActivationStore": "No activation store",
+    "overviewTitle": "Browser Automation",
+    "profileFallback": "Logged-in sites require a selected browser profile with a valid session.",
+    "profileLabel": "Profile requirement",
+    "skillStatusLabel": "Skill status",
+    "switchDetail": "Adds built-in guidance and browser tools to future default agent turns in this workspace.",
+    "switchTitle": "Enable Browser Automation",
+    "toolsFallback": "Browser tools follow host policy and profile configuration.",
+    "toolsLabel": "Tool boundary",
+    "updating": "Updating"
   },
   "mcpSettings": {
     "catalogTitle": "MCP servers",

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -189,11 +189,32 @@
     "workspaceSwitcher": "工作区"
   },
   "settings": {
+    "browserAutomation": "Browser Automation",
     "general": "通用",
     "memory": "记忆状态",
     "mcp": "MCP",
     "skills": "Skills",
     "workspaces": "工作区"
+  },
+  "browserAutomationSettings": {
+    "detailsTitle": "运行环境说明",
+    "disableAction": "停用",
+    "disabled": "已停用",
+    "enableAction": "启用",
+    "enabled": "已启用",
+    "errorTitle": "Browser Automation 不可用",
+    "loadingBody": "正在读取当前工作区的 Browser Automation 设置。",
+    "loadingTitle": "正在加载 Browser Automation",
+    "noActivationStore": "没有 activation store",
+    "overviewTitle": "Browser Automation",
+    "profileFallback": "需要登录状态的网站必须选择有有效 session 的浏览器 profile。",
+    "profileLabel": "Profile 条件",
+    "skillStatusLabel": "Skill 状态",
+    "switchDetail": "为当前工作区未来的 default agent turns 加入内置指引与 browser tools。",
+    "switchTitle": "启用 Browser Automation",
+    "toolsFallback": "Browser tools 会遵守 host policy 与 profile 设置。",
+    "toolsLabel": "Tool 边界",
+    "updating": "更新中"
   },
   "mcpSettings": {
     "catalogTitle": "MCP servers",

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -189,11 +189,32 @@
     "workspaceSwitcher": "工作區"
   },
   "settings": {
+    "browserAutomation": "Browser Automation",
     "general": "一般",
     "memory": "記憶狀態",
     "mcp": "MCP",
     "skills": "Skills",
     "workspaces": "工作區"
+  },
+  "browserAutomationSettings": {
+    "detailsTitle": "執行環境說明",
+    "disableAction": "停用",
+    "disabled": "已停用",
+    "enableAction": "啟用",
+    "enabled": "已啟用",
+    "errorTitle": "Browser Automation 無法使用",
+    "loadingBody": "正在讀取目前工作區的 Browser Automation 設定。",
+    "loadingTitle": "正在載入 Browser Automation",
+    "noActivationStore": "沒有 activation store",
+    "overviewTitle": "Browser Automation",
+    "profileFallback": "需要登入狀態的網站必須選擇有有效 session 的瀏覽器 profile。",
+    "profileLabel": "Profile 條件",
+    "skillStatusLabel": "Skill 狀態",
+    "switchDetail": "為目前工作區未來的 default agent turns 加入內建指引與 browser tools。",
+    "switchTitle": "啟用 Browser Automation",
+    "toolsFallback": "Browser tools 會遵守 host policy 與 profile 設定。",
+    "toolsLabel": "Tool 邊界",
+    "updating": "更新中"
   },
   "mcpSettings": {
     "catalogTitle": "MCP servers",

--- a/src/web-v2/layout/AppRoutes.tsx
+++ b/src/web-v2/layout/AppRoutes.tsx
@@ -7,6 +7,7 @@ import {
 import type { AppSurfaceId, SettingsSectionId } from '@web/layout/types';
 import {
   WorkbenchView,
+  type BrowserAutomationSettingsViewProps,
   type MemorySettingsViewProps,
   type McpSettingsViewProps,
   type SkillsSettingsViewProps,
@@ -18,6 +19,7 @@ import {
 interface AppRoutesProps {
   activeSurfaceId: AppSurfaceId;
   activeSettingsSectionId: SettingsSectionId;
+  browserAutomationSettingsView: BrowserAutomationSettingsViewProps;
   memorySettingsView: MemorySettingsViewProps;
   mcpSettingsView: McpSettingsViewProps;
   sessionView: SessionWorkbenchViewProps;
@@ -43,6 +45,7 @@ const appRoutePaths = APP_ROUTES.flatMap((route) => (
 export function AppRoutes({
   activeSurfaceId,
   activeSettingsSectionId,
+  browserAutomationSettingsView,
   memorySettingsView,
   mcpSettingsView,
   sessionView,
@@ -52,6 +55,7 @@ export function AppRoutes({
 }: AppRoutesProps) {
   const sharedWorkbenchProps = {
     activeSettingsSectionId,
+    browserAutomationSettingsView,
     memorySettingsView,
     mcpSettingsView,
     sessionView,

--- a/src/web-v2/layout/routes.ts
+++ b/src/web-v2/layout/routes.ts
@@ -23,6 +23,7 @@ export const APP_ROUTES = [
 export const SETTINGS_ROUTES = [
   { id: 'general', labelKey: 'settings.general', href: '/settings/general' },
   { id: 'workspaces', labelKey: 'settings.workspaces', href: '/settings/workspaces' },
+  { id: 'browserAutomation', labelKey: 'settings.browserAutomation', href: '/settings/browser-automation' },
   { id: 'skills', labelKey: 'settings.skills', href: '/settings/skills' },
   { id: 'mcp', labelKey: 'settings.mcp', href: '/settings/mcp' },
   { id: 'memory', labelKey: 'settings.memory', href: '/settings/memory' },

--- a/src/web-v2/layout/types.ts
+++ b/src/web-v2/layout/types.ts
@@ -1,7 +1,7 @@
 import type { I18nMessageKey } from '@web/i18n/messages';
 
 export type AppSurfaceId = 'sessions' | 'tasks';
-export type SettingsSectionId = 'general' | 'workspaces' | 'skills' | 'mcp' | 'memory';
+export type SettingsSectionId = 'general' | 'workspaces' | 'browserAutomation' | 'skills' | 'mcp' | 'memory';
 
 export interface NavigationItem {
   id: AppSurfaceId | SettingsSectionId;

--- a/src/web-v2/views/WorkbenchView.tsx
+++ b/src/web-v2/views/WorkbenchView.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, ReactNode } from 'react';
 import { ConversationThread } from '@web/components/conversation';
-import { GeneralSettingsView, McpSettingsView, MemorySettingsView, SkillsSettingsView, WorkspaceSettingsView } from '@web/components/settings';
+import { BrowserAutomationSettingsView, GeneralSettingsView, McpSettingsView, MemorySettingsView, SkillsSettingsView, WorkspaceSettingsView } from '@web/components/settings';
 import type { I18nMessageKey } from '@web/i18n';
 import { useI18n } from '@web/i18n';
 import type { AppSurfaceId, SettingsSectionId } from '@web/layout/types';
@@ -8,6 +8,7 @@ import { TasksWorkbenchView } from './TasksWorkbenchView';
 
 export type SessionWorkbenchViewProps = Omit<ComponentProps<typeof ConversationThread>, 'emptyTitle'>;
 export type TaskWorkbenchViewProps = ComponentProps<typeof TasksWorkbenchView>;
+export type BrowserAutomationSettingsViewProps = ComponentProps<typeof BrowserAutomationSettingsView>;
 export type MemorySettingsViewProps = ComponentProps<typeof MemorySettingsView>;
 export type McpSettingsViewProps = ComponentProps<typeof McpSettingsView>;
 export type SkillsSettingsViewProps = ComponentProps<typeof SkillsSettingsView>;
@@ -16,6 +17,7 @@ export type WorkspaceSettingsViewProps = ComponentProps<typeof WorkspaceSettings
 interface WorkbenchViewProps {
   activeSurfaceId: AppSurfaceId;
   activeSettingsSectionId: SettingsSectionId;
+  browserAutomationSettingsView: BrowserAutomationSettingsViewProps;
   memorySettingsView: MemorySettingsViewProps;
   mcpSettingsView: McpSettingsViewProps;
   sessionView: SessionWorkbenchViewProps;
@@ -31,6 +33,7 @@ const appSurfaceLabelKeys = {
 } satisfies Record<AppSurfaceId, I18nMessageKey>;
 
 const settingsSectionLabelKeys = {
+  browserAutomation: 'settings.browserAutomation',
   general: 'settings.general',
   memory: 'settings.memory',
   mcp: 'settings.mcp',
@@ -43,6 +46,7 @@ const settingsSectionLabelKeys = {
 export function WorkbenchView({
   activeSurfaceId,
   activeSettingsSectionId,
+  browserAutomationSettingsView,
   memorySettingsView,
   mcpSettingsView,
   sessionView,
@@ -63,6 +67,7 @@ export function WorkbenchView({
     },
   } satisfies Record<AppSurfaceId, { title: string; content: ReactNode }>;
   const settingsViews = {
+    browserAutomation: <BrowserAutomationSettingsView {...browserAutomationSettingsView} />,
     general: <GeneralSettingsView />,
     memory: <MemorySettingsView {...memorySettingsView} />,
     mcp: <McpSettingsView {...mcpSettingsView} />,


### PR DESCRIPTION
## Summary
- add a YAML-backed built-in browser automation Agent Skill, copied into dist for published packages
- add a core Browser Automation capability switch that activates/deactivates the package-owned built-in skill, even if a project/user skill tries to shadow the same name
- resolve active Agent Skills by stored source and file path so read_agent_skill reads the skill the user actually enabled
- when Browser Automation is enabled, add browser tools to future default agent turns; without explicit domain config, the first opened URL establishes the same-domain browsing boundary
- expose the switch through /browser slash commands, control-plane routes, and Settings -> Browser Automation
- add dedicated Browser Automation sections and next-step agenda notes to the English README and restructure the Chinese README to match the English README outline and depth
- clarify the skill instructions so agents prefer browser tools over web_search when the user explicitly asks to use a browser, while still allowing web_search for URL discovery
- update repo docs and focused tests for built-in skill discovery, activation, browser tool availability, shadowing protection, and slash output

## Verification
- yarn lint
- yarn build
- yarn test
- npm pack --dry-run --cache /tmp/heddle-npm-cache includes dist/src/core/skills/browser-automation.skill.yaml and dist/src/core/skills/built-ins.js
- git diff --check after README updates
