### PR TITLE
chore: prepare Heddle v4.5.0

### DIFF
--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -278,6 +278,7 @@ Current example release note drafts:
 - [`v4.2.0.md`](./v4.2.0.md)
 - [`v4.3.0.md`](./v4.3.0.md)
 - [`v4.4.0.md`](./v4.4.0.md)
+- [`v4.5.0.md`](./v4.5.0.md)
 
 ## Agent Rule
 

--- a/docs/releases/v4.5.0.md
+++ b/docs/releases/v4.5.0.md
@@ -1,0 +1,55 @@
+# Heddle v4.5.0
+
+Heddle v4.5.0 gives hosted products a safe, typed way to explain why a model
+run failed. Authentication, permission, rate-limit, request, transport, empty-
+response, and unknown model failures now travel through the same retry,
+finisher, loop, and conversation-turn path as successful results.
+
+This release is additive. Existing hosts can ignore the new `failure` field;
+hosts that accept user-supplied model credentials can map it into stable product
+copy without parsing provider messages or exposing provider diagnostics.
+
+## Safe model failure results
+
+- **Model failures have a public typed shape.** `RunFailure` and
+  `ModelRunFailureCode` are exported from the root package and appear on runtime
+  and conversation turn results when the model stage cannot complete.
+- **Classification stays in the model retry service.** Authentication,
+  permission, rate-limit, request, transport, empty-response, and unknown
+  failures are resolved where retry status is already owned instead of being
+  reconstructed by each host.
+- **Provider messages stay private.** Logs, traces, control-plane results, and
+  persisted conversation summaries use safe Heddle text rather than raw SDK or
+  provider error messages.
+- **Hosted services can project product errors safely.** The hosted examples
+  demonstrate mapping a typed authentication failure to stable public behavior
+  without string matching.
+
+## Upgrade notes
+
+- Install `@roackb2/heddle@4.5.0` to consume the new failure contract.
+- `ConversationTurnResultSummary.failure` and runtime result failure fields are
+  optional, so existing success handling remains source-compatible.
+- `@roackb2/heddle-remote@4.5.0` is released in lockstep. Its runtime protocol
+  is unchanged in this release.
+- Hosts should continue to keep credentials out of prompts, persisted sessions,
+  traces, logs, and public error messages.
+
+## Verification
+
+- `yarn lint`
+- `yarn typecheck`
+- `yarn test`
+- `yarn build`
+- `npm pack --dry-run --cache /tmp/heddle-npm-cache`
+- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`
+- Downstream SlideX server tests against an exact locally packed candidate,
+  including rejected-key mapping and sentinel credential non-persistence
+
+## Release state
+
+- Package versions are `4.5.0` in both manifests.
+- The latest published npm and GitHub release before this release is `4.4.0`.
+- This note is curated from the real git range `v4.4.0..HEAD`.
+- Final npm publication remains the manual operator step after the tagged
+  GitHub release is created and verified.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "An open-source AI coding agent runtime and terminal CLI for real repositories, with persistent memory, sessions, approvals, heartbeat, and a browser control plane",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/packages/heddle-remote/package.json
+++ b/packages/heddle-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle-remote",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Browser-safe protocol and run-consumer services for remotely hosted Heddle conversations",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- prepare `@roackb2/heddle` and `@roackb2/heddle-remote` 4.5.0 in lockstep
- document the new typed, sanitized model-failure contract for hosted products
- record the real `v4.4.0..HEAD` release scope and downstream BYOK validation

## Why

Hosted products that accept user-supplied model credentials need to distinguish an invalid credential from generic execution failure without parsing provider messages or leaking provider diagnostics. Heddle #243 now owns that classification through its existing retry, finisher, loop, and conversation-turn path; this release makes the merged contract available to downstream servers from npm.

## Validation

- `yarn lint`
- `yarn typecheck`
- `yarn test` — 674 unit and 293 integration tests
- `yarn build`
- root and remote `npm pack --dry-run`
- exact local `@roackb2/heddle@4.5.0` tarball installed into the SlideX BYOK server
- SlideX server: 37 tests, typecheck, and production build

## Release handoff

After this PR is merged, create the annotated `v4.5.0` tag and GitHub release from `docs/releases/v4.5.0.md`, then publish `@roackb2/heddle-remote` before `@roackb2/heddle`.
