### PR TITLE
feat: restore remote run cursors

### DIFF
--- a/examples/sdk/05-hosted-agent/03-browser-client/run.ts
+++ b/examples/sdk/05-hosted-agent/03-browser-client/run.ts
@@ -39,8 +39,9 @@ console.log(`Accepted ${accepted.runId}.`);
 const consumer = createRunConsumer(accepted.runId);
 await disconnectAfterFirstActivity(client, consumer);
 const cursor = requireSubscriptionInput(consumer).afterSequence;
-console.log(`Browser subscription disconnected at sequence ${cursor}; reconnecting.`);
-const terminal = await consumeUntilTerminal(client, consumer);
+console.log(`Browser subscription disconnected at sequence ${cursor}; restoring client state.`);
+const restoredConsumer = createRunConsumer(accepted.runId, cursor);
+const terminal = await consumeUntilTerminal(client, restoredConsumer);
 console.log(`Run settled as ${terminal.kind}.`);
 
 if (cancelDemo) {
@@ -59,11 +60,11 @@ if (cancelDemo) {
   }
 }
 
-function createRunConsumer(runId: string): HostedAgentRunConsumer {
+function createRunConsumer(runId: string, afterSequence = 0): HostedAgentRunConsumer {
   const consumer = new ConversationRunConsumerService<HostedAgentRunReference>({
     retry: { maxAttempts: 5, baseDelayMs: 250, maxDelayMs: 2_000 },
   });
-  consumer.select({ runId });
+  consumer.select({ runId }, { afterSequence });
   return consumer;
 }
 

--- a/examples/sdk/05-hosted-agent/README.md
+++ b/examples/sdk/05-hosted-agent/README.md
@@ -221,9 +221,10 @@ abort propagation.
 [`run.ts`](03-browser-client/run.ts) is the consuming application policy. It
 uses Heddle's `ConversationRunConsumerService` for cursor advancement,
 duplicate/gap handling, terminal detection, and bounded reconnect timing. The
-runner deliberately disconnects after one activity while retaining ownership
-of the actual timer and transport lifecycle. Add `--cancel-demo` to exercise
-explicit cancellation.
+runner deliberately disconnects after one activity, discards its in-memory
+consumer, then reconstructs it from the last handled sequence before resuming.
+This models a browser refresh while retaining ownership of the actual timer and
+transport lifecycle. Add `--cancel-demo` to exercise explicit cancellation.
 
 ### Responsibility boundary
 

--- a/src/__tests__/unit/core/conversation-run-consumer.test.ts
+++ b/src/__tests__/unit/core/conversation-run-consumer.test.ts
@@ -39,6 +39,27 @@ describe('ConversationRunConsumerService', () => {
     expect(service.subscriptionInput()?.afterSequence).toBe(0);
   });
 
+  it('restores a selected run from a validated nonzero cursor', () => {
+    const service = createConsumer();
+    service.select(run('run-1'), { afterSequence: 4 });
+
+    expect(service.subscriptionInput()).toMatchObject({
+      runId: 'run-1',
+      afterSequence: 4,
+    });
+    expect(service.accept(event('activity', 4))).toEqual({ accepted: false, terminal: false });
+    expect(service.accept(event('activity', 5))).toEqual({ accepted: true, terminal: false });
+  });
+
+  it('preserves monotonic progress when the selected run is selected again', () => {
+    const service = createConsumer();
+    service.select(run('run-1'), { afterSequence: 2 });
+    service.accept(event('activity', 3));
+
+    expect(service.select(run('run-1'), { afterSequence: 0 })).toBe(false);
+    expect(service.subscriptionInput()?.afterSequence).toBe(3);
+  });
+
   it('rejects sequence gaps instead of silently losing activity', () => {
     const service = createConsumer();
     service.select(run('run-1'));
@@ -80,6 +101,12 @@ describe('ConversationRunConsumerService', () => {
     expect(service.select(run('run-2'))).toBe(true);
     expect(service.subscriptionInput()).toMatchObject({ runId: 'run-2', afterSequence: 0 });
     expect(() => service.select(run('  '))).toThrow('non-empty runId');
+    expect(() => service.select(run('run-3'), { afterSequence: -1 })).toThrow(
+      'replay cursor must be a non-negative safe integer',
+    );
+    expect(() => service.select(run('run-3'), { afterSequence: 1.5 })).toThrow(
+      'replay cursor must be a non-negative safe integer',
+    );
     expect(() => service.accept(event('activity', 0, 'run-2'))).toThrow('positive safe integer');
   });
 

--- a/src/core/chat/remote/README.md
+++ b/src/core/chat/remote/README.md
@@ -6,6 +6,7 @@ conversation run across a remote boundary.
 ## Owns
 
 - selecting one accepted run reference;
+- restoring a selected run from a host-persisted replay cursor;
 - advancing the greatest accepted sequence cursor;
 - suppressing replayed duplicates;
 - rejecting sequence gaps and post-terminal events;
@@ -41,7 +42,19 @@ const protocol = new ConversationRunProtocolCodec({
 const consumer = new ConversationRunConsumerService({
   retry: { maxAttempts: 6, baseDelayMs: 500, maxDelayMs: 4_000 },
 })
+
+consumer.select(
+  { runId: persistedRunId },
+  { afterSequence: persistedSequence },
+)
 ```
+
+Pass `afterSequence` when reconstructing a consumer after a page reload or
+process-local client restart. The next accepted event must be exactly
+`afterSequence + 1`; duplicates remain suppressed and gaps still fail loudly.
+Selecting the current run again is idempotent and never rewinds or skips its
+in-memory cursor. Persist the latest `subscriptionInput().afterSequence` only
+after the application has successfully handled the corresponding event.
 
 The host must supply synchronous
 [Standard Schema](https://standardschema.dev/schema) validators that expose only

--- a/src/core/chat/remote/consumer-service.ts
+++ b/src/core/chat/remote/consumer-service.ts
@@ -1,5 +1,6 @@
 import type {
   ConversationRunConsumerEvent,
+  ConversationRunConsumerSelectionOptions,
   ConversationRunConsumerServiceOptions,
   ConversationRunEventAcceptance,
   ConversationRunReference,
@@ -53,14 +54,22 @@ export class ConversationRunConsumerService<
     this.retry = ConversationRunConsumerService.resolveRetryOptions(options.retry);
   }
 
-  select(run: Reference): boolean {
+  select(
+    run: Reference,
+    options: ConversationRunConsumerSelectionOptions = {},
+  ): boolean {
     ConversationRunConsumerService.assertRunId(run.runId);
+    const afterSequence = options.afterSequence ?? 0;
+    ConversationRunConsumerService.assertNonNegativeSafeInteger(
+      'Conversation run replay cursor',
+      afterSequence,
+    );
     if (this.isCurrent(run)) {
       return false;
     }
 
     this.run = run;
-    this.sequence = 0;
+    this.sequence = afterSequence;
     this.terminal = false;
     this.retryAttempt = 0;
     return true;

--- a/src/core/chat/remote/index.ts
+++ b/src/core/chat/remote/index.ts
@@ -12,6 +12,7 @@ export {
 export type {
   ConversationRunConsumerEvent,
   ConversationRunConsumerRetryOptions,
+  ConversationRunConsumerSelectionOptions,
   ConversationRunConsumerServiceOptions,
   ConversationRunEventAcceptance,
   ConversationRunProtocolCodecOptions,

--- a/src/core/chat/remote/types.ts
+++ b/src/core/chat/remote/types.ts
@@ -25,6 +25,10 @@ export type ConversationRunConsumerServiceOptions = {
   retry?: ConversationRunConsumerRetryOptions;
 };
 
+export type ConversationRunConsumerSelectionOptions = {
+  afterSequence?: number;
+};
+
 export type ConversationRunRetry<Reference extends ConversationRunReference> = {
   attempt: number;
   delayMs: number;


### PR DESCRIPTION
## What changed

- let `ConversationRunConsumerService.select(...)` initialize a run from a validated `afterSequence` cursor
- preserve idempotent selection so the current run cannot be rewound or skipped accidentally
- export the additive selection-options type from `@roackb2/heddle-remote`
- update the hosted browser example to discard and reconstruct its consumer, modeling refresh-style resume
- document cursor persistence and responsibility boundaries in the remote service README

## Why

Remote products can persist an accepted run ID and last handled event sequence across a page refresh, but the consumer previously always restarted at sequence `0`. That forced a product such as a browser editor to replay the entire retained stream even when it already had a durable cursor.

The cursor state machine already belongs to Heddle's remote consumer service, so this extends that existing boundary instead of adding a second product-specific resume implementation.

## Developer impact

Existing callers are unchanged. A reconstructed client can now resume with:

```ts
consumer.select(
  { runId: persistedRunId },
  { afterSequence: persistedSequence },
)
```

The next accepted event must be exactly `persistedSequence + 1`. Duplicates remain suppressed, gaps still fail loudly, and selecting the same current run again never changes its cursor.

## Validation

- targeted consumer tests: 9 passed
- full Heddle tests: 110 unit files / 640 tests; 32 integration files / 291 tests
- `yarn typecheck`
- `yarn eslint`
- `yarn remote:build`
- `npm pack ./packages/heddle-remote --dry-run --cache /private/tmp/heddle-remote-npm-cache`
