### PR TITLE
feat: injectable artifact storage — ArtifactRepository port (SDK P2, slice 1)

### DIFF
--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -36,8 +36,11 @@ There are two import entry points:
 5. **Advanced: storage** — back Heddle with your own persistence.
    - [Result artifacts](result-artifacts.md): save large generated values as
      reusable artifacts.
-   - Bringing your own session/artifact store (for hosted services) is on the
-     roadmap; today the engine persists under a local state root.
+   - Artifact storage is injectable: implement `ArtifactRepository` and pass it
+     as `artifactRepository` (see
+     [Conversation engine → Bring your own artifact storage](conversation-engine.md#bring-your-own-artifact-storage)).
+     Sessions, traces, and memory still persist under a local state root; making
+     them injectable follows the same pattern.
 
 Runnable versions of the first few rungs live in
 [`examples/sdk/`](../../../examples/sdk/README.md).

--- a/docs/guides/programmatic/conversation-engine.md
+++ b/docs/guides/programmatic/conversation-engine.md
@@ -52,3 +52,38 @@ const source = engine.artifacts.read(artifactId)?.content
 correct even when a host extension sets a custom `artifacts.root`. Do not
 recompute the artifact root (`stateRoot/artifacts`) in host code — that breaks
 when the root is customized.
+
+## Bring your own artifact storage
+
+Hosted services usually cannot persist under a local state root. Implement the
+`ArtifactRepository` port and pass it to the engine (or the quickstart runner):
+
+```ts
+import { createConversationEngine, type ArtifactRepository } from '@roackb2/heddle'
+
+const artifactRepository: ArtifactRepository = {
+  readCatalog: () => loadCatalogFromDatabase(),
+  writeCatalog: (store) => saveCatalogToDatabase(store),
+  contentKey: (id, extension) => `artifacts/${id}.${extension}`,
+  contentExists: (key) => blobExists(key),
+  writeContent: (key, content) => putBlob(key, content),
+  readContent: (key) => getBlob(key),
+}
+
+const engine = createConversationEngine({
+  workspaceRoot,
+  stateRoot,
+  model: 'gpt-5.4',
+  artifactRepository,
+})
+```
+
+The injected repository is resolved once at the engine boundary and used
+everywhere artifacts are persisted or read: `engine.artifacts`, per-turn
+artifact listings in turn results, the `save_artifact`/`read_artifact` tool
+family, and MCP host-extension result-artifact capture. `contentKey` owns
+content addressing — return whatever key your storage understands; it is stored
+as `RuntimeArtifact.path`.
+
+Sessions, traces, and memory still persist under the state root today. Making
+them injectable follows the same port-per-domain pattern.

--- a/src/__tests__/unit/core/artifacts.test.ts
+++ b/src/__tests__/unit/core/artifacts.test.ts
@@ -3,6 +3,27 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { ArtifactService, FileArtifactRepository } from '@/core/artifacts/index.js';
+import type { ArtifactRepository, ArtifactStore } from '@/core/artifacts/index.js';
+
+/** Non-file ArtifactRepository proving the port is not shaped around the filesystem. */
+function createInMemoryArtifactRepository(): ArtifactRepository & { contents: Map<string, string> } {
+  let catalog: ArtifactStore = FileArtifactRepository.emptyStore();
+  const contents = new Map<string, string>();
+
+  return {
+    contents,
+    readCatalog: () => structuredClone(catalog),
+    writeCatalog: (store) => {
+      catalog = structuredClone(store);
+    },
+    contentKey: (id, extension) => `memory://${id}.${extension}`,
+    contentExists: (key) => contents.has(key),
+    writeContent: (key, content) => {
+      contents.set(key, content);
+    },
+    readContent: (key) => contents.get(key),
+  };
+}
 
 describe('artifact registry', () => {
   it('saves text artifacts, stores metadata, and reads content back', () => {
@@ -120,14 +141,48 @@ describe('artifact registry', () => {
     });
 
     expect(existsSync(artifact.path)).toBe(true);
-    expect(repository.read().artifacts).toHaveLength(1);
+    expect(repository.readCatalog().artifacts).toHaveLength(1);
 
     const storePath = FileArtifactRepository.resolveStorePath(artifactRoot);
     // Keep malformed JSON from surfacing partial or invalid artifact state.
     writeFileSync(storePath, '{not valid json', 'utf8');
 
-    expect(repository.read()).toEqual(FileArtifactRepository.emptyStore());
+    expect(repository.readCatalog()).toEqual(FileArtifactRepository.emptyStore());
     expect(existsSync(artifact.path)).toBe(true);
+  });
+
+  it('runs the full artifact lifecycle through a custom repository with no filesystem access', () => {
+    const repository = createInMemoryArtifactRepository();
+    let id = 0;
+    const service = new ArtifactService({
+      repository,
+      now: () => `2026-07-02T00:00:0${id}.000Z`,
+      nextId: () => `artifact-${++id}`,
+    });
+
+    const source = service.saveText({
+      kind: 'source',
+      content: '# Deck',
+      sessionId: 'session-1',
+    });
+    const html = service.saveText({
+      kind: 'html',
+      content: '<html></html>',
+      sessionId: 'session-1',
+    });
+
+    expect(source.path).toBe('memory://artifact-1.txt');
+    expect(repository.contents.get('memory://artifact-1.txt')).toBe('# Deck');
+    expect(service.list({ sessionId: 'session-1' }).map((artifact) => artifact.id)).toEqual([html.id, source.id]);
+    expect(service.read(source.id)).toEqual({ artifact: source, content: '# Deck' });
+    expect(service.current('session-1')).toEqual(html);
+
+    service.setCurrent(source.id, { sessionId: 'session-1' });
+    expect(service.current('session-1')).toEqual(source);
+  });
+
+  it('requires either a repository or an artifactRoot', () => {
+    expect(() => new ArtifactService({})).toThrow('ArtifactService requires either a repository or an artifactRoot.');
   });
 
   it('rejects duplicate artifact ids instead of overwriting stored files', () => {

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -89,6 +89,40 @@ describe('createConversationEngine', () => {
     expect(engine.artifacts.read(saved.id)?.content).toBe('# Deck');
     // Backed by the default stateRoot/artifacts root.
     expect(new ArtifactService({ artifactRoot: join(stateRoot, 'artifacts') }).get(saved.id)?.id).toBe(saved.id);
+  });
+
+  it('persists artifacts through an injected repository without touching the state root', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-artifact-repo-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    let catalog = { version: 1 as const, artifacts: [], current: { sessionArtifactIds: {} } };
+    const contents = new Map<string, string>();
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      apiKeyPresent: true,
+      artifactRepository: {
+        readCatalog: () => structuredClone(catalog),
+        writeCatalog: (store) => {
+          catalog = structuredClone(store) as typeof catalog;
+        },
+        contentKey: (id, extension) => `hosted://${id}.${extension}`,
+        contentExists: (key) => contents.has(key),
+        writeContent: (key, content) => {
+          contents.set(key, content);
+        },
+        readContent: (key) => contents.get(key),
+      },
+    });
+    const session = engine.sessions.create({ id: 'session-1', name: 'Hosted artifacts' });
+
+    const saved = engine.artifacts.saveText({ content: '# Hosted deck', kind: 'source', sessionId: session.id });
+
+    expect(saved.path).toBe(`hosted://${saved.id}.txt`);
+    expect(contents.get(saved.path)).toBe('# Hosted deck');
+    expect(engine.artifacts.read(saved.id)?.content).toBe('# Hosted deck');
+    // Nothing was written to the default on-disk artifact store.
+    expect(existsSync(join(stateRoot, 'artifacts'))).toBe(false);
   });
 
   it('roots the artifacts reader at a custom host-extension artifacts root', () => {

--- a/src/__tests__/unit/tools/artifact-toolkit.test.ts
+++ b/src/__tests__/unit/tools/artifact-toolkit.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -66,6 +66,41 @@ describe('artifact toolkit', () => {
 
     await tools.set_current_artifact.execute({ id: secondId });
     expect(new ArtifactService({ artifactRoot }).current('session-1')?.id).toBe(secondId);
+  });
+
+  it('persists through a context-injected artifact repository instead of the artifact root', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-artifact-toolkit-injected-'));
+    const artifactRoot = join(root, '.heddle', 'artifacts');
+    let catalog = { version: 1 as const, artifacts: [], current: { sessionArtifactIds: {} } };
+    const contents = new Map<string, string>();
+    const tools = toolMap(artifactsToolkit.createTools({
+      ...toolContext(root, artifactRoot, 'session-1'),
+      artifactRepository: {
+        readCatalog: () => structuredClone(catalog),
+        writeCatalog: (store) => {
+          catalog = structuredClone(store) as typeof catalog;
+        },
+        contentKey: (id, extension) => `hosted://${id}.${extension}`,
+        contentExists: (key) => contents.has(key),
+        writeContent: (key, content) => {
+          contents.set(key, content);
+        },
+        readContent: (key) => contents.get(key),
+      },
+    }));
+
+    const saved = await tools.save_artifact.execute({
+      kind: 'source',
+      content: '# Hosted deck',
+    });
+    expect(saved.ok).toBe(true);
+    const artifactId = ((saved.output as Record<string, unknown>).artifact as Record<string, unknown>).id as string;
+
+    const read = await tools.read_artifact.execute({ id: artifactId });
+    expect(read.output).toMatchObject({ content: '# Hosted deck' });
+    expect(contents.get(`hosted://${artifactId}.txt`)).toBe('# Hosted deck');
+    // The on-disk artifact root stayed untouched.
+    expect(existsSync(artifactRoot)).toBe(false);
   });
 
   it('returns a tool error when reading without a current artifact', async () => {

--- a/src/core/artifacts/README.md
+++ b/src/core/artifacts/README.md
@@ -13,11 +13,25 @@ Artifacts are not memory, traces, or tool results:
 
 This domain owns:
 
-- the persisted artifact index under `stateRoot/artifacts/artifacts.json`;
-- text-like artifact file storage under `stateRoot/artifacts/files/`;
+- the `ArtifactRepository` persistence port (catalog document + content blobs);
+- the default file-backed implementation: the index at
+  `artifactRoot/artifacts.json` and text-like content under
+  `artifactRoot/files/`;
 - current artifact pointers for a workspace or session;
-- repository validation for the on-disk JSON contract;
+- repository validation for the persisted JSON contract;
 - service operations for save, list, read, and current-artifact selection.
+
+Ownership split inside the domain:
+
+- `ArtifactService` owns artifact policy: id validation, extension resolution,
+  catalog shape, and current-pointer semantics. It never touches storage
+  directly.
+- `ArtifactRepository` (port in `types.ts`) owns persistence. The default is
+  `FileArtifactRepository`; hosted services inject their own implementation via
+  `createConversationEngine({ artifactRepository })`, and it flows to the
+  engine artifact reader, turn-result listing, and artifact tools.
+- `RuntimeArtifact.path` stores the repository-owned content key: an absolute
+  file path for the file store, an opaque key for custom stores.
 
 This domain does not own:
 

--- a/src/core/artifacts/index.ts
+++ b/src/core/artifacts/index.ts
@@ -15,6 +15,7 @@ export type {
   ArtifactKind,
   ArtifactListOptions,
   ArtifactReadResult,
+  ArtifactRepository,
   ArtifactServiceOptions,
   ArtifactStore,
   FileArtifactRepositoryOptions,

--- a/src/core/artifacts/repository.ts
+++ b/src/core/artifacts/repository.ts
@@ -1,16 +1,22 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { ArtifactStoreSchema } from './schemas.js';
-import type { ArtifactStore, FileArtifactRepositoryOptions } from './types.js';
+import type { ArtifactRepository, ArtifactStore, FileArtifactRepositoryOptions } from './types.js';
 
 /**
- * File-backed artifact repository for the artifact index.
+ * Default file-backed artifact persistence: the catalog index at
+ * `artifactRoot/artifacts.json` and content blobs under `artifactRoot/files/`.
+ * Implements the `ArtifactRepository` port so hosts can swap in their own
+ * storage without touching artifact policy.
  */
-export class FileArtifactRepository {
+export class FileArtifactRepository implements ArtifactRepository {
   private readonly storePath: string;
+  private readonly filesRoot: string;
 
   constructor(options: FileArtifactRepositoryOptions) {
-    this.storePath = FileArtifactRepository.resolveStorePath(options.artifactRoot);
+    const artifactRoot = resolve(options.artifactRoot);
+    this.storePath = FileArtifactRepository.resolveStorePath(artifactRoot);
+    this.filesRoot = join(artifactRoot, 'files');
   }
 
   static resolveStorePath(artifactRoot: string): string {
@@ -27,7 +33,7 @@ export class FileArtifactRepository {
     };
   }
 
-  read(): ArtifactStore {
+  readCatalog(): ArtifactStore {
     if (!existsSync(this.storePath)) {
       return FileArtifactRepository.emptyStore();
     }
@@ -39,8 +45,29 @@ export class FileArtifactRepository {
     }
   }
 
-  write(store: ArtifactStore): void {
+  writeCatalog(store: ArtifactStore): void {
     mkdirSync(dirname(this.storePath), { recursive: true });
     writeFileSync(this.storePath, `${JSON.stringify(ArtifactStoreSchema.parse(store), null, 2)}\n`, 'utf8');
+  }
+
+  contentKey(id: string, extension: string): string {
+    return join(this.filesRoot, `${id}.${extension}`);
+  }
+
+  contentExists(key: string): boolean {
+    return existsSync(key);
+  }
+
+  writeContent(key: string, content: string): void {
+    mkdirSync(dirname(key), { recursive: true });
+    writeFileSync(key, content, 'utf8');
+  }
+
+  readContent(key: string): string | undefined {
+    if (!existsSync(key)) {
+      return undefined;
+    }
+
+    return readFileSync(key, 'utf8');
   }
 }

--- a/src/core/artifacts/service.ts
+++ b/src/core/artifacts/service.ts
@@ -1,12 +1,12 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { basename, extname, join, relative, resolve } from 'node:path';
+import { basename, extname, relative, resolve } from 'node:path';
 import dayjs from 'dayjs';
 import { FileArtifactRepository } from './repository.js';
 import type {
   ArtifactKind,
   ArtifactListOptions,
   ArtifactReadResult,
+  ArtifactRepository,
   ArtifactServiceOptions,
   ArtifactStore,
   RuntimeArtifact,
@@ -24,19 +24,18 @@ const KIND_EXTENSION: Record<ArtifactKind, string> = {
 };
 
 /**
- * Owns artifact persistence and current-artifact selection.
+ * Owns artifact policy: id validation, extension resolution, catalog shape,
+ * and current-artifact selection. All persistence goes through the
+ * `ArtifactRepository` port (file-backed by default), so hosts can supply
+ * their own storage.
  */
 export class ArtifactService {
-  private readonly artifactRoot: string;
-  private readonly filesRoot: string;
-  private readonly repository: FileArtifactRepository;
+  private readonly repository: ArtifactRepository;
   private readonly now: () => string;
   private readonly nextId: () => string;
 
   constructor(options: ArtifactServiceOptions) {
-    this.artifactRoot = resolve(options.artifactRoot);
-    this.filesRoot = join(this.artifactRoot, 'files');
-    this.repository = new FileArtifactRepository({ artifactRoot: this.artifactRoot });
+    this.repository = ArtifactService.resolveRepository(options);
     this.now = options.now ?? (() => dayjs().toISOString());
     this.nextId = options.nextId ?? (() => `artifact-${randomUUID()}`);
   }
@@ -44,8 +43,8 @@ export class ArtifactService {
   saveText(input: SaveTextArtifactInput): RuntimeArtifact {
     const id = this.assertArtifactId(this.nextId());
     const timestamp = this.now();
-    const path = join(this.filesRoot, `${id}.${this.resolveExtension(input)}`);
-    if (this.get(id) || existsSync(path)) {
+    const path = this.repository.contentKey(id, this.resolveExtension(input));
+    if (this.get(id) || this.repository.contentExists(path)) {
       throw new Error(`Artifact already exists: ${id}`);
     }
 
@@ -64,14 +63,13 @@ export class ArtifactService {
       ...(input.metadata ? { metadata: input.metadata } : {}),
     };
 
-    mkdirSync(this.filesRoot, { recursive: true });
-    writeFileSync(path, input.content, 'utf8');
+    this.repository.writeContent(path, input.content);
     this.upsertArtifact(artifact, { setCurrent: input.setCurrent ?? true });
     return artifact;
   }
 
   list(options: ArtifactListOptions = {}): RuntimeArtifact[] {
-    return this.repository.read().artifacts
+    return this.repository.readCatalog().artifacts
       .filter((artifact) => !options.sessionId || artifact.sessionId === options.sessionId)
       .filter((artifact) => !options.domain || artifact.domain === options.domain)
       .filter((artifact) => !options.kind || artifact.kind === options.kind)
@@ -79,23 +77,21 @@ export class ArtifactService {
   }
 
   get(id: string): RuntimeArtifact | undefined {
-    return this.repository.read().artifacts.find((artifact) => artifact.id === id);
+    return this.repository.readCatalog().artifacts.find((artifact) => artifact.id === id);
   }
 
   read(id: string): ArtifactReadResult | undefined {
     const artifact = this.get(id);
-    if (!artifact || !existsSync(artifact.path)) {
+    if (!artifact) {
       return undefined;
     }
 
-    return {
-      artifact,
-      content: readFileSync(artifact.path, 'utf8'),
-    };
+    const content = this.repository.readContent(artifact.path);
+    return content === undefined ? undefined : { artifact, content };
   }
 
   current(sessionId?: string): RuntimeArtifact | undefined {
-    const store = this.repository.read();
+    const store = this.repository.readCatalog();
     const artifactId = sessionId
       ? store.current.sessionArtifactIds[sessionId] ?? store.current.workspaceArtifactId
       : store.current.workspaceArtifactId;
@@ -104,7 +100,7 @@ export class ArtifactService {
   }
 
   setCurrent(artifactId: string, options: { sessionId?: string } = {}): RuntimeArtifact {
-    const store = this.repository.read();
+    const store = this.repository.readCatalog();
     const artifact = store.artifacts.find((candidate) => candidate.id === artifactId);
     if (!artifact) {
       throw new Error(`Artifact not found: ${artifactId}`);
@@ -115,12 +111,12 @@ export class ArtifactService {
     } else {
       store.current.workspaceArtifactId = artifactId;
     }
-    this.repository.write(store);
+    this.repository.writeCatalog(store);
     return artifact;
   }
 
   private upsertArtifact(artifact: RuntimeArtifact, options: { setCurrent: boolean }): void {
-    const store = this.repository.read();
+    const store = this.repository.readCatalog();
     const artifacts = [
       artifact,
       ...store.artifacts.filter((candidate) => candidate.id !== artifact.id),
@@ -136,7 +132,7 @@ export class ArtifactService {
         },
       },
     };
-    this.repository.write(nextStore);
+    this.repository.writeCatalog(nextStore);
   }
 
   private resolveExtension(input: SaveTextArtifactInput): string {
@@ -149,6 +145,18 @@ export class ArtifactService {
       throw new Error(`Invalid artifact id "${id}". Use only letters, numbers, dots, underscores, and hyphens.`);
     }
     return id;
+  }
+
+  private static resolveRepository(options: ArtifactServiceOptions): ArtifactRepository {
+    if (options.repository) {
+      return options.repository;
+    }
+
+    if (!options.artifactRoot) {
+      throw new Error('ArtifactService requires either a repository or an artifactRoot.');
+    }
+
+    return new FileArtifactRepository({ artifactRoot: options.artifactRoot });
   }
 
   private static extensionFromPath(path: string | undefined): string | undefined {

--- a/src/core/artifacts/types.ts
+++ b/src/core/artifacts/types.ts
@@ -58,11 +58,36 @@ export type ArtifactReadResult = {
   content: string;
 };
 
+/**
+ * Persistence port for the artifacts domain: the catalog document plus
+ * text-like content blobs. `ArtifactService` owns artifact policy (ids,
+ * extensions, current-pointer semantics) and delegates ALL persistence here,
+ * so a host can back artifacts with its own storage (database, object store,
+ * in-memory) by implementing this contract.
+ *
+ * Content addressing: the repository owns key generation via `contentKey`.
+ * The returned key is stored as `RuntimeArtifact.path` — an absolute file
+ * path for the default file-backed store, an opaque storage key for custom
+ * stores.
+ */
+export type ArtifactRepository = {
+  readCatalog(): ArtifactStore;
+  writeCatalog(store: ArtifactStore): void;
+  contentKey(id: string, extension: string): string;
+  contentExists(key: string): boolean;
+  writeContent(key: string, content: string): void;
+  readContent(key: string): string | undefined;
+};
+
 export type FileArtifactRepositoryOptions = {
   artifactRoot: string;
 };
 
-export type ArtifactServiceOptions = FileArtifactRepositoryOptions & {
+export type ArtifactServiceOptions = {
+  /** Root for the default file-backed repository. Ignored when `repository` is provided. */
+  artifactRoot?: string;
+  /** Custom persistence implementation. Wins over `artifactRoot`. */
+  repository?: ArtifactRepository;
   now?: () => string;
   nextId?: () => string;
 };

--- a/src/core/chat/engine/config.ts
+++ b/src/core/chat/engine/config.ts
@@ -1,4 +1,6 @@
 import { join, resolve } from 'node:path';
+import { FileArtifactRepository } from '@/core/artifacts/index.js';
+import type { ArtifactRepository } from '@/core/artifacts/index.js';
 import type { ToolApprovalPolicy } from '../../approvals/types.js';
 import type { ReasoningEffort } from '../../llm/types.js';
 import type { TraceSummaryService } from '@/core/observability/index.js';
@@ -23,6 +25,7 @@ export type NormalizedConversationEngineConfig = {
   toolkits?: ToolToolkit[];
   hiddenMcpServerIds?: string[];
   artifactRoot: string;
+  artifactRepository: ArtifactRepository;
   artifactsEnabled: boolean;
   sessionStoragePath: string;
   memoryDir: string;
@@ -39,6 +42,9 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
   const traceDir = resolve(join(stateRoot, 'traces'));
   const hostExtensions = ConversationEngineHostExtensionService.compose(config.hostExtensions);
   const artifactRoot = resolve(hostExtensions?.artifacts?.root ?? join(stateRoot, 'artifacts'));
+  // Resolve artifact persistence once at the engine boundary; everything
+  // downstream (reader, turn results, artifact tools) receives this instance.
+  const artifactRepository = config.artifactRepository ?? new FileArtifactRepository({ artifactRoot });
   const credentialStorePath = config.credentialStorePath ? resolve(config.credentialStorePath) : undefined;
   const tools = [
     ...(config.tools ?? []),
@@ -65,6 +71,7 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     toolkits: hostExtensions?.toolkits,
     hiddenMcpServerIds: hostExtensions?.mcp?.hideDefaultServers,
     artifactRoot,
+    artifactRepository,
     artifactsEnabled: hostExtensions?.artifacts?.enabled ?? true,
     sessionStoragePath,
     memoryDir,

--- a/src/core/chat/engine/conversation-engine.ts
+++ b/src/core/chat/engine/conversation-engine.ts
@@ -10,6 +10,6 @@ export function createConversationEngine(config: ConversationEngineConfig): Conv
   return {
     sessions: new FileConversationSessionService(normalizedConfig),
     turns: new EngineConversationTurnService(normalizedConfig),
-    artifacts: new ArtifactService({ artifactRoot: normalizedConfig.artifactRoot }),
+    artifacts: new ArtifactService({ repository: normalizedConfig.artifactRepository }),
   };
 }

--- a/src/core/chat/engine/mcp-host-extension/auto-result-artifact-service.ts
+++ b/src/core/chat/engine/mcp-host-extension/auto-result-artifact-service.ts
@@ -43,7 +43,7 @@ export class McpAutoResultArtifactService {
       const kind = hint.kind ?? args.auto.kind ?? McpAutoResultArtifactService.inferArtifactKind(primary);
       const extension = hint.extension ?? args.auto.extension ?? McpAutoResultArtifactService.inferArtifactExtension(kind, primary);
       const contentPath = primary.path;
-      const artifact = new ArtifactService({ artifactRoot: args.context.artifactRoot }).saveText({
+      const artifact = new ArtifactService({ artifactRoot: args.context.artifactRoot, repository: args.context.artifactRepository }).saveText({
         content: primary.content,
         kind,
         domain: hint.domain ?? args.auto.domain,

--- a/src/core/chat/engine/mcp-host-extension/result-artifact-service.ts
+++ b/src/core/chat/engine/mcp-host-extension/result-artifact-service.ts
@@ -55,7 +55,7 @@ export class McpResultArtifactService {
     }
 
     const content = McpHostValueService.serializeArtifactContent(value);
-    const artifact = new ArtifactService({ artifactRoot: args.context.artifactRoot }).saveText({
+    const artifact = new ArtifactService({ artifactRoot: args.context.artifactRoot, repository: args.context.artifactRepository }).saveText({
       content,
       kind: args.rule.kind,
       domain: args.rule.domain,

--- a/src/core/chat/engine/quickstart-cli/service.ts
+++ b/src/core/chat/engine/quickstart-cli/service.ts
@@ -61,6 +61,7 @@ export class QuickstartConversationCliRunnerService {
       memoryMaintenanceMode: defaults.memoryMaintenanceMode,
       tools: options.tools,
       hostExtensions: options.hostExtensions,
+      artifactRepository: options.artifactRepository,
     });
     let session = QuickstartConversationCliRunnerService.resolveSession({ engine, options });
     const textHost = createConversationTextHost({

--- a/src/core/chat/engine/quickstart-cli/types.ts
+++ b/src/core/chat/engine/quickstart-cli/types.ts
@@ -1,4 +1,5 @@
 import type { Readable, Writable } from 'node:stream';
+import type { ArtifactRepository } from '@/core/artifacts/index.js';
 import type { ReasoningEffort } from '@/core/llm/types.js';
 import type { LlmProvider } from '@/core/llm/types.js';
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
@@ -67,6 +68,7 @@ export type QuickstartConversationCliRunnerOptions = {
   memoryMaintenanceMode?: QuickstartConversationCliMemoryMaintenanceMode;
   tools?: ToolDefinition[];
   hostExtensions?: ConversationEngineHostExtension[];
+  artifactRepository?: ArtifactRepository;
   host?: ConversationEngineHost;
   localCommands?: QuickstartConversationCliLocalCommand[];
   formatPrompt?: (prompt: string) => string;

--- a/src/core/chat/engine/turns/context/types.ts
+++ b/src/core/chat/engine/turns/context/types.ts
@@ -1,3 +1,4 @@
+import type { ArtifactRepository } from '@/core/artifacts/index.js';
 import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
 import type { ChatSession } from '@/core/chat/types.js';
@@ -18,6 +19,7 @@ export type PrepareConversationTurnContextArgs = {
   toolkits?: ToolToolkit[];
   hiddenMcpServerIds?: string[];
   artifactRoot: string;
+  artifactRepository?: ArtifactRepository;
   artifactsEnabled: boolean;
   agentSnapshot?: CustomAgentExecutionSnapshot;
   searchIgnoreDirs?: string[];
@@ -36,6 +38,7 @@ export type ConversationTurnToolContextArgs = Pick<
   | 'toolkits'
   | 'hiddenMcpServerIds'
   | 'artifactRoot'
+  | 'artifactRepository'
   | 'artifactsEnabled'
   | 'sessionId'
 >;

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -1,6 +1,7 @@
 import { AgentLoopRuntimeService } from '@/core/runtime/loop/index.js';
 import { AutonomyPermissionModeService, ToolApprovalProfileService } from '@/core/approvals/index.js';
 import { ArtifactService } from '@/core/artifacts/index.js';
+import type { ArtifactRepository } from '@/core/artifacts/index.js';
 import { HeddleEventType } from '@/core/event-types.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
 import { FileConversationSessionService } from '@/core/chat/engine/sessions/service.js';
@@ -176,6 +177,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
         traceFile: persisted.traceFile,
         artifacts: EngineConversationTurnService.listTurnArtifacts({
           artifactRoot: args.artifactRoot,
+          artifactRepository: args.artifactRepository,
           artifactsEnabled: args.artifactsEnabled,
           sessionId: session.id,
         }),
@@ -231,11 +233,13 @@ export class EngineConversationTurnService implements ConversationTurnService {
 
   private static listTurnArtifacts(args: {
     artifactRoot: string;
+    artifactRepository?: ArtifactRepository;
     artifactsEnabled: boolean;
     sessionId: string;
   }): RunConversationTurnResult['artifacts'] {
     return args.artifactsEnabled
-      ? new ArtifactService({ artifactRoot: args.artifactRoot }).list({ sessionId: args.sessionId })
+      ? new ArtifactService({ artifactRoot: args.artifactRoot, repository: args.artifactRepository })
+        .list({ sessionId: args.sessionId })
       : [];
   }
 

--- a/src/core/chat/engine/turns/types.ts
+++ b/src/core/chat/engine/turns/types.ts
@@ -1,3 +1,4 @@
+import type { ArtifactRepository } from '@/core/artifacts/index.js';
 import type { ToolApprovalPolicy } from '@/core/approvals/types.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import type { ConversationCompactionStatus } from '@/core/live/index.js';
@@ -30,6 +31,7 @@ export type RunConversationTurnArgs = {
   toolkits?: ToolToolkit[];
   hiddenMcpServerIds?: string[];
   artifactRoot: string;
+  artifactRepository?: ArtifactRepository;
   artifactsEnabled: boolean;
   agentProfileId?: string;
   agentSnapshot?: CustomAgentExecutionSnapshot;
@@ -57,6 +59,7 @@ export type TurnRuntimeConfigInput = Pick<
   | 'toolkits'
   | 'hiddenMcpServerIds'
   | 'artifactRoot'
+  | 'artifactRepository'
   | 'artifactsEnabled'
   | 'traceSummarizerRegistry'
 >;

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -1,4 +1,4 @@
-import type { ArtifactService } from '@/core/artifacts/index.js';
+import type { ArtifactRepository, ArtifactService } from '@/core/artifacts/index.js';
 import type { ToolApprovalPolicy, ToolApprovalSurface } from '../../approvals/types.js';
 import type {
   ConversationActivity,
@@ -43,6 +43,13 @@ export type ConversationEngineConfig = {
   memoryDir?: string;
   workspaceId?: string;
   apiKeyPresent?: boolean;
+  /**
+   * Custom artifact persistence for hosted services that cannot use the
+   * default file store under the state root. When set, the engine's artifact
+   * reader, turn-result artifact listing, and artifact tools all persist
+   * through this repository instead of `stateRoot/artifacts`.
+   */
+  artifactRepository?: ArtifactRepository;
 };
 
 export type ConversationEngineHostExtensions = ConversationEngineHostExtensionBundle;

--- a/src/core/runtime/tools/service.ts
+++ b/src/core/runtime/tools/service.ts
@@ -40,6 +40,7 @@ export class RuntimeToolService {
           workspaceRoot,
           stateRoot,
           artifactRoot,
+          artifactRepository: options.artifactRepository,
           sessionId: options.sessionId,
           model: options.model,
           apiKey: options.apiKey,

--- a/src/core/runtime/tools/types.ts
+++ b/src/core/runtime/tools/types.ts
@@ -1,3 +1,4 @@
+import type { ArtifactRepository } from '@/core/artifacts/index.js';
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { RuntimeToolSelectionProfile } from './profiles/index.js';
 import type { ToolDefinition } from '@/core/types.js';
@@ -12,6 +13,7 @@ export type DefaultAgentToolsOptions = {
   stateDir?: string;
   stateRoot?: string;
   artifactRoot?: string;
+  artifactRepository?: ArtifactRepository;
   artifactsEnabled?: boolean;
   sessionId?: string;
   memoryDir?: string;

--- a/src/core/tools/toolkit.ts
+++ b/src/core/tools/toolkit.ts
@@ -4,6 +4,8 @@ export type ToolToolkitContext = {
   workspaceRoot: string;
   stateRoot: string;
   artifactRoot: string;
+  /** Custom artifact persistence. When set, artifact tools use it instead of the file store at `artifactRoot`. */
+  artifactRepository?: import('../artifacts/index.js').ArtifactRepository;
   sessionId?: string;
   model: string;
   apiKey?: string;

--- a/src/core/tools/toolkits/artifacts/toolkit.ts
+++ b/src/core/tools/toolkits/artifacts/toolkit.ts
@@ -44,7 +44,10 @@ const SetCurrentArtifactInputSchema = z.object({
 export const artifactsToolkit: ToolToolkit = {
   id: 'artifacts',
   createTools(context) {
-    const service = new ArtifactService({ artifactRoot: context.artifactRoot });
+    const service = new ArtifactService({
+      artifactRoot: context.artifactRoot,
+      repository: context.artifactRepository,
+    });
     const serviceContext = {
       service,
       artifactRoot: context.artifactRoot,

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,17 +207,20 @@ export type {
 // ---------------------------------------------------------------------------
 // 5. Advanced: storage — back Heddle with your own persistence
 // ---------------------------------------------------------------------------
-// Heddle defaults to local file-backed stores. These interfaces + File impls
-// are the seams a hosted service replaces with its own storage. NOTE: today
-// `createConversationEngine` is still path-oriented (stateRoot); injecting
-// custom repositories at the engine boundary is planned (see SDK posture,
-// rung 5 / plan P2), not yet fully wired here.
+// Heddle defaults to local file-backed stores. Artifacts are injectable today:
+// implement `ArtifactRepository` and pass it as `artifactRepository` to
+// `createConversationEngine(...)` (or the quickstart runner) to persist
+// artifacts through your own storage — the engine reader, turn results, and
+// artifact tools all flow through it. Sessions, traces, and memory remain
+// path-oriented (stateRoot) for now; making them injectable follows the same
+// pattern (see SDK posture, rung 5).
 export { ArtifactService, FileArtifactRepository } from './core/artifacts/index.js';
 export type {
   ArtifactCurrentPointers,
   ArtifactKind,
   ArtifactListOptions,
   ArtifactReadResult,
+  ArtifactRepository,
   ArtifactServiceOptions,
   ArtifactStore,
   FileArtifactRepositoryOptions,


### PR DESCRIPTION
## Summary

First slice of SDK maturation **P2** (pluggable storage, posture rung 5): the **artifacts domain** is now backed by an injectable persistence port, so a hosted service can persist artifacts through its own storage (database, object store, memory) instead of Heddle's local `.heddle/artifacts` file store.

## Design

**Port, in the owning domain.** `ArtifactRepository` (in `src/core/artifacts/types.ts`) covers both halves of artifact persistence:
- catalog: `readCatalog()` / `writeCatalog(store)`
- content blobs: `contentKey(id, ext)` / `contentExists` / `writeContent` / `readContent`

The repository owns **content addressing**: `contentKey` returns whatever key the storage understands, stored as `RuntimeArtifact.path` (absolute file path for the default store, opaque key for custom stores).

**Policy stays in the service.** `ArtifactService` no longer touches `node:fs` — it owns id validation, extension resolution, catalog shape, and current-pointer semantics, delegating all persistence to the port. `FileArtifactRepository` implements the full port (absorbing the blob fs logic that previously lived in the service) and remains the default.

**Resolve once at the engine boundary.** `createConversationEngine({ artifactRepository })` resolves `config.artifactRepository ?? new FileArtifactRepository({ artifactRoot })` once in config normalization; the instance then flows to **every** artifact persistence/read site:
- `engine.artifacts` (the P3 reader)
- turn-result artifact listing
- the `save_artifact` / `read_artifact` / `list_artifacts` / `set_current_artifact` / `artifact_dashboard` tools (via `ToolToolkitContext.artifactRepository`)
- MCP host-extension result-artifact capture (`resultArtifacts: true`)
- quickstart runner pass-through (`runQuickstartConversationCli({ artifactRepository })`)

**Renames (pre-release, no aliases):** `FileArtifactRepository.read/write` → `readCatalog/writeCatalog` to fit the widened port.

Sessions, traces, and memory stay path-oriented for now — they follow the same port-per-domain pattern as subsequent P2 slices.

## Proof (no-fs end-to-end)
New tests drive an **in-memory `ArtifactRepository`** through three layers, asserting the on-disk artifact root is never created:
- full artifact lifecycle via `ArtifactService` (save/list/read/current/setCurrent, `memory://` keys)
- the artifact toolkit tools with a context-injected repository
- `createConversationEngine({ artifactRepository })` → `engine.artifacts` (`hosted://` keys)

## Verification
- `yarn build` — pass
- `yarn test:unit` — 600 passed (4 new) · `yarn test:integration` — 285 passed
- `yarn lint` — clean

Docs: artifacts domain README ownership split, “Bring your own artifact storage” guide section with a DB/blob-shaped example, ladder README rung 5 updated, curated `src/index.ts` rung-5 note rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjFdZgZhov8wdwFinVTfjz