### PR TITLE
fix: only send OpenAI reasoning params for models that support them

### DIFF
--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -329,4 +329,12 @@ describe('llm adapter factory', () => {
       disabledReason: undefined,
     });
   });
+
+  it('owns reasoning-summary support independently from configurable effort', () => {
+    expect(ModelPolicyService.supportsOpenAiReasoningSummary('gpt-4.1')).toBe(false);
+    expect(ModelPolicyService.supportsOpenAiReasoningSummary('o4-mini')).toBe(true);
+    expect(ModelPolicyService.supportsReasoningEffort('o4-mini')).toBe(false);
+    expect(ModelPolicyService.supportsOpenAiReasoningSummary('gpt-5.2-codex')).toBe(true);
+    expect(ModelPolicyService.supportsOpenAiReasoningSummary('gpt-5.4-2026-01-01')).toBe(true);
+  });
 });

--- a/src/__tests__/unit/core/openai-codec.test.ts
+++ b/src/__tests__/unit/core/openai-codec.test.ts
@@ -30,6 +30,16 @@ describe('OpenAiCodec.buildResponsesRequest reasoning parameter', () => {
     expect(request.reasoning).toEqual({ summary: 'detailed', effort: 'medium' });
   });
 
+  it('keeps summaries for o-series models without a Heddle-managed effort', () => {
+    const request = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'o4-mini',
+      tools: [],
+      oauthMode: false,
+    });
+
+    expect(request.reasoning).toEqual({ summary: 'detailed' });
+  });
+
   it('keeps summary auto in OAuth mode', () => {
     const request = OpenAiCodec.buildResponsesRequest(messages, {
       model: 'gpt-5.4',
@@ -40,11 +50,19 @@ describe('OpenAiCodec.buildResponsesRequest reasoning parameter', () => {
     expect(request.reasoning).toEqual(expect.objectContaining({ summary: 'auto' }));
   });
 
-  it('omits reasoning for API-key models without a reasoning policy entry', () => {
-    // Codex-family models are OAuth-first and have no API-key reasoning policy;
-    // sending nothing lets the server apply its own default.
+  it('keeps summaries for Codex API-key models without a Heddle-managed effort', () => {
     const request = OpenAiCodec.buildResponsesRequest(messages, {
       model: 'gpt-5.2-codex',
+      tools: [],
+      oauthMode: false,
+    });
+
+    expect(request.reasoning).toEqual({ summary: 'detailed' });
+  });
+
+  it('omits reasoning for unknown API-key models', () => {
+    const request = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'custom-openai-model',
       tools: [],
       oauthMode: false,
     });

--- a/src/__tests__/unit/core/openai-codec.test.ts
+++ b/src/__tests__/unit/core/openai-codec.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { OpenAiCodec } from '@/core/llm/adapters/openai/openai-codec.js';
+import type { ChatMessage } from '@/core/llm/types.js';
+
+const messages: ChatMessage[] = [
+  { role: 'system', content: 'You are helpful.' },
+  { role: 'user', content: 'Hello' },
+];
+
+describe('OpenAiCodec.buildResponsesRequest reasoning parameter', () => {
+  it('omits reasoning for non-reasoning API-key models like gpt-4.1', () => {
+    const request = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'gpt-4.1',
+      tools: [],
+      oauthMode: false,
+    });
+
+    // gpt-4.1 rejects `reasoning.summary` with a 400; it must not be sent.
+    expect(request.reasoning).toBeUndefined();
+    expect(request.model).toBe('gpt-4.1');
+  });
+
+  it('sends reasoning with the resolved default effort for reasoning API-key models', () => {
+    const request = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'gpt-5.4',
+      tools: [],
+      oauthMode: false,
+    });
+
+    expect(request.reasoning).toEqual({ summary: 'detailed', effort: 'medium' });
+  });
+
+  it('keeps summary auto in OAuth mode', () => {
+    const request = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'gpt-5.4',
+      tools: [],
+      oauthMode: true,
+    });
+
+    expect(request.reasoning).toEqual(expect.objectContaining({ summary: 'auto' }));
+  });
+
+  it('omits reasoning for API-key models without a reasoning policy entry', () => {
+    // Codex-family models are OAuth-first and have no API-key reasoning policy;
+    // sending nothing lets the server apply its own default.
+    const request = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'gpt-5.2-codex',
+      tools: [],
+      oauthMode: false,
+    });
+
+    expect(request.reasoning).toBeUndefined();
+  });
+
+  it('still sends reasoning in OAuth mode for codex models', () => {
+    const request = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'gpt-5.2-codex',
+      tools: [],
+      oauthMode: true,
+    });
+
+    expect(request.reasoning).toEqual({ summary: 'auto' });
+  });
+});

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -128,7 +128,7 @@ export class OpenAiCodec {
     input: ResponseInputItem[];
     tools?: FunctionTool[];
     store: boolean;
-    reasoning: { summary: 'auto' | 'detailed'; effort?: OpenAiReasoningEffort };
+    reasoning?: { summary: 'auto' | 'detailed'; effort?: OpenAiReasoningEffort };
     instructions?: string;
   } {
     const systemMessages = options.oauthMode ? messages.filter((message): message is Extract<ChatMessage, { role: 'system' }> => message.role === 'system') : [];
@@ -141,16 +141,26 @@ export class OpenAiCodec {
       model: options.model,
       explicitEffort: options.reasoningEffort,
     });
+    // Non-reasoning API-key models (e.g. gpt-4.1) reject `reasoning.summary`
+    // with a 400, so only send the reasoning block when the model supports it.
+    // OAuth mode keeps its current behavior: the account sign-in allowlist is
+    // reasoning models only, and that path expects `summary: 'auto'`.
+    const includeReasoning =
+      options.oauthMode ||
+      Boolean(reasoningEffort) ||
+      ModelPolicyService.supportsReasoningEffort(options.model);
 
     return {
       model: options.model,
       input: OpenAiCodec.toResponseInput(inputMessages),
       tools: options.tools.length > 0 ? options.tools.map((tool) => OpenAiCodec.toResponseTool(tool)) : undefined,
       store: false,
-      reasoning: {
-        summary: options.oauthMode ? 'auto' : 'detailed',
-        ...(reasoningEffort ? { effort: reasoningEffort } : {}),
-      },
+      ...(includeReasoning ? {
+        reasoning: {
+          summary: options.oauthMode ? 'auto' as const : 'detailed' as const,
+          ...(reasoningEffort ? { effort: reasoningEffort } : {}),
+        },
+      } : {}),
       ...(instructions ? { instructions } : {}),
     };
   }

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -141,14 +141,14 @@ export class OpenAiCodec {
       model: options.model,
       explicitEffort: options.reasoningEffort,
     });
-    // Non-reasoning API-key models (e.g. gpt-4.1) reject `reasoning.summary`
-    // with a 400, so only send the reasoning block when the model supports it.
-    // OAuth mode keeps its current behavior: the account sign-in allowlist is
-    // reasoning models only, and that path expects `summary: 'auto'`.
+    // Summary support and configurable effort are independent capabilities.
+    // Non-reasoning API-key models (e.g. gpt-4.1) reject the entire block,
+    // while established reasoning models may support summaries without a
+    // Heddle-managed effort setting.
     const includeReasoning =
       options.oauthMode ||
       Boolean(reasoningEffort) ||
-      ModelPolicyService.supportsReasoningEffort(options.model);
+      ModelPolicyService.supportsOpenAiReasoningSummary(options.model);
 
     return {
       model: options.model,

--- a/src/core/llm/models/model-policy-service.ts
+++ b/src/core/llm/models/model-policy-service.ts
@@ -28,6 +28,33 @@ export const OPENAI_OAUTH_MODE_DESCRIPTION = 'OAuth mode supports a smaller Open
 
 const OPENAI_OAUTH_DISABLED_REASON = 'Not supported';
 const OPENAI_OAUTH_IMAGE_MODEL_PREFERENCES = ['gpt-5.4', 'gpt-5.4-mini'];
+// Keep this explicit and aligned with the curated reasoning models in
+// model-catalog.ts so unknown/non-reasoning models never receive this parameter.
+const OPENAI_REASONING_SUMMARY_CAPABLE_MODELS = [
+  'gpt-5.5',
+  'gpt-5.5-pro',
+  'gpt-5.4',
+  'gpt-5.4-pro',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
+  'gpt-5',
+  'gpt-5-pro',
+  'gpt-5-mini',
+  'gpt-5-nano',
+  'gpt-5.2',
+  'gpt-5.2-pro',
+  'gpt-5.1',
+  'gpt-5.3-codex',
+  'gpt-5.3-codex-spark',
+  'gpt-5.2-codex',
+  'gpt-5.1-codex',
+  'gpt-5.1-codex-max',
+  'gpt-5.1-codex-mini',
+  'o3-pro',
+  'o3',
+  'o3-mini',
+  'o4-mini',
+] as const;
 const REASONING_EFFORT_CAPABLE_OPENAI_MODELS = [
   'gpt-5.4',
   'gpt-5.4-pro',
@@ -202,6 +229,13 @@ export class ModelPolicyService {
 
   static supportsReasoningEffort(model: string): boolean {
     return REASONING_EFFORT_CAPABLE_OPENAI_MODELS.includes(model as (typeof REASONING_EFFORT_CAPABLE_OPENAI_MODELS)[number]);
+  }
+
+  static supportsOpenAiReasoningSummary(model: string): boolean {
+    const normalized = model.trim();
+    return OPENAI_REASONING_SUMMARY_CAPABLE_MODELS.some((candidate) =>
+      normalized === candidate || normalized.startsWith(`${candidate}-20`),
+    );
   }
 
   static supportsOpenAiRequestReasoningEffort(model: string): boolean {


### PR DESCRIPTION
## Bug

`OpenAiCodec.buildResponsesRequest` sent `reasoning.summary` on every request. Non-reasoning API-key models reject it:

```
LLM error: 400 Unsupported parameter: 'reasoning.summary' is not supported with the 'gpt-4.1-2025-04-14' model.
```

This surfaced in an embedded host whose default model is `gpt-4.1`.

## Fix

Model policy now treats reasoning summaries and configurable reasoning effort as separate capabilities:

- OAuth requests retain their existing `summary: 'auto'` behavior.
- Curated GPT-5, Codex, and o-series reasoning models retain `summary: 'detailed'` in API-key mode.
- A reasoning effort is included only when Heddle has an explicit supported effort for that model.
- Non-reasoning and unknown API-key models omit the entire `reasoning` block.
- Dated snapshots of curated reasoning models inherit the corresponding summary capability.

This follows the Responses API contract, where reasoning configuration is model-specific and summary support is not equivalent to Heddle's narrower effort-selection UI.

## Review follow-up

Addresses the review finding that the first implementation dropped summaries for o-series models. Coverage also protects older GPT-5 and Codex API-key models from the same regression.

## Verification

- Unit: 610 passed
- Integration: 285 passed
- `yarn lint`
- `yarn build`
