### PR TITLE
Add curated MCP host extension controls

### DIFF
--- a/docs/guides/programmatic-use.md
+++ b/docs/guides/programmatic-use.md
@@ -213,6 +213,8 @@ in declaration order:
 - `systemContext` blocks are joined with blank lines in order.
 - `artifacts` options are merged in order, with later `enabled` or `root`
   values overriding earlier values.
+- `mcp.hideDefaultServers` values are de-duplicated and passed to the default
+  MCP toolkit so curated host tools do not compete with raw generic MCP tools.
 
 Host tools must use unique names. If a host tool collides with a built-in tool
 name, Heddle rejects the runtime bundle instead of silently overriding
@@ -302,6 +304,7 @@ const presentationExtension = defineMcpHostExtension({
   id: 'presentation',
   serverId: 'slides',
   includeTools: ['create_deck'],
+  hideDefaultMcpTools: true,
   toolOverrides: {
     create_deck: {
       name: 'presentation_create_deck',
@@ -311,6 +314,40 @@ const presentationExtension = defineMcpHostExtension({
   },
 })
 ```
+
+Set `hideDefaultMcpTools: true` when the host extension is the intended tool
+surface for that MCP server. Heddle will still call the same MCP server behind
+the scenes, but the default `mcp_list_tools`, `mcp_call_tool`, and
+`mcp__server__tool` paths will not expose that server to the model.
+
+Use `resultArtifacts` when an MCP tool returns a large generated value that
+should be persisted and inspected through artifact tools instead of copied back
+into the model context:
+
+```ts
+const presentationExtension = defineMcpHostExtension({
+  id: 'presentation',
+  serverId: 'slides',
+  includeTools: ['export_html'],
+  hideDefaultMcpTools: true,
+  resultArtifacts: [{
+    toolName: 'export_html',
+    path: 'html',
+    kind: 'html',
+    domain: 'preview',
+    title: 'presentation-preview.html',
+    extension: 'html',
+    mimeType: 'text/html',
+    maxPreviewChars: 800,
+  }],
+})
+```
+
+`resultArtifacts` paths point into the MCP tool result output. When the path is
+present, Heddle saves the value under the configured artifact root and replaces
+that field with `{ artifact, contentPath, preview, omittedCharacters }`. The
+full content remains available through `read_artifact`, while the model sees a
+small preview plus the artifact id and relative path.
 
 `defineMcpHostExtension(...)` reads the cached MCP catalog when a turn builds
 its tool bundle. It does not launch MCP servers or refresh catalogs during the

--- a/docs/guides/programmatic-use.md
+++ b/docs/guides/programmatic-use.md
@@ -526,7 +526,21 @@ const result = await engine.turns.submit({
 console.log('\nOutcome:', result.outcome)
 console.log('Summary:', result.summary)
 console.log('Session:', result.session.id)
+console.log('Trace file:', result.traceFile)
+console.log('Artifacts:', result.artifacts.map((artifact) => artifact.id))
+console.log('Tool calls:', result.toolResults.map((entry) => entry.call.tool))
 ```
+
+Submitted turns return host-facing summary fields in addition to the persisted
+session:
+
+- `traceFile` points at the persisted trace for the turn.
+- `artifacts` lists Heddle artifacts currently associated with the session.
+- `toolResults` lists completed tool calls with their call input, result,
+  duration, step, and timestamp.
+
+Use those fields for common SDK-host summaries. Reach for raw trace files only
+when your host needs lower-level evidence or custom analysis.
 
 ## `EngineConversationTurnService.run(...)`
 

--- a/docs/guides/programmatic-use.md
+++ b/docs/guides/programmatic-use.md
@@ -333,6 +333,7 @@ const presentationExtension = defineMcpHostExtension({
   resultArtifacts: [{
     toolName: 'export_html',
     path: 'html',
+    replacePaths: ['content.0.text'],
     kind: 'html',
     domain: 'preview',
     title: 'presentation-preview.html',
@@ -348,6 +349,11 @@ present, Heddle saves the value under the configured artifact root and replaces
 that field with `{ artifact, contentPath, preview, omittedCharacters }`. The
 full content remains available through `read_artifact`, while the model sees a
 small preview plus the artifact id and relative path.
+
+Use `replacePaths` when the same large value also appears elsewhere in the MCP
+envelope, such as a standard `content[0].text` mirror of structured output. The
+additional paths are replaced with the same artifact reference without saving
+duplicate artifacts.
 
 `defineMcpHostExtension(...)` reads the cached MCP catalog when a turn builds
 its tool bundle. It does not launch MCP servers or refresh catalogs during the

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ProviderCredentialRepository } from '@/core/auth/index.js';
+import { ArtifactService } from '@/core/artifacts/index.js';
 import { EngineConversationTurnService } from '@/core/chat/engine/turns/service.js';
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
 import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
@@ -309,6 +310,8 @@ describe('conversation turn lifecycle', () => {
       prompt: 'Edit safely.',
       apiKey: 'explicit-key',
       memoryMaintenanceMode: 'none',
+      artifactRoot: storage.artifactRoot,
+      artifactsEnabled: true,
       approvalPolicies: [policy],
       host: {
         approveToolCall: (call, tool) => requestToolApproval({ call, tool }),
@@ -334,6 +337,75 @@ describe('conversation turn lifecycle', () => {
     expect(requestToolApproval).toHaveBeenCalledWith({ call, tool });
   });
 
+  it('returns persisted trace, session artifacts, and completed tool results to hosts', async () => {
+    const storage = createConversationTurnStorage();
+    const artifact = new ArtifactService({ artifactRoot: storage.artifactRoot }).saveText({
+      sessionId: storage.sessionId,
+      content: '# Brief',
+      kind: 'source',
+      domain: 'document',
+      title: 'brief.md',
+      sourceTool: 'doc_create',
+    });
+    const call: ToolCall = { id: 'call-1', tool: 'doc_create', input: { title: 'Brief' } };
+    const result = { ok: true, output: { artifactId: artifact.id } };
+    vi.spyOn(agentLoopModule.AgentLoopRuntimeService, 'run').mockResolvedValue(createLoopResult({
+      workspaceRoot: storage.workspaceRoot,
+      prompt: 'Create a brief.',
+      summary: 'Created.',
+      trace: [
+        {
+          type: 'tool.completed',
+          call,
+          result,
+          durationMs: 42,
+          step: 1,
+          timestamp: '2026-05-03T00:00:01.000Z',
+        },
+        {
+          type: 'run.finished',
+          outcome: 'done',
+          summary: 'Created.',
+          step: 2,
+          timestamp: '2026-05-03T00:00:02.000Z',
+        },
+      ],
+    }) as never);
+
+    const turnResult = await EngineConversationTurnService.run({
+      workspaceRoot: storage.workspaceRoot,
+      stateRoot: storage.stateRoot,
+      traceDir: join(storage.stateRoot, 'traces'),
+      sessionStoragePath: storage.sessionStoragePath,
+      sessionId: storage.sessionId,
+      prompt: 'Create a brief.',
+      apiKey: 'explicit-key',
+      memoryMaintenanceMode: 'none',
+      artifactRoot: storage.artifactRoot,
+      artifactsEnabled: true,
+    });
+
+    expect(turnResult.traceFile).toEqual(expect.stringContaining('trace-'));
+    expect(turnResult.artifacts).toEqual([
+      expect.objectContaining({
+        id: artifact.id,
+        kind: 'source',
+        domain: 'document',
+        sessionId: storage.sessionId,
+        sourceTool: 'doc_create',
+      }),
+    ]);
+    expect(turnResult.toolResults).toEqual([
+      {
+        call,
+        result,
+        durationMs: 42,
+        step: 1,
+        timestamp: '2026-05-03T00:00:01.000Z',
+      },
+    ]);
+  });
+
   it('clears the session lease when the run loop fails', async () => {
     const storage = createConversationTurnStorage();
     vi.spyOn(agentLoopModule.AgentLoopRuntimeService, 'run').mockRejectedValue(new Error('loop failed'));
@@ -346,6 +418,8 @@ describe('conversation turn lifecycle', () => {
       prompt: 'Fail after preflight.',
       apiKey: 'explicit-key',
       memoryMaintenanceMode: 'none',
+      artifactRoot: storage.artifactRoot,
+      artifactsEnabled: true,
       leaseOwner: {
         ownerKind: 'daemon',
         ownerId: 'daemon-test',
@@ -387,6 +461,7 @@ function createConversationTurnStorage() {
     stateRoot,
     sessionStoragePath,
     sessionId: session.id,
+    artifactRoot: join(stateRoot, 'artifacts'),
   };
 }
 
@@ -394,8 +469,9 @@ function createLoopResult(args: {
   workspaceRoot: string;
   prompt: string;
   summary: string;
+  trace?: RunResult['trace'];
 }) {
-  const trace: RunResult['trace'] = [
+  const trace: RunResult['trace'] = args.trace ?? [
     {
       type: 'assistant.turn',
       content: args.summary,

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -90,6 +90,9 @@ describe('createConversationEngine', () => {
           root: join(stateRoot, 'custom-artifacts'),
           enabled: false,
         },
+        mcp: {
+          hideDefaultServers: ['deck_service'],
+        },
       },
       apiKeyPresent: true,
     });
@@ -106,6 +109,7 @@ describe('createConversationEngine', () => {
       systemContext: 'Base context\n\nHost context',
       artifactRoot: join(stateRoot, 'custom-artifacts'),
       artifactsEnabled: false,
+      hiddenMcpServerIds: ['deck_service'],
       sessionId: session.id,
       prompt: 'Create a deck',
     }));

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -22,6 +22,8 @@ describe('createConversationEngine', () => {
       summary: 'ok',
       session: new FileChatSessionRepository({ sessionStoragePath: args.sessionStoragePath })
         .read(args.sessionId) as ChatSession,
+      artifacts: [],
+      toolResults: [],
     }));
   });
 

--- a/src/__tests__/unit/core/mcp-host-extension.test.ts
+++ b/src/__tests__/unit/core/mcp-host-extension.test.ts
@@ -220,6 +220,10 @@ describe('defineMcpHostExtension', () => {
       ok: true,
       output: {
         html,
+        content: [{
+          type: 'text',
+          text: html,
+        }],
         diagnostics: {
           valid: true,
         },
@@ -232,6 +236,7 @@ describe('defineMcpHostExtension', () => {
       resultArtifacts: [{
         toolName: 'create-deck',
         path: 'html',
+        replacePaths: ['content.0.text'],
         kind: 'html',
         domain: 'preview',
         title: 'preview.html',
@@ -261,6 +266,10 @@ describe('defineMcpHostExtension', () => {
         preview: string;
         omittedCharacters: number;
       };
+      content: Array<{
+        text: unknown;
+        type: string;
+      }>;
       diagnostics: {
         valid: boolean;
       };
@@ -276,6 +285,7 @@ describe('defineMcpHostExtension', () => {
       preview: html.slice(0, 16),
       omittedCharacters: html.length - 16,
     }));
+    expect(output.content[0]?.text).toEqual(output.html);
     expect(output.html.artifact).toEqual(expect.objectContaining({
       kind: 'html',
       domain: 'preview',
@@ -292,6 +302,8 @@ describe('defineMcpHostExtension', () => {
       },
     }));
     expect(readFileSync(output.html.artifact.path, 'utf8')).toBe(html);
+    expect(new ArtifactService({ artifactRoot: context.artifactRoot }).list({ sessionId: 'session-123' }))
+      .toHaveLength(1);
     expect(new ArtifactService({ artifactRoot: context.artifactRoot }).current('session-123')?.id)
       .toBe(output.html.artifact.id);
   });

--- a/src/__tests__/unit/core/mcp-host-extension.test.ts
+++ b/src/__tests__/unit/core/mcp-host-extension.test.ts
@@ -1,7 +1,8 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ArtifactService } from '@/core/artifacts/index.js';
 import {
   FileMcpCatalogRepository,
   FileMcpConfigRepository,
@@ -98,6 +99,7 @@ function contextFixture(): ToolToolkitContext {
     workspaceRoot,
     stateRoot,
     artifactRoot: join(stateRoot, 'artifacts'),
+    sessionId: 'session-123',
     model: 'gpt-5.5',
     memoryDir: join(stateRoot, 'memory'),
     memoryMode: 'none',
@@ -105,6 +107,10 @@ function contextFixture(): ToolToolkitContext {
 }
 
 describe('defineMcpHostExtension', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('creates host tools from cached MCP descriptors without manual schema mapping', () => {
     const context = contextFixture();
     const extension = defineMcpHostExtension({
@@ -168,6 +174,19 @@ describe('defineMcpHostExtension', () => {
     expect(tools.find((tool) => tool.name === 'docs__search_pages')?.requiresApproval).toBe(false);
   });
 
+  it('can hide the source MCP server from the default MCP surface', () => {
+    const extension = defineMcpHostExtension({
+      id: 'slides',
+      serverId: 'deck_service',
+      includeTools: ['create-deck'],
+      hideDefaultMcpTools: true,
+    });
+    const bundle = ConversationEngineHostExtensionService.compose([extension]);
+
+    expect(extension.mcp).toEqual({ hideDefaultServers: ['deck_service'] });
+    expect(bundle?.mcp).toEqual({ hideDefaultServers: ['deck_service'] });
+  });
+
   it('allows host-specific names, descriptions, capabilities, and approval policy overrides', () => {
     const context = contextFixture();
     const extension = defineMcpHostExtension({
@@ -192,6 +211,89 @@ describe('defineMcpHostExtension', () => {
       capabilities: ['workspace.write'],
       requiresApproval: false,
     }));
+  });
+
+  it('stores configured MCP result fields as artifacts and returns compact references', async () => {
+    const context = contextFixture();
+    const html = `<!doctype html><html><body>${'x'.repeat(64)}</body></html>`;
+    vi.spyOn(McpService.prototype, 'callTool').mockResolvedValue({
+      ok: true,
+      output: {
+        html,
+        diagnostics: {
+          valid: true,
+        },
+      },
+    });
+    const extension = defineMcpHostExtension({
+      id: 'slides',
+      serverId: 'deck_service',
+      includeTools: ['create-deck'],
+      resultArtifacts: [{
+        toolName: 'create-deck',
+        path: 'html',
+        kind: 'html',
+        domain: 'preview',
+        title: 'preview.html',
+        extension: 'html',
+        mimeType: 'text/html',
+        metadata: {
+          source: 'unit-test',
+        },
+        maxPreviewChars: 16,
+      }],
+    });
+    const [tool] = extension.toolkits?.flatMap((toolkit) => toolkit.createTools(context)) ?? [];
+    if (!tool) {
+      throw new Error('Expected create-deck host tool');
+    }
+
+    const result = await tool.execute({ title: 'Quarterly plan' });
+    const output = result.output as {
+      html: {
+        artifact: {
+          id: string;
+          path: string;
+          relativePath: string;
+          metadata: Record<string, unknown>;
+        };
+        contentPath: string[];
+        preview: string;
+        omittedCharacters: number;
+      };
+      diagnostics: {
+        valid: boolean;
+      };
+    };
+
+    expect(result.ok).toBe(true);
+    expect(McpService.prototype.callTool).toHaveBeenCalledWith('deck_service', 'create-deck', {
+      title: 'Quarterly plan',
+    });
+    expect(output.diagnostics).toEqual({ valid: true });
+    expect(output.html).toEqual(expect.objectContaining({
+      contentPath: ['html'],
+      preview: html.slice(0, 16),
+      omittedCharacters: html.length - 16,
+    }));
+    expect(output.html.artifact).toEqual(expect.objectContaining({
+      kind: 'html',
+      domain: 'preview',
+      title: 'preview.html',
+      mimeType: 'text/html',
+      sessionId: 'session-123',
+      sourceTool: 'create_deck',
+      relativePath: expect.stringMatching(/^files\/artifact-/),
+      metadata: {
+        source: 'unit-test',
+        mcpServerId: 'deck_service',
+        mcpToolName: 'create-deck',
+        resultPath: ['html'],
+      },
+    }));
+    expect(readFileSync(output.html.artifact.path, 'utf8')).toBe(html);
+    expect(new ArtifactService({ artifactRoot: context.artifactRoot }).current('session-123')?.id)
+      .toBe(output.html.artifact.id);
   });
 
   it('returns no tools until the MCP server is enabled and refreshed', () => {

--- a/src/__tests__/unit/tools/mcp-toolkit.test.ts
+++ b/src/__tests__/unit/tools/mcp-toolkit.test.ts
@@ -9,7 +9,10 @@ import {
 } from '@/core/mcp/index.js';
 import { mcpToolkit } from '@/core/tools/toolkits/mcp/toolkit.js';
 
-function contextFixture() {
+function contextFixture(options: {
+  hiddenMcpServerIds?: string[];
+  includeGithub?: boolean;
+} = {}) {
   const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-mcp-toolkit-'));
   const stateRoot = join(workspaceRoot, '.heddle');
   mkdirSync(stateRoot, { recursive: true });
@@ -22,9 +25,21 @@ function contextFixture() {
           approval: 'always',
         },
       },
+      ...(options.includeGithub ? {
+        github: {
+          command: 'npx',
+          args: ['-y', 'github-mcp'],
+          tools: {
+            approval: 'never',
+          },
+        },
+      } : {}),
     },
   }), 'utf8');
   new McpService({ workspaceRoot, stateRoot }).activateServer('notion');
+  if (options.includeGithub) {
+    new McpService({ workspaceRoot, stateRoot }).activateServer('github');
+  }
   new FileMcpCatalogRepository({ stateRoot }).write({
     version: 1,
     servers: {
@@ -42,15 +57,33 @@ function contextFixture() {
         }],
         refreshedAt: '2026-06-08T00:00:00.000Z',
       },
+      ...(options.includeGithub ? {
+        github: {
+          serverId: 'github',
+          tools: [{
+            name: 'list-issues',
+            description: 'List GitHub issues.',
+            inputSchema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: { repo: { type: 'string' } },
+              required: ['repo'],
+            },
+          }],
+          refreshedAt: '2026-06-08T00:00:00.000Z',
+        },
+      } : {}),
     },
   });
 
   return {
     workspaceRoot,
     stateRoot,
+    artifactRoot: join(stateRoot, 'artifacts'),
     model: 'gpt-5.5',
     memoryDir: join(stateRoot, 'memory'),
     memoryMode: 'none' as const,
+    hiddenMcpServerIds: options.hiddenMcpServerIds,
   };
 }
 
@@ -97,5 +130,45 @@ describe('MCP toolkit', () => {
       }),
       required: ['serverId', 'toolName', 'arguments'],
     }));
+  });
+
+  it('hides host-owned MCP servers from the default tool surface', async () => {
+    const tools = mcpToolkit.createTools(contextFixture({
+      includeGithub: true,
+      hiddenMcpServerIds: ['notion'],
+    }));
+    const listTools = tools.find((candidate) => candidate.name === 'mcp_list_tools');
+    const callTool = tools.find((candidate) => candidate.name === 'mcp_call_tool');
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'mcp_list_tools',
+      'mcp_call_tool',
+      'mcp__github__list_issues',
+    ]);
+    await expect(listTools?.execute({})).resolves.toEqual({
+      ok: true,
+      output: {
+        servers: [expect.objectContaining({
+          id: 'github',
+          tools: [expect.objectContaining({
+            name: 'list-issues',
+            heddleToolName: 'mcp__github__list_issues',
+          })],
+        })],
+        issues: [],
+      },
+    });
+    await expect(callTool?.execute({
+      serverId: 'notion',
+      toolName: 'search-pages',
+      arguments: { query: 'roadmap' },
+    })).resolves.toEqual({
+      ok: false,
+      error: 'MCP server is not available through default MCP tools: notion',
+    });
+  });
+
+  it('removes the default MCP toolkit when every configured server is hidden', () => {
+    expect(mcpToolkit.createTools(contextFixture({ hiddenMcpServerIds: ['notion'] }))).toEqual([]);
   });
 });

--- a/src/core/chat/engine/README.md
+++ b/src/core/chat/engine/README.md
@@ -21,6 +21,8 @@ not each invent their own version.
 - The alpha programmatic API through `conversation-engine.ts` and `index.ts`.
 - Host-extension composition for SDK integrations, including curated MCP tool
   surfaces and artifact behavior.
+- Host-facing turn result summaries, including trace file, completed tool
+  results, and session artifacts.
 
 ## Domain Ownership Rule
 
@@ -90,6 +92,8 @@ Use this pattern when it fits the domain:
 - Put submit/continue behavior in `turns/service.ts`.
 - Put persisted turn phases in the explicit `turns/*/` subdomains.
 - Put shared compaction behavior in `compaction/`.
+- Put public turn result vocabulary in `turn-result.ts` so SDK hosts do not
+  parse trace or artifact storage for common summaries.
 - Put host-extension policy in `host-extension.ts` or focused helpers such as
   `mcp-host-extension.ts`; runtime toolkits should receive resolved policy,
   not re-read host-extension config.

--- a/src/core/chat/engine/README.md
+++ b/src/core/chat/engine/README.md
@@ -19,6 +19,8 @@ not each invent their own version.
 - User-facing live conversation activity under `live/`. This is the shared
   event contract for TUI, browser control plane, and programmatic hosts.
 - The alpha programmatic API through `conversation-engine.ts` and `index.ts`.
+- Host-extension composition for SDK integrations, including curated MCP tool
+  surfaces and artifact behavior.
 
 ## Domain Ownership Rule
 
@@ -88,6 +90,9 @@ Use this pattern when it fits the domain:
 - Put submit/continue behavior in `turns/service.ts`.
 - Put persisted turn phases in the explicit `turns/*/` subdomains.
 - Put shared compaction behavior in `compaction/`.
+- Put host-extension policy in `host-extension.ts` or focused helpers such as
+  `mcp-host-extension.ts`; runtime toolkits should receive resolved policy,
+  not re-read host-extension config.
 
 ## Notes For Coding Agents
 

--- a/src/core/chat/engine/config.ts
+++ b/src/core/chat/engine/config.ts
@@ -21,6 +21,7 @@ export type NormalizedConversationEngineConfig = {
   approvalPolicies?: ToolApprovalPolicy[];
   tools?: ToolDefinition[];
   toolkits?: ToolToolkit[];
+  hiddenMcpServerIds?: string[];
   artifactRoot: string;
   artifactsEnabled: boolean;
   sessionStoragePath: string;
@@ -62,6 +63,7 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     approvalPolicies: config.approvalPolicies,
     tools: tools.length ? tools : undefined,
     toolkits: hostExtensions?.toolkits,
+    hiddenMcpServerIds: hostExtensions?.mcp?.hideDefaultServers,
     artifactRoot,
     artifactsEnabled: hostExtensions?.artifacts?.enabled ?? true,
     sessionStoragePath,

--- a/src/core/chat/engine/host-extension.ts
+++ b/src/core/chat/engine/host-extension.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
+import uniq from 'lodash/uniq.js';
 
 const HOST_EXTENSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 
@@ -8,12 +9,22 @@ export type ConversationEngineHostArtifactOptions = {
   root?: string;
 };
 
+export type ConversationEngineHostMcpOptions = {
+  /**
+   * Server ids that should be hidden from the default generic MCP toolkit.
+   * Use this when a host extension exposes a curated tool surface for the same
+   * MCP server and the generic mcp_* tools would create a duplicate path.
+   */
+  hideDefaultServers?: string[];
+};
+
 export type ConversationEngineHostExtension = {
   id: string;
   tools?: ToolDefinition[];
   toolkits?: ToolToolkit[];
   systemContext?: string;
   artifacts?: ConversationEngineHostArtifactOptions;
+  mcp?: ConversationEngineHostMcpOptions;
 };
 
 export type ConversationEngineHostExtensionBundle = Omit<ConversationEngineHostExtension, 'id'> & {
@@ -60,12 +71,14 @@ export class ConversationEngineHostExtensionService {
       .filter((value): value is string => Boolean(value?.trim()))
       .join('\n\n') || undefined;
     const artifacts = ConversationEngineHostExtensionService.composeArtifacts(extensions);
+    const mcp = ConversationEngineHostExtensionService.composeMcp(extensions);
 
     return {
       ...(tools.length ? { tools } : {}),
       ...(toolkits.length ? { toolkits } : {}),
       ...(systemContext ? { systemContext } : {}),
       ...(artifacts ? { artifacts } : {}),
+      ...(mcp ? { mcp } : {}),
     };
   }
 
@@ -137,6 +150,15 @@ export class ConversationEngineHostExtensionService {
       ...(artifacts.enabled === undefined ? {} : { enabled: artifacts.enabled }),
       ...(artifacts.root === undefined ? {} : { root: artifacts.root }),
     }), {});
+  }
+
+  private static composeMcp(extensions: ConversationEngineHostExtensionBundle[]): ConversationEngineHostMcpOptions | undefined {
+    const hideDefaultServers = uniq(extensions
+      .flatMap((extension) => extension.mcp?.hideDefaultServers ?? [])
+      .map((serverId) => serverId.trim())
+      .filter((serverId) => serverId.length > 0));
+
+    return hideDefaultServers.length ? { hideDefaultServers } : undefined;
   }
 }
 

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -1,5 +1,9 @@
 export { createConversationEngine } from './conversation-engine.js';
 export { defineHostExtension, ConversationEngineHostExtensionService } from './host-extension.js';
+export type {
+  ConversationEngineHostArtifactOptions,
+  ConversationEngineHostMcpOptions,
+} from './host-extension.js';
 export {
   defineMcpHostExtension,
   McpHostExtensionService,
@@ -8,6 +12,9 @@ export {
 } from './mcp-host-extension.js';
 export type {
   DefineMcpHostExtensionOptions,
+  McpHostResultArtifactOutput,
+  McpHostResultArtifactReference,
+  McpHostResultArtifactRule,
   McpHostToolOverride,
   PrepareMcpHostExtensionOptions,
   PrepareMcpHostExtensionResult,

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -1,6 +1,10 @@
 export { createConversationEngine } from './conversation-engine.js';
 export { defineHostExtension, ConversationEngineHostExtensionService } from './host-extension.js';
 export type {
+  ConversationTurnResultSummary,
+  ConversationTurnToolResult,
+} from './turn-result.js';
+export type {
   ConversationEngineHostArtifactOptions,
   ConversationEngineHostMcpOptions,
 } from './host-extension.js';

--- a/src/core/chat/engine/mcp-host-extension.ts
+++ b/src/core/chat/engine/mcp-host-extension.ts
@@ -3,9 +3,14 @@ import {
   isToolAllowed,
   shouldMcpToolRequireApproval,
 } from '@/core/mcp/index.js';
+import { ArtifactService } from '@/core/artifacts/index.js';
 import type { McpRefreshResult, McpServerConfig, McpToolDescriptor } from '@/core/mcp/index.js';
+import type { ArtifactKind, RuntimeArtifact } from '@/core/artifacts/index.js';
 import type { ToolDefinition, ToolResult } from '@/core/types.js';
 import type { ToolToolkit, ToolToolkitContext } from '@/core/tools/index.js';
+import cloneDeep from 'lodash/cloneDeep.js';
+import get from 'lodash/get.js';
+import set from 'lodash/set.js';
 import {
   defineHostExtension,
   type ConversationEngineHostArtifactOptions,
@@ -19,6 +24,32 @@ export type McpHostToolOverride = {
   requiresApproval?: boolean;
 };
 
+export type McpHostResultArtifactRule = {
+  /** Original MCP tool name from the cached catalog, before host renaming. */
+  toolName: string;
+  /** Path inside the MCP result output that should be persisted as an artifact. */
+  path: string | string[];
+  kind: ArtifactKind;
+  domain?: string;
+  title?: string;
+  extension?: string;
+  mimeType?: string;
+  metadata?: Record<string, unknown>;
+  setCurrent?: boolean;
+  maxPreviewChars?: number;
+};
+
+export type McpHostResultArtifactReference = RuntimeArtifact & {
+  relativePath: string;
+};
+
+export type McpHostResultArtifactOutput = {
+  artifact: McpHostResultArtifactReference;
+  contentPath: string[];
+  preview: string;
+  omittedCharacters: number;
+};
+
 export type DefineMcpHostExtensionOptions = {
   id: string;
   serverId: string;
@@ -28,6 +59,8 @@ export type DefineMcpHostExtensionOptions = {
   toolNamePrefix?: string;
   defaultCapabilities?: string[];
   toolOverrides?: Record<string, McpHostToolOverride>;
+  hideDefaultMcpTools?: boolean;
+  resultArtifacts?: McpHostResultArtifactRule[];
   systemContext?: string;
   artifacts?: ConversationEngineHostArtifactOptions;
 };
@@ -83,6 +116,7 @@ export class McpHostExtensionService {
       toolkits: [toolkit],
       ...(options.systemContext ? { systemContext: options.systemContext } : {}),
       ...(options.artifacts ? { artifacts: options.artifacts } : {}),
+      ...(options.hideDefaultMcpTools ? { mcp: { hideDefaultServers: [options.serverId] } } : {}),
     });
   }
 
@@ -132,9 +166,10 @@ export class McpHostExtensionService {
     tool: McpToolDescriptor;
   }): ToolDefinition {
     const override = args.options.toolOverrides?.[args.tool.name];
+    const name = override?.name ?? McpHostExtensionService.toHostToolName(args.options, args.tool.name);
 
     return {
-      name: override?.name ?? McpHostExtensionService.toHostToolName(args.options, args.tool.name),
+      name,
       requiresApproval: override?.requiresApproval ?? shouldMcpToolRequireApproval(args.server),
       description: override?.description ?? McpHostExtensionService.describeTool(args.options, args.tool),
       capabilities: override?.capabilities ?? args.options.defaultCapabilities ?? ['mcp.unknown'],
@@ -143,9 +178,123 @@ export class McpHostExtensionService {
         const result = await McpHostExtensionService.createMcpService(args.context)
           .callTool(args.options.serverId, args.tool.name, isRecord(raw) ? raw : {});
 
-        return result.ok ? { ok: true, output: result.output } : { ok: false, error: result.error };
+        return result.ok
+          ? {
+              ok: true,
+              output: McpHostExtensionService.applyResultArtifactRules({
+                context: args.context,
+                options: args.options,
+                output: result.output,
+                sourceTool: name,
+                toolName: args.tool.name,
+              }),
+            }
+          : { ok: false, error: result.error };
       },
     };
+  }
+
+  private static applyResultArtifactRules(args: {
+    context: ToolToolkitContext;
+    options: DefineMcpHostExtensionOptions;
+    output: unknown;
+    sourceTool: string;
+    toolName: string;
+  }): unknown {
+    const rules = (args.options.resultArtifacts ?? [])
+      .filter((rule) => rule.toolName === args.toolName);
+    if (!rules.length) {
+      return args.output;
+    }
+
+    return rules.reduce((currentOutput, rule) => McpHostExtensionService.applyResultArtifactRule({
+      ...args,
+      output: currentOutput,
+      rule,
+    }), cloneDeep(args.output));
+  }
+
+  private static applyResultArtifactRule(args: {
+    context: ToolToolkitContext;
+    options: DefineMcpHostExtensionOptions;
+    output: unknown;
+    rule: McpHostResultArtifactRule;
+    sourceTool: string;
+    toolName: string;
+  }): unknown {
+    const path = McpHostExtensionService.normalizeResultPath(args.rule.path);
+    if (!path.length) {
+      return args.output;
+    }
+
+    const value = get(args.output, path);
+    if (value === undefined) {
+      return args.output;
+    }
+
+    const content = McpHostExtensionService.serializeArtifactContent(value);
+    const artifact = new ArtifactService({ artifactRoot: args.context.artifactRoot }).saveText({
+      content,
+      kind: args.rule.kind,
+      domain: args.rule.domain,
+      title: args.rule.title ?? McpHostExtensionService.defaultArtifactTitle({
+        rule: args.rule,
+        sourceTool: args.sourceTool,
+        path,
+      }),
+      extension: args.rule.extension,
+      mimeType: args.rule.mimeType,
+      sessionId: args.context.sessionId,
+      sourceTool: args.sourceTool,
+      metadata: {
+        ...(args.rule.metadata ?? {}),
+        mcpServerId: args.options.serverId,
+        mcpToolName: args.toolName,
+        resultPath: path,
+      },
+      setCurrent: args.rule.setCurrent,
+    });
+    const preview = content.slice(0, args.rule.maxPreviewChars ?? 1_000);
+
+    set(args.output as object, path, {
+      artifact: {
+        ...artifact,
+        relativePath: ArtifactService.relativeArtifactPath(args.context.artifactRoot, artifact),
+      },
+      contentPath: path,
+      preview,
+      omittedCharacters: Math.max(content.length - preview.length, 0),
+    } satisfies McpHostResultArtifactOutput);
+
+    return args.output;
+  }
+
+  private static normalizeResultPath(path: string | string[]): string[] {
+    return Array.isArray(path)
+      ? path
+      : path.split('.').map((part) => part.trim()).filter((part) => part.length > 0);
+  }
+
+  private static serializeArtifactContent(value: unknown): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    try {
+      return JSON.stringify(value, null, 2) ?? String(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  private static defaultArtifactTitle(args: {
+    rule: McpHostResultArtifactRule;
+    sourceTool: string;
+    path: string[];
+  }): string {
+    const resultName = args.path[args.path.length - 1] ?? 'result';
+    const extension = args.rule.extension?.replace(/^\./, '') ?? args.rule.kind;
+    return `${args.sourceTool}-${resultName}.${extension}`;
   }
 
   private static describeTool(options: DefineMcpHostExtensionOptions, tool: McpToolDescriptor): string {

--- a/src/core/chat/engine/mcp-host-extension.ts
+++ b/src/core/chat/engine/mcp-host-extension.ts
@@ -28,9 +28,9 @@ export type McpHostResultArtifactRule = {
   /** Original MCP tool name from the cached catalog, before host renaming. */
   toolName: string;
   /** Path inside the MCP result output that should be persisted as an artifact. */
-  path: string | string[];
+  path: string | readonly string[];
   /** Additional output paths to replace with the same artifact reference. */
-  replacePaths?: Array<string | string[]>;
+  replacePaths?: ReadonlyArray<string | readonly string[]>;
   kind: ArtifactKind;
   domain?: string;
   title?: string;
@@ -281,10 +281,10 @@ export class McpHostExtensionService {
     return [path, ...replacementPaths];
   }
 
-  private static normalizeResultPath(path: string | string[]): string[] {
-    return Array.isArray(path)
-      ? path
-      : path.split('.').map((part) => part.trim()).filter((part) => part.length > 0);
+  private static normalizeResultPath(path: string | readonly string[]): string[] {
+    return typeof path === 'string'
+      ? path.split('.').map((part) => part.trim()).filter((part) => part.length > 0)
+      : [...path];
   }
 
   private static serializeArtifactContent(value: unknown): string {

--- a/src/core/chat/engine/mcp-host-extension.ts
+++ b/src/core/chat/engine/mcp-host-extension.ts
@@ -29,6 +29,8 @@ export type McpHostResultArtifactRule = {
   toolName: string;
   /** Path inside the MCP result output that should be persisted as an artifact. */
   path: string | string[];
+  /** Additional output paths to replace with the same artifact reference. */
+  replacePaths?: Array<string | string[]>;
   kind: ArtifactKind;
   domain?: string;
   title?: string;
@@ -255,8 +257,7 @@ export class McpHostExtensionService {
       setCurrent: args.rule.setCurrent,
     });
     const preview = content.slice(0, args.rule.maxPreviewChars ?? 1_000);
-
-    set(args.output as object, path, {
+    const artifactOutput = {
       artifact: {
         ...artifact,
         relativePath: ArtifactService.relativeArtifactPath(args.context.artifactRoot, artifact),
@@ -264,9 +265,20 @@ export class McpHostExtensionService {
       contentPath: path,
       preview,
       omittedCharacters: Math.max(content.length - preview.length, 0),
-    } satisfies McpHostResultArtifactOutput);
+    } satisfies McpHostResultArtifactOutput;
+
+    McpHostExtensionService.outputReplacementPaths(args.rule, path)
+      .forEach((replacementPath) => set(args.output as object, replacementPath, artifactOutput));
 
     return args.output;
+  }
+
+  private static outputReplacementPaths(rule: McpHostResultArtifactRule, path: string[]): string[][] {
+    const replacementPaths = (rule.replacePaths ?? [])
+      .map((candidate) => McpHostExtensionService.normalizeResultPath(candidate))
+      .filter((candidate) => candidate.length > 0);
+
+    return [path, ...replacementPaths];
   }
 
   private static normalizeResultPath(path: string | string[]): string[] {

--- a/src/core/chat/engine/turn-result.ts
+++ b/src/core/chat/engine/turn-result.ts
@@ -1,0 +1,20 @@
+import type { RuntimeArtifact } from '@/core/artifacts/index.js';
+import type { ToolCall, ToolResult } from '@/core/types.js';
+import type { ChatSession } from '@/core/chat/types.js';
+
+export type ConversationTurnToolResult = {
+  call: ToolCall;
+  result: ToolResult;
+  durationMs?: number;
+  step: number;
+  timestamp: string;
+};
+
+export type ConversationTurnResultSummary = {
+  outcome: string;
+  summary: string;
+  session: ChatSession;
+  traceFile?: string;
+  artifacts: RuntimeArtifact[];
+  toolResults: ConversationTurnToolResult[];
+};

--- a/src/core/chat/engine/turns/context/types.ts
+++ b/src/core/chat/engine/turns/context/types.ts
@@ -16,6 +16,7 @@ export type PrepareConversationTurnContextArgs = {
   systemContext?: string;
   tools?: ToolDefinition[];
   toolkits?: ToolToolkit[];
+  hiddenMcpServerIds?: string[];
   artifactRoot: string;
   artifactsEnabled: boolean;
   agentSnapshot?: CustomAgentExecutionSnapshot;
@@ -33,6 +34,7 @@ export type ConversationTurnToolContextArgs = Pick<
   | 'stateRoot'
   | 'tools'
   | 'toolkits'
+  | 'hiddenMcpServerIds'
   | 'artifactRoot'
   | 'artifactsEnabled'
   | 'sessionId'

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -1,5 +1,7 @@
 import { AgentLoopRuntimeService } from '@/core/runtime/loop/index.js';
 import { AutonomyPermissionModeService, ToolApprovalProfileService } from '@/core/approvals/index.js';
+import { ArtifactService } from '@/core/artifacts/index.js';
+import { HeddleEventType } from '@/core/event-types.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
 import { FileConversationSessionService } from '@/core/chat/engine/sessions/service.js';
 import type { NormalizedConversationEngineConfig } from '@/core/chat/engine/config.js';
@@ -32,6 +34,7 @@ import type {
   TurnRuntimeConfigInput,
   TurnSubmitInput,
 } from './types.js';
+import type { TraceEvent } from '@/core/types.js';
 
 export class EngineConversationTurnService implements ConversationTurnService {
   private readonly sessions: ConversationSessionService;
@@ -170,6 +173,13 @@ export class EngineConversationTurnService implements ConversationTurnService {
         outcome: resultForPersistence.outcome,
         summary: persisted.summary,
         session: persisted.session,
+        traceFile: persisted.traceFile,
+        artifacts: EngineConversationTurnService.listTurnArtifacts({
+          artifactRoot: args.artifactRoot,
+          artifactsEnabled: args.artifactsEnabled,
+          sessionId: session.id,
+        }),
+        toolResults: EngineConversationTurnService.summarizeToolResults(resultForPersistence.trace),
       };
     } finally {
       EngineConversationTurnService.clearLeaseFromStorage(args.sessionStoragePath, session.id, leaseOwner);
@@ -217,5 +227,29 @@ export class EngineConversationTurnService implements ConversationTurnService {
         args.host?.onCompactionStatus?.(event, phase);
       },
     };
+  }
+
+  private static listTurnArtifacts(args: {
+    artifactRoot: string;
+    artifactsEnabled: boolean;
+    sessionId: string;
+  }): RunConversationTurnResult['artifacts'] {
+    return args.artifactsEnabled
+      ? new ArtifactService({ artifactRoot: args.artifactRoot }).list({ sessionId: args.sessionId })
+      : [];
+  }
+
+  private static summarizeToolResults(trace: TraceEvent[]): RunConversationTurnResult['toolResults'] {
+    return trace
+      .filter((event): event is Extract<TraceEvent, { type: typeof HeddleEventType.toolCompleted }> => (
+        event.type === HeddleEventType.toolCompleted
+      ))
+      .map((event) => ({
+        call: event.call,
+        result: event.result,
+        ...(event.durationMs === undefined ? {} : { durationMs: event.durationMs }),
+        step: event.step,
+        timestamp: event.timestamp,
+      }));
   }
 }

--- a/src/core/chat/engine/turns/types.ts
+++ b/src/core/chat/engine/turns/types.ts
@@ -3,11 +3,11 @@ import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js
 import type { ConversationCompactionStatus } from '@/core/live/index.js';
 import type { TraceSummaryService } from '@/core/observability/index.js';
 import type { RunAgentLoopOptions } from '@/core/runtime/loop/index.js';
-import type { ChatSession } from '@/core/chat/types.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import type { ChatTurnHostPort } from './host/index.js';
 import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
+import type { ConversationTurnResultSummary } from '../turn-result.js';
 
 export type RunConversationTurnArgs = {
   workspaceRoot: string;
@@ -94,8 +94,4 @@ export type TurnPersistenceInput = Pick<
   'sessionStoragePath' | 'stateRoot' | 'traceDir' | 'traceSummarizerRegistry' | 'prompt'
 >;
 
-export type RunConversationTurnResult = {
-  outcome: string;
-  summary: string;
-  session: ChatSession;
-};
+export type RunConversationTurnResult = ConversationTurnResultSummary;

--- a/src/core/chat/engine/turns/types.ts
+++ b/src/core/chat/engine/turns/types.ts
@@ -28,6 +28,7 @@ export type RunConversationTurnArgs = {
   approvalPolicies?: ToolApprovalPolicy[];
   tools?: ToolDefinition[];
   toolkits?: ToolToolkit[];
+  hiddenMcpServerIds?: string[];
   artifactRoot: string;
   artifactsEnabled: boolean;
   agentProfileId?: string;
@@ -54,6 +55,7 @@ export type TurnRuntimeConfigInput = Pick<
   | 'approvalPolicies'
   | 'tools'
   | 'toolkits'
+  | 'hiddenMcpServerIds'
   | 'artifactRoot'
   | 'artifactsEnabled'
   | 'traceSummarizerRegistry'

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -13,6 +13,7 @@ import type { ChatSessionLeaseOwner } from './sessions/leases/index.js';
 import type { ChatSession, ChatSessionRetention, QueuedConversationPrompt } from '../types.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import type { ChatTurnHostPort } from './turns/host/index.js';
+import type { ConversationTurnResultSummary } from './turn-result.js';
 import type { ConversationCompactionResult } from '@/core/chat/engine/compaction/index.js';
 import type {
   ConversationEngineHostExtension,
@@ -232,11 +233,7 @@ export type ClearConversationTurnLeaseInput = {
   owner: ChatSessionLeaseOwner;
 };
 
-export type SubmitConversationTurnResult = {
-  outcome: string;
-  summary: string;
-  session: ChatSession;
-};
+export type SubmitConversationTurnResult = ConversationTurnResultSummary;
 
 export type ConversationEngineHost = {
   events?: {

--- a/src/core/runtime/tools/README.md
+++ b/src/core/runtime/tools/README.md
@@ -16,6 +16,11 @@ Programmatic hosts can also pass additional `ToolToolkit` values. Runtime tools
 compose host toolkits after the default toolkit list, using the same
 duplicate-id and duplicate-tool-name checks as built-in toolkits.
 
+Runtime tools also enforce resolved default-tool visibility policy. For MCP,
+`hiddenMcpServerIds` hides host-owned servers from the generic `mcp_*` toolkit
+surface while leaving curated host-extension tools free to call the same MCP
+server through their own definitions.
+
 Artifact tools are part of the default runtime bundle. They expose the generic
 artifact registry through ordinary tools while keeping persistence semantics in
 `src/core/artifacts`.

--- a/src/core/runtime/tools/service.ts
+++ b/src/core/runtime/tools/service.ts
@@ -48,6 +48,7 @@ export class RuntimeToolService {
           memoryDir,
           memoryMode,
           searchIgnoreDirs: options.searchIgnoreDirs,
+          hiddenMcpServerIds: options.hiddenMcpServerIds,
         },
       }),
       hostTools: options.tools,

--- a/src/core/runtime/tools/types.ts
+++ b/src/core/runtime/tools/types.ts
@@ -18,6 +18,7 @@ export type DefaultAgentToolsOptions = {
   memoryMode?: 'none' | 'read-and-record' | 'maintainer' | 'legacy-full';
   tools?: ToolDefinition[];
   toolkits?: ToolToolkit[];
+  hiddenMcpServerIds?: string[];
   toolProfile?: RuntimeToolSelectionProfile;
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;

--- a/src/core/tools/toolkit.ts
+++ b/src/core/tools/toolkit.ts
@@ -12,6 +12,7 @@ export type ToolToolkitContext = {
   memoryDir: string;
   memoryMode: 'none' | 'read-and-record' | 'maintainer' | 'legacy-full';
   searchIgnoreDirs?: string[];
+  hiddenMcpServerIds?: string[];
 };
 
 export type ToolToolkit = {

--- a/src/core/tools/toolkits/mcp/toolkit.ts
+++ b/src/core/tools/toolkits/mcp/toolkit.ts
@@ -16,12 +16,18 @@ const MCP_CALL_TOOL_NAME = 'mcp_call_tool';
 export const mcpToolkit: ToolToolkit = {
   id: 'mcp',
   createTools(context) {
+    const hiddenServerIds = new Set(
+      (context.hiddenMcpServerIds ?? [])
+        .map((serverId) => serverId.trim())
+        .filter((serverId) => serverId.length > 0),
+    );
     const config = new FileMcpConfigRepository({
       workspaceRoot: context.workspaceRoot,
       stateRoot: context.stateRoot,
     }).read();
 
-    if (!config.servers.length) {
+    const visibleServers = config.servers.filter((server) => !hiddenServerIds.has(server.id));
+    if (!visibleServers.length) {
       return [];
     }
 
@@ -29,9 +35,10 @@ export const mcpToolkit: ToolToolkit = {
     const enabledServerIds = new Set(
       Object.values(new FileMcpActivationRepository({ stateRoot: context.stateRoot }).read().servers)
         .filter((record) => record.status === 'enabled')
+        .filter((record) => !hiddenServerIds.has(record.serverId))
         .map((record) => record.serverId),
     );
-    const serversById = new Map(config.servers.map((server) => [server.id, server]));
+    const serversById = new Map(visibleServers.map((server) => [server.id, server]));
     const discoveredTools = Object.values(catalog.servers)
       .filter((record) => enabledServerIds.has(record.serverId))
       .flatMap((record) => record.tools.map((tool) => ({
@@ -44,10 +51,12 @@ export const mcpToolkit: ToolToolkit = {
 
     return [
       createMcpListToolsTool({
+        hiddenServerIds,
         stateRoot: context.stateRoot,
         workspaceRoot: context.workspaceRoot,
       }),
       createMcpCallToolTool({
+        hiddenServerIds,
         stateRoot: context.stateRoot,
         workspaceRoot: context.workspaceRoot,
       }),
@@ -64,6 +73,7 @@ export const mcpToolkit: ToolToolkit = {
 function createMcpListToolsTool(options: {
   workspaceRoot: string;
   stateRoot: string;
+  hiddenServerIds: ReadonlySet<string>;
 }): ToolDefinition {
   return {
     name: MCP_LIST_TOOLS_NAME,
@@ -79,18 +89,20 @@ function createMcpListToolsTool(options: {
       return {
         ok: true,
         output: {
-          servers: overview.servers.map((server) => ({
-            id: server.id,
-            status: server.status,
-            transport: server.config?.transport,
-            tools: server.catalog?.tools.map((tool) => ({
-              name: tool.name,
-              title: tool.title,
-              description: tool.description,
-              heddleToolName: server.config ? toHeddleToolName(server.id, tool.name) : undefined,
-            })) ?? [],
-          })),
-          issues: overview.issues,
+          servers: overview.servers
+            .filter((server) => !options.hiddenServerIds.has(server.id))
+            .map((server) => ({
+              id: server.id,
+              status: server.status,
+              transport: server.config?.transport,
+              tools: server.catalog?.tools.map((tool) => ({
+                name: tool.name,
+                title: tool.title,
+                description: tool.description,
+                heddleToolName: server.config ? toHeddleToolName(server.id, tool.name) : undefined,
+              })) ?? [],
+            })),
+          issues: overview.issues.filter((issue) => !isHiddenServerIssue(issue.path, options.hiddenServerIds)),
         },
       };
     },
@@ -100,6 +112,7 @@ function createMcpListToolsTool(options: {
 function createMcpCallToolTool(options: {
   workspaceRoot: string;
   stateRoot: string;
+  hiddenServerIds: ReadonlySet<string>;
 }): ToolDefinition {
   return {
     name: MCP_CALL_TOOL_NAME,
@@ -123,6 +136,10 @@ function createMcpCallToolTool(options: {
     async execute(raw: unknown): Promise<ToolResult> {
       if (!isMcpCallInput(raw)) {
         return { ok: false, error: 'Invalid input for mcp_call_tool. Required fields: serverId, toolName, arguments.' };
+      }
+
+      if (options.hiddenServerIds.has(raw.serverId)) {
+        return { ok: false, error: `MCP server is not available through default MCP tools: ${raw.serverId}` };
       }
 
       const result = await mcpService(options).callTool(raw.serverId, raw.toolName, raw.arguments);
@@ -184,6 +201,10 @@ function isMcpCallInput(raw: unknown): raw is {
 
 function isRecord(raw: unknown): raw is Record<string, unknown> {
   return raw !== null && typeof raw === 'object' && !Array.isArray(raw);
+}
+
+function isHiddenServerIssue(path: string, hiddenServerIds: ReadonlySet<string>): boolean {
+  return Array.from(hiddenServerIds).some((serverId) => path.endsWith(`#${serverId}`));
 }
 
 function mcpService(options: { workspaceRoot: string; stateRoot: string }): McpService {

--- a/src/index.ts
+++ b/src/index.ts
@@ -372,6 +372,10 @@ export {
 // Chat alpha API
 export { createConversationEngine } from './core/chat/engine/conversation-engine.js';
 export { defineHostExtension, ConversationEngineHostExtensionService } from './core/chat/engine/host-extension.js';
+export type {
+  ConversationEngineHostArtifactOptions,
+  ConversationEngineHostMcpOptions,
+} from './core/chat/engine/host-extension.js';
 export {
   defineMcpHostExtension,
   McpHostExtensionService,
@@ -380,6 +384,9 @@ export {
 } from './core/chat/engine/mcp-host-extension.js';
 export type {
   DefineMcpHostExtensionOptions,
+  McpHostResultArtifactOutput,
+  McpHostResultArtifactReference,
+  McpHostResultArtifactRule,
   McpHostToolOverride,
   PrepareMcpHostExtensionOptions,
   PrepareMcpHostExtensionResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -376,6 +376,10 @@ export type {
   ConversationEngineHostArtifactOptions,
   ConversationEngineHostMcpOptions,
 } from './core/chat/engine/host-extension.js';
+export type {
+  ConversationTurnResultSummary,
+  ConversationTurnToolResult,
+} from './core/chat/engine/turn-result.js';
 export {
   defineMcpHostExtension,
   McpHostExtensionService,


### PR DESCRIPTION
## Summary
- add generic MCP host-extension controls to hide a host-owned server from the default mcp_* tool surface
- add resultArtifacts rules so MCP host tools can persist selected output fields as artifacts and return compact references
- thread hidden MCP server ids through conversation engine/runtime tool assembly and document the new SDK options

## Verification
- yarn test:unit src/__tests__/unit/core/mcp-host-extension.test.ts src/__tests__/unit/tools/mcp-toolkit.test.ts src/__tests__/unit/core/conversation-engine.test.ts
- yarn lint
- yarn build