### PR TITLE
feat: session-scoped artifacts reader on the engine (SDK P3)

### DIFF
--- a/docs/guides/programmatic/conversation-engine.md
+++ b/docs/guides/programmatic/conversation-engine.md
@@ -35,3 +35,20 @@ The normalized engine config derives default paths from `stateRoot`:
 
 Use `EngineConversationTurnService.run(...)` only when your host already owns
 session ids and storage paths. For new hosts, prefer `createConversationEngine`.
+
+## Reading artifacts
+
+Each turn result already includes the artifacts produced by that turn. To review
+all artifacts a session has accumulated (for example, a host `/artifacts`
+command), use `engine.artifacts` instead of constructing an `ArtifactService`
+against a guessed path:
+
+```ts
+const artifacts = engine.artifacts.list({ sessionId: session.id })
+const source = engine.artifacts.read(artifactId)?.content
+```
+
+`engine.artifacts` is backed by the engine's resolved artifact root, so it stays
+correct even when a host extension sets a custom `artifacts.root`. Do not
+recompute the artifact root (`stateRoot/artifacts`) in host code — that breaks
+when the root is customized.

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createConversationEngine } from '../../../core/chat/engine/conversation-engine.js';
 import { defineHostExtension } from '../../../core/chat/engine/host-extension.js';
+import { ArtifactService } from '@/core/artifacts/index.js';
 import { EngineConversationTurnService } from '../../../core/chat/engine/turns/service.js';
 import type { AgentLoopEvent } from '@/core/runtime/loop/index.js';
 import type { TraceEvent } from '../../../core/types.js';
@@ -69,6 +70,45 @@ describe('createConversationEngine', () => {
       history: [],
       messages: [],
     }));
+  });
+
+  it('exposes an artifacts reader rooted at the resolved artifact root', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-artifacts-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      apiKeyPresent: true,
+    });
+    const session = engine.sessions.create({ id: 'session-1', name: 'Artifacts' });
+
+    const saved = engine.artifacts.saveText({ content: '# Deck', kind: 'source', sessionId: session.id });
+
+    expect(engine.artifacts.list({ sessionId: session.id }).map((artifact) => artifact.id)).toContain(saved.id);
+    expect(engine.artifacts.read(saved.id)?.content).toBe('# Deck');
+    // Backed by the default stateRoot/artifacts root.
+    expect(new ArtifactService({ artifactRoot: join(stateRoot, 'artifacts') }).get(saved.id)?.id).toBe(saved.id);
+  });
+
+  it('roots the artifacts reader at a custom host-extension artifacts root', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-artifacts-custom-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const customRoot = join(stateRoot, 'deck-artifacts');
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      apiKeyPresent: true,
+      hostExtensions: [defineHostExtension({ id: 'decks', artifacts: { root: customRoot, enabled: true } })],
+    });
+    const session = engine.sessions.create({ id: 'session-1', name: 'Custom artifacts' });
+
+    const saved = engine.artifacts.saveText({ content: '<html></html>', kind: 'html', sessionId: session.id });
+
+    // The reader uses the resolved custom root, not the default stateRoot/artifacts.
+    expect(new ArtifactService({ artifactRoot: customRoot }).get(saved.id)?.id).toBe(saved.id);
+    expect(new ArtifactService({ artifactRoot: join(stateRoot, 'artifacts') }).get(saved.id)).toBeUndefined();
   });
 
   it('passes host extensions into submitted turns', async () => {

--- a/src/core/chat/engine/conversation-engine.ts
+++ b/src/core/chat/engine/conversation-engine.ts
@@ -1,3 +1,4 @@
+import { ArtifactService } from '@/core/artifacts/index.js';
 import { normalizeConversationEngineConfig } from './config.js';
 import { FileConversationSessionService } from './sessions/service.js';
 import { EngineConversationTurnService } from './turns/service.js';
@@ -9,5 +10,6 @@ export function createConversationEngine(config: ConversationEngineConfig): Conv
   return {
     sessions: new FileConversationSessionService(normalizedConfig),
     turns: new EngineConversationTurnService(normalizedConfig),
+    artifacts: new ArtifactService({ artifactRoot: normalizedConfig.artifactRoot }),
   };
 }

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -1,3 +1,4 @@
+import type { ArtifactService } from '@/core/artifacts/index.js';
 import type { ToolApprovalPolicy, ToolApprovalSurface } from '../../approvals/types.js';
 import type {
   ConversationActivity,
@@ -51,6 +52,13 @@ export type { ConversationEngineHostExtension };
 export type ConversationEngine = {
   sessions: ConversationSessionService;
   turns: ConversationTurnService;
+  /**
+   * Read/inspect artifacts saved during turns (e.g. for a host `/artifacts`
+   * review command) without reconstructing the on-disk artifact root. Backed by
+   * the engine's resolved `artifactRoot`, so it honors a custom
+   * `hostExtensions.artifacts.root`.
+   */
+  artifacts: ArtifactService;
 };
 
 export type ConversationSessionService = {


### PR DESCRIPTION
## Summary

SDK maturation **P3** (partial — the artifact-reader half). Adds `engine.artifacts` so a host can review the artifacts a session produced without reaching into Heddle's on-disk storage layout.

### Why
The playground's `/artifacts` command does `new ArtifactService({ artifactRoot: join(stateRoot, 'artifacts') })` — it reconstructs Heddle's storage path. That's not just a leak, it's a **latent bug**: the engine resolves `artifactRoot` from `hostExtensions.artifacts.root ?? stateRoot/artifacts`, so the hardcoded guess is wrong whenever a host customizes the artifacts root.

### Change
- `ConversationEngine` gains `artifacts: ArtifactService`, constructed once in `createConversationEngine` from the normalized `artifactRoot`.
- Hosts use `engine.artifacts.list({ sessionId })` / `engine.artifacts.read(id)` instead of recomputing the path.
- No new exports (`ArtifactService` is already in the curated surface, rung 5). This is the **read side of the planned pluggable storage layer** (posture rung 5 / plan P2) — when the store becomes injectable, this reader reflects it automatically.

### Deliberately deferred: the run-recorder
P3 also floated a generic host "run-recorder" (turns.jsonl/summary capture). I'm **not** building it here: that's host-side file logging with unclear ownership, and forcing it into Heddle risks a thin wrapper / host-owns-semantics smell. Recommend it stays host-specific unless a second host shows the exact same capture is genuinely generic. Happy to revisit.

## Verification
- `yarn build` — pass
- `yarn test:unit` — 596 passed, incl. two new tests: reader lists/reads a saved artifact at the default root, and honors a **custom** host-extension artifacts root (proving the correctness fix)
- `yarn lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjFdZgZhov8wdwFinVTfjz