### PR TITLE
chore: prepare Heddle v4.4.0

### DIFF
--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -275,6 +275,9 @@ Current example release note drafts:
 - [`v3.1.0.md`](./v3.1.0.md)
 - [`v4.0.0.md`](./v4.0.0.md)
 - [`v4.1.0.md`](./v4.1.0.md)
+- [`v4.2.0.md`](./v4.2.0.md)
+- [`v4.3.0.md`](./v4.3.0.md)
+- [`v4.4.0.md`](./v4.4.0.md)
 
 ## Agent Rule
 

--- a/docs/releases/v4.4.0.md
+++ b/docs/releases/v4.4.0.md
@@ -1,0 +1,96 @@
+# Heddle v4.4.0
+
+Heddle v4.4.0 turns the reconnectable run foundation from v4.3 into a more
+complete hosted-product toolkit. It adds mature run finalization hooks,
+browser and Node HTTP/SSE presets, and a rendered React reference that shows
+how those layers compose without making React or a specific server mandatory.
+
+This release is additive for existing SDK and CLI users. Hosts can adopt the
+new layers independently: keep the transport-neutral run service, add the
+standard HTTP/SSE preset, or follow the full reference while retaining their
+own authentication, persistence, product identity, and UI policy.
+
+## Mature hosted run finalization
+
+- **Typed lifecycle failures replace message matching.** Conflict,
+  retained-run lookup, and replay-expiry errors are public types, so hosts can
+  map stable product behavior without depending on internal error text.
+- **Retained run handles remove duplicate host registries.** A host can recover
+  an authorized run by ID while keeping its own address and user checks.
+- **Async result projection publishes only durable terminal results.** Hosts
+  can finalize artifacts or product records before the canonical result event
+  becomes visible.
+- **Public error projection keeps failures safe.** A host can translate an
+  internal provider or persistence failure into a stable public code/message;
+  invalid projectors fall back to a generic error.
+- **Error and settled hooks preserve application ownership.** Product history,
+  observability, and cleanup can compose around one Heddle run lifecycle
+  without building a parallel coordinator.
+
+## Standard HTTP/SSE presets
+
+- **Browser clients can import
+  `@roackb2/heddle-remote/http-sse`.** The client owns start, subscribe,
+  cancel, incremental SSE parsing, content-type and canonical ID/event checks,
+  schema validation, typed HTTP errors, injected headers, and abort cleanup.
+- **Node hosts can import `@roackb2/heddle/hosted/http-sse`.** The helpers own
+  replay-cursor parsing, SSE headers and framing, backpressure, request-close
+  cancellation, subscriber cleanup, and terminal stream closure.
+- **The default resource shape is intentionally conventional.** It assumes
+  `POST /runs`, `GET /runs/:runId/events`, and
+  `POST /runs/:runId/cancel`; authentication, authorization, CORS, limits,
+  product sessions, and deployment remain host policy.
+- **Remote consumers can resume at a validated stored cursor.** A reconstructed
+  consumer starts after the greatest rendered sequence without replaying
+  already committed UI work.
+
+## Complete hosted-agent reference
+
+- **The numbered guide now ends in a runnable React/Vite application.** Stage
+  04 builds on the transport-neutral service, Express API, and browser client
+  instead of creating a second starter architecture.
+- **The UI demonstrates a real conversational lifecycle.** It includes a
+  stable product conversation ID, visible messages and activities, submit,
+  stop, a second turn, refresh recovery, active-run reattachment, replay
+  fallback, and explicit reset.
+- **Run and render checkpoints are separate.** The reference persists both the
+  last accepted transport sequence and the last rendered terminal sequence so
+  refresh cannot duplicate or skip visible results.
+- **Responsibility boundaries stay explicit.** Heddle owns execution and run
+  correctness; the transport preset owns HTTP/SSE mechanics; the host owns
+  auth, durable product history, storage choice, and presentation.
+
+## Upgrade notes
+
+- Existing `@roackb2/heddle`, `@roackb2/heddle/hosted`, and
+  `@roackb2/heddle-remote` imports remain valid.
+- Install `@roackb2/heddle-remote@4.4.0` for browser HTTP/SSE clients and import
+  its `/http-sse` subpath.
+- Server hosts using the Node preset should install
+  `@roackb2/heddle@4.4.0` and import `/hosted/http-sse`.
+- The root and remote packages continue to release in lockstep. The remote
+  package stays browser-safe and does not depend on the root Node runtime.
+- Live run retention remains process-local and bounded. Durable or distributed
+  in-flight delivery is still a separate host/deployment concern.
+
+## Verification
+
+- `yarn lint`
+- `yarn typecheck`
+- `yarn test`
+- `yarn build`
+- `npm pack --dry-run --cache /tmp/heddle-npm-cache`
+- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`
+- Standalone React reference build and real browser ready/reset proof
+- Package export and browser-boundary inspection for both artifacts
+- Private downstream dogfood against exact local tarballs: real cross-origin
+  server/client flow, two turns, refresh hydration, cursor-bounded active-run
+  recovery, reset, and graceful server drain
+
+## Release state
+
+- Package versions are `4.4.0` in both manifests.
+- The latest published npm and GitHub release before this release is `4.3.0`.
+- This note is curated from the real git range `v4.3.0..HEAD`.
+- Final npm publication remains the manual operator step after the tagged
+  GitHub release is created and verified.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "An open-source AI coding agent runtime and terminal CLI for real repositories, with persistent memory, sessions, approvals, heartbeat, and a browser control plane",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/packages/heddle-remote/package.json
+++ b/packages/heddle-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle-remote",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Browser-safe protocol and run-consumer services for remotely hosted Heddle conversations",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `@roackb2/heddle` and `@roackb2/heddle-remote` in lockstep to `4.4.0`
- add curated release notes from the real `v4.3.0..HEAD` range
- refresh the release-note index through `v4.4.0`

## Stack

This is intentionally based on #241 so its diff contains release metadata only.
Review it now, but do not merge it into the feature branch. After #241 merges,
I will rebase/retarget this PR to `main`, rerun the release checks on the final
commit, and make it merge-ready.

## Verification

- `yarn lint`
- `yarn typecheck`
- `yarn test` — 667 unit and 291 integration tests
- `yarn build`
- root `npm pack --dry-run`
- remote `npm pack --dry-run`
- exact unpublished packages already passed private downstream cross-origin,
  multi-turn, refresh, active-cursor recovery, reset, and graceful-drain dogfood

No tag, GitHub release, or npm publication is performed by this PR.
