### PR TITLE
chore: add guarded remote publish command

### DIFF
--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -137,9 +137,14 @@ remote package has no dependency on the Node package, so publish it first and
 then publish Heddle:
 
 ```bash
-npm publish ./packages/heddle-remote
+yarn remote:publish
 npm publish
 ```
+
+`yarn remote:publish` cleans, verifies, and compiles the remote package before
+invoking npm, so the operator cannot accidentally publish stale `dist` output.
+Pass normal npm publish flags through the script when needed, for example
+`yarn remote:publish --dry-run`.
 
 This remains a manual operator step unless npm publication was explicitly
 delegated.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "remote:compile": "yarn remote:verify && tsc -p tsconfig.remote-package.json",
     "remote:build": "yarn remote:clean && yarn remote:compile",
     "remote:pack": "yarn remote:build && npm pack ./packages/heddle-remote",
+    "remote:publish": "yarn remote:build && npm publish ./packages/heddle-remote",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "eslint": "eslint .",
     "lint": "yarn eslint",


### PR DESCRIPTION
## Summary

- add `yarn remote:publish` for publishing `@roackb2/heddle-remote`
- rebuild, version-check, dependency-check, and compile the remote package before npm runs
- document the command and npm flag passthrough in the release runbook

Publication remains an explicit operator action; this command does not alter the release sequence or publish the root package.

## Verification

- `yarn remote:publish --dry-run`
- confirmed the generated 4.3.0 artifact matches the published remote package shape (19 files, 12.0 kB)