### PR TITLE
Add host extension SDK helper

### DIFF
--- a/docs/guides/programmatic-use.md
+++ b/docs/guides/programmatic-use.md
@@ -152,11 +152,12 @@ before applying custom-agent tool profiles.
 ```ts
 import {
   createConversationEngine,
+  defineHostExtension,
   type ToolDefinition,
   type ToolToolkit,
 } from '@roackb2/heddle'
 
-const createDeckTool: ToolDefinition = {
+const createReportTool: ToolDefinition = {
   name: 'create_project_brief',
   description: 'Create a project brief from a structured prompt.',
   capabilities: ['workspace.write'],
@@ -168,7 +169,7 @@ const createDeckTool: ToolDefinition = {
     required: ['brief'],
   },
   execute: async (input) => {
-    return { ok: true, output: { deckId: 'deck-123', input } }
+    return { ok: true, output: { documentId: 'brief-123', input } }
   },
 }
 
@@ -177,23 +178,41 @@ const projectBriefToolkit: ToolToolkit = {
   createTools(context) {
     return [
       {
-        ...createDeckTool,
-        description: `${createDeckTool.description} Workspace: ${context.workspaceRoot}`,
+        ...createReportTool,
+        description: `${createReportTool.description} Workspace: ${context.workspaceRoot}`,
       },
     ]
   },
 }
 
+const projectBriefExtension = defineHostExtension({
+  id: 'project-brief-workspace',
+  toolkits: [projectBriefToolkit],
+  systemContext: 'When generating durable project briefs, save source and preview files as artifacts.',
+  artifacts: {
+    enabled: true,
+  },
+})
+
 const engine = createConversationEngine({
   workspaceRoot: process.cwd(),
   stateRoot: `${process.cwd()}/.heddle`,
   model: 'gpt-5.4',
-  hostExtensions: {
-    toolkits: [projectBriefToolkit],
-    systemContext: 'When generating durable outputs, save source and preview files as artifacts.',
-  },
+  hostExtensions: [projectBriefExtension],
 })
 ```
+
+Use `defineHostExtension(...)` for new SDK integrations. It validates the
+extension id plus duplicate host tool and toolkit names before the first turn
+runs. `hostExtensions` accepts either one legacy object or an ordered array of
+defined extensions. When multiple extensions are provided, Heddle composes them
+in declaration order:
+
+- `tools` are appended in order.
+- `toolkits` are appended in order.
+- `systemContext` blocks are joined with blank lines in order.
+- `artifacts` options are merged in order, with later `enabled` or `root`
+  values overriding earlier values.
 
 Host tools must use unique names. If a host tool collides with a built-in tool
 name, Heddle rejects the runtime bundle instead of silently overriding
@@ -202,7 +221,7 @@ behavior. Host toolkits must also use unique toolkit ids.
 Use `capabilities` when you want custom-agent tool profiles to filter host
 tools by read/write or domain-specific access. `tools` is still accepted at the
 top level for compatibility, but new hosts should prefer
-`hostExtensions.tools`.
+`hostExtensions: [defineHostExtension(...)]`.
 
 ## Artifact Tools
 

--- a/examples/conversation-engine.ts
+++ b/examples/conversation-engine.ts
@@ -14,10 +14,12 @@
 
 import {
   createConversationEngine,
+  defineHostExtension,
   LlmAdapterService,
   RuntimeCredentialService,
   type ConversationActivity,
   type ConversationCompactionStatus,
+  type ToolDefinition,
   type ToolApprovalPolicyContext,
   type TraceEvent,
 } from '../src/index.js';
@@ -51,6 +53,7 @@ async function main() {
     model,
     apiKey,
     preferApiKey: true,
+    hostExtensions: [createExampleHostExtension()],
   });
 
   const session = engine.sessions.create({
@@ -100,6 +103,36 @@ async function main() {
   console.log(`Session ID: ${result.session.id}`);
   console.log(`Session name: ${result.session.name}`);
   console.log(`Turns stored: ${result.session.turns.length}`);
+}
+
+function createExampleHostExtension() {
+  const createProjectBriefTool: ToolDefinition = {
+    name: 'create_project_brief',
+    description: 'Create a compact project brief artifact from a title and summary.',
+    capabilities: ['workspace.write'],
+    parameters: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        title: { type: 'string' },
+        summary: { type: 'string' },
+      },
+      required: ['title', 'summary'],
+    },
+    execute: async (input) => ({
+      ok: true,
+      output: input,
+    }),
+  };
+
+  return defineHostExtension({
+    id: 'project-brief-workspace',
+    tools: [createProjectBriefTool],
+    systemContext: 'Use create_project_brief when the user asks for a structured project brief, then save durable outputs as artifacts.',
+    artifacts: {
+      enabled: true,
+    },
+  });
 }
 
 const requestExampleToolApproval = async (request: ToolApprovalPolicyContext) => {

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createConversationEngine } from '../../../core/chat/engine/conversation-engine.js';
+import { defineHostExtension } from '../../../core/chat/engine/host-extension.js';
 import { EngineConversationTurnService } from '../../../core/chat/engine/turns/service.js';
 import type { AgentLoopEvent } from '@/core/runtime/loop/index.js';
 import type { TraceEvent } from '../../../core/types.js';
@@ -108,6 +109,102 @@ describe('createConversationEngine', () => {
       sessionId: session.id,
       prompt: 'Create a deck',
     }));
+  });
+
+  it('composes multiple host extensions into submitted turns in declaration order', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-host-extension-array-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const reportTool = tool('report_generate');
+    const reviewTool = tool('report_review');
+    const reportToolkit: ToolToolkit = {
+      id: 'report.workspace',
+      createTools: () => [tool('report_validate')],
+    };
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      systemContext: 'Base context',
+      hostExtensions: [
+        defineHostExtension({
+          id: 'reporting',
+          tools: [reportTool],
+          toolkits: [reportToolkit],
+          systemContext: 'Use report workspace tools for report outputs.',
+          artifacts: {
+            root: join(stateRoot, 'report-artifacts'),
+          },
+        }),
+        defineHostExtension({
+          id: 'review',
+          tools: [reviewTool],
+          systemContext: 'Review reports before finalizing them.',
+          artifacts: {
+            enabled: false,
+          },
+        }),
+      ],
+      apiKeyPresent: true,
+    });
+    const session = engine.sessions.create({ id: 'session-1', name: 'Host extension array' });
+
+    await engine.turns.submit({
+      sessionId: session.id,
+      prompt: 'Create a report',
+    });
+
+    expect(EngineConversationTurnService.run).toHaveBeenCalledWith(expect.objectContaining({
+      tools: [reportTool, reviewTool],
+      toolkits: [reportToolkit],
+      systemContext: [
+        'Base context',
+        'Use report workspace tools for report outputs.',
+        'Review reports before finalizing them.',
+      ].join('\n\n'),
+      artifactRoot: join(stateRoot, 'report-artifacts'),
+      artifactsEnabled: false,
+      sessionId: session.id,
+      prompt: 'Create a report',
+    }));
+  });
+
+  it('rejects invalid or conflicting host extension definitions before turns run', () => {
+    expect(() => defineHostExtension({
+      id: 'invalid id',
+    })).toThrow('Invalid host extension id: invalid id');
+
+    expect(() => createConversationEngine({
+      workspaceRoot: mkdtempSync(join(tmpdir(), 'heddle-engine-duplicate-extension-')),
+      stateRoot: mkdtempSync(join(tmpdir(), 'heddle-engine-state-')),
+      model: 'gpt-5.4',
+      hostExtensions: [
+        defineHostExtension({ id: 'reporting' }),
+        defineHostExtension({ id: 'reporting' }),
+      ],
+      apiKeyPresent: true,
+    })).toThrow('Duplicate host extension id: reporting');
+
+    expect(() => createConversationEngine({
+      workspaceRoot: mkdtempSync(join(tmpdir(), 'heddle-engine-duplicate-extension-tool-')),
+      stateRoot: mkdtempSync(join(tmpdir(), 'heddle-engine-state-')),
+      model: 'gpt-5.4',
+      hostExtensions: [
+        defineHostExtension({ id: 'reporting', tools: [tool('shared_tool')] }),
+        defineHostExtension({ id: 'review', tools: [tool('shared_tool')] }),
+      ],
+      apiKeyPresent: true,
+    })).toThrow('Duplicate host extension tool name: shared_tool');
+
+    expect(() => createConversationEngine({
+      workspaceRoot: mkdtempSync(join(tmpdir(), 'heddle-engine-duplicate-extension-toolkit-')),
+      stateRoot: mkdtempSync(join(tmpdir(), 'heddle-engine-state-')),
+      model: 'gpt-5.4',
+      hostExtensions: [
+        defineHostExtension({ id: 'reporting', toolkits: [{ id: 'shared.toolkit', createTools: () => [] }] }),
+        defineHostExtension({ id: 'review', toolkits: [{ id: 'shared.toolkit', createTools: () => [] }] }),
+      ],
+      apiKeyPresent: true,
+    })).toThrow('Duplicate host extension toolkit id: shared.toolkit');
   });
 
   it('keeps top-level host tools as a compatibility input', async () => {

--- a/src/__tests__/unit/core/import-boundaries.test.ts
+++ b/src/__tests__/unit/core/import-boundaries.test.ts
@@ -29,6 +29,7 @@ const FORBIDDEN_PRODUCTION_TOKENS = [
 
 const PUBLIC_EXPORT_EXPECTATIONS = [
   'createConversationEngine',
+  'defineHostExtension',
   'EngineConversationTurnService',
 ];
 

--- a/src/core/chat/engine/config.ts
+++ b/src/core/chat/engine/config.ts
@@ -5,6 +5,7 @@ import type { TraceSummaryService } from '@/core/observability/index.js';
 import type { ConversationEngineConfig } from './types.js';
 import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
+import { ConversationEngineHostExtensionService } from './host-extension.js';
 
 export type NormalizedConversationEngineConfig = {
   workspaceRoot: string;
@@ -35,15 +36,16 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
   const sessionStoragePath = resolve(config.sessionStoragePath ?? join(stateRoot, 'chat-sessions.catalog.json'));
   const memoryDir = resolve(config.memoryDir ?? join(stateRoot, 'memory'));
   const traceDir = resolve(join(stateRoot, 'traces'));
-  const artifactRoot = resolve(config.hostExtensions?.artifacts?.root ?? join(stateRoot, 'artifacts'));
+  const hostExtensions = ConversationEngineHostExtensionService.compose(config.hostExtensions);
+  const artifactRoot = resolve(hostExtensions?.artifacts?.root ?? join(stateRoot, 'artifacts'));
   const credentialStorePath = config.credentialStorePath ? resolve(config.credentialStorePath) : undefined;
   const tools = [
     ...(config.tools ?? []),
-    ...(config.hostExtensions?.tools ?? []),
+    ...(hostExtensions?.tools ?? []),
   ];
   const systemContext = [
     config.systemContext,
-    config.hostExtensions?.systemContext,
+    hostExtensions?.systemContext,
   ].filter((value): value is string => Boolean(value)).join('\n\n') || undefined;
 
   return {
@@ -59,9 +61,9 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     traceSummarizerRegistry: config.traceSummarizerRegistry,
     approvalPolicies: config.approvalPolicies,
     tools: tools.length ? tools : undefined,
-    toolkits: config.hostExtensions?.toolkits,
+    toolkits: hostExtensions?.toolkits,
     artifactRoot,
-    artifactsEnabled: config.hostExtensions?.artifacts?.enabled ?? true,
+    artifactsEnabled: hostExtensions?.artifacts?.enabled ?? true,
     sessionStoragePath,
     memoryDir,
     traceDir,

--- a/src/core/chat/engine/host-extension.ts
+++ b/src/core/chat/engine/host-extension.ts
@@ -1,0 +1,145 @@
+import type { ToolDefinition } from '@/core/types.js';
+import type { ToolToolkit } from '@/core/tools/index.js';
+
+const HOST_EXTENSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+
+export type ConversationEngineHostArtifactOptions = {
+  enabled?: boolean;
+  root?: string;
+};
+
+export type ConversationEngineHostExtension = {
+  id: string;
+  tools?: ToolDefinition[];
+  toolkits?: ToolToolkit[];
+  systemContext?: string;
+  artifacts?: ConversationEngineHostArtifactOptions;
+};
+
+export type ConversationEngineHostExtensionBundle = Omit<ConversationEngineHostExtension, 'id'> & {
+  id?: string;
+};
+
+export type ConversationEngineHostExtensionInput =
+  | ConversationEngineHostExtensionBundle
+  | readonly ConversationEngineHostExtension[];
+
+/**
+ * Owns public SDK host-extension validation and deterministic composition.
+ */
+export class ConversationEngineHostExtensionService {
+  static define(extension: ConversationEngineHostExtension): ConversationEngineHostExtension {
+    ConversationEngineHostExtensionService.validateExtension(extension, { idRequired: true });
+    return extension;
+  }
+
+  static compose(input?: ConversationEngineHostExtensionInput): ConversationEngineHostExtensionBundle | undefined {
+    const extensions = ConversationEngineHostExtensionService.toExtensionArray(input);
+    if (!extensions.length) {
+      return undefined;
+    }
+
+    ConversationEngineHostExtensionService.assertUniqueExtensionIds(extensions);
+    extensions.forEach((extension) => {
+      ConversationEngineHostExtensionService.validateExtension(extension, { idRequired: 'id' in extension });
+    });
+
+    const tools = extensions.flatMap((extension) => extension.tools ?? []);
+    const toolkits = extensions.flatMap((extension) => extension.toolkits ?? []);
+    ConversationEngineHostExtensionService.assertUniqueNames({
+      values: tools.map((tool) => tool.name),
+      label: 'host extension tool name',
+    });
+    ConversationEngineHostExtensionService.assertUniqueNames({
+      values: toolkits.map((toolkit) => toolkit.id),
+      label: 'host extension toolkit id',
+    });
+
+    const systemContext = extensions
+      .map((extension) => extension.systemContext)
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join('\n\n') || undefined;
+    const artifacts = ConversationEngineHostExtensionService.composeArtifacts(extensions);
+
+    return {
+      ...(tools.length ? { tools } : {}),
+      ...(toolkits.length ? { toolkits } : {}),
+      ...(systemContext ? { systemContext } : {}),
+      ...(artifacts ? { artifacts } : {}),
+    };
+  }
+
+  private static toExtensionArray(input?: ConversationEngineHostExtensionInput): ConversationEngineHostExtensionBundle[] {
+    if (!input) {
+      return [];
+    }
+
+    return ConversationEngineHostExtensionService.isExtensionArray(input) ? [...input] : [input];
+  }
+
+  private static isExtensionArray(input: ConversationEngineHostExtensionInput): input is readonly ConversationEngineHostExtension[] {
+    return Array.isArray(input);
+  }
+
+  private static validateExtension(extension: ConversationEngineHostExtensionBundle, options: { idRequired: boolean }): void {
+    if (options.idRequired || extension.id) {
+      ConversationEngineHostExtensionService.assertValidId(extension.id);
+    }
+
+    ConversationEngineHostExtensionService.assertUniqueNames({
+      values: (extension.tools ?? []).map((tool) => tool.name),
+      label: `host extension "${extension.id ?? '<legacy>'}" tool name`,
+    });
+    ConversationEngineHostExtensionService.assertUniqueNames({
+      values: (extension.toolkits ?? []).map((toolkit) => toolkit.id),
+      label: `host extension "${extension.id ?? '<legacy>'}" toolkit id`,
+    });
+  }
+
+  private static assertValidId(id: string | undefined): void {
+    if (!id || !HOST_EXTENSION_ID_PATTERN.test(id)) {
+      throw new Error(`Invalid host extension id: ${id ?? '<missing>'}`);
+    }
+  }
+
+  private static assertUniqueExtensionIds(extensions: ConversationEngineHostExtensionBundle[]): void {
+    ConversationEngineHostExtensionService.assertUniqueNames({
+      values: extensions.map((extension) => extension.id).filter((id): id is string => Boolean(id)),
+      label: 'host extension id',
+    });
+  }
+
+  private static assertUniqueNames(args: { values: string[]; label: string }): void {
+    const seen = new Set<string>();
+    const duplicate = args.values.find((value) => {
+      if (seen.has(value)) {
+        return true;
+      }
+
+      seen.add(value);
+      return false;
+    });
+    if (duplicate) {
+      throw new Error(`Duplicate ${args.label}: ${duplicate}`);
+    }
+  }
+
+  private static composeArtifacts(extensions: ConversationEngineHostExtensionBundle[]): ConversationEngineHostArtifactOptions | undefined {
+    const artifactConfigs = extensions
+      .map((extension) => extension.artifacts)
+      .filter((artifacts): artifacts is ConversationEngineHostArtifactOptions => Boolean(artifacts));
+    if (!artifactConfigs.length) {
+      return undefined;
+    }
+
+    return artifactConfigs.reduce<ConversationEngineHostArtifactOptions>((merged, artifacts) => ({
+      ...merged,
+      ...(artifacts.enabled === undefined ? {} : { enabled: artifacts.enabled }),
+      ...(artifacts.root === undefined ? {} : { root: artifacts.root }),
+    }), {});
+  }
+}
+
+export function defineHostExtension(extension: ConversationEngineHostExtension): ConversationEngineHostExtension {
+  return ConversationEngineHostExtensionService.define(extension);
+}

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -1,4 +1,5 @@
 export { createConversationEngine } from './conversation-engine.js';
+export { defineHostExtension, ConversationEngineHostExtensionService } from './host-extension.js';
 export { EngineConversationTurnService } from './turns/service.js';
 export type { RunConversationTurnArgs, RunConversationTurnResult } from './turns/types.js';
 export type {
@@ -18,7 +19,9 @@ export type {
   ConversationEngine,
   ConversationEngineConfig,
   ConversationEngineHost,
+  ConversationEngineHostExtension,
   ConversationEngineHostExtensions,
+  ConversationEngineHostExtensionsInput,
   ConversationSessionService,
   ConversationTurnService,
   CreateConversationSessionInput,

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -14,7 +14,11 @@ import type { ChatSession, ChatSessionRetention, QueuedConversationPrompt } from
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import type { ChatTurnHostPort } from './turns/host/index.js';
 import type { ConversationCompactionResult } from '@/core/chat/engine/compaction/index.js';
-import type { ToolToolkit } from '@/core/tools/index.js';
+import type {
+  ConversationEngineHostExtension,
+  ConversationEngineHostExtensionBundle,
+  ConversationEngineHostExtensionInput,
+} from './host-extension.js';
 
 export type ConversationEngineConfig = {
   workspaceRoot: string;
@@ -28,7 +32,7 @@ export type ConversationEngineConfig = {
   memoryMaintenanceMode?: 'none' | 'background' | 'inline';
   traceSummarizerRegistry?: TraceSummaryService;
   approvalPolicies?: ToolApprovalPolicy[];
-  hostExtensions?: ConversationEngineHostExtensions;
+  hostExtensions?: ConversationEngineHostExtensionsInput;
   /**
    * @deprecated Prefer hostExtensions.tools for new programmatic hosts.
    */
@@ -39,15 +43,9 @@ export type ConversationEngineConfig = {
   apiKeyPresent?: boolean;
 };
 
-export type ConversationEngineHostExtensions = {
-  tools?: ToolDefinition[];
-  toolkits?: ToolToolkit[];
-  systemContext?: string;
-  artifacts?: {
-    enabled?: boolean;
-    root?: string;
-  };
-};
+export type ConversationEngineHostExtensions = ConversationEngineHostExtensionBundle;
+export type ConversationEngineHostExtensionsInput = ConversationEngineHostExtensionInput;
+export type { ConversationEngineHostExtension };
 
 export type ConversationEngine = {
   sessions: ConversationSessionService;

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,12 +371,15 @@ export {
 
 // Chat alpha API
 export { createConversationEngine } from './core/chat/engine/conversation-engine.js';
+export { defineHostExtension, ConversationEngineHostExtensionService } from './core/chat/engine/host-extension.js';
 export type {
   ClearConversationTurnLeaseInput,
   ConversationEngine,
   ConversationEngineConfig,
   ConversationEngineHost,
+  ConversationEngineHostExtension,
   ConversationEngineHostExtensions,
+  ConversationEngineHostExtensionsInput,
   ConversationSessionService,
   ConversationTurnService,
   CreateConversationSessionInput,


### PR DESCRIPTION
## Summary
- add defineHostExtension and host extension composition for ordered SDK integrations
- keep legacy single-object hostExtensions compatibility while allowing ordered extension arrays
- document and example a generic project brief/report extension flow

## Verification
- yarn test
- yarn build