### PR TITLE
feat: add hosted HTTP SSE transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,9 @@ Heddle is not only a CLI. The npm package exposes explicit programmatic layers:
 
 - `createConversationEngine`: an alpha API for persisted multi-turn sessions with session storage, compaction, approvals, traces, semantic activity, and custom frontends or local hosts
 - `@roackb2/heddle/hosted`: process-local run identity, ordered activity, bounded replay, cancellation, and approval resolution for reconnectable hosted conversations
-- `@roackb2/heddle/remote`: runtime-validated public run envelopes plus shared cursor, duplicate, gap, terminal, and reconnect correctness for remote clients
+- `@roackb2/heddle/hosted/http-sse`: optional Node HTTP/SSE framing, cursor, backpressure, and subscriber-disconnect correctness without choosing a server framework
+- `@roackb2/heddle-remote`: independently installable runtime-validated run envelopes plus shared cursor, duplicate, gap, terminal, and reconnect correctness for remote clients
+- `@roackb2/heddle-remote/http-sse`: optional browser-safe fetch/SSE transport for the conventional REST run resource
 - `AgentLoopRuntimeService.run(...)`: a lower-level single-run execution loop for hosts that do not need persisted chat or session behavior
 
 Advanced hosts can also reuse lower-level class APIs such as `ToolRegistry`, `ToolExecutionService`, `TraceRecorder`, `TraceConsoleFormatter`, and `ReviewDiffParser` when they intentionally assemble custom runtime or review surfaces.

--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -15,9 +15,13 @@ hosting assumptions.
   product host needs to build an agentic experience.
 - `@roackb2/heddle/hosted` — process-local run identity, replay, cancellation,
   and approvals for a long-lived host process.
+- `@roackb2/heddle/hosted/http-sse` — opt-in Node HTTP/SSE framing,
+  backpressure, replay-cursor, and subscriber-disconnect correctness.
 - `@roackb2/heddle-remote` — an independently installable, browser-safe package
   with runtime contracts plus transport-neutral cursor, duplicate, gap,
   terminal, and reconnect correctness.
+- `@roackb2/heddle-remote/http-sse` — opt-in browser-safe fetch/SSE parsing and
+  transport validation for the conventional REST run resource.
 - `@roackb2/heddle/advanced` — the **deep core customization** surface: the curated exports plus
   lower-level building blocks (LLM adapters, individual tools, trace, memory,
   models, awareness) and specialized runtimes (agent loop, heartbeat,

--- a/docs/guides/programmatic/integration-layers.md
+++ b/docs/guides/programmatic/integration-layers.md
@@ -15,9 +15,9 @@ in control.
 HOST-OWNED PRODUCT
   UI state and rendering
           |
-  @roackb2/heddle-remote consumer + public contract
+  @roackb2/heddle-remote consumer + optional HTTP/SSE client
           |
-  transport client/server adapter                  optional
+  host transport adapter + optional Node SSE helper
           |
   application service and composition root
   (product session IDs, tools, config, repositories, policy)
@@ -47,7 +47,7 @@ not transport infrastructure.
 | Remote consumption | Cursor advancement, duplicate suppression, sequence-gap failure, terminal detection, bounded reconnect timing, and runtime envelope validation | Public activity/result schemas, actual transport timer/handle, and error UX |
 | Persistence | File-backed defaults plus injectable session/artifact repository ports | Production repository implementations, retention, encryption, backup, and tenancy |
 | Identity and authorization | No identity-provider assumption | Authentication, tenant/user mapping, authorization for start/subscribe/cancel |
-| Transport/API | No HTTP, tRPC, SSE, or WebSocket assumption | Framework, routes/procedures, wire schemas, errors, limits, CORS, and rate limiting |
+| Transport/API | Optional fetch/SSE client and Node SSE streaming correctness when that preset is selected | Framework, routes/procedures, wire schemas, auth, errors, limits, CORS, and rate limiting |
 | Client experience | Semantic activities, terminal run events, and remote cursor/retry calculations | Messages, tool rendering, UI state, transport timers, retry UX, notifications, and product-specific result presentation |
 
 Do not rebuild Heddle-owned conversation or run behavior in the host. In
@@ -63,9 +63,9 @@ disconnect as implicit cancellation.
 | A local loop that needs product tools or MCP | Quickstart plus tools/host extensions | [`02-add-a-tool.ts`](../../../examples/sdk/02-add-a-tool.ts), [`03-add-an-mcp-server.ts`](../../../examples/sdk/03-add-an-mcp-server.ts) |
 | Its own output sink or local UI | `createConversationEngine` + `createConversationTextHost` or host callbacks | [`04-custom-output.ts`](../../../examples/sdk/04-custom-output.ts) |
 | A server/worker that owns transport | `@roackb2/heddle` + `@roackb2/heddle/hosted` | [`05-hosted-agent/01-hosted-service`](../../../examples/sdk/05-hosted-agent/01-hosted-service) |
-| Express with REST + SSE | Same core plus a host adapter | [`05-hosted-agent/02-http-sse-api`](../../../examples/sdk/05-hosted-agent/02-http-sse-api) |
+| Express with REST + SSE | Core plus `@roackb2/heddle/hosted/http-sse` | [`05-hosted-agent/02-http-sse-api`](../../../examples/sdk/05-hosted-agent/02-http-sse-api) |
 | A remote client over any transport | `@roackb2/heddle-remote` plus a host transport | [Remote conversation runs](remote-runs.md) |
-| A browser using the example REST/SSE contract | Remote layer plus the example protocol client | [`05-hosted-agent/03-browser-client`](../../../examples/sdk/05-hosted-agent/03-browser-client) |
+| A browser using the conventional REST/SSE contract | `@roackb2/heddle-remote/http-sse` | [`05-hosted-agent/03-browser-client`](../../../examples/sdk/05-hosted-agent/03-browser-client) |
 
 For tRPC, Fastify, Hono, Nest, WebSocket, Electron IPC, queues, or another
 transport, stop at the hosted-service layer and implement the adapter in the
@@ -108,7 +108,9 @@ The host supplies public activity/result schemas; Heddle owns envelope
 validation, JSON safety, cursor advancement, duplicate/gap handling, terminal
 detection, and retry calculation.
 
-This layer does not own HTTP, SSE, tRPC, timers, auth, or UI state. See
+This base layer does not own HTTP, SSE, tRPC, timers, auth, or UI state. Add
+`@roackb2/heddle-remote/http-sse` only when the host uses the conventional REST
+run resource and authenticated streaming `fetch`. See
 [Remote conversation runs](remote-runs.md).
 
 ### Transport adapter
@@ -118,9 +120,13 @@ approval operations. Validate all untrusted wire data and project internal run
 results into an explicitly public schema. Authentication and authorization must
 happen before resolving the Heddle run address.
 
-Web-standard HTTP/SSE helpers are a planned higher assumption layer; Express
-and tRPC remain framework recipes until their residual code proves a meaningful
-adapter boundary.
+For Node HTTP/SSE, `@roackb2/heddle/hosted/http-sse` owns strict replay cursor
+parsing, canonical frames, backpressure, and subscriber disconnect cleanup.
+The host still owns route registration, authentication/authorization, public
+schemas, JSON error policy, CORS, and limits. Express and other Node frameworks
+can share the helper because it targets `IncomingMessage` and `ServerResponse`.
+tRPC, WebSocket, native bridges, and other transports stay on the neutral base
+layer.
 
 ### Client protocol and UI
 
@@ -142,7 +148,9 @@ normal client architecture.
 | Public API fields | Host-owned validation schemas and terminal-result projection |
 | Remote cursor/retry correctness | `ConversationRunConsumerService` |
 | Runtime run-envelope validation | `ConversationRunProtocolCodec` with host activity/result schemas |
-| REST, tRPC, SSE, WebSocket, or IPC | Host transport adapter above the application service |
+| Conventional Node HTTP/SSE | `@roackb2/heddle/hosted/http-sse` plus host routes and policy |
+| Conventional browser REST/SSE | `@roackb2/heddle-remote/http-sse` plus host schemas and headers |
+| tRPC, WebSocket, or IPC | Host transport adapter above the application service |
 | React or other UI state | Product client/application layer above the protocol client |
 | Multi-process live delivery | Host-selected shared routing/broker infrastructure |
 

--- a/docs/guides/programmatic/remote-runs.md
+++ b/docs/guides/programmatic/remote-runs.md
@@ -12,13 +12,16 @@ import {
   ConversationRunConsumerService,
   ConversationRunProtocolCodec,
 } from '@roackb2/heddle-remote'
+import { ConversationRunHttpSseClient } from '@roackb2/heddle-remote/http-sse'
 ```
 
 - `@roackb2/heddle` owns persisted conversation semantics.
 - `@roackb2/heddle/hosted` owns process-local active-run coordination.
 - `@roackb2/heddle-remote` is independently installable and owns client cursor
-  correctness plus runtime wire validation without choosing HTTP, SSE, tRPC,
-  WebSocket, React, or auth.
+  correctness plus runtime wire validation without choosing a transport.
+- `@roackb2/heddle-remote/http-sse` is an optional assumption layer for the
+  conventional REST run resource and streaming `fetch`; it still does not
+  choose React or auth policy.
 
 ## Define the public wire payload
 
@@ -139,6 +142,40 @@ The consumer computes retry correctness and timing. The host still owns the
 actual timer, subscription handle, error presentation, online/offline policy,
 and UI state. Accepted progress resets the retry attempt budget.
 
+## Opt into the REST/SSE preset
+
+When the host exposes `POST /runs`, `GET /runs/:runId/events`, and
+`POST /runs/:runId/cancel`, use the browser-safe preset instead of recreating
+incremental SSE parsing and transport validation:
+
+```ts
+import { ConversationRunHttpSseClient } from '@roackb2/heddle-remote/http-sse'
+
+const client = new ConversationRunHttpSseClient({
+  baseUrl: '/api/agent',
+  protocol,
+  accepted: StartRunResultSchema,
+  cancellation: CancelRunResultSchema,
+  getHeaders: () => ({ Authorization: `Bearer ${accessToken}` }),
+})
+
+const accepted = await client.start({ sessionId, prompt })
+await client.subscribe({
+  runId: accepted.runId,
+  afterSequence: consumer.subscriptionInput()?.afterSequence,
+  signal: subscription.signal,
+  onEvent(event) {
+    consumer.accept(event)
+  },
+})
+```
+
+The preset owns URL encoding, header composition, response schema validation,
+incremental SSE parsing, reader cleanup, and verification that the SSE ID,
+event name, payload `runId`, and canonical envelope agree. The host supplies
+auth headers, public schemas, abort/timer lifecycle, cursor persistence, retry
+UX, and product event handling.
+
 ## Server-side run ownership
 
 Use one host-long-lived `ConversationRunService` from the hosted entrypoint:
@@ -159,10 +196,18 @@ not promise restart recovery or cross-instance delivery. Add shared routing or
 durable delivery only when the deployment explicitly requires that additional
 assumption layer.
 
+For the same conventional Node HTTP/SSE transport, import
+`parseConversationRunSseReplayCursor` and `streamConversationRunSse` from
+`@roackb2/heddle/hosted/http-sse`. They own cursor precedence, SSE headers and
+frames, backpressure, and subscriber-only disconnect cleanup. They intentionally
+do not register routes or choose authentication, authorization, CORS, rate
+limits, request validation, or public error responses.
+
 ## What remains host-owned
 
 - start/cancel routes or procedures;
-- HTTP/SSE/tRPC/WebSocket adapters;
+- routes/procedures and non-HTTP/SSE transport adapters;
+- HTTP authentication, authorization, CORS, rate limits, and public errors;
 - authentication, tenancy, CORS, rate limits, and audit;
 - engine construction, credentials, tools, and approval policy;
 - public activity/result projection;

--- a/examples/sdk/05-hosted-agent/02-http-sse-api/README.md
+++ b/examples/sdk/05-hosted-agent/02-http-sse-api/README.md
@@ -16,8 +16,9 @@ for curl commands, lifecycle details, and production replacements.
 
 1. [`contracts.ts`](contracts.ts) — host-owned public payload schemas composed
    with `ConversationRunProtocolCodec` from `@roackb2/heddle-remote`.
-2. [`http-api.ts`](http-api.ts) — authenticated start, cursor subscribe, and
-   explicit cancel handlers.
+2. [`http-api.ts`](http-api.ts) — authenticated start/cancel handlers plus
+   host-owned routes composed with `@roackb2/heddle/hosted/http-sse` for cursor,
+   framing, backpressure, and disconnect correctness.
 3. [`server.ts`](server.ts) — runnable local composition with deliberately
    non-production auth.
 

--- a/examples/sdk/05-hosted-agent/02-http-sse-api/contracts.ts
+++ b/examples/sdk/05-hosted-agent/02-http-sse-api/contracts.ts
@@ -53,8 +53,10 @@ export const HostedAgentApiErrorSchema = z.object({
 
 export type StartHostedAgentRunInput = z.infer<typeof StartHostedAgentRunInputSchema>;
 export type StartHostedAgentRunResult = z.infer<typeof StartHostedAgentRunResultSchema>;
+export type HostedAgentActivity = z.infer<typeof HostedAgentActivitySchema>;
+export type HostedAgentResult = z.infer<typeof HostedAgentResultSchema>;
 export type HostedAgentRunEvent = ConversationRunProtocolEvent<
-  z.infer<typeof HostedAgentActivitySchema>,
-  z.infer<typeof HostedAgentResultSchema>
+  HostedAgentActivity,
+  HostedAgentResult
 >;
 export type CancelHostedAgentRunResult = z.infer<typeof CancelHostedAgentRunResultSchema>;

--- a/examples/sdk/05-hosted-agent/02-http-sse-api/http-api.ts
+++ b/examples/sdk/05-hosted-agent/02-http-sse-api/http-api.ts
@@ -5,7 +5,6 @@
  * and deployment. Reimplement this adapter in the host's existing framework
  * when Express/SSE is not already part of the stack.
  */
-import { once } from 'node:events';
 import {
   Router,
   type Request,
@@ -15,6 +14,11 @@ import {
 import { z, ZodError } from 'zod';
 import { ConversationRunConflictError } from '../../../../src/hosted.js';
 import {
+  ConversationRunSseReplayCursorError,
+  parseConversationRunSseReplayCursor,
+  streamConversationRunSse,
+} from '../../../../src/hosted/http-sse.js';
+import {
   HostedAgentInputError,
   HostedAgentRunNotFoundError,
   type HostedAgentService,
@@ -23,20 +27,14 @@ import {
   CancelHostedAgentRunResultSchema,
   HostedAgentApiErrorSchema,
   HostedAgentRunProtocol,
-  HostedAgentRunEventSchema,
   StartHostedAgentRunInputSchema,
   StartHostedAgentRunResultSchema,
-  type HostedAgentRunEvent,
 } from './contracts.js';
 
 const AuthenticatedAccountSchema = z.object({
   accountId: z.string().trim().min(1),
 });
 const RunIdSchema = z.string().trim().min(1);
-const ReplayCursorSchema = z.string()
-  .regex(/^(0|[1-9]\d*)$/, 'Replay cursor must be a non-negative integer.')
-  .transform(Number)
-  .refine(Number.isSafeInteger, 'Replay cursor must be a safe integer.');
 
 export type HostedAgentApiDeps = {
   agent: HostedAgentService;
@@ -77,40 +75,30 @@ export function createStartHostedAgentRunHandler(deps: HostedAgentApiDeps): Requ
 
 export function createSubscribeHostedAgentRunHandler(deps: HostedAgentApiDeps): RequestHandler {
   return async (request, response) => {
-    const subscription = new AbortController();
-    const abortSubscription = () => subscription.abort();
-    request.once('aborted', abortSubscription);
-    response.once('close', abortSubscription);
-
     try {
       const { accountId } = await authenticate(deps, request);
       const runId = RunIdSchema.parse(request.params.runId);
-      const afterSequence = parseReplayCursor(request);
-      const events = deps.agent.subscribe({
-        accountId,
-        runId,
-        afterSequence,
-        signal: subscription.signal,
+      const afterSequence = parseConversationRunSseReplayCursor({
+        query: request.query.after,
+        lastEventId: request.header('Last-Event-ID'),
       });
-
-      setSseHeaders(response);
-      for await (const event of events) {
-        await writeSseEvent(response, HostedAgentRunEventSchema.parse(event), subscription.signal);
-      }
-      endResponse(response);
+      await streamConversationRunSse({
+        request,
+        response,
+        protocol: HostedAgentRunProtocol,
+        subscribe: (signal) => deps.agent.subscribe({
+          accountId,
+          runId,
+          afterSequence,
+          signal,
+        }),
+      });
     } catch (error) {
-      if (subscription.signal.aborted) {
-        return;
-      }
       if (!response.headersSent) {
         sendRequestError(deps, response, error);
         return;
       }
       deps.onError?.(error);
-      endResponse(response);
-    } finally {
-      request.off('aborted', abortSubscription);
-      response.off('close', abortSubscription);
     }
   };
 }
@@ -131,40 +119,6 @@ export function createCancelHostedAgentRunHandler(deps: HostedAgentApiDeps): Req
 
 async function authenticate(deps: HostedAgentApiDeps, request: Request): Promise<{ accountId: string }> {
   return AuthenticatedAccountSchema.parse(await deps.authenticate(request));
-}
-
-function parseReplayCursor(request: Request): number | undefined {
-  // An explicit query cursor wins over Last-Event-ID so fetch clients can
-  // deliberately choose their checkpoint; native EventSource uses the header.
-  const value = request.query.after ?? request.header('Last-Event-ID');
-  return value === undefined ? undefined : ReplayCursorSchema.parse(value);
-}
-
-function setSseHeaders(response: Response): void {
-  response.status(200);
-  response.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
-  response.setHeader('Cache-Control', 'no-cache, no-transform');
-  response.setHeader('Connection', 'keep-alive');
-  response.setHeader('X-Accel-Buffering', 'no');
-  response.flushHeaders?.();
-}
-
-async function writeSseEvent(
-  response: Response,
-  event: HostedAgentRunEvent,
-  signal: AbortSignal,
-): Promise<void> {
-  const frame = `event: ${event.kind}\nid: ${event.sequence}\ndata: ${HostedAgentRunProtocol.stringifyEvent(event)}\n\n`;
-  if (response.write(frame)) {
-    return;
-  }
-  await once(response, 'drain', { signal });
-}
-
-function endResponse(response: Response): void {
-  if (!response.destroyed && !response.writableEnded) {
-    response.end();
-  }
 }
 
 function sendRequestError(deps: HostedAgentApiDeps, response: Response, error: unknown): void {
@@ -190,7 +144,9 @@ function toApiError(error: unknown): HostedAgentApiError {
   if (error instanceof ConversationRunConflictError) {
     return new HostedAgentApiError(409, 'run_conflict', error.message);
   }
-  if (error instanceof HostedAgentInputError || error instanceof ZodError) {
+  if (error instanceof HostedAgentInputError
+    || error instanceof ConversationRunSseReplayCursorError
+    || error instanceof ZodError) {
     return new HostedAgentApiError(400, 'invalid_request', 'Request validation failed.');
   }
   return new HostedAgentApiError(500, 'internal_error', 'The hosted agent request failed.');

--- a/examples/sdk/05-hosted-agent/03-browser-client/README.md
+++ b/examples/sdk/05-hosted-agent/03-browser-client/README.md
@@ -13,8 +13,10 @@ for the runnable reconnect/cancel flow.
 
 ## Read in this order
 
-1. [`browser-client.ts`](browser-client.ts) — URL/auth/error/SSE parsing, schema
-   validation, cursor validation, and abort propagation.
+1. [`browser-client.ts`](browser-client.ts) — host-owned public schemas and
+   protocol configured for `ConversationRunHttpSseClient`; URL, HTTP error,
+   incremental SSE parsing, identity checks, cursor validation, and abort
+   cleanup come from `@roackb2/heddle-remote/http-sse`.
 2. [`run.ts`](run.ts) — Heddle's public remote consumer composed with
    application-owned transport timers, terminal rendering, and cancel policy.
 

--- a/examples/sdk/05-hosted-agent/03-browser-client/browser-client.ts
+++ b/examples/sdk/05-hosted-agent/03-browser-client/browser-client.ts
@@ -1,172 +1,31 @@
 /**
- * Stage 05.3 browser-compatible client for the example REST/SSE contract.
+ * Stage 05.3 browser client contract for the example REST/SSE API.
  *
- * This module owns protocol mechanics only. Product messages, tool rendering,
- * reconnect UX, UI state, and terminal-result handling stay above it.
+ * Heddle owns fetch/SSE correctness. This module supplies the host's public
+ * schemas and protocol without wrapping the SDK client in another service.
  */
-import {
-  createParser,
-  type EventSourceMessage,
-} from 'eventsource-parser';
-import type { ZodType } from 'zod';
+import type { ConversationRunHttpSseClient } from '../../../../src/core/chat/remote/http-sse/index.js';
 import {
   CancelHostedAgentRunResultSchema,
-  HostedAgentApiErrorSchema,
   HostedAgentRunProtocol,
   StartHostedAgentRunResultSchema,
   type CancelHostedAgentRunResult,
-  type HostedAgentRunEvent,
+  type HostedAgentActivity,
+  type HostedAgentResult,
   type StartHostedAgentRunInput,
   type StartHostedAgentRunResult,
 } from '../02-http-sse-api/contracts.js';
 
-type Fetch = typeof globalThis.fetch;
+export const HostedAgentClientContract = {
+  protocol: HostedAgentRunProtocol,
+  accepted: StartHostedAgentRunResultSchema,
+  cancellation: CancelHostedAgentRunResultSchema,
+} as const;
 
-export type HostedAgentClientOptions = {
-  baseUrl: string;
-  getHeaders?: () => HeadersInit | Promise<HeadersInit>;
-  fetch?: Fetch;
-};
-
-export class HostedAgentClientError extends Error {
-  constructor(
-    message: string,
-    readonly status?: number,
-    readonly code?: string,
-  ) {
-    super(message);
-  }
-}
-
-export class HostedAgentClient {
-  private readonly baseUrl: string;
-  private readonly fetch: Fetch;
-
-  constructor(private readonly options: HostedAgentClientOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
-    this.fetch = options.fetch ?? globalThis.fetch;
-  }
-
-  async start(input: StartHostedAgentRunInput, signal?: AbortSignal): Promise<StartHostedAgentRunResult> {
-    return await this.request('/runs', StartHostedAgentRunResultSchema, {
-      method: 'POST',
-      body: JSON.stringify(input),
-      signal,
-    });
-  }
-
-  async subscribe(input: {
-    runId: string;
-    afterSequence?: number;
-    signal?: AbortSignal;
-    onEvent(event: HostedAgentRunEvent): void | Promise<void>;
-  }): Promise<void> {
-    if (input.afterSequence !== undefined
-      && (!Number.isSafeInteger(input.afterSequence) || input.afterSequence < 0)) {
-      throw new HostedAgentClientError('afterSequence must be a non-negative safe integer.');
-    }
-
-    const query = input.afterSequence === undefined ? '' : `?after=${input.afterSequence}`;
-    const response = await this.fetch(
-      `${this.baseUrl}/runs/${encodeURIComponent(input.runId)}/events${query}`,
-      {
-        headers: await this.headers({ Accept: 'text/event-stream' }),
-        signal: input.signal,
-      },
-    );
-    if (!response.ok || !response.body) {
-      throw await this.responseError(response);
-    }
-    if (!response.headers.get('content-type')?.startsWith('text/event-stream')) {
-      throw new HostedAgentClientError('Hosted agent event response was not an SSE stream.', response.status);
-    }
-
-    const pending: EventSourceMessage[] = [];
-    const parser = createParser({
-      onEvent: (event) => pending.push(event),
-      onError: (error) => {
-        throw error;
-      },
-    });
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    const flushPending = async () => {
-      while (pending.length > 0) {
-        input.signal?.throwIfAborted();
-        const message = pending.shift();
-        if (message) {
-          await input.onEvent(parseEvent(message));
-        }
-      }
-    };
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          parser.feed(decoder.decode());
-          parser.reset({ consume: true });
-          await flushPending();
-          return;
-        }
-        parser.feed(decoder.decode(value, { stream: true }));
-        await flushPending();
-      }
-    } finally {
-      reader.releaseLock();
-    }
-  }
-
-  async cancel(runId: string, signal?: AbortSignal): Promise<CancelHostedAgentRunResult> {
-    return await this.request(
-      `/runs/${encodeURIComponent(runId)}/cancel`,
-      CancelHostedAgentRunResultSchema,
-      { method: 'POST', signal },
-    );
-  }
-
-  private async request<Result>(path: string, schema: ZodType<Result>, init: RequestInit): Promise<Result> {
-    const headers = await this.headers(init.headers ?? {});
-    headers.set('Content-Type', 'application/json');
-    const response = await this.fetch(`${this.baseUrl}${path}`, {
-      ...init,
-      headers,
-    });
-    if (!response.ok) {
-      throw await this.responseError(response);
-    }
-    return schema.parse(await response.json());
-  }
-
-  private async headers(additions: HeadersInit): Promise<Headers> {
-    const headers = new Headers(await this.options.getHeaders?.());
-    new Headers(additions).forEach((value, name) => headers.set(name, value));
-    return headers;
-  }
-
-  private async responseError(response: Response): Promise<HostedAgentClientError> {
-    const body = await response.json().catch(() => undefined);
-    const parsed = HostedAgentApiErrorSchema.safeParse(body);
-    return parsed.success
-      ? new HostedAgentClientError(parsed.data.error.message, response.status, parsed.data.error.code)
-      : new HostedAgentClientError(`Hosted agent request failed (${response.status}).`, response.status);
-  }
-}
-
-function parseEvent(message: EventSourceMessage): HostedAgentRunEvent {
-  let body: unknown;
-  try {
-    body = JSON.parse(message.data);
-  } catch {
-    throw new HostedAgentClientError('Hosted agent event contained invalid JSON.');
-  }
-
-  const event = HostedAgentRunProtocol.parseEvent(body);
-  if (message.id !== String(event.sequence)) {
-    throw new HostedAgentClientError('Hosted agent event ID did not match its canonical sequence.');
-  }
-  if (message.event !== event.kind) {
-    throw new HostedAgentClientError('Hosted agent SSE event name did not match its payload kind.');
-  }
-  return event;
-}
+export type HostedAgentClient = ConversationRunHttpSseClient<
+  StartHostedAgentRunInput,
+  StartHostedAgentRunResult,
+  HostedAgentActivity,
+  HostedAgentResult,
+  CancelHostedAgentRunResult
+>;

--- a/examples/sdk/05-hosted-agent/03-browser-client/run.ts
+++ b/examples/sdk/05-hosted-agent/03-browser-client/run.ts
@@ -8,8 +8,12 @@
 import { setTimeout as delay } from 'node:timers/promises';
 import { ConversationRunConsumerService } from '../../../../src/core/chat/remote/index.js';
 import {
-  HostedAgentClient,
-  HostedAgentClientError,
+  ConversationRunHttpSseClient,
+  ConversationRunHttpSseClientError,
+} from '../../../../src/core/chat/remote/http-sse/index.js';
+import {
+  HostedAgentClientContract,
+  type HostedAgentClient,
 } from './browser-client.js';
 import type { HostedAgentRunEvent } from '../02-http-sse-api/contracts.js';
 
@@ -29,8 +33,9 @@ const prompt = process.argv
   || 'Read the repository README and summarize the project in three sentences.';
 const baseUrl = process.env.HEDDLE_EXAMPLE_AGENT_URL ?? 'http://127.0.0.1:8787/api/agent';
 const sessionId = process.env.HEDDLE_EXAMPLE_SESSION_ID ?? 'hosted-agent-browser-example';
-const client = new HostedAgentClient({
+const client: HostedAgentClient = new ConversationRunHttpSseClient({
   baseUrl,
+  ...HostedAgentClientContract,
   getHeaders: () => ({ Authorization: `Bearer ${bearerToken}` }),
 });
 
@@ -126,7 +131,7 @@ async function consumeUntilTerminal(
         lastError = new Error('Hosted agent event stream ended before a terminal event.');
       }
     } catch (error) {
-      if (error instanceof HostedAgentClientError
+      if (error instanceof ConversationRunHttpSseClientError
         && (error.status === undefined || error.status < 500)) {
         throw error;
       }

--- a/examples/sdk/05-hosted-agent/README.md
+++ b/examples/sdk/05-hosted-agent/README.md
@@ -28,9 +28,10 @@ imports with `@roackb2/heddle`, `@roackb2/heddle/hosted`, and the independently
 installable `@roackb2/heddle-remote` package as shown by each layer. Stage 01
 requires Heddle only; stage 02 additionally uses `express`, its TypeScript
 types, `zod`, and `@roackb2/heddle-remote`; stage 03 uses
-`@roackb2/heddle-remote`, `eventsource-parser`, and the shared Zod wire
-contracts. Declare those libraries directly in the host project instead of
-relying on transitive dependencies.
+`@roackb2/heddle-remote` and the shared Zod wire contracts. Stage 03 opts into
+`@roackb2/heddle-remote/http-sse`, which declares its SSE parser directly.
+Declare the packages each layer imports instead of relying on transitive
+dependencies.
 
 ## Choose the layers that match your stack
 
@@ -59,7 +60,7 @@ relying on transitive dependencies.
              |
              v
   03-browser-client/
-    browser-client.ts      typed fetch/SSE protocol adapter
+    browser-client.ts      host schemas for Heddle's HTTP/SSE client
     run.ts                 public consumer + transport reconnect demo
 ```
 
@@ -158,7 +159,8 @@ POST /api/agent/runs/:runId/cancel
 [`contracts.ts`](02-http-sse-api/contracts.ts) validates untrusted wire data and
 defines the public browser contract through Heddle's
 `ConversationRunProtocolCodec`. [`http-api.ts`](02-http-sse-api/http-api.ts)
-adapts HTTP operations to the transport-neutral service:
+registers host-owned Express routes and composes
+`@roackb2/heddle/hosted/http-sse` with the transport-neutral service:
 
 - start returns `202 Accepted` after Heddle assigns a stable run identity;
 - subscribe uses each canonical run sequence as the SSE `id`;
@@ -223,10 +225,11 @@ HEDDLE_EXAMPLE_BEARER_TOKEN=local-example-secret \
 
 ### What it showcases
 
-[`browser-client.ts`](03-browser-client/browser-client.ts) owns URL
-construction, authentication headers, HTTP error decoding, incremental SSE
-parsing with `eventsource-parser`, Zod validation, event-ID validation, and
-abort propagation.
+[`browser-client.ts`](03-browser-client/browser-client.ts) supplies the
+host-owned public schemas and protocol to
+`@roackb2/heddle-remote/http-sse`. The Heddle client owns URL construction,
+header composition, HTTP error decoding, incremental SSE parsing, response
+validation, event identity checks, reader cleanup, and abort propagation.
 
 [`run.ts`](03-browser-client/run.ts) is the consuming application policy. It
 uses Heddle's `ConversationRunConsumerService` for cursor advancement,

--- a/examples/sdk/README.md
+++ b/examples/sdk/README.md
@@ -29,8 +29,8 @@ platform, an identity provider, or a database.
 | A local chat that needs product capabilities | [`02-add-a-tool.ts`](02-add-a-tool.ts) or [`03-add-an-mcp-server.ts`](03-add-an-mcp-server.ts) | Tool implementation or MCP server selection |
 | A process that already owns output/rendering | [`04-custom-output.ts`](04-custom-output.ts) | Output sink and presentation policy |
 | A server, worker, Electron backend, or custom transport | [`05-hosted-agent/01-hosted-service`](05-hosted-agent/01-hosted-service) | Identity scope, durable session IDs, engine composition, and process lifetime |
-| An Express server using REST + SSE | [`05-hosted-agent/02-http-sse-api`](05-hosted-agent/02-http-sse-api) | Authentication, API policy, HTTP operations, and deployment |
-| A browser consuming that REST + SSE contract | [`05-hosted-agent/03-browser-client`](05-hosted-agent/03-browser-client) | Transport lifecycle, UI state, rendering, retry UX, and product result handling |
+| An Express server using REST + SSE | [`05-hosted-agent/02-http-sse-api`](05-hosted-agent/02-http-sse-api) | Authentication, routes/API policy, CORS/limits, and deployment |
+| A browser consuming that REST + SSE contract | [`05-hosted-agent/03-browser-client`](05-hosted-agent/03-browser-client) | Auth headers, abort/timer lifecycle, UI state, retry UX, and product result handling |
 
 If your server already uses tRPC, Fastify, Hono, Nest, WebSocket, or another
 transport, follow the hosted-service stage and write an adapter for that stack.
@@ -88,9 +88,10 @@ yarn example:sdk:hosted-agent "What does this repository do?"
 This directory contains its own numbered path:
 
 1. `01-hosted-service` — transport-neutral account/session/run lifecycle.
-2. `02-http-sse-api` — optional Express + REST/SSE adapter.
-3. `03-browser-client` — optional framework-neutral browser protocol client
-   composed with Heddle's public remote-run consumer.
+2. `02-http-sse-api` — optional Express routes composed with Heddle's Node
+   HTTP/SSE streaming helper.
+3. `03-browser-client` — optional browser-safe HTTP/SSE preset composed with
+   Heddle's transport-neutral remote-run consumer.
 
 Read the [hosted-agent walkthrough](05-hosted-agent/README.md) before copying
 this stage. Each later folder depends only on the earlier layer it extends, so

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/src/hosted.d.ts",
       "import": "./dist/src/hosted.js"
     },
+    "./hosted/http-sse": {
+      "types": "./dist/src/hosted/http-sse.d.ts",
+      "import": "./dist/src/hosted/http-sse.js"
+    },
     "./advanced": {
       "types": "./dist/src/advanced.d.ts",
       "import": "./dist/src/advanced.js"

--- a/packages/heddle-remote/README.md
+++ b/packages/heddle-remote/README.md
@@ -26,16 +26,34 @@ const consumer = new ConversationRunConsumerService({
 })
 ```
 
+If the host uses the conventional REST/SSE run resource, opt into the transport
+preset instead of rebuilding fetch and SSE correctness:
+
+```ts
+import { ConversationRunHttpSseClient } from '@roackb2/heddle-remote/http-sse'
+
+const client = new ConversationRunHttpSseClient({
+  baseUrl: '/api/agent',
+  protocol,
+  accepted: StartRunResultSchema,
+  cancellation: CancelRunResultSchema,
+  getHeaders: () => ({ Authorization: `Bearer ${accessToken}` }),
+})
+```
+
 ## Responsibility boundary
 
-This package owns the canonical run envelope, runtime wire validation,
+The root entrypoint owns the canonical run envelope, runtime wire validation,
 JSON-safety, accepted-sequence cursor, duplicate and gap handling, terminal
-detection, and bounded retry calculation.
+detection, and bounded retry calculation. The optional `/http-sse` entrypoint
+adds conventional run resource paths, fetch lifecycle, response validation,
+incremental SSE parsing, and event identity checks.
 
-It does not own HTTP, SSE, tRPC, WebSocket, React, timers, authentication,
-authorization, public-field policy, product messages, or UI state. Hosts must
-supply synchronous Standard Schema validators whose output contains only the
-activity and result fields authorized for remote clients.
+It does not own tRPC, WebSocket, React, timers, authentication, authorization,
+public-field policy, product messages, or UI state. The HTTP/SSE preset also
+does not own retry timing or cursor persistence. Hosts must supply Standard
+Schema validators whose output contains only the activity and result fields
+authorized for remote clients.
 
 The Node host normally combines `@roackb2/heddle` with
 `@roackb2/heddle/hosted`. The browser or other remote consumer installs this

--- a/packages/heddle-remote/package.json
+++ b/packages/heddle-remote/package.json
@@ -25,6 +25,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./http-sse": {
+      "types": "./dist/http-sse/index.d.ts",
+      "import": "./dist/http-sse/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -43,6 +47,7 @@
   ],
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
+    "eventsource-parser": "^3.1.0",
     "zod": "^4.3.6"
   }
 }

--- a/scripts/verify-remote-package.mjs
+++ b/scripts/verify-remote-package.mjs
@@ -15,6 +15,7 @@ assert.deepEqual(
   remotePackage.dependencies,
   {
     '@standard-schema/spec': rootPackage.dependencies['@standard-schema/spec'],
+    'eventsource-parser': rootPackage.devDependencies['eventsource-parser'],
     zod: rootPackage.dependencies.zod,
   },
   '@roackb2/heddle-remote must keep its explicit browser-safe dependency boundary.',

--- a/src/__tests__/integration/sdk/hosted-agent-stack.test.ts
+++ b/src/__tests__/integration/sdk/hosted-agent-stack.test.ts
@@ -14,8 +14,10 @@ import {
   HostedAgentService,
 } from '../../../../examples/sdk/05-hosted-agent/01-hosted-service/agent-service.js';
 import {
-  HostedAgentClient,
+  HostedAgentClientContract,
+  type HostedAgentClient,
 } from '../../../../examples/sdk/05-hosted-agent/03-browser-client/browser-client.js';
+import { ConversationRunHttpSseClient } from '../../../core/chat/remote/http-sse/index.js';
 import type {
   HostedAgentRunEvent,
 } from '../../../../examples/sdk/05-hosted-agent/02-http-sse-api/contracts.js';
@@ -313,8 +315,9 @@ async function startApi(agent: HostedAgentService): Promise<{
 }
 
 function createClient(baseUrl: string, token: string): HostedAgentClient {
-  return new HostedAgentClient({
+  return new ConversationRunHttpSseClient({
     baseUrl,
+    ...HostedAgentClientContract,
     getHeaders: () => ({ Authorization: `Bearer ${token}` }),
   });
 }

--- a/src/__tests__/integration/sdk/public-hosting-entrypoints.test.ts
+++ b/src/__tests__/integration/sdk/public-hosting-entrypoints.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { ConversationRunService as CuratedConversationRunService } from '../../../index.js';
 import { ConversationRunService as HostedConversationRunService } from '../../../hosted.js';
+import { streamConversationRunSse } from '../../../hosted/http-sse.js';
 
 describe('public hosting entrypoints', () => {
   it('exposes the existing run coordinator through the explicit hosted subpath', () => {
     expect(HostedConversationRunService).toBe(CuratedConversationRunService);
+    expect(streamConversationRunSse).toBeTypeOf('function');
   });
 });

--- a/src/__tests__/integration/sdk/remote-package-boundary.test.ts
+++ b/src/__tests__/integration/sdk/remote-package-boundary.test.ts
@@ -13,7 +13,16 @@ describe('@roackb2/heddle-remote package boundary', () => {
   it('installs only its browser-safe protocol dependencies', () => {
     expect(remotePackage.dependencies).toEqual({
       '@standard-schema/spec': rootPackage.dependencies['@standard-schema/spec'],
+      'eventsource-parser': rootPackage.devDependencies['eventsource-parser'],
       zod: rootPackage.dependencies.zod,
+    });
+    expect(remotePackage.exports['./http-sse']).toEqual({
+      types: './dist/http-sse/index.d.ts',
+      import: './dist/http-sse/index.js',
+    });
+    expect(rootPackage.exports['./hosted/http-sse']).toEqual({
+      types: './dist/src/hosted/http-sse.d.ts',
+      import: './dist/src/hosted/http-sse.js',
     });
   });
 });

--- a/src/__tests__/unit/core/conversation-run-http-sse-client.test.ts
+++ b/src/__tests__/unit/core/conversation-run-http-sse-client.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  ConversationRunHttpSseClient,
+  ConversationRunHttpSseClientError,
+} from '@/core/chat/remote/http-sse/index.js';
+import { ConversationRunProtocolCodec } from '@/core/chat/remote/index.js';
+
+const protocol = new ConversationRunProtocolCodec({
+  activity: z.object({ type: z.string() }),
+  result: z.object({ summary: z.string() }),
+});
+const accepted = z.object({ runId: z.string(), accepted: z.literal(true) });
+const cancellation = z.object({ cancelled: z.boolean() });
+
+describe('ConversationRunHttpSseClient', () => {
+  it('validates start/cancel responses and composes host headers', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(jsonResponse({ runId: 'run-1', accepted: true }, 202))
+      .mockResolvedValueOnce(jsonResponse({ cancelled: true }));
+    const client = createClient(fetch);
+
+    await expect(client.start({ prompt: 'Hello' })).resolves.toEqual({
+      runId: 'run-1',
+      accepted: true,
+    });
+    await expect(client.cancel('run-1')).resolves.toEqual({ cancelled: true });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, 'https://example.test/api/agent/runs', expect.objectContaining({
+      method: 'POST',
+      body: '{"prompt":"Hello"}',
+      headers: expect.any(Headers),
+    }));
+    const startHeaders = new Headers(fetch.mock.calls[0]?.[1]?.headers);
+    expect(startHeaders.get('authorization')).toBe('Bearer test-token');
+    expect(startHeaders.get('content-type')).toBe('application/json');
+  });
+
+  it('parses fragmented SSE and verifies the canonical run identity', async () => {
+    const event = {
+      kind: 'activity' as const,
+      runId: 'run/with space',
+      sequence: 3,
+      timestamp: '2026-07-12T00:00:00.000Z',
+      activity: { type: 'assistant.stream' },
+    };
+    const frame = `event: activity\nid: 3\ndata: ${protocol.stringifyEvent(event)}\n\n`;
+    const midpoint = Math.floor(frame.length / 2);
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(sseResponse([
+      frame.slice(0, midpoint),
+      frame.slice(midpoint),
+    ]));
+    const client = createClient(fetch);
+    const received: unknown[] = [];
+
+    await client.subscribe({
+      runId: 'run/with space',
+      afterSequence: 2,
+      onEvent: async (item) => {
+        await Promise.resolve();
+        received.push(item);
+      },
+    });
+
+    expect(received).toEqual([event]);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.test/api/agent/runs/run%2Fwith%20space/events?after=2',
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    const headers = new Headers(fetch.mock.calls[0]?.[1]?.headers);
+    expect(headers.get('accept')).toBe('text/event-stream');
+  });
+
+  it('rejects mismatched payload identity instead of accepting another run', async () => {
+    const event = {
+      kind: 'result' as const,
+      runId: 'another-run',
+      sequence: 1,
+      timestamp: '2026-07-12T00:00:00.000Z',
+      result: { summary: 'Done' },
+    };
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(sseResponse([
+      `event: result\nid: 1\ndata: ${protocol.stringifyEvent(event)}\n\n`,
+    ]));
+    const client = createClient(fetch);
+
+    await expect(client.subscribe({
+      runId: 'expected-run',
+      onEvent: () => undefined,
+    })).rejects.toThrow('event belonged to a different run');
+  });
+
+  it('cancels the response reader when application event handling fails', async () => {
+    const cancel = vi.fn();
+    const event = {
+      kind: 'activity' as const,
+      runId: 'run-1',
+      sequence: 1,
+      timestamp: '2026-07-12T00:00:00.000Z',
+      activity: { type: 'assistant.stream' },
+    };
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(
+          `event: activity\nid: 1\ndata: ${protocol.stringifyEvent(event)}\n\n`,
+        ));
+      },
+      cancel,
+    });
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(stream, {
+      headers: { 'Content-Type': 'text/event-stream' },
+    }));
+    const client = createClient(fetch);
+
+    await expect(client.subscribe({
+      runId: 'run-1',
+      onEvent: () => {
+        throw new Error('render failed');
+      },
+    })).rejects.toThrow('render failed');
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes the shared public HTTP error shape', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(jsonResponse({
+      error: { code: 'run_conflict', message: 'A run is active.' },
+    }, 409));
+    const client = createClient(fetch);
+
+    await expect(client.start({ prompt: 'Hello' })).rejects.toEqual(expect.objectContaining({
+      name: 'ConversationRunHttpSseClientError',
+      status: 409,
+      code: 'run_conflict',
+      message: 'A run is active.',
+    }));
+  });
+
+  it('reports invalid successful JSON as a typed transport error', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response('not-json', {
+      status: 202,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    const client = createClient(fetch);
+
+    await expect(client.start({ prompt: 'Hello' })).rejects.toEqual(expect.objectContaining({
+      name: 'ConversationRunHttpSseClientError',
+      status: 202,
+      message: 'Conversation run response contained invalid JSON.',
+    }));
+  });
+
+  it('rejects invalid cursors before making a request', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>();
+    const client = createClient(fetch);
+
+    await expect(client.subscribe({
+      runId: 'run-1',
+      afterSequence: -1,
+      onEvent: () => undefined,
+    })).rejects.toBeInstanceOf(ConversationRunHttpSseClientError);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function createClient(fetch: typeof globalThis.fetch) {
+  return new ConversationRunHttpSseClient<
+    { prompt: string },
+    z.infer<typeof accepted>,
+    { type: string },
+    { summary: string },
+    z.infer<typeof cancellation>
+  >({
+    baseUrl: 'https://example.test/api/agent/',
+    protocol,
+    accepted,
+    cancellation,
+    getHeaders: () => ({ Authorization: 'Bearer test-token' }),
+    fetch,
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function sseResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(encoder.encode(chunk)));
+      controller.close();
+    },
+  }), {
+    headers: { 'Content-Type': 'text/event-stream; charset=utf-8' },
+  });
+}

--- a/src/__tests__/unit/core/conversation-run-http-sse-server.test.ts
+++ b/src/__tests__/unit/core/conversation-run-http-sse-server.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ConversationRunSseReplayCursorError,
+  parseConversationRunSseReplayCursor,
+} from '@/core/chat/runs/http-sse/index.js';
+
+describe('conversation run HTTP/SSE server helpers', () => {
+  it('uses an explicit query cursor before Last-Event-ID', () => {
+    expect(parseConversationRunSseReplayCursor({
+      query: '0',
+      lastEventId: '12',
+    })).toBe(0);
+    expect(parseConversationRunSseReplayCursor({ lastEventId: '12' })).toBe(12);
+    expect(parseConversationRunSseReplayCursor({})).toBeUndefined();
+  });
+
+  it.each(['', '-1', '01', '1.5', '9007199254740992', ['1']])(
+    'rejects malformed replay cursor %j',
+    (value) => {
+      expect(() => parseConversationRunSseReplayCursor({ query: value }))
+        .toThrow(ConversationRunSseReplayCursorError);
+    },
+  );
+});

--- a/src/core/chat/remote/http-sse/README.md
+++ b/src/core/chat/remote/http-sse/README.md
@@ -1,0 +1,26 @@
+# Remote HTTP/SSE Client
+
+`src/core/chat/remote/http-sse` is the browser-safe REST/SSE preset above the
+transport-neutral remote run protocol.
+
+## Owns
+
+- the conventional `/runs` start, event, and cancel resource paths;
+- injected authentication headers and `fetch`;
+- accepted/cancel response validation through host-supplied Standard Schemas;
+- incremental SSE parsing and reader cleanup;
+- content-type, run ID, SSE event name, and SSE ID verification;
+- normalized HTTP errors for the shared `{ error: { code, message } }` shape.
+
+## Does not own
+
+- authentication or authorization policy;
+- product request, activity, and result schemas;
+- retry timing, cursor persistence, or duplicate/gap handling, which remain in
+  `ConversationRunConsumerService`;
+- messages, tool rendering, optimistic state, React, or another UI framework;
+- a server implementation or deployment policy.
+
+Import this opt-in assumption layer from `@roackb2/heddle-remote/http-sse`.
+Use the root `@roackb2/heddle-remote` entrypoint when the host owns another
+transport such as tRPC, WebSocket, or a native bridge.

--- a/src/core/chat/remote/http-sse/client.ts
+++ b/src/core/chat/remote/http-sse/client.ts
@@ -1,0 +1,280 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import {
+  createParser,
+  type EventSourceMessage,
+} from 'eventsource-parser';
+import { z } from 'zod';
+import {
+  ConversationRunReplayCursorSchema,
+} from '../protocol-codec.js';
+import type {
+  ConversationRunProtocolEvent,
+  ConversationRunReference,
+} from '../types.js';
+import type {
+  ConversationRunHttpErrorPayload,
+  ConversationRunHttpSseClientOptions,
+  SubscribeConversationRunHttpSseInput,
+} from './types.js';
+
+const ConversationRunHttpErrorPayloadSchema = z.object({
+  error: z.object({
+    code: z.string().trim().min(1),
+    message: z.string(),
+  }),
+});
+
+/** A REST/SSE request failed or returned a malformed transport envelope. */
+export class ConversationRunHttpSseClientError extends Error {
+  readonly name = 'ConversationRunHttpSseClientError';
+
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly code?: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+  }
+}
+
+/**
+ * Browser-safe client for Heddle's conventional REST/SSE run resource.
+ *
+ * This preset assumes POST `/runs`, GET `/runs/:runId/events`, and POST
+ * `/runs/:runId/cancel`. Authentication headers and public payload schemas
+ * remain host-owned.
+ */
+export class ConversationRunHttpSseClient<
+  StartInput,
+  Accepted extends ConversationRunReference,
+  Activity,
+  Result,
+  Cancellation,
+> {
+  private readonly baseUrl: string;
+  private readonly fetch: typeof globalThis.fetch;
+
+  constructor(private readonly options: ConversationRunHttpSseClientOptions<
+    Accepted,
+    Activity,
+    Result,
+    Cancellation
+  >) {
+    this.baseUrl = options.baseUrl.trim().replace(/\/+$/, '');
+    if (!this.baseUrl) {
+      throw new ConversationRunHttpSseClientError('Conversation run baseUrl cannot be empty.');
+    }
+    if (!options.fetch && typeof globalThis.fetch !== 'function') {
+      throw new ConversationRunHttpSseClientError('Conversation run HTTP client requires fetch.');
+    }
+    this.fetch = options.fetch ?? globalThis.fetch;
+  }
+
+  async start(input: StartInput, signal?: AbortSignal): Promise<Accepted> {
+    return await this.request('/runs', this.options.accepted, {
+      method: 'POST',
+      body: JSON.stringify(input),
+      signal,
+    });
+  }
+
+  async subscribe(input: SubscribeConversationRunHttpSseInput<Activity, Result>): Promise<void> {
+    const runId = input.runId.trim();
+    if (!runId) {
+      throw new ConversationRunHttpSseClientError('Conversation run ID cannot be empty.');
+    }
+    if (input.afterSequence !== undefined) {
+      const cursor = ConversationRunReplayCursorSchema.safeParse(input.afterSequence);
+      if (!cursor.success) {
+        throw new ConversationRunHttpSseClientError('afterSequence must be a non-negative safe integer.');
+      }
+    }
+
+    const query = input.afterSequence === undefined ? '' : `?after=${input.afterSequence}`;
+    const response = await this.fetch(
+      `${this.baseUrl}/runs/${encodeURIComponent(runId)}/events${query}`,
+      {
+        headers: await this.headers({ Accept: 'text/event-stream' }),
+        signal: input.signal,
+      },
+    );
+    if (!response.ok) {
+      throw await this.responseError(response);
+    }
+    if (!response.body) {
+      throw new ConversationRunHttpSseClientError(
+        'Conversation run event response did not include a readable body.',
+        response.status,
+      );
+    }
+    const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
+    if (contentType !== 'text/event-stream') {
+      throw new ConversationRunHttpSseClientError(
+        'Conversation run event response was not an SSE stream.',
+        response.status,
+      );
+    }
+
+    await this.consumeEventStream(response.body, runId, input);
+  }
+
+  async cancel(runId: string, signal?: AbortSignal): Promise<Cancellation> {
+    const normalizedRunId = runId.trim();
+    if (!normalizedRunId) {
+      throw new ConversationRunHttpSseClientError('Conversation run ID cannot be empty.');
+    }
+    return await this.request(
+      `/runs/${encodeURIComponent(normalizedRunId)}/cancel`,
+      this.options.cancellation,
+      { method: 'POST', signal },
+    );
+  }
+
+  private async consumeEventStream(
+    body: ReadableStream<Uint8Array>,
+    runId: string,
+    input: SubscribeConversationRunHttpSseInput<Activity, Result>,
+  ): Promise<void> {
+    const pending: EventSourceMessage[] = [];
+    const parser = createParser({
+      onEvent: (event) => pending.push(event),
+      onError: (error) => {
+        throw new ConversationRunHttpSseClientError('Conversation run SSE framing was invalid.', undefined, undefined, {
+          cause: error,
+        });
+      },
+    });
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let completed = false;
+    const flushPending = async () => {
+      while (pending.length > 0) {
+        input.signal?.throwIfAborted();
+        const message = pending.shift();
+        if (message) {
+          await input.onEvent(this.parseEvent(message, runId));
+        }
+      }
+    };
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          parser.feed(decoder.decode());
+          parser.reset({ consume: true });
+          await flushPending();
+          completed = true;
+          return;
+        }
+        parser.feed(decoder.decode(value, { stream: true }));
+        await flushPending();
+      }
+    } finally {
+      if (!completed) {
+        await reader.cancel().catch(() => undefined);
+      }
+      reader.releaseLock();
+    }
+  }
+
+  private parseEvent(
+    message: EventSourceMessage,
+    expectedRunId: string,
+  ): ConversationRunProtocolEvent<Activity, Result> {
+    let body: unknown;
+    try {
+      body = JSON.parse(message.data);
+    } catch (error) {
+      throw new ConversationRunHttpSseClientError('Conversation run event contained invalid JSON.', undefined, undefined, {
+        cause: error,
+      });
+    }
+
+    const event = this.options.protocol.parseEvent(body);
+    if (event.runId !== expectedRunId) {
+      throw new ConversationRunHttpSseClientError('Conversation run event belonged to a different run.');
+    }
+    if (message.id !== String(event.sequence)) {
+      throw new ConversationRunHttpSseClientError('Conversation run event ID did not match its canonical sequence.');
+    }
+    if (message.event !== event.kind) {
+      throw new ConversationRunHttpSseClientError('Conversation run SSE event name did not match its payload kind.');
+    }
+    return event;
+  }
+
+  private async request<Output>(
+    path: string,
+    schema: StandardSchemaV1<unknown, Output>,
+    init: RequestInit,
+  ): Promise<Output> {
+    const headers = await this.headers(init.headers ?? {});
+    if (init.body !== undefined) {
+      headers.set('Content-Type', 'application/json');
+    }
+    const response = await this.fetch(`${this.baseUrl}${path}`, {
+      ...init,
+      headers,
+    });
+    if (!response.ok) {
+      throw await this.responseError(response);
+    }
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (error) {
+      throw new ConversationRunHttpSseClientError(
+        'Conversation run response contained invalid JSON.',
+        response.status,
+        undefined,
+        { cause: error },
+      );
+    }
+    return await parseResponse(schema, body, response.status);
+  }
+
+  private async headers(additions: HeadersInit): Promise<Headers> {
+    const headers = new Headers(await this.options.getHeaders?.());
+    new Headers(additions).forEach((value, name) => headers.set(name, value));
+    return headers;
+  }
+
+  private async responseError(response: Response): Promise<ConversationRunHttpSseClientError> {
+    const body = await response.json().catch(() => undefined);
+    const parsed = ConversationRunHttpErrorPayloadSchema.safeParse(body);
+    return parsed.success
+      ? errorFromPayload(response.status, parsed.data)
+      : new ConversationRunHttpSseClientError(
+        `Conversation run request failed (${response.status}).`,
+        response.status,
+      );
+  }
+}
+
+async function parseResponse<Output>(
+  schema: StandardSchemaV1<unknown, Output>,
+  input: unknown,
+  status: number,
+): Promise<Output> {
+  const result = await schema['~standard'].validate(input);
+  if (result.issues) {
+    throw new ConversationRunHttpSseClientError(
+      `Conversation run response validation failed: ${result.issues.map(({ message }) => message).join('; ')}`,
+      status,
+    );
+  }
+  return result.value;
+}
+
+function errorFromPayload(
+  status: number,
+  payload: ConversationRunHttpErrorPayload,
+): ConversationRunHttpSseClientError {
+  return new ConversationRunHttpSseClientError(
+    payload.error.message,
+    status,
+    payload.error.code,
+  );
+}

--- a/src/core/chat/remote/http-sse/index.ts
+++ b/src/core/chat/remote/http-sse/index.ts
@@ -1,0 +1,9 @@
+export {
+  ConversationRunHttpSseClient,
+  ConversationRunHttpSseClientError,
+} from './client.js';
+export type {
+  ConversationRunHttpErrorPayload,
+  ConversationRunHttpSseClientOptions,
+  SubscribeConversationRunHttpSseInput,
+} from './types.js';

--- a/src/core/chat/remote/http-sse/types.ts
+++ b/src/core/chat/remote/http-sse/types.ts
@@ -1,0 +1,35 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type { ConversationRunProtocolCodec } from '../protocol-codec.js';
+import type {
+  ConversationRunProtocolEvent,
+  ConversationRunReference,
+} from '../types.js';
+
+export type ConversationRunHttpSseClientOptions<
+  Accepted extends ConversationRunReference,
+  Activity,
+  Result,
+  Cancellation,
+> = {
+  /** Base URL whose REST resource is `/runs`. Relative browser URLs are valid. */
+  baseUrl: string;
+  protocol: ConversationRunProtocolCodec<Activity, Result>;
+  accepted: StandardSchemaV1<unknown, Accepted>;
+  cancellation: StandardSchemaV1<unknown, Cancellation>;
+  getHeaders?: () => HeadersInit | Promise<HeadersInit>;
+  fetch?: typeof globalThis.fetch;
+};
+
+export type SubscribeConversationRunHttpSseInput<Activity, Result> = {
+  runId: string;
+  afterSequence?: number;
+  signal?: AbortSignal;
+  onEvent(event: ConversationRunProtocolEvent<Activity, Result>): void | Promise<void>;
+};
+
+export type ConversationRunHttpErrorPayload = {
+  error: {
+    code: string;
+    message: string;
+  };
+};

--- a/src/core/chat/runs/http-sse/README.md
+++ b/src/core/chat/runs/http-sse/README.md
@@ -1,0 +1,24 @@
+# Hosted HTTP/SSE Transport
+
+`src/core/chat/runs/http-sse` is the opt-in Node HTTP/SSE assumption layer for
+hosted conversation runs.
+
+## Owns
+
+- strict replay cursor parsing with query-over-header precedence;
+- Node HTTP SSE headers and canonical `event`, `id`, and JSON `data` frames;
+- response backpressure;
+- request-abort and response-close subscription cleanup;
+- ending an opened stream on completion or failure.
+
+## Does not own
+
+- route registration or a server framework;
+- authentication, authorization, CORS, payload limits, rate limits, or public
+  error policy;
+- run lookup, replay, cancellation, or result projection;
+- cross-process event delivery or durable replay.
+
+The helper accepts Node `IncomingMessage` and `ServerResponse`, so Express,
+Fastify, Nest, and other Node server adapters can use it without making Heddle
+depend on those frameworks. Import it from `@roackb2/heddle/hosted/http-sse`.

--- a/src/core/chat/runs/http-sse/index.ts
+++ b/src/core/chat/runs/http-sse/index.ts
@@ -1,0 +1,11 @@
+export {
+  ConversationRunSseReplayCursorError,
+  parseConversationRunSseReplayCursor,
+  streamConversationRunSse,
+} from './server.js';
+export type {
+  ConversationRunSseEvent,
+  ConversationRunSseProtocol,
+  ParseConversationRunSseReplayCursorInput,
+  StreamConversationRunSseOptions,
+} from './types.js';

--- a/src/core/chat/runs/http-sse/server.ts
+++ b/src/core/chat/runs/http-sse/server.ts
@@ -1,0 +1,103 @@
+import { once } from 'node:events';
+import type { ServerResponse } from 'node:http';
+import type {
+  ConversationRunSseEvent,
+  ParseConversationRunSseReplayCursorInput,
+  StreamConversationRunSseOptions,
+} from './types.js';
+
+const ReplayCursorPattern = /^(0|[1-9]\d*)$/;
+
+/** An explicit query or Last-Event-ID replay cursor is malformed. */
+export class ConversationRunSseReplayCursorError extends Error {
+  readonly name = 'ConversationRunSseReplayCursorError';
+
+  constructor(readonly value: unknown) {
+    super('Conversation run replay cursor must be a non-negative safe integer.');
+  }
+}
+
+/**
+ * Parses the conventional SSE replay cursor. An explicit query value takes
+ * precedence over Last-Event-ID so fetch clients can choose their checkpoint.
+ */
+export function parseConversationRunSseReplayCursor(
+  input: ParseConversationRunSseReplayCursorInput,
+): number | undefined {
+  const value = input.query !== undefined ? input.query : input.lastEventId;
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string' || !ReplayCursorPattern.test(value)) {
+    throw new ConversationRunSseReplayCursorError(value);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new ConversationRunSseReplayCursorError(value);
+  }
+  return parsed;
+}
+
+/**
+ * Streams one canonical conversation run over Node HTTP SSE.
+ *
+ * Request abort and response close stop only this subscription. The run keeps
+ * executing until its run handle is explicitly cancelled. A subscribe failure
+ * happens before headers so the host can still send its own JSON error policy.
+ */
+export async function streamConversationRunSse<Event extends ConversationRunSseEvent>(
+  options: StreamConversationRunSseOptions<Event>,
+): Promise<void> {
+  const connection = new AbortController();
+  const abortConnection = () => connection.abort();
+  options.request.once('aborted', abortConnection);
+  options.response.once('close', abortConnection);
+  const signal = options.signal
+    ? AbortSignal.any([connection.signal, options.signal])
+    : connection.signal;
+
+  try {
+    const events = options.subscribe(signal);
+    setSseHeaders(options.response);
+    for await (const event of events) {
+      await writeSseEvent(options.response, options.protocol, event, signal);
+    }
+  } catch (error) {
+    if (!signal.aborted) {
+      throw error;
+    }
+  } finally {
+    options.request.off('aborted', abortConnection);
+    options.response.off('close', abortConnection);
+    if (options.response.headersSent) {
+      endResponse(options.response);
+    }
+  }
+}
+
+function setSseHeaders(response: ServerResponse): void {
+  response.statusCode = 200;
+  response.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+  response.setHeader('Cache-Control', 'no-cache, no-transform');
+  response.setHeader('Connection', 'keep-alive');
+  response.setHeader('X-Accel-Buffering', 'no');
+  response.flushHeaders();
+}
+
+async function writeSseEvent<Event extends ConversationRunSseEvent>(
+  response: ServerResponse,
+  protocol: StreamConversationRunSseOptions<Event>['protocol'],
+  event: Event,
+  signal: AbortSignal,
+): Promise<void> {
+  const frame = `event: ${event.kind}\nid: ${event.sequence}\ndata: ${protocol.stringifyEvent(event)}\n\n`;
+  if (!response.write(frame)) {
+    await once(response, 'drain', { signal });
+  }
+}
+
+function endResponse(response: ServerResponse): void {
+  if (!response.destroyed && !response.writableEnded) {
+    response.end();
+  }
+}

--- a/src/core/chat/runs/http-sse/types.ts
+++ b/src/core/chat/runs/http-sse/types.ts
@@ -1,0 +1,24 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+export type ConversationRunSseEvent = {
+  kind: string;
+  sequence: number;
+};
+
+export type ConversationRunSseProtocol = {
+  stringifyEvent(input: unknown): string;
+};
+
+export type StreamConversationRunSseOptions<Event extends ConversationRunSseEvent> = {
+  request: IncomingMessage;
+  response: ServerResponse;
+  protocol: ConversationRunSseProtocol;
+  subscribe(signal: AbortSignal): AsyncIterable<Event>;
+  signal?: AbortSignal;
+};
+
+export type ParseConversationRunSseReplayCursorInput = {
+  /** Explicit query value. When present, it wins over Last-Event-ID. */
+  query?: unknown;
+  lastEventId?: unknown;
+};

--- a/src/hosted/http-sse.ts
+++ b/src/hosted/http-sse.ts
@@ -1,0 +1,13 @@
+// Opt-in Node HTTP/SSE hosting assumption. Framework, auth, and product policy
+// remain outside Heddle.
+export {
+  ConversationRunSseReplayCursorError,
+  parseConversationRunSseReplayCursor,
+  streamConversationRunSse,
+} from '../core/chat/runs/http-sse/index.js';
+export type {
+  ConversationRunSseEvent,
+  ConversationRunSseProtocol,
+  ParseConversationRunSseReplayCursorInput,
+  StreamConversationRunSseOptions,
+} from '../core/chat/runs/http-sse/index.js';


### PR DESCRIPTION
## Summary

- add `@roackb2/heddle/hosted/http-sse` for strict replay cursors, canonical SSE frames, backpressure, and subscriber-only disconnect cleanup on Node HTTP
- add `@roackb2/heddle-remote/http-sse` for browser-safe REST/fetch lifecycle, accepted/cancel validation, incremental SSE parsing, reader cleanup, and event identity checks
- keep auth, authorization, public schemas, route registration, retry timers, cursor persistence, UI state, CORS, and limits host-owned
- refactor the hosted example to remove its duplicated Node SSE writer and ~180-line browser transport client
- document the opt-in import paths and assumption boundaries for coding agents

## API shape

```ts
import {
  parseConversationRunSseReplayCursor,
  streamConversationRunSse,
} from '@roackb2/heddle/hosted/http-sse'

import {
  ConversationRunHttpSseClient,
} from '@roackb2/heddle-remote/http-sse'
```

The preset intentionally standardizes only the conventional `POST /runs`, `GET /runs/:runId/events`, and `POST /runs/:runId/cancel` resource. tRPC, WebSocket, IPC, and other transports continue to use the neutral base layer.

## Verification

- `yarn test:unit` — 660 passed
- `yarn test:integration` — 291 passed, including the real HTTP hosted-stack flow
- `yarn remote:build`
- `yarn build`
- focused lint/typecheck
- `npm pack ./packages/heddle-remote --dry-run` — `/http-sse` declarations and runtime files included

PR #239 is merged; this branch is rebased onto the resulting `main`.