### PR TITLE
Add browser task intent and native Chrome auto-launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,11 @@ browser_close
 
 The built-in skill teaches the agent when browser automation is appropriate and when `web_search` is only useful for discovering a starting URL. Browser policy still remains authoritative: unsafe actions, off-domain navigation, and ambiguous JavaScript-only clicks can be blocked or require approval.
 
+For normal work, ask the task in chat. Use the composer plus menu -> Use browser
+when you want to nudge the next message toward browser inspection or website
+interaction. This does not enable the workspace capability by itself; it only
+adds task-level context for the next agent turn.
+
 Current behavior:
 
 - if no explicit domain allowlist is configured, the first `browser_open` URL establishes the same-domain browsing boundary for that browser session
@@ -449,6 +454,7 @@ Current behavior:
 - `/browser headed` opens future runs in a visible Playwright window so you can prepare a logged-in session; `/browser headless` reuses that profile without showing the window
 - Settings -> Browser Automation and `/browser open-profile [url]` can open the selected profile in a visible manual window for login/session management; close it with `/browser close-profile` before asking an agent to use the same profile
 - Settings -> Browser Automation and `/browser launch-native [url]` can launch locally installed Chrome with a Heddle-owned profile and CDP endpoint; keep that Chrome window open, then verify it with `/browser check-native`
+- when the backend is native Chrome and the configured CDP endpoint is not reachable, the first agent `browser_open` can launch local Chrome with the task URL rather than a diagnostic page
 - logged-in sites require the selected browser profile to already have a valid session
 
 Browser Automation agenda:

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -424,6 +424,8 @@ browser_close
 
 內建 skill 會教代理什麼時候適合使用瀏覽器自動化，以及什麼時候 `web_search` 只適合用來發現起始 URL。瀏覽器政策仍然是最終邊界：不安全操作、跨網域導覽、語意不明的 JavaScript-only 點擊可能被阻擋或要求核准。
 
+一般工作時，直接在聊天中描述任務即可。當你希望下一則訊息偏向瀏覽器檢查或網站互動，可以在 composer 的加號選單選擇「使用瀏覽器」。這不會自行啟用工作區能力，只會為下一個代理回合加入任務層級的脈絡提示。
+
 目前行為：
 
 - 如果沒有明確的網域允許清單，第一個 `browser_open` URL 會建立該瀏覽器工作階段的同網域瀏覽邊界
@@ -434,6 +436,7 @@ browser_close
 - `/browser headed` 會讓之後的瀏覽器執行顯示 Playwright 視窗，方便你先手動登入；`/browser headless` 則會在不顯示視窗的狀態下重用該設定檔
 - Settings -> Browser Automation 與 `/browser open-profile [url]` 可用可見的手動視窗開啟選定設定檔，供你登入或管理工作階段；請在要求代理使用同一設定檔前，用 `/browser close-profile` 關閉它
 - Settings -> Browser Automation 與 `/browser launch-native [url]` 可用 Heddle 管理的設定檔與 CDP endpoint 啟動本機安裝的 Chrome；請保持該 Chrome 視窗開啟，並用 `/browser check-native` 檢查連線
+- 後端為原生 Chrome 且設定的 CDP endpoint 尚未連上時，代理第一次 `browser_open` 可以用任務 URL 啟動本機 Chrome，而不是開啟診斷頁
 - 需要登入的網站要求目前選定的瀏覽器設定檔已經有有效的登入狀態
 
 瀏覽器自動化待辦方向：

--- a/examples/native-chrome-cdp-spike.ts
+++ b/examples/native-chrome-cdp-spike.ts
@@ -2,7 +2,7 @@
 // Example: Native Chrome CDP Attach Spike
 //
 // Usage:
-//   yarn spike:native-chrome-profile --profile personal --port 9223 --url https://example.com
+//   yarn spike:native-chrome-profile --profile personal --port 9223 --url https://en.wikipedia.org/wiki/Main_Page
 //   HEDDLE_NATIVE_CHROME_CDP_ENDPOINT=http://127.0.0.1:9223 yarn example:native-chrome-cdp-spike
 //
 // This validates the first native Chrome backend slice without involving an
@@ -27,7 +27,7 @@ type SnapshotOutput = {
 };
 
 const STATE_ROOT = join(process.cwd(), '.heddle', 'examples', 'native-chrome-cdp-spike');
-const START_URL = process.env.HEDDLE_BROWSER_START_URL ?? 'https://example.com';
+const START_URL = process.env.HEDDLE_BROWSER_START_URL ?? 'https://en.wikipedia.org/wiki/Main_Page';
 const CDP_ENDPOINT = process.env.HEDDLE_NATIVE_CHROME_CDP_ENDPOINT ?? 'http://127.0.0.1:9222';
 
 async function main() {

--- a/src/__tests__/unit/core/browser-intent-context.test.ts
+++ b/src/__tests__/unit/core/browser-intent-context.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { BrowserAutomationIntentContextService } from '../../../core/browser/index.js';
+
+describe('BrowserAutomationIntentContextService', () => {
+  it('leaves system context unchanged when no browser intent is selected', () => {
+    expect(BrowserAutomationIntentContextService.append({
+      systemContext: 'Existing context.',
+    })).toBe('Existing context.');
+  });
+
+  it('adds task-level browser guidance without naming a specific site', () => {
+    const context = BrowserAutomationIntentContextService.append({
+      intent: 'preferred',
+      systemContext: 'Existing context.',
+    });
+
+    expect(context).toContain('Existing context.');
+    expect(context).toContain('Browser automation was explicitly requested');
+    expect(context).toContain('Use the URL, page, product, app, or workflow named by the user');
+    expect(context).not.toContain('example.com');
+    expect(context).not.toContain('Airspace');
+    expect(context).not.toContain('Shopee');
+  });
+});

--- a/src/__tests__/unit/tools/browser-research-toolkit.test.ts
+++ b/src/__tests__/unit/tools/browser-research-toolkit.test.ts
@@ -12,6 +12,9 @@ import type {
   BrowserDriverLaunchOptions,
   BrowserDriverSnapshotOptions,
   BrowserDriverSnapshotResult,
+  NativeChromeConnectionStatus,
+  NativeChromeLaunchInput,
+  NativeChromeLaunchResult,
 } from '../../../core/browser/index.js';
 import type { ToolDefinition } from '../../../core/types.js';
 
@@ -126,6 +129,34 @@ describe('createBrowserResearchToolkit', () => {
         profileId: 'personal',
         backend: 'native-chrome-cdp',
         userDataDir: join(stateRoot, 'native-chrome-profiles', 'personal'),
+        cdpEndpoint: 'http://127.0.0.1:9223',
+      },
+    });
+  });
+
+  it('auto-launches native Chrome with the requested browser_open URL before CDP attach', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-browser-toolkit-native-auto-'));
+    const nativeChromeLauncher = new FakeNativeChromeLauncher();
+    const { tools, driverFactory } = await createTools({
+      stateRoot,
+      profileId: 'native-research',
+      backend: 'native-chrome-cdp',
+      allowedDomains: ['wikipedia.org'],
+      nativeChromeLauncher,
+      autoLaunchNativeChrome: true,
+    });
+
+    await expect(tools.browser_open.execute({ url: 'https://en.wikipedia.org/wiki/Browser_automation' }))
+      .resolves
+      .toMatchObject({ ok: true });
+
+    expect(nativeChromeLauncher.launchInput).toMatchObject({
+      profileId: 'native-research',
+      url: 'https://en.wikipedia.org/wiki/Browser_automation',
+    });
+    expect(driverFactory.launchOptions).toMatchObject({
+      profile: {
+        backend: 'native-chrome-cdp',
         cdpEndpoint: 'http://127.0.0.1:9223',
       },
     });
@@ -263,6 +294,8 @@ async function createTools(options: {
   backend?: 'playwright-managed' | 'native-chrome-cdp';
   cdpEndpoint?: string;
   headless?: boolean;
+  nativeChromeLauncher?: FakeNativeChromeLauncher;
+  autoLaunchNativeChrome?: boolean;
 } = {}) {
   const stateRoot = options.stateRoot ?? (await mkdtemp(join(tmpdir(), 'heddle-browser-toolkit-')));
   const driver = options.driver ?? new FakeBrowserDriver();
@@ -276,6 +309,8 @@ async function createTools(options: {
       backend: options.backend,
       cdpEndpoint: options.cdpEndpoint,
       headless: options.headless ?? true,
+      nativeChromeLauncher: options.nativeChromeLauncher,
+      autoLaunchNativeChrome: options.autoLaunchNativeChrome,
     }).createTools(context(stateRoot)).map((tool) => [tool.name, tool]),
   );
 
@@ -369,4 +404,37 @@ class ThrowingCloseBrowserDriver extends FakeBrowserDriver {
   override async close(): Promise<void> {
     throw new Error('driver close failed');
   }
+}
+
+class FakeNativeChromeLauncher {
+  launchInput?: NativeChromeLaunchInput;
+
+  async status(stateRoot: string): Promise<NativeChromeConnectionStatus> {
+    return fakeNativeChromeStatus(stateRoot, 'unreachable');
+  }
+
+  async launch(stateRoot: string, input: NativeChromeLaunchInput = {}): Promise<NativeChromeLaunchResult> {
+    this.launchInput = input;
+    return {
+      ok: true,
+      status: fakeNativeChromeStatus(stateRoot, 'reachable'),
+      startUrl: input.url ?? 'https://en.wikipedia.org/wiki/Main_Page',
+      reusedExisting: false,
+    };
+  }
+}
+
+function fakeNativeChromeStatus(
+  stateRoot: string,
+  state: NativeChromeConnectionStatus['state'],
+): NativeChromeConnectionStatus {
+  return {
+    state,
+    profileId: 'native-research',
+    userDataDir: join(stateRoot, 'native-chrome-profiles', 'native-research'),
+    endpoint: 'http://127.0.0.1:9223',
+    port: 9223,
+    defaultStartUrl: 'https://en.wikipedia.org/wiki/Main_Page',
+    checkedAt: '2026-06-16T00:00:00.000Z',
+  };
 }

--- a/src/core/browser/README.md
+++ b/src/core/browser/README.md
@@ -52,6 +52,8 @@ unwinding chat, server, or web-v2 behavior.
 - `native-chrome/`: launches locally installed Chrome with a Heddle-owned
   profile, verifies the local CDP endpoint, and records the profile/endpoint
   for future native CDP attach.
+- `intent/`: converts a per-message "use browser" UI nudge into model-facing
+  runtime context. It does not choose URLs or enable the capability.
 - `profile-windows/`: opens and tracks manual Playwright-managed profile
   windows for login/session preparation. It does not launch native Chrome CDP
   windows.
@@ -62,6 +64,24 @@ unwinding chat, server, or web-v2 behavior.
 - `chrome-cdp/`: owns the native Chrome CDP attach driver.
 - `sessions/`: owns browser session lifecycle and policy-gated browser
   operations over a driver.
+
+## User Mental Model
+
+Users should not need to start from Browser Automation settings for ordinary
+tasks. The normal path is:
+
+1. Enable Browser Automation for the workspace.
+2. Prepare a profile only when the task needs a logged-in session.
+3. Ask the task in chat, optionally adding the composer "Use browser" context
+   nudge for that message.
+4. Let the agent choose the relevant user/task URL and call browser tools.
+
+Settings and slash commands are setup surfaces. They prepare profiles, backend,
+display mode, channel, and native CDP endpoint. They are not task launchers.
+
+The browser intent context must stay site-agnostic. It may tell the agent to
+prefer browser tools when useful, but it must never hard-code a validation URL,
+commerce site, account route, locale prefix, or product workflow.
 
 ## Validation Spike
 
@@ -115,6 +135,12 @@ from terminal chat:
 
 The default validation URL is Wikipedia. It has real rendered text and links but
 does not require login, shopping, or account actions.
+
+When the workspace backend is `native-chrome-cdp`, an agent `browser_open` call
+may auto-launch native Chrome if the configured CDP endpoint is not already
+reachable. The launch URL is the `browser_open` URL from the user task, not a
+diagnostic default. If the endpoint is already reachable, the driver attaches
+and navigates the existing browser page.
 
 ```bash
 yarn spike:native-chrome-profile

--- a/src/core/browser/index.ts
+++ b/src/core/browser/index.ts
@@ -31,6 +31,11 @@ export type {
   BrowserProfileSettingsUpdateResult,
   BrowserProfileView,
 } from './settings/index.js';
+export { BrowserAutomationIntentContextService } from './intent/index.js';
+export type {
+  BrowserAutomationIntent,
+  BrowserAutomationIntentContextInput,
+} from './intent/index.js';
 export {
   DEFAULT_NATIVE_CHROME_CDP_PORT,
   DEFAULT_NATIVE_CHROME_START_URL,

--- a/src/core/browser/intent/index.ts
+++ b/src/core/browser/intent/index.ts
@@ -1,0 +1,2 @@
+export { BrowserAutomationIntentContextService } from './service.js';
+export type { BrowserAutomationIntent, BrowserAutomationIntentContextInput } from './service.js';

--- a/src/core/browser/intent/service.ts
+++ b/src/core/browser/intent/service.ts
@@ -1,0 +1,32 @@
+export type BrowserAutomationIntent = 'preferred';
+
+export type BrowserAutomationIntentContextInput = {
+  intent?: BrowserAutomationIntent;
+  systemContext?: string;
+};
+
+const BROWSER_AUTOMATION_INTENT_CONTEXT = [
+  'Browser automation was explicitly requested for this user message.',
+  'If browser tools are available and useful for the task, prefer opening the user-relevant page in the configured browser instead of relying only on web search or guessing URLs.',
+  'Use the URL, page, product, app, or workflow named by the user or discovered from the task context; do not navigate to placeholder or diagnostic pages unless the user asks for a diagnostic.',
+  'Keep normal browser policy authoritative: avoid forbidden actions, request approval when required, and summarize browser evidence such as page title, visible text, links, and screenshots when it helps the user evaluate the result.',
+].join('\n');
+
+/**
+ * Owns the model-facing instruction generated from a per-message browser nudge.
+ *
+ * UI surfaces only send a small intent flag. They must not duplicate this text
+ * or choose browser URLs; the agent and browser tools resolve task-specific
+ * navigation from the user request under browser policy.
+ */
+export class BrowserAutomationIntentContextService {
+  static append(input: BrowserAutomationIntentContextInput): string | undefined {
+    if (input.intent !== 'preferred') {
+      return input.systemContext;
+    }
+
+    return [input.systemContext, BROWSER_AUTOMATION_INTENT_CONTEXT]
+      .filter((part): part is string => Boolean(part?.trim()))
+      .join('\n\n');
+  }
+}

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -202,6 +202,9 @@ const QueuedConversationPromptSchema = z.object({
     .describe('Resolved custom-agent execution snapshot selected when this prompt entered the queue.')
     .optional()
     .catch(undefined),
+  systemContext: z.string()
+    .describe('Optional runtime context that should be applied when this queued prompt runs.')
+    .optional(),
   createdAt: z.string().describe('Timestamp when this prompt entered the session queue.'),
   updatedAt: z.string().describe('Timestamp when this queued prompt was last edited.'),
 });

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -187,6 +187,7 @@ export class FileConversationSessionService implements ConversationSessionServic
       prompt,
       agentProfileId: input.agentProfileId,
       agentSnapshot: input.agentSnapshot,
+      systemContext: input.systemContext,
       createdAt: now,
       updatedAt: now,
     };

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -143,6 +143,7 @@ export type EnqueueConversationPromptInput = {
   prompt: string;
   agentProfileId?: string;
   agentSnapshot?: CustomAgentExecutionSnapshot;
+  systemContext?: string;
 };
 
 export type UpdateQueuedConversationPromptInput = {

--- a/src/core/chat/types.ts
+++ b/src/core/chat/types.ts
@@ -144,6 +144,7 @@ export type QueuedConversationPrompt = {
   prompt: string;
   agentProfileId?: string;
   agentSnapshot?: CustomAgentExecutionSnapshot;
+  systemContext?: string;
   createdAt: string;
   updatedAt: string;
 };

--- a/src/core/tools/toolkits/browser-research/README.md
+++ b/src/core/tools/toolkits/browser-research/README.md
@@ -45,6 +45,12 @@ When `allowedDomains` is empty, `browser_open` derives the session allowlist
 from the first opened URL. Subsequent clicks remain same-domain unless a host
 provides a broader explicit allowlist.
 
+For the native Chrome CDP backend, `browser_open` is also the task entrypoint.
+If the configured local CDP endpoint is not reachable, the toolkit asks the
+browser domain to launch native Chrome with the same URL that `browser_open`
+received. Do not add placeholder launch URLs here; validation examples belong
+in examples, and production tool behavior must follow the user's task URL.
+
 ## Example
 
 Run the deterministic toolkit example from the browser automation worktree:

--- a/src/core/tools/toolkits/browser-research/toolkit.ts
+++ b/src/core/tools/toolkits/browser-research/toolkit.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 
 import {
   BrowserDriverFactoryService,
+  NativeChromeProfileService,
   BrowserProfileService,
   BrowserProfileSettingsService,
   BrowserSessionService,
@@ -11,9 +12,17 @@ import {
   type BrowserDriverFactory,
   type BrowserSessionConfig,
   type BrowserSnapshot,
+  type NativeChromeConnectionStatus,
+  type NativeChromeLaunchInput,
+  type NativeChromeLaunchResult,
 } from '../../../browser/index.js';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
 import type { ToolToolkit } from '../../toolkit.js';
+
+type NativeChromeLauncher = {
+  status: (stateRoot: string) => Promise<NativeChromeConnectionStatus>;
+  launch: (stateRoot: string, input?: NativeChromeLaunchInput) => Promise<NativeChromeLaunchResult>;
+};
 
 export type BrowserResearchToolkitOptions = {
   stateRoot: string;
@@ -26,6 +35,8 @@ export type BrowserResearchToolkitOptions = {
   cdpEndpoint?: string;
   maxElementsPerSnapshot?: number;
   driverFactory?: BrowserDriverFactory;
+  nativeChromeLauncher?: NativeChromeLauncher;
+  autoLaunchNativeChrome?: boolean;
 };
 
 type BrowserOpenInput = {
@@ -282,7 +293,7 @@ async function getBrowserSession(
     return state.session;
   }
 
-  const profile = await resolveBrowserProfile(options, state);
+  const profile = await resolveBrowserProfile(options, state, initialUrl);
   state.session = new BrowserSessionService(
     createSessionConfig(options, profile, initialUrl),
     options.driverFactory ?? BrowserDriverFactoryService.resolve(profile.backend),
@@ -293,8 +304,11 @@ async function getBrowserSession(
 async function resolveBrowserProfile(
   options: BrowserResearchToolkitOptions,
   state: BrowserRuntimeState,
+  initialUrl?: string,
 ): Promise<BrowserProfileConfig> {
   if (options.backend === 'native-chrome-cdp') {
+    const launcher = options.nativeChromeLauncher ?? NativeChromeProfileService;
+    const launchResult = await prepareNativeChromeProfile(options, launcher, initialUrl);
     return {
       profileId: options.profileId ?? 'browser-research',
       userDataDir: BrowserProfileSettingsService.resolveNativeChromeProfileDir(
@@ -302,7 +316,7 @@ async function resolveBrowserProfile(
         options.profileId ?? 'browser-research',
       ),
       backend: 'native-chrome-cdp',
-      cdpEndpoint: options.cdpEndpoint,
+      cdpEndpoint: launchResult?.status.endpoint ?? options.cdpEndpoint,
     };
   }
 
@@ -317,6 +331,34 @@ async function resolveBrowserProfile(
     ...lease.profile,
     backend: 'playwright-managed',
   };
+}
+
+async function prepareNativeChromeProfile(
+  options: BrowserResearchToolkitOptions,
+  launcher: NativeChromeLauncher,
+  initialUrl: string | undefined,
+): Promise<NativeChromeLaunchResult | undefined> {
+  if (!shouldAutoLaunchNativeChrome(options)) {
+    return undefined;
+  }
+
+  const status = await launcher.status(options.stateRoot);
+  if (status.state === 'reachable') {
+    return undefined;
+  }
+
+  const launchResult = await launcher.launch(options.stateRoot, {
+    profileId: options.profileId,
+    url: initialUrl,
+  });
+  if (!launchResult.ok) {
+    throw new Error(`Native Chrome launch failed: ${launchResult.error}`);
+  }
+  return launchResult;
+}
+
+function shouldAutoLaunchNativeChrome(options: BrowserResearchToolkitOptions): boolean {
+  return options.autoLaunchNativeChrome ?? !options.driverFactory;
 }
 
 async function closeBrowserState(state: BrowserRuntimeState): Promise<Awaited<ReturnType<BrowserSessionService['close']>> | undefined> {

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -112,6 +112,7 @@ type SubmitChatPromptArgs = ControlPlaneSessionReadArgs & {
   prompt: string;
   agentProfileId?: string;
   agentSnapshot?: CustomAgentExecutionSnapshot;
+  systemContext?: string;
   maxSteps?: number;
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;
@@ -476,6 +477,7 @@ export class ControlPlaneChatSessionsController {
       prompt: args.prompt,
       agentProfileId: args.agentProfileId,
       agentSnapshot: args.agentSnapshot,
+      systemContext: args.systemContext,
     });
     this.publishQueueUpdated(args, queued.session);
 
@@ -511,12 +513,14 @@ export class ControlPlaneChatSessionsController {
         prompt: dequeued.item.prompt,
         agentProfileId: dequeued.item.agentProfileId,
         agentSnapshot: dequeued.item.agentSnapshot,
+        systemContext: dequeued.item.systemContext,
       }));
     } catch (error) {
       const restored = sessions.enqueuePrompt(args.sessionId, {
         prompt: dequeued.item.prompt,
         agentProfileId: dequeued.item.agentProfileId,
         agentSnapshot: dequeued.item.agentSnapshot,
+        systemContext: dequeued.item.systemContext,
       });
       this.publishQueueUpdated(args, restored.session);
       args.logger?.debug(

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -22,6 +22,7 @@ import { controlPlaneSlashCommandsController } from '@/server/controllers/trpc/c
 import { controlPlaneSessionRuntimeContextService } from '@/server/services/control-plane/session-runtime-context-service.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 import { CustomAgentService } from '@/core/custom-agents/index.js';
+import { BrowserAutomationIntentContextService } from '@/core/browser/index.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
 import { controlPlaneWorkspaceProcedure, type ControlPlaneWorkspaceContext } from './control-plane-workspace.js';
@@ -712,10 +713,15 @@ type SessionMessageInput = z.infer<typeof sessionMessageInputSchema>;
 
 function buildSubmitPromptArgs(ctx: ControlPlaneWorkspaceContext, input: SessionMessageInput) {
   const { logger, sessionEngineArgs } = ctx.requestWorkspace;
+  const { browserIntent, ...messageInput } = input;
   return {
-    ...input,
+    ...messageInput,
     ...sessionEngineArgs,
     preferApiKey: input.preferApiKey ?? ctx.preferApiKey,
+    systemContext: BrowserAutomationIntentContextService.append({
+      intent: browserIntent,
+      systemContext: input.systemContext,
+    }),
     logger,
     leaseOwner: resolveControlPlaneLeaseOwner(ctx),
   };

--- a/src/server/routes/trpc/schema.ts
+++ b/src/server/routes/trpc/schema.ts
@@ -61,6 +61,7 @@ export const sessionMessageInputSchema = z.object({
   sessionId: z.string().min(1),
   prompt: z.string().min(1),
   agentProfileId: z.string().min(1).optional(),
+  browserIntent: z.enum(['preferred']).optional(),
   maxSteps: z.number().int().min(1).max(500).optional(),
   searchIgnoreDirs: z.array(z.string().min(1)).optional(),
   includePlanTool: z.boolean().optional(),

--- a/src/web-v2/components/conversation/ComposerContextMenu.tsx
+++ b/src/web-v2/components/conversation/ComposerContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Bot, Check, ImagePlus, Plus, ShieldCheck } from 'lucide-react';
+import { Bot, Check, Globe2, ImagePlus, Plus, ShieldCheck } from 'lucide-react';
 import { Link } from 'react-router';
 import type { ControlPlaneCustomAgent, ControlPlaneCustomAgents, ControlPlanePermissionMode, ControlPlaneSessionRuntimeContext } from '@web/api/client';
 import { Button } from '@web/components/ui/button';
@@ -22,12 +22,14 @@ type ComposerContextMenuProps = {
   disabled?: boolean;
   driftEnabled: boolean;
   driftLevel: SessionDriftLevel;
+  browserIntentEnabled?: boolean;
   permissionMode?: ControlPlanePermissionMode;
   permissionModeOptions?: ControlPlaneSessionRuntimeContext['permissionModeOptions'];
   selectedAgentProfileId: string;
   settingsUpdating?: boolean;
   uploadDisabled?: boolean;
   onSelectAgentProfileId: (agentProfileId: string) => void;
+  onToggleBrowserIntent?: () => void;
   onUploadImagesClick?: () => void;
   onUpdateDriftEnabled?: (enabled: boolean) => Promise<void>;
   onUpdatePermissionMode?: (mode: ControlPlanePermissionMode) => Promise<void>;
@@ -92,12 +94,14 @@ export function ComposerContextMenu({
   disabled,
   driftEnabled,
   driftLevel,
+  browserIntentEnabled,
   permissionMode,
   permissionModeOptions,
   selectedAgentProfileId,
   settingsUpdating,
   uploadDisabled,
   onSelectAgentProfileId,
+  onToggleBrowserIntent,
   onUploadImagesClick,
   onUpdateDriftEnabled,
   onUpdatePermissionMode,
@@ -168,6 +172,37 @@ export function ComposerContextMenu({
                 <span className="v2-drift-menu-status truncate">
                   {t('composer.images.uploadDescription')}
                 </span>
+              </span>
+            </Button>
+          </div>
+        ) : null}
+        {onToggleBrowserIntent ? (
+          <div className="v2-browser-intent-menu-section">
+            <Button
+              type="button"
+              variant="ghost"
+              size="none"
+              role="menuitemcheckbox"
+              aria-checked={browserIntentEnabled ?? false}
+              className="v2-browser-intent-menu-row"
+              disabled={disabled}
+              onClick={onToggleBrowserIntent}
+            >
+              <Globe2
+                aria-hidden="true"
+                data-icon="inline-start"
+                className="v2-drift-menu-icon"
+              />
+              <span className="v2-drift-menu-copy">
+                <span className="v2-drift-menu-title truncate">
+                  {t('composer.browser.useAction')}
+                </span>
+                <span className="v2-drift-menu-status truncate">
+                  {t('composer.browser.useDescription')}
+                </span>
+              </span>
+              <span className="v2-composer-menu-option-check-slot" aria-hidden="true">
+                {browserIntentEnabled ? <Check data-icon="inline-end" /> : null}
               </span>
             </Button>
           </div>

--- a/src/web-v2/components/conversation/ConversationComposer.tsx
+++ b/src/web-v2/components/conversation/ConversationComposer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ArrowUp } from 'lucide-react';
+import { ArrowUp, Globe2, X } from 'lucide-react';
 import type { ControlPlaneCustomAgents, ControlPlaneModelOptions, ControlPlanePermissionMode, ControlPlaneSessionRuntimeContext } from '@web/api/client';
 import { Button } from '@web/components/ui/button';
 import { Textarea } from '@web/components/ui/textarea';
@@ -68,7 +68,7 @@ export function ConversationComposer({
   submitting?: boolean;
   running?: boolean;
   cancelling?: boolean;
-  onSubmitPrompt: (prompt: string, options?: { agentProfileId?: string }) => Promise<void>;
+  onSubmitPrompt: (prompt: string, options?: { agentProfileId?: string; browserIntent?: 'preferred' }) => Promise<void>;
   onCancelRun?: () => Promise<void>;
   onUpdateDriftEnabled?: (enabled: boolean) => Promise<void>;
   onUpdatePermissionMode?: (mode: ControlPlanePermissionMode) => Promise<void>;
@@ -80,6 +80,7 @@ export function ConversationComposer({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [draft, setDraft] = useState('');
   const [selectedAgentProfileId, setSelectedAgentProfileId] = useState<string>(BUILT_IN_COMPOSER_AGENT_IDS.code);
+  const [browserIntentEnabled, setBrowserIntentEnabled] = useState(false);
   const {
     attachments: imageUploadAttachments,
     clearUploadedAttachments,
@@ -135,11 +136,15 @@ export function ConversationComposer({
       return;
     }
 
-    await onSubmitPrompt(prompt, { agentProfileId: selectedAgentProfileId });
+    await onSubmitPrompt(prompt, {
+      agentProfileId: selectedAgentProfileId,
+      browserIntent: browserIntentEnabled ? 'preferred' : undefined,
+    });
     recordPrompt(prompt);
     setDraft('');
+    setBrowserIntentEnabled(false);
     clearUploadedAttachments();
-  }, [clearUploadedAttachments, draft, onSubmitPrompt, recordPrompt, selectedAgentProfileId, sendDisabled, uploadedImagePaths]);
+  }, [browserIntentEnabled, clearUploadedAttachments, draft, onSubmitPrompt, recordPrompt, selectedAgentProfileId, sendDisabled, uploadedImagePaths]);
   const fileMentions = useFileMentionAutocomplete({
     workspaceId,
     value: draft,
@@ -162,6 +167,25 @@ export function ConversationComposer({
           void handleSubmit();
         }}
       >
+      {browserIntentEnabled ? (
+        <div className="v2-composer-intent-strip" aria-label={t('composer.browser.intentLabel')}>
+          <span className="v2-composer-intent-chip">
+            <Globe2 aria-hidden="true" data-icon="inline-start" />
+            <span className="truncate">{t('composer.browser.intentChip')}</span>
+            <Button
+              type="button"
+              size="none"
+              variant="ghost"
+              className="v2-composer-intent-remove"
+              aria-label={t('composer.browser.clearIntent')}
+              disabled={controlsDisabled}
+              onClick={() => setBrowserIntentEnabled(false)}
+            >
+              <X aria-hidden="true" data-icon="inline-end" />
+            </Button>
+          </span>
+        </div>
+      ) : null}
       <Textarea
         ref={fileMentions.textareaRef}
         aria-label={t('composer.promptAriaLabel')}
@@ -207,10 +231,12 @@ export function ConversationComposer({
           driftLevel={effectiveDriftLevel}
           permissionMode={permissionMode}
           permissionModeOptions={permissionModeOptions}
+          browserIntentEnabled={browserIntentEnabled}
           selectedAgentProfileId={selectedAgentProfileId}
           settingsUpdating={settingsUpdating}
           uploadDisabled={imageUploadDisabled}
           onSelectAgentProfileId={setSelectedAgentProfileId}
+          onToggleBrowserIntent={() => setBrowserIntentEnabled((current) => !current)}
           onUploadImagesClick={() => imageUploadControlsRef.current?.openFilePicker()}
           onUpdateDriftEnabled={onUpdateDriftEnabled}
           onUpdatePermissionMode={onUpdatePermissionMode}

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
@@ -21,7 +21,7 @@ type UseControlPlaneSessionPromptSubmitArgs = {
 
 export type ControlPlaneSessionPromptSubmitState = {
   submitting: boolean;
-  submitPrompt: (prompt: string, options?: { agentProfileId?: string }) => Promise<void>;
+  submitPrompt: (prompt: string, options?: { agentProfileId?: string; browserIntent?: 'preferred' }) => Promise<void>;
   directShellConfirmation?: ControlPlaneSessionDirectShellPreflight;
   confirmDirectShell: () => Promise<void>;
   cancelDirectShellConfirmation: () => void;
@@ -62,6 +62,7 @@ export function useControlPlaneSessionPromptSubmit({
   const submitToControlPlane = useCallback(async (input: {
     prompt: string;
     agentProfileId?: string;
+    browserIntent?: 'preferred';
     directShell?: { command: string; riskAccepted?: boolean };
   }) => {
     if (!workspaceId || !sessionId || submitting) {
@@ -108,6 +109,7 @@ export function useControlPlaneSessionPromptSubmit({
           sessionId,
           prompt: input.prompt,
           agentProfileId: input.agentProfileId,
+          browserIntent: input.browserIntent,
         });
       }
       if (isCurrentSubmission()) {
@@ -154,7 +156,7 @@ export function useControlPlaneSessionPromptSubmit({
     workspaceId,
   ]);
 
-  const submitPrompt = useCallback(async (prompt: string, options?: { agentProfileId?: string }) => {
+  const submitPrompt = useCallback(async (prompt: string, options?: { agentProfileId?: string; browserIntent?: 'preferred' }) => {
     const trimmed = prompt.trim();
     if (!workspaceId || !sessionId || !trimmed || submitting) {
       return;
@@ -190,7 +192,11 @@ export function useControlPlaneSessionPromptSubmit({
       return;
     }
 
-    await submitToControlPlane({ prompt: trimmed, agentProfileId: options?.agentProfileId });
+    await submitToControlPlane({
+      prompt: trimmed,
+      agentProfileId: options?.agentProfileId,
+      browserIntent: options?.browserIntent,
+    });
   }, [
     running,
     sessionId,

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -18,6 +18,13 @@
   "composer": {
     "addContext": "Add context",
     "contextMenu": "Context",
+    "browser": {
+      "clearIntent": "Remove browser request",
+      "intentChip": "Use browser",
+      "intentLabel": "Browser request for next message",
+      "useAction": "Use browser",
+      "useDescription": "Nudge the agent to inspect or operate the relevant page for this task."
+    },
     "drift": {
       "ariaLabel": "Semantic drift",
       "disabled": "Drift off",

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -18,6 +18,13 @@
   "composer": {
     "addContext": "添加上下文",
     "contextMenu": "上下文",
+    "browser": {
+      "clearIntent": "移除浏览器请求",
+      "intentChip": "使用浏览器",
+      "intentLabel": "下一条消息的浏览器请求",
+      "useAction": "使用浏览器",
+      "useDescription": "提示代理为这个任务检查或操作相关页面。"
+    },
     "drift": {
       "ariaLabel": "语义漂移",
       "disabled": "漂移关闭",

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -18,6 +18,13 @@
   "composer": {
     "addContext": "加入脈絡",
     "contextMenu": "脈絡",
+    "browser": {
+      "clearIntent": "移除瀏覽器要求",
+      "intentChip": "使用瀏覽器",
+      "intentLabel": "下一則訊息的瀏覽器要求",
+      "useAction": "使用瀏覽器",
+      "useDescription": "提示代理為這個任務檢查或操作相關頁面。"
+    },
     "drift": {
       "ariaLabel": "語意漂移",
       "disabled": "漂移關閉",

--- a/src/web-v2/styles/composer.css
+++ b/src/web-v2/styles/composer.css
@@ -49,6 +49,51 @@
     box-shadow: 0 -8px 22px hsl(235 18% 3% / 0.16);
   }
 
+  .v2-composer-intent-strip {
+    display: flex;
+    min-width: 0;
+    padding: 0.125rem 0.125rem 0;
+  }
+
+  .v2-composer-intent-chip {
+    display: inline-flex;
+    max-width: min(18rem, 100%);
+    min-width: 0;
+    align-items: center;
+    gap: 0.375rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid color-mix(in oklab, var(--color-ring) 42%, var(--color-border));
+    background: color-mix(in oklab, var(--color-accent) 46%, var(--color-card));
+    padding: 0.1875rem 0.25rem 0.1875rem 0.5rem;
+    color: var(--color-accent-foreground);
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+
+  .v2-composer-intent-chip > svg {
+    height: 0.8125rem;
+    width: 0.8125rem;
+    flex-shrink: 0;
+  }
+
+  .v2-composer-intent-remove {
+    height: 1rem;
+    width: 1rem;
+    min-width: 1rem;
+    border-radius: 999px;
+    color: color-mix(in oklab, currentcolor 72%, transparent);
+  }
+
+  .v2-composer-intent-remove:hover {
+    background: color-mix(in oklab, var(--color-background) 54%, transparent);
+    color: currentcolor;
+  }
+
+  .v2-composer-intent-remove svg {
+    height: 0.75rem;
+    width: 0.75rem;
+  }
+
   .v2-direct-shell-result {
     border-radius: 0.625rem;
     border: 1px solid color-mix(in oklab, var(--color-border) 72%, transparent);
@@ -564,6 +609,12 @@
     flex-direction: column;
   }
 
+  .v2-browser-intent-menu-section {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+  }
+
   .v2-permission-mode-menu-section {
     display: flex;
     min-width: 0;
@@ -573,11 +624,13 @@
 
   .v2-composer-context-menu > :is(
     .v2-upload-menu-section,
+    .v2-browser-intent-menu-section,
     .v2-permission-mode-menu-section,
     .v2-agent-menu-section,
     .v2-drift-menu-section
   ) + :is(
     .v2-upload-menu-section,
+    .v2-browser-intent-menu-section,
     .v2-permission-mode-menu-section,
     .v2-agent-menu-section,
     .v2-drift-menu-section
@@ -631,6 +684,25 @@
     padding: 0.375rem 0.25rem;
     color: var(--color-popover-foreground);
     text-align: left;
+  }
+
+  .v2-browser-intent-menu-row {
+    display: grid !important;
+    grid-template-columns: 1rem minmax(0, 1fr) 1rem;
+    min-height: 2.75rem;
+    width: 100%;
+    min-width: 0;
+    align-items: center;
+    gap: 0.625rem;
+    border-radius: var(--radius-sm);
+    padding: 0.375rem 0.25rem;
+    color: var(--color-popover-foreground);
+    text-align: left;
+  }
+
+  .v2-browser-intent-menu-row:hover {
+    background: color-mix(in oklab, var(--color-accent) 72%, transparent);
+    color: var(--color-accent-foreground);
   }
 
   .v2-upload-menu-row:hover {


### PR DESCRIPTION
## Summary
- add a one-shot composer Use browser intent that travels with the prompt and survives queued follow-ups
- translate that structured intent into core-owned model context instead of UI prompt text
- auto-launch native Chrome CDP from the actual browser_open URL when the endpoint is not already reachable
- document browser service boundaries and remove stale example.com defaults from the native CDP spike

## Verification
- yarn test src/__tests__/unit/tools/browser-research-toolkit.test.ts src/__tests__/unit/core/browser-intent-context.test.ts
- yarn build
- yarn lint