### PR TITLE
feat: split remote SDK package

### DIFF
--- a/docs/architecture/live-events.md
+++ b/docs/architecture/live-events.md
@@ -209,7 +209,7 @@ The server keeps a bounded replay buffer for retained runs. A reconnecting
 client sends the last accepted `sequence` as `afterSequence`; the server replays
 only newer items and then resumes live delivery.
 
-`ConversationRunConsumerService` from `@roackb2/heddle/remote` is the
+`ConversationRunConsumerService` from `@roackb2/heddle-remote` is the
 mandatory CLI/web policy:
 
 - ignore duplicate sequence numbers;

--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -15,8 +15,9 @@ hosting assumptions.
   product host needs to build an agentic experience.
 - `@roackb2/heddle/hosted` — process-local run identity, replay, cancellation,
   and approvals for a long-lived host process.
-- `@roackb2/heddle/remote` — browser-safe runtime contracts plus transport-
-  neutral cursor, duplicate, gap, terminal, and reconnect correctness.
+- `@roackb2/heddle-remote` — an independently installable, browser-safe package
+  with runtime contracts plus transport-neutral cursor, duplicate, gap,
+  terminal, and reconnect correctness.
 - `@roackb2/heddle/advanced` — the **deep core customization** surface: the curated exports plus
   lower-level building blocks (LLM adapters, individual tools, trace, memory,
   models, awareness) and specialized runtimes (agent loop, heartbeat,

--- a/docs/guides/programmatic/integration-layers.md
+++ b/docs/guides/programmatic/integration-layers.md
@@ -15,7 +15,7 @@ in control.
 HOST-OWNED PRODUCT
   UI state and rendering
           |
-  @roackb2/heddle/remote consumer + public contract
+  @roackb2/heddle-remote consumer + public contract
           |
   transport client/server adapter                  optional
           |
@@ -64,7 +64,7 @@ disconnect as implicit cancellation.
 | Its own output sink or local UI | `createConversationEngine` + `createConversationTextHost` or host callbacks | [`04-custom-output.ts`](../../../examples/sdk/04-custom-output.ts) |
 | A server/worker that owns transport | `@roackb2/heddle` + `@roackb2/heddle/hosted` | [`05-hosted-agent/01-hosted-service`](../../../examples/sdk/05-hosted-agent/01-hosted-service) |
 | Express with REST + SSE | Same core plus a host adapter | [`05-hosted-agent/02-http-sse-api`](../../../examples/sdk/05-hosted-agent/02-http-sse-api) |
-| A remote client over any transport | `@roackb2/heddle/remote` plus a host transport | [Remote conversation runs](remote-runs.md) |
+| A remote client over any transport | `@roackb2/heddle-remote` plus a host transport | [Remote conversation runs](remote-runs.md) |
 | A browser using the example REST/SSE contract | Remote layer plus the example protocol client | [`05-hosted-agent/03-browser-client`](../../../examples/sdk/05-hosted-agent/03-browser-client) |
 
 For tRPC, Fastify, Hono, Nest, WebSocket, Electron IPC, queues, or another
@@ -101,10 +101,12 @@ visible. The root export remains available for compatibility.
 ### Remote run protocol
 
 Use `ConversationRunProtocolCodec` and `ConversationRunConsumerService` from
-`@roackb2/heddle/remote` when events cross an untrusted transport boundary or a
-client can reconnect. The host supplies public activity/result schemas; Heddle
-owns envelope validation, JSON safety, cursor advancement, duplicate/gap
-handling, terminal detection, and retry calculation.
+`@roackb2/heddle-remote` when events cross an untrusted transport boundary or a
+client can reconnect. The independent package keeps the Node runtime, server,
+CLI, model providers, and control-plane dependencies out of remote clients.
+The host supplies public activity/result schemas; Heddle owns envelope
+validation, JSON safety, cursor advancement, duplicate/gap handling, terminal
+detection, and retry calculation.
 
 This layer does not own HTTP, SSE, tRPC, timers, auth, or UI state. See
 [Remote conversation runs](remote-runs.md).

--- a/docs/guides/programmatic/remote-runs.md
+++ b/docs/guides/programmatic/remote-runs.md
@@ -11,13 +11,14 @@ import { ConversationRunService } from '@roackb2/heddle/hosted'
 import {
   ConversationRunConsumerService,
   ConversationRunProtocolCodec,
-} from '@roackb2/heddle/remote'
+} from '@roackb2/heddle-remote'
 ```
 
 - `@roackb2/heddle` owns persisted conversation semantics.
 - `@roackb2/heddle/hosted` owns process-local active-run coordination.
-- `@roackb2/heddle/remote` owns client cursor correctness and runtime wire
-  validation without choosing HTTP, SSE, tRPC, WebSocket, React, or auth.
+- `@roackb2/heddle-remote` is independently installable and owns client cursor
+  correctness plus runtime wire validation without choosing HTTP, SSE, tRPC,
+  WebSocket, React, or auth.
 
 ## Define the public wire payload
 
@@ -29,11 +30,11 @@ validators use the validator-neutral
 
 ```ts
 import { z } from 'zod'
-import { ConversationRunProtocolCodec } from '@roackb2/heddle/remote'
+import { ConversationRunProtocolCodec } from '@roackb2/heddle-remote'
 
 const PublicActivitySchema = z.object({
   type: z.string().min(1),
-}).passthrough()
+})
 
 const PublicResultSchema = z.object({
   outcome: z.string().min(1),
@@ -48,7 +49,9 @@ const protocol = new ConversationRunProtocolCodec({
 
 Payload validation must be synchronous because streaming parse and
 serialization are synchronous. The codec rejects an asynchronous validator with
-a clear boundary error.
+a clear boundary error. The validator output is the public projection: the Zod
+object above strips unknown internal activity fields. With another Standard
+Schema library, configure the equivalent allowlist behavior explicitly.
 
 `protocol.parseEvent(untrustedValue)` validates:
 
@@ -75,7 +78,7 @@ The consumer is a transport-neutral state machine. A reference may include any
 host fields as long as it has a stable `runId`:
 
 ```ts
-import { ConversationRunConsumerService } from '@roackb2/heddle/remote'
+import { ConversationRunConsumerService } from '@roackb2/heddle-remote'
 
 type ProductRunReference = {
   accountId: string

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -16,7 +16,9 @@ For a user-facing release:
 
 1. Choose the version to ship.
 2. Check the latest published npm version and existing GitHub tags/releases so you do not reuse an already shipped version.
-3. Update the package version in `package.json`.
+3. Update the package version in both `package.json` and
+   `packages/heddle-remote/package.json`. The packages initially release in
+   lockstep, and the build fails when their versions diverge.
 4. Verify the release candidate on the intended commit.
 5. Review the actual scope from git.
 6. Write curated release notes from that real scope.
@@ -31,6 +33,7 @@ Before tagging a release, use the normal green checkpoint baseline:
 - `yarn build`
 - `yarn test`
 - `npm pack --dry-run --cache /tmp/heddle-npm-cache`
+- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`
 
 Add more verification if the release changes a workflow that needs manual validation.
 
@@ -97,7 +100,8 @@ Do not infer release boundaries from version-bump commit messages alone when an 
 For the actual release pass:
 
 1. Confirm the latest already-published version on npm and the latest GitHub release/tag.
-2. Confirm the intended next version in `package.json`.
+2. Confirm the intended next version matches in `package.json` and
+   `packages/heddle-remote/package.json`.
 3. Run the release verification baseline.
 4. Review the git range since the previous release tag.
 5. Update or draft the release note in `docs/releases/`.
@@ -120,12 +124,25 @@ gh api user
 yarn build
 yarn test
 npm pack --dry-run --cache /tmp/heddle-npm-cache
+npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache
 yarn release:context <previous-tag> HEAD
 git tag -a vX.Y.Z -m "Heddle vX.Y.Z"
 git push origin main
 git push origin vX.Y.Z
 gh release create vX.Y.Z --title "Heddle vX.Y.Z" --notes-file docs/releases/vX.Y.Z.md
 ```
+
+After the GitHub release, the operator publishes both verified artifacts. The
+remote package has no dependency on the Node package, so publish it first and
+then publish Heddle:
+
+```bash
+npm publish ./packages/heddle-remote
+npm publish
+```
+
+This remains a manual operator step unless npm publication was explicitly
+delegated.
 
 If the repo does not have a previous tag yet, run `yarn release:context <base-ref> HEAD` with the intended release boundary instead.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['dist/**', 'coverage/**', 'node_modules/**', 'local/**', '.heddle/**', 'test-results/**', 'evals/results/**'],
+    ignores: ['dist/**', 'packages/*/dist/**', 'coverage/**', 'node_modules/**', 'local/**', '.heddle/**', 'test-results/**', 'evals/results/**'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/examples/sdk/05-hosted-agent/02-http-sse-api/README.md
+++ b/examples/sdk/05-hosted-agent/02-http-sse-api/README.md
@@ -15,7 +15,7 @@ for curl commands, lifecycle details, and production replacements.
 ## Read in this order
 
 1. [`contracts.ts`](contracts.ts) — host-owned public payload schemas composed
-   with `ConversationRunProtocolCodec` from `@roackb2/heddle/remote`.
+   with `ConversationRunProtocolCodec` from `@roackb2/heddle-remote`.
 2. [`http-api.ts`](http-api.ts) — authenticated start, cursor subscribe, and
    explicit cancel handlers.
 3. [`server.ts`](server.ts) — runnable local composition with deliberately

--- a/examples/sdk/05-hosted-agent/02-http-sse-api/contracts.ts
+++ b/examples/sdk/05-hosted-agent/02-http-sse-api/contracts.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
 import {
   ConversationRunProtocolCodec,
   type ConversationRunProtocolEvent,
-} from '../../../../src/remote.js';
+} from '../../../../src/core/chat/remote/index.js';
 
 export const StartHostedAgentRunInputSchema = z.object({
   sessionId: z.string().trim().min(1).max(128),
@@ -22,9 +22,11 @@ export const StartHostedAgentRunResultSchema = z.object({
   sessionId: z.string().min(1),
 });
 
+// The parsed value is the public projection. Zod strips every internal
+// activity field that is not explicitly allowlisted here.
 const HostedAgentActivitySchema = z.object({
   type: z.string().min(1),
-}).passthrough();
+});
 
 const HostedAgentResultSchema = z.object({
   outcome: z.string().min(1),

--- a/examples/sdk/05-hosted-agent/03-browser-client/run.ts
+++ b/examples/sdk/05-hosted-agent/03-browser-client/run.ts
@@ -6,7 +6,7 @@
  * Start the stage-2 server first, then run this script with the same token.
  */
 import { setTimeout as delay } from 'node:timers/promises';
-import { ConversationRunConsumerService } from '../../../../src/remote.js';
+import { ConversationRunConsumerService } from '../../../../src/core/chat/remote/index.js';
 import {
   HostedAgentClient,
   HostedAgentClientError,

--- a/examples/sdk/05-hosted-agent/README.md
+++ b/examples/sdk/05-hosted-agent/README.md
@@ -24,12 +24,13 @@ Express, SSE, bearer auth, and the sample browser client are replaceable host
 choices.
 
 When copying this example into another project, replace the relative source
-imports with `@roackb2/heddle`, `@roackb2/heddle/hosted`, and
-`@roackb2/heddle/remote` as shown by each layer. Stage 01 requires Heddle only;
-stage 02 additionally uses `express`, its TypeScript types, and `zod`; stage 03
-uses `eventsource-parser` and the shared Zod wire contracts. Declare those
-libraries directly in the host project instead of relying on transitive
-dependencies.
+imports with `@roackb2/heddle`, `@roackb2/heddle/hosted`, and the independently
+installable `@roackb2/heddle-remote` package as shown by each layer. Stage 01
+requires Heddle only; stage 02 additionally uses `express`, its TypeScript
+types, `zod`, and `@roackb2/heddle-remote`; stage 03 uses
+`@roackb2/heddle-remote`, `eventsource-parser`, and the shared Zod wire
+contracts. Declare those libraries directly in the host project instead of
+relying on transitive dependencies.
 
 ## Choose the layers that match your stack
 

--- a/package.json
+++ b/package.json
@@ -33,10 +33,6 @@
       "types": "./dist/src/hosted.d.ts",
       "import": "./dist/src/hosted.js"
     },
-    "./remote": {
-      "types": "./dist/src/remote.d.ts",
-      "import": "./dist/src/remote.js"
-    },
     "./advanced": {
       "types": "./dist/src/advanced.d.ts",
       "import": "./dist/src/advanced.js"
@@ -52,11 +48,16 @@
   ],
   "scripts": {
     "clean": "node scripts/clean-dist.mjs",
+    "remote:clean": "node scripts/clean-dist.mjs remote",
+    "remote:verify": "node scripts/verify-remote-package.mjs",
+    "remote:compile": "yarn remote:verify && tsc -p tsconfig.remote-package.json",
+    "remote:build": "yarn remote:clean && yarn remote:compile",
+    "remote:pack": "yarn remote:build && npm pack ./packages/heddle-remote",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "eslint": "eslint .",
     "lint": "yarn eslint",
     "release:context": "node scripts/release-context.mjs",
-    "build": "yarn clean && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && node scripts/copy-built-in-skill-assets.mjs && node scripts/mark-bin-executable.mjs && yarn client:build",
+    "build": "yarn clean && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && yarn remote:compile && node scripts/copy-built-in-skill-assets.mjs && node scripts/mark-bin-executable.mjs && yarn client:build",
     "client:build": "tsc -p src/web-v2/tsconfig.json --noEmit && vite build --config src/web-v2/vite.config.ts",
     "client:dev": "vite --config src/web-v2/vite.config.ts",
     "client:build:v2": "tsc -p src/web-v2/tsconfig.json --noEmit && vite build --config src/web-v2/vite.config.ts",

--- a/packages/heddle-remote/LICENSE
+++ b/packages/heddle-remote/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jay / Fienna Liang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/heddle-remote/README.md
+++ b/packages/heddle-remote/README.md
@@ -1,0 +1,44 @@
+# @roackb2/heddle-remote
+
+Browser-safe, transport-neutral services for consuming a remotely hosted
+Heddle conversation run.
+
+Install this package in browser applications that should not install Heddle's
+Node agent runtime, model providers, server, CLI, or web control plane:
+
+```bash
+npm install @roackb2/heddle-remote
+```
+
+```ts
+import {
+  ConversationRunConsumerService,
+  ConversationRunProtocolCodec,
+} from '@roackb2/heddle-remote'
+
+const protocol = new ConversationRunProtocolCodec({
+  activity: PublicActivitySchema,
+  result: PublicResultSchema,
+})
+
+const consumer = new ConversationRunConsumerService({
+  retry: { maxAttempts: 6, baseDelayMs: 500, maxDelayMs: 4_000 },
+})
+```
+
+## Responsibility boundary
+
+This package owns the canonical run envelope, runtime wire validation,
+JSON-safety, accepted-sequence cursor, duplicate and gap handling, terminal
+detection, and bounded retry calculation.
+
+It does not own HTTP, SSE, tRPC, WebSocket, React, timers, authentication,
+authorization, public-field policy, product messages, or UI state. Hosts must
+supply synchronous Standard Schema validators whose output contains only the
+activity and result fields authorized for remote clients.
+
+The Node host normally combines `@roackb2/heddle` with
+`@roackb2/heddle/hosted`. The browser or other remote consumer installs this
+package independently.
+
+See the complete [remote conversation run guide](https://github.com/roackb2/heddle/blob/main/docs/guides/programmatic/remote-runs.md).

--- a/packages/heddle-remote/package.json
+++ b/packages/heddle-remote/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@roackb2/heddle-remote",
+  "version": "4.2.0",
+  "description": "Browser-safe protocol and run-consumer services for remotely hosted Heddle conversations",
+  "author": "Jay / Fienna Liang <roackb2@gmail.com>",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/roackb2/heddle.git",
+    "directory": "packages/heddle-remote"
+  },
+  "homepage": "https://heddleagent.com",
+  "bugs": {
+    "url": "https://github.com/roackb2/heddle/issues"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "agent",
+    "ai-agent",
+    "browser",
+    "conversation",
+    "remote",
+    "sdk",
+    "streaming"
+  ],
+  "dependencies": {
+    "@standard-schema/spec": "^1.1.0",
+    "zod": "^4.3.6"
+  }
+}

--- a/scripts/clean-dist.mjs
+++ b/scripts/clean-dist.mjs
@@ -1,3 +1,22 @@
 import { rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
-rmSync('dist', { recursive: true, force: true });
+const OUTPUT_DIRECTORIES = new Map([
+  ['root', new URL('../dist/', import.meta.url)],
+  ['remote', new URL('../packages/heddle-remote/dist/', import.meta.url)],
+]);
+
+const requestedTargets = process.argv.slice(2);
+const targets = requestedTargets.length > 0
+  ? requestedTargets
+  : [...OUTPUT_DIRECTORIES.keys()];
+
+for (const target of targets) {
+  const directory = OUTPUT_DIRECTORIES.get(target);
+  if (!directory) {
+    throw new Error(
+      `Unknown build output "${target}". Expected one of: ${[...OUTPUT_DIRECTORIES.keys()].join(', ')}.`,
+    );
+  }
+  rmSync(fileURLToPath(directory), { recursive: true, force: true });
+}

--- a/scripts/verify-remote-package.mjs
+++ b/scripts/verify-remote-package.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const rootPackage = readPackage(new URL('../package.json', import.meta.url));
+const remotePackage = readPackage(
+  new URL('../packages/heddle-remote/package.json', import.meta.url),
+);
+
+assert.equal(
+  remotePackage.version,
+  rootPackage.version,
+  'Heddle and @roackb2/heddle-remote must be released at the same version.',
+);
+assert.deepEqual(
+  remotePackage.dependencies,
+  {
+    '@standard-schema/spec': rootPackage.dependencies['@standard-schema/spec'],
+    zod: rootPackage.dependencies.zod,
+  },
+  '@roackb2/heddle-remote must keep its explicit browser-safe dependency boundary.',
+);
+assert.equal(
+  rootPackage.exports['./remote'],
+  undefined,
+  'The root package must not recreate the remote package as an install-heavy subpath.',
+);
+assert.equal(
+  readFileSync(new URL('../packages/heddle-remote/LICENSE', import.meta.url), 'utf8'),
+  readFileSync(new URL('../LICENSE', import.meta.url), 'utf8'),
+  'The remote package must ship the repository license without drift.',
+);
+
+function readPackage(url) {
+  return JSON.parse(readFileSync(url, 'utf8'));
+}

--- a/src/__tests__/integration/sdk/public-hosting-entrypoints.test.ts
+++ b/src/__tests__/integration/sdk/public-hosting-entrypoints.test.ts
@@ -1,31 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { ConversationRunService as CuratedConversationRunService } from '../../../index.js';
 import { ConversationRunService as HostedConversationRunService } from '../../../hosted.js';
-import {
-  ConversationRunConsumerService,
-  ConversationRunProtocolCodec,
-} from '../../../remote.js';
-import { z } from 'zod';
 
 describe('public hosting entrypoints', () => {
   it('exposes the existing run coordinator through the explicit hosted subpath', () => {
     expect(HostedConversationRunService).toBe(CuratedConversationRunService);
-  });
-
-  it('exposes the browser-safe remote consumer and protocol codec', () => {
-    const consumer = new ConversationRunConsumerService();
-    const codec = new ConversationRunProtocolCodec({
-      activity: z.object({ type: z.string() }),
-      result: z.object({ summary: z.string() }),
-    });
-
-    expect(consumer.select({ runId: 'run-1' })).toBe(true);
-    expect(codec.parseEvent({
-      kind: 'result',
-      runId: 'run-1',
-      sequence: 1,
-      timestamp: '2026-07-11T00:00:00.000Z',
-      result: { summary: 'Done' },
-    })).toMatchObject({ kind: 'result', result: { summary: 'Done' } });
   });
 });

--- a/src/__tests__/integration/sdk/remote-package-boundary.test.ts
+++ b/src/__tests__/integration/sdk/remote-package-boundary.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const rootPackage = readPackage('package.json');
+const remotePackage = readPackage('packages/heddle-remote/package.json');
+
+describe('@roackb2/heddle-remote package boundary', () => {
+  it('is versioned with Heddle without remaining a root package subpath', () => {
+    expect(remotePackage.version).toBe(rootPackage.version);
+    expect(rootPackage.exports['./remote']).toBeUndefined();
+  });
+
+  it('installs only its browser-safe protocol dependencies', () => {
+    expect(remotePackage.dependencies).toEqual({
+      '@standard-schema/spec': rootPackage.dependencies['@standard-schema/spec'],
+      zod: rootPackage.dependencies.zod,
+    });
+  });
+});
+
+function readPackage(path: string) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -4,10 +4,11 @@
 // The deep core-customization surface: the curated SDK (rungs 1-5, re-exported
 // below) plus lower-level building blocks and specialized runtimes. Remote
 // hosting remains an orthogonal opt-in through `@roackb2/heddle/hosted` and
-// `@roackb2/heddle/remote`; those subpaths are not re-exported here. Reach for
-// this entry when you need LLM adapters, individual ready-made tools, trace/memory
-// internals, the agent loop, heartbeat, or integrations. Most product hosts
-// only need the curated default entry (`@roackb2/heddle`, see src/index.ts).
+// the independent `@roackb2/heddle-remote` package; those surfaces are not
+// re-exported here. Reach for this entry when you need LLM adapters, individual
+// ready-made tools, trace/memory internals, the agent loop, heartbeat, or
+// integrations. Most product hosts only need the curated default entry
+// (`@roackb2/heddle`, see src/index.ts).
 // ===========================================================================
 
 export * from './index.js';

--- a/src/core/chat/remote/README.md
+++ b/src/core/chat/remote/README.md
@@ -31,7 +31,7 @@ Import this layer explicitly so the remote-hosting assumption is visible:
 import {
   ConversationRunConsumerService,
   ConversationRunProtocolCodec,
-} from '@roackb2/heddle/remote'
+} from '@roackb2/heddle-remote'
 
 const protocol = new ConversationRunProtocolCodec({
   activity: PublicActivitySchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@
 //   5. Advanced: storage     — back artifacts/credentials with your own store
 //
 // Remote-hosting assumptions are explicit peer entrypoints:
-// `@roackb2/heddle/hosted` and `@roackb2/heddle/remote`.
+// `@roackb2/heddle/hosted` and the lightweight `@roackb2/heddle-remote`
+// package.
 // Lower-level runtime plumbing (LLM adapters, individual tools, trace, memory,
 // models, awareness, the agent loop, heartbeat, integrations, utilities) lives
 // behind the `@roackb2/heddle/advanced` subpath — see src/advanced.ts.

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,3 +1,0 @@
-// Public browser-safe remote-run entrypoint. Transport/framework adapters live
-// outside this module and depend inward on these contracts and services.
-export * from './core/chat/remote/index.js';

--- a/tsconfig.remote-package.json
+++ b/tsconfig.remote-package.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src/core/chat/remote",
+    "outDir": "./packages/heddle-remote/dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "inlineSources": true
+  },
+  "include": ["src/core/chat/remote/**/*.ts"],
+  "exclude": ["node_modules", "packages/heddle-remote/dist"]
+}


### PR DESCRIPTION
## What changed

- publish the existing transport-neutral remote-run domain as the independent `@roackb2/heddle-remote` package
- keep `src/core/chat/remote` as the single implementation used by Heddle internally and by the package build
- remove the unreleased `@roackb2/heddle/remote` root export
- enforce lockstep versions, a two-dependency browser boundary, and synchronized license content during builds
- update programmatic guides, hosted examples, and release instructions for the physical package boundary
- replace the permissive public activity example with an explicit allowlist projection

## Why

The root `/remote` subpath was browser-bundle-safe, but npm still installed Heddle's complete Node, CLI, server, model-provider, and control-plane dependency graph. The standalone package makes the install boundary match the architecture boundary without duplicating the remote-run implementation.

## Developer impact

Remote clients import from:

```ts
import {
  ConversationRunConsumerService,
  ConversationRunProtocolCodec,
} from '@roackb2/heddle-remote'
```

Node hosts continue to use `@roackb2/heddle` and `@roackb2/heddle/hosted`.

The packages initially release at the same version. npm publication remains deferred until this PR is reviewed and merged.

## Verification

- `yarn lint`
- `yarn typecheck`
- `yarn test` — 110 unit files / 638 tests; 32 integration files / 291 tests
- `yarn build`
- packed remote artifact: 9.7 kB compressed / 37.1 kB unpacked / 19 files
- empty-project install: 3 packages total (`@roackb2/heddle-remote`, Zod, Standard Schema)
- SlideX editor: deterministic protocol tests, production Next.js build, MCP build, lint with only 38 existing warnings
- SlideX editor install: 630 packages versus the prior 990-package root dependency baseline
- SlideX server: 10 tests, typecheck, and production build
- real two-turn editor flow: title/subtitle edit, follow-up layout correction, MotionDoc validation, canvas application, and no browser console errors

## Coordinated release note

npm cannot install a child package from a Git repository subdirectory. The downstream server/editor migrations were verified with local tarballs and should be pinned to the exact npm version only after this package is published; no machine-specific `file:` dependency belongs in a merge-ready downstream PR.
