### PR TITLE
[codex] document session management actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ It gives you a browser-based view into workspaces, saved conversations, live ass
 
 The workspace switcher and `Settings > Workspace` page let you register local projects, switch the control plane between them, rename workspace entries, and pick a project folder from the browser UI. The `Sessions` section is built around current work first: review starts from the live Git working tree, with changed files, structured read-only diffs, and a larger full-diff viewer when the side panel is too tight.
 
+Session rows in the browser control plane support right-click actions for common session management: pin or unpin important conversations, rename a session inline, or archive a session so it is hidden from normal session lists. Archiving is reversible immediately from the toast undo action.
+
 If terminal chat is the execution surface, the control plane is the oversight surface.
 
 More: [Control plane guide](docs/guides/control-plane.md)
@@ -217,12 +219,20 @@ Typical session commands include:
 
 ```text
 /session list
+/session choose <query>
+/session new [name]
 /session switch <id>
+/session continue <id>
+/session rename <name>
+/session pin
+/session unpin
 /continue
 /compact
 /model set
 /reasoning set
 ```
+
+The browser control plane adds right-click session actions for pinning, inline rename, and archiving. Archived sessions are hidden from the normal session list; the archive toast includes an undo action right after archiving.
 
 More: [Chat and sessions guide](docs/guides/chat-and-sessions.md)
 

--- a/docs/guides/chat-and-sessions.md
+++ b/docs/guides/chat-and-sessions.md
@@ -98,6 +98,8 @@ Useful chat commands:
 - `/session switch <id>`: switch to another session
 - `/session continue <id>`: switch and immediately continue that session
 - `/session rename <name>`: rename the current session
+- `/session pin`: keep the current session grouped above normal recent sessions
+- `/session unpin`: return the current session to the normal recent session order
 - `/session close <id>`: remove a saved session
 - `/clear`: clear the current transcript
 - `/compact`: compact older session history immediately
@@ -108,6 +110,12 @@ Useful chat commands:
 - `/drift on`: re-enable observe-only CyberLoop telemetry for chat runs
 - `/drift off`: disable CyberLoop semantic drift detection
 - `!<command>`: run a shell command directly in chat
+
+In the browser control plane, right-click a session row to manage it without
+typing slash commands. You can pin or unpin a session, rename it inline, or
+archive it. Archived sessions are hidden from normal session lists across the
+control plane and terminal session pickers. Immediately after archiving, the
+toast includes an undo action that restores the session to the list.
 
 Prompt editing shortcuts:
 

--- a/docs/guides/control-plane.md
+++ b/docs/guides/control-plane.md
@@ -18,7 +18,7 @@ The default control plane includes:
 - active workspace and `.heddle/` state location
 - workspace management with registered workspaces, recent known workspaces, folder picking, switching, and renaming
 - saved chat sessions with sidebar navigation, resizable desktop panels, conversation view, and review-oriented detail inspection
-- browser-side session actions for new session, send, continue, cancel, and pending approval resolution
+- browser-side session actions for new session, pin/unpin, inline rename, archive with toast undo, send, continue, cancel, and pending approval resolution
 - live per-session updates for run status, tool progress, approval waits, assistant streaming text, thinking summaries, and saved-session changes
 - a model selector and reasoning-effort control backed by the server-side built-in model catalog and session state, plus a drift toggle and latest trace-derived drift level
 - an auth status indicator in the session composer footer so you can see whether the selected model is using OAuth or API-key mode without spending header space
@@ -103,6 +103,7 @@ On mobile, the default client uses:
 - focused navigation for Sessions, Tasks, and Settings
 - a dedicated session list for choosing saved conversations
 - native-style session navigation for Chat and Review
+- right-click session actions for pin/unpin, rename, and archive; archived sessions are hidden from the normal list and the archive toast can undo the action immediately
 - a compact composer that keeps the latest conversation visible
 - current workspace diff review without desktop sidebars
 - full-diff expansion for reviewing larger patches on small screens

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -43,7 +43,7 @@ Current runtime features include:
 
 - multi-turn chat sessions with saved history under `.heddle/`
 - API-backed terminal chat through the same control-plane session path as the browser UI
-- session management with create, switch, continue, rename, and close flows
+- session management with create, switch, continue, rename, pin, unpin, archive, and close flows
 - automatic conversation compaction for longer chats
 - manual `/compact` support when an operator wants to shrink session history immediately
 - inline `@file` mentions so important files are inspected first
@@ -68,6 +68,7 @@ Current runtime features include:
 Beyond terminal chat, Heddle includes:
 
 - a local browser control plane via `heddle daemon`
+- browser-side session actions for new session, pin/unpin, inline rename, archive with toast undo, send, continue, cancel, and pending approval resolution
 - live per-session updates for assistant streaming, tool progress, approval waits, and saved-session refreshes
 - workspace management for registering, renaming, choosing, and switching local project workspaces
 - Git-backed current workspace review with changed files and selected-file patches

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -116,6 +116,13 @@ Inside `heddle` / `heddle chat`, the most-used local commands are:
 - `/reasoning default`: clear explicit reasoning effort for the current session
 - `/session list`: show recent saved sessions
 - `/session choose <query>`: filter and choose a saved session
+- `/session new [name]`: create and switch to a new session
+- `/session switch <id>`: switch to another saved session
+- `/session continue <id>`: switch to a session and resume it immediately
+- `/session rename <name>`: rename the current session
+- `/session pin`: keep the current session grouped above normal recent sessions
+- `/session unpin`: return the current session to normal recent ordering
+- `/session close <id>`: remove a saved session
 - `/continue`: continue the current session
 - `/compact`: compact older session history
 - `/skills`: list discovered Agent Skills and activation status for this workspace


### PR DESCRIPTION
## Summary
- document terminal session management slash commands in README and CLI reference
- document browser session right-click actions for pin/unpin, inline rename, and archive undo
- update capabilities and control-plane guides with archive visibility semantics

## Verification
- yarn lint