### PR TITLE
[codex] discover Ollama models for selectors

### DIFF
--- a/docs/reference/providers-and-models.md
+++ b/docs/reference/providers-and-models.md
@@ -117,6 +117,14 @@ In chat, you can also use:
 - `/model set <query>`
 - `/model <name>`
 
+When Ollama is running, `/model set <query>` and the web model selector include
+installed local Ollama models from the local Ollama API. Pick one from the
+selector, or type it directly with the `ollama/` prefix:
+
+```text
+/model ollama/llama3.2:latest
+```
+
 ## Auth Commands
 
 Provider credential commands:

--- a/src/__tests__/unit/cli-v2/picker-service.test.ts
+++ b/src/__tests__/unit/cli-v2/picker-service.test.ts
@@ -14,6 +14,14 @@ describe('CliV2PickerService', () => {
             { id: 'gpt-5.4-mini', disabled: false },
           ],
         },
+        {
+          label: 'Ollama · Installed local models',
+          models: ['ollama/llama3.2:latest'],
+          source: 'local-discovered',
+          options: [
+            { id: 'ollama/llama3.2:latest', label: 'llama3.2:latest', disabled: false },
+          ],
+        },
       ],
     };
 
@@ -22,6 +30,9 @@ describe('CliV2PickerService', () => {
     expect(query).toBe('mini');
     expect(CliV2PickerService.filterModels(modelOptions, query)).toEqual([
       { id: 'gpt-5.4-mini', disabled: false },
+    ]);
+    expect(CliV2PickerService.filterModels(modelOptions, 'llama')).toEqual([
+      { id: 'ollama/llama3.2:latest', label: 'llama3.2:latest', disabled: false },
     ]);
   });
 

--- a/src/__tests__/unit/core/model-options.test.ts
+++ b/src/__tests__/unit/core/model-options.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ModelOptionsService } from '@/core/llm/models/index.js';
+
+describe('ModelOptionsService', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('adds installed Ollama models to the shared control-plane model options', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      models: [
+        {
+          name: 'qwen3:8b',
+          size: 5_234,
+          modified_at: '2026-06-11T00:00:00Z',
+          capabilities: ['completion', 'tools'],
+        },
+        {
+          name: 'llama3.2:latest',
+          size: 1_234,
+          modified_at: '2026-06-10T00:00:00Z',
+          capabilities: ['completion'],
+        },
+        {
+          name: 'nomic-embed-text:latest',
+          size: 234,
+          modified_at: '2026-06-09T00:00:00Z',
+          capabilities: ['embedding'],
+        },
+      ],
+    })));
+
+    const options = await ModelOptionsService.resolve({
+      ollamaBaseUrl: 'http://ollama.local/',
+      fetchImpl,
+    });
+    const ollamaGroup = options.groups.find((group) => group.label === 'Ollama · Installed local models');
+
+    expect(fetchImpl).toHaveBeenCalledWith('http://ollama.local/api/tags', {
+      method: 'GET',
+      signal: undefined,
+    });
+    expect(ollamaGroup).toMatchObject({
+      label: 'Ollama · Installed local models',
+      source: 'local-discovered',
+      models: ['ollama/llama3.2:latest', 'ollama/qwen3:8b'],
+      options: [
+        {
+          id: 'ollama/llama3.2:latest',
+          label: 'llama3.2:latest',
+          disabled: false,
+          disabledReason: undefined,
+        },
+        {
+          id: 'ollama/qwen3:8b',
+          label: 'qwen3:8b',
+          disabled: false,
+          disabledReason: undefined,
+        },
+      ],
+    });
+  });
+
+  it('keeps built-in model options available when Ollama is not running', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('connection refused');
+    });
+
+    const options = await ModelOptionsService.resolve({
+      ollamaBaseUrl: 'http://ollama.local',
+      fetchImpl,
+    });
+
+    expect(options.groups.some((group) => group.label === 'OpenAI · GPT-5.4')).toBe(true);
+    expect(options.groups.some((group) => group.label === 'Ollama · Installed local models')).toBe(false);
+  });
+});

--- a/src/__tests__/unit/core/runtime-credentials.test.ts
+++ b/src/__tests__/unit/core/runtime-credentials.test.ts
@@ -58,6 +58,7 @@ describe('RuntimeCredentialService', () => {
     vi.stubEnv('OLLAMA_OPENAI_BASE_URL', '');
     vi.stubEnv('OLLAMA_BASE_URL', 'http://localhost:11434/');
 
+    expect(RuntimeCredentialService.resolveOllamaBaseUrl()).toBe('http://localhost:11434');
     expect(RuntimeCredentialService.resolveCredentialSourceForModel('ollama/qwen3:8b')).toEqual({
       type: 'local-endpoint',
       provider: 'ollama',

--- a/src/__tests__/unit/core/slash-command-modules.test.ts
+++ b/src/__tests__/unit/core/slash-command-modules.test.ts
@@ -212,7 +212,7 @@ describe('core slash command modules', () => {
 
     await expect(registry.run(context, '/model ollama/qwen3:8b')).resolves.toMatchObject({
       kind: 'message',
-      message: "Switched model to ollama/qwen3:8b. This name is not in Heddle's common shortlist, so the next API call will fail if the provider does not recognize it.",
+      message: 'Switched model to ollama/qwen3:8b',
     });
     expect(setActive).toHaveBeenCalledWith('ollama/qwen3:8b');
   });

--- a/src/__tests__/unit/web-v2/composer-execution-menu.test.tsx
+++ b/src/__tests__/unit/web-v2/composer-execution-menu.test.tsx
@@ -1,0 +1,41 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ControlPlaneModelOptions } from '@/client-shared/api/types.js';
+import { ComposerExecutionMenu } from '../../../web-v2/components/conversation/ComposerExecutionMenu.js';
+import { I18nProvider } from '../../../web-v2/i18n/I18nProvider.js';
+
+describe('web-v2 ComposerExecutionMenu', () => {
+  it('renders discovered Ollama models from shared model options', () => {
+    const modelOptions: ControlPlaneModelOptions = {
+      groups: [
+        {
+          label: 'Ollama · Installed local models',
+          models: ['ollama/llama3.2:latest'],
+          source: 'local-discovered',
+          options: [
+            { id: 'ollama/llama3.2:latest', label: 'llama3.2:latest', disabled: false },
+          ],
+        },
+      ],
+    };
+
+    render(
+      <I18nProvider>
+        <ComposerExecutionMenu
+          model="gpt-5.4"
+          modelOptions={modelOptions}
+          reasoningEffort="medium"
+          onUpdateModel={vi.fn()}
+          onUpdateReasoningEffort={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Ollama · Installed local models')).toBeTruthy();
+    expect(screen.getByText('llama3.2:latest')).toBeTruthy();
+  });
+});

--- a/src/core/commands/slash/modules/model/model-commands.ts
+++ b/src/core/commands/slash/modules/model/model-commands.ts
@@ -4,7 +4,6 @@ import type { SlashCommandModule } from '../../types.js';
 import type { SlashCommandExecutionContext } from '../context.js';
 import { argumentAfterPrefix, slashMessageResult } from '../results.js';
 import {
-  COMMON_BUILT_IN_MODELS,
   ModelCatalogService,
   ModelPolicyService,
 } from '../../../../llm/models/index.js';
@@ -117,9 +116,10 @@ function switchModel(
     return aliased;
   }
 
+  const provider = LlmAdapterService.inferProvider(value);
   const compatibility = ModelPolicyService.validateCredentialCompatibility({
     model: value,
-    provider: LlmAdapterService.inferProvider(value),
+    provider,
     credentialMode: ModelPolicyService.credentialModeFromSource(context.model.credentialSource()),
   });
   if (!compatibility.ok) {
@@ -128,7 +128,7 @@ function switchModel(
 
   context.model.setActive(value);
   return slashMessageResult(
-    COMMON_BUILT_IN_MODELS.includes(value) ?
+    ModelCatalogService.isCommonBuiltInModel(value) || provider !== 'openai' ?
       `Switched model to ${value}`
     : `Switched model to ${value}. This name is not in Heddle's common shortlist, so the next API call will fail if the provider does not recognize it.`,
   );

--- a/src/core/llm/adapters/ollama/README.md
+++ b/src/core/llm/adapters/ollama/README.md
@@ -1,0 +1,15 @@
+# Ollama Adapter Boundary
+
+This package owns Heddle's Ollama provider integration.
+
+- `OllamaProviderAdapter` registers the provider and enforces explicit model
+  selection through `ollama/<model>` or `OLLAMA_MODEL`.
+- `OllamaAdapter` translates Heddle chat requests to Ollama's
+  OpenAI-compatible `/v1/chat/completions` endpoint.
+- `OllamaModelDiscoveryService` discovers installed local models through
+  Ollama's native `/api/tags` endpoint for shared model pickers.
+
+Do not shell out to `ollama list` from UI, server, or TUI code. The control
+plane may run in daemon/web contexts where a CLI path is unreliable. Keep model
+discovery endpoint-based here, then expose picker-ready options through
+`src/core/llm/models/ModelOptionsService`.

--- a/src/core/llm/adapters/ollama/index.ts
+++ b/src/core/llm/adapters/ollama/index.ts
@@ -1,3 +1,5 @@
 export { OllamaAdapter } from './ollama-adapter.js';
 export type { OllamaAdapterOptions } from './ollama-adapter.js';
+export { OllamaModelDiscoveryService } from './ollama-model-discovery.js';
+export type { OllamaDiscoveredModel, OllamaModelDiscoveryOptions } from './ollama-model-discovery.js';
 export { OllamaProviderAdapter } from './ollama-provider-adapter.js';

--- a/src/core/llm/adapters/ollama/ollama-model-discovery.ts
+++ b/src/core/llm/adapters/ollama/ollama-model-discovery.ts
@@ -1,0 +1,81 @@
+import { OllamaModelName } from './ollama-model.js';
+
+export type OllamaDiscoveredModel = {
+  id: string;
+  name: string;
+  sizeBytes?: number;
+  modifiedAt?: string;
+};
+
+export type OllamaModelDiscoveryOptions = {
+  baseUrl: string;
+  fetchImpl?: (url: unknown, init?: unknown) => Promise<globalThis.Response>;
+  signal?: AbortSignal;
+};
+
+type OllamaTagsResponse = {
+  models?: Array<{
+    name?: unknown;
+    size?: unknown;
+    modified_at?: unknown;
+    capabilities?: unknown;
+  }>;
+};
+
+/**
+ * Discovers installed Ollama models through Ollama's local HTTP API. This
+ * provider-owned service avoids shelling out to `ollama list`, so control-plane
+ * clients, daemon hosts, and tests all use the same endpoint-based behavior.
+ */
+export class OllamaModelDiscoveryService {
+  static async listInstalledModels(options: OllamaModelDiscoveryOptions): Promise<OllamaDiscoveredModel[]> {
+    const response = await (options.fetchImpl ?? fetch)(`${OllamaModelDiscoveryService.trimTrailingSlash(options.baseUrl)}/api/tags`, {
+      method: 'GET',
+      signal: options.signal,
+    });
+    const payload = await OllamaModelDiscoveryService.readJsonResponse(response);
+
+    return (payload.models ?? [])
+      .flatMap((model) => OllamaModelDiscoveryService.toDiscoveredModel(model) ?? [])
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private static toDiscoveredModel(model: NonNullable<OllamaTagsResponse['models']>[number]): OllamaDiscoveredModel | undefined {
+    if (typeof model.name !== 'string' || !model.name.trim()) {
+      return undefined;
+    }
+
+    if (!OllamaModelDiscoveryService.isChatCapable(model.capabilities)) {
+      return undefined;
+    }
+
+    return {
+      id: OllamaModelName.toHeddleModel(model.name),
+      name: model.name.trim(),
+      sizeBytes: typeof model.size === 'number' ? model.size : undefined,
+      modifiedAt: typeof model.modified_at === 'string' ? model.modified_at : undefined,
+    };
+  }
+
+  private static isChatCapable(capabilities: unknown): boolean {
+    if (!Array.isArray(capabilities)) {
+      return true;
+    }
+
+    return capabilities.some((capability) => capability === 'completion' || capability === 'chat');
+  }
+
+  private static async readJsonResponse(response: globalThis.Response): Promise<OllamaTagsResponse> {
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`Ollama model discovery request failed: ${response.status} ${response.statusText}${text ? `: ${text}` : ''}`);
+    }
+
+    const parsed = text.trim() ? JSON.parse(text) as unknown : {};
+    return typeof parsed === 'object' && parsed !== null ? parsed as OllamaTagsResponse : {};
+  }
+
+  private static trimTrailingSlash(value: string): string {
+    return value.replace(/\/+$/, '');
+  }
+}

--- a/src/core/llm/models/README.md
+++ b/src/core/llm/models/README.md
@@ -8,6 +8,8 @@ This package owns:
 
 - the curated list of models Heddle exposes in user-facing pickers and command
   help;
+- the shared model-options contract consumed by control-plane clients, including
+  provider-owned local discovery such as installed Ollama models;
 - provider-specific model allowlists, including OpenAI account sign-in support;
 - reasoning-effort support, defaults, and per-model supported effort levels;
 - model-specific system selections such as compaction and session-title models;
@@ -20,9 +22,16 @@ Other services should consume `ModelCatalogService` and `ModelPolicyService`.
 They should not recreate model lists, infer reasoning support, invent context
 window estimates, or decide model fallback policy locally.
 
+`ModelOptionsService` is the control-plane-facing aggregation boundary. It
+combines the static catalog with provider discovery and returns the grouped
+`modelOptions` shape used by web, TUI, task forms, and model slash-command
+pickers. Provider-specific discovery logic should live with the provider adapter
+or provider family, then be composed here.
+
 ## Extension Rules
 
 - Add or update model availability in `model-catalog.ts`.
+- Add or update provider-backed picker aggregation in `model-options-service.ts`.
 - Add or update model policy in `model-policy-service.ts`.
 - Prefer named service methods over exporting raw constants for callers to
   combine themselves.

--- a/src/core/llm/models/index.ts
+++ b/src/core/llm/models/index.ts
@@ -3,10 +3,14 @@ export {
   COMMON_BUILT_IN_MODELS,
   COMMON_OPENAI_MODELS,
   ModelCatalogService,
+  type ModelCatalogResolutionContext,
+  type ModelOptionGroup,
+  type ModelOptionSource,
   OPENAI_ACCOUNT_SIGN_IN_MODELS,
   OPENAI_MODEL_GROUPS,
 } from './model-catalog.js';
 export type { BuiltInModelGroup } from './model-catalog.js';
+export { ModelOptionsService } from './model-options-service.js';
 export {
   ANTHROPIC_COMPACTION_MODEL,
   ModelPolicyService,

--- a/src/core/llm/models/model-catalog.ts
+++ b/src/core/llm/models/model-catalog.ts
@@ -1,3 +1,7 @@
+import type { LlmProvider } from '@/core/llm/types.js';
+import type { CredentialAwareModelOption } from './model-policy-service.js';
+import type { ModelCredentialMode } from './model-policy-service.js';
+
 // ---------------------------------------------------------------------------
 // Built-in model shortlist used by Heddle's current UI and local commands.
 // Keep this curated rather than mirroring the entire provider catalog.
@@ -72,6 +76,22 @@ export const OPENAI_ACCOUNT_SIGN_IN_MODELS = [
   'gpt-5.3-codex',
   'gpt-5.3-codex-spark',
 ];
+
+export type ModelOptionSource = 'built-in' | 'local-discovered';
+
+export type ModelOptionGroup = {
+  label: string;
+  models: string[];
+  options: CredentialAwareModelOption[];
+  source?: ModelOptionSource;
+};
+
+export type ModelCatalogResolutionContext = {
+  credentialModes?: Partial<Record<LlmProvider, ModelCredentialMode>>;
+  ollamaBaseUrl?: string;
+  fetchImpl?: (url: unknown, init?: unknown) => Promise<globalThis.Response>;
+  signal?: AbortSignal;
+};
 
 /**
  * Curated model catalog and formatting helpers for current product surfaces.
@@ -152,6 +172,10 @@ export class ModelCatalogService {
     }
 
     return 200_000;
+  }
+
+  static isCommonBuiltInModel(model: string): boolean {
+    return COMMON_BUILT_IN_MODELS.includes(model.trim());
   }
 }
 

--- a/src/core/llm/models/model-options-service.ts
+++ b/src/core/llm/models/model-options-service.ts
@@ -1,0 +1,86 @@
+import type { LlmProvider } from '@/core/llm/types.js';
+import { OllamaModelDiscoveryService } from '@/core/llm/adapters/ollama/ollama-model-discovery.js';
+import { LlmProviderInference } from '../registry/provider-inference.js';
+import {
+  BUILT_IN_MODEL_GROUPS,
+  type BuiltInModelGroup,
+  type ModelCatalogResolutionContext,
+  type ModelOptionGroup,
+} from './model-catalog.js';
+import { ModelPolicyService, type ModelCredentialMode } from './model-policy-service.js';
+
+/**
+ * Resolves the shared model picker contract for control-plane clients. Static
+ * provider shortlists and local provider discovery meet here so TUI, web, task
+ * forms, and slash-command pickers render the same provider-aware model list.
+ */
+export class ModelOptionsService {
+  static async resolve(context: ModelCatalogResolutionContext = {}): Promise<{ groups: ModelOptionGroup[] }> {
+    const credentialModes = context.credentialModes ?? {};
+    const builtInGroups = BUILT_IN_MODEL_GROUPS.map((group) => ModelOptionsService.toBuiltInModelOptionGroup(group, credentialModes));
+    const localGroups = await ModelOptionsService.resolveLocalModelOptionGroups(context);
+
+    return {
+      groups: [
+        ...builtInGroups,
+        ...localGroups,
+      ],
+    };
+  }
+
+  private static toBuiltInModelOptionGroup(
+    group: BuiltInModelGroup,
+    credentialModes: Partial<Record<LlmProvider, ModelCredentialMode>>,
+  ): ModelOptionGroup {
+    const options = group.models.map((model) => {
+      const provider = LlmProviderInference.inferBuiltin(model);
+      return ModelPolicyService.buildCredentialAwareModelOption({
+        model,
+        provider,
+        credentialMode: credentialModes[provider],
+      });
+    });
+
+    return {
+      label: group.label,
+      models: group.models,
+      options,
+      source: 'built-in',
+    };
+  }
+
+  private static async resolveLocalModelOptionGroups(context: ModelCatalogResolutionContext): Promise<ModelOptionGroup[]> {
+    const ollamaModels = await ModelOptionsService.discoverOllamaModels(context);
+    if (ollamaModels.length === 0) {
+      return [];
+    }
+
+    return [{
+      label: 'Ollama · Installed local models',
+      models: ollamaModels.map((model) => model.id),
+      options: ollamaModels.map((model) => ModelPolicyService.buildCredentialAwareModelOption({
+        model: model.id,
+        provider: 'ollama',
+        label: model.name,
+        credentialMode: 'api-key',
+      })),
+      source: 'local-discovered',
+    }];
+  }
+
+  private static async discoverOllamaModels(context: ModelCatalogResolutionContext) {
+    if (!context.ollamaBaseUrl) {
+      return [];
+    }
+
+    try {
+      return await OllamaModelDiscoveryService.listInstalledModels({
+        baseUrl: context.ollamaBaseUrl,
+        fetchImpl: context.fetchImpl,
+        signal: context.signal,
+      });
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/core/runtime/credentials/service.ts
+++ b/src/core/runtime/credentials/service.ts
@@ -11,6 +11,7 @@ import type { ApiKeyRuntime, ProviderCredentialSource } from './types.js';
  */
 export class RuntimeCredentialService {
   static readonly DEFAULT_OLLAMA_OPENAI_BASE_URL = 'http://127.0.0.1:11434/v1';
+  static readonly DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 
   static resolveProviderApiKey(provider: LlmProvider): string | undefined {
     switch (provider) {
@@ -137,7 +138,19 @@ export class RuntimeCredentialService {
     return values.find((value) => typeof value === 'string' && value.trim().length > 0);
   }
 
-  private static resolveOllamaOpenAiBaseUrl(): string {
+  static resolveOllamaBaseUrl(): string {
+    const configured = RuntimeCredentialService.firstDefinedNonEmpty(
+      process.env.OLLAMA_BASE_URL,
+      process.env.OLLAMA_OPENAI_BASE_URL,
+    );
+    if (!configured) {
+      return RuntimeCredentialService.DEFAULT_OLLAMA_BASE_URL;
+    }
+
+    return configured.replace(/\/+$/, '').replace(/\/v1$/i, '');
+  }
+
+  static resolveOllamaOpenAiBaseUrl(): string {
     const configured = RuntimeCredentialService.firstDefinedNonEmpty(
       process.env.OLLAMA_OPENAI_BASE_URL,
       process.env.OLLAMA_BASE_URL,

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -1,11 +1,9 @@
 import dayjs from 'dayjs';
 import type { z } from 'zod';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
-import { BUILT_IN_MODEL_GROUPS, ModelPolicyService } from '@/core/llm/models/index.js';
-import { LlmAdapterService } from '@/core/llm/index.js';
+import { ModelOptionsService, ModelPolicyService } from '@/core/llm/models/index.js';
 import { AutonomyPermissionModeService } from '@/core/approvals/index.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
-import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import { procedure, router } from '@/server/trpc.js';
 import type { HeddleServerContext } from '@/server/types.js';
 import { controlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
@@ -23,6 +21,7 @@ import { ControlPlaneSkillsController } from '@/server/controllers/trpc/control-
 import { controlPlaneSlashCommandsController } from '@/server/controllers/trpc/control-plane/slash-commands-controller.js';
 import { controlPlaneSessionRuntimeContextService } from '@/server/services/control-plane/session-runtime-context-service.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
+import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
 import { controlPlaneWorkspaceProcedure, type ControlPlaneWorkspaceContext } from './control-plane-workspace.js';
 import {
@@ -118,21 +117,19 @@ export const controlPlaneRouter = router({
       signal,
     });
   }),
-  modelOptions: procedure.query(({ ctx }) => {
-    const credentialMode = ModelPolicyService.credentialModeFromSource(RuntimeCredentialService.resolveCredentialSourceForModel('gpt-5.4', {
-      preferApiKey: ctx.preferApiKey,
-    }));
-    return {
-      groups: BUILT_IN_MODEL_GROUPS.map((group) => ({
-        label: group.label,
-        models: group.models,
-        options: group.models.map((model) => ModelPolicyService.buildCredentialAwareModelOption({
-          model,
-          provider: LlmAdapterService.inferProvider(model),
-          credentialMode,
+  modelOptions: procedure.query(async ({ ctx }) => {
+    return await ModelOptionsService.resolve({
+      credentialModes: {
+        openai: ModelPolicyService.credentialModeFromSource(RuntimeCredentialService.resolveCredentialSourceForModel('gpt-5.4', {
+          preferApiKey: ctx.preferApiKey,
         })),
-      })),
-    };
+        anthropic: ModelPolicyService.credentialModeFromSource(RuntimeCredentialService.resolveCredentialSourceForModel('claude-sonnet-4-6', {
+          preferApiKey: ctx.preferApiKey,
+        })),
+        ollama: 'api-key',
+      },
+      ollamaBaseUrl: RuntimeCredentialService.resolveOllamaBaseUrl(),
+    });
   }),
   workspacePermissionModeUpdate: controlPlaneWorkspaceProcedure.input(workspacePermissionModeUpdateInputSchema).mutation(({ ctx, input }) => {
     const { workspace } = ctx.requestWorkspace;


### PR DESCRIPTION
## Summary
- add endpoint-based Ollama model discovery through the Ollama adapter boundary
- aggregate built-in and local provider models through shared ModelOptionsService for TUI, web, and task selectors
- filter embedding-only Ollama models out of chat model pickers
- document the service boundaries and user-facing model selection behavior

## Verification
- yarn test
- yarn typecheck
- yarn lint
- yarn build
- yarn smoke:ollama
- npx tsx live ModelOptionsService query against local Ollama API
- yarn -s cli:dev --model ollama/llama3.2:latest ask "Reply with exactly: ok"