### PR TITLE
[codex] Fix workspace-scoped OAuth auth

### DIFF
--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import pino from 'pino';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ProviderCredentialCommandService } from '@/core/auth/index.js';
+import { ProviderCredentialCommandService, ProviderCredentialRepository } from '@/core/auth/index.js';
 import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
 import { createConversationEngine } from '@/core/chat/engine/conversation-engine.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
@@ -500,7 +500,7 @@ description: Research web pages through a browser.
   it('executes auth login through the shared core auth command service', async () => {
     const login = vi.spyOn(ProviderCredentialCommandService, 'loginProviderWithOAuth')
       .mockResolvedValue('Stored OpenAI OAuth credential.');
-    const { caller } = createControlPlaneCaller();
+    const { caller, activeWorkspace } = createControlPlaneCaller();
     const session = await caller.sessionCreate({ name: 'Auth slash command session' });
 
     await expect(caller.slashCommandExecute({
@@ -511,7 +511,9 @@ description: Research web pages through a browser.
       kind: 'message',
       message: 'Stored OpenAI OAuth credential.',
     });
-    expect(login).toHaveBeenCalledWith('openai', { storePath: undefined });
+    expect(login).toHaveBeenCalledWith('openai', {
+      storePath: ProviderCredentialRepository.resolveStorePath(activeWorkspace.stateRoot),
+    });
   });
 
   it('returns selected-session runtime context for commands and status surfaces', async () => {

--- a/src/__tests__/unit/cli-v2/main-command-routing.test.ts
+++ b/src/__tests__/unit/cli-v2/main-command-routing.test.ts
@@ -64,6 +64,6 @@ describe('CLI command routing', () => {
     expect(source).toMatch(/const memoryCommand = program[\s\S]*?\.command\('memory'\)[\s\S]*?\.addHelpCommand\('help \[command\]'[\s\S]*?\.action\(\(\) => \{\s*memoryCommand\.outputHelp\(\);\s*\}\);/);
     expect(source).toMatch(/memoryCommand\s*\n\s*\.command\('status'\)[\s\S]*?await MemoryCliV2CommandEdgeService\.run\('status', resolved\);/);
     expect(source).toMatch(/const authCommand = program[\s\S]*?\.command\('auth'\)[\s\S]*?\.action\(\(\) => \{\s*authCommand\.outputHelp\(\);\s*\}\);/);
-    expect(source).toMatch(/authCommand\s*\n\s*\.command\('status'\)[\s\S]*?await AuthCliCommandEdgeService\.run\('status'\);/);
+    expect(source).toMatch(/authCommand\s*\n\s*\.command\('status'\)[\s\S]*?await AuthCliCommandEdgeService\.run\('status', undefined, \{[\s\S]*?storePath: resolveWorkspaceCredentialStorePath\(resolved\),[\s\S]*?\}\);/);
   });
 });

--- a/src/__tests__/unit/control-plane/control-plane-workspace.test.ts
+++ b/src/__tests__/unit/control-plane/control-plane-workspace.test.ts
@@ -44,6 +44,7 @@ describe('resolveControlPlaneRequestWorkspace', () => {
         requireApproval: ['staging', 'production', 'unknown'],
       },
     });
+    expect(resolved.sessionEngineArgs.credentialStorePath).toBe(join(stateRoot, 'auth.json'));
   });
 });
 

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -101,6 +101,48 @@ describe('OpenAI OAuth helpers', () => {
     expect(new URLSearchParams(requests[1]?.body).get('refresh_token')).toBe('refresh-token');
   });
 
+  it('completes browser login after callback token exchange succeeds', async () => {
+    const requests: Array<{ url: string; body: string }> = [];
+    let callbackResponse: Promise<Response> | undefined;
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({
+        url: String(url),
+        body: String(init?.body),
+      });
+      return Response.json({
+        access_token: 'access',
+        refresh_token: 'refresh',
+        expires_in: 3600,
+      });
+    }) as typeof fetch;
+
+    const credential = await OpenAiOAuthService.runBrowserLogin({
+      port: 0,
+      openBrowser: false,
+      fetchImpl,
+      onAuthorizeUrl: (authorizeUrl) => {
+        const url = new URL(authorizeUrl);
+        const redirectUri = url.searchParams.get('redirect_uri');
+        const state = url.searchParams.get('state');
+        if (!redirectUri || !state) {
+          throw new Error('OAuth authorize URL did not include callback metadata');
+        }
+        callbackResponse = fetch(`${redirectUri}?code=callback-code&state=${state}`);
+      },
+    });
+
+    await expect(callbackResponse).resolves.toMatchObject({ status: 200 });
+    expect(credential).toMatchObject({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      label: 'ChatGPT/Codex OAuth',
+    });
+    expect(requests).toHaveLength(1);
+    expect(new URLSearchParams(requests[0]?.body).get('code')).toBe('callback-code');
+  });
+
   it('rewrites Responses calls to the Codex endpoint with refreshed OAuth headers', async () => {
     const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-oauth-fetch-')), 'auth.json');
     const requests: Array<{ url: string; headers: Headers; body: string }> = [];

--- a/src/cli-v2/main.ts
+++ b/src/cli-v2/main.ts
@@ -18,6 +18,7 @@ import { RuntimeHostResolver } from '@/core/runtime/daemon/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
+import { ProviderCredentialRepository } from '@/core/auth/index.js';
 
 type RootCliOptions = {
   cwd?: string;
@@ -219,21 +220,31 @@ async function main() {
     .description('log in to a provider')
     .option('--no-browser', 'print the authorization URL without opening a browser')
     .action(async (provider: string, flags: { browser?: boolean }) => {
-      await AuthCliCommandEdgeService.run('login', provider, { openBrowser: flags.browser });
+      const resolved = resolveCliOptions(program.opts<RootCliOptions>());
+      await AuthCliCommandEdgeService.run('login', provider, {
+        openBrowser: flags.browser,
+        storePath: resolveWorkspaceCredentialStorePath(resolved),
+      });
     });
 
   authCommand
     .command('status')
     .description('show stored provider credentials')
     .action(async () => {
-      await AuthCliCommandEdgeService.run('status');
+      const resolved = resolveCliOptions(program.opts<RootCliOptions>());
+      await AuthCliCommandEdgeService.run('status', undefined, {
+        storePath: resolveWorkspaceCredentialStorePath(resolved),
+      });
     });
 
   authCommand
     .command('logout <provider>')
     .description('remove a stored provider credential')
     .action(async (provider: string) => {
-      await AuthCliCommandEdgeService.run('logout', provider);
+      const resolved = resolveCliOptions(program.opts<RootCliOptions>());
+      await AuthCliCommandEdgeService.run('logout', provider, {
+        storePath: resolveWorkspaceCredentialStorePath(resolved),
+      });
     });
 
   program
@@ -361,6 +372,10 @@ function resolveCliOptions(flags: RootCliOptions): ResolvedCliOptions {
     runtimeHost: RuntimeHostResolver.resolveLiveServer(),
     forceOwnerConflict: Boolean(flags.forceOwnerConflict),
   };
+}
+
+function resolveWorkspaceCredentialStorePath(options: Pick<ResolvedCliOptions, 'workspaceRoot' | 'stateDir'>): string {
+  return ProviderCredentialRepository.resolveStorePath(resolve(options.workspaceRoot, options.stateDir));
 }
 
 function readCliVersion(): string {

--- a/src/core/auth/openai-oauth.ts
+++ b/src/core/auth/openai-oauth.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { createServer, type Server } from 'node:http';
-import type { AddressInfo } from 'node:net';
+import type { AddressInfo, Socket } from 'node:net';
 import type {
   OpenAiIdTokenClaims,
   OpenAiOAuthCallbackServer,
@@ -104,6 +104,7 @@ export class OpenAiOAuthService {
     redirectUri: string;
     codeVerifier: string;
     fetchImpl?: typeof fetch;
+    signal?: AbortSignal;
   }): Promise<OpenAiOAuthTokenResponse> {
     const fetcher = args.fetchImpl ?? fetch;
     const response = await fetcher(`${OPENAI_AUTH_ISSUER}/oauth/token`, {
@@ -116,6 +117,7 @@ export class OpenAiOAuthService {
         client_id: OPENAI_CODEX_CLIENT_ID,
         code_verifier: args.codeVerifier,
       }).toString(),
+      signal: args.signal,
     });
 
     if (!response.ok) {
@@ -135,6 +137,7 @@ export class OpenAiOAuthService {
         refresh_token: options.refreshToken,
         client_id: OPENAI_CODEX_CLIENT_ID,
       }).toString(),
+      signal: options.signal,
     });
 
     if (!response.ok) {
@@ -230,6 +233,7 @@ export class OpenAiOAuthService {
         rejectTokens(new Error('OpenAI OAuth callback timed out'));
       }
     }, args.timeoutMs ?? 5 * 60 * 1000);
+    const sockets = new Set<Socket>();
 
     const server = createServer((req, res) => {
       const url = new URL(req.url ?? '/', `http://localhost:${args.port}`);
@@ -268,15 +272,34 @@ export class OpenAiOAuthService {
 
       settled = true;
       const redirectUri = `http://localhost:${OpenAiOAuthService.getServerPort(server) ?? args.port}${OPENAI_OAUTH_CALLBACK_PATH}`;
+      const controller = new AbortController();
+      const exchangeTimeout = setTimeout(() => controller.abort(), args.timeoutMs ?? 5 * 60 * 1000);
       void OpenAiOAuthService.exchangeCode({
         code,
         redirectUri,
         codeVerifier: args.pkce.verifier,
         fetchImpl: args.fetchImpl,
-      }).then(resolveTokens, rejectTokens);
-
-      res.writeHead(200, { 'Content-Type': 'text/html' });
-      res.end(OpenAiOAuthService.renderCallbackHtml('Authorization successful', 'You can close this window and return to Heddle.'));
+        signal: controller.signal,
+      }).then((tokens) => {
+        clearTimeout(exchangeTimeout);
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(
+          OpenAiOAuthService.renderCallbackHtml('Authorization successful', 'You can close this window and return to Heddle.'),
+          () => resolveTokens(tokens),
+        );
+      }, (exchangeError) => {
+        clearTimeout(exchangeTimeout);
+        const error = exchangeError instanceof Error ? exchangeError : new Error(String(exchangeError));
+        res.writeHead(500, { 'Content-Type': 'text/html' });
+        res.end(
+          OpenAiOAuthService.renderCallbackHtml('Authorization failed', 'Return to Heddle and retry the login command.'),
+          () => rejectTokens(error),
+        );
+      });
+    });
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
     });
 
     await new Promise<void>((resolve, reject) => {
@@ -301,6 +324,10 @@ export class OpenAiOAuthService {
             return;
           }
           server.close(() => resolve());
+          server.closeIdleConnections?.();
+          for (const socket of sockets) {
+            socket.destroy();
+          }
         });
       },
     };

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -71,6 +71,7 @@ export type OpenAiOAuthLoginOptions = {
 export type OpenAiOAuthRefreshOptions = {
   refreshToken: string;
   fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
 };
 
 export type OpenAiIdTokenClaims = {

--- a/src/server/controllers/trpc/control-plane/control-plane-state.ts
+++ b/src/server/controllers/trpc/control-plane/control-plane-state.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import type { HeddleServerContext } from '@/server/types.js';
 import type { ControlPlaneState } from '@/server/control-plane-types.js';
+import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
@@ -15,6 +16,7 @@ export class ControlPlaneStateController {
   ): Promise<ControlPlaneState> {
     const workspaceRoot = workspace.workspaceRoot;
     const stateRoot = workspace.stateRoot;
+    const credentialStorePath = ProviderCredentialRepository.resolveStorePath(stateRoot);
     const [tasks, memory] = await Promise.all([
       ControlPlaneHeartbeatController.listTasks(stateRoot),
       ControlPlaneMemoryController.readStatus(stateRoot),
@@ -25,8 +27,14 @@ export class ControlPlaneStateController {
       stateRoot,
       auth: {
         preferApiKey: context.preferApiKey,
-        openai: RuntimeCredentialService.resolveCredentialSourceForModel('gpt-5.4', { preferApiKey: context.preferApiKey }),
-        anthropic: RuntimeCredentialService.resolveCredentialSourceForModel('claude-sonnet-4-6', { preferApiKey: context.preferApiKey }),
+        openai: RuntimeCredentialService.resolveCredentialSourceForModel('gpt-5.4', {
+          credentialStorePath,
+          preferApiKey: context.preferApiKey,
+        }),
+        anthropic: RuntimeCredentialService.resolveCredentialSourceForModel('claude-sonnet-4-6', {
+          credentialStorePath,
+          preferApiKey: context.preferApiKey,
+        }),
       },
       activeWorkspaceId: workspace.id,
       workspace,
@@ -37,6 +45,7 @@ export class ControlPlaneStateController {
         workspaceRoot,
         stateRoot,
         sessionStoragePath: resolve(stateRoot, 'chat-sessions.catalog.json'),
+        credentialStorePath,
         preferApiKey: context.preferApiKey,
         workspaceId: workspace.id,
       }),

--- a/src/server/routes/trpc/control-plane-workspace.ts
+++ b/src/server/routes/trpc/control-plane-workspace.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import type { Logger } from 'pino';
 import { AutonomyPermissionModeService, type AutopilotProfile } from '@/core/approvals/index.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
+import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { getWorkspaceOperationLogger } from '@/server/logging/workspace-operation-logger.js';
@@ -20,6 +21,7 @@ export type ControlPlaneRequestWorkspace = {
     workspaceRoot: string;
     stateRoot: string;
     sessionStoragePath: string;
+    credentialStorePath: string;
     preferApiKey: boolean;
     workspaceId: string;
     autopilot?: AutopilotProfile;
@@ -83,6 +85,7 @@ export function resolveControlPlaneRequestWorkspace(
       workspaceRoot: workspace.workspaceRoot,
       stateRoot: workspace.stateRoot,
       sessionStoragePath: resolve(workspace.stateRoot, 'chat-sessions.catalog.json'),
+      credentialStorePath: ProviderCredentialRepository.resolveStorePath(workspace.stateRoot),
       preferApiKey: ctx.preferApiKey,
       workspaceId: workspace.id,
       autopilot,


### PR DESCRIPTION
## Summary

- Route `heddle auth login/status/logout` through the active workspace credential store instead of the global default store.
- Make control-plane auth status and session engine args resolve credentials from the same workspace `.heddle/auth.json` path.
- Tighten OpenAI OAuth callback handling so the browser success page is only sent after token exchange succeeds, and callback server shutdown does not hang on idle sockets.

## Root Cause

The CLI auth command path defaulted to the global `~/.heddle/auth.json` store while control-plane/session runtime paths could use workspace-scoped credential stores. That made auth status and actual runtime credentials easy to desynchronize. Separately, the OAuth callback flow rendered success before token exchange completed, so a browser success page could appear while the terminal was still waiting or failing.

## Validation

- `yarn test`
- `yarn build`

`yarn build` completed with the existing Vite large chunk warning.