### PR TITLE
[codex] add Ollama runtime provider

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -106,18 +106,21 @@ yarn chat:dev:anthropic
 
 These rely on the personal fallback environment variables described in [Providers and models](../reference/providers-and-models.md).
 
-To inspect a local Ollama server's OpenAI-compatible surface without enabling
-Ollama as a Heddle runtime provider, run the opt-in smoke command:
+To inspect a local Ollama server's OpenAI-compatible surface, run the opt-in
+smoke command:
 
 ```bash
 yarn smoke:ollama
 ```
 
-The smoke command checks `http://127.0.0.1:11434/v1/models`, then runs bounded
-chat-completions and tool-call requests with explicit timeouts. Override the
-defaults with `OLLAMA_OPENAI_BASE_URL`, `OLLAMA_MODEL`, or
-`OLLAMA_SMOKE_TIMEOUT_MS`, or pass `--base-url`, `--model`, and
-`--timeout-ms`.
+The smoke command discovers an installed non-embedding model from Ollama's local
+model list when `OLLAMA_MODEL` or `--model` is not provided, then checks
+`http://127.0.0.1:11434/v1/models` and runs bounded chat-completions and
+tool-call requests with explicit timeouts. Tool calls are reported as WARN by
+default when the selected model does not return them; pass
+`--require-tool-calls` to make that capability mandatory. Override the endpoint
+or model with `OLLAMA_OPENAI_BASE_URL`, `OLLAMA_MODEL`, or
+`OLLAMA_SMOKE_TIMEOUT_MS`, or pass `--base-url`, `--model`, and `--timeout-ms`.
 
 ### Control plane
 

--- a/docs/reference/providers-and-models.md
+++ b/docs/reference/providers-and-models.md
@@ -4,6 +4,7 @@ Heddle currently has working provider adapters for:
 
 - OpenAI
 - Anthropic
+- Ollama
 
 ## Provider Access
 
@@ -33,12 +34,28 @@ export ANTHROPIC_API_KEY=your_key_here
 
 Heddle does not support Anthropic consumer subscription OAuth. That path is intentionally deferred unless Anthropic documents or approves a third-party auth route.
 
+For Ollama, install and start Ollama locally, then select an installed model
+with the `ollama/` prefix:
+
+```bash
+heddle --model ollama/llama3.2:latest ask "Reply with exactly: ok"
+```
+
+Ollama uses the local OpenAI-compatible endpoint and does not require a hosted
+provider API key. The default endpoint is `http://127.0.0.1:11434/v1`.
+
 ## Environment Variables
 
 Supported provider API-key environment variables:
 
 - `OPENAI_API_KEY` for OpenAI models
 - `ANTHROPIC_API_KEY` for Anthropic models
+
+Supported local-provider environment variables:
+
+- `OLLAMA_OPENAI_BASE_URL` to override the OpenAI-compatible Ollama endpoint
+- `OLLAMA_BASE_URL` to override the native Ollama base URL; Heddle appends `/v1`
+- `OLLAMA_MODEL` for scripts or explicit Ollama provider defaults
 
 For local development inside this repository, fallback env vars are also accepted:
 
@@ -59,6 +76,10 @@ Current defaults:
 
 - OpenAI: `gpt-5.4`
 - Anthropic: `claude-sonnet-4-6`
+
+Ollama has no hardcoded default model because installed local model names vary
+by machine. Select an installed model with `ollama/<model>` or set
+`OLLAMA_MODEL`.
 
 ## Built-In Model Shortlist
 
@@ -86,6 +107,7 @@ You can select a model with CLI flags or chat commands:
 ```bash
 heddle --model gpt-5.4-mini
 heddle chat --model claude-3-5-haiku-latest
+heddle --model ollama/llama3.2:latest ask "Summarize this repository"
 ```
 
 In chat, you can also use:
@@ -112,7 +134,7 @@ Inside terminal chat, the same auth surface is available as slash commands:
 - `/auth login openai`
 - `/auth logout openai`
 
-The chat footer shows the active credential source for the selected model, such as `auth=openai-oauth`, `auth=openai-key`, or `auth=missing-openai`.
+The chat footer shows the active credential source for the selected model, such as `auth=openai-oauth`, `auth=openai-key`, `auth=ollama-local`, or `auth=missing-openai`.
 
 In the browser control plane, the same auth indicator appears in the session composer footer so it stays visible without taking space away from the conversation header.
 
@@ -136,6 +158,7 @@ Use `OPENAI_API_KEY` for other OpenAI Platform models or features that require P
 ## Notes
 
 - Provider selection is inferred from the model name prefix.
+- Ollama model names are recognized with `ollama/` or `ollama:` prefixes.
 - Gemini model names are recognized by provider inference, but a Google adapter is not wired yet.
 - You can pass another supported model name with `--model` if the relevant provider adapter can handle it.
 - Hosted web search and image viewing currently require Platform API-key mode for OpenAI.

--- a/scripts/ollama-openai-compat-smoke.mjs
+++ b/scripts/ollama-openai-compat-smoke.mjs
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
 
 const DEFAULT_BASE_URL = 'http://127.0.0.1:11434/v1';
-const DEFAULT_MODEL = 'qwen3:8b';
 const DEFAULT_TIMEOUT_MS = 20_000;
+const MAX_PREFERRED_MODEL_BYTES = 8 * 1024 * 1024 * 1024;
 
 const args = parseArgs(process.argv.slice(2));
 const baseURL = trimTrailingSlash(args.baseURL ?? process.env.OLLAMA_OPENAI_BASE_URL ?? DEFAULT_BASE_URL);
-const model = args.model ?? process.env.OLLAMA_MODEL ?? DEFAULT_MODEL;
 const timeoutMs = parsePositiveInt(args.timeoutMs ?? process.env.OLLAMA_SMOKE_TIMEOUT_MS) ?? DEFAULT_TIMEOUT_MS;
+const requireToolCalls = Boolean(args.requireToolCalls);
+const requestedModel = args.model ?? process.env.OLLAMA_MODEL;
+const modelSelection = requestedModel ?
+  { model: requestedModel, source: 'explicit' }
+: await resolveSmokeModel({ baseURL, timeoutMs });
+const model = modelSelection.model;
 
 const checks = [
   {
@@ -68,11 +73,10 @@ const checks = [
         max_tokens: 64,
       },
     }),
+    validate: (result) => validateToolCalls(result, { required: requireToolCalls }),
     summarize: (result) => {
       const toolCalls = result.choices?.[0]?.message?.tool_calls;
-      return Array.isArray(toolCalls) && toolCalls.length > 0 ?
-        `tool_calls=${JSON.stringify(toolCalls)}`
-      : 'no tool calls returned';
+      return `tool_calls=${JSON.stringify(toolCalls)}`;
     },
   },
 ];
@@ -86,10 +90,11 @@ const failures = results.filter((result) => result.status === 'fail');
 console.log([
   `Ollama OpenAI-compatible smoke`,
   `baseURL=${baseURL}`,
-  `model=${model}`,
+  `model=${model} (${modelSelection.source})`,
   `timeoutMs=${timeoutMs}`,
+  `requireToolCalls=${requireToolCalls}`,
   '',
-  ...results.map((result) => `${result.status === 'pass' ? 'PASS' : 'FAIL'} ${result.name}: ${result.message}`),
+  ...results.map((result) => `${formatStatus(result.status)} ${result.name}: ${result.message}`),
 ].join('\n'));
 
 process.exitCode = failures.length > 0 ? 1 : 0;
@@ -97,10 +102,11 @@ process.exitCode = failures.length > 0 ? 1 : 0;
 async function runCheck(check) {
   try {
     const result = await check.run();
+    const validation = check.validate?.(result);
     return {
       name: check.name,
-      status: 'pass',
-      message: check.summarize(result),
+      status: validation?.status ?? 'pass',
+      message: validation?.message ?? check.summarize(result),
     };
   } catch (error) {
     return {
@@ -109,6 +115,105 @@ async function runCheck(check) {
       message: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+function validateToolCalls(result, options) {
+  const toolCalls = result.choices?.[0]?.message?.tool_calls;
+  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+    return undefined;
+  }
+
+  const content = result.choices?.[0]?.message?.content;
+  const message =
+    typeof content === 'string' && content.trim() ?
+      `no tool calls returned; content=${JSON.stringify(content)}`
+    : 'no tool calls returned';
+
+  return {
+    status: options.required ? 'fail' : 'warn',
+    message,
+  };
+}
+
+async function resolveSmokeModel(options) {
+  const tagsURL = `${ollamaNativeBaseURL(options.baseURL)}/api/tags`;
+  try {
+    const result = await requestJson(tagsURL, {
+      method: 'GET',
+      timeoutMs: options.timeoutMs,
+    });
+    const candidates = Array.isArray(result.models) ?
+      result.models.flatMap((entry) => toSmokeModelCandidate(entry))
+    : [];
+    const selected = selectSmokeModel(candidates);
+    if (selected) {
+      return {
+        model: selected.name,
+        source: selected.size ?
+          `auto-selected from installed models, size=${formatBytes(selected.size)}`
+        : 'auto-selected from installed models',
+      };
+    }
+  } catch (error) {
+    console.warn(`WARN model-discovery: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const models = await requestJson(`${options.baseURL}/models`, {
+    method: 'GET',
+    timeoutMs: options.timeoutMs,
+  });
+  const candidate = Array.isArray(models.data) ?
+    models.data.map((entry) => entry?.id).filter((name) => typeof name === 'string' && !isEmbeddingModel(name))[0]
+  : undefined;
+  if (candidate) {
+    return { model: candidate, source: 'auto-selected from OpenAI-compatible /models' };
+  }
+
+  throw new Error('No installed Ollama chat model found. Install one with `ollama pull <model>` or pass --model.');
+}
+
+function toSmokeModelCandidate(entry) {
+  if (!entry || typeof entry !== 'object' || typeof entry.name !== 'string' || isEmbeddingModel(entry.name)) {
+    return [];
+  }
+
+  const size = typeof entry.size === 'number' && Number.isFinite(entry.size) ? entry.size : undefined;
+  return [{
+    name: entry.name,
+    size,
+    preference: smokeModelPreference(entry.name),
+  }];
+}
+
+function selectSmokeModel(candidates) {
+  const preferredSize = candidates.filter((candidate) => !candidate.size || candidate.size <= MAX_PREFERRED_MODEL_BYTES);
+  const pool = preferredSize.length > 0 ? preferredSize : candidates;
+  const sorted = pool.toSorted((left, right) =>
+    left.preference - right.preference
+    || (left.size ?? Number.MAX_SAFE_INTEGER) - (right.size ?? Number.MAX_SAFE_INTEGER)
+    || left.name.localeCompare(right.name));
+  return sorted[0];
+}
+
+function smokeModelPreference(name) {
+  const normalized = name.toLowerCase();
+  const preferences = [
+    'llama3.2',
+    'llama3.1',
+    'qwen3',
+    'qwen2.5',
+    'mistral',
+    'gemma3',
+    'phi4-mini',
+    'phi3',
+  ];
+  const index = preferences.findIndex((prefix) => normalized.startsWith(prefix));
+  return index >= 0 ? index : preferences.length;
+}
+
+function isEmbeddingModel(name) {
+  const normalized = name.toLowerCase();
+  return ['embed', 'embedding', 'nomic-embed', 'bge', 'clip'].some((part) => normalized.includes(part));
 }
 
 async function requestJson(url, options) {
@@ -154,6 +259,10 @@ function parseArgs(values) {
     if (value === '--timeout-ms' && next) {
       parsed.timeoutMs = next;
       index += 1;
+      continue;
+    }
+    if (value === '--require-tool-calls') {
+      parsed.requireToolCalls = true;
     }
   }
   return parsed;
@@ -161,6 +270,19 @@ function parseArgs(values) {
 
 function trimTrailingSlash(value) {
   return value.replace(/\/+$/, '');
+}
+
+function ollamaNativeBaseURL(value) {
+  return trimTrailingSlash(value).replace(/\/v1$/i, '');
+}
+
+function formatBytes(value) {
+  const gib = value / (1024 * 1024 * 1024);
+  return `${gib.toFixed(gib >= 10 ? 0 : 1)}GiB`;
+}
+
+function formatStatus(status) {
+  return status === 'pass' ? 'PASS' : status === 'warn' ? 'WARN' : 'FAIL';
 }
 
 function parsePositiveInt(value) {

--- a/src/__tests__/unit/cli-v2/memory-command.test.ts
+++ b/src/__tests__/unit/cli-v2/memory-command.test.ts
@@ -110,7 +110,14 @@ describe('MemoryCliV2CommandEdgeService', () => {
 
     await MemoryCliV2CommandEdgeService.run('maintain', commandOptions(workspaceRoot));
 
-    expect(createLlm).toHaveBeenCalledWith({ model: 'gpt-5.4', credentials: undefined });
+    expect(createLlm).toHaveBeenCalledWith({
+      model: 'gpt-5.4',
+      credentials: undefined,
+      runtime: {
+        endpoint: undefined,
+        reasoningEffort: undefined,
+      },
+    });
     const output = stdout.mock.calls.map(([message]) => message).join('');
     expect(output).toContain('Outcome: done');
     expect(output).toContain('Candidates: 1/1 processed');

--- a/src/__tests__/unit/cli-v2/memory-command.test.ts
+++ b/src/__tests__/unit/cli-v2/memory-command.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MemoryCliV2CommandEdgeService } from '@/cli-v2/commands/memory-command.js';
 import type { CliV2CommandEdgeOptions } from '@/cli-v2/commands/types.js';
+import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
 import { MemoryMaintenanceService } from '@/core/memory/maintainer.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
@@ -75,8 +76,23 @@ describe('MemoryCliV2CommandEdgeService', () => {
 
   it('allows maintainer runs to use stored credentials when no provider API key is present', async () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-memory-command-stored-credential-'));
+    const credentialStorePath = join(workspaceRoot, '.heddle', 'auth.json');
+    new ProviderCredentialRepository({ storePath: credentialStorePath }).write({
+      version: 1,
+      credentials: {
+        openai: {
+          type: 'oauth',
+          provider: 'openai',
+          accessToken: 'access-token-test',
+          refreshToken: 'refresh-token-test',
+          expiresAt: Date.now() + 60_000,
+          createdAt: '2026-06-04T00:00:00.000Z',
+          updatedAt: '2026-06-04T00:00:00.000Z',
+          accountId: 'account-test',
+        },
+      },
+    });
     vi.spyOn(RuntimeCredentialService, 'resolveApiKeyForModel').mockReturnValue(undefined);
-    vi.spyOn(RuntimeCredentialService, 'hasCredentialForModel').mockReturnValue(true);
     const createLlm = vi.spyOn(LlmAdapterService, 'create').mockReturnValue({} as ReturnType<typeof LlmAdapterService.create>);
     vi.spyOn(MemoryMaintenanceService.prototype, 'readPendingCandidates').mockResolvedValue([
       {
@@ -112,7 +128,10 @@ describe('MemoryCliV2CommandEdgeService', () => {
 
     expect(createLlm).toHaveBeenCalledWith({
       model: 'gpt-5.4',
-      credentials: undefined,
+      credentials: {
+        apiKey: undefined,
+        credentialStorePath,
+      },
       runtime: {
         endpoint: undefined,
         reasoningEffort: undefined,

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -164,6 +164,34 @@ describe('chat turn preparation modules', () => {
     })).toThrow('Missing Anthropic credential. Set ANTHROPIC_API_KEY for Anthropic models.');
   });
 
+  it('resolves Ollama chat turns as local endpoint runtime without hosted credentials', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'openai-key');
+    vi.stubEnv('ANTHROPIC_API_KEY', 'anthropic-key');
+    vi.stubEnv('OLLAMA_OPENAI_BASE_URL', 'http://localhost:11434/v1');
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-ollama-'));
+
+    const runtime = ConversationTurnRuntimeResolver.resolve({
+      config: {
+        stateRoot: join(root, '.heddle'),
+        env: { OPENAI_MODEL: undefined, ANTHROPIC_MODEL: undefined },
+      },
+      session: { model: 'ollama/llama3.2:latest' },
+    });
+
+    expect(runtime.model).toBe('ollama/llama3.2:latest');
+    expect(runtime.provider).toBe('ollama');
+    expect(runtime.apiKey).toBeUndefined();
+    expect(runtime.providerCredentialSource).toEqual({
+      type: 'local-endpoint',
+      provider: 'ollama',
+      baseUrl: 'http://localhost:11434/v1',
+    });
+    expect(runtime.llm.info).toMatchObject({
+      provider: 'ollama',
+      model: 'ollama/llama3.2:latest',
+    });
+  });
+
   it('prepares ordinary turn context with runtime, tool bundle, and default lease owner', () => {
     const root = mkdtempSync(join(tmpdir(), 'heddle-turn-context-'));
     const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');

--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -15,6 +15,7 @@ describe('llm adapter factory', () => {
     expect(LlmAdapterService.inferProvider('gpt-5.1-codex')).toBe('openai');
     expect(LlmAdapterService.inferProvider('claude-sonnet-4-6')).toBe('anthropic');
     expect(LlmAdapterService.inferProvider('gemini-2.5-pro')).toBe('google');
+    expect(LlmAdapterService.inferProvider('ollama/llama3.2:latest')).toBe('ollama');
   });
 
   it('prefers an explicit provider over model inference', () => {
@@ -93,6 +94,105 @@ describe('llm adapter factory', () => {
         systemMessages: true,
         reasoningSummaries: false,
         parallelToolCalls: false,
+      },
+    });
+  });
+
+  it('returns an Ollama adapter with provider metadata for local models', () => {
+    const adapter = LlmAdapterService.create({
+      model: 'ollama/llama3.2:latest',
+      runtime: {
+        endpoint: {
+          baseUrl: 'http://127.0.0.1:11434/v1',
+          auth: { type: 'none' },
+        },
+      },
+    });
+
+    expect(adapter.info).toEqual({
+      provider: 'ollama',
+      model: 'ollama/llama3.2:latest',
+      capabilities: {
+        toolCalls: true,
+        systemMessages: true,
+        reasoningSummaries: false,
+        parallelToolCalls: false,
+      },
+    });
+  });
+
+  it('sends Ollama chat-completions requests with provider-local model names and parses tool calls', async () => {
+    const requests: Array<{ url: string; body: unknown }> = [];
+    const adapter = LlmAdapterService.create({
+      model: 'ollama/llama3.2:latest',
+      runtime: {
+        endpoint: {
+          baseUrl: 'http://ollama.test/v1',
+          auth: { type: 'none' },
+        },
+        fetchImpl: (async (url, init) => {
+          requests.push({
+            url: String(url),
+            body: JSON.parse(String((init as RequestInit).body)),
+          });
+          return new Response(JSON.stringify({
+            choices: [{
+              message: {
+                content: '',
+                tool_calls: [{
+                  id: 'call_1',
+                  type: 'function',
+                  function: {
+                    name: 'add',
+                    arguments: '{"a":2,"b":3}',
+                  },
+                }],
+              },
+            }],
+            usage: {
+              prompt_tokens: 10,
+              completion_tokens: 4,
+              total_tokens: 14,
+            },
+          }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }) as typeof fetch,
+      },
+    });
+
+    const result = await adapter.chat(
+      [{ role: 'user', content: 'add 2 and 3' }],
+      [{
+        name: 'add',
+        description: 'Add two numbers.',
+        parameters: {
+          type: 'object',
+          properties: {
+            a: { type: 'number' },
+            b: { type: 'number' },
+          },
+          required: ['a', 'b'],
+        },
+        execute: async () => ({ ok: true, output: 5 }),
+      }],
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe('http://ollama.test/v1/chat/completions');
+    expect(requests[0]?.body).toMatchObject({
+      model: 'llama3.2:latest',
+      tool_choice: 'auto',
+    });
+    expect(result).toEqual({
+      content: undefined,
+      toolCalls: [{ id: 'call_1', tool: 'add', input: { a: 2, b: 3 } }],
+      usage: {
+        inputTokens: 10,
+        outputTokens: 4,
+        totalTokens: 14,
+        requests: 1,
       },
     });
   });

--- a/src/__tests__/unit/core/runtime-credentials.test.ts
+++ b/src/__tests__/unit/core/runtime-credentials.test.ts
@@ -34,6 +34,37 @@ describe('RuntimeCredentialService', () => {
     });
   });
 
+  it('resolves Ollama as a local endpoint instead of reusing hosted provider keys', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'openai-key');
+    vi.stubEnv('ANTHROPIC_API_KEY', 'anthropic-key');
+    vi.stubEnv('OLLAMA_OPENAI_BASE_URL', 'http://127.0.0.1:11434/v1/');
+
+    expect(RuntimeCredentialService.resolveApiKeyForModel('ollama/llama3.2:latest', {
+      apiKey: 'explicit-key',
+      apiKeyProvider: 'explicit',
+    })).toBeUndefined();
+    expect(RuntimeCredentialService.resolveCredentialSourceForModel('ollama/llama3.2:latest', {
+      apiKey: 'explicit-key',
+      apiKeyProvider: 'explicit',
+    })).toEqual({
+      type: 'local-endpoint',
+      provider: 'ollama',
+      baseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    expect(RuntimeCredentialService.hasCredentialForModel('ollama/llama3.2:latest')).toBe(true);
+  });
+
+  it('normalizes OLLAMA_BASE_URL to the OpenAI-compatible v1 endpoint', () => {
+    vi.stubEnv('OLLAMA_OPENAI_BASE_URL', '');
+    vi.stubEnv('OLLAMA_BASE_URL', 'http://localhost:11434/');
+
+    expect(RuntimeCredentialService.resolveCredentialSourceForModel('ollama/qwen3:8b')).toEqual({
+      type: 'local-endpoint',
+      provider: 'ollama',
+      baseUrl: 'http://localhost:11434/v1',
+    });
+  });
+
   it('resolves the provider-specific key for the requested model', () => {
     vi.stubEnv('OPENAI_API_KEY', 'openai-key');
     vi.stubEnv('ANTHROPIC_API_KEY', 'anthropic-key');

--- a/src/cli-v2/commands/memory-command.ts
+++ b/src/cli-v2/commands/memory-command.ts
@@ -6,7 +6,7 @@ import { MemoryMaintenanceService } from '@/core/memory/maintainer.js';
 import { MemoryValidationService } from '@/core/memory/validation.js';
 import { MemoryVisibilityService } from '@/core/memory/visibility.js';
 import type { MemoryValidationResult } from '@/core/memory/types.js';
-import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
+import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
 import type { CliV2CommandEdgeOptions } from './types.js';
 
 export type MemoryCliCommand = 'status' | 'init' | 'list' | 'read' | 'search' | 'validate' | 'maintain';
@@ -26,7 +26,7 @@ export type MemoryCliCommandFlags = {
  * Command edge for `heddle memory`.
  *
  * Owns: terminal subcommand dispatch, flag-to-service option parsing, provider
- * credential selection for the explicit maintainer command, and terminal
+ * provider runtime selection for the explicit maintainer command, and terminal
  * formatting.
  *
  * Does not own: catalog invariants, note traversal/search semantics, memory
@@ -185,15 +185,17 @@ export class MemoryCliV2CommandEdgeService {
     }
 
     const model = options.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
-    const apiKey = RuntimeCredentialService.resolveApiKeyForModel(model);
-    if (!apiKey && !RuntimeCredentialService.hasCredentialForModel(model, { preferApiKey: options.preferApiKey })) {
-      throw new Error(RuntimeCredentialService.formatMissingCredentialMessage(model));
-    }
+    const providerRuntime = LlmProviderRuntimeService.resolve({
+      model,
+      preferApiKey: options.preferApiKey,
+    });
+    LlmProviderRuntimeService.assertRunnable(providerRuntime);
 
     const result = await context.maintenance.runBacklog({
       llm: LlmAdapterService.create({
         model,
-        credentials: apiKey ? { apiKey } : undefined,
+        credentials: providerRuntime.apiKey ? { apiKey: providerRuntime.apiKey } : undefined,
+        runtime: providerRuntime.llmRuntime,
       }),
       source: 'heddle memory maintain',
     });

--- a/src/cli-v2/commands/memory-command.ts
+++ b/src/cli-v2/commands/memory-command.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import compact from 'lodash/compact.js';
 import { DEFAULT_OPENAI_MODEL, LlmAdapterService } from '@/index.js';
+import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import { MemoryCatalogService } from '@/core/memory/catalog.js';
 import { MemoryMaintenanceService } from '@/core/memory/maintainer.js';
 import { MemoryValidationService } from '@/core/memory/validation.js';
@@ -185,8 +186,10 @@ export class MemoryCliV2CommandEdgeService {
     }
 
     const model = options.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
+    const credentialStorePath = ProviderCredentialRepository.resolveStorePath(resolve(options.workspaceRoot, options.stateDir));
     const providerRuntime = LlmProviderRuntimeService.resolve({
       model,
+      credentialStorePath,
       preferApiKey: options.preferApiKey,
     });
     LlmProviderRuntimeService.assertRunnable(providerRuntime);
@@ -194,7 +197,10 @@ export class MemoryCliV2CommandEdgeService {
     const result = await context.maintenance.runBacklog({
       llm: LlmAdapterService.create({
         model,
-        credentials: providerRuntime.apiKey ? { apiKey: providerRuntime.apiKey } : undefined,
+        credentials: {
+          apiKey: providerRuntime.apiKey,
+          credentialStorePath,
+        },
         runtime: providerRuntime.llmRuntime,
       }),
       source: 'heddle memory maintain',

--- a/src/cli-v2/services/status/runtime-status-service.ts
+++ b/src/cli-v2/services/status/runtime-status-service.ts
@@ -37,6 +37,8 @@ export class RuntimeStatusService {
         return `auth=${source.provider}-key`;
       case 'oauth':
         return `auth=${source.provider}-oauth`;
+      case 'local-endpoint':
+        return `auth=${source.provider}-local`;
       case 'missing':
         return `auth=missing-${source.provider}`;
     }

--- a/src/core/chat/engine/compaction/summarizer/service.ts
+++ b/src/core/chat/engine/compaction/summarizer/service.ts
@@ -4,6 +4,7 @@ import {
   type ApiKeyRuntime,
   type ProviderCredentialSource,
 } from '@/core/runtime/credentials/index.js';
+import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
 import { ModelPolicyService, type ModelCredentialMode } from '@/core/llm/models/index.js';
 import { CompactionText } from '../text.js';
 import type { ConversationCompactionOptions } from '../types.js';
@@ -42,12 +43,16 @@ export class ConversationArchiveSummarizer {
           credentialSource: options.summarizer?.credentialSource,
         }),
       });
-    const apiKey = options.summarizer?.apiKey ?? RuntimeCredentialService.resolveApiKeyForModel(model);
+    const providerRuntime = LlmProviderRuntimeService.resolve({
+      model,
+      apiKey: options.summarizer?.apiKey,
+    });
+    const apiKey = options.summarizer?.apiKey ?? providerRuntime.apiKey;
     const summarizerCredentialRuntime: ApiKeyRuntime = {
       apiKey,
       apiKeyProvider: options.summarizer?.apiKey ? 'explicit' : apiKey ? provider : undefined,
     };
-    if (!RuntimeCredentialService.hasCredentialForModel(model, summarizerCredentialRuntime)) {
+    if (providerRuntime.credentialSource.type === 'missing' || !RuntimeCredentialService.hasCredentialForModel(model, summarizerCredentialRuntime)) {
       return { model };
     }
 
@@ -56,6 +61,7 @@ export class ConversationArchiveSummarizer {
       llm: LlmAdapterService.create({
         model,
         credentials: { apiKey },
+        runtime: providerRuntime.llmRuntime,
       }),
     };
   }

--- a/src/core/chat/engine/turns/runtime/runtime-resolver.ts
+++ b/src/core/chat/engine/turns/runtime/runtime-resolver.ts
@@ -1,9 +1,7 @@
 import { join } from 'node:path';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
-import {
-  RuntimeCredentialService,
-} from '@/core/runtime/credentials/index.js';
+import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
 import { appendAwarenessDomainSystemContext } from '@/core/awareness/domain-prompt.js';
 import { MemoryCatalogService } from '@/core/memory/catalog.js';
 import type { ApiKeyRuntime } from '@/core/runtime/credentials/index.js';
@@ -27,26 +25,21 @@ export class ConversationTurnRuntimeResolver {
       sessionModel: session.model,
       env: config.env,
     });
-    const provider = LlmAdapterService.inferProvider(model);
     const credentialRuntime = ConversationTurnRuntimeResolver.credentialRuntime(config);
-    const apiKey = config.apiKey ?? RuntimeCredentialService.resolveApiKeyForModel(model, credentialRuntime);
-    const providerCredentialSource = RuntimeCredentialService.resolveCredentialSourceForModel(model, {
+    const providerRuntime = LlmProviderRuntimeService.resolve({
       ...credentialRuntime,
-      apiKey,
-      apiKeyProvider: config.apiKey ? 'explicit' : apiKey ? provider : undefined,
-    });
-
-    ConversationTurnRuntimeResolver.assertCredential({
       model,
-      credentialRuntime,
+      reasoningEffort: session.reasoningEffort,
     });
+    LlmProviderRuntimeService.assertRunnable(providerRuntime);
 
+    const apiKey = config.apiKey ?? providerRuntime.apiKey;
     const memoryDir = join(config.stateRoot, 'memory');
     return {
       model,
-      provider,
+      provider: providerRuntime.provider,
       apiKey,
-      providerCredentialSource,
+      providerCredentialSource: providerRuntime.credentialSource,
       memoryDir,
       systemContext: appendAwarenessDomainSystemContext(new MemoryCatalogService(memoryDir).appendCatalogSystemContext({
         systemContext: config.systemContext,
@@ -59,6 +52,7 @@ export class ConversationTurnRuntimeResolver {
           credentialStorePath: config.credentialStorePath,
         },
         runtime: {
+          ...providerRuntime.llmRuntime,
           reasoningEffort: session.reasoningEffort,
         },
       }),
@@ -72,13 +66,5 @@ export class ConversationTurnRuntimeResolver {
       credentialStorePath: config.credentialStorePath,
       preferApiKey: config.preferApiKey,
     };
-  }
-
-  private static assertCredential(args: { model: string; credentialRuntime: ApiKeyRuntime }) {
-    const hasCredential = RuntimeCredentialService.hasCredentialForModel(args.model, args.credentialRuntime);
-
-    if (!hasCredential) {
-      throw new Error(RuntimeCredentialService.formatMissingCredentialMessage(args.model));
-    }
   }
 }

--- a/src/core/llm/adapters/ollama/index.ts
+++ b/src/core/llm/adapters/ollama/index.ts
@@ -1,0 +1,3 @@
+export { OllamaAdapter } from './ollama-adapter.js';
+export type { OllamaAdapterOptions } from './ollama-adapter.js';
+export { OllamaProviderAdapter } from './ollama-provider-adapter.js';

--- a/src/core/llm/adapters/ollama/ollama-adapter.ts
+++ b/src/core/llm/adapters/ollama/ollama-adapter.ts
@@ -1,0 +1,114 @@
+import type {
+  ChatMessage,
+  LlmAdapter,
+  LlmAdapterCapabilities,
+  LlmAdapterCreateInput,
+  LlmProviderEndpointAuth,
+  LlmResponse,
+  LlmStreamEvent,
+} from '@/core/llm/types.js';
+import type { ToolDefinition } from '@/core/types.js';
+import { OllamaCodec } from './ollama-codec.js';
+import { OllamaModelName } from './ollama-model.js';
+
+export type OllamaAdapterOptions = LlmAdapterCreateInput & {
+  provider: 'ollama';
+  model: string;
+};
+
+/**
+ * Ollama implementation of the LLM port using Ollama's OpenAI-compatible
+ * `/chat/completions` endpoint. Runtime code must pass the resolved endpoint;
+ * this adapter only translates Heddle messages/tools to provider HTTP.
+ */
+export class OllamaAdapter implements LlmAdapter {
+  private static readonly capabilities: LlmAdapterCapabilities = {
+    toolCalls: true,
+    systemMessages: true,
+    reasoningSummaries: false,
+    parallelToolCalls: false,
+  };
+
+  readonly info;
+
+  private readonly model: string;
+  private readonly displayModel: string;
+  private readonly endpointBaseUrl: string;
+  private readonly endpointAuth: LlmProviderEndpointAuth;
+  private readonly fetcher: (url: unknown, init?: unknown) => Promise<globalThis.Response>;
+
+  constructor(options: OllamaAdapterOptions) {
+    const endpoint = options.runtime?.endpoint;
+    if (!endpoint) {
+      throw new Error('Missing Ollama endpoint runtime. Resolve provider runtime before creating the Ollama adapter.');
+    }
+
+    this.model = OllamaModelName.toProviderModel(options.model);
+    this.displayModel = OllamaModelName.toHeddleModel(this.model);
+    this.endpointBaseUrl = OllamaAdapter.trimTrailingSlash(endpoint.baseUrl);
+    this.endpointAuth = endpoint.auth;
+    this.fetcher = options.runtime?.fetchImpl ?? OllamaAdapter.defaultFetch;
+    this.info = {
+      provider: 'ollama',
+      model: this.displayModel,
+      capabilities: OllamaAdapter.capabilities,
+    } satisfies LlmAdapter['info'];
+  }
+
+  async chat(
+    messages: ChatMessage[],
+    tools: ToolDefinition[],
+    signal?: AbortSignal,
+    onStreamEvent?: (event: LlmStreamEvent) => void,
+  ): Promise<LlmResponse> {
+    const response = await this.fetcher(`${this.endpointBaseUrl}/chat/completions`, {
+      method: 'POST',
+      signal,
+      headers: OllamaAdapter.headers(this.endpointAuth),
+      body: JSON.stringify({
+        model: this.model,
+        messages: OllamaCodec.toMessages(messages),
+        tools: tools.length > 0 ? OllamaCodec.toTools(tools) : undefined,
+        tool_choice: tools.length > 0 ? 'auto' : undefined,
+        stream: false,
+      }),
+    });
+
+    const body = await OllamaAdapter.readJsonResponse(response);
+    const content = OllamaCodec.extractContent(body);
+    if (content) {
+      onStreamEvent?.({ type: 'content.delta', delta: content });
+      onStreamEvent?.({ type: 'content.done', content });
+    }
+
+    return {
+      content,
+      toolCalls: OllamaCodec.extractToolCalls(body),
+      usage: OllamaCodec.extractUsage(body),
+    };
+  }
+
+  private static async readJsonResponse(response: globalThis.Response): Promise<unknown> {
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`Ollama chat-completions request failed: ${response.status} ${response.statusText}${text ? `: ${text}` : ''}`);
+    }
+
+    return text.trim() ? JSON.parse(text) : {};
+  }
+
+  private static trimTrailingSlash(value: string): string {
+    return value.replace(/\/+$/, '');
+  }
+
+  private static headers(auth: LlmProviderEndpointAuth): Record<string, string> {
+    return {
+      'content-type': 'application/json',
+      ...(auth.type === 'bearer' ? { authorization: `Bearer ${auth.token}` } : {}),
+    };
+  }
+
+  private static async defaultFetch(url: unknown, init?: unknown): Promise<globalThis.Response> {
+    return await fetch(url as URL | RequestInfo, init as RequestInit | undefined);
+  }
+}

--- a/src/core/llm/adapters/ollama/ollama-codec.ts
+++ b/src/core/llm/adapters/ollama/ollama-codec.ts
@@ -1,0 +1,156 @@
+import type { ChatMessage, LlmUsage } from '@/core/llm/types.js';
+import type { ToolCall, ToolDefinition } from '@/core/types.js';
+
+type OllamaChatCompletionMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  tool_call_id?: string;
+  tool_calls?: OllamaToolCall[];
+};
+
+type OllamaToolCall = {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
+type OllamaFunctionTool = {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+};
+
+/**
+ * Provider-owned codec for Ollama's OpenAI-compatible chat completions API.
+ * Keep request/response quirks here so the agent loop only sees Heddle's
+ * provider-neutral ChatMessage, ToolDefinition, ToolCall, and LlmUsage types.
+ */
+export class OllamaCodec {
+  static toMessages(messages: ChatMessage[]): OllamaChatCompletionMessage[] {
+    return messages.map((message) => {
+      if (message.role === 'assistant') {
+        return {
+          role: 'assistant',
+          content: message.content || null,
+          tool_calls: message.toolCalls?.map((call) => OllamaCodec.toToolCall(call)),
+        };
+      }
+
+      if (message.role === 'tool') {
+        return {
+          role: 'tool',
+          content: message.content,
+          tool_call_id: message.toolCallId,
+        };
+      }
+
+      return {
+        role: message.role,
+        content: message.content,
+      };
+    });
+  }
+
+  static toTools(tools: ToolDefinition[]): OllamaFunctionTool[] {
+    return tools.map((tool) => ({
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      },
+    }));
+  }
+
+  static extractContent(response: unknown): string | undefined {
+    const content = OllamaCodec.firstMessage(response)?.content;
+    return typeof content === 'string' && content.length > 0 ? content : undefined;
+  }
+
+  static extractToolCalls(response: unknown): ToolCall[] | undefined {
+    const toolCalls = OllamaCodec.firstMessage(response)?.tool_calls;
+    if (!Array.isArray(toolCalls)) {
+      return undefined;
+    }
+
+    const parsed = toolCalls.flatMap((call): ToolCall[] => {
+      if (!call || typeof call !== 'object') {
+        return [];
+      }
+      const entry = call as Partial<OllamaToolCall>;
+      const id = typeof entry.id === 'string' ? entry.id : undefined;
+      const name = typeof entry.function?.name === 'string' ? entry.function.name : undefined;
+      const argumentsText = typeof entry.function?.arguments === 'string' ? entry.function.arguments : undefined;
+      if (!id || !name || typeof argumentsText !== 'string') {
+        return [];
+      }
+
+      return [{
+        id,
+        tool: name,
+        input: argumentsText.trim() ? JSON.parse(argumentsText) : {},
+      }];
+    });
+
+    return parsed.length > 0 ? parsed : undefined;
+  }
+
+  static extractUsage(response: unknown): LlmUsage | undefined {
+    if (!response || typeof response !== 'object') {
+      return undefined;
+    }
+
+    const usage = (response as { usage?: unknown }).usage;
+    if (!usage || typeof usage !== 'object') {
+      return undefined;
+    }
+
+    const inputTokens = OllamaCodec.numberField(usage, 'prompt_tokens') ?? 0;
+    const outputTokens = OllamaCodec.numberField(usage, 'completion_tokens') ?? 0;
+    return {
+      inputTokens,
+      outputTokens,
+      totalTokens: OllamaCodec.numberField(usage, 'total_tokens') ?? inputTokens + outputTokens,
+      requests: 1,
+    };
+  }
+
+  private static toToolCall(call: ToolCall): OllamaToolCall {
+    return {
+      id: call.id,
+      type: 'function',
+      function: {
+        name: call.tool,
+        arguments: JSON.stringify(call.input),
+      },
+    };
+  }
+
+  private static firstMessage(response: unknown): {
+    content?: unknown;
+    tool_calls?: unknown;
+  } | undefined {
+    if (!response || typeof response !== 'object') {
+      return undefined;
+    }
+
+    const choices = (response as { choices?: unknown }).choices;
+    if (!Array.isArray(choices)) {
+      return undefined;
+    }
+
+    const message = (choices[0] as { message?: unknown } | undefined)?.message;
+    return message && typeof message === 'object' ? message : undefined;
+  }
+
+  private static numberField(value: object, key: string): number | undefined {
+    const field = (value as Record<string, unknown>)[key];
+    return typeof field === 'number' ? field : undefined;
+  }
+}

--- a/src/core/llm/adapters/ollama/ollama-model.ts
+++ b/src/core/llm/adapters/ollama/ollama-model.ts
@@ -1,0 +1,17 @@
+/**
+ * Ollama models are selected in Heddle with an `ollama/` or `ollama:` prefix,
+ * while Ollama's OpenAI-compatible endpoint expects the local model name.
+ */
+export class OllamaModelName {
+  static toProviderModel(model: string): string {
+    return model.trim().replace(/^ollama[/:]/i, '');
+  }
+
+  static toHeddleModel(model: string): string {
+    const providerModel = OllamaModelName.toProviderModel(model);
+    if (!providerModel) {
+      throw new Error('Ollama model name is required.');
+    }
+    return `ollama/${providerModel}`;
+  }
+}

--- a/src/core/llm/adapters/ollama/ollama-provider-adapter.ts
+++ b/src/core/llm/adapters/ollama/ollama-provider-adapter.ts
@@ -1,0 +1,30 @@
+import type { LlmAdapterCreateInput } from '@/core/llm/types.js';
+import type { LlmProviderAdapter } from '@/core/llm/registry/index.js';
+import { LlmProviderInference } from '@/core/llm/registry/provider-inference.js';
+import { OllamaAdapter } from './ollama-adapter.js';
+import { OllamaModelName } from './ollama-model.js';
+
+/**
+ * Registers Ollama as a first-class provider. The adapter requires an explicit
+ * model selection or OLLAMA_MODEL, because installed local model names vary by
+ * machine and should not be hardcoded in runtime policy.
+ */
+export class OllamaProviderAdapter implements LlmProviderAdapter {
+  readonly provider = 'ollama' as const;
+
+  inferModel(model: string): boolean {
+    return LlmProviderInference.matchesProviderModel(this.provider, model.trim());
+  }
+
+  defaultModel(): string {
+    const model = process.env.OLLAMA_MODEL?.trim();
+    if (!model) {
+      throw new Error('Ollama model is required. Set OLLAMA_MODEL or select a model with the ollama/<model> prefix.');
+    }
+    return OllamaModelName.toHeddleModel(model);
+  }
+
+  createAdapter(input: LlmAdapterCreateInput & { provider: 'ollama'; model: string }): OllamaAdapter {
+    return new OllamaAdapter(input);
+  }
+}

--- a/src/core/llm/index.ts
+++ b/src/core/llm/index.ts
@@ -1,6 +1,8 @@
 export { LlmAdapterService } from './service.js';
 export { AnthropicAdapter, AnthropicProviderAdapter } from './adapters/anthropic/index.js';
 export type { AnthropicAdapterOptions } from './adapters/anthropic/index.js';
+export { OllamaAdapter, OllamaProviderAdapter } from './adapters/ollama/index.js';
+export type { OllamaAdapterOptions } from './adapters/ollama/index.js';
 export {
   OpenAiAdapter,
   OpenAiCodexSseService,
@@ -29,6 +31,8 @@ export type {
   LlmAdapterCreateInput,
   LlmAdapterInfo,
   LlmCredentialContext,
+  LlmProviderEndpointAuth,
+  LlmProviderEndpointRuntime,
   LlmProvider,
   LlmProviderResolutionInput,
   LlmResponse,

--- a/src/core/llm/registry/builtin-llm-providers.ts
+++ b/src/core/llm/registry/builtin-llm-providers.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_LLM_PROVIDER } from '@/core/config.js';
 import { AnthropicProviderAdapter } from '../adapters/anthropic/index.js';
+import { OllamaProviderAdapter } from '../adapters/ollama/index.js';
 import { OpenAiProviderAdapter } from '../adapters/openai/index.js';
 import { LlmProviderRegistry } from './llm-provider-registry.js';
 
@@ -10,6 +11,7 @@ export class BuiltinLlmProviderRegistry {
       providers: [
         new OpenAiProviderAdapter(),
         new AnthropicProviderAdapter(),
+        new OllamaProviderAdapter(),
       ],
     });
   }

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -76,9 +76,20 @@ export type LlmCredentialContext = {
   credentialStorePath?: string;
 };
 
+export type LlmProviderEndpointAuth =
+  | { type: 'none' }
+  | { type: 'bearer'; token: string };
+
+export type LlmProviderEndpointRuntime = {
+  baseUrl: string;
+  auth: LlmProviderEndpointAuth;
+  timeoutMs?: number;
+};
+
 export type LlmRuntimeContext = {
   reasoningEffort?: ReasoningEffort;
   fetchImpl?: (url: unknown, init?: unknown) => Promise<globalThis.Response>;
+  endpoint?: LlmProviderEndpointRuntime;
 };
 
 export type LlmAdapterCreateInput = {

--- a/src/core/runtime/README.md
+++ b/src/core/runtime/README.md
@@ -26,6 +26,8 @@ coordination that sit around the lower-level agent loop.
 - `loop/`: evented programmatic run service, loop event contracts, and
   checkpoint state helpers.
 - `credentials/`: provider credential source resolution for runtime execution.
+- `provider-runtime/`: provider, credential-source, and adapter-runtime
+  resolution for selected models.
 - `tools/`: default runtime tool bundle assembly.
 - `workspaces/`: workspace catalog service, repository, types, and schemas.
 - `daemon/`: daemon registry service, host resolver, message formatter, types,

--- a/src/core/runtime/credentials/README.md
+++ b/src/core/runtime/credentials/README.md
@@ -4,6 +4,11 @@ Runtime credentials own provider credential source selection for generic agent
 execution.
 
 `RuntimeCredentialService` decides whether a model will use an explicit API key,
-an environment API key, a stored OAuth credential, or no available credential.
-Callers should resolve this once at their owning runtime boundary and pass the
-concrete result downward.
+an environment API key, a stored OAuth credential, a local no-auth endpoint, or
+no available credential. Callers should resolve this once at their owning
+runtime boundary and pass the concrete result downward.
+
+Local providers are not "missing credentials." For example, Ollama resolves to a
+`local-endpoint` source with the OpenAI-compatible base URL. Adapter creation
+still happens in `src/core/llm`; this domain only owns the runtime credential
+source used to decide whether execution is allowed.

--- a/src/core/runtime/credentials/service.ts
+++ b/src/core/runtime/credentials/service.ts
@@ -10,6 +10,8 @@ import type { ApiKeyRuntime, ProviderCredentialSource } from './types.js';
  * Resolves runtime credential sources for provider-backed agent execution.
  */
 export class RuntimeCredentialService {
+  static readonly DEFAULT_OLLAMA_OPENAI_BASE_URL = 'http://127.0.0.1:11434/v1';
+
   static resolveProviderApiKey(provider: LlmProvider): string | undefined {
     switch (provider) {
       case 'openai':
@@ -25,6 +27,10 @@ export class RuntimeCredentialService {
 
   static resolveApiKeyForModel(model: string, runtime?: ApiKeyRuntime): string | undefined {
     const source = this.resolveCredentialSourceForModel(model, runtime);
+
+    if (source.type === 'local-endpoint') {
+      return undefined;
+    }
 
     if (source.type === 'explicit-api-key') {
       return runtime?.apiKey;
@@ -60,6 +66,11 @@ export class RuntimeCredentialService {
     runtime?: ApiKeyRuntime,
   ): ProviderCredentialSource {
     const provider = LlmAdapterService.inferProvider(model);
+    const localEndpointSource = this.resolveLocalEndpointCredentialSource(provider);
+    if (localEndpointSource) {
+      return localEndpointSource;
+    }
+
     if (runtime?.apiKey && runtime.apiKeyProvider === 'explicit') {
       return { type: 'explicit-api-key' };
     }
@@ -97,6 +108,18 @@ export class RuntimeCredentialService {
     return { type: 'missing', provider };
   }
 
+  static resolveLocalEndpointCredentialSource(provider: LlmProvider): Extract<ProviderCredentialSource, { type: 'local-endpoint' }> | undefined {
+    if (provider !== 'ollama') {
+      return undefined;
+    }
+
+    return {
+      type: 'local-endpoint',
+      provider,
+      baseUrl: RuntimeCredentialService.resolveOllamaOpenAiBaseUrl(),
+    };
+  }
+
   static formatMissingCredentialMessage(model: string): string {
     const provider = LlmAdapterService.inferProvider(model);
     if (provider === 'openai') {
@@ -112,5 +135,18 @@ export class RuntimeCredentialService {
 
   private static firstDefinedNonEmpty(...values: Array<string | undefined>): string | undefined {
     return values.find((value) => typeof value === 'string' && value.trim().length > 0);
+  }
+
+  private static resolveOllamaOpenAiBaseUrl(): string {
+    const configured = RuntimeCredentialService.firstDefinedNonEmpty(
+      process.env.OLLAMA_OPENAI_BASE_URL,
+      process.env.OLLAMA_BASE_URL,
+    );
+    if (!configured) {
+      return RuntimeCredentialService.DEFAULT_OLLAMA_OPENAI_BASE_URL;
+    }
+
+    const trimmed = configured.replace(/\/+$/, '');
+    return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
   }
 }

--- a/src/core/runtime/credentials/types.ts
+++ b/src/core/runtime/credentials/types.ts
@@ -11,4 +11,5 @@ export type ProviderCredentialSource =
   | { type: 'explicit-api-key' }
   | { type: 'env-api-key'; provider: LlmProvider }
   | { type: 'oauth'; provider: LlmProvider; accountId?: string; expiresAt?: number }
+  | { type: 'local-endpoint'; provider: Extract<LlmProvider, 'ollama'>; baseUrl: string }
   | { type: 'missing'; provider: LlmProvider };

--- a/src/core/runtime/loop/service.ts
+++ b/src/core/runtime/loop/service.ts
@@ -30,7 +30,9 @@ export class AgentLoopRuntimeService {
       credentialStorePath,
       reasoningEffort: options.reasoningEffort,
     });
-    LlmProviderRuntimeService.assertRunnable(providerRuntime);
+    if (!options.llm) {
+      LlmProviderRuntimeService.assertRunnable(providerRuntime);
+    }
     const apiKey = options.apiKey ?? providerRuntime.apiKey;
     const llm = options.llm ?? await this.createLoopLlmAdapter({
       model,

--- a/src/core/runtime/loop/service.ts
+++ b/src/core/runtime/loop/service.ts
@@ -6,11 +6,11 @@ import { AgentRunService } from '@/core/agent/index.js';
 import type { AgentRunEvent } from '@/core/agent/index.js';
 import { AgentSkillsRuntimeContextService } from '@/core/skills/index.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
-import type { LlmAdapter, ReasoningEffort } from '@/core/llm/types.js';
+import type { LlmAdapter, LlmRuntimeContext, ReasoningEffort } from '@/core/llm/types.js';
 import type { ToolDefinition } from '@/core/types.js';
 import { createLogger } from '@/core/utils/logger.js';
-import { RuntimeCredentialService } from '../credentials/index.js';
 import type { ProviderCredentialSource } from '../credentials/index.js';
+import { LlmProviderRuntimeService } from '../provider-runtime/index.js';
 import { RuntimeToolService } from '../tools/index.js';
 import { AgentLoopCheckpointService } from './checkpoint.js';
 import type { AgentLoopResult, RunAgentLoopOptions } from './types.js';
@@ -22,26 +22,28 @@ export class AgentLoopRuntimeService {
   static async run(options: RunAgentLoopOptions): Promise<AgentLoopResult> {
     const runId = AgentLoopCheckpointService.generateRunId();
     const model = options.model ?? options.llm?.info?.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
-    const provider = LlmAdapterService.inferProvider(model);
     const workspaceRoot = resolve(options.workspaceRoot ?? process.cwd());
-    const apiKey = options.apiKey ?? RuntimeCredentialService.resolveApiKeyForModel(model);
     const credentialStorePath = this.resolveCredentialStorePath({ workspaceRoot, stateDir: options.stateDir });
-    const providerCredentialSource = RuntimeCredentialService.resolveCredentialSourceForModel(model, {
-      apiKey,
-      apiKeyProvider: options.apiKey ? 'explicit' : apiKey ? provider : undefined,
+    const providerRuntime = LlmProviderRuntimeService.resolve({
+      model,
+      apiKey: options.apiKey,
       credentialStorePath,
+      reasoningEffort: options.reasoningEffort,
     });
+    LlmProviderRuntimeService.assertRunnable(providerRuntime);
+    const apiKey = options.apiKey ?? providerRuntime.apiKey;
     const llm = options.llm ?? await this.createLoopLlmAdapter({
       model,
       apiKey,
       credentialStorePath,
       reasoningEffort: options.reasoningEffort,
+      runtime: providerRuntime.llmRuntime,
     });
     const logger = options.logger ?? createLogger({ pretty: false, level: 'info', console: false });
     const tools = this.resolveTools(options, {
       model,
       apiKey,
-      providerCredentialSource,
+      providerCredentialSource: providerRuntime.credentialSource,
       workspaceRoot,
       credentialStorePath,
     });
@@ -55,9 +57,9 @@ export class AgentLoopRuntimeService {
 
     logger.info({
       model,
-      provider,
-      credentialSource: providerCredentialSource.type,
-      credentialProvider: 'provider' in providerCredentialSource ? providerCredentialSource.provider : undefined,
+      provider: providerRuntime.provider,
+      credentialSource: providerRuntime.credentialSource.type,
+      credentialProvider: 'provider' in providerRuntime.credentialSource ? providerRuntime.credentialSource.provider : undefined,
     }, 'Agent runtime configured');
 
     const resumeMetadata = AgentLoopCheckpointService.resolveResumeMetadata(options.resumeFrom);
@@ -68,7 +70,7 @@ export class AgentLoopRuntimeService {
       runId,
       goal: options.goal,
       model,
-      provider,
+      provider: providerRuntime.provider,
       workspaceRoot,
       resumedFromCheckpoint: resumeMetadata?.checkpointRunId,
       timestamp: startedAt,
@@ -107,7 +109,7 @@ export class AgentLoopRuntimeService {
       runId,
       goal: options.goal,
       model,
-      provider,
+      provider: providerRuntime.provider,
       workspaceRoot,
       startedAt,
       finishedAt,
@@ -128,7 +130,7 @@ export class AgentLoopRuntimeService {
     return {
       ...result,
       model,
-      provider,
+      provider: providerRuntime.provider,
       workspaceRoot,
       state,
     };
@@ -164,6 +166,7 @@ export class AgentLoopRuntimeService {
     apiKey?: string;
     credentialStorePath?: string;
     reasoningEffort?: ReasoningEffort;
+    runtime: LlmRuntimeContext;
   }): Promise<LlmAdapter> {
     return LlmAdapterService.create({
       model: options.model,
@@ -172,6 +175,7 @@ export class AgentLoopRuntimeService {
         credentialStorePath: options.credentialStorePath,
       },
       runtime: {
+        ...options.runtime,
         reasoningEffort: options.reasoningEffort,
       },
     });

--- a/src/core/runtime/provider-runtime/README.md
+++ b/src/core/runtime/provider-runtime/README.md
@@ -1,0 +1,12 @@
+# Provider Runtime
+
+Provider runtime resolution composes the lower-level LLM adapter boundary with
+runtime credential policy. It answers one question for host-facing execution:
+"given this selected model, what concrete provider, credential source, API key,
+and adapter runtime should be used?"
+
+Keep provider transport facts here when they are runtime concerns, such as the
+Ollama OpenAI-compatible endpoint. Do not move this logic into CLI/web/server
+controllers, and do not make `src/core/llm` import runtime credential services.
+`src/core/llm` defines adapter contracts and provider adapters; this domain
+resolves the executable runtime facts and passes them downward.

--- a/src/core/runtime/provider-runtime/index.ts
+++ b/src/core/runtime/provider-runtime/index.ts
@@ -1,0 +1,5 @@
+export { LlmProviderRuntimeService } from './service.js';
+export type {
+  LlmProviderRuntimeInput,
+  LlmProviderRuntimeResolution,
+} from './types.js';

--- a/src/core/runtime/provider-runtime/service.ts
+++ b/src/core/runtime/provider-runtime/service.ts
@@ -1,0 +1,53 @@
+import { LlmAdapterService } from '@/core/llm/index.js';
+import {
+  RuntimeCredentialService,
+} from '../credentials/index.js';
+import type { ApiKeyRuntime } from '../credentials/index.js';
+import type { LlmProviderRuntimeInput, LlmProviderRuntimeResolution } from './types.js';
+
+/**
+ * Resolves provider-specific execution facts once at the runtime boundary.
+ * Callers should pass the returned `llmRuntime` into `LlmAdapterService.create`
+ * instead of reconstructing endpoint or credential policy at call sites.
+ */
+export class LlmProviderRuntimeService {
+  static resolve(input: LlmProviderRuntimeInput): LlmProviderRuntimeResolution {
+    const provider = LlmAdapterService.inferProvider(input.model);
+    const credentialRuntime = LlmProviderRuntimeService.credentialRuntime(input);
+    const apiKey = RuntimeCredentialService.resolveApiKeyForModel(input.model, credentialRuntime);
+    const credentialSource = RuntimeCredentialService.resolveCredentialSourceForModel(input.model, {
+      ...credentialRuntime,
+      apiKey,
+      apiKeyProvider: input.apiKey ? 'explicit' : apiKey ? provider : undefined,
+    });
+
+    return {
+      model: input.model,
+      provider,
+      apiKey,
+      credentialSource,
+      llmRuntime: {
+        reasoningEffort: input.reasoningEffort,
+        endpoint: credentialSource.type === 'local-endpoint' ? {
+          baseUrl: credentialSource.baseUrl,
+          auth: { type: 'none' },
+        } : undefined,
+      },
+    };
+  }
+
+  static assertRunnable(resolution: Pick<LlmProviderRuntimeResolution, 'model' | 'credentialSource'>): void {
+    if (resolution.credentialSource.type === 'missing') {
+      throw new Error(RuntimeCredentialService.formatMissingCredentialMessage(resolution.model));
+    }
+  }
+
+  private static credentialRuntime(input: LlmProviderRuntimeInput): ApiKeyRuntime {
+    return {
+      apiKey: input.apiKey,
+      apiKeyProvider: input.apiKey ? 'explicit' : undefined,
+      credentialStorePath: input.credentialStorePath,
+      preferApiKey: input.preferApiKey,
+    };
+  }
+}

--- a/src/core/runtime/provider-runtime/types.ts
+++ b/src/core/runtime/provider-runtime/types.ts
@@ -1,0 +1,15 @@
+import type { LlmProvider, LlmRuntimeContext, ReasoningEffort } from '@/core/llm/types.js';
+import type { ApiKeyRuntime, ProviderCredentialSource } from '../credentials/index.js';
+
+export type LlmProviderRuntimeInput = ApiKeyRuntime & {
+  model: string;
+  reasoningEffort?: ReasoningEffort;
+};
+
+export type LlmProviderRuntimeResolution = {
+  model: string;
+  provider: LlmProvider;
+  apiKey: string | undefined;
+  credentialSource: ProviderCredentialSource;
+  llmRuntime: LlmRuntimeContext;
+};

--- a/src/server/controllers/trpc/control-plane/ask.ts
+++ b/src/server/controllers/trpc/control-plane/ask.ts
@@ -6,11 +6,11 @@ import {
   createLogger,
   TraceConsoleFormatter,
   AgentLoopRuntimeService,
-  RuntimeCredentialService,
   type RunResult,
 } from '@/index.js';
 import { MemoryCatalogService } from '@/core/memory/catalog.js';
 import { MemoryMaintenanceIntegrationService } from '@/core/memory/maintenance-integration.js';
+import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
 
 // Legacy control-plane one-shot ask path. New ask callers should create a
 // `retention: "one_off"` chat session and submit through the session turn API
@@ -38,14 +38,17 @@ export class ControlPlaneAskController {
     const maxSteps = args.maxSteps ?? ControlPlaneAskController.parsePositiveInt(process.env.HEDDLE_MAX_STEPS) ?? 100;
     const logger = createLogger({ pretty: true, level: 'debug' });
     const memoryDir = join(args.stateRoot, 'memory');
-    const apiKey = RuntimeCredentialService.resolveApiKeyForModel(model, {
+    const providerRuntime = LlmProviderRuntimeService.resolve({
+      model,
       apiKey: args.apiKey,
-      apiKeyProvider: args.apiKey ? 'explicit' : undefined,
       preferApiKey: args.preferApiKey,
     });
+    LlmProviderRuntimeService.assertRunnable(providerRuntime);
+    const apiKey = args.apiKey ?? providerRuntime.apiKey;
     const llm = LlmAdapterService.create({
       model,
       credentials: { apiKey },
+      runtime: providerRuntime.llmRuntime,
     });
 
     const result = await AgentLoopRuntimeService.run({

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -42,6 +42,7 @@ import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import { ModelPolicyService } from '@/core/llm/models/index.js';
 import { LlmAdapterService } from '@/core/llm/index.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
+import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
 import { RuntimeSubscriptionStream } from '@/core/runtime/subscriptions/index.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
 import { ControlPlaneChatSessionEventsController } from './chat-session-events.js';
@@ -731,17 +732,21 @@ export class ControlPlaneChatSessionsController {
       activeModel,
       credentialMode,
     });
-    const titleCredentialSource = RuntimeCredentialService.resolveCredentialSourceForModel(titleModel, args);
-    if (titleCredentialSource.type === 'missing') {
+    const providerRuntime = LlmProviderRuntimeService.resolve({
+      ...args,
+      model: titleModel,
+    });
+    if (providerRuntime.credentialSource.type === 'missing') {
       return undefined;
     }
 
     return LlmAdapterService.create({
       model: titleModel,
       credentials: {
-        apiKey: RuntimeCredentialService.resolveApiKeyForModel(titleModel, args),
+        apiKey: providerRuntime.apiKey,
         credentialStorePath: args.credentialStorePath,
       },
+      runtime: providerRuntime.llmRuntime,
     });
   }
 

--- a/src/server/services/control-plane/session-runtime-context-service.ts
+++ b/src/server/services/control-plane/session-runtime-context-service.ts
@@ -6,7 +6,7 @@ import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import { AutonomyPermissionModeService } from '@/core/approvals/index.js';
 import { ModelCatalogService, ModelPolicyService } from '@/core/llm/models/index.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
-import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
+import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
 import type { ChatSessionView, ControlPlaneSessionRuntimeContext } from '@/server/control-plane-types.js';
 import { ControlPlaneSessionDriftService } from './session-drift-service.js';
 
@@ -58,7 +58,12 @@ export class ControlPlaneSessionRuntimeContextService {
     const session = sessions.require(args.sessionId);
     const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
     const estimatedInputTokens = session.context?.request?.usage?.inputTokens ?? session.context?.request?.estimatedTokens;
-    const credentialSource = RuntimeCredentialService.resolveCredentialSourceForModel(model, args);
+    const providerRuntime = LlmProviderRuntimeService.resolve({
+      ...args,
+      model,
+      reasoningEffort: session.reasoningEffort,
+    });
+    const credentialSource = providerRuntime.credentialSource;
     const projectConfig = ProjectConfigService.read(args.workspaceRoot);
     const permissionMode = AutonomyPermissionModeService.resolveMode({
       config: projectConfig,


### PR DESCRIPTION
## Summary
- add a first-class Ollama LLM adapter using Ollama's OpenAI-compatible chat-completions endpoint
- add runtime provider resolution so local endpoint credentials, adapter runtime, chat turns, ask, memory maintenance, and session runtime context share one boundary
- update Ollama smoke/docs to auto-select an installed non-embedding model and support strict tool-call gating

## Validation
- yarn typecheck
- yarn lint
- yarn test
- yarn build
- yarn smoke:ollama --require-tool-calls
- yarn -s cli:dev --force-owner-conflict --model ollama/llama3.2:latest --max-steps 1 ask "Reply with exactly: ok"

## Notes
- Ollama has no hardcoded default model. Runtime use should pass ollama/<installed-model> or set OLLAMA_MODEL.
- During verification, an older live Heddle chat server was serving port 8765; I stopped it and reran the CLI check against this branch's embedded server.