### PR TITLE
[codex] Add MCP host extension SDK

### DIFF
--- a/docs/guides/programmatic-use.md
+++ b/docs/guides/programmatic-use.md
@@ -218,6 +218,106 @@ Host tools must use unique names. If a host tool collides with a built-in tool
 name, Heddle rejects the runtime bundle instead of silently overriding
 behavior. Host toolkits must also use unique toolkit ids.
 
+### MCP Host Extensions
+
+If your host already has an MCP server, you do not need to copy every MCP tool
+schema into hand-written Heddle tools. Configure and refresh the MCP server in
+Heddle state, then use `defineMcpHostExtension(...)` to expose selected cached
+MCP tools as a host extension.
+
+This is useful when a host wants a domain-specific prompt, artifact behavior, or
+tool naming surface while still letting MCP own the tool schemas and call
+protocol.
+
+```ts
+import {
+  createConversationEngine,
+  defineMcpHostExtension,
+  prepareMcpHostExtension,
+} from '@roackb2/heddle'
+
+const presentation = await prepareMcpHostExtension({
+  id: 'presentation',
+  workspaceRoot: process.cwd(),
+  stateRoot: `${process.cwd()}/.heddle`,
+  serverId: 'slides',
+  server: {
+    type: 'stdio',
+    command: 'npm',
+    args: ['run', 'mcp'],
+    tools: {
+      approval: 'never',
+    },
+  },
+  includeTools: ['create_deck', 'validate_deck', 'export_html'],
+  systemContext: [
+    'Use presentation tools when the user asks for deck creation or revision.',
+    'Save reusable source and preview outputs as artifacts when appropriate.',
+  ].join('\n'),
+  artifacts: {
+    enabled: true,
+  },
+})
+
+if (!presentation.ok) {
+  throw new Error(`Failed to prepare MCP extension: ${presentation.step}: ${presentation.error}`)
+}
+
+const knowledgeBaseExtension = defineMcpHostExtension({
+  id: 'knowledge-base',
+  serverId: 'notion',
+  includeTools: ['search_pages', 'create_page'],
+  systemContext: 'Use the knowledge base tools for durable team documentation.',
+})
+
+const engine = createConversationEngine({
+  workspaceRoot: process.cwd(),
+  stateRoot: `${process.cwd()}/.heddle`,
+  model: 'gpt-5.4',
+  hostExtensions: [
+    presentation.extension,
+    knowledgeBaseExtension,
+  ],
+})
+```
+
+By default, Heddle keeps the MCP tool names, descriptions, and input schemas
+from the cached MCP catalog. Use `toolNamePrefix` only when multiple MCP
+servers expose overlapping tool names in the same engine:
+
+```ts
+const presentationExtension = defineMcpHostExtension({
+  id: 'presentation',
+  serverId: 'slides',
+  includeTools: ['create_deck'],
+  toolNamePrefix: 'slides',
+})
+```
+
+Use `toolOverrides` only when the host needs a sharper name, description,
+capability, or approval behavior:
+
+```ts
+const presentationExtension = defineMcpHostExtension({
+  id: 'presentation',
+  serverId: 'slides',
+  includeTools: ['create_deck'],
+  toolOverrides: {
+    create_deck: {
+      name: 'presentation_create_deck',
+      description: 'Create a deck using the host presentation workspace.',
+      capabilities: ['workspace.write'],
+    },
+  },
+})
+```
+
+`defineMcpHostExtension(...)` reads the cached MCP catalog when a turn builds
+its tool bundle. It does not launch MCP servers or refresh catalogs during the
+turn. Use `prepareMcpHostExtension(...)` before creating the engine when your
+host owns the MCP server definition. That keeps turn startup synchronous and
+predictable while still giving SDK hosts a one-call setup path.
+
 Use `capabilities` when you want custom-agent tool profiles to filter host
 tools by read/write or domain-specific access. `tools` is still accepted at the
 top level for compatibility, but new hosts should prefer

--- a/src/__tests__/unit/core/mcp-host-extension.test.ts
+++ b/src/__tests__/unit/core/mcp-host-extension.test.ts
@@ -1,0 +1,258 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  FileMcpCatalogRepository,
+  FileMcpConfigRepository,
+  McpService,
+} from '@/core/mcp/index.js';
+import {
+  ConversationEngineHostExtensionService,
+  defineMcpHostExtension,
+  prepareMcpHostExtension,
+  prepareMcpHostExtensionCatalog,
+} from '@/core/chat/engine/index.js';
+import type { ToolToolkitContext } from '@/core/tools/index.js';
+
+function contextFixture(): ToolToolkitContext {
+  const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-mcp-host-extension-'));
+  const stateRoot = join(workspaceRoot, '.heddle');
+  mkdirSync(stateRoot, { recursive: true });
+  writeFileSync(FileMcpConfigRepository.resolvePath(stateRoot), JSON.stringify({
+    mcpServers: {
+      deck_service: {
+        command: 'npm',
+        args: ['run', 'mcp'],
+        tools: {
+          approval: 'always',
+        },
+      },
+      notion: {
+        command: 'npx',
+        args: ['-y', 'notion-mcp'],
+        tools: {
+          approval: 'never',
+        },
+      },
+    },
+  }), 'utf8');
+
+  const mcp = new McpService({ workspaceRoot, stateRoot });
+  mcp.activateServer('deck_service');
+  mcp.activateServer('notion');
+  new FileMcpCatalogRepository({ stateRoot }).write({
+    version: 1,
+    servers: {
+      deck_service: {
+        serverId: 'deck_service',
+        tools: [
+          {
+            name: 'create-deck',
+            title: 'Create deck',
+            description: 'Create a presentation deck.',
+            inputSchema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                title: { type: 'string' },
+              },
+              required: ['title'],
+            },
+          },
+          {
+            name: 'validate-deck',
+            description: 'Validate a presentation deck.',
+            inputSchema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                source: { type: 'string' },
+              },
+              required: ['source'],
+            },
+          },
+        ],
+        refreshedAt: '2026-07-01T00:00:00.000Z',
+      },
+      notion: {
+        serverId: 'notion',
+        tools: [{
+          name: 'search-pages',
+          description: 'Search Notion pages.',
+          inputSchema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              query: { type: 'string' },
+            },
+            required: ['query'],
+          },
+        }],
+        refreshedAt: '2026-07-01T00:00:00.000Z',
+      },
+    },
+  });
+
+  return {
+    workspaceRoot,
+    stateRoot,
+    artifactRoot: join(stateRoot, 'artifacts'),
+    model: 'gpt-5.5',
+    memoryDir: join(stateRoot, 'memory'),
+    memoryMode: 'none',
+  };
+}
+
+describe('defineMcpHostExtension', () => {
+  it('creates host tools from cached MCP descriptors without manual schema mapping', () => {
+    const context = contextFixture();
+    const extension = defineMcpHostExtension({
+      id: 'slides',
+      serverId: 'deck_service',
+      includeTools: ['create-deck'],
+      defaultCapabilities: ['workspace.write'],
+      systemContext: 'Use slide tools for presentation work.',
+      artifacts: {
+        enabled: true,
+      },
+    });
+
+    const tools = extension.toolkits?.flatMap((toolkit) => toolkit.createTools(context)) ?? [];
+
+    expect(extension).toEqual(expect.objectContaining({
+      id: 'slides',
+      systemContext: 'Use slide tools for presentation work.',
+      artifacts: { enabled: true },
+    }));
+    expect(extension.toolkits?.map((toolkit) => toolkit.id)).toEqual(['mcp.slides']);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toEqual(expect.objectContaining({
+      name: 'create_deck',
+      description: 'Create a presentation deck.',
+      requiresApproval: true,
+      capabilities: ['workspace.write'],
+      parameters: expect.objectContaining({
+        properties: {
+          title: { type: 'string' },
+        },
+        required: ['title'],
+      }),
+    }));
+  });
+
+  it('supports multiple MCP host extensions without tool name conflicts', () => {
+    const context = contextFixture();
+    const extensions = [
+      defineMcpHostExtension({
+        id: 'slides',
+        serverId: 'deck_service',
+        includeTools: ['create-deck'],
+        toolNamePrefix: 'slides',
+      }),
+      defineMcpHostExtension({
+        id: 'docs',
+        serverId: 'notion',
+        includeTools: ['search-pages'],
+        toolNamePrefix: 'docs',
+      }),
+    ];
+    const bundle = ConversationEngineHostExtensionService.compose(extensions);
+    const tools = bundle?.toolkits?.flatMap((toolkit) => toolkit.createTools(context)) ?? [];
+
+    expect(bundle?.toolkits?.map((toolkit) => toolkit.id)).toEqual(['mcp.slides', 'mcp.docs']);
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'slides__create_deck',
+      'docs__search_pages',
+    ]);
+    expect(tools.find((tool) => tool.name === 'docs__search_pages')?.requiresApproval).toBe(false);
+  });
+
+  it('allows host-specific names, descriptions, capabilities, and approval policy overrides', () => {
+    const context = contextFixture();
+    const extension = defineMcpHostExtension({
+      id: 'presentation',
+      serverId: 'deck_service',
+      excludeTools: ['validate-deck'],
+      toolOverrides: {
+        'create-deck': {
+          name: 'presentation_create_deck',
+          description: 'Create a deck using the host presentation workspace.',
+          capabilities: ['workspace.write'],
+          requiresApproval: false,
+        },
+      },
+    });
+
+    const tools = extension.toolkits?.flatMap((toolkit) => toolkit.createTools(context)) ?? [];
+
+    expect(tools.map((tool) => tool.name)).toEqual(['presentation_create_deck']);
+    expect(tools[0]).toEqual(expect.objectContaining({
+      description: 'Create a deck using the host presentation workspace.',
+      capabilities: ['workspace.write'],
+      requiresApproval: false,
+    }));
+  });
+
+  it('returns no tools until the MCP server is enabled and refreshed', () => {
+    const context = contextFixture();
+    const extension = defineMcpHostExtension({
+      id: 'missing',
+      serverId: 'linear',
+    });
+
+    expect(extension.toolkits?.flatMap((toolkit) => toolkit.createTools(context))).toEqual([]);
+  });
+
+  it('reports MCP catalog preparation failures with the failing setup step', async () => {
+    const context = contextFixture();
+
+    const result = await prepareMcpHostExtensionCatalog({
+      workspaceRoot: context.workspaceRoot,
+      stateRoot: context.stateRoot,
+      serverId: 'broken',
+      server: {
+        type: 'stdio',
+        command: 'node',
+        args: ['-e', 'process.exit(1)'],
+      },
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      serverId: 'broken',
+      step: 'refresh_catalog',
+    }));
+    expect(new FileMcpConfigRepository({
+      workspaceRoot: context.workspaceRoot,
+      stateRoot: context.stateRoot,
+    }).read().servers.map((server) => server.id).sort()).toEqual([
+      'broken',
+      'deck_service',
+      'notion',
+    ]);
+  });
+
+  it('prepares MCP host extension failures with the same setup contract', async () => {
+    const context = contextFixture();
+
+    const result = await prepareMcpHostExtension({
+      id: 'broken-extension',
+      workspaceRoot: context.workspaceRoot,
+      stateRoot: context.stateRoot,
+      serverId: 'broken',
+      server: {
+        type: 'stdio',
+        command: 'node',
+        args: ['-e', 'process.exit(1)'],
+      },
+      includeTools: ['search-pages'],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      serverId: 'broken',
+      step: 'refresh_catalog',
+    }));
+  });
+});

--- a/src/core/chat/engine/README.md
+++ b/src/core/chat/engine/README.md
@@ -72,6 +72,8 @@ Use this pattern when it fits the domain:
 
 - `createConversationEngine`
 - `EngineConversationTurnService`
+- `defineHostExtension`
+- `defineMcpHostExtension`
 - engine-facing types in `types.ts`
 
 ## Common Changes

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -1,5 +1,19 @@
 export { createConversationEngine } from './conversation-engine.js';
 export { defineHostExtension, ConversationEngineHostExtensionService } from './host-extension.js';
+export {
+  defineMcpHostExtension,
+  McpHostExtensionService,
+  prepareMcpHostExtension,
+  prepareMcpHostExtensionCatalog,
+} from './mcp-host-extension.js';
+export type {
+  DefineMcpHostExtensionOptions,
+  McpHostToolOverride,
+  PrepareMcpHostExtensionOptions,
+  PrepareMcpHostExtensionResult,
+  PrepareMcpHostExtensionCatalogOptions,
+  PrepareMcpHostExtensionCatalogResult,
+} from './mcp-host-extension.js';
 export { EngineConversationTurnService } from './turns/service.js';
 export type { RunConversationTurnArgs, RunConversationTurnResult } from './turns/types.js';
 export type {

--- a/src/core/chat/engine/mcp-host-extension.ts
+++ b/src/core/chat/engine/mcp-host-extension.ts
@@ -1,0 +1,279 @@
+import {
+  McpService,
+  isToolAllowed,
+  shouldMcpToolRequireApproval,
+} from '@/core/mcp/index.js';
+import type { McpRefreshResult, McpServerConfig, McpToolDescriptor } from '@/core/mcp/index.js';
+import type { ToolDefinition, ToolResult } from '@/core/types.js';
+import type { ToolToolkit, ToolToolkitContext } from '@/core/tools/index.js';
+import {
+  defineHostExtension,
+  type ConversationEngineHostArtifactOptions,
+  type ConversationEngineHostExtension,
+} from './host-extension.js';
+
+export type McpHostToolOverride = {
+  name?: string;
+  description?: string;
+  capabilities?: string[];
+  requiresApproval?: boolean;
+};
+
+export type DefineMcpHostExtensionOptions = {
+  id: string;
+  serverId: string;
+  includeTools?: string[];
+  excludeTools?: string[];
+  /** Prefix exposed tool names only when multiple MCP servers may collide. */
+  toolNamePrefix?: string;
+  defaultCapabilities?: string[];
+  toolOverrides?: Record<string, McpHostToolOverride>;
+  systemContext?: string;
+  artifacts?: ConversationEngineHostArtifactOptions;
+};
+
+export type PrepareMcpHostExtensionCatalogOptions = {
+  workspaceRoot: string;
+  stateRoot: string;
+  serverId: string;
+  server: Record<string, unknown>;
+};
+
+export type PrepareMcpHostExtensionOptions = DefineMcpHostExtensionOptions & {
+  workspaceRoot: string;
+  stateRoot: string;
+  server: Record<string, unknown>;
+};
+
+export type PrepareMcpHostExtensionCatalogResult =
+  | {
+      ok: true;
+      serverId: string;
+      refresh: Extract<McpRefreshResult, { ok: true }>;
+      toolNames: string[];
+    }
+  | {
+      ok: false;
+      serverId: string;
+      step: 'save_config' | 'activate_server' | 'refresh_catalog';
+      error: string;
+    };
+
+export type PrepareMcpHostExtensionResult =
+  | (Extract<PrepareMcpHostExtensionCatalogResult, { ok: true }> & {
+      extension: ConversationEngineHostExtension;
+    })
+  | Extract<PrepareMcpHostExtensionCatalogResult, { ok: false }>;
+
+type ResolvedMcpTool = {
+  server: McpServerConfig;
+  tool: McpToolDescriptor;
+};
+
+/**
+ * Builds host extensions from cached MCP tool descriptors without requiring
+ * programmatic hosts to copy MCP schemas into hand-written ToolDefinitions.
+ */
+export class McpHostExtensionService {
+  static define(options: DefineMcpHostExtensionOptions): ConversationEngineHostExtension {
+    const toolkit = McpHostExtensionService.createToolkit(options);
+
+    return defineHostExtension({
+      id: options.id,
+      toolkits: [toolkit],
+      ...(options.systemContext ? { systemContext: options.systemContext } : {}),
+      ...(options.artifacts ? { artifacts: options.artifacts } : {}),
+    });
+  }
+
+  private static createToolkit(options: DefineMcpHostExtensionOptions): ToolToolkit {
+    return {
+      id: `mcp.${options.id}`,
+      createTools(context) {
+        return McpHostExtensionService.resolveTools({ context, options })
+          .map(({ server, tool }) => McpHostExtensionService.createTool({
+            context,
+            options,
+            server,
+            tool,
+          }));
+      },
+    };
+  }
+
+  private static resolveTools(args: {
+    context: ToolToolkitContext;
+    options: DefineMcpHostExtensionOptions;
+  }): ResolvedMcpTool[] {
+    const mcp = McpHostExtensionService.createMcpService(args.context);
+    const server = mcp.listOverview().servers.find((candidate) => candidate.id === args.options.serverId);
+    if (server?.status !== 'enabled' || !server.config || !server.catalog) {
+      return [];
+    }
+
+    const { config, catalog } = server;
+    const include = args.options.includeTools ? new Set(args.options.includeTools) : undefined;
+    const exclude = new Set(args.options.excludeTools ?? []);
+
+    return catalog.tools
+      .filter((tool) => (include ? include.has(tool.name) : true))
+      .filter((tool) => !exclude.has(tool.name))
+      .filter((tool) => isToolAllowed(config, tool.name))
+      .map((tool) => ({
+        server: config,
+        tool,
+      }));
+  }
+
+  private static createTool(args: {
+    context: ToolToolkitContext;
+    options: DefineMcpHostExtensionOptions;
+    server: McpServerConfig;
+    tool: McpToolDescriptor;
+  }): ToolDefinition {
+    const override = args.options.toolOverrides?.[args.tool.name];
+
+    return {
+      name: override?.name ?? McpHostExtensionService.toHostToolName(args.options, args.tool.name),
+      requiresApproval: override?.requiresApproval ?? shouldMcpToolRequireApproval(args.server),
+      description: override?.description ?? McpHostExtensionService.describeTool(args.options, args.tool),
+      capabilities: override?.capabilities ?? args.options.defaultCapabilities ?? ['mcp.unknown'],
+      parameters: args.tool.inputSchema,
+      async execute(raw: unknown): Promise<ToolResult> {
+        const result = await McpHostExtensionService.createMcpService(args.context)
+          .callTool(args.options.serverId, args.tool.name, isRecord(raw) ? raw : {});
+
+        return result.ok ? { ok: true, output: result.output } : { ok: false, error: result.error };
+      },
+    };
+  }
+
+  private static describeTool(options: DefineMcpHostExtensionOptions, tool: McpToolDescriptor): string {
+    return tool.description ?? tool.title ?? `MCP tool "${tool.name}" from server "${options.serverId}".`;
+  }
+
+  private static toHostToolName(options: DefineMcpHostExtensionOptions, toolName: string): string {
+    const normalizedToolName = normalizeToolPart(toolName);
+    return options.toolNamePrefix
+      ? `${normalizeToolPart(options.toolNamePrefix)}__${normalizedToolName}`
+      : normalizedToolName;
+  }
+
+  private static createMcpService(context: ToolToolkitContext): McpService {
+    return new McpService({
+      workspaceRoot: context.workspaceRoot,
+      stateRoot: context.stateRoot,
+    });
+  }
+}
+
+export function defineMcpHostExtension(options: DefineMcpHostExtensionOptions): ConversationEngineHostExtension {
+  return McpHostExtensionService.define(options);
+}
+
+export async function prepareMcpHostExtensionCatalog(
+  options: PrepareMcpHostExtensionCatalogOptions,
+): Promise<PrepareMcpHostExtensionCatalogResult> {
+  const mcp = new McpService({
+    workspaceRoot: options.workspaceRoot,
+    stateRoot: options.stateRoot,
+  });
+  const currentDocument = mcp.readConfigDocument();
+
+  if (currentDocument.issues.length > 0) {
+    return {
+      ok: false,
+      serverId: options.serverId,
+      step: 'save_config',
+      error: currentDocument.issues.map((issue) => issue.message).join('; '),
+    };
+  }
+
+  const save = mcp.saveConfigDocument(buildMcpConfigDocumentContent({
+    content: currentDocument.content,
+    serverId: options.serverId,
+    server: options.server,
+  }));
+
+  if (!save.ok) {
+    return {
+      ok: false,
+      serverId: options.serverId,
+      step: 'save_config',
+      error: save.error,
+    };
+  }
+
+  const activation = mcp.activateServer(options.serverId);
+  if (!activation.ok) {
+    return {
+      ok: false,
+      serverId: options.serverId,
+      step: 'activate_server',
+      error: activation.reason,
+    };
+  }
+
+  const refresh = await mcp.refreshServer(options.serverId);
+  if (!refresh.ok) {
+    return {
+      ok: false,
+      serverId: options.serverId,
+      step: 'refresh_catalog',
+      error: refresh.error,
+    };
+  }
+
+  return {
+    ok: true,
+    serverId: options.serverId,
+    refresh,
+    toolNames: refresh.record.tools.map((tool) => tool.name),
+  };
+}
+
+export async function prepareMcpHostExtension(
+  options: PrepareMcpHostExtensionOptions,
+): Promise<PrepareMcpHostExtensionResult> {
+  const prepared = await prepareMcpHostExtensionCatalog({
+    workspaceRoot: options.workspaceRoot,
+    stateRoot: options.stateRoot,
+    serverId: options.serverId,
+    server: options.server,
+  });
+
+  return prepared.ok
+    ? {
+        ...prepared,
+        extension: defineMcpHostExtension(options),
+      }
+    : prepared;
+}
+
+function normalizeToolPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9_]+/g, '_').replace(/^_+|_+$/g, '') || 'mcp';
+}
+
+function buildMcpConfigDocumentContent(input: {
+  content: string;
+  serverId: string;
+  server: Record<string, unknown>;
+}): string {
+  const raw = input.content.trim().length > 0
+    ? JSON.parse(input.content) as unknown
+    : {};
+  const config = isRecord(raw) ? raw : {};
+  const mcpServers = isRecord(config.mcpServers) ? config.mcpServers : {};
+
+  return JSON.stringify({
+    ...config,
+    mcpServers: {
+      ...mcpServers,
+      [input.serverId]: input.server,
+    },
+  }, null, 2);
+}
+
+function isRecord(raw: unknown): raw is Record<string, unknown> {
+  return raw !== null && typeof raw === 'object' && !Array.isArray(raw);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -372,6 +372,20 @@ export {
 // Chat alpha API
 export { createConversationEngine } from './core/chat/engine/conversation-engine.js';
 export { defineHostExtension, ConversationEngineHostExtensionService } from './core/chat/engine/host-extension.js';
+export {
+  defineMcpHostExtension,
+  McpHostExtensionService,
+  prepareMcpHostExtension,
+  prepareMcpHostExtensionCatalog,
+} from './core/chat/engine/mcp-host-extension.js';
+export type {
+  DefineMcpHostExtensionOptions,
+  McpHostToolOverride,
+  PrepareMcpHostExtensionOptions,
+  PrepareMcpHostExtensionResult,
+  PrepareMcpHostExtensionCatalogOptions,
+  PrepareMcpHostExtensionCatalogResult,
+} from './core/chat/engine/mcp-host-extension.js';
 export type {
   ClearConversationTurnLeaseInput,
   ConversationEngine,


### PR DESCRIPTION
## Summary
- add defineMcpHostExtension for building host extensions from cached MCP tool descriptors
- support include/exclude filters, generated tool names, capability defaults, and per-tool overrides
- document raw MCP-to-host-extension usage and multiple MCP extension composition

## Why
Programmatic hosts should not have to copy MCP tool schemas into hand-written Heddle ToolDefinitions. This helper lets MCP own schemas and call protocol while Heddle owns host-extension composition, prompt context, artifacts, and optional domain overrides.

## Validation
- yarn test src/__tests__/unit/core/mcp-host-extension.test.ts
- yarn test src/__tests__/unit/core/mcp-host-extension.test.ts src/__tests__/unit/tools/mcp-toolkit.test.ts src/__tests__/unit/core/conversation-engine.test.ts
- yarn build