### PR TITLE
[codex] Restructure README guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,50 @@
 
 [English](README.md) | [繁體中文](README.zh-TW.md)
 
-Heddle is an open-source AI coding agent runtime and terminal-first workspace for real project work.
+Heddle is an open-source AI coding agent runtime and terminal-first workspace for shipping features, fixing bugs, and operating software with reviewable agent help.
 
 Official website: [heddleagent.com](https://heddleagent.com)
 
-> **Terminal UI v2 is now the default.** Run `heddle` or `heddle chat` to use the API-backed terminal experience. Messages, run events, and agent response streams now flow through the shared control-plane path, so terminal, browser, and mobile clients can follow the same work at the same time for smoother cross-device workflows.
+> **Terminal UI v2 is now the default.** Run `heddle` or `heddle chat` to use the API-backed terminal experience. Messages, run events, and agent response streams flow through the shared control-plane path, so terminal, browser, and mobile clients can follow the same work at the same time.
 
 ## Agenda
 
-- [See Heddle In Action](#see-heddle-in-action)
-- [Why Try Heddle](#why-try-heddle)
-- [What Heddle Does](#what-heddle-does)
-- [Programmatic Use Layers](#programmatic-use-layers)
-- [See Heddle](#see-heddle)
-- [2-Minute Try-It Path](#2-minute-try-it-path)
-- [Major Features](#major-features)
+- [What Heddle Can Do](#what-heddle-can-do)
+- [See It In Action](#see-it-in-action)
+- [Quick Start](#quick-start)
+- [Core Workflows](#core-workflows)
 - [Install](#install)
 - [Requirements](#requirements)
+- [Optional CyberLoop Integration](#optional-cyberloop-integration)
 - [Documentation](#documentation)
 - [Project Status](#project-status)
 - [Development](#development)
+- [License](#license)
 
-## See Heddle In Action
+## What Heddle Can Do
+
+Heddle is for engineers, maintainers, and side-project builders who want an AI coding assistant that can help with day-to-day software work while keeping local continuity and reviewable execution.
+
+It is a good fit when you want to:
+
+- inspect and understand unfamiliar repositories
+- develop new product features for work or side projects
+- build frontend pages, backend services, CLIs, docs, and tests
+- fix bugs, investigate regressions, and explain unfamiliar code paths
+- refactor existing modules while preserving reviewable diffs
+- run bounded verification such as builds, tests, and repo review
+- keep multi-step implementation work going across saved sessions
+- review file diffs, commands, approvals, traces, and semantic activity before accepting changes
+- switch between local workspaces from a browser control plane
+- let the agent learn durable project knowledge over time
+- activate standard Agent Skills only when a workspace should expose them
+- connect configured MCP servers such as Notion, Anytype, GitHub, or other tools
+- opt into Browser Automation for rendered page inspection and user-requested web workflows
+- build custom hosts on top of Heddle's runtime APIs
+
+Heddle is probably not the right fit if you only want a very simple one-shot prompt runner and do not care about sessions, persistence, observability, or operator control.
+
+## See It In Action
 
 Terminal, browser, and mobile surfaces can observe the same live session at once:
 
@@ -37,90 +59,17 @@ Inspect workspace diffs from browser and mobile while the same conversation cont
 
 ![Heddle diff review across browser and mobile](docs/images/heddle-diff-view.gif)
 
-It is designed for workflows where an agent needs to inspect a live repository, make bounded changes, verify results, keep continuity across sessions, and stay observable to the operator. Heddle supports OpenAI and Anthropic models, stores local workspace state under `.heddle/`, includes both a terminal chat experience and a browser control plane, learns durable workspace knowledge while it works, and gives users a review path for file diffs, commands, approvals, and traces.
-
-In plain terms: Heddle is for people who want an AI coding assistant that can work inside actual projects, learn each project's operating knowledge over time, switch between local workspaces, and remain inspectable instead of acting like a black box.
-
-## Why Try Heddle
-
-Heddle is aimed at people who want more than a one-shot coding chat wrapper or stateless AI code assistant.
-
-It is a good fit if you want:
-
-- a terminal-first coding agent that works in a real repository
-- an agent that learns durable project knowledge while working with you, using inspectable local memory
-- standard Agent Skills support for opt-in reusable workflows and tool-use instructions
-- opt-in Browser Automation for rendered page inspection and user-requested web workflows
-- explicit traces, approvals, and reviewable workflow artifacts
-- a browser control plane for local oversight, workspace switching, and session review
-- a path from interactive use to programmatic and scheduled agent workflows
-
-Heddle is probably not the right fit if you only want a very simple one-shot prompt runner and do not care about sessions, persistence, observability, or operator control.
-
-## What Heddle Does
-
-At a high level, Heddle helps with:
-
-- understanding unfamiliar repositories
-- making code or doc changes inside a real workspace
-- running bounded verification like builds, tests, and repo review
-- keeping multi-step work going across sessions instead of starting from scratch each time
-- switching between local workspaces from the browser control plane
-- learning durable facts, preferences, and workflows from real usage
-- enabling workspace-approved Agent Skills so the agent can load specialized instructions only when needed
-- enabling Browser Automation when an agent should inspect, screenshot, or operate real web pages
-- exposing more operator visibility than a black-box chat tool
-
-If you want a terminal-first coding agent with local state, review traces, workspace memory, and a path toward longer-running workflows, that is the problem Heddle is trying to solve.
-
-## Programmatic Use Layers
-
-Heddle currently has two main programmatic layers:
-
-- `createConversationEngine`: an alpha API for persisted multi-turn sessions with session storage, compaction, approvals, traces, semantic activity, and custom frontends or local hosts
-- `AgentLoopRuntimeService.run(...)`: a lower-level single-run execution loop for hosts that do not need persisted chat or session behavior
-
-Advanced hosts can also reuse lower-level class APIs such as `ToolRegistry`,
-`ToolExecutionService`, `TraceRecorder`, `TraceConsoleFormatter`, and
-`ReviewDiffParser` when they intentionally assemble custom runtime or review
-surfaces.
-
-If you want the programmatic surface, start with the [Programmatic use guide](docs/guides/programmatic-use.md).
-
-For contributors, the compact architecture map lives in
-[Core Layering](docs/architecture/core-layering.md) and
-[Chat Layering](docs/architecture/chat-layering.md).
-
-## See Heddle
-
-### Terminal coding workflow
-
-Heddle working in the terminal with live progress, tool activity, plans, and review output:
+Heddle also works as a terminal-first coding agent with live progress, tool activity, plans, and review output:
 
 ![Heddle terminal coding workflow](docs/images/terminal-active-run.png)
-
-Heddle can inspect files, search with ignore-aware fallbacks, explain code, make edits, run shell commands with the right approval model, and carry a task through multiple turns. Terminal chat keeps long-running turns visible with tool activity, dim `Thinking:` progress text, real-time assistant markdown, and clearer approval prompts for repeated commands or searches.
-
-### Terminal change review
 
 Terminal chat/dev workflow showing file edits, inline diff output, and verification-oriented follow-through:
 
 ![Heddle terminal change review](docs/images/terminal-change-review.png)
 
-### Browser control plane overview
-
-The default local control plane is the web-v2 browser client served by `heddle daemon`. It is the oversight surface for coding sessions, workspace state, current changes, heartbeat tasks, and settings:
+The default local control plane is the web-v2 browser client served by `heddle daemon`:
 
 ![Heddle web-v2 control plane](docs/images/control-plane-v2.png)
-
-The web-v2 client includes:
-
-- `Sessions`: saved conversations, live assistant streaming, tool progress, approvals, and current workspace diff review.
-- `Composer controls`: model and reasoning settings, semantic drift controls, `@file` mentions, and image attachments saved as local paths for `view_image`.
-- `Workspace switching`: sidebar workspace selection plus `Settings > Workspace` for registering, renaming, and switching local projects.
-- `Tasks`: heartbeat task creation, edit, enable/disable, run, resume, delete, live run state, and saved run records.
-- `Settings`: language preferences, workspace management, and memory status with catalog health, note counts, pending candidates, and latest maintenance run.
-- `Mobile`: focused panels for session list, conversation workbench, task detail, settings, and diff review.
 
 The task workbench covers recurring heartbeat tasks, live run state, and run result review:
 
@@ -134,7 +83,7 @@ The same control plane supports mobile layouts, with the session list, workbench
   <img src="docs/images/control-plane-v2-diff-view.PNG" alt="Heddle web-v2 mobile diff preview" width="220">
 </p>
 
-## 2-Minute Try-It Path
+## Quick Start
 
 1. Install Heddle:
 
@@ -198,15 +147,13 @@ heddle daemon
 
 Open the browser control plane from the daemon output. From there you can use `Sessions`, `Tasks`, and `Settings` to inspect the active workspace, continue saved sessions, review changes, inspect memory status, and switch to another local project.
 
-If you prefer a one-shot CLI run instead of interactive chat, use:
+For a one-shot run instead of interactive chat:
 
 ```bash
 heddle ask "Summarize this repository"
 ```
 
-`ask` still exits after one prompt, but it now records the run as a one-off saved session under `.heddle/` so traces, memory maintenance, and later inspection use the same persisted conversation path as normal sessions.
-
-The terminal chat footer and the control-plane session composer both show the active auth source for the selected model, so you can tell whether a session is using OpenAI account sign-in, API-key mode, or missing credentials.
+`ask` exits after one prompt, but it records the run as a one-off saved session under `.heddle/` so traces, memory maintenance, and later inspection use the same persisted conversation path as normal sessions.
 
 ### Try The Learning Loop
 
@@ -230,9 +177,9 @@ heddle memory list
 heddle memory search ticket
 ```
 
-## Major Features
+## Core Workflows
 
-### Terminal chat for real coding work
+### Terminal Coding
 
 The main way to use Heddle is interactive chat in a repository:
 
@@ -240,23 +187,46 @@ The main way to use Heddle is interactive chat in a repository:
 heddle
 ```
 
-From there, Heddle can inspect files, explain code, make edits, run shell commands with the right approval model, and carry a task through multiple turns.
-
-This is the core feature. If you only use Heddle as a coding agent in the terminal, this is the part you care about.
+From there, Heddle can inspect files, search with ignore-aware fallbacks, explain code, make edits, run shell commands with the right approval model, and carry a task through multiple turns.
 
 The terminal composer supports multiline prompts, prompt undo/redo, prompt history navigation, model picking with `/model set`, and reasoning-effort picking with `/reasoning set`. During a run, Heddle streams visible activity so you can see whether it is thinking, searching, calling tools, updating a plan, or waiting for approval.
 
 More: [Chat and sessions guide](docs/guides/chat-and-sessions.md)
 
-### Terminal UI v2 is the default
+### Browser Control Plane
 
-The default terminal chat is now the API-backed `cli-v2` experience. Run `heddle` or `heddle chat` from a project to start it.
+The control plane is Heddle's local browser UI:
 
-The v2 terminal UI consumes the same local control-plane API as the browser UI and does not reach directly into core services. For users, the goal is one behavior model across interfaces. A saved conversation, selected model, reasoning setting, approval state, and live run status should be the same whether you are looking from the terminal, the browser control plane, or another device connected to the same local control-plane server. Messages, tool events, approval waits, and streamed agent responses are delivered through the shared session event path, so multiple devices can observe and continue the same work simultaneously instead of waiting for one surface to finish or refresh.
+```bash
+heddle daemon
+```
 
-For contributors, the goal is a cleaner implementation path: TUI-specific rendering and keyboard behavior stay in `cli-v2`, shared semantics stay in core and server-owned control-plane APIs, and future advanced features can build on a maintainable API-first foundation instead of duplicating command/session logic in each interface.
+It gives you a browser-based view into workspaces, saved conversations, live assistant streaming, tool progress, approvals, current workspace diffs, heartbeat tasks, memory health, and settings.
 
-### Project instructions
+The workspace switcher and `Settings > Workspace` page let you register local projects, switch the control plane between them, rename workspace entries, and pick a project folder from the browser UI. The `Sessions` section is built around current work first: review starts from the live Git working tree, with changed files, structured read-only diffs, and a larger full-diff viewer when the side panel is too tight.
+
+If terminal chat is the execution surface, the control plane is the oversight surface.
+
+More: [Control plane guide](docs/guides/control-plane.md)
+
+### Sessions And Continuity
+
+Heddle keeps saved sessions under `.heddle/` so longer work does not have to reset every time. Current versions store the session catalog at `.heddle/chat-sessions.catalog.json` and per-session bodies under `.heddle/chat-sessions/`.
+
+Typical session commands include:
+
+```text
+/session list
+/session switch <id>
+/continue
+/compact
+/model set
+/reasoning set
+```
+
+More: [Chat and sessions guide](docs/guides/chat-and-sessions.md)
+
+### Project Instructions
 
 Heddle can load a short project instruction file at startup so a fresh session starts with the repository's operating context. By default it loads the first non-empty file found in this order: `HEDDLE.md`, `AGENTS.md`, `CLAUDE.md`.
 
@@ -264,12 +234,19 @@ Only one default file is loaded to preserve context space. If a project needs a 
 
 More: [Project config](docs/reference/config.md)
 
+### Knowledge Persistence
+
+Heddle can learn durable project knowledge while it works with you.
+
+When the agent notices reusable information such as a preferred ticket format, a canonical verification command, an operational convention, a recurring repo quirk, or a stable workflow pattern, it can record a memory candidate and let a dedicated maintainer path fold that knowledge into cataloged markdown notes under `.heddle/memory/`.
+
+The goal is practical recall: future sessions should know where to look instead of rediscovering the same context from scratch. Heddle does this through explicit catalogs, readable local notes, maintenance logs, and memory visibility commands rather than opaque retrieval.
+
+More: [Knowledge persistence](docs/guides/knowledge-persistence.md)
+
 ### Agent Skills
 
-Heddle supports the standard Agent Skills folder format for reusable, opt-in
-agent workflows. Put project skills under `.agents/skills/<name>/SKILL.md` or
-user skills under `~/.agents/skills/<name>/SKILL.md`, then manage workspace
-activation from chat:
+Heddle supports the standard Agent Skills folder format for reusable, opt-in agent workflows. Put project skills under `.agents/skills/<name>/SKILL.md` or user skills under `~/.agents/skills/<name>/SKILL.md`, then manage workspace activation from chat:
 
 ```text
 /skills
@@ -277,27 +254,17 @@ activation from chat:
 /skills disable <name>
 ```
 
-Heddle also ships built-in skills for Heddle-owned capabilities. Capability
-settings can activate those built-ins without asking users to install separate
-skill files.
+Heddle also ships built-in skills for Heddle-owned capabilities. Capability settings can activate those built-ins without asking users to install separate skill files.
 
-Only active skills are shown to the agent. Heddle initially exposes a compact
-catalog with each active skill's name and description, then the agent can call
-`read_agent_skill` to fetch the full `SKILL.md` body when a skill is relevant.
-Activation state is stored under `.heddle/skills/activation.json`; skill
-definitions stay in their original folders.
+Only active skills are shown to the agent. Heddle initially exposes a compact catalog with each active skill's name and description, then the agent can call `read_agent_skill` to fetch the full `SKILL.md` body when a skill is relevant. Activation state is stored under `.heddle/skills/activation.json`; skill definitions stay in their original folders.
 
-Skills are instructions, not permissions. They do not bypass Heddle's approval
-policy or tool safety checks, so users remain responsible for which project or
-user skills they enable.
+Skills are instructions, not permissions. They do not bypass Heddle's approval policy or tool safety checks, so users remain responsible for which project or user skills they enable.
 
 More: [Agent Skills guide](docs/guides/agent-skills.md)
 
 ### Browser Automation
 
-Browser Automation is an opt-in capability for tasks where the agent should see
-or operate real web pages instead of relying only on code inspection, tests, or
-plain web search.
+Browser Automation is an opt-in capability for tasks where the agent should see or operate real web pages instead of relying only on code inspection, tests, or plain web search.
 
 Use it when you want Heddle to:
 
@@ -307,8 +274,7 @@ Use it when you want Heddle to:
 - compare visible product/listing pages
 - use rendered DOM state that is not available from static files or APIs
 
-Browser Automation is off by default. Enable it from Settings -> Browser
-Automation or chat:
+Browser Automation is off by default. Enable it from Settings -> Browser Automation or chat:
 
 ```text
 /browser
@@ -316,9 +282,7 @@ Automation or chat:
 /browser disable
 ```
 
-Enabling Browser Automation activates Heddle's package-owned
-`browser-automation` Agent Skill and adds these tools to future default agent
-turns:
+Enabling Browser Automation activates Heddle's package-owned `browser-automation` Agent Skill and adds these tools to future default agent turns:
 
 ```text
 browser_open
@@ -328,43 +292,29 @@ browser_screenshot
 browser_close
 ```
 
-The built-in skill teaches the agent when browser automation is appropriate and
-when `web_search` is only useful for discovering a starting URL. Browser policy
-still remains authoritative: unsafe actions, off-domain navigation, and
-ambiguous JavaScript-only clicks can be blocked or require approval.
+The built-in skill teaches the agent when browser automation is appropriate and when `web_search` is only useful for discovering a starting URL. Browser policy still remains authoritative: unsafe actions, off-domain navigation, and ambiguous JavaScript-only clicks can be blocked or require approval.
 
-#### Current Browser Automation Behavior
+Current behavior:
 
-- if no explicit domain allowlist is configured, the first `browser_open` URL
-  establishes the same-domain browsing boundary for that browser session
+- if no explicit domain allowlist is configured, the first `browser_open` URL establishes the same-domain browsing boundary for that browser session
 - snapshots return scoped refs for safe `browser_click` calls
 - screenshots and browser evidence are stored under Heddle state
 - logged-in sites require a persistent browser profile with a valid session
 
-#### Browser Automation Next Steps
+Browser Automation agenda:
 
-- add profile management in Settings, including selected profile, Chrome
-  channel, headless/headed mode, and profile path visibility
-- add an "open profile for login" flow so users can prepare logged-in sessions
-  manually before agents reuse them
-- add form-safe browser tools such as `browser_type`, `browser_fill`, and
-  `browser_press`
+- add profile management in Settings, including selected profile, Chrome channel, headless/headed mode, and profile path visibility
+- add an "open profile for login" flow so users can prepare logged-in sessions manually before agents reuse them
+- add form-safe browser tools such as `browser_type`, `browser_fill`, and `browser_press`
 - surface browser evidence and screenshots in the control plane
-- design a live browser preview path, likely screenshot/CDP screencast based
-  rather than embedding Playwright's native headed window
+- design a live browser preview path, likely screenshot/CDP screencast based rather than embedding Playwright's native headed window
 - add richer policy and approval flows for harmless same-origin UI clicks
 
-### MCP integrations
+### MCP Integrations
 
-Heddle can connect to user-configured Model Context Protocol servers so the
-agent can use ecosystem tools such as Notion, Anytype, GitHub, or other MCP
-integrations through Heddle's approval and trace path.
+Heddle can connect to user-configured Model Context Protocol servers so the agent can use ecosystem tools such as Notion, Anytype, GitHub, or other MCP integrations through Heddle's approval and trace path.
 
-Configure servers by pasting a standard `mcpServers` JSON document into
-Settings -> MCP, editing `.heddle/mcp.json` directly, or opening that file from
-chat with `/mcp config`. Server config is separate from workspace activation:
-after saving config, explicitly enable and refresh the server before future
-agent turns can see its cached tools.
+Configure servers by pasting a standard `mcpServers` JSON document into Settings -> MCP, editing `.heddle/mcp.json` directly, or opening that file from chat with `/mcp config`. Server config is separate from workspace activation: after saving config, explicitly enable and refresh the server before future agent turns can see its cached tools.
 
 ```text
 /mcp
@@ -374,101 +324,15 @@ agent turns can see its cached tools.
 /mcp disable <server>
 ```
 
-Refreshing an enabled server caches its tool catalog under `.heddle/mcp/`.
-Future agent turns can inspect MCP tools with `mcp_list_tools` and call them
-through approval-gated MCP tool adapters.
+Refreshing an enabled server caches its tool catalog under `.heddle/mcp/`. Future agent turns can inspect MCP tools with `mcp_list_tools` and call them through approval-gated MCP tool adapters.
 
 More: [MCP integrations](docs/reference/mcp.md)
-
-### Sessions and continuity
-
-Heddle keeps saved sessions under `.heddle/` so longer work does not have to reset every time. Current versions store the session catalog at `.heddle/chat-sessions.catalog.json` and per-session bodies under `.heddle/chat-sessions/`. That means you can come back to an interrupted task, continue a previous debugging thread, or preserve project-specific context across runs.
-
-This matters if you are doing real multi-step work rather than one-shot prompts.
-
-Typical session commands include:
-
-- `/session list`
-- `/session switch <id>`
-- `/continue`
-- `/compact`
-- `/model set`
-- `/reasoning set`
-
-More: [Chat and sessions guide](docs/guides/chat-and-sessions.md)
-
-### Knowledge Persistence: Heddle Learns While It Works
-
-Heddle can learn durable project knowledge while it works with you.
-
-When the agent notices reusable information — a preferred ticket format, a canonical verification command, an operational convention, a recurring repo quirk, or a stable workflow pattern — it can record a memory candidate and let a dedicated maintainer path fold that knowledge into cataloged markdown notes under `.heddle/memory/`.
-
-The goal is practical recall: future sessions should know where to look instead of rediscovering the same context from scratch. Heddle does this through explicit catalogs, readable local notes, maintenance logs, and memory visibility commands rather than opaque retrieval.
-
-The learning loop is intentionally concrete:
-
-- notices durable facts and preferences during normal work
-- records memory candidates without interrupting the user
-- folds candidates into cataloged markdown through a maintainer path
-- lets future sessions recover context through explicit discovery paths
-- lets users audit memory with `heddle memory status/list/read/search/validate`
-
-Try it on a real project: tell Heddle a durable preference or let it discover a stable workflow detail, then start a fresh session and watch it recover that context through the memory catalog.
-
-For example, tell Heddle your preferred ticket template once, then ask for a ticket in a new session. The point is not just storing a note; it is making future work start from the operating knowledge you already taught the agent.
-
-More: [Knowledge persistence](docs/guides/knowledge-persistence.md)
-
-### Control plane and workspaces
-
-The control plane is Heddle's local browser UI:
-
-```bash
-heddle daemon
-```
-
-It gives you a browser-based view into workspaces, sessions, run state, heartbeat tasks, memory health, and review-oriented details. The purpose is operator oversight: seeing what the agent is doing, reviewing history more comfortably, and managing local runs from a UI instead of only from the terminal.
-
-If terminal chat is the execution surface, the control plane is the oversight surface.
-
-The workspace switcher and `Settings > Workspace` page let you register local projects, switch the control plane between them, rename workspace entries, and pick a project folder from the browser UI. Heddle also keeps a user-level workspace registry so projects you have opened from the CLI or daemon can be rediscovered later.
-
-The `Sessions` section supports a coding-review flow built around current work first. Review starts from the live Git working tree for the active workspace, with changed files, structured read-only diffs, and a larger full-diff viewer when the side panel is too tight. Historical turn diffs, review commands, verification commands, approvals, and trace events are still available, but they are separated from current review so old evidence does not distract from the task at hand.
-
-Session chat in the control plane renders assistant markdown, receives per-session live updates for assistant streaming, tool progress, approvals, and saved-session refreshes, and keeps model/reasoning controls aligned with the terminal workflow. The session composer also includes drift controls, `@file` mention suggestions, and image upload controls for attaching local screenshots or reference images to a prompt.
-
-The task surface has also moved beyond passive visibility: operators can create, edit, enable, disable, run, resume, and delete heartbeat tasks, inspect live run state, and review saved run records from the browser. Settings now include workspace and memory status views, so memory catalog health and maintenance history are visible without dropping back to terminal commands.
-
-This is useful if you want a more inspectable and operator-friendly workflow than a plain CLI transcript. The layout adapts for phone use as well, with mobile-native navigation for Sessions, Tasks, and Settings, plus focused Chat/Review and task-run workflows.
-
-More: [Control plane guide](docs/guides/control-plane.md)
-
-### Runtime host model
-
-Heddle is local-first, but it still has a runtime ownership model.
-
-The short version is:
-
-- Heddle uses one local control-plane server path for interactive chat and browser control.
-- `heddle` / `heddle chat` attach to a live control-plane server when one exists, or start an embedded one when needed.
-- `heddle daemon` starts the same server path as a standalone process for browser and longer-lived workflows.
-- Workspaces own their local `.heddle/` state, but the server does not own one global active workspace. Clients send workspace identity with workspace-scoped requests.
-
-If you want to understand how `chat`, `ask`, the daemon, the control plane, and workspace-local state fit together, read:
-
-- [Runtime host model](docs/guides/runtime-host-model.md)
 
 ### Heartbeat
 
 Heartbeat is Heddle's model for bounded autonomous wake cycles.
 
 Instead of only running when a human types a prompt, a heartbeat task lets Heddle wake up on a schedule, do a limited amount of work, checkpoint the result, and decide whether to continue, pause, complete, or escalate.
-
-Heartbeat keeps the latest runner result and saved run history in the same
-record shape, so terminal commands and the browser control plane show the same
-decision, summary, outcome, and usage data. Tasks can use operator-controlled
-continuation or agent-selected continuation depending on how much autonomy the
-host should allow.
 
 Example commands:
 
@@ -480,11 +344,22 @@ heddle heartbeat task list
 
 Why this exists: some agent work is not a single interactive chat. You may want periodic repo inspection, recurring maintenance checks, scheduled summaries, or a host that can resume work in bounded steps.
 
-If you do not need scheduled or semi-autonomous workflows, you can ignore heartbeat entirely and just use chat.
-
 More: [Heartbeat guide](docs/guides/heartbeat.md)
 
-### Semantic drift
+### Programmatic Runtime
+
+Heddle is not only a CLI. The npm package exposes two main programmatic layers:
+
+- `createConversationEngine`: an alpha API for persisted multi-turn sessions with session storage, compaction, approvals, traces, semantic activity, and custom frontends or local hosts
+- `AgentLoopRuntimeService.run(...)`: a lower-level single-run execution loop for hosts that do not need persisted chat or session behavior
+
+Advanced hosts can also reuse lower-level class APIs such as `ToolRegistry`, `ToolExecutionService`, `TraceRecorder`, `TraceConsoleFormatter`, and `ReviewDiffParser` when they intentionally assemble custom runtime or review surfaces.
+
+Other exported primitives include `HeartbeatRunnerAgent.run`, `HeartbeatSchedulerService.runDueTasks`, and `FileHeartbeatTaskService` for scheduled or custom host workflows.
+
+More: [Programmatic use](docs/guides/programmatic-use.md)
+
+### Semantic Drift
 
 Semantic drift is optional telemetry that helps you see whether the assistant's responses appear to be moving away from the recent semantic trajectory of the conversation.
 
@@ -495,19 +370,9 @@ With optional [CyberLoop](https://www.npmjs.com/package/cyberloop) integration i
 - `drift=medium`
 - `drift=high`
 
-This is an observability feature, not a magic correctness guarantee. It is meant to help operators notice when a run may be getting less aligned with its recent direction.
-
-If you are just looking for a coding agent, you do not need to care about this on day one. If you care about agent observability and runtime behavior, it is one of Heddle's more distinctive features.
+This is an observability feature, not a correctness guarantee. It is meant to help operators notice when a run may be getting less aligned with its recent direction.
 
 More: [Semantic drift](docs/guides/semantic-drift.md)
-
-### Programmatic runtime APIs
-
-Heddle is not only a CLI. The npm package also exposes runtime primitives such as `createConversationEngine`, `AgentLoopRuntimeService.run(...)`, `HeartbeatRunnerAgent.run`, `HeartbeatSchedulerService.runDueTasks`, and `FileHeartbeatTaskService` so other hosts can build on top of it.
-
-This is for people building their own agent hosts, schedulers, or control surfaces rather than only using the packaged CLI.
-
-More: [Programmatic use](docs/guides/programmatic-use.md)
 
 ## Install
 
@@ -552,16 +417,15 @@ npx -p @roackb2/heddle -p cyberloop heddle
 
 ## Documentation
 
-### Start here
+Start here:
 
 - [Documentation hub](docs/README.md)
 - [Runtime host model](docs/guides/runtime-host-model.md)
 - [Chat and sessions guide](docs/guides/chat-and-sessions.md)
 - [CLI reference](docs/reference/cli.md)
 
-### Feature guides
+Feature guides:
 
-- [Runtime host model](docs/guides/runtime-host-model.md)
 - [Control plane](docs/guides/control-plane.md)
 - [Heartbeat](docs/guides/heartbeat.md)
 - [Agent Skills](docs/guides/agent-skills.md)
@@ -571,7 +435,7 @@ npx -p @roackb2/heddle -p cyberloop heddle
 - [Semantic drift](docs/guides/semantic-drift.md)
 - [Programmatic use](docs/guides/programmatic-use.md)
 
-### Contributors
+Contributors:
 
 - [Agent context](docs/agent-context.md)
 - [Project posture](docs/project-posture.md)
@@ -590,6 +454,7 @@ Current strengths include:
 - autonomous, catalog-backed workspace memory that helps the agent learn from normal usage
 - standard Agent Skills support with workspace-level activation and progressive disclosure
 - opt-in Browser Automation with browser snapshots, screenshots, policy checks, and a published next-step agenda
+- MCP integration support for user-configured ecosystem tools
 - explicit traces, approval previews, diff review, and local workspace state
 - browser-based oversight and workspace switching through the control plane
 - local-first heartbeat primitives for scheduled agent work
@@ -598,6 +463,7 @@ Current strengths include:
 Current limitations include:
 
 - the browser control plane is read-only for file review; it is not yet an editable IDE-like diff environment
+- Browser Automation still needs profile management, form-safe actions, and richer browser evidence surfaces
 - some advanced workflows remain better documented in source and examples than in polished product UX
 - the project surface is still changing as the runtime matures
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,126 +2,80 @@
 
 [English](README.md) | [繁體中文](README.zh-TW.md)
 
-Heddle 是一個開源的 AI coding agent runtime，也是 terminal-first 的 workspace，目標是支援真實專案工作。
+Heddle 是開源 AI 程式開發代理執行環境，也是以終端機為優先，協助你開發功能、修正錯誤、維護軟體，並保留可審查代理執行過程的工作區。
 
 官方網站：[heddleagent.com](https://heddleagent.com)
 
-> **Terminal UI v2 已是預設介面。** 執行 `heddle` 或 `heddle chat` 會使用 API-backed 的 terminal experience。訊息、run events 與 agent response streams 現在都會走 shared control-plane path，因此 terminal、browser 與 mobile clients 可以同時跟進同一份工作，讓跨裝置工作流程更順。
+> **Terminal UI v2 現在是預設介面。** 執行 `heddle` 或 `heddle chat` 會進入 API-backed 終端機體驗。訊息、執行事件、代理回應串流會走同一條 shared control-plane path，讓終端機、瀏覽器、行動端可以同時追蹤同一個工作。
 
-## Agenda
+## 目錄
 
-- [看 Heddle 實際運作](#看-heddle-實際運作)
-- [為什麼試試 Heddle](#為什麼試試-heddle)
 - [Heddle 能做什麼](#heddle-能做什麼)
-- [Programmatic Use Layers](#programmatic-use-layers)
-- [介面展示](#介面展示)
-- [兩分鐘快速開始](#兩分鐘快速開始)
-- [主要功能](#主要功能)
+- [實際運作畫面](#實際運作畫面)
+- [快速開始](#快速開始)
+- [核心工作流程](#核心工作流程)
 - [安裝](#安裝)
 - [需求](#需求)
+- [選用 CyberLoop 整合](#選用-cyberloop-整合)
 - [文件](#文件)
 - [專案狀態](#專案狀態)
 - [開發](#開發)
-
-## 看 Heddle 實際運作
-
-Terminal、browser 與 mobile surfaces 可以同時觀察同一個 live session：
-
-![Heddle streams the same session across terminal, browser, and mobile](docs/images/heddle-cross-device-stream.gif)
-
-在 control plane 中 review 與 approve sensitive actions，同時讓 agent run 持續可見：
-
-![Heddle request approval flow in the browser control plane](docs/images/heddle-request-approval.gif)
-
-同一個 conversation 繼續進行時，也可以從 browser 與 mobile 檢查 workspace diffs：
-
-![Heddle diff review across browser and mobile](docs/images/heddle-diff-view.gif)
-
-Heddle 是為這類 workflow 設計：agent 需要檢查 live repository、做有邊界的修改、驗證結果、跨 sessions 保持 continuity，並且讓 operator 能看清楚它正在做什麼。Heddle 支援 OpenAI 與 Anthropic models，會把 local workspace state 存在 `.heddle/`，包含 terminal chat experience 與 browser control plane，能在工作時學習 durable workspace knowledge，也提供 file diffs、commands、approvals 與 traces 的 review path。
-
-白話來說：Heddle 適合想要 AI coding assistant 真正進入專案工作、逐漸學會每個 project 的 operating knowledge、能在 local workspaces 之間切換，而且保持可檢查、不像黑盒的人。
-
-## 為什麼試試 Heddle
-
-Heddle 是給想要超越一次性 coding chat wrapper 或 stateless AI code assistant 的人。
-
-如果你想要以下能力，Heddle 會很適合：
-
-- terminal-first 的 coding agent，可以在真實 repository 裡工作
-- agent 能在工作時學習 durable project knowledge，並使用可檢查的 local memory
-- 標準 Agent Skills 支援，可用於 opt-in reusable workflows 與 tool-use instructions
-- opt-in Browser Automation，可用於 rendered page inspection 與使用者要求的網站工作流程
-- 明確 traces、approvals 與可 review 的 workflow artifacts
-- browser control plane，可用於 local oversight、workspace switching 與 session review
-- 從 interactive use 延伸到 programmatic 與 scheduled agent workflows 的路徑
-
-如果你只想要非常簡單的一次性 prompt runner，而且不在意 sessions、persistence、observability 或 operator control，那 Heddle 可能不是最適合的工具。
+- [授權](#授權)
 
 ## Heddle 能做什麼
 
-概略來說，Heddle 可以協助：
+Heddle 適合想讓 AI 程式開發助理參與日常軟體開發，同時保留本地工作脈絡與可審查執行過程的工程師、維護者、個人專案開發者。
 
-- 理解陌生 repositories
-- 在真實 workspace 裡修改 code 或 docs
-- 執行 bounded verification，例如 builds、tests 與 repo review
-- 讓多步驟工作跨 sessions 延續，而不是每次重新開始
-- 從 browser control plane 在 local workspaces 之間切換
-- 從真實使用中學習 durable facts、preferences 與 workflows
-- 啟用 workspace-approved Agent Skills，讓 agent 只在需要時載入 specialized instructions
-- 啟用 Browser Automation，讓 agent 在需要時檢查、截圖或操作真實網頁
-- 提供比黑盒 chat tool 更多 operator visibility
+它適合用來：
 
-如果你想要一個 terminal-first coding agent，具有 local state、review traces、workspace memory，並且能往 longer-running workflows 發展，那就是 Heddle 想解決的問題。
+- 檢查與理解陌生程式碼庫
+- 為工作或個人專案開發新的產品功能
+- 建立前端頁面、後端服務、CLI 工具、文件與測試
+- 修正錯誤、調查退化問題，並解釋陌生程式路徑
+- 重構既有模組，同時保留可審查的差異
+- 執行有界驗證，例如建置、測試、程式碼庫 review
+- 讓多步驟實作工作跨已儲存的 sessions 持續進行
+- 在接受變更前審查檔案差異、命令、approvals、traces、semantic activity
+- 從瀏覽器 control plane 切換本地工作區
+- 讓 agent 隨著實際工作學習持久專案知識
+- 只在工作區需要時啟用標準 Agent Skills
+- 連接使用者設定的 MCP servers，例如 Notion、Anytype、GitHub 或其他工具
+- 選擇性啟用 Browser Automation，用於渲染後頁面檢查與使用者要求的網頁流程
+- 基於 Heddle runtime APIs 建立自訂 host
 
-## Programmatic Use Layers
+如果你只需要非常簡單的單次提示執行工具，而且不在意 sessions、持久化、可觀測性或操作員控制，Heddle 可能不是最適合的工具。
 
-Heddle 目前有兩個主要 programmatic layers：
+## 實際運作畫面
 
-- `createConversationEngine`：alpha API，用於 persisted multi-turn sessions，包含 session storage、compaction、approvals、traces、semantic activity，以及 custom frontends 或 local hosts
-- `AgentLoopRuntimeService.run(...)`：較低階的 single-run execution loop，適合不需要 persisted chat 或 session behavior 的 hosts
+終端機、瀏覽器、行動端介面可以同時觀察同一個即時 session：
 
-Advanced hosts 也可以重用較低階 class APIs，例如 `ToolRegistry`、`ToolExecutionService`、`TraceRecorder`、`TraceConsoleFormatter` 與 `ReviewDiffParser`，在明確需要 custom runtime 或 review surfaces 時自行組裝。
+![Heddle streams the same session across terminal, browser, and mobile](docs/images/heddle-cross-device-stream.gif)
 
-如果你想使用 programmatic surface，請從 [Programmatic use guide](docs/guides/programmatic-use.md) 開始。
+你可以在 control plane 裡審查與核准敏感操作，同時 agent run 仍然保持可見：
 
-給 contributors 的 compact architecture map 在 [Core Layering](docs/architecture/core-layering.md) 與 [Chat Layering](docs/architecture/chat-layering.md)。
+![Heddle request approval flow in the browser control plane](docs/images/heddle-request-approval.gif)
 
-## 介面展示
+瀏覽器與行動端可以檢查工作區差異，而同一個 conversation 仍然持續：
 
-### Terminal coding workflow
+![Heddle diff review across browser and mobile](docs/images/heddle-diff-view.gif)
 
-Heddle 在 terminal 中顯示 live progress、tool activity、plans 與 review output：
+Heddle 也可以作為 terminal-first coding agent，顯示即時進度、工具活動、plans 與審查輸出：
 
 ![Heddle terminal coding workflow](docs/images/terminal-active-run.png)
 
-Heddle 可以 inspect files、用 ignore-aware fallbacks 搜尋、解釋 code、做 edits、以正確 approval model 執行 shell commands，並跨多輪完成任務。Terminal chat 會用 tool activity、dim `Thinking:` progress text、real-time assistant markdown，以及更清楚的 repeated command/search approval prompts 讓 long-running turns 保持可見。
-
-### Terminal change review
-
-Terminal chat/dev workflow 顯示 file edits、inline diff output，以及 verification-oriented follow-through：
+Terminal chat/dev workflow 展示檔案編輯、inline diff output 與以驗證為導向的後續處理：
 
 ![Heddle terminal change review](docs/images/terminal-change-review.png)
 
-### Browser control plane overview
-
-預設 local control plane 是由 `heddle daemon` 提供的 web-v2 browser client。它是 coding sessions、workspace state、current changes、heartbeat tasks 與 settings 的 oversight surface：
+預設的本地 control plane 是由 `heddle daemon` 提供的 web-v2 瀏覽器 client：
 
 ![Heddle web-v2 control plane](docs/images/control-plane-v2.png)
 
-web-v2 client 包含：
-
-- `Sessions`：saved conversations、live assistant streaming、tool progress、approvals 與 current workspace diff review。
-- `Composer controls`：model 與 reasoning settings、semantic drift controls、`@file` mentions，以及會保存為 local paths 給 `view_image` 使用的 image attachments。
-- `Workspace switching`：sidebar workspace selection，以及 `Settings > Workspace` 中註冊、重新命名與切換 local projects。
-- `Tasks`：heartbeat task creation、edit、enable/disable、run、resume、delete、live run state 與 saved run records。
-- `Settings`：language preferences、workspace management、memory status，以及 catalog health、note counts、pending candidates 與 latest maintenance run。
-- `Mobile`：針對 session list、conversation workbench、task detail、settings 與 diff review 的 focused panels。
-
-Task workbench 涵蓋 recurring heartbeat tasks、live run state 與 run result review：
+Task workbench 支援週期性 heartbeat tasks、即時執行狀態與執行結果審查：
 
 ![Heddle web-v2 heartbeat task workbench](docs/images/control-plane-v2-heartbeat-task.png)
 
-同一個 control plane 支援 mobile layouts，session list、workbench 與 diff preview 都會以 focused panels 呈現：
+同一個 control plane 也支援行動版 layout，提供 session list、workbench 與 diff preview 的 focused panels：
 
 <p>
   <img src="docs/images/control-plane-v2-session-list.PNG" alt="Heddle web-v2 mobile session list" width="220">
@@ -129,7 +83,7 @@ Task workbench 涵蓋 recurring heartbeat tasks、live run state 與 run result 
   <img src="docs/images/control-plane-v2-diff-view.PNG" alt="Heddle web-v2 mobile diff preview" width="220">
 </p>
 
-## 兩分鐘快速開始
+## 快速開始
 
 1. 安裝 Heddle：
 
@@ -137,21 +91,21 @@ Task workbench 涵蓋 recurring heartbeat tasks、live run state 與 run result 
 npm install -g @roackb2/heddle
 ```
 
-2. 設定 provider access。
+2. 設定 provider 存取權。
 
-OpenAI 可以用你自己的 ChatGPT/Codex account 登入：
+OpenAI 可以使用自己的 ChatGPT/Codex account 登入：
 
 ```bash
 heddle auth login openai
 ```
 
-或使用 Platform API key：
+也可以使用 Platform API key：
 
 ```bash
 export OPENAI_API_KEY=your_key_here
 ```
 
-如果你同時保留 OpenAI OAuth credential 與 API key 方便測試，可以明確讓本次 run 偏好 API key：
+如果你同時保留 OpenAI OAuth credential 和 API key 用於測試，可以明確要求某次執行優先使用 API key：
 
 ```bash
 heddle --prefer-api-key
@@ -165,59 +119,57 @@ Anthropic 使用 API key：
 export ANTHROPIC_API_KEY=your_key_here
 ```
 
-OpenAI account sign-in 是 experimental、由使用者自行選擇的 transport。它不是 OpenAI 官方支援；Heddle 與 OpenAI 沒有從屬、背書或贊助關係。使用 OpenAI 服務仍需遵守 OpenAI 的 terms 與 policies。
+OpenAI account sign-in 是 Heddle 提供的實驗性、由使用者選擇的傳輸方式。這不是 OpenAI 官方支援，Heddle 與 OpenAI 沒有 affiliation、endorsement 或 sponsorship。使用 OpenAI 服務仍受 OpenAI terms and policies 約束。
 
-3. 進入任何你想 inspect 的 repository：
+3. 進入你想檢查的程式碼庫：
 
 ```bash
 cd /path/to/project
 ```
 
-4. 開始 chat：
+4. 啟動 chat：
 
 ```bash
 heddle
 ```
 
-5. 試試這個 prompt：
+5. 試一個 prompt：
 
 ```text
 Summarize this repository, show me the main build/test commands, and point out the likely entrypoints.
 ```
 
-6. 如果你也想使用 browser oversight UI：
+6. 如果也想使用瀏覽器監督 UI：
 
 ```bash
 heddle daemon
 ```
 
-從 daemon output 打開 browser control plane。你可以在那裡使用 `Sessions`、`Tasks` 與 `Settings` 檢查 active workspace、continue saved sessions、review changes、inspect memory status，或切換到另一個 local project。
+從 daemon output 開啟瀏覽器 control plane。你可以在裡面使用 `Sessions`、`Tasks`、`Settings` 檢查目前工作區、繼續已儲存的 sessions、審查變更、檢查 memory status，或切換到其他本地專案。
 
-如果你偏好一次性的 CLI run，而不是 interactive chat，可以用：
+如果想執行一次性 run，而不是進入互動式 chat：
 
 ```bash
 heddle ask "Summarize this repository"
 ```
 
-`ask` 仍會在一個 prompt 後結束，但它現在會把 run 記錄成 `.heddle/` 下的一個 one-off saved session，所以 traces、memory maintenance 與後續 inspection 會使用和 normal sessions 相同的 persisted conversation path。
+`ask` 會在一個 prompt 後結束，但它仍會把 run 記錄為 `.heddle/` 底下的一次性 saved session，讓 traces、memory maintenance 與後續檢查都使用和一般 session 相同的 persisted conversation path。
 
-Terminal chat footer 與 control-plane session composer 都會顯示 selected model 的 active auth source，所以你可以知道 session 正在使用 OpenAI account sign-in、API-key mode，或是缺少 credentials。
+### 試試 Learning Loop
 
-### Try The Learning Loop
-
-當 Heddle 學會 reusable preference 並在之後套用時，它會更有用。你可以在 chat 裡教它一個 ticket format：
+當 Heddle 學會可重用偏好並在之後套用時，它會變得更有用。你可以在 chat 裡教它 ticket 格式：
 
 ```text
 Whenever I ask you to create a ticket, use these sections: problem statement, proposed approach, considered alternatives, conclusion.
 ```
 
-然後開一個 fresh session 並詢問：
+然後開一個新的 session 並詢問：
 
 ```text
 Create a ticket for maintaining doc consistency after feature updates.
 ```
 
-Heddle 應該會從 local memory catalog 找回這個 preference，並用指定結構產出 ticket。你可以用以下指令檢查它學到了什麼：
+Heddle 應該會從本地 memory catalog 取回這個偏好，並用該結構產生 ticket。你可以用以下指令檢查它學到了什麼：
 
 ```bash
 heddle memory status
@@ -225,43 +177,76 @@ heddle memory list
 heddle memory search ticket
 ```
 
-## 主要功能
+## 核心工作流程
 
-### Terminal chat for real coding work
+### Terminal Coding
 
-Heddle 的主要使用方式是在 repository 中進行 interactive chat：
+Heddle 的主要使用方式是在程式碼庫裡開啟互動式 chat：
 
 ```bash
 heddle
 ```
 
-在這裡，Heddle 可以 inspect files、explain code、make edits、用正確 approval model 執行 shell commands，並跨多輪完成任務。
+在 chat 裡，Heddle 可以檢查檔案、使用 ignore-aware fallbacks 搜尋、解釋程式碼、進行編輯、用正確 approval model 執行 shell commands，並讓任務跨多個 turns 持續前進。
 
-這是核心功能。如果你只把 Heddle 當成 terminal 裡的 coding agent 使用，這就是你最需要關心的部分。
-
-Terminal composer 支援 multiline prompts、prompt undo/redo、prompt history navigation、用 `/model set` 選 model，以及用 `/reasoning set` 選 reasoning effort。Run 進行中，Heddle 會 streaming visible activity，讓你看見它是在 thinking、searching、calling tools、updating a plan，還是 waiting for approval。
+Terminal composer 支援多行 prompts、prompt undo/redo、prompt history navigation、透過 `/model set` 選 model，以及透過 `/reasoning set` 選 reasoning effort。Run 進行時，Heddle 會串流可見活動，讓你知道它是在思考、搜尋、呼叫工具、更新 plan，還是在等待 approval。
 
 更多：[Chat and sessions guide](docs/guides/chat-and-sessions.md)
 
-### Terminal UI v2 is the default
+### Browser Control Plane
 
-預設 terminal chat 現在是 API-backed 的 `cli-v2` experience。從 project 中執行 `heddle` 或 `heddle chat` 就能開始。
+Control plane 是 Heddle 的本地瀏覽器 UI：
 
-v2 terminal UI 使用和 browser UI 相同的 local control-plane API，不會直接碰 core services。對使用者來說，目標是在所有 interfaces 中保持同一套 behavior model。Saved conversation、selected model、reasoning setting、approval state 與 live run status 應該不管從 terminal、browser control plane，或另一台連到同一 local control-plane server 的裝置看，都會是一致的。Messages、tool events、approval waits 與 streamed agent responses 會透過 shared session event path 傳遞，因此多個 devices 可以同時 observe 與 continue 同一份工作，而不是等待某個 surface 完成或 refresh。
+```bash
+heddle daemon
+```
 
-對 contributors 來說，目標是更乾淨的 implementation path：TUI-specific rendering 與 keyboard behavior 留在 `cli-v2`，shared semantics 留在 core 與 server-owned control-plane APIs，future advanced features 可以建立在 maintainable API-first foundation 上，而不是在每個 interface 裡重複 command/session logic。
+它提供瀏覽器介面，用來查看工作區、已儲存 conversations、即時 assistant 串流、工具進度、approvals、目前工作區差異、heartbeat tasks、memory health 與 settings。
 
-### Project instructions
+Workspace switcher 與 `Settings > Workspace` page 讓你註冊本地專案、在 control plane 裡切換專案、重新命名 workspace entries，並從瀏覽器 UI 選擇專案資料夾。`Sessions` section 以目前工作為核心：審查從 active workspace 的即時 Git working tree 開始，包含 changed files、structured read-only diffs，以及當 side panel 太窄時使用的 larger full-diff viewer。
 
-Heddle 啟動時可以載入短的 project instruction file，讓 fresh session 一開始就知道 repository operating context。預設會依序讀取第一個非空檔案：`HEDDLE.md`、`AGENTS.md`、`CLAUDE.md`。
+如果 terminal chat 是執行介面，那 control plane 就是監督介面。
 
-為了保留 context space，預設只讀一個 default file。如果 project 需要不同路徑，或明確想讀多個 files，可以在 `.heddle/config.json` 設定 `agentContextPaths`。
+更多：[Control plane guide](docs/guides/control-plane.md)
+
+### Sessions And Continuity
+
+Heddle 會把已儲存的 sessions 放在 `.heddle/`，所以較長的工作不需要每次重新開始。目前版本把 session catalog 存在 `.heddle/chat-sessions.catalog.json`，並把每個 session 的內容存在 `.heddle/chat-sessions/`。
+
+常用 session commands：
+
+```text
+/session list
+/session switch <id>
+/continue
+/compact
+/model set
+/reasoning set
+```
+
+更多：[Chat and sessions guide](docs/guides/chat-and-sessions.md)
+
+### Project Instructions
+
+Heddle 可以在啟動時載入短的 project instruction file，讓新的 session 一開始就有程式碼庫的操作脈絡。預設會依序尋找第一個非空檔案：`HEDDLE.md`、`AGENTS.md`、`CLAUDE.md`。
+
+為了保留 context 空間，預設只載入一個檔案。如果專案需要不同路徑，或刻意想載入多個檔案，可以在 `.heddle/config.json` 設定 `agentContextPaths`。
 
 更多：[Project config](docs/reference/config.md)
 
+### Knowledge Persistence
+
+Heddle 可以在工作過程中學習持久專案知識。
+
+當 agent 注意到可重用資訊，例如偏好的 ticket 格式、標準驗證命令、操作慣例、反覆出現的程式碼庫特性或穩定工作流程，它可以記錄 memory candidate，並讓專門的維護流程把這些知識整理進 `.heddle/memory/` 底下的 cataloged markdown notes。
+
+目標是 practical recall：future sessions 應該知道要去哪裡找，而不是每次從頭重新探索相同脈絡。Heddle 透過明確 catalogs、可讀的本地 notes、maintenance logs 與 memory visibility commands 達成，而不是不透明 retrieval。
+
+更多：[Knowledge persistence](docs/guides/knowledge-persistence.md)
+
 ### Agent Skills
 
-Heddle 支援標準 Agent Skills folder format，可用於 reusable、opt-in agent workflows。把 project skills 放在 `.agents/skills/<name>/SKILL.md`，或把 user skills 放在 `~/.agents/skills/<name>/SKILL.md`，再從 chat 管理 workspace activation：
+Heddle 支援 standard Agent Skills folder format，用於可重用、opt-in 的 agent workflows。你可以把專案 skills 放在 `.agents/skills/<name>/SKILL.md`，或把使用者 skills 放在 `~/.agents/skills/<name>/SKILL.md`，然後從 chat 管理 workspace activation：
 
 ```text
 /skills
@@ -269,27 +254,27 @@ Heddle 支援標準 Agent Skills folder format，可用於 reusable、opt-in age
 /skills disable <name>
 ```
 
-Heddle 也會內建一些 Heddle-owned capabilities 的 skills。Capability settings 可以啟用這些 built-ins，不需要使用者另外安裝 skill files。
+Heddle 也會內建一些 Heddle-owned capabilities 的 built-in skills。Capability settings 可以啟用這些 built-ins，不需要使用者另外安裝 skill files。
 
-只有 active skills 會提供給 agent。Heddle 一開始只會把每個 active skill 的 name 與 description 放進 compact catalog；agent 判斷某個 skill 相關時，才會呼叫 `read_agent_skill` 讀取完整 `SKILL.md` body。Activation state 存在 `.heddle/skills/activation.json`；skill definitions 仍留在原本 folders。
+只有 active skills 會顯示給 agent。Heddle 一開始只 expose compact catalog，包含每個 active skill 的名稱與描述；當某個 skill relevant 時，agent 可以呼叫 `read_agent_skill` 取得完整 `SKILL.md` body。Activation state 存在 `.heddle/skills/activation.json`；skill definitions 仍留在原本的 folders。
 
-Skills 是 instructions，不是 permissions。它們不會繞過 Heddle 的 approval policy 或 tool safety checks，所以使用者仍需自行負責啟用哪些 project 或 user skills。
+Skills 是 instructions，不是 permissions。它們不會繞過 Heddle 的 approval policy 或 tool safety checks，所以使用者仍需要對自己啟用哪些 project/user skills 負責。
 
 更多：[Agent Skills guide](docs/guides/agent-skills.md)
 
 ### Browser Automation
 
-Browser Automation 是一個 opt-in capability，適合 agent 需要看見或操作真實網頁，而不是只依賴 code inspection、tests 或 plain web search 的任務。
+Browser Automation 是 opt-in capability，用於 agent 需要看見或操作真實網頁，而不能只依賴程式碼檢查、測試或一般 web search 的任務。
 
-適合在這些情境啟用：
+適合在你希望 Heddle 做這些事時使用：
 
-- frontend UI 修改後，需要 visual inspection
-- 需要擷取 page snapshots 或 screenshots 作為 evidence
-- 使用者要求 agent 瀏覽或操作某個網站
-- 需要比較可見的商品頁、listing 或搜尋結果
-- 任務依賴 rendered DOM state，而不是 static files 或 APIs 就能回答
+- 在本地 UI 變更後目視檢查前端
+- 擷取 page snapshots 或截圖作為證據
+- 與使用者指定的網站互動
+- 比較可見的商品頁或列表頁
+- 使用 static files 或 APIs 看不到的渲染後 DOM 狀態
 
-Browser Automation 預設關閉。你可以從 Settings -> Browser Automation，或在 chat 中使用以下指令啟用：
+Browser Automation 預設關閉。可以從 Settings -> Browser Automation 或 chat 啟用：
 
 ```text
 /browser
@@ -297,7 +282,7 @@ Browser Automation 預設關閉。你可以從 Settings -> Browser Automation，
 /browser disable
 ```
 
-啟用 Browser Automation 會啟用 Heddle package-owned 的 `browser-automation` Agent Skill，並讓未來 default agent turns 可以使用：
+啟用 Browser Automation 會 activate Heddle package-owned `browser-automation` Agent Skill，並把以下工具加入未來預設的 agent turns：
 
 ```text
 browser_open
@@ -307,29 +292,29 @@ browser_screenshot
 browser_close
 ```
 
-內建 skill 會教 agent 什麼時候適合使用 browser automation，以及什麼時候 `web_search` 只適合用來尋找起始 URL。Browser policy 仍然是最終邊界：unsafe actions、off-domain navigation、模糊的 JavaScript-only clicks 都可能被 block 或要求 approval。
+Built-in skill 會教 agent 什麼時候適合使用 browser automation，以及什麼時候 `web_search` 只適合用來發現起始 URL。Browser policy 仍然是最終邊界：不安全操作、off-domain navigation、ambiguous JavaScript-only clicks 可能被阻擋或要求 approval。
 
-#### Browser Automation 目前行為
+目前行為：
 
-- 如果沒有明確設定 domain allowlist，第一個 `browser_open` URL 會成為該 browser session 的 same-domain browsing boundary
-- snapshots 會回傳 scoped refs，供安全的 `browser_click` 使用
-- screenshots 與 browser evidence 會存放在 Heddle state 底下
-- 需要登入狀態的網站仍然需要 persistent browser profile 與有效 session
+- 如果沒有 explicit domain allowlist，第一個 `browser_open` URL 會建立該 browser session 的 same-domain browsing boundary
+- snapshots 會回傳 scoped refs，供 safe `browser_click` calls 使用
+- 截圖與 browser evidence 會存放在 Heddle state
+- 需要登入的網站需要 persistent browser profile 與有效 session
 
-#### Browser Automation 下一步
+Browser Automation agenda：
 
-- 在 Settings 加入 profile management，包括 selected profile、Chrome channel、headless/headed mode、profile path visibility
-- 加入「open profile for login」流程，讓使用者可以手動準備 logged-in sessions，再讓 agent 重用
-- 加入 form-safe browser tools，例如 `browser_type`、`browser_fill`、`browser_press`
-- 在 control plane 顯示 browser evidence 與 screenshots
-- 設計 live browser preview，方向比較可能是 screenshot/CDP screencast，而不是嵌入 Playwright native headed window
-- 加入更細緻的 policy 與 approval flows，支援 harmless same-origin UI clicks
+- 在 Settings 增加 profile 管理，包含 selected profile、Chrome channel、headless/headed mode 與 profile path visibility
+- 增加「open profile for login」流程，讓使用者可以先手動準備 logged-in sessions，再讓 agents reuse
+- 增加表單安全的 browser tools，例如 `browser_type`、`browser_fill`、`browser_press`
+- 在 control plane 顯示 browser evidence 與截圖
+- 設計即時 browser preview path，較可能基於 screenshot/CDP screencast，而不是 embedding Playwright 的 native headed window
+- 為 harmless same-origin UI clicks 加上更完整的 policy 與 approval flows
 
-### MCP integrations
+### MCP Integrations
 
-Heddle 可以連接使用者設定的 Model Context Protocol servers，讓 agent 透過 Heddle 的 approval 與 trace path 使用 Notion、Anytype、GitHub 或其他 MCP 生態系工具。
+Heddle 可以連接使用者設定的 Model Context Protocol servers，讓 agent 透過 Heddle 的 approval 與 trace path 使用生態系工具，例如 Notion、Anytype、GitHub 或其他 MCP integrations。
 
-你可以在 Settings -> MCP 貼上標準 `mcpServers` JSON document，也可以直接編輯 `.heddle/mcp.json`，或在 chat 中用 `/mcp config` 打開這個檔案。Server config 與 workspace activation 是分開的：儲存 config 後，仍然需要明確 enable 並 refresh server，未來 agent turns 才能看到 cached tools。
+你可以把 standard `mcpServers` JSON document 貼到 Settings -> MCP、直接編輯 `.heddle/mcp.json`，或在 chat 裡用 `/mcp config` 開啟該檔案。Server config 與 workspace activation 是分開的：儲存 config 後，仍需要明確 enable 並 refresh server，未來 agent turns 才能看到 cached tools。
 
 ```text
 /mcp
@@ -339,153 +324,65 @@ Heddle 可以連接使用者設定的 Model Context Protocol servers，讓 agent
 /mcp disable <server>
 ```
 
-刷新已啟用 server 會把 tool catalog cache 到 `.heddle/mcp/`。未來 agent turns 可以用 `mcp_list_tools` inspect MCP tools，並透過 approval-gated MCP tool adapters 呼叫它們。
+Refresh enabled server 會把 tool catalog cache 到 `.heddle/mcp/`。未來 agent turns 可以透過 `mcp_list_tools` 檢查 MCP tools，並透過 approval-gated MCP tool adapters 呼叫它們。
 
 更多：[MCP integrations](docs/reference/mcp.md)
 
-### Sessions and continuity
-
-Heddle 會把 saved sessions 存在 `.heddle/`，讓較長工作不必每次重新開始。目前版本把 session catalog 存在 `.heddle/chat-sessions.catalog.json`，per-session bodies 存在 `.heddle/chat-sessions/`。這表示你可以回到中斷的 task、繼續之前的 debugging thread，或跨 runs 保留 project-specific context。
-
-如果你在做真實的 multi-step work，而不是 one-shot prompts，這點會很重要。
-
-常用 session commands 包含：
-
-- `/session list`
-- `/session switch <id>`
-- `/continue`
-- `/compact`
-- `/model set`
-- `/reasoning set`
-
-更多：[Chat and sessions guide](docs/guides/chat-and-sessions.md)
-
-### Knowledge Persistence: Heddle Learns While It Works
-
-Heddle 可以在工作時學習 durable project knowledge。
-
-當 agent 注意到 reusable information，例如 preferred ticket format、canonical verification command、operational convention、recurring repo quirk，或 stable workflow pattern，它可以記錄 memory candidate，並讓 dedicated maintainer path 把這些 knowledge 整理成 `.heddle/memory/` 底下 cataloged markdown notes。
-
-目標是 practical recall：future sessions 應該知道從哪裡找，而不是每次重新探索相同 context。Heddle 透過 explicit catalogs、readable local notes、maintenance logs 與 memory visibility commands 完成這件事，而不是依賴 opaque retrieval。
-
-Learning loop 是刻意具體化的：
-
-- 在正常工作中注意 durable facts 與 preferences
-- 不打斷使用者就記錄 memory candidates
-- 透過 maintainer path 把 candidates 整理進 cataloged markdown
-- 讓 future sessions 透過 explicit discovery paths 找回 context
-- 讓 users 用 `heddle memory status/list/read/search/validate` audit memory
-
-你可以在真實 project 上嘗試：告訴 Heddle 一個 durable preference，或讓它發現 stable workflow detail，然後開一個 fresh session，看它透過 memory catalog 找回 context。
-
-例如，先告訴 Heddle 你偏好的 ticket template，再在新 session 中請它產 ticket。重點不只是存一份 note，而是讓 future work 從你已經教過 agent 的 operating knowledge 開始。
-
-更多：[Knowledge persistence](docs/guides/knowledge-persistence.md)
-
-### Control plane and workspaces
-
-Control plane 是 Heddle 的 local browser UI：
-
-```bash
-heddle daemon
-```
-
-它會啟動 local server，讓你：
-
-- 查看 saved sessions
-- 觀察 active runs
-- review current workspace changes
-- 切換 registered workspaces
-- 檢查 memory status
-- 管理 heartbeat tasks
-
-Control plane 的目標不是取代 IDE，而是提供 agent work 的 operator view。
-
-更多：[Control plane](docs/guides/control-plane.md)
-
-### Runtime host model
-
-Heddle 的核心不只是 CLI。它也可以被當成 runtime host foundation。
-
-Host model 把幾個 concerns 拆開：
-
-- conversation/session persistence
-- model/provider resolution
-- tools and approvals
-- trace recording
-- memory maintenance
-- UI/control-plane presentation
-
-這讓未來可以建立不同 agent surfaces，而不需要重寫整個 runtime。
-
-更多：[Runtime host model](docs/guides/runtime-host-model.md)
-
 ### Heartbeat
 
-Heartbeat 是 Heddle 對 recurring 或 long-running bounded agent work 的模型。
+Heartbeat 是 Heddle 的有界自主喚醒週期模型。
 
-Heartbeat task 可以：
+不只是在人類輸入 prompt 時執行，heartbeat task 讓 Heddle 可以依照排程喚醒、做有限範圍的工作、checkpoint result，並決定要 continue、pause、complete 或 escalate。
 
-- 週期性執行
-- reuse checkpoint state
-- 在 budget 內做一小段 work
-- 決定 pause、continue、complete 或 escalate
-
-這不是 hidden daemon magic；它是 explicit local state 與 scheduler-friendly APIs 的組合。
-
-常用 commands：
+範例指令：
 
 ```bash
-heddle heartbeat start --every 30m --task "Check for safe repository maintenance work"
+heddle heartbeat start --every 30m
+heddle heartbeat task add --id repo-gardener --task "Check for safe maintenance work" --every 1h
 heddle heartbeat task list
-heddle heartbeat run --task repo-gardener
-heddle heartbeat runs show latest --task repo-gardener
 ```
 
-更多：[Heartbeat](docs/guides/heartbeat.md)
+它存在的理由是：有些 agent work 不是單一互動式 chat。你可能需要週期性程式碼庫檢查、定期維護檢查、排程摘要，或能在 bounded steps 中 resume work 的 host。
 
-### Semantic drift
+更多：[Heartbeat guide](docs/guides/heartbeat.md)
 
-Heddle 可以選擇性顯示 semantic drift telemetry，協助你觀察 agent run 是否開始偏離目前 task。
+### Programmatic Runtime
 
-在 chat 中：
+Heddle 不只是 CLI。npm package expose 兩個主要 programmatic layers：
 
-```text
-/drift
-/drift on
-/drift off
-```
+- `createConversationEngine`：alpha API，用於 persisted multi-turn sessions，包含 session storage、compaction、approvals、traces、semantic activity，以及 custom frontends 或 local hosts
+- `AgentLoopRuntimeService.run(...)`：較低階的 single-run execution loop，適合不需要 persisted chat 或 session behavior 的 hosts
 
-Footer 會顯示：
+Advanced hosts 也可以重用較低階的 class APIs，例如 `ToolRegistry`、`ToolExecutionService`、`TraceRecorder`、`TraceConsoleFormatter`、`ReviewDiffParser`，在需要時組裝 custom runtime 或 review surfaces。
 
-- `drift=off`
-- `drift=stable`
-- `drift=medium`
-- `drift=high`
-
-這是 observability feature，不是 magic correctness guarantee。它的目標是幫助 operator 注意到 run 可能開始偏離最近方向。
-
-如果你只是想找 coding agent，day one 不需要在意這個功能。如果你關心 agent observability 與 runtime behavior，它是 Heddle 比較有特色的功能之一。
-
-更多：[Semantic drift](docs/guides/semantic-drift.md)
-
-### Programmatic runtime APIs
-
-Heddle 不只是 CLI。npm package 也 expose runtime primitives，例如 `createConversationEngine`、`AgentLoopRuntimeService.run(...)`、`HeartbeatRunnerAgent.run`、`HeartbeatSchedulerService.runDueTasks` 與 `FileHeartbeatTaskService`，讓其他 hosts 可以建立在它之上。
-
-這是給想建立自己的 agent hosts、schedulers 或 control surfaces 的人，而不只是使用 packaged CLI。
+其他 exported primitives 包含 `HeartbeatRunnerAgent.run`、`HeartbeatSchedulerService.runDueTasks` 與 `FileHeartbeatTaskService`，用於 scheduled 或 custom host workflows。
 
 更多：[Programmatic use](docs/guides/programmatic-use.md)
 
+### Semantic Drift
+
+Semantic drift 是 optional telemetry，用來幫助你觀察 assistant responses 是否似乎偏離 conversation 最近的語意軌跡。
+
+搭配 optional [CyberLoop](https://www.npmjs.com/package/cyberloop) integration 時，Heddle 可以顯示 drift levels，例如：
+
+- `drift=unknown`
+- `drift=low`
+- `drift=medium`
+- `drift=high`
+
+這是 observability feature，不是正確性保證。它的目的，是讓 operator 注意到 run 可能變得比較不貼近最近的方向。
+
+更多：[Semantic drift](docs/guides/semantic-drift.md)
+
 ## 安裝
 
-全域安裝：
+Global install：
 
 ```bash
 npm install -g @roackb2/heddle
 ```
 
-不全域安裝也可以執行：
+不安裝 global package 也可以執行：
 
 ```bash
 npx @roackb2/heddle
@@ -496,15 +393,15 @@ npx @roackb2/heddle
 ## 需求
 
 - Node.js 20+
-- 至少要能存取一個 supported provider：
-  - 透過 `heddle auth login openai` 使用 OpenAI account sign-in，或設定 `OPENAI_API_KEY`
+- 至少一個 supported provider：
+  - OpenAI account sign-in：`heddle auth login openai`，或 `OPENAI_API_KEY`
   - Anthropic models 使用 `ANTHROPIC_API_KEY`
 
-Heddle 刻意不支援 Anthropic consumer subscription OAuth。除非 Anthropic 提供 approved third-party auth route，否則請使用 Anthropic API-key access。
+Heddle 不支援 Anthropic consumer subscription OAuth。除非 Anthropic 提供 approved third-party auth route，請使用 Anthropic API-key access。
 
-## Optional CyberLoop Integration
+## 選用 CyberLoop 整合
 
-如果你想在 chat 中使用 semantic drift telemetry，請在和 Heddle 相同的 environment 安裝 `cyberloop`：
+如果你想在 chat 裡使用 semantic drift telemetry，請在和 Heddle 相同的 environment 安裝 `cyberloop`：
 
 ```bash
 npm install -g cyberloop
@@ -512,7 +409,7 @@ npm install -g cyberloop
 npm install cyberloop
 ```
 
-如果不想全域安裝，也可以一次性使用：
+如果只想一次性使用而不 global install：
 
 ```bash
 npx -p @roackb2/heddle -p cyberloop heddle
@@ -520,17 +417,15 @@ npx -p @roackb2/heddle -p cyberloop heddle
 
 ## 文件
 
-### 從這裡開始
+從這裡開始：
 
 - [Documentation hub](docs/README.md)
 - [Runtime host model](docs/guides/runtime-host-model.md)
 - [Chat and sessions guide](docs/guides/chat-and-sessions.md)
 - [CLI reference](docs/reference/cli.md)
 
-### Feature guides
+功能指南：
 
-- [Runtime host model](docs/guides/runtime-host-model.md)
-- [Control plane](docs/guides/control-plane.md)
 - [Control plane](docs/guides/control-plane.md)
 - [Heartbeat](docs/guides/heartbeat.md)
 - [Agent Skills](docs/guides/agent-skills.md)
@@ -540,7 +435,7 @@ npx -p @roackb2/heddle -p cyberloop heddle
 - [Semantic drift](docs/guides/semantic-drift.md)
 - [Programmatic use](docs/guides/programmatic-use.md)
 
-### Contributors
+貢獻者：
 
 - [Agent context](docs/agent-context.md)
 - [Project posture](docs/project-posture.md)
@@ -551,23 +446,25 @@ npx -p @roackb2/heddle -p cyberloop heddle
 
 ## 專案狀態
 
-Heddle 已經能用於真實 coding-agent workflows，但仍在持續演進。
+Heddle 已經能用於真實 coding-agent workflows，但仍在演進。
 
-目前強項包括：
+目前強項包含：
 
-- terminal-first coding 與 repository workflows
-- autonomous、catalog-backed workspace memory，能讓 agent 從正常使用中學習
-- 標準 Agent Skills 支援，包含 workspace-level activation 與 progressive disclosure
-- opt-in Browser Automation，包含 browser snapshots、screenshots、policy checks 與公開 next-step agenda
+- terminal-first coding 與程式碼庫 workflows
+- autonomous、catalog-backed workspace memory，讓 agent 從一般使用中學習
+- standard Agent Skills support，包含 workspace-level activation 與 progressive disclosure
+- opt-in Browser Automation，包含 browser snapshots、screenshots、policy checks 與 published next-step agenda
+- MCP integration support，可連接使用者設定的生態系工具
 - explicit traces、approval previews、diff review 與 local workspace state
-- 透過 control plane 進行 browser-based oversight 與 workspace switching
-- local-first heartbeat primitives，可用於 scheduled agent work
-- practical programmatic hooks，可用於 custom hosts
+- 透過 control plane 進行瀏覽器監督與 workspace switching
+- local-first heartbeat primitives，用於 scheduled agent work
+- 可用於 custom hosts 的 practical programmatic hooks
 
-目前限制包括：
+目前限制包含：
 
-- browser control plane 對 file review 仍是 read-only；還不是 editable IDE-like diff environment
-- 某些 advanced workflows 在 source 與 examples 中比 polished product UX 更完整
+- browser control plane 對 file review 是 read-only；尚未是可編輯的 IDE-like diff environment
+- Browser Automation 仍需要 profile 管理、表單安全操作與更完整的 browser evidence surfaces
+- 有些 advanced workflows 在 source 與 examples 中已有記錄，但 product UX 文件仍需要打磨
 - 隨著 runtime 成熟，project surface 仍在變動
 
 ## 開發
@@ -575,25 +472,17 @@ Heddle 已經能用於真實 coding-agent workflows，但仍在持續演進。
 如果你想開發 Heddle 本身：
 
 ```bash
+git clone https://github.com/roackb2/heddle.git
+cd heddle
 yarn install
 yarn build
 yarn test
 ```
 
-常見 entrypoints：
+`yarn test` 會執行預設 unit 與 integration suites。Browser integration coverage 位於 `src/__tests__/browser-integration`，並會在 PRs 中執行；本地可以用 `yarn test:browser-integration` 執行。
 
-- `src/cli-v2/`：目前預設 terminal UI
-- `src/server/`：local control-plane API
-- `src/web-v2/`：browser control-plane client
-- `src/core/chat/engine/`：persisted conversation/session engine
-- `src/core/runtime/`：programmatic runtime host layer
-- `src/core/tools/`：built-in tools and toolkits
-- `src/core/memory/`：workspace memory system
-- `src/core/heartbeat/`：heartbeat task/run services
-- `docs/`：user 與 contributor documentation
-
-請先閱讀 [Agent context](docs/agent-context.md) 與 [Project posture](docs/project-posture.md)，再進行 non-trivial changes。
+完整 contributor workflow 請見 [Development and contributing](docs/guides/development.md)。
 
 ## 授權
 
-MIT
+Heddle 使用 MIT License。詳見 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary

- consolidate overlapping README sections into a clearer product overview, visual tour, quick start, and core workflow structure
- keep the existing gifs and screenshots in the main README flow
- mirror the same outline and depth in the Traditional Chinese README

## Validation

- `git diff --check`
- checked top-level and nested README heading parity outside fenced code blocks
- checked agenda anchor links for both README files