### PR TITLE
feat: mature hosted run lifecycle

### DIFF
--- a/examples/sdk/05-hosted-agent/01-hosted-service/agent-service.ts
+++ b/examples/sdk/05-hosted-agent/01-hosted-service/agent-service.ts
@@ -17,8 +17,6 @@ import {
   type ConversationRunStreamItem,
 } from '../../../../src/hosted.js';
 
-const DEFAULT_RUN_RETENTION_MS = 5 * 60_000;
-
 export type HostedRunAddress = {
   accountId: string;
   sessionId: string;
@@ -35,7 +33,9 @@ export type HostedAgentRunAccepted = {
   sessionId: string;
 };
 
-export type HostedAgentRunStreamItem = ConversationRunStreamItem<ConversationTurnResultSummary>;
+export type HostedAgentResult = Pick<ConversationTurnResultSummary, 'outcome' | 'summary'>;
+
+export type HostedAgentRunStreamItem = ConversationRunStreamItem<HostedAgentResult>;
 
 export type HostedAgentServiceOptions = {
   createEngine(address: HostedRunAddress): ConversationEngine | Promise<ConversationEngine>;
@@ -43,13 +43,7 @@ export type HostedAgentServiceOptions = {
   replay?: ConversationRunReplayOptions;
 };
 
-type HostedRunContext = {
-  address: HostedRunAddress;
-  run: ConversationRunHandle<HostedRunAddress, ConversationTurnResultSummary>;
-};
-
 export class HostedAgentRunNotFoundError extends Error {}
-export class HostedAgentRunConflictError extends Error {}
 export class HostedAgentInputError extends Error {}
 
 /**
@@ -62,17 +56,11 @@ export class HostedAgentInputError extends Error {}
  */
 export class HostedAgentService {
   private readonly runs: ConversationRunService<HostedRunAddress>;
-  private readonly contexts = new Map<string, HostedRunContext>();
-  private readonly retentionMs: number;
 
   constructor(private readonly options: HostedAgentServiceOptions) {
-    this.retentionMs = options.replay?.retentionMs ?? DEFAULT_RUN_RETENTION_MS;
     this.runs = new ConversationRunService<HostedRunAddress>({
       addressKey: ({ accountId, sessionId }) => JSON.stringify([accountId, sessionId]),
-      replay: {
-        maxEventsPerRun: options.replay?.maxEventsPerRun,
-        retentionMs: this.retentionMs,
-      },
+      replay: options.replay,
     });
   }
 
@@ -82,18 +70,10 @@ export class HostedAgentService {
     if (!prompt) {
       throw new HostedAgentInputError('Hosted agent prompts cannot be empty.');
     }
-    if (this.runs.isRunning(address)) {
-      throw new HostedAgentRunConflictError(`A run is already active for session ${address.sessionId}.`);
-    }
-
     const engine = await this.options.createEngine(address);
     const host = await this.options.createHost?.(address);
     const session = engine.sessions.readExisting(address.sessionId)
       ?? engine.sessions.create({ id: address.sessionId, name: 'Hosted agent conversation' });
-
-    if (this.runs.isRunning(address)) {
-      throw new HostedAgentRunConflictError(`A run is already active for session ${address.sessionId}.`);
-    }
 
     const run = this.runs.startTurn({
       address,
@@ -103,10 +83,14 @@ export class HostedAgentService {
         prompt,
         host,
       },
+      // Projection is awaited before Heddle publishes the terminal result.
+      // Real hosts can persist or reconcile authorized product state here and
+      // return only the public data that reconnecting clients may replay.
+      projectResult: (result): HostedAgentResult => ({
+        outcome: result.outcome,
+        summary: result.summary,
+      }),
     });
-
-    this.contexts.set(run.runId, { address, run });
-    this.expireContext(run);
 
     return {
       accepted: true,
@@ -122,34 +106,25 @@ export class HostedAgentService {
     afterSequence?: number;
     signal?: AbortSignal;
   }): AsyncIterable<HostedAgentRunStreamItem> {
-    return this.requireOwnedRun(input.accountId, input.runId).run.events({
+    return this.requireOwnedRun(input.accountId, input.runId).events({
       afterSequence: input.afterSequence,
       signal: input.signal,
     });
   }
 
   cancel(accountId: string, runId: string): boolean {
-    return this.requireOwnedRun(accountId, runId).run.cancel();
+    return this.requireOwnedRun(accountId, runId).cancel();
   }
 
-  private requireOwnedRun(accountId: string, runId: string): HostedRunContext {
-    const context = this.contexts.get(runId);
-    if (!context || context.address.accountId !== accountId.trim()) {
+  private requireOwnedRun(
+    accountId: string,
+    runId: string,
+  ): ConversationRunHandle<HostedRunAddress, HostedAgentResult> {
+    const run = this.runs.getRetainedRun<HostedAgentResult>(runId);
+    if (!run || run.accountId !== accountId.trim()) {
       throw new HostedAgentRunNotFoundError(`Hosted agent run not found: ${runId}`);
     }
-    return context;
-  }
-
-  private expireContext(run: HostedRunContext['run']): void {
-    void run.result.finally(() => {
-      if (this.retentionMs === 0) {
-        this.contexts.delete(run.runId);
-        return;
-      }
-
-      const timer = setTimeout(() => this.contexts.delete(run.runId), this.retentionMs);
-      timer.unref?.();
-    }).catch(() => undefined);
+    return run;
   }
 
   private static normalizeAddress(input: { accountId: string; sessionId: string }): HostedRunAddress {

--- a/examples/sdk/05-hosted-agent/02-http-sse-api/http-api.ts
+++ b/examples/sdk/05-hosted-agent/02-http-sse-api/http-api.ts
@@ -13,9 +13,9 @@ import {
   type Response,
 } from 'express';
 import { z, ZodError } from 'zod';
+import { ConversationRunConflictError } from '../../../../src/hosted.js';
 import {
   HostedAgentInputError,
-  HostedAgentRunConflictError,
   HostedAgentRunNotFoundError,
   type HostedAgentService,
 } from '../01-hosted-service/agent-service.js';
@@ -187,7 +187,7 @@ function toApiError(error: unknown): HostedAgentApiError {
   if (error instanceof HostedAgentRunNotFoundError) {
     return new HostedAgentApiError(404, 'run_not_found', error.message);
   }
-  if (error instanceof HostedAgentRunConflictError) {
+  if (error instanceof ConversationRunConflictError) {
     return new HostedAgentApiError(409, 'run_conflict', error.message);
   }
   if (error instanceof HostedAgentInputError || error instanceof ZodError) {

--- a/examples/sdk/05-hosted-agent/README.md
+++ b/examples/sdk/05-hosted-agent/README.md
@@ -99,6 +99,9 @@ service or a required SDK wrapper. It demonstrates how a host can:
   telemetry stay application-owned;
 - reuse `engine.sessions.readExisting(...)` before creating a conversation;
 - return an accepted run ID immediately, then subscribe or cancel separately;
+- project internal engine output before Heddle publishes the retained terminal;
+- authorize retained run handles through their host-defined address without a
+  second host-side run registry;
 - use Heddle's canonical ordered replay instead of adding a second event bus.
 
 ### Responsibility boundary
@@ -108,6 +111,12 @@ artifacts, run identity, ordered activities, bounded replay, and cancellation.
 The host owns account-to-scope mapping, durable session IDs, engine
 configuration, injected repositories, approval decisions, and process
 lifecycle.
+
+The example's `projectResult` callback reduces Heddle's internal turn result to
+`outcome` and `summary`. In a product, this callback is also the place to await
+authorized state persistence or reconciliation before clients observe success.
+Projection failure becomes the run's error terminal; it cannot race behind a
+premature successful result.
 
 [`example-agent.ts`](01-hosted-service/example-agent.ts) is the local
 composition root. It chooses a model, filesystem state root, inspect-only tool
@@ -159,10 +168,11 @@ adapts HTTP operations to the transport-neutral service:
 - closing an SSE connection aborts only that subscription, not the run;
 - cancel is a separate, authenticated operation.
 
-The API deliberately projects terminal results to public `outcome` and
-`summary` fields. Trace paths, artifacts, tool results, and internal session
-state are not serialized to the browser. Extend the public Zod schema with only
-the product data the client is authorized to receive.
+The hosted service deliberately projects terminal results to public `outcome`
+and `summary` fields before replay. The API schema validates that boundary
+again. Trace paths, artifacts, tool results, and internal session state are not
+serialized to the browser. Extend the public projection and Zod schema with
+only the product data the client is authorized to receive.
 
 ### Responsibility boundary
 

--- a/src/__tests__/unit/core/conversation-run-service.test.ts
+++ b/src/__tests__/unit/core/conversation-run-service.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ConversationRunService } from '@/core/chat/runs/index.js';
+import {
+  ConversationRunCancelledError,
+  ConversationRunConflictError,
+  ConversationRunNotFoundError,
+  ConversationRunReplayUnavailableError,
+  ConversationRunService,
+} from '@/core/chat/runs/index.js';
 import type { ConversationEngine, ConversationTurnResultSummary } from '@/core/chat/engine/index.js';
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
 import { HeddleEventType } from '@/core/event-types.js';
@@ -63,6 +69,77 @@ describe('ConversationRunService', () => {
     expect(service.isRunning({ scopeId: 'tenant-1', sessionId: 'session-cancel' })).toBe(false);
   });
 
+  it('lets cancellation win when an executor ignores abort and resolves late', async () => {
+    const service = createRunService();
+    let finish: ((result: ConversationTurnResultSummary) => void) | undefined;
+    const run = service.startTurn({
+      address: { scopeId: 'tenant-1', sessionId: 'session-late-cancel' },
+      engine: engineThatRuns(async () => await new Promise<ConversationTurnResultSummary>((resolve) => {
+        finish = resolve;
+      })),
+      turn: { sessionId: 'session-late-cancel', prompt: 'Ignore cancellation' },
+    });
+    const items = collect(run.events());
+
+    await Promise.resolve();
+    expect(run.cancel()).toBe(true);
+    finish?.(turnResult());
+
+    await expect(run.result).rejects.toBeInstanceOf(ConversationRunCancelledError);
+    await expect(items).resolves.toEqual([
+      expect.objectContaining({ kind: 'cancelled', reason: 'Cancelled by user' }),
+    ]);
+  });
+
+  it('awaits host result projection before publishing the canonical terminal', async () => {
+    const service = createRunService();
+    const releaseProjection = deferred<void>();
+    const run = service.startTurn({
+      address: { scopeId: 'tenant-1', sessionId: 'session-projected' },
+      engine: engineThatRuns(async () => turnResult()),
+      turn: { sessionId: 'session-projected', prompt: 'Project this result' },
+      projectResult: async (result) => {
+        await releaseProjection.promise;
+        return { outcome: result.outcome, summary: result.summary };
+      },
+    });
+    const resultState = vi.fn();
+    void run.result.then(() => resultState('settled'));
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resultState).not.toHaveBeenCalled();
+    releaseProjection.resolve();
+
+    await expect(run.result).resolves.toEqual({ outcome: 'done', summary: 'Updated' });
+    await expect(collect(run.events())).resolves.toEqual([
+      expect.objectContaining({
+        kind: 'result',
+        result: { outcome: 'done', summary: 'Updated' },
+      }),
+    ]);
+  });
+
+  it('settles as failed when host result projection fails', async () => {
+    const service = createRunService();
+    const run = service.startTurn({
+      address: { scopeId: 'tenant-1', sessionId: 'session-projection-failed' },
+      engine: engineThatRuns(async () => turnResult()),
+      turn: { sessionId: 'session-projection-failed', prompt: 'Fail projection' },
+      projectResult: () => {
+        throw new Error('Could not persist public result');
+      },
+    });
+
+    await expect(run.result).rejects.toThrow('Could not persist public result');
+    await expect(collect(run.events())).resolves.toEqual([
+      expect.objectContaining({
+        kind: 'error',
+        error: { code: 'run_failed', message: 'Could not persist public result' },
+      }),
+    ]);
+  });
+
   it('exposes the active run identity and refuses to cancel a different run id', async () => {
     const service = createRunService();
     let finish: (() => void) | undefined;
@@ -92,6 +169,56 @@ describe('ConversationRunService', () => {
     await result;
 
     expect(service.getActiveRun({ scopeId: 'tenant-1', sessionId: 'session-active' })).toBeUndefined();
+  });
+
+  it('returns retained handles with host-owned addresses for authorization', async () => {
+    const service = createRunService();
+    const run = service.startTurn({
+      address: { scopeId: 'tenant-1', sessionId: 'session-retained' },
+      engine: engineThatRuns(async () => turnResult()),
+      turn: { sessionId: 'session-retained', prompt: 'Retain this run' },
+    });
+    await run.result;
+
+    const retained = service.getRetainedRun<ConversationTurnResultSummary>(run.runId);
+
+    expect(retained).toMatchObject({
+      scopeId: 'tenant-1',
+      sessionId: 'session-retained',
+      runId: run.runId,
+      accepted: true,
+    });
+    await expect(retained?.result).resolves.toMatchObject({ outcome: 'done', summary: 'Updated' });
+    expect(retained?.cancel()).toBe(false);
+    expect(service.getRetainedRun('unknown-run')).toBeUndefined();
+  });
+
+  it('throws typed conflicts and avoids delimiter collisions in default addresses', async () => {
+    let runIndex = 0;
+    const service = new ConversationRunService({
+      replay: { retentionMs: 60_000 },
+      createRunId: () => `run-${runIndex += 1}`,
+    });
+    const first = service.startTurn({
+      address: { scopeId: 'tenant:a', sessionId: 'session' },
+      engine: engineThatWaitsForAbort(),
+      turn: { sessionId: 'session', prompt: 'First' },
+    });
+    const distinct = service.startTurn({
+      address: { scopeId: 'tenant', sessionId: 'a:session' },
+      engine: engineThatWaitsForAbort(),
+      turn: { sessionId: 'a:session', prompt: 'Distinct' },
+    });
+
+    expect(() => service.startTurn({
+      address: { scopeId: 'tenant:a', sessionId: 'session' },
+      engine: engineThatRuns(async () => turnResult()),
+      turn: { sessionId: 'session', prompt: 'Conflict' },
+    })).toThrow(ConversationRunConflictError);
+    expect(first.runId).not.toBe(distinct.runId);
+    first.cancel();
+    distinct.cancel();
+    await Promise.allSettled([first.result, distinct.result]);
   });
 
   it('prevents a stale run identity from resolving a newer pending approval', async () => {
@@ -150,7 +277,7 @@ describe('ConversationRunService', () => {
       address: { scopeId: 'tenant-1', sessionId: 'session-bounded' },
       runId: run.runId,
       afterSequence: 0,
-    })).toThrow('replay cursor 0 is older than retained sequence 3');
+    })).toThrow(ConversationRunReplayUnavailableError);
 
     const retained = await collect(service.subscribe({
       address: { scopeId: 'tenant-1', sessionId: 'session-bounded' },
@@ -161,6 +288,15 @@ describe('ConversationRunService', () => {
       [3, 'activity'],
       [4, 'result'],
     ]);
+  });
+
+  it('throws a typed not-found error for unknown subscriptions', () => {
+    const service = createRunService();
+
+    expect(() => service.subscribe({
+      address: { scopeId: 'tenant-1', sessionId: 'session-unknown' },
+      runId: 'unknown-run',
+    })).toThrow(ConversationRunNotFoundError);
   });
 });
 
@@ -181,6 +317,13 @@ function engineThatRuns(
       clearLease: () => undefined,
     },
   } as unknown as ConversationEngine;
+}
+
+function engineThatWaitsForAbort(): ConversationEngine {
+  return engineThatRuns(async (input) => await new Promise<never>((_resolve, reject) => {
+    input.abortSignal?.throwIfAborted();
+    input.abortSignal?.addEventListener('abort', () => reject(new Error('turn aborted')), { once: true });
+  }));
 }
 
 function assistantActivity(step: number, text: string): ConversationActivity {
@@ -215,4 +358,14 @@ async function collect<Result>(items: AsyncIterable<Result>): Promise<Result[]> 
     collected.push(item);
   }
   return collected;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }

--- a/src/core/chat/runs/README.md
+++ b/src/core/chat/runs/README.md
@@ -8,16 +8,20 @@ conversation work embedded in a host process.
 - one active run per host-defined session address;
 - stable run IDs and cancellation controllers;
 - active-run discovery for hosts reconnecting after a client refresh;
+- retained run lookup with the host-defined address for authorization;
 - pending approval resolution;
 - ordered `ConversationActivity` delivery;
 - bounded replay for reconnecting subscribers;
-- result/error/cancellation settlement and cleanup.
+- awaited host result projection before terminal publication;
+- typed conflict, lookup, replay, and cancellation errors;
+- result/error/cancellation settlement and cleanup, including late completion
+  after cancellation.
 
 ## Does not own
 
 - persisted conversation semantics, which remain in `ConversationEngine`;
 - HTTP, SSE, tRPC, React, authentication, or tenant policy;
-- product-specific result projection;
+- the contents of product-specific result projection;
 - durable cross-process event replay.
 
 The Heddle control plane and external programmatic hosts must use this same
@@ -35,6 +39,11 @@ const run = runs.startTurn({
   address: { scopeId: 'tenant-1', sessionId: session.id },
   engine,
   turn: { sessionId: session.id, prompt: 'Revise the current document.' },
+  projectResult: async (result, { controller }) => {
+    controller.signal.throwIfAborted();
+    await productRepository.persist(result);
+    return { outcome: result.outcome, summary: result.summary };
+  },
 });
 
 const activeRun = runs.getActiveRun({
@@ -45,7 +54,24 @@ const activeRun = runs.getActiveRun({
 for await (const item of run.events()) {
   // Serialize through the host's transport without changing Heddle semantics.
 }
+
+const retained = runs.getRetainedRun(run.runId);
+if (retained?.scopeId !== authenticatedScopeId) {
+  throw new Error('Run not found');
+}
 ```
 
 `run.cancel()` and `run.resolveApproval(...)` remain bound to that accepted run
 identity. A stale handle cannot affect a later run at the same address.
+Cancellation remains authoritative if an executor ignores its abort signal and
+resolves late: the result promise rejects and replay ends with `cancelled`.
+
+`projectResult` is the host's transaction boundary between internal engine
+output and the retained/public result. It may persist or reconcile product
+state and is awaited before the `result` terminal is published. If projection
+fails, the run fails instead of reporting a successful terminal prematurely.
+
+`getRetainedRun(...)` returns the original host-defined address with the handle
+so the host can authorize subscribe and cancel operations without maintaining a
+second run registry. A run ID is only a lookup key; possession is never proof of
+authorization.

--- a/src/core/chat/runs/errors.ts
+++ b/src/core/chat/runs/errors.ts
@@ -1,0 +1,37 @@
+/** A host attempted to start a second run for the same active address. */
+export class ConversationRunConflictError extends Error {
+  constructor(readonly addressKey: string) {
+    super(`A conversation run is already in progress for address ${addressKey}.`);
+    this.name = 'ConversationRunConflictError';
+  }
+}
+
+/** A run ID is unknown, expired, or does not belong to the supplied address. */
+export class ConversationRunNotFoundError extends Error {
+  constructor(readonly runId: string) {
+    super(`Conversation run not found: ${runId}`);
+    this.name = 'ConversationRunNotFoundError';
+  }
+}
+
+/** A subscriber requested events that have already left the bounded replay window. */
+export class ConversationRunReplayUnavailableError extends Error {
+  constructor(
+    readonly runId: string,
+    readonly requestedSequence: number,
+    readonly oldestRetainedSequence: number,
+  ) {
+    super(
+      `Conversation run replay cursor ${requestedSequence} is older than retained sequence ${oldestRetainedSequence}.`,
+    );
+    this.name = 'ConversationRunReplayUnavailableError';
+  }
+}
+
+/** Internal execution signal used when cancellation wins a late completion race. */
+export class ConversationRunCancelledError extends Error {
+  constructor(readonly runId: string) {
+    super(`Conversation run cancelled: ${runId}`);
+    this.name = 'ConversationRunCancelledError';
+  }
+}

--- a/src/core/chat/runs/index.ts
+++ b/src/core/chat/runs/index.ts
@@ -1,9 +1,16 @@
 export { ConversationRunService } from './service.js';
+export {
+  ConversationRunCancelledError,
+  ConversationRunConflictError,
+  ConversationRunNotFoundError,
+  ConversationRunReplayUnavailableError,
+} from './errors.js';
 export type {
   ConversationRunAccepted,
   ConversationRunAddress,
   ConversationRunContext,
   ConversationRunHandle,
+  ConversationTurnResultProjector,
   ConversationRunReplayOptions,
   ConversationRunServiceOptions,
   ConversationRunStreamItem,
@@ -11,5 +18,7 @@ export type {
   StartConversationContinueRunInput,
   StartConversationRunInput,
   StartConversationTurnRunInput,
+  StartProjectedConversationContinueRunInput,
+  StartProjectedConversationTurnRunInput,
   SubscribeConversationRunInput,
 } from './types.js';

--- a/src/core/chat/runs/service.ts
+++ b/src/core/chat/runs/service.ts
@@ -12,6 +12,12 @@ import { SESSION_LEASE_REFRESH_INTERVAL_MS } from '@/core/chat/engine/sessions/l
 import type { ConversationActivity } from '@/core/live/index.js';
 import { RuntimeSubscriptionStream } from '@/core/runtime/subscriptions/index.js';
 import type { RuntimeSubscriptionSink } from '@/core/runtime/subscriptions/index.js';
+import {
+  ConversationRunCancelledError,
+  ConversationRunConflictError,
+  ConversationRunNotFoundError,
+  ConversationRunReplayUnavailableError,
+} from './errors.js';
 import type {
   ConversationRunAccepted,
   ConversationRunAddress,
@@ -21,6 +27,8 @@ import type {
   ConversationRunStreamItem,
   PendingConversationRunApproval,
   StartConversationContinueRunInput,
+  StartProjectedConversationContinueRunInput,
+  StartProjectedConversationTurnRunInput,
   StartConversationRunInput,
   StartConversationTurnRunInput,
   SubscribeConversationRunInput,
@@ -96,37 +104,59 @@ export class ConversationRunService<
     return await this.startRecord(input).record.result;
   }
 
-  startTurn(input: StartConversationTurnRunInput<Address>): ConversationRunHandle<Address, SubmitConversationTurnResult> {
+  startTurn<Result>(
+    input: StartProjectedConversationTurnRunInput<Address, Result>,
+  ): ConversationRunHandle<Address, Result>;
+  startTurn(
+    input: StartConversationTurnRunInput<Address>,
+  ): ConversationRunHandle<Address, SubmitConversationTurnResult>;
+  startTurn<Result>(
+    input: StartConversationTurnRunInput<Address> | StartProjectedConversationTurnRunInput<Address, Result>,
+  ): ConversationRunHandle<Address, SubmitConversationTurnResult | Result> {
     const started = this.startRecord({
       address: input.address,
       onAccepted: input.onAccepted,
       onHeartbeat: input.onHeartbeat,
       onError: input.onError,
       onSettled: input.onSettled,
-      execute: async (run) => await input.engine.turns.submit({
-        ...input.turn,
-        abortSignal: ConversationRunService.combineAbortSignals(run.controller.signal, input.turn.abortSignal),
-        shouldStop: ConversationRunService.combineShouldStop(run.controller.signal, input.turn.shouldStop),
-        host: ConversationRunService.withActivityPublisher(input.turn.host, run.publishActivity),
-      }),
-    });
+      execute: async (run) => {
+        const result = await input.engine.turns.submit({
+          ...input.turn,
+          abortSignal: ConversationRunService.combineAbortSignals(run.controller.signal, input.turn.abortSignal),
+          shouldStop: ConversationRunService.combineShouldStop(run.controller.signal, input.turn.shouldStop),
+          host: ConversationRunService.withActivityPublisher(input.turn.host, run.publishActivity),
+        });
+        return await ConversationRunService.projectTurnResult(input, result, run);
+      },
+    }, { cancelWinsCompletion: true });
     return this.createHandle(started.accepted, started.record.result);
   }
 
-  startContinue(input: StartConversationContinueRunInput<Address>): ConversationRunHandle<Address, SubmitConversationTurnResult> {
+  startContinue<Result>(
+    input: StartProjectedConversationContinueRunInput<Address, Result>,
+  ): ConversationRunHandle<Address, Result>;
+  startContinue(
+    input: StartConversationContinueRunInput<Address>,
+  ): ConversationRunHandle<Address, SubmitConversationTurnResult>;
+  startContinue<Result>(
+    input: StartConversationContinueRunInput<Address> | StartProjectedConversationContinueRunInput<Address, Result>,
+  ): ConversationRunHandle<Address, SubmitConversationTurnResult | Result> {
     const started = this.startRecord({
       address: input.address,
       onAccepted: input.onAccepted,
       onHeartbeat: input.onHeartbeat,
       onError: input.onError,
       onSettled: input.onSettled,
-      execute: async (run) => await input.engine.turns.continue({
-        ...input.turn,
-        abortSignal: ConversationRunService.combineAbortSignals(run.controller.signal, input.turn.abortSignal),
-        shouldStop: ConversationRunService.combineShouldStop(run.controller.signal, input.turn.shouldStop),
-        host: ConversationRunService.withActivityPublisher(input.turn.host, run.publishActivity),
-      }),
-    });
+      execute: async (run) => {
+        const result = await input.engine.turns.continue({
+          ...input.turn,
+          abortSignal: ConversationRunService.combineAbortSignals(run.controller.signal, input.turn.abortSignal),
+          shouldStop: ConversationRunService.combineShouldStop(run.controller.signal, input.turn.shouldStop),
+          host: ConversationRunService.withActivityPublisher(input.turn.host, run.publishActivity),
+        });
+        return await ConversationRunService.projectTurnResult(input, result, run);
+      },
+    }, { cancelWinsCompletion: true });
     return this.createHandle(started.accepted, started.record.result);
   }
 
@@ -135,8 +165,10 @@ export class ConversationRunService<
     const afterSequence = input.afterSequence ?? 0;
     const oldestSequence = record.events[0]?.sequence;
     if (oldestSequence !== undefined && afterSequence < oldestSequence - 1) {
-      throw new Error(
-        `Conversation run replay cursor ${afterSequence} is older than retained sequence ${oldestSequence}.`,
+      throw new ConversationRunReplayUnavailableError(
+        input.runId,
+        afterSequence,
+        oldestSequence,
       );
     }
 
@@ -175,6 +207,25 @@ export class ConversationRunService<
       runId: run.context.runId,
       acceptedAt: run.context.acceptedAt,
     };
+  }
+
+  /**
+   * Returns a retained run handle together with its host-defined address.
+   * Possession of a run ID is not authorization; hosts must verify the address
+   * before exposing the handle to a caller.
+   */
+  getRetainedRun<Result = unknown>(runId: string): ConversationRunHandle<Address, Result> | undefined {
+    const record = this.runsById.get(runId) as ConversationRunRecord<Address, Result> | undefined;
+    if (!record) {
+      return undefined;
+    }
+
+    return this.createHandle({
+      ...record.address,
+      accepted: true,
+      runId: record.context.runId,
+      acceptedAt: record.context.acceptedAt,
+    }, record.result);
   }
 
   cancelRun(address: Address, runId?: string): boolean {
@@ -224,13 +275,16 @@ export class ConversationRunService<
     return true;
   }
 
-  private startRecord<Result>(input: StartConversationRunInput<Address, Result>): {
+  private startRecord<Result>(
+    input: StartConversationRunInput<Address, Result>,
+    options: { cancelWinsCompletion?: boolean } = {},
+  ): {
     accepted: ConversationRunAccepted<Address>;
     record: ConversationRunRecord<Address, Result>;
   } {
     const addressKey = this.addressKey(input.address);
     if (this.activeRuns.has(addressKey)) {
-      throw new Error('A run is already in progress for this session.');
+      throw new ConversationRunConflictError(addressKey);
     }
 
     const runId = this.createRunId();
@@ -256,6 +310,9 @@ export class ConversationRunService<
         return input.execute(context);
       })
       .then((value) => {
+        if (options.cancelWinsCompletion) {
+          ConversationRunService.throwIfCancelled(context);
+        }
         this.publish(record, { kind: 'result', result: value });
         return value;
       })
@@ -381,9 +438,34 @@ export class ConversationRunService<
   private requireRetainedRun<Result>(address: Address, runId: string): ConversationRunRecord<Address, Result> {
     const record = this.runsById.get(runId);
     if (!record || record.addressKey !== this.addressKey(address)) {
-      throw new Error(`Conversation run not found: ${runId}`);
+      throw new ConversationRunNotFoundError(runId);
     }
     return record as ConversationRunRecord<Address, Result>;
+  }
+
+  private static async projectTurnResult<Result>(
+    input:
+      | StartConversationTurnRunInput<{ sessionId: string }>
+      | StartProjectedConversationTurnRunInput<{ sessionId: string }, Result>
+      | StartConversationContinueRunInput<{ sessionId: string }>
+      | StartProjectedConversationContinueRunInput<{ sessionId: string }, Result>,
+    result: SubmitConversationTurnResult,
+    run: ConversationRunContext,
+  ): Promise<SubmitConversationTurnResult | Result> {
+    ConversationRunService.throwIfCancelled(run);
+    if (!('projectResult' in input)) {
+      return result;
+    }
+
+    const projected = await input.projectResult(result, run);
+    ConversationRunService.throwIfCancelled(run);
+    return projected;
+  }
+
+  private static throwIfCancelled(run: ConversationRunContext): void {
+    if (run.controller.signal.aborted) {
+      throw new ConversationRunCancelledError(run.runId);
+    }
   }
 
   private startHeartbeat(
@@ -443,6 +525,6 @@ export class ConversationRunService<
     if (!address.scopeId?.trim() || !address.sessionId.trim()) {
       throw new Error('Conversation run addresses require non-empty scopeId and sessionId values.');
     }
-    return `${address.scopeId}:${address.sessionId}`;
+    return JSON.stringify([address.scopeId, address.sessionId]);
   }
 }

--- a/src/core/chat/runs/types.ts
+++ b/src/core/chat/runs/types.ts
@@ -89,24 +89,50 @@ export type SubscribeConversationRunInput<Address extends { sessionId: string }>
   signal?: AbortSignal;
 };
 
-export type StartConversationTurnRunInput<Address extends { sessionId: string }> = {
+type ConversationRunLifecycleHooks<Address extends { sessionId: string }> = Pick<
+  StartConversationRunInput<Address, unknown>,
+  'onAccepted' | 'onHeartbeat' | 'onError' | 'onSettled'
+>;
+
+type ConversationTurnRunInputBase<Address extends { sessionId: string }> =
+  ConversationRunLifecycleHooks<Address> & {
   address: Address;
   engine: ConversationEngine;
   turn: SubmitConversationTurnInput;
-  onAccepted?: StartConversationRunInput<Address, SubmitConversationTurnResult>['onAccepted'];
-  onHeartbeat?: StartConversationRunInput<Address, SubmitConversationTurnResult>['onHeartbeat'];
-  onError?: StartConversationRunInput<Address, SubmitConversationTurnResult>['onError'];
-  onSettled?: StartConversationRunInput<Address, SubmitConversationTurnResult>['onSettled'];
 };
 
-export type StartConversationContinueRunInput<Address extends { sessionId: string }> = {
+type ConversationContinueRunInputBase<Address extends { sessionId: string }> =
+  ConversationRunLifecycleHooks<Address> & {
   address: Address;
   engine: ConversationEngine;
   turn: ContinueConversationTurnInput;
-  onAccepted?: StartConversationRunInput<Address, SubmitConversationTurnResult>['onAccepted'];
-  onHeartbeat?: StartConversationRunInput<Address, SubmitConversationTurnResult>['onHeartbeat'];
-  onError?: StartConversationRunInput<Address, SubmitConversationTurnResult>['onError'];
-  onSettled?: StartConversationRunInput<Address, SubmitConversationTurnResult>['onSettled'];
+};
+
+export type ConversationTurnResultProjector<Result> = (
+  result: SubmitConversationTurnResult,
+  run: ConversationRunContext,
+) => Result | Promise<Result>;
+
+export type StartConversationTurnRunInput<Address extends { sessionId: string }> =
+  ConversationTurnRunInputBase<Address>;
+
+export type StartProjectedConversationTurnRunInput<
+  Address extends { sessionId: string },
+  Result,
+> = ConversationTurnRunInputBase<Address> & {
+  /** Runs before the canonical result terminal is published. */
+  projectResult: ConversationTurnResultProjector<Result>;
+};
+
+export type StartConversationContinueRunInput<Address extends { sessionId: string }> =
+  ConversationContinueRunInputBase<Address>;
+
+export type StartProjectedConversationContinueRunInput<
+  Address extends { sessionId: string },
+  Result,
+> = ConversationContinueRunInputBase<Address> & {
+  /** Runs before the canonical result terminal is published. */
+  projectResult: ConversationTurnResultProjector<Result>;
 };
 
 export type ConversationRunHandle<Address extends { sessionId: string }, Result> =

--- a/src/hosted.ts
+++ b/src/hosted.ts
@@ -1,11 +1,18 @@
 // Public hosted-process entrypoint. This adds no new implementation: it makes
 // the ConversationRunService hosting assumption explicit in package imports.
-export { ConversationRunService } from './core/chat/runs/index.js';
+export {
+  ConversationRunCancelledError,
+  ConversationRunConflictError,
+  ConversationRunNotFoundError,
+  ConversationRunReplayUnavailableError,
+  ConversationRunService,
+} from './core/chat/runs/index.js';
 export type {
   ConversationRunAccepted,
   ConversationRunAddress,
   ConversationRunContext,
   ConversationRunHandle,
+  ConversationTurnResultProjector,
   ConversationRunReplayOptions,
   ConversationRunServiceOptions,
   ConversationRunStreamItem,
@@ -13,5 +20,7 @@ export type {
   StartConversationContinueRunInput,
   StartConversationRunInput,
   StartConversationTurnRunInput,
+  StartProjectedConversationContinueRunInput,
+  StartProjectedConversationTurnRunInput,
   SubscribeConversationRunInput,
 } from './core/chat/runs/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,12 +161,19 @@ export { ToolActivitySummarizer } from './core/live/index.js';
 // Types and services for hosts that embed `createConversationEngine` (rung 1)
 // directly and manage session create/resume/turn lifecycle and approval policy
 // themselves.
-export { ConversationRunService } from './core/chat/runs/index.js';
+export {
+  ConversationRunCancelledError,
+  ConversationRunConflictError,
+  ConversationRunNotFoundError,
+  ConversationRunReplayUnavailableError,
+  ConversationRunService,
+} from './core/chat/runs/index.js';
 export type {
   ConversationRunAccepted,
   ConversationRunAddress,
   ConversationRunContext,
   ConversationRunHandle,
+  ConversationTurnResultProjector,
   ConversationRunReplayOptions,
   ConversationRunServiceOptions,
   ConversationRunStreamItem,
@@ -174,6 +181,8 @@ export type {
   StartConversationContinueRunInput,
   StartConversationRunInput,
   StartConversationTurnRunInput,
+  StartProjectedConversationContinueRunInput,
+  StartProjectedConversationTurnRunInput,
   SubscribeConversationRunInput,
 } from './core/chat/runs/index.js';
 export type {


### PR DESCRIPTION
## Summary

- add typed conflict, not-found, replay-window, and cancellation errors to the existing `ConversationRunService`
- let hosted turn runs await a host-owned result projection before publishing their terminal result
- expose retained run handles with their host-defined address so hosts can authorize without a duplicate registry
- make cancellation win late completion for `startTurn` / `startContinue` while preserving existing generic control-plane stop semantics
- refactor the hosted SDK example to delete its parallel context map and demonstrate safe terminal projection

## Why

The hosted example and downstream integrations had to rebuild run retention, ownership lookup, and terminal projection around Heddle. These are run-domain responsibilities that belong in the existing coordinator. Product identity, authorization decisions, persistence contents, HTTP, and UI remain host-owned.

## Verification

- `yarn test:unit` — 646 passed
- `yarn test:integration` — 291 passed
- `yarn typecheck`
- `yarn eslint ...`
- `yarn build`

This is PR 1 of a planned stack. The next PR will add transport-focused HTTP/SSE primitives and refactor the same example to use them.