### PR TITLE
Add conversation engine tool profiles

### DIFF
--- a/docs/guides/programmatic/conversation-engine.md
+++ b/docs/guides/programmatic/conversation-engine.md
@@ -36,6 +36,30 @@ The normalized engine config derives default paths from `stateRoot`:
 Use `EngineConversationTurnService.run(...)` only when your host already owns
 session ids and storage paths. For new hosts, prefer `createConversationEngine`.
 
+## Control model-visible tools
+
+Use `toolProfile` to set the engine's default model-visible tool policy. For
+example, a host that does not use Heddle-managed memory can keep the ordinary
+tool bundle while removing every memory tool:
+
+```ts
+const engine = createConversationEngine({
+  workspaceRoot,
+  stateRoot,
+  model: 'gpt-5.4',
+  toolProfile: {
+    preset: 'default',
+    memoryMode: 'none',
+  },
+})
+```
+
+This is separate from `memoryMaintenanceMode`. `toolProfile.memoryMode`
+controls the memory tools visible to the model, while
+`memoryMaintenanceMode` controls post-turn memory maintenance scheduling. If a
+turn selects a custom agent, that agent's tool profile overrides the engine
+default for the turn.
+
 ## Reading artifacts
 
 Each turn result already includes the artifacts produced by that turn. To review

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -317,6 +317,67 @@ describe('chat turn preparation modules', () => {
     ]));
   });
 
+  it('applies the host tool profile when no custom agent is selected', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-host-profile-'));
+    const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');
+    const session = ChatSessionRecords.create({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.4',
+    });
+    new FileChatSessionRepository({ sessionStoragePath }).save([session]);
+
+    const context = ConversationTurnContextBuilder.build({
+      workspaceRoot: root,
+      stateRoot: join(root, '.heddle'),
+      sessionRepository: new FileChatSessionRepository({ sessionStoragePath }),
+      sessionId: 'session-1',
+      apiKey: 'explicit-key',
+      toolProfile: {
+        preset: 'default',
+        memoryMode: 'none',
+      },
+    });
+
+    expect(context.toolNames).toContain('read_file');
+    expect(context.toolNames).not.toEqual(expect.arrayContaining([
+      'list_memory_notes',
+      'read_memory_note',
+      'search_memory_notes',
+      'memory_checkpoint',
+      'record_knowledge',
+    ]));
+  });
+
+  it('lets a selected custom agent override the host tool profile', () => {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-agent-profile-'));
+    const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');
+    const session = ChatSessionRecords.create({
+      id: 'session-1',
+      name: 'Session 1',
+      apiKeyPresent: true,
+      model: 'gpt-5.4',
+    });
+    new FileChatSessionRepository({ sessionStoragePath }).save([session]);
+
+    const context = ConversationTurnContextBuilder.build({
+      workspaceRoot: root,
+      stateRoot: join(root, '.heddle'),
+      sessionRepository: new FileChatSessionRepository({ sessionStoragePath }),
+      sessionId: 'session-1',
+      apiKey: 'explicit-key',
+      toolProfile: { preset: 'none' },
+      agentSnapshot: askAgentSnapshot(),
+    });
+
+    expect(context.toolNames).toEqual(expect.arrayContaining([
+      'read_file',
+      'search_files',
+      'run_shell_inspect',
+    ]));
+  });
+
   it('adds host-provided tools to prepared turn context', () => {
     const root = mkdtempSync(join(tmpdir(), 'heddle-turn-host-tools-'));
     const sessionStoragePath = join(root, '.heddle', 'chat-sessions.catalog.json');

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -737,6 +737,10 @@ describe('createConversationEngine', () => {
       credentialStorePath: join(stateRoot, 'auth.json'),
       systemContext: 'Engine system context',
       memoryMaintenanceMode: 'background',
+      toolProfile: {
+        preset: 'default',
+        memoryMode: 'none',
+      },
       approvalPolicies,
       traceSummarizerRegistry,
       workspaceId: 'workspace-1',
@@ -788,6 +792,10 @@ describe('createConversationEngine', () => {
       credentialStorePath: join(stateRoot, 'auth.json'),
       systemContext: 'Engine system context',
       memoryMaintenanceMode: 'inline',
+      toolProfile: {
+        preset: 'default',
+        memoryMode: 'none',
+      },
       approvalPolicies: overridePolicies,
       traceSummarizerRegistry: overrideRegistry,
     }));

--- a/src/core/chat/engine/config.ts
+++ b/src/core/chat/engine/config.ts
@@ -10,6 +10,7 @@ import type { ConversationEngineConfig } from './types.js';
 import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
 import { ConversationEngineHostExtensionService } from './host-extension.js';
+import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
 
 export type NormalizedConversationEngineConfig = {
   workspaceRoot: string;
@@ -21,6 +22,7 @@ export type NormalizedConversationEngineConfig = {
   credentialStorePath?: string;
   systemContext?: string;
   memoryMaintenanceMode: 'none' | 'background' | 'inline';
+  toolProfile?: RuntimeToolSelectionProfile;
   traceSummarizerRegistry?: TraceSummaryService;
   approvalPolicies?: ToolApprovalPolicy[];
   tools?: ToolDefinition[];
@@ -71,6 +73,7 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     credentialStorePath,
     systemContext,
     memoryMaintenanceMode: config.memoryMaintenanceMode ?? 'background',
+    toolProfile: config.toolProfile,
     traceSummarizerRegistry: config.traceSummarizerRegistry,
     approvalPolicies: config.approvalPolicies,
     tools: tools.length ? tools : undefined,

--- a/src/core/chat/engine/turns/context/turn-context-builder.ts
+++ b/src/core/chat/engine/turns/context/turn-context-builder.ts
@@ -31,13 +31,14 @@ export class ConversationTurnContextBuilder {
     };
     const toolContext: ConversationTurnToolContextArgs = args;
     const toolRuntime: ConversationTurnToolRuntimeArgs = runtime;
+    const toolProfile = args.agentSnapshot?.toolProfile ?? args.toolProfile;
     const tools = RuntimeToolService.createDefaultAgentTools({
       ...toolContext,
       ...toolRuntime,
       stateRoot: args.stateRoot,
       sessionId: session.id,
-      memoryMode: args.agentSnapshot?.toolProfile.memoryMode,
-      toolProfile: args.agentSnapshot?.toolProfile,
+      memoryMode: toolProfile?.memoryMode,
+      toolProfile,
     });
 
     return {

--- a/src/core/chat/engine/turns/context/types.ts
+++ b/src/core/chat/engine/turns/context/types.ts
@@ -6,6 +6,7 @@ import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/i
 import type { ChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import type { ChatTurnRuntime } from '../runtime/index.js';
+import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
 
 export type PrepareConversationTurnContextArgs = {
   workspaceRoot: string;
@@ -22,6 +23,7 @@ export type PrepareConversationTurnContextArgs = {
   artifactRoot: string;
   artifactRepository?: ArtifactRepository;
   artifactsEnabled: boolean;
+  toolProfile?: RuntimeToolSelectionProfile;
   agentSnapshot?: CustomAgentExecutionSnapshot;
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;
@@ -41,6 +43,7 @@ export type ConversationTurnToolContextArgs = Pick<
   | 'artifactRoot'
   | 'artifactRepository'
   | 'artifactsEnabled'
+  | 'toolProfile'
   | 'sessionId'
 >;
 

--- a/src/core/chat/engine/turns/types.ts
+++ b/src/core/chat/engine/turns/types.ts
@@ -10,6 +10,7 @@ import type { ChatTurnHostPort } from './host/index.js';
 import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
 import type { ConversationTurnResultSummary } from '../turn-result.js';
+import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
 
 export type RunConversationTurnArgs = {
   workspaceRoot: string;
@@ -28,6 +29,7 @@ export type RunConversationTurnArgs = {
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;
   memoryMaintenanceMode?: 'none' | 'background' | 'inline';
+  toolProfile?: RuntimeToolSelectionProfile;
   host?: ChatTurnHostPort;
   approvalPolicies?: ToolApprovalPolicy[];
   tools?: ToolDefinition[];
@@ -58,6 +60,7 @@ export type TurnRuntimeConfigInput = Pick<
   | 'systemContext'
   | 'traceDir'
   | 'memoryMaintenanceMode'
+  | 'toolProfile'
   | 'approvalPolicies'
   | 'tools'
   | 'toolkits'

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -17,6 +17,7 @@ import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js
 import type { ChatTurnHostPort } from './turns/host/index.js';
 import type { ConversationTurnResultSummary } from './turn-result.js';
 import type { ConversationCompactionResult } from '@/core/chat/engine/compaction/index.js';
+import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
 import type {
   ConversationEngineHostExtension,
   ConversationEngineHostExtensionBundle,
@@ -33,6 +34,8 @@ export type ConversationEngineConfig = {
   credentialStorePath?: string;
   systemContext?: string;
   memoryMaintenanceMode?: 'none' | 'background' | 'inline';
+  /** Default model-visible tool policy. A selected custom agent overrides it for that turn. */
+  toolProfile?: RuntimeToolSelectionProfile;
   traceSummarizerRegistry?: TraceSummaryService;
   approvalPolicies?: ToolApprovalPolicy[];
   hostExtensions?: ConversationEngineHostExtensionsInput;

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,7 @@ export type {
   UpdateConversationSessionSettingsInput,
 } from './core/chat/engine/types.js';
 export { EngineConversationTurnService } from './core/chat/engine/turns/service.js';
+export type { RuntimeToolSelectionProfile, ToolCapability } from './core/runtime/tools/index.js';
 export type {
   RunConversationTurnArgs,
   RunConversationTurnResult,


### PR DESCRIPTION
## What changed

- add an engine-level `toolProfile` option to `createConversationEngine`
- propagate the profile through normalized engine and turn configuration
- use the host profile by default while preserving custom-agent profile precedence
- export `RuntimeToolSelectionProfile` from the package entrypoint
- document model-visible memory tools separately from memory maintenance scheduling

## Why

Programmatic hosts could configure post-turn memory maintenance, but they could not control the default tools exposed to the model. As a result, disabling memory maintenance did not remove tools such as `memory_checkpoint`.

This change reuses Heddle's existing runtime tool-profile policy instead of adding host-specific filtering.

## Impact

Existing engines keep the current default tool bundle. Hosts can now disable memory tools while retaining other defaults:

```ts
toolProfile: {
  preset: 'default',
  memoryMode: 'none',
}
```

A selected custom agent still owns its per-turn tool profile and overrides the engine default.

## Validation

- `yarn lint`
- `yarn build`
- `yarn test` — 613 unit tests and 285 integration tests passed
- verified no private integration names were added to the public repository
