### PR TITLE
Refine embedded host SDK surfaces

### DIFF
--- a/docs/guides/programmatic/conversation-engine.md
+++ b/docs/guides/programmatic/conversation-engine.md
@@ -36,6 +36,10 @@ The normalized engine config derives default paths from `stateRoot`:
 Use `EngineConversationTurnService.run(...)` only when your host already owns
 session ids and storage paths. For new hosts, prefer `createConversationEngine`.
 
+Use `engine.sessions.readExisting(id)` when checking whether a persisted session
+already exists. Unlike `read(id)`, it does not materialize Heddle's host-facing
+fallback session in an empty repository.
+
 ## Control model-visible tools
 
 Use `toolProfile` to set the engine's default model-visible tool policy. For
@@ -59,6 +63,17 @@ controls the memory tools visible to the model, while
 `memoryMaintenanceMode` controls post-turn memory maintenance scheduling. If a
 turn selects a custom agent, that agent's tool profile overrides the engine
 default for the turn.
+
+For host event adapters, import `HeddleEventType` instead of duplicating event
+name strings:
+
+```ts
+import { HeddleEventType } from '@roackb2/heddle'
+
+if (activity.type === HeddleEventType.assistantStream) {
+  renderDelta(activity.text)
+}
+```
 
 ## Reading artifacts
 

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -40,6 +40,8 @@ describe('createConversationEngine', () => {
     });
 
     expect(engine.sessions.listExisting()).toEqual([]);
+    expect(engine.sessions.readExisting('session-1')).toBeUndefined();
+    expect(existsSync(join(stateRoot, 'chat-sessions.catalog.json'))).toBe(false);
     const fallback = engine.sessions.latest();
     expect(fallback).toEqual(expect.objectContaining({
       id: 'session-1',
@@ -54,6 +56,8 @@ describe('createConversationEngine', () => {
     const session = engine.sessions.create({ name: 'Repo investigation' });
 
     expect(engine.sessions.listExisting().map((candidate) => candidate.id)).toEqual([session.id, 'session-1']);
+    expect(engine.sessions.readExisting(session.id)?.id).toBe(session.id);
+    expect(engine.sessions.readExisting('missing')).toBeUndefined();
     const sessionRepository = new FileChatSessionRepository({
       sessionStoragePath: join(stateRoot, 'chat-sessions.catalog.json'),
     });

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -69,6 +69,15 @@ export class FileConversationSessionService implements ConversationSessionServic
     return FileConversationSessionService.activeSessions(this.loadExistingSessions());
   }
 
+  readExisting(id: string): ChatSession | undefined {
+    const entry = this.repository.readCatalog().find((candidate) => candidate.id === id);
+    if (!entry || entry.archivedAt) {
+      return undefined;
+    }
+
+    return this.repository.read(id);
+  }
+
   read(id: string): ChatSession | undefined {
     return this.readSession(id);
   }

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -82,8 +82,9 @@ export type ConversationEngine = {
 export type ConversationSessionService = {
   // Reads
   list(): ChatSession[];
-  // Reads persisted sessions without materializing the host-facing fallback.
+  // Persisted reads that do not materialize the host-facing fallback.
   listExisting(): ChatSession[];
+  readExisting(id: string): ChatSession | undefined;
   read(id: string): ChatSession | undefined;
   require(id: string): ChatSession;
   latest(): ChatSession | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,8 @@ export type {
   ToolResultSummaryOptions,
   ToolSummaryOptions,
 } from './core/chat/engine/index.js';
+export { HeddleEventType } from './core/event-types.js';
+export type { HeddleEventTypeValue } from './core/event-types.js';
 export type {
   ConversationTurnResultSummary,
   ConversationTurnToolResult,


### PR DESCRIPTION
## What changed

- add `engine.sessions.readExisting(id)` for direct persisted-session lookup without materializing the fallback session
- export `HeddleEventType` and `HeddleEventTypeValue` from the curated package entrypoint
- document both embedded-host APIs in the programmatic conversation-engine guide

## Why

Embedded hosts currently need to scan `listExisting()` to safely reuse a deterministic session ID. Calling `read(id)` is not equivalent because it materializes Heddle's fallback session in an empty repository.

Hosts translating conversation activity into their own event stream also had to duplicate event-name string literals even though Heddle already owns a canonical vocabulary.

These additions expose the existing domain semantics directly without adding host-side workarounds or a parallel event model.

## Impact

- persisted session lookup is direct and non-materializing
- host event adapters can compare against the canonical `HeddleEventType` values
- existing session and event behavior remains unchanged

## Validation

- `yarn lint`
- `yarn test` — 613 unit tests and 285 integration tests passed
- `yarn build`
- packed and installed the unpublished package into an external embedded host
- external host typecheck, tests, and production build passed
- real three-turn direct and HTTP/SSE flows reused one durable session, produced validated artifacts, and exposed zero memory-tool events when using `toolProfile.memoryMode: 'none'`
