### PR TITLE
[codex] Add local model provider foundation

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -106,6 +106,19 @@ yarn chat:dev:anthropic
 
 These rely on the personal fallback environment variables described in [Providers and models](../reference/providers-and-models.md).
 
+To inspect a local Ollama server's OpenAI-compatible surface without enabling
+Ollama as a Heddle runtime provider, run the opt-in smoke command:
+
+```bash
+yarn smoke:ollama
+```
+
+The smoke command checks `http://127.0.0.1:11434/v1/models`, then runs bounded
+chat-completions and tool-call requests with explicit timeouts. Override the
+defaults with `OLLAMA_OPENAI_BASE_URL`, `OLLAMA_MODEL`, or
+`OLLAMA_SMOKE_TIMEOUT_MS`, or pass `--base-url`, `--model`, and
+`--timeout-ms`.
+
 ### Control plane
 
 For control-plane development, run the backend and frontend separately:

--- a/docs/reference/providers-and-models.md
+++ b/docs/reference/providers-and-models.md
@@ -57,7 +57,7 @@ heddle --prefer-api-key daemon
 
 Current defaults:
 
-- OpenAI: `gpt-5.1-codex`
+- OpenAI: `gpt-5.4`
 - Anthropic: `claude-sonnet-4-6`
 
 ## Built-In Model Shortlist

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "verify:tui-behavior": "node --import tsx/esm scripts/verify-tui-behavior.tsx",
     "verify:tui-session-boundary": "yarn verify:tui-behavior",
     "verify:tui-session-switch": "yarn verify:tui-behavior",
+    "smoke:ollama": "node scripts/ollama-openai-compat-smoke.mjs",
     "eval:agent": "tsx --no-cache src/cli-v2/main.ts eval agent",
     "eval:clean": "tsx --no-cache src/cli-v2/main.ts eval clean",
     "test:browser-integration": "node scripts/browser-integration-playwright.mjs --project web-v2-chromium",

--- a/scripts/ollama-openai-compat-smoke.mjs
+++ b/scripts/ollama-openai-compat-smoke.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:11434/v1';
+const DEFAULT_MODEL = 'qwen3:8b';
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+const args = parseArgs(process.argv.slice(2));
+const baseURL = trimTrailingSlash(args.baseURL ?? process.env.OLLAMA_OPENAI_BASE_URL ?? DEFAULT_BASE_URL);
+const model = args.model ?? process.env.OLLAMA_MODEL ?? DEFAULT_MODEL;
+const timeoutMs = parsePositiveInt(args.timeoutMs ?? process.env.OLLAMA_SMOKE_TIMEOUT_MS) ?? DEFAULT_TIMEOUT_MS;
+
+const checks = [
+  {
+    name: 'models',
+    run: () => requestJson(`${baseURL}/models`, {
+      method: 'GET',
+      timeoutMs,
+    }),
+    summarize: (result) => {
+      const models = Array.isArray(result.data) ? result.data.map((entry) => entry?.id).filter(Boolean) : [];
+      return models.includes(model) ?
+        `found ${model}; available=${models.join(', ')}`
+      : `did not find ${model}; available=${models.join(', ') || 'none'}`;
+    },
+  },
+  {
+    name: 'chat-completions',
+    run: () => requestJson(`${baseURL}/chat/completions`, {
+      method: 'POST',
+      timeoutMs,
+      body: {
+        model,
+        messages: [{ role: 'user', content: 'Reply with exactly: ok' }],
+        stream: false,
+        max_tokens: 8,
+      },
+    }),
+    summarize: (result) => {
+      const text = result.choices?.[0]?.message?.content;
+      return typeof text === 'string' ? `content=${JSON.stringify(text)}` : 'no assistant content returned';
+    },
+  },
+  {
+    name: 'tool-calls',
+    run: () => requestJson(`${baseURL}/chat/completions`, {
+      method: 'POST',
+      timeoutMs,
+      body: {
+        model,
+        messages: [{ role: 'user', content: 'Use the add tool to add 2 and 3.' }],
+        tools: [{
+          type: 'function',
+          function: {
+            name: 'add',
+            description: 'Add two numbers.',
+            parameters: {
+              type: 'object',
+              properties: {
+                a: { type: 'number' },
+                b: { type: 'number' },
+              },
+              required: ['a', 'b'],
+            },
+          },
+        }],
+        tool_choice: 'auto',
+        stream: false,
+        max_tokens: 64,
+      },
+    }),
+    summarize: (result) => {
+      const toolCalls = result.choices?.[0]?.message?.tool_calls;
+      return Array.isArray(toolCalls) && toolCalls.length > 0 ?
+        `tool_calls=${JSON.stringify(toolCalls)}`
+      : 'no tool calls returned';
+    },
+  },
+];
+
+const results = [];
+for (const check of checks) {
+  results.push(await runCheck(check));
+}
+
+const failures = results.filter((result) => result.status === 'fail');
+console.log([
+  `Ollama OpenAI-compatible smoke`,
+  `baseURL=${baseURL}`,
+  `model=${model}`,
+  `timeoutMs=${timeoutMs}`,
+  '',
+  ...results.map((result) => `${result.status === 'pass' ? 'PASS' : 'FAIL'} ${result.name}: ${result.message}`),
+].join('\n'));
+
+process.exitCode = failures.length > 0 ? 1 : 0;
+
+async function runCheck(check) {
+  try {
+    const result = await check.run();
+    return {
+      name: check.name,
+      status: 'pass',
+      message: check.summarize(result),
+    };
+  } catch (error) {
+    return {
+      name: check.name,
+      status: 'fail',
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function requestJson(url, options) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method: options.method,
+      signal: controller.signal,
+      headers: options.body ? { 'content-type': 'application/json' } : undefined,
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}: ${text || 'no response body'}`);
+    }
+    return text.trim() ? JSON.parse(text) : {};
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`timed out after ${options.timeoutMs}ms`, { cause: error });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function parseArgs(values) {
+  const parsed = {};
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    const next = values[index + 1];
+    if (value === '--base-url' && next) {
+      parsed.baseURL = next;
+      index += 1;
+      continue;
+    }
+    if (value === '--model' && next) {
+      parsed.model = next;
+      index += 1;
+      continue;
+    }
+    if (value === '--timeout-ms' && next) {
+      parsed.timeoutMs = next;
+      index += 1;
+    }
+  }
+  return parsed;
+}
+
+function trimTrailingSlash(value) {
+  return value.replace(/\/+$/, '');
+}
+
+function parsePositiveInt(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}

--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -132,6 +132,27 @@ describe('llm adapter factory', () => {
     });
   });
 
+  it('uses the active model for non-OpenAI system model selection', () => {
+    expect(ModelPolicyService.resolveSystemSelectedModel({
+      purpose: 'chat-compaction',
+      provider: 'ollama',
+      activeModel: 'ollama/qwen3:8b',
+    })).toBe('ollama/qwen3:8b');
+
+    expect(ModelPolicyService.resolveSystemSelectedModel({
+      purpose: 'session-title',
+      provider: 'huggingface',
+      activeModel: 'huggingface/meta-llama/Llama-3.3-70B-Instruct',
+    })).toBe('huggingface/meta-llama/Llama-3.3-70B-Instruct');
+  });
+
+  it('fails clearly when non-OpenAI system model selection has no active model', () => {
+    expect(() => ModelPolicyService.resolveSystemSelectedModel({
+      purpose: 'chat-compaction',
+      provider: 'ollama',
+    })).toThrow('No chat-compaction system model is configured for ollama.');
+  });
+
   it('owns per-model reasoning effort support', () => {
     expect(ModelPolicyService.supportsOpenAiRequestReasoningEffortLevel('gpt-5.4', 'ultrahigh')).toBe(false);
     expect(ModelPolicyService.supportsOpenAiRequestReasoningEffortLevel('gpt-5.5', 'ultrahigh')).toBe(true);

--- a/src/__tests__/unit/core/slash-command-modules.test.ts
+++ b/src/__tests__/unit/core/slash-command-modules.test.ts
@@ -195,6 +195,28 @@ describe('core slash command modules', () => {
     expect(setActive).not.toHaveBeenCalled();
   });
 
+  it('uses shared provider inference when switching local-prefixed models', async () => {
+    const setActive = vi.fn();
+    const context = createContext({
+      model: {
+        active: () => 'gpt-5.4',
+        setActive,
+        credentialSource: () => ({
+          type: 'oauth',
+          provider: 'openai',
+          accountId: 'acct',
+          expiresAt: Date.now() + 60_000,
+        }),
+      },
+    });
+
+    await expect(registry.run(context, '/model ollama/qwen3:8b')).resolves.toMatchObject({
+      kind: 'message',
+      message: "Switched model to ollama/qwen3:8b. This name is not in Heddle's common shortlist, so the next API call will fail if the provider does not recognize it.",
+    });
+    expect(setActive).toHaveBeenCalledWith('ollama/qwen3:8b');
+  });
+
   it('uses shared reasoning policy before setting reasoning effort', async () => {
     const setReasoningEffort = vi.fn();
     const context = createContext({

--- a/src/core/commands/slash/modules/model/model-commands.ts
+++ b/src/core/commands/slash/modules/model/model-commands.ts
@@ -8,7 +8,8 @@ import {
   ModelCatalogService,
   ModelPolicyService,
 } from '../../../../llm/models/index.js';
-import type { LlmProvider, ReasoningEffort } from '../../../../llm/types.js';
+import { LlmAdapterService } from '../../../../llm/index.js';
+import type { ReasoningEffort } from '../../../../llm/types.js';
 import {
   formatSessionReasoningEffortStatus,
   resolveEffectiveReasoningEffort,
@@ -118,7 +119,7 @@ function switchModel(
 
   const compatibility = ModelPolicyService.validateCredentialCompatibility({
     model: value,
-    provider: inferProviderForModel(value),
+    provider: LlmAdapterService.inferProvider(value),
     credentialMode: ModelPolicyService.credentialModeFromSource(context.model.credentialSource()),
   });
   if (!compatibility.ok) {
@@ -174,8 +175,4 @@ function setReasoningEffort(
 }
 function isReasoningEffort(value: string): value is ReasoningEffort {
   return value === 'low' || value === 'medium' || value === 'high' || value === 'ultrahigh';
-}
-
-function inferProviderForModel(model: string): LlmProvider {
-  return model.startsWith('claude') ? 'anthropic' : 'openai';
 }

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -1,4 +1,5 @@
 import type { AgentLoopCheckpoint, AgentLoopState } from '@/core/runtime/loop/index.js';
+import type { LlmProvider } from '@/core/llm/types.js';
 import type { AgentHeartbeatEvent, AgentHeartbeatResult, RunAgentHeartbeatOptions } from '../agent/index.js';
 import type { HeartbeatTask, HeartbeatTaskRunRecord, HeartbeatTaskStatus, HeartbeatTaskStore } from '../tasks/index.js';
 
@@ -46,7 +47,7 @@ export type HeartbeatTaskRunnerRuntimeOptions = {
   stateDir?: string;
   memoryDir?: string;
   apiKey?: string;
-  apiKeyProvider?: 'explicit' | 'openai' | 'anthropic';
+  apiKeyProvider?: 'explicit' | LlmProvider;
   preferApiKey?: boolean;
   model?: string;
   maxSteps?: number;

--- a/src/core/llm/models/model-policy-service.ts
+++ b/src/core/llm/models/model-policy-service.ts
@@ -94,7 +94,12 @@ export class ModelPolicyService {
       return args.purpose === 'chat-compaction' ? OPENAI_API_KEY_COMPACTION_MODEL : DEFAULT_OPENAI_MODEL;
     }
 
-    return DEFAULT_OPENAI_MODEL;
+    const activeModel = args.activeModel?.trim();
+    if (activeModel) {
+      return activeModel;
+    }
+
+    throw new Error(`No ${args.purpose} system model is configured for ${args.provider}.`);
   }
 
   static validateCredentialCompatibility(args: {

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -727,7 +727,7 @@ export class ControlPlaneChatSessionsController {
     );
     const titleModel = ModelPolicyService.resolveSystemSelectedModel({
       purpose: 'session-title',
-      provider: 'openai',
+      provider: LlmAdapterService.inferProvider(activeModel),
       activeModel,
       credentialMode,
     });


### PR DESCRIPTION
## Summary

Adds the first production-readiness slice for local/OpenAI-compatible model support:

- routes `/model` compatibility checks through shared provider inference so local-prefixed models are not treated as OpenAI OAuth models
- prevents non-OpenAI/non-Anthropic system model selection from silently falling back to OpenAI defaults
- generalizes heartbeat runtime API-key provider typing for future providers
- adds an opt-in Ollama OpenAI-compatible smoke command with explicit request timeouts
- documents the smoke command and fixes the live OpenAI default in provider docs

## Why

Local providers like Ollama need guardrails before Heddle routes real agent loops through them. The current OpenAI adapter owns OpenAI Responses/OAuth semantics, so local compatibility work should start by removing unsafe fallback behavior and adding observable smoke checks rather than treating `baseURL` as a hidden OpenAI variant.

## Validation

- `yarn test:unit src/__tests__/unit/core/slash-command-modules.test.ts src/__tests__/unit/core/llm-factory.test.ts`
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `yarn smoke:ollama --timeout-ms 1000`

The Ollama smoke result on the maintainer machine found `qwen3:8b` through `/v1/models`, then reported explicit timeouts for chat-completions and tool-call checks. That is expected for this foundation slice and confirms the smoke command fails clearly instead of hanging.
