### PR TITLE
feat: curated default entry + /advanced subpath (SDK P1b)

### DIFF
--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -6,8 +6,16 @@ owns durable sessions, turn execution, compaction, traces, artifacts, default
 tools, host extensions, and approval callbacks.
 
 These guides follow a **progressive-disclosure ladder**. Start at rung 1 and go
-deeper only when you need to. This mirrors how the public API is organized in
-`src/index.ts`.
+deeper only when you need to. This mirrors how the public API is organized.
+
+There are two import entry points:
+
+- `@roackb2/heddle` — the **curated** default surface (rungs 1–5): everything a
+  product host needs to build an agentic experience.
+- `@roackb2/heddle/advanced` — the **full** surface: the curated exports plus
+  lower-level building blocks (LLM adapters, individual tools, trace, memory,
+  models, awareness) and specialized runtimes (agent loop, heartbeat,
+  integrations). Reach for this only when the curated surface is not enough.
 
 1. **Start here** — stand up a conversation agent.
    - [Quickstart](quickstart.md): a minimal persisted conversation with default

--- a/examples/browser-agent-smoke.ts
+++ b/examples/browser-agent-smoke.ts
@@ -22,7 +22,7 @@ import {
   type AgentLoopEvent,
   type BrowserResearchToolkitOptions,
   type ProviderCredentialSource,
-} from '../src/index.js';
+} from '../src/advanced.js';
 import { LlmAdapterService } from '../src/core/llm/index.js';
 import type { TraceEvent } from '../src/core/types.js';
 

--- a/examples/browser-research-toolkit.ts
+++ b/examples/browser-research-toolkit.ts
@@ -14,7 +14,7 @@
 
 import { join } from 'node:path';
 
-import { createBrowserResearchToolkit, type BrowserResearchToolkitOptions } from '../src/index.js';
+import { createBrowserResearchToolkit, type BrowserResearchToolkitOptions } from '../src/advanced.js';
 import type { ToolDefinition, ToolResult } from '../src/core/types.js';
 
 type SnapshotOutput = {

--- a/examples/conversation-engine.ts
+++ b/examples/conversation-engine.ts
@@ -20,7 +20,7 @@ import {
   RuntimeCredentialService,
   type ToolDefinition,
   type ToolApprovalPolicyContext,
-} from '../src/index.js';
+} from '../src/advanced.js';
 
 const DEFAULT_EXAMPLE_MODEL = 'gpt-5.1-codex-mini';
 

--- a/examples/cyberloop-observer.ts
+++ b/examples/cyberloop-observer.ts
@@ -7,7 +7,7 @@ import {
   type LlmAdapter,
   type LlmResponse,
   type ToolDefinition,
-} from '../src/index.js';
+} from '../src/advanced.js';
 
 const createMockLlm = (): LlmAdapter => {
   let turn = 0;

--- a/examples/host-events.ts
+++ b/examples/host-events.ts
@@ -12,7 +12,7 @@
  *   HEDDLE_EXAMPLE_MODEL=gpt-5.1-codex-mini npx tsx examples/host-events.ts
  */
 
-import { AgentLoopRuntimeService, HeartbeatRunnerAgent, type AgentHeartbeatEvent, type ToolDefinition } from '../src/index.js';
+import { AgentLoopRuntimeService, HeartbeatRunnerAgent, type AgentHeartbeatEvent, type ToolDefinition } from '../src/advanced.js';
 import type { LlmAdapter, LlmResponse } from '../src/core/llm/types.js';
 
 // ---------------------------------------------------------------------------

--- a/examples/native-chrome-cdp-spike.ts
+++ b/examples/native-chrome-cdp-spike.ts
@@ -13,7 +13,7 @@
 
 import { join } from 'node:path';
 
-import { createBrowserResearchToolkit } from '../src/index.js';
+import { createBrowserResearchToolkit } from '../src/advanced.js';
 import type { ToolDefinition, ToolResult } from '../src/core/types.js';
 
 type SnapshotOutput = {

--- a/examples/repo-investigator.ts
+++ b/examples/repo-investigator.ts
@@ -19,7 +19,7 @@ import {
   createRunShellMutateTool,
   TraceConsoleFormatter,
   createLogger,
-} from '../src/index.js';
+} from '../src/advanced.js';
 
 async function main() {
   const goal = process.argv[2];

--- a/package.json
+++ b/package.json
@@ -24,6 +24,17 @@
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./advanced": {
+      "types": "./dist/src/advanced.d.ts",
+      "import": "./dist/src/advanced.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist",
     "!dist/src/__tests__",

--- a/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
+++ b/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import pino from 'pino';
 import { describe, expect, it } from 'vitest';
-import { FileHeartbeatTaskService, type HeartbeatTask } from '@/index.js';
+import { FileHeartbeatTaskService, type HeartbeatTask } from '@/advanced.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
 import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
 import { ControlPlaneHeartbeatController } from '@/server/controllers/trpc/control-plane/heartbeat.js';

--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -7,7 +7,7 @@ import { RuntimeToolService } from '@/core/runtime/tools/index.js';
 import { ToolBundleComposer, type ToolToolkit } from '@/core/tools/index.js';
 import { AgentSkillService, FileAgentSkillActivationRepository } from '@/core/skills/index.js';
 import type { ChatMessage, LlmAdapter, LlmResponse } from '../../../core/llm/types.js';
-import type { AgentHeartbeatEvent, AgentLoopEvent, ToolDefinition } from '../../../index.js';
+import type { AgentHeartbeatEvent, AgentLoopEvent, ToolDefinition } from '../../../advanced.js';
 import { createLogger } from '../../../core/utils/logger.js';
 import {
   HeartbeatDecisionPolicy,

--- a/src/__tests__/integration/core/heartbeat-scheduler.test.ts
+++ b/src/__tests__/integration/core/heartbeat-scheduler.test.ts
@@ -8,7 +8,7 @@ import {
   type HeartbeatSchedulerEvent,
   type HeartbeatTask,
   type HeartbeatTaskStore,
-} from '../../../index.js';
+} from '../../../advanced.js';
 import type { AgentHeartbeatResult } from '@/core/heartbeat/index.js';
 import { AgentLoopCheckpointService, type AgentLoopCheckpoint } from '@/core/runtime/loop/index.js';
 

--- a/src/__tests__/unit/core/heartbeat-lucid.test.ts
+++ b/src/__tests__/unit/core/heartbeat-lucid.test.ts
@@ -6,7 +6,7 @@ import {
   type HeartbeatRunView,
   type HeartbeatSchedulerEvent,
   type HeartbeatTaskView,
-} from '../../../index.js';
+} from '../../../advanced.js';
 
 describe('heartbeat Lucid adapter', () => {
   it('maps heartbeat task states into Lucid-style agent statuses', () => {

--- a/src/__tests__/unit/core/heartbeat-views.test.ts
+++ b/src/__tests__/unit/core/heartbeat-views.test.ts
@@ -8,7 +8,7 @@ import {
   type AgentLoopState,
   type HeartbeatTask,
   type HeartbeatTaskRunRecordEntry,
-} from '../../../index.js';
+} from '../../../advanced.js';
 
 describe('heartbeat task service views', () => {
   it('projects heartbeat task state into a host-facing view', () => {

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -1,0 +1,294 @@
+// ===========================================================================
+// Heddle — Advanced / full surface (`@roackb2/heddle/advanced`)
+// ===========================================================================
+// The complete public surface: the curated SDK (rungs 1-5, re-exported below)
+// plus lower-level building blocks and specialized runtimes. Reach for this
+// entry when you need LLM adapters, individual ready-made tools, trace/memory
+// internals, the agent loop, heartbeat, or integrations. Most product hosts
+// only need the curated default entry (`@roackb2/heddle`, see src/index.ts).
+// ===========================================================================
+
+export * from './index.js';
+
+// ===========================================================================
+// Building blocks
+// ===========================================================================
+
+// --- Building blocks: LLM adapters & models --------------------------------
+export type {
+  LlmAdapter,
+  LlmAdapterCreateInput,
+  ChatMessage,
+  LlmResponse,
+  LlmProvider,
+  ReasoningEffort,
+  LlmAdapterCapabilities,
+  LlmAdapterInfo,
+  LlmUsage,
+} from './core/llm/types.js';
+export {
+  AnthropicAdapter,
+  AnthropicProviderAdapter,
+  LlmAdapterService,
+  LlmProviderRegistry,
+  OpenAiAdapter,
+  OpenAiCompatibleAdapter,
+  OpenAiCompatibleModelDiscoveryService,
+  OpenAiCompatibleModelName,
+  OpenAiCompatibleProviderAdapter,
+  OPENAI_COMPATIBLE_PROVIDER_PROFILES,
+  OpenAiCompatibleProviderProfileService,
+  OpenAiCodexSseService,
+  OpenAiOAuthFetchService,
+  OpenAiProviderAdapter,
+} from './core/llm/index.js';
+export type {
+  AnthropicAdapterOptions,
+  LlmProviderAdapter,
+  OpenAiAdapterOptions,
+  OpenAiCompatibleAdapterOptions,
+  OpenAiCompatibleDiscoveredModel,
+  OpenAiCompatibleModelDiscoveryOptions,
+  OpenAiCompatibleModelDiscoverySource,
+  OpenAiCompatibleProviderId,
+  OpenAiCompatibleProviderProfile,
+  OpenAiOAuthFetchOptions,
+} from './core/llm/index.js';
+export {
+  OPENAI_MODEL_GROUPS,
+  COMMON_OPENAI_MODELS,
+  COMMON_BUILT_IN_MODELS,
+  ModelCatalogService,
+  ModelPolicyService,
+} from './core/llm/models/index.js';
+export type { BuiltInModelGroup } from './core/llm/models/index.js';
+
+// --- Building blocks: ready-made tools -------------------------------------
+export { listFilesTool } from './core/tools/toolkits/coding-files/list-files.js';
+export { readFileTool } from './core/tools/toolkits/coding-files/read-file.js';
+export { editFileTool } from './core/tools/toolkits/coding-files/edit-file.js';
+export { deleteFileTool, createDeleteFileTool } from './core/tools/toolkits/coding-files/delete-file.js';
+export type { DeleteFileToolOptions } from './core/tools/toolkits/coding-files/delete-file.js';
+export { moveFileTool, createMoveFileTool } from './core/tools/toolkits/coding-files/move-file.js';
+export type { MoveFileToolOptions } from './core/tools/toolkits/coding-files/move-file.js';
+export { searchFilesTool, createSearchFilesTool, DEFAULT_SEARCH_EXCLUDED_DIRS } from './core/tools/toolkits/coding-files/search-files.js';
+export type { SearchFilesOptions } from './core/tools/toolkits/coding-files/search-files.js';
+export { webSearchTool, createWebSearchTool } from './core/tools/toolkits/external-context/web-search.js';
+export type { WebSearchToolOptions } from './core/tools/toolkits/external-context/web-search.js';
+export { viewImageTool, createViewImageTool } from './core/tools/toolkits/external-context/view-image.js';
+export type { ViewImageToolOptions } from './core/tools/toolkits/external-context/view-image.js';
+export { updatePlanTool } from './core/tools/toolkits/internal/update-plan.js';
+export type { PlanItem, PlanItemStatus } from './core/tools/toolkits/internal/update-plan.js';
+export { createRunShellInspectTool, createRunShellMutateTool } from './core/tools/toolkits/shell-process/run-shell.js';
+export { createRunShellTool } from './core/tools/toolkits/shell-process/run-shell.js';
+export type { RunShellOptions } from './core/tools/toolkits/shell-process/run-shell.js';
+export { createBrowserResearchToolkit } from './core/tools/toolkits/browser-research/index.js';
+export type { BrowserResearchToolkitOptions } from './core/tools/toolkits/browser-research/toolkit.js';
+
+// --- Building blocks: trace, observability & review ------------------------
+export { TraceConsoleFormatter, TraceRecorder } from './core/trace/index.js';
+export type { TraceRecordSink } from './core/trace/index.js';
+export { ReviewDiffParser } from './core/review/index.js';
+export type {
+  ReviewDiffFile,
+  ReviewDiffHunk,
+  ReviewDiffLine,
+  ReviewFileStatus,
+} from './core/review/index.js';
+export {
+  DEFAULT_TRACE_SUMMARIZERS,
+  TraceSummaryService,
+} from './core/observability/index.js';
+export type {
+  TraceEventOfType,
+  TraceEventType,
+  TraceSummarizer,
+  TraceSummarizerMap,
+  TraceSummaryContext,
+  TraceSummaryValue,
+} from './core/observability/index.js';
+export {
+  TRACE_CORRELATION_FIELDS,
+  TRACE_EVENT_DOMAINS,
+  TRACE_EVENT_TYPES,
+} from './core/observability/index.js';
+export { buildSystemPrompt } from './core/prompts/system-prompt.js';
+
+// --- Building blocks: memory & knowledge -----------------------------------
+export { buildMemoryDomainSystemContext } from './core/memory/domain-prompt.js';
+export {
+  DEFAULT_MEMORY_CATEGORIES,
+  DEFAULT_MEMORY_FOLDER_CATALOG_MAX_BYTES,
+  DEFAULT_MEMORY_FOLDER_CATALOG_TARGET_BYTES,
+  DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES,
+  DEFAULT_MEMORY_ROOT_CATALOG_TARGET_BYTES,
+  MemoryCatalogService,
+} from './core/memory/catalog.js';
+export { MemoryMaintenanceRepository } from './core/memory/maintenance-repository.js';
+export { MemoryMaintenanceService } from './core/memory/maintainer.js';
+export { MemoryMaintenanceIntegrationService } from './core/memory/maintenance-integration.js';
+export { MemoryNoteService } from './core/memory/note-service.js';
+export { MemoryValidationService } from './core/memory/validation.js';
+export { MemoryVisibilityService } from './core/memory/visibility.js';
+export type {
+  BootstrapMemoryWorkspaceResult,
+  KnowledgeCandidate,
+  KnowledgeCandidateStatusRecord,
+  KnowledgeMaintenanceRunRecord,
+  ListMemoryNotesInput,
+  MemoryCatalogLoadResult,
+  MemoryCatalogShapeValidation,
+  MemoryCategory,
+  MemoryStatusView,
+  MemoryValidationIssue,
+  MemoryValidationResult,
+  ReadMemoryNoteInput,
+  RunMaintenanceForRecordedCandidatesOptions,
+  RunMaintenanceForRecordedCandidatesResult,
+  RunKnowledgeMaintenanceOptions,
+  RunKnowledgeMaintenanceResult,
+  SearchMemoryNotesInput,
+} from './core/memory/types.js';
+export { createMemoryMaintainerTools } from './core/memory/maintainer-tools.js';
+export { createMemoryNoteTemplate, slugifyMemoryTitle } from './core/memory/templates.js';
+export {
+  listMemoryNotesTool,
+  readMemoryNoteTool,
+  searchMemoryNotesTool,
+  editMemoryNoteTool,
+  createListMemoryNotesTool,
+  createReadMemoryNoteTool,
+  createSearchMemoryNotesTool,
+  createEditMemoryNoteTool,
+} from './core/tools/toolkits/knowledge/memory-notes.js';
+export type { MemoryNotesToolOptions } from './core/tools/toolkits/knowledge/memory-notes.js';
+export { createMemoryCheckpointTool } from './core/tools/toolkits/knowledge/memory-checkpoint.js';
+export type { MemoryCheckpointToolOptions } from './core/tools/toolkits/knowledge/memory-checkpoint.js';
+export { createRecordKnowledgeTool, recordKnowledgeTool } from './core/tools/toolkits/knowledge/record-knowledge.js';
+export type { RecordKnowledgeToolOptions } from './core/tools/toolkits/knowledge/record-knowledge.js';
+
+// --- Building blocks: awareness --------------------------------------------
+export {
+  createAwarenessService,
+  createCodingAwarenessProvider,
+  formatCodingProjectDashboardSnapshot,
+} from './core/awareness/index.js';
+export type {
+  AwarenessCollectInput,
+  AwarenessDomain,
+  AwarenessLimit,
+  AwarenessProfile,
+  AwarenessProvider,
+  AwarenessSnapshot,
+  AwarenessSource,
+  CodingAwarenessSection,
+  CodingAwarenessSnapshot,
+  CodingProjectDashboardOutput,
+  CodingWorkingEnvironment,
+  CodingWorkspaceTree,
+  CodingWorkspaceTreeEntry,
+} from './core/awareness/index.js';
+
+// ===========================================================================
+// Specialized runtimes
+// ===========================================================================
+
+// --- Specialized runtimes: agent loop --------------------------------------
+export { AgentRunService } from './core/agent/index.js';
+export type { RunAgentOptions } from './core/agent/index.js';
+export { AgentLoopCheckpointService, AgentLoopRuntimeService } from './core/runtime/loop/index.js';
+export type { AgentLoopCheckpoint, AgentLoopEvent, AgentLoopResult, AgentLoopState, AgentLoopStatus, RunAgentLoopOptions } from './core/runtime/loop/index.js';
+
+// --- Specialized runtimes: heartbeat ---------------------------------------
+export { HeartbeatRunnerAgent } from './core/heartbeat/agent/index.js';
+export type {
+  AgentHeartbeatEvent,
+  AgentHeartbeatResult,
+  HeartbeatDecision,
+  HeartbeatDecisionEvent,
+  HeartbeatEscalationEvent,
+  RunAgentHeartbeatOptions,
+} from './core/heartbeat/agent/index.js';
+export {
+  FileHeartbeatCheckpointRepository,
+  StoredHeartbeatService,
+} from './core/heartbeat/checkpoint/index.js';
+export type {
+  FileHeartbeatCheckpointRepositoryOptions,
+  HeartbeatCheckpointStore,
+  RunStoredHeartbeatOptions,
+  StoredHeartbeatResult,
+} from './core/heartbeat/checkpoint/index.js';
+export {
+  FileHeartbeatTaskService,
+} from './core/heartbeat/tasks/index.js';
+export type {
+  FileHeartbeatTaskServiceOptions,
+  HeartbeatTask,
+  HeartbeatTaskRunRecord,
+  HeartbeatTaskRunRecordEntry,
+  HeartbeatTaskStore,
+} from './core/heartbeat/tasks/index.js';
+export {
+  HeartbeatSchedulerService,
+} from './core/heartbeat/scheduler/index.js';
+export type {
+  HeartbeatSchedulerHandle,
+  HeartbeatSchedulerEvent,
+  HeartbeatTaskRunner,
+  HeartbeatTaskRunnerRuntimeOptions,
+  RunDueHeartbeatTasksOptions,
+  RunDueHeartbeatTasksResult,
+  RunHeartbeatSchedulerOptions,
+  StartHeartbeatSchedulerOptions,
+} from './core/heartbeat/scheduler/index.js';
+export type {
+  HeartbeatRunView,
+  HeartbeatTaskView,
+} from './core/heartbeat/views/index.js';
+export {
+  HeartbeatLucidPresenter,
+} from './core/heartbeat/views/index.js';
+export type {
+  LucidAgentMessage,
+  LucidAgentProgressNotification,
+  LucidAgentResponseNotification,
+  LucidAgentStatus,
+  LucidAgentStatusNotification,
+  LucidAdapterOptions,
+} from './core/heartbeat/views/index.js';
+
+// --- Specialized runtimes: integrations (cyberloop) ------------------------
+export {
+  createCyberLoopObserver,
+  createRuntimeFrameEmbedder,
+  eventToRuntimeFrame,
+  formatRuntimeFrameForEmbedding,
+  inferDriftLevel,
+} from './integrations/cyberloop.js';
+export { createCyberLoopKinematicsObserver } from './integrations/cyberloop-kinematics.js';
+export type {
+  CyberLoopCompatibleMiddleware,
+  CyberLoopCompatibleStateEmbedder,
+  CyberLoopDriftLevel,
+  CyberLoopMetadataChannels,
+  CyberLoopObserver,
+  CyberLoopObserverAnnotation,
+  CyberLoopStepContext,
+  CyberLoopStepResult,
+  CreateRuntimeFrameEmbedderOptions,
+  HeddleRuntimeFrame,
+  HeddleRuntimeFrameKind,
+  RuntimeFrameEmbedText,
+} from './integrations/cyberloop.js';
+export type {
+  CreateCyberLoopKinematicsObserverOptions,
+  CyberLoopKinematicsObserver,
+} from './integrations/cyberloop-kinematics.js';
+
+// ---------------------------------------------------------------------------
+// Utilities & errors
+// ---------------------------------------------------------------------------
+export { AgentStepBudget } from './core/agent/budget/index.js';
+export { HeddleError, ToolExecutionError, LlmError, BudgetExhaustedError } from './core/utils/errors.js';
+export { createLogger, logger } from './core/utils/logger.js';

--- a/src/cli-v2/commands/memory-command.ts
+++ b/src/cli-v2/commands/memory-command.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 import compact from 'lodash/compact.js';
-import { DEFAULT_OPENAI_MODEL, LlmAdapterService } from '@/index.js';
+import { DEFAULT_OPENAI_MODEL, LlmAdapterService } from '@/advanced.js';
 import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import { MemoryCatalogService } from '@/core/memory/catalog.js';
 import { MemoryMaintenanceService } from '@/core/memory/maintainer.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,21 @@
 // ===========================================================================
-// Heddle — Public SDK
+// Heddle — Public SDK (curated entry)
 // ===========================================================================
-// This surface is organized as a progressive-disclosure ladder. Start at the
-// top and go deeper only when you need to. Full guide:
-// docs/guides/programmatic/quickstart.md
+// This is the default `@roackb2/heddle` import: the curated surface a product
+// host needs to build an agentic experience, organized as a progressive-
+// disclosure ladder. Start at the top and go deeper only when you need to.
+// Full guide: docs/guides/programmatic/quickstart.md
 //
 //   1. Start here            — stand up a conversation agent in a few lines
 //   • Core types             — the handful of types shared across the ladder
 //   2. Add capabilities      — your own tools, MCP servers, skills
 //   3. Shape input/output    — render streaming activity / text, read results
-//   4. Advanced: lifecycle   — drive the conversation engine and sessions
+//   4. Advanced: lifecycle   — drive the engine, sessions, and approvals
 //   5. Advanced: storage     — back artifacts/credentials with your own store
-//   —  Building blocks        — LLM adapters, individual tools, approvals,
-//                                trace, memory, models, awareness
-//   —  Specialized runtimes   — agent loop, heartbeat, integrations
-//   —  Utilities & errors
 //
-// Rungs 1–5 are what most product hosts need. Everything below "Building
-// blocks" is lower-level runtime plumbing you can reach for, but a beginner
-// should not need to.
+// Lower-level runtime plumbing (LLM adapters, individual tools, trace, memory,
+// models, awareness, the agent loop, heartbeat, integrations, utilities) lives
+// behind the `@roackb2/heddle/advanced` subpath — see src/advanced.ts.
 // ===========================================================================
 
 // ---------------------------------------------------------------------------
@@ -63,7 +60,7 @@ export type {
 // ---------------------------------------------------------------------------
 // Author a tool with the `ToolDefinition` type above; wire an MCP server with
 // `prepareMcpHostExtension`; compose host tools/context with
-// `defineHostExtension`. Ready-made tools live under "Building blocks".
+// `defineHostExtension`. Ready-made tools live in `@roackb2/heddle/advanced`.
 export {
   defineMcpHostExtension,
   McpHostExtensionService,
@@ -154,10 +151,11 @@ export type {
 export { ToolActivitySummarizer } from './core/live/index.js';
 
 // ---------------------------------------------------------------------------
-// 4. Advanced: conversation engine lifecycle & sessions
+// 4. Advanced: engine lifecycle, sessions & approvals
 // ---------------------------------------------------------------------------
 // Types and services for hosts that embed `createConversationEngine` (rung 1)
-// directly and manage session create/resume/turn lifecycle themselves.
+// directly and manage session create/resume/turn lifecycle and approval policy
+// themselves.
 export type {
   ClearConversationTurnLeaseInput,
   ConversationEngine,
@@ -179,106 +177,6 @@ export type {
   RunConversationTurnArgs,
   RunConversationTurnResult,
 } from './core/chat/engine/turns/types.js';
-
-// ---------------------------------------------------------------------------
-// 5. Advanced: storage — back Heddle with your own persistence
-// ---------------------------------------------------------------------------
-// Heddle defaults to local file-backed stores. These interfaces + File impls
-// are the seams a hosted service replaces with its own storage. NOTE: today
-// `createConversationEngine` is still path-oriented (stateRoot); injecting
-// custom repositories at the engine boundary is planned (see SDK posture,
-// rung 5 / plan P2), not yet fully wired here.
-export { ArtifactService, FileArtifactRepository } from './core/artifacts/index.js';
-export type {
-  ArtifactCurrentPointers,
-  ArtifactKind,
-  ArtifactListOptions,
-  ArtifactReadResult,
-  ArtifactServiceOptions,
-  ArtifactStore,
-  FileArtifactRepositoryOptions,
-  RuntimeArtifact,
-  SaveTextArtifactInput,
-} from './core/artifacts/index.js';
-export { RuntimeCredentialService } from './core/runtime/credentials/index.js';
-export type { ApiKeyRuntime, ProviderCredentialSource } from './core/runtime/credentials/index.js';
-
-// ===========================================================================
-// Building blocks
-// ===========================================================================
-
-// --- Building blocks: LLM adapters & models --------------------------------
-export type {
-  LlmAdapter,
-  LlmAdapterCreateInput,
-  ChatMessage,
-  LlmResponse,
-  LlmProvider,
-  ReasoningEffort,
-  LlmAdapterCapabilities,
-  LlmAdapterInfo,
-  LlmUsage,
-} from './core/llm/types.js';
-export {
-  AnthropicAdapter,
-  AnthropicProviderAdapter,
-  LlmAdapterService,
-  LlmProviderRegistry,
-  OpenAiAdapter,
-  OpenAiCompatibleAdapter,
-  OpenAiCompatibleModelDiscoveryService,
-  OpenAiCompatibleModelName,
-  OpenAiCompatibleProviderAdapter,
-  OPENAI_COMPATIBLE_PROVIDER_PROFILES,
-  OpenAiCompatibleProviderProfileService,
-  OpenAiCodexSseService,
-  OpenAiOAuthFetchService,
-  OpenAiProviderAdapter,
-} from './core/llm/index.js';
-export type {
-  AnthropicAdapterOptions,
-  LlmProviderAdapter,
-  OpenAiAdapterOptions,
-  OpenAiCompatibleAdapterOptions,
-  OpenAiCompatibleDiscoveredModel,
-  OpenAiCompatibleModelDiscoveryOptions,
-  OpenAiCompatibleModelDiscoverySource,
-  OpenAiCompatibleProviderId,
-  OpenAiCompatibleProviderProfile,
-  OpenAiOAuthFetchOptions,
-} from './core/llm/index.js';
-export {
-  OPENAI_MODEL_GROUPS,
-  COMMON_OPENAI_MODELS,
-  COMMON_BUILT_IN_MODELS,
-  ModelCatalogService,
-  ModelPolicyService,
-} from './core/llm/models/index.js';
-export type { BuiltInModelGroup } from './core/llm/models/index.js';
-
-// --- Building blocks: ready-made tools -------------------------------------
-export { listFilesTool } from './core/tools/toolkits/coding-files/list-files.js';
-export { readFileTool } from './core/tools/toolkits/coding-files/read-file.js';
-export { editFileTool } from './core/tools/toolkits/coding-files/edit-file.js';
-export { deleteFileTool, createDeleteFileTool } from './core/tools/toolkits/coding-files/delete-file.js';
-export type { DeleteFileToolOptions } from './core/tools/toolkits/coding-files/delete-file.js';
-export { moveFileTool, createMoveFileTool } from './core/tools/toolkits/coding-files/move-file.js';
-export type { MoveFileToolOptions } from './core/tools/toolkits/coding-files/move-file.js';
-export { searchFilesTool, createSearchFilesTool, DEFAULT_SEARCH_EXCLUDED_DIRS } from './core/tools/toolkits/coding-files/search-files.js';
-export type { SearchFilesOptions } from './core/tools/toolkits/coding-files/search-files.js';
-export { webSearchTool, createWebSearchTool } from './core/tools/toolkits/external-context/web-search.js';
-export type { WebSearchToolOptions } from './core/tools/toolkits/external-context/web-search.js';
-export { viewImageTool, createViewImageTool } from './core/tools/toolkits/external-context/view-image.js';
-export type { ViewImageToolOptions } from './core/tools/toolkits/external-context/view-image.js';
-export { updatePlanTool } from './core/tools/toolkits/internal/update-plan.js';
-export type { PlanItem, PlanItemStatus } from './core/tools/toolkits/internal/update-plan.js';
-export { createRunShellInspectTool, createRunShellMutateTool } from './core/tools/toolkits/shell-process/run-shell.js';
-export { createRunShellTool } from './core/tools/toolkits/shell-process/run-shell.js';
-export type { RunShellOptions } from './core/tools/toolkits/shell-process/run-shell.js';
-export { createBrowserResearchToolkit } from './core/tools/toolkits/browser-research/index.js';
-export type { BrowserResearchToolkitOptions } from './core/tools/toolkits/browser-research/toolkit.js';
-
-// --- Building blocks: approvals --------------------------------------------
 export {
   ToolApprovalPolicies,
   ToolApprovalService,
@@ -306,210 +204,25 @@ export type {
   ProjectApprovalRule,
 } from './core/approvals/remembered-rules/index.js';
 
-// --- Building blocks: trace, observability & review ------------------------
-export { TraceConsoleFormatter, TraceRecorder } from './core/trace/index.js';
-export type { TraceRecordSink } from './core/trace/index.js';
-export { ReviewDiffParser } from './core/review/index.js';
-export type {
-  ReviewDiffFile,
-  ReviewDiffHunk,
-  ReviewDiffLine,
-  ReviewFileStatus,
-} from './core/review/index.js';
-export {
-  DEFAULT_TRACE_SUMMARIZERS,
-  TraceSummaryService,
-} from './core/observability/index.js';
-export type {
-  TraceEventOfType,
-  TraceEventType,
-  TraceSummarizer,
-  TraceSummarizerMap,
-  TraceSummaryContext,
-  TraceSummaryValue,
-} from './core/observability/index.js';
-export {
-  TRACE_CORRELATION_FIELDS,
-  TRACE_EVENT_DOMAINS,
-  TRACE_EVENT_TYPES,
-} from './core/observability/index.js';
-export { buildSystemPrompt } from './core/prompts/system-prompt.js';
-
-// --- Building blocks: memory & knowledge -----------------------------------
-export { buildMemoryDomainSystemContext } from './core/memory/domain-prompt.js';
-export {
-  DEFAULT_MEMORY_CATEGORIES,
-  DEFAULT_MEMORY_FOLDER_CATALOG_MAX_BYTES,
-  DEFAULT_MEMORY_FOLDER_CATALOG_TARGET_BYTES,
-  DEFAULT_MEMORY_ROOT_CATALOG_MAX_BYTES,
-  DEFAULT_MEMORY_ROOT_CATALOG_TARGET_BYTES,
-  MemoryCatalogService,
-} from './core/memory/catalog.js';
-export { MemoryMaintenanceRepository } from './core/memory/maintenance-repository.js';
-export { MemoryMaintenanceService } from './core/memory/maintainer.js';
-export { MemoryMaintenanceIntegrationService } from './core/memory/maintenance-integration.js';
-export { MemoryNoteService } from './core/memory/note-service.js';
-export { MemoryValidationService } from './core/memory/validation.js';
-export { MemoryVisibilityService } from './core/memory/visibility.js';
-export type {
-  BootstrapMemoryWorkspaceResult,
-  KnowledgeCandidate,
-  KnowledgeCandidateStatusRecord,
-  KnowledgeMaintenanceRunRecord,
-  ListMemoryNotesInput,
-  MemoryCatalogLoadResult,
-  MemoryCatalogShapeValidation,
-  MemoryCategory,
-  MemoryStatusView,
-  MemoryValidationIssue,
-  MemoryValidationResult,
-  ReadMemoryNoteInput,
-  RunMaintenanceForRecordedCandidatesOptions,
-  RunMaintenanceForRecordedCandidatesResult,
-  RunKnowledgeMaintenanceOptions,
-  RunKnowledgeMaintenanceResult,
-  SearchMemoryNotesInput,
-} from './core/memory/types.js';
-export { createMemoryMaintainerTools } from './core/memory/maintainer-tools.js';
-export { createMemoryNoteTemplate, slugifyMemoryTitle } from './core/memory/templates.js';
-export {
-  listMemoryNotesTool,
-  readMemoryNoteTool,
-  searchMemoryNotesTool,
-  editMemoryNoteTool,
-  createListMemoryNotesTool,
-  createReadMemoryNoteTool,
-  createSearchMemoryNotesTool,
-  createEditMemoryNoteTool,
-} from './core/tools/toolkits/knowledge/memory-notes.js';
-export type { MemoryNotesToolOptions } from './core/tools/toolkits/knowledge/memory-notes.js';
-export { createMemoryCheckpointTool } from './core/tools/toolkits/knowledge/memory-checkpoint.js';
-export type { MemoryCheckpointToolOptions } from './core/tools/toolkits/knowledge/memory-checkpoint.js';
-export { createRecordKnowledgeTool, recordKnowledgeTool } from './core/tools/toolkits/knowledge/record-knowledge.js';
-export type { RecordKnowledgeToolOptions } from './core/tools/toolkits/knowledge/record-knowledge.js';
-
-// --- Building blocks: awareness --------------------------------------------
-export {
-  createAwarenessService,
-  createCodingAwarenessProvider,
-  formatCodingProjectDashboardSnapshot,
-} from './core/awareness/index.js';
-export type {
-  AwarenessCollectInput,
-  AwarenessDomain,
-  AwarenessLimit,
-  AwarenessProfile,
-  AwarenessProvider,
-  AwarenessSnapshot,
-  AwarenessSource,
-  CodingAwarenessSection,
-  CodingAwarenessSnapshot,
-  CodingProjectDashboardOutput,
-  CodingWorkingEnvironment,
-  CodingWorkspaceTree,
-  CodingWorkspaceTreeEntry,
-} from './core/awareness/index.js';
-
-// ===========================================================================
-// Specialized runtimes
-// ===========================================================================
-
-// --- Specialized runtimes: agent loop --------------------------------------
-export { AgentRunService } from './core/agent/index.js';
-export type { RunAgentOptions } from './core/agent/index.js';
-export { AgentLoopCheckpointService, AgentLoopRuntimeService } from './core/runtime/loop/index.js';
-export type { AgentLoopCheckpoint, AgentLoopEvent, AgentLoopResult, AgentLoopState, AgentLoopStatus, RunAgentLoopOptions } from './core/runtime/loop/index.js';
-
-// --- Specialized runtimes: heartbeat ---------------------------------------
-export { HeartbeatRunnerAgent } from './core/heartbeat/agent/index.js';
-export type {
-  AgentHeartbeatEvent,
-  AgentHeartbeatResult,
-  HeartbeatDecision,
-  HeartbeatDecisionEvent,
-  HeartbeatEscalationEvent,
-  RunAgentHeartbeatOptions,
-} from './core/heartbeat/agent/index.js';
-export {
-  FileHeartbeatCheckpointRepository,
-  StoredHeartbeatService,
-} from './core/heartbeat/checkpoint/index.js';
-export type {
-  FileHeartbeatCheckpointRepositoryOptions,
-  HeartbeatCheckpointStore,
-  RunStoredHeartbeatOptions,
-  StoredHeartbeatResult,
-} from './core/heartbeat/checkpoint/index.js';
-export {
-  FileHeartbeatTaskService,
-} from './core/heartbeat/tasks/index.js';
-export type {
-  FileHeartbeatTaskServiceOptions,
-  HeartbeatTask,
-  HeartbeatTaskRunRecord,
-  HeartbeatTaskRunRecordEntry,
-  HeartbeatTaskStore,
-} from './core/heartbeat/tasks/index.js';
-export {
-  HeartbeatSchedulerService,
-} from './core/heartbeat/scheduler/index.js';
-export type {
-  HeartbeatSchedulerHandle,
-  HeartbeatSchedulerEvent,
-  HeartbeatTaskRunner,
-  HeartbeatTaskRunnerRuntimeOptions,
-  RunDueHeartbeatTasksOptions,
-  RunDueHeartbeatTasksResult,
-  RunHeartbeatSchedulerOptions,
-  StartHeartbeatSchedulerOptions,
-} from './core/heartbeat/scheduler/index.js';
-export type {
-  HeartbeatRunView,
-  HeartbeatTaskView,
-} from './core/heartbeat/views/index.js';
-export {
-  HeartbeatLucidPresenter,
-} from './core/heartbeat/views/index.js';
-export type {
-  LucidAgentMessage,
-  LucidAgentProgressNotification,
-  LucidAgentResponseNotification,
-  LucidAgentStatus,
-  LucidAgentStatusNotification,
-  LucidAdapterOptions,
-} from './core/heartbeat/views/index.js';
-
-// --- Specialized runtimes: integrations (cyberloop) ------------------------
-export {
-  createCyberLoopObserver,
-  createRuntimeFrameEmbedder,
-  eventToRuntimeFrame,
-  formatRuntimeFrameForEmbedding,
-  inferDriftLevel,
-} from './integrations/cyberloop.js';
-export { createCyberLoopKinematicsObserver } from './integrations/cyberloop-kinematics.js';
-export type {
-  CyberLoopCompatibleMiddleware,
-  CyberLoopCompatibleStateEmbedder,
-  CyberLoopDriftLevel,
-  CyberLoopMetadataChannels,
-  CyberLoopObserver,
-  CyberLoopObserverAnnotation,
-  CyberLoopStepContext,
-  CyberLoopStepResult,
-  CreateRuntimeFrameEmbedderOptions,
-  HeddleRuntimeFrame,
-  HeddleRuntimeFrameKind,
-  RuntimeFrameEmbedText,
-} from './integrations/cyberloop.js';
-export type {
-  CreateCyberLoopKinematicsObserverOptions,
-  CyberLoopKinematicsObserver,
-} from './integrations/cyberloop-kinematics.js';
-
 // ---------------------------------------------------------------------------
-// Utilities & errors
+// 5. Advanced: storage — back Heddle with your own persistence
 // ---------------------------------------------------------------------------
-export { AgentStepBudget } from './core/agent/budget/index.js';
-export { HeddleError, ToolExecutionError, LlmError, BudgetExhaustedError } from './core/utils/errors.js';
-export { createLogger, logger } from './core/utils/logger.js';
+// Heddle defaults to local file-backed stores. These interfaces + File impls
+// are the seams a hosted service replaces with its own storage. NOTE: today
+// `createConversationEngine` is still path-oriented (stateRoot); injecting
+// custom repositories at the engine boundary is planned (see SDK posture,
+// rung 5 / plan P2), not yet fully wired here.
+export { ArtifactService, FileArtifactRepository } from './core/artifacts/index.js';
+export type {
+  ArtifactCurrentPointers,
+  ArtifactKind,
+  ArtifactListOptions,
+  ArtifactReadResult,
+  ArtifactServiceOptions,
+  ArtifactStore,
+  FileArtifactRepositoryOptions,
+  RuntimeArtifact,
+  SaveTextArtifactInput,
+} from './core/artifacts/index.js';
+export { RuntimeCredentialService } from './core/runtime/credentials/index.js';
+export type { ApiKeyRuntime, ProviderCredentialSource } from './core/runtime/credentials/index.js';

--- a/src/server/controllers/trpc/control-plane/ask.ts
+++ b/src/server/controllers/trpc/control-plane/ask.ts
@@ -7,7 +7,7 @@ import {
   TraceConsoleFormatter,
   AgentLoopRuntimeService,
   type RunResult,
-} from '@/index.js';
+} from '@/advanced.js';
 import { MemoryCatalogService } from '@/core/memory/catalog.js';
 import { MemoryMaintenanceIntegrationService } from '@/core/memory/maintenance-integration.js';
 import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';


### PR DESCRIPTION
## Summary

SDK maturation **P1b** (follow-on to #221). Introduce package `exports` subpaths so the public surface is genuinely tiered, not just documented:

- **`@roackb2/heddle`** (default) → the **curated** rung 1–5 surface: everything a product host needs to build an agentic experience.
- **`@roackb2/heddle/advanced`** → the **full** surface: curated exports plus lower-level building blocks (LLM adapters, individual tools, trace, memory, models, awareness) and specialized runtimes (agent loop, heartbeat, integrations, utilities).

A newcomer's first import now autocompletes the handful of things that start an agent, not the whole runtime.

## Structure
- `src/index.ts` = curated entry. **Approvals moved into rung 4 (lifecycle)** — a product host owning approval policy (e.g. via `ToolApprovalPolicyContext`) needs those types from the default entry.
- `src/advanced.ts` = `export * from './index.js'` + building blocks + specialized runtimes. The union of the two files equals the previous flat surface **exactly** (366 = 366 exported names, verified).
- `package.json` `exports`: `.` → curated, `./advanced` → full, plus `./package.json`.
- Internal consumers that pulled *advanced* symbols from the root barrel (`@/index.js` / `../../../index.js`) now import from the advanced entry; curated-only consumers (e.g. core types) are unchanged.
- Top-level examples using advanced symbols import from `../src/advanced.js`; `examples/sdk/01–04` stay on the curated default to model beginner usage.

Not in scope: storage-layer injection (P2).

## Verification
- `yarn build` — pass; `dist/src/advanced.{js,d.ts}` emitted
- `yarn test:unit` — 641 passed (incl. all repointed heartbeat/agent-loop/control-plane/session tests)
- `yarn lint` — clean
- Exported-symbol union (index ∪ advanced) vs previous surface: identical, zero drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjFdZgZhov8wdwFinVTfjz