### PR TITLE
[codex] Add artifact registry substrate

### DIFF
--- a/src/__tests__/unit/core/artifacts.test.ts
+++ b/src/__tests__/unit/core/artifacts.test.ts
@@ -1,0 +1,152 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ArtifactService, FileArtifactRepository } from '@/core/artifacts/index.js';
+
+describe('artifact registry', () => {
+  it('saves text artifacts, stores metadata, and reads content back', () => {
+    const artifactRoot = mkdtempSync(join(tmpdir(), 'heddle-artifacts-'));
+    const service = new ArtifactService({
+      artifactRoot,
+      now: () => '2026-07-01T00:00:00.000Z',
+      nextId: () => 'deck-source',
+    });
+
+    const artifact = service.saveText({
+      kind: 'source',
+      domain: 'presentation',
+      title: 'deck.motion.md',
+      content: '# Deck\n\n<Slide />',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      sourceTool: 'mcp__slidex__slidex_create_deck',
+      metadata: { slideCount: 1 },
+    });
+
+    expect(artifact).toMatchObject({
+      id: 'deck-source',
+      kind: 'source',
+      domain: 'presentation',
+      title: 'deck.motion.md',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      sourceTool: 'mcp__slidex__slidex_create_deck',
+      metadata: { slideCount: 1 },
+    });
+    expect(artifact.path).toBe(join(artifactRoot, 'files', 'deck-source.md'));
+    expect(readFileSync(artifact.path, 'utf8')).toBe('# Deck\n\n<Slide />');
+    expect(service.read('deck-source')).toMatchObject({
+      artifact: {
+        id: artifact.id,
+        kind: artifact.kind,
+        path: artifact.path,
+      },
+      content: '# Deck\n\n<Slide />',
+    });
+    expect(service.current('session-1')).toEqual(artifact);
+  });
+
+  it('lists artifacts by session, domain, and kind with newest first', () => {
+    const artifactRoot = mkdtempSync(join(tmpdir(), 'heddle-artifacts-'));
+    let id = 0;
+    const service = new ArtifactService({
+      artifactRoot,
+      now: () => `2026-07-01T00:00:0${id}.000Z`,
+      nextId: () => `artifact-${++id}`,
+    });
+
+    const first = service.saveText({
+      kind: 'source',
+      domain: 'presentation',
+      content: 'source',
+      sessionId: 'session-1',
+    });
+    const second = service.saveText({
+      kind: 'html',
+      domain: 'presentation',
+      content: '<html></html>',
+      sessionId: 'session-1',
+    });
+    service.saveText({
+      kind: 'source',
+      domain: 'report',
+      content: 'report',
+      sessionId: 'session-2',
+    });
+
+    expect(service.list({ sessionId: 'session-1' }).map((artifact) => artifact.id)).toEqual([second.id, first.id]);
+    expect(service.list({ domain: 'presentation', kind: 'source' }).map((artifact) => artifact.id)).toEqual([first.id]);
+  });
+
+  it('supports workspace and session current artifact pointers', () => {
+    const artifactRoot = mkdtempSync(join(tmpdir(), 'heddle-artifacts-'));
+    let id = 0;
+    const service = new ArtifactService({
+      artifactRoot,
+      now: () => '2026-07-01T00:00:00.000Z',
+      nextId: () => `artifact-${++id}`,
+    });
+
+    const workspaceArtifact = service.saveText({
+      kind: 'html',
+      content: '<html></html>',
+    });
+    const sessionArtifact = service.saveText({
+      kind: 'source',
+      content: 'source',
+      sessionId: 'session-1',
+    });
+
+    expect(service.current()).toEqual(workspaceArtifact);
+    expect(service.current('session-1')).toEqual(sessionArtifact);
+    expect(service.current('session-2')).toEqual(workspaceArtifact);
+
+    service.setCurrent(sessionArtifact.id);
+    expect(service.current()).toEqual(sessionArtifact);
+  });
+
+  it('returns an empty store for malformed indexes without deleting artifact files', () => {
+    const artifactRoot = mkdtempSync(join(tmpdir(), 'heddle-artifacts-'));
+    const repository = new FileArtifactRepository({ artifactRoot });
+    const service = new ArtifactService({
+      artifactRoot,
+      now: () => '2026-07-01T00:00:00.000Z',
+      nextId: () => 'artifact-1',
+    });
+    const artifact = service.saveText({
+      kind: 'source',
+      content: 'content',
+    });
+
+    expect(existsSync(artifact.path)).toBe(true);
+    expect(repository.read().artifacts).toHaveLength(1);
+
+    const storePath = FileArtifactRepository.resolveStorePath(artifactRoot);
+    // Keep malformed JSON from surfacing partial or invalid artifact state.
+    writeFileSync(storePath, '{not valid json', 'utf8');
+
+    expect(repository.read()).toEqual(FileArtifactRepository.emptyStore());
+    expect(existsSync(artifact.path)).toBe(true);
+  });
+
+  it('rejects duplicate artifact ids instead of overwriting stored files', () => {
+    const artifactRoot = mkdtempSync(join(tmpdir(), 'heddle-artifacts-'));
+    const service = new ArtifactService({
+      artifactRoot,
+      now: () => '2026-07-01T00:00:00.000Z',
+      nextId: () => 'same-id',
+    });
+
+    service.saveText({
+      kind: 'source',
+      content: 'original',
+    });
+
+    expect(() => service.saveText({
+      kind: 'source',
+      content: 'replacement',
+    })).toThrow('Artifact already exists: same-id');
+    expect(readFileSync(join(artifactRoot, 'files', 'same-id.txt'), 'utf8')).toBe('original');
+  });
+});

--- a/src/core/artifacts/README.md
+++ b/src/core/artifacts/README.md
@@ -1,0 +1,30 @@
+# Artifacts
+
+The artifacts domain owns Heddle-generated or host-provided output files that
+should remain addressable across conversation turns.
+
+Artifacts are not memory, traces, or tool results:
+
+- memory stores durable knowledge for future reasoning;
+- traces store evidence of what happened during a run;
+- tool results are raw execution outputs;
+- artifacts are reusable outputs that a user or host may preview, reopen, or
+  ask the agent to modify in a follow-up turn.
+
+This domain owns:
+
+- the persisted artifact index under `stateRoot/artifacts/artifacts.json`;
+- text-like artifact file storage under `stateRoot/artifacts/files/`;
+- current artifact pointers for a workspace or session;
+- repository validation for the on-disk JSON contract;
+- service operations for save, list, read, and current-artifact selection.
+
+This domain does not own:
+
+- UI preview rendering;
+- domain-specific parsing such as SlideX MotionDoc analysis;
+- automatic promotion of arbitrary tool results into artifacts;
+- runtime tool exposure for artifact operations.
+
+Those behaviors should depend on this service boundary instead of reading or
+writing artifact files directly.

--- a/src/core/artifacts/index.ts
+++ b/src/core/artifacts/index.ts
@@ -1,0 +1,19 @@
+export { FileArtifactRepository } from './repository.js';
+export { ArtifactService } from './service.js';
+export {
+  ArtifactCurrentPointersSchema,
+  ArtifactKindSchema,
+  ArtifactStoreSchema,
+  RuntimeArtifactSchema,
+} from './schemas.js';
+export type {
+  ArtifactCurrentPointers,
+  ArtifactKind,
+  ArtifactListOptions,
+  ArtifactReadResult,
+  ArtifactServiceOptions,
+  ArtifactStore,
+  FileArtifactRepositoryOptions,
+  RuntimeArtifact,
+  SaveTextArtifactInput,
+} from './types.js';

--- a/src/core/artifacts/repository.ts
+++ b/src/core/artifacts/repository.ts
@@ -1,0 +1,46 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { ArtifactStoreSchema } from './schemas.js';
+import type { ArtifactStore, FileArtifactRepositoryOptions } from './types.js';
+
+/**
+ * File-backed artifact repository for the artifact index.
+ */
+export class FileArtifactRepository {
+  private readonly storePath: string;
+
+  constructor(options: FileArtifactRepositoryOptions) {
+    this.storePath = FileArtifactRepository.resolveStorePath(options.artifactRoot);
+  }
+
+  static resolveStorePath(artifactRoot: string): string {
+    return resolve(artifactRoot, 'artifacts.json');
+  }
+
+  static emptyStore(): ArtifactStore {
+    return {
+      version: 1,
+      artifacts: [],
+      current: {
+        sessionArtifactIds: {},
+      },
+    };
+  }
+
+  read(): ArtifactStore {
+    if (!existsSync(this.storePath)) {
+      return FileArtifactRepository.emptyStore();
+    }
+
+    try {
+      return ArtifactStoreSchema.parse(JSON.parse(readFileSync(this.storePath, 'utf8')) as unknown) as ArtifactStore;
+    } catch {
+      return FileArtifactRepository.emptyStore();
+    }
+  }
+
+  write(store: ArtifactStore): void {
+    mkdirSync(dirname(this.storePath), { recursive: true });
+    writeFileSync(this.storePath, `${JSON.stringify(ArtifactStoreSchema.parse(store), null, 2)}\n`, 'utf8');
+  }
+}

--- a/src/core/artifacts/schemas.ts
+++ b/src/core/artifacts/schemas.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const ArtifactKindSchema = z.enum(['source', 'html', 'json', 'image', 'document', 'binary', 'domain']);
+
+export const RuntimeArtifactSchema = z.object({
+  id: z.string().min(1),
+  kind: ArtifactKindSchema,
+  domain: z.string().min(1).optional(),
+  title: z.string().min(1).optional(),
+  path: z.string().min(1),
+  mimeType: z.string().min(1).optional(),
+  sessionId: z.string().min(1).optional(),
+  turnId: z.string().min(1).optional(),
+  sourceTool: z.string().min(1).optional(),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const ArtifactCurrentPointersSchema = z.object({
+  workspaceArtifactId: z.string().min(1).optional(),
+  sessionArtifactIds: z.record(z.string(), z.string().min(1)).default({}),
+});
+
+export const ArtifactStoreSchema = z.object({
+  version: z.literal(1),
+  artifacts: z.array(RuntimeArtifactSchema).default([]),
+  current: ArtifactCurrentPointersSchema.default({ sessionArtifactIds: {} }),
+});

--- a/src/core/artifacts/service.ts
+++ b/src/core/artifacts/service.ts
@@ -1,0 +1,165 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, extname, join, relative, resolve } from 'node:path';
+import dayjs from 'dayjs';
+import { FileArtifactRepository } from './repository.js';
+import type {
+  ArtifactKind,
+  ArtifactListOptions,
+  ArtifactReadResult,
+  ArtifactServiceOptions,
+  ArtifactStore,
+  RuntimeArtifact,
+  SaveTextArtifactInput,
+} from './types.js';
+
+const KIND_EXTENSION: Record<ArtifactKind, string> = {
+  source: 'txt',
+  html: 'html',
+  json: 'json',
+  image: 'bin',
+  document: 'txt',
+  binary: 'bin',
+  domain: 'txt',
+};
+
+/**
+ * Owns artifact persistence and current-artifact selection.
+ */
+export class ArtifactService {
+  private readonly artifactRoot: string;
+  private readonly filesRoot: string;
+  private readonly repository: FileArtifactRepository;
+  private readonly now: () => string;
+  private readonly nextId: () => string;
+
+  constructor(options: ArtifactServiceOptions) {
+    this.artifactRoot = resolve(options.artifactRoot);
+    this.filesRoot = join(this.artifactRoot, 'files');
+    this.repository = new FileArtifactRepository({ artifactRoot: this.artifactRoot });
+    this.now = options.now ?? (() => dayjs().toISOString());
+    this.nextId = options.nextId ?? (() => `artifact-${randomUUID()}`);
+  }
+
+  saveText(input: SaveTextArtifactInput): RuntimeArtifact {
+    const id = this.assertArtifactId(this.nextId());
+    const timestamp = this.now();
+    const path = join(this.filesRoot, `${id}.${this.resolveExtension(input)}`);
+    if (this.get(id) || existsSync(path)) {
+      throw new Error(`Artifact already exists: ${id}`);
+    }
+
+    const artifact: RuntimeArtifact = {
+      id,
+      kind: input.kind,
+      path,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      ...(input.domain ? { domain: input.domain } : {}),
+      ...(input.title ? { title: input.title } : {}),
+      ...(input.mimeType ? { mimeType: input.mimeType } : {}),
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      ...(input.turnId ? { turnId: input.turnId } : {}),
+      ...(input.sourceTool ? { sourceTool: input.sourceTool } : {}),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    };
+
+    mkdirSync(this.filesRoot, { recursive: true });
+    writeFileSync(path, input.content, 'utf8');
+    this.upsertArtifact(artifact, { setCurrent: input.setCurrent ?? true });
+    return artifact;
+  }
+
+  list(options: ArtifactListOptions = {}): RuntimeArtifact[] {
+    return this.repository.read().artifacts
+      .filter((artifact) => !options.sessionId || artifact.sessionId === options.sessionId)
+      .filter((artifact) => !options.domain || artifact.domain === options.domain)
+      .filter((artifact) => !options.kind || artifact.kind === options.kind)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || right.id.localeCompare(left.id));
+  }
+
+  get(id: string): RuntimeArtifact | undefined {
+    return this.repository.read().artifacts.find((artifact) => artifact.id === id);
+  }
+
+  read(id: string): ArtifactReadResult | undefined {
+    const artifact = this.get(id);
+    if (!artifact || !existsSync(artifact.path)) {
+      return undefined;
+    }
+
+    return {
+      artifact,
+      content: readFileSync(artifact.path, 'utf8'),
+    };
+  }
+
+  current(sessionId?: string): RuntimeArtifact | undefined {
+    const store = this.repository.read();
+    const artifactId = sessionId
+      ? store.current.sessionArtifactIds[sessionId] ?? store.current.workspaceArtifactId
+      : store.current.workspaceArtifactId;
+
+    return artifactId ? store.artifacts.find((artifact) => artifact.id === artifactId) : undefined;
+  }
+
+  setCurrent(artifactId: string, options: { sessionId?: string } = {}): RuntimeArtifact {
+    const store = this.repository.read();
+    const artifact = store.artifacts.find((candidate) => candidate.id === artifactId);
+    if (!artifact) {
+      throw new Error(`Artifact not found: ${artifactId}`);
+    }
+
+    if (options.sessionId) {
+      store.current.sessionArtifactIds[options.sessionId] = artifactId;
+    } else {
+      store.current.workspaceArtifactId = artifactId;
+    }
+    this.repository.write(store);
+    return artifact;
+  }
+
+  private upsertArtifact(artifact: RuntimeArtifact, options: { setCurrent: boolean }): void {
+    const store = this.repository.read();
+    const artifacts = [
+      artifact,
+      ...store.artifacts.filter((candidate) => candidate.id !== artifact.id),
+    ];
+    const nextStore: ArtifactStore = {
+      ...store,
+      artifacts,
+      current: {
+        workspaceArtifactId: options.setCurrent && !artifact.sessionId ? artifact.id : store.current.workspaceArtifactId,
+        sessionArtifactIds: {
+          ...store.current.sessionArtifactIds,
+          ...(options.setCurrent && artifact.sessionId ? { [artifact.sessionId]: artifact.id } : {}),
+        },
+      },
+    };
+    this.repository.write(nextStore);
+  }
+
+  private resolveExtension(input: SaveTextArtifactInput): string {
+    const extension = input.extension ?? ArtifactService.extensionFromPath(input.title) ?? KIND_EXTENSION[input.kind];
+    return extension.replace(/^\./, '').replaceAll(/[^A-Za-z0-9_-]/g, '').toLowerCase() || KIND_EXTENSION[input.kind];
+  }
+
+  private assertArtifactId(id: string): string {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id)) {
+      throw new Error(`Invalid artifact id "${id}". Use only letters, numbers, dots, underscores, and hyphens.`);
+    }
+    return id;
+  }
+
+  private static extensionFromPath(path: string | undefined): string | undefined {
+    if (!path) {
+      return undefined;
+    }
+    const extension = extname(basename(path));
+    return extension ? extension.slice(1) : undefined;
+  }
+
+  static relativeArtifactPath(artifactRoot: string, artifact: Pick<RuntimeArtifact, 'path'>): string {
+    return relative(resolve(artifactRoot), artifact.path);
+  }
+}

--- a/src/core/artifacts/types.ts
+++ b/src/core/artifacts/types.ts
@@ -1,0 +1,68 @@
+export type ArtifactKind =
+  | 'source'
+  | 'html'
+  | 'json'
+  | 'image'
+  | 'document'
+  | 'binary'
+  | 'domain';
+
+export type RuntimeArtifact = {
+  id: string;
+  kind: ArtifactKind;
+  domain?: string;
+  title?: string;
+  path: string;
+  mimeType?: string;
+  sessionId?: string;
+  turnId?: string;
+  sourceTool?: string;
+  createdAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type ArtifactCurrentPointers = {
+  workspaceArtifactId?: string;
+  sessionArtifactIds: Record<string, string>;
+};
+
+export type ArtifactStore = {
+  version: 1;
+  artifacts: RuntimeArtifact[];
+  current: ArtifactCurrentPointers;
+};
+
+export type ArtifactListOptions = {
+  sessionId?: string;
+  domain?: string;
+  kind?: ArtifactKind;
+};
+
+export type SaveTextArtifactInput = {
+  content: string;
+  kind: ArtifactKind;
+  domain?: string;
+  title?: string;
+  extension?: string;
+  mimeType?: string;
+  sessionId?: string;
+  turnId?: string;
+  sourceTool?: string;
+  metadata?: Record<string, unknown>;
+  setCurrent?: boolean;
+};
+
+export type ArtifactReadResult = {
+  artifact: RuntimeArtifact;
+  content: string;
+};
+
+export type FileArtifactRepositoryOptions = {
+  artifactRoot: string;
+};
+
+export type ArtifactServiceOptions = FileArtifactRepositoryOptions & {
+  now?: () => string;
+  nextId?: () => string;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,18 @@ export {
   RuntimeCredentialService,
 } from './core/runtime/credentials/index.js';
 export type { ApiKeyRuntime, ProviderCredentialSource } from './core/runtime/credentials/index.js';
+export { ArtifactService, FileArtifactRepository } from './core/artifacts/index.js';
+export type {
+  ArtifactCurrentPointers,
+  ArtifactKind,
+  ArtifactListOptions,
+  ArtifactReadResult,
+  ArtifactServiceOptions,
+  ArtifactStore,
+  FileArtifactRepositoryOptions,
+  RuntimeArtifact,
+  SaveTextArtifactInput,
+} from './core/artifacts/index.js';
 export { RuntimeToolService } from './core/runtime/tools/index.js';
 export type { DefaultAgentToolsOptions } from './core/runtime/tools/index.js';
 export { AgentSkillService, AgentSkillsRuntimeContextService, FileAgentSkillActivationRepository } from './core/skills/index.js';


### PR DESCRIPTION
## Summary

- Add a new `src/core/artifacts` domain with README, public types, zod schemas, file-backed repository, and service boundary.
- Support text-like artifact save/read/list flows under `stateRoot/artifacts`, including session/workspace current artifact pointers.
- Export `ArtifactService`, `FileArtifactRepository`, and artifact types from the package public API.
- Add unit coverage for saving metadata/content, filtering, current artifact fallback behavior, malformed index handling, and duplicate-id protection.

## Scope

This is Phase 1 of the host-extension work. It intentionally does not yet add artifact runtime tools, artifact awareness, host tool injection, MCP injection, or UI preview behavior. Those should build on this substrate in later PRs.

## Validation

- `yarn test src/__tests__/unit/core/artifacts.test.ts`
- `yarn build`

`yarn build` completed with the existing Vite large chunk warning.