### PR TITLE
Add host tool injection for conversation engine

### DIFF
--- a/docs/guides/programmatic-use.md
+++ b/docs/guides/programmatic-use.md
@@ -139,6 +139,44 @@ context. The model can then call `read_agent_skill` to read one active
 Skills are instructions, not permissions. Hosts still own approval callbacks,
 tool policy, workspace boundaries, and any UI needed for activation management.
 
+## Host-Provided Tools
+
+Programmatic hosts can add their own tool definitions at engine creation time.
+Heddle appends these host-provided tools to the default runtime bundle before
+applying custom-agent tool profiles.
+
+```ts
+import { createConversationEngine, type ToolDefinition } from '@roackb2/heddle'
+
+const createDeckTool: ToolDefinition = {
+  name: 'slidex_create_deck',
+  description: 'Create a SlideX deck from a structured brief.',
+  capabilities: ['workspace.write'],
+  parameters: {
+    type: 'object',
+    properties: {
+      brief: { type: 'string' },
+    },
+    required: ['brief'],
+  },
+  execute: async (input) => {
+    return { ok: true, output: { deckId: 'deck-123', input } }
+  },
+}
+
+const engine = createConversationEngine({
+  workspaceRoot: process.cwd(),
+  stateRoot: `${process.cwd()}/.heddle`,
+  model: 'gpt-5.4',
+  tools: [createDeckTool],
+})
+```
+
+Host tools must use unique names. If a host tool collides with a built-in tool
+name, Heddle rejects the runtime bundle instead of silently overriding behavior.
+Use `capabilities` when you want custom-agent tool profiles to filter host tools
+by read/write or domain-specific access.
+
 ## Host Callbacks
 
 `createConversationEngine` accepts host callbacks per submitted turn through `host`.

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -11,6 +11,7 @@ import { ConversationTurnRuntimeResolver } from '../../../core/chat/engine/turns
 import { DEFAULT_OPENAI_MODEL } from '../../../core/config.js';
 import type { CustomAgentExecutionSnapshot } from '../../../core/custom-agents/index.js';
 import { BROWSER_AUTOMATION_SKILL_NAME, FileAgentSkillActivationRepository } from '../../../core/skills/index.js';
+import type { ToolDefinition } from '../../../core/types.js';
 
 describe('chat turn preparation modules', () => {
   afterEach(() => {
@@ -281,6 +282,32 @@ describe('chat turn preparation modules', () => {
     ]));
   });
 
+  it('adds host-provided tools to prepared turn context', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-host-tools-'));
+    const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');
+    const session = ChatSessionRecords.create({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.4',
+    });
+    new FileChatSessionRepository({ sessionStoragePath }).save([session]);
+
+    const context = ConversationTurnContextBuilder.build({
+      workspaceRoot: root,
+      stateRoot: join(root, '.heddle'),
+      sessionStoragePath,
+      sessionId: 'session-1',
+      apiKey: 'explicit-key',
+      tools: [tool('slidex_create_deck')],
+    });
+
+    expect(context.toolNames).toEqual(expect.arrayContaining([
+      'read_file',
+      'slidex_create_deck',
+    ]));
+  });
+
   it('adds browser tools to future turns when Browser Automation is enabled', () => {
     const root = mkdtempSync(join(tmpdir(), 'heddle-turn-browser-automation-'));
     const stateRoot = join(root, '.heddle');
@@ -512,5 +539,14 @@ function askAgentSnapshot(): CustomAgentExecutionSnapshot {
     },
     approvalProfile: { preset: 'read_only' },
     systemContextAppendix: 'You are running in ask mode.',
+  };
+}
+
+function tool(name: string): ToolDefinition {
+  return {
+    name,
+    description: name,
+    parameters: {},
+    execute: async () => ({ ok: true }),
   };
 }

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -10,6 +10,7 @@ import { FileChatSessionRepository } from '../../../core/chat/engine/sessions/re
 import type { ChatSession } from '../../../core/chat/types.js';
 import { TraceSummaryService } from '@/core/observability/index.js';
 import type { LlmAdapter } from '@/core/llm/types.js';
+import type { ToolDefinition } from '../../../core/types.js';
 
 describe('createConversationEngine', () => {
   beforeEach(() => {
@@ -63,6 +64,31 @@ describe('createConversationEngine', () => {
       workspaceId: 'workspace-1',
       history: [],
       messages: [],
+    }));
+  });
+
+  it('passes engine-level host tools into submitted turns', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-host-tools-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const hostTools = [tool('slidex_create_deck')];
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      tools: hostTools,
+      apiKeyPresent: true,
+    });
+    const session = engine.sessions.create({ id: 'session-1', name: 'Host tools' });
+
+    await engine.turns.submit({
+      sessionId: session.id,
+      prompt: 'Create a deck',
+    });
+
+    expect(EngineConversationTurnService.run).toHaveBeenCalledWith(expect.objectContaining({
+      tools: hostTools,
+      sessionId: session.id,
+      prompt: 'Create a deck',
     }));
   });
 
@@ -616,6 +642,15 @@ describe('createConversationEngine', () => {
     expect(sessionRepository.read('session-1')?.lease).toBeUndefined();
   });
 });
+
+function tool(name: string): ToolDefinition {
+  return {
+    name,
+    description: name,
+    parameters: {},
+    execute: async () => ({ ok: true }),
+  };
+}
 
 function fakeTitleLlm(title: string): LlmAdapter {
   return {

--- a/src/__tests__/unit/core/runtime-tool-profiles.test.ts
+++ b/src/__tests__/unit/core/runtime-tool-profiles.test.ts
@@ -68,6 +68,52 @@ describe('runtime tool profiles', () => {
       'mcp_call_tool',
     ]));
   });
+
+  it('adds host-provided tools before applying runtime tool profiles', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-host-tool-profile-'));
+    const tools = RuntimeToolService.createDefaultAgentTools({
+      model: 'gpt-5.4',
+      workspaceRoot,
+      stateRoot: join(workspaceRoot, '.heddle'),
+      apiKey: 'explicit-key',
+      tools: [
+        {
+          ...tool('slidex_create_deck'),
+          capabilities: ['workspace.write'],
+        },
+        {
+          ...tool('slidex_read_templates'),
+          capabilities: ['workspace.read'],
+        },
+      ],
+      toolProfile: {
+        preset: 'custom',
+        allowedCapabilities: ['workspace.read'],
+      },
+    });
+
+    expect(tools.map((candidate) => candidate.name)).toEqual(expect.arrayContaining([
+      'project_dashboard',
+      'list_files',
+      'read_file',
+      'search_files',
+      'read_agent_skill',
+      'slidex_read_templates',
+    ]));
+    expect(tools.map((candidate) => candidate.name)).not.toContain('slidex_create_deck');
+  });
+
+  it('rejects duplicate host-provided runtime tool names', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-host-tool-duplicate-'));
+
+    expect(() => RuntimeToolService.createDefaultAgentTools({
+      model: 'gpt-5.4',
+      workspaceRoot,
+      stateRoot: join(workspaceRoot, '.heddle'),
+      apiKey: 'explicit-key',
+      tools: [tool('read_file')],
+    })).toThrow('Duplicate runtime tool name: read_file');
+  });
 });
 
 function tool(name: string): ToolDefinition {

--- a/src/core/chat/engine/config.ts
+++ b/src/core/chat/engine/config.ts
@@ -3,6 +3,7 @@ import type { ToolApprovalPolicy } from '../../approvals/types.js';
 import type { ReasoningEffort } from '../../llm/types.js';
 import type { TraceSummaryService } from '@/core/observability/index.js';
 import type { ConversationEngineConfig } from './types.js';
+import type { ToolDefinition } from '@/core/types.js';
 
 export type NormalizedConversationEngineConfig = {
   workspaceRoot: string;
@@ -16,6 +17,7 @@ export type NormalizedConversationEngineConfig = {
   memoryMaintenanceMode: 'none' | 'background' | 'inline';
   traceSummarizerRegistry?: TraceSummaryService;
   approvalPolicies?: ToolApprovalPolicy[];
+  tools?: ToolDefinition[];
   sessionStoragePath: string;
   memoryDir: string;
   traceDir: string;
@@ -43,6 +45,7 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     memoryMaintenanceMode: config.memoryMaintenanceMode ?? 'background',
     traceSummarizerRegistry: config.traceSummarizerRegistry,
     approvalPolicies: config.approvalPolicies,
+    tools: config.tools,
     sessionStoragePath,
     memoryDir,
     traceDir,

--- a/src/core/chat/engine/turns/context/types.ts
+++ b/src/core/chat/engine/turns/context/types.ts
@@ -13,6 +13,7 @@ export type PrepareConversationTurnContextArgs = {
   preferApiKey?: boolean;
   credentialStorePath?: string;
   systemContext?: string;
+  tools?: ToolDefinition[];
   agentSnapshot?: CustomAgentExecutionSnapshot;
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;
@@ -21,7 +22,7 @@ export type PrepareConversationTurnContextArgs = {
 
 export type ConversationTurnToolContextArgs = Pick<
   PrepareConversationTurnContextArgs,
-  'workspaceRoot' | 'credentialStorePath' | 'searchIgnoreDirs' | 'includePlanTool' | 'stateRoot'
+  'workspaceRoot' | 'credentialStorePath' | 'searchIgnoreDirs' | 'includePlanTool' | 'stateRoot' | 'tools'
 >;
 
 export type ConversationTurnToolRuntimeArgs = Pick<

--- a/src/core/chat/engine/turns/types.ts
+++ b/src/core/chat/engine/turns/types.ts
@@ -6,6 +6,7 @@ import type { RunAgentLoopOptions } from '@/core/runtime/loop/index.js';
 import type { ChatSession } from '@/core/chat/types.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import type { ChatTurnHostPort } from './host/index.js';
+import type { ToolDefinition } from '@/core/types.js';
 
 export type RunConversationTurnArgs = {
   workspaceRoot: string;
@@ -24,6 +25,7 @@ export type RunConversationTurnArgs = {
   memoryMaintenanceMode?: 'none' | 'background' | 'inline';
   host?: ChatTurnHostPort;
   approvalPolicies?: ToolApprovalPolicy[];
+  tools?: ToolDefinition[];
   agentProfileId?: string;
   agentSnapshot?: CustomAgentExecutionSnapshot;
   traceSummarizerRegistry?: TraceSummaryService;
@@ -46,6 +48,7 @@ export type TurnRuntimeConfigInput = Pick<
   | 'traceDir'
   | 'memoryMaintenanceMode'
   | 'approvalPolicies'
+  | 'tools'
   | 'traceSummarizerRegistry'
 >;
 

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -8,7 +8,7 @@ import type {
 } from '@/core/observability/index.js';
 import type { AgentLoopEvent, RunAgentLoopOptions } from '../../runtime/loop/index.js';
 import type { ChatMessage, LlmAdapter, ReasoningEffort } from '../../llm/types.js';
-import type { TraceEvent } from '../../types.js';
+import type { ToolDefinition, TraceEvent } from '../../types.js';
 import type { ChatSessionLeaseOwner } from './sessions/leases/index.js';
 import type { ChatSession, ChatSessionRetention, QueuedConversationPrompt } from '../types.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
@@ -27,6 +27,7 @@ export type ConversationEngineConfig = {
   memoryMaintenanceMode?: 'none' | 'background' | 'inline';
   traceSummarizerRegistry?: TraceSummaryService;
   approvalPolicies?: ToolApprovalPolicy[];
+  tools?: ToolDefinition[];
   sessionStoragePath?: string;
   memoryDir?: string;
   workspaceId?: string;

--- a/src/core/runtime/tools/README.md
+++ b/src/core/runtime/tools/README.md
@@ -6,6 +6,12 @@ Runtime tools own the default tool bundle policy for generic agent execution.
 toolkits and host context. Individual tool behavior stays in `src/core/tools`;
 this folder only decides which toolkits the generic runtime includes by default.
 
+Programmatic hosts can pass additional tool definitions through the runtime
+options. Runtime tools append those host-provided tools to the default bundle,
+reject duplicate names, and then apply the same tool profile filtering used for
+custom agents. Tool execution, approval, and trace recording still happen in
+the normal agent loop path.
+
 ## Tool Profiles
 
 `profiles/` owns runtime tool visibility profiles. A profile is an execution-time

--- a/src/core/runtime/tools/service.ts
+++ b/src/core/runtime/tools/service.ts
@@ -26,23 +26,26 @@ export class RuntimeToolService {
       join(stateRoot, 'memory');
     const memoryMode = options.memoryMode ?? 'read-and-record';
 
-    const tools = ToolBundleComposer.compose({
-      toolkits: this.createDefaultToolkits({
-        includePlanTool: options.includePlanTool,
-        browserAutomationEnabled: BrowserAutomationCapabilityService.isEnabled({ stateRoot }),
-        stateRoot,
+    const tools = RuntimeToolService.withHostTools({
+      defaultTools: ToolBundleComposer.compose({
+        toolkits: this.createDefaultToolkits({
+          includePlanTool: options.includePlanTool,
+          browserAutomationEnabled: BrowserAutomationCapabilityService.isEnabled({ stateRoot }),
+          stateRoot,
+        }),
+        context: {
+          workspaceRoot,
+          stateRoot,
+          model: options.model,
+          apiKey: options.apiKey,
+          providerCredentialSource: options.providerCredentialSource,
+          credentialStorePath: options.credentialStorePath,
+          memoryDir,
+          memoryMode,
+          searchIgnoreDirs: options.searchIgnoreDirs,
+        },
       }),
-      context: {
-        workspaceRoot,
-        stateRoot,
-        model: options.model,
-        apiKey: options.apiKey,
-        providerCredentialSource: options.providerCredentialSource,
-        credentialStorePath: options.credentialStorePath,
-        memoryDir,
-        memoryMode,
-        searchIgnoreDirs: options.searchIgnoreDirs,
-      },
+      hostTools: options.tools,
     });
     return RuntimeToolProfileService.apply({
       tools,
@@ -99,5 +102,29 @@ export class RuntimeToolService {
         return internalToolkit.createTools(context).filter((tool) => tool.name !== 'update_plan');
       },
     };
+  }
+
+  private static withHostTools(args: {
+    defaultTools: ToolDefinition[];
+    hostTools?: ToolDefinition[];
+  }): ToolDefinition[] {
+    const tools = [
+      ...args.defaultTools,
+      ...(args.hostTools ?? []),
+    ];
+    const names = new Set<string>();
+    const duplicate = tools.find((tool) => {
+      if (names.has(tool.name)) {
+        return true;
+      }
+
+      names.add(tool.name);
+      return false;
+    });
+    if (duplicate) {
+      throw new Error(`Duplicate runtime tool name: ${duplicate.name}`);
+    }
+
+    return tools;
   }
 }

--- a/src/core/runtime/tools/types.ts
+++ b/src/core/runtime/tools/types.ts
@@ -1,5 +1,6 @@
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { RuntimeToolSelectionProfile } from './profiles/index.js';
+import type { ToolDefinition } from '@/core/types.js';
 
 export type DefaultAgentToolsOptions = {
   model: string;
@@ -11,6 +12,7 @@ export type DefaultAgentToolsOptions = {
   stateRoot?: string;
   memoryDir?: string;
   memoryMode?: 'none' | 'read-and-record' | 'maintainer' | 'legacy-full';
+  tools?: ToolDefinition[];
   toolProfile?: RuntimeToolSelectionProfile;
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;


### PR DESCRIPTION
## Summary
- Add `tools?: ToolDefinition[]` to the conversation engine config and thread it into turn runtime context.
- Append host-provided tools to the default runtime tool bundle before applying tool profiles.
- Reject duplicate runtime tool names to avoid silently overriding built-in behavior.
- Document host-provided tools in the programmatic-use guide and runtime tools README.

## Verification
- `yarn test src/__tests__/unit/core/runtime-tool-profiles.test.ts src/__tests__/unit/core/chat-turn-runtime.test.ts src/__tests__/unit/core/conversation-engine.test.ts`
- `yarn build`