### PR TITLE
fix: classify model quota failures

### DIFF
--- a/docs/guides/programmatic/turn-results.md
+++ b/docs/guides/programmatic/turn-results.md
@@ -40,5 +40,17 @@ if (result.failure?.code === 'authentication') {
 }
 ```
 
+Quota exhaustion has a separate recovery path from transient rate limiting:
+
+```ts
+if (result.failure?.code === 'quota') {
+  throw new ProductModelQuotaError()
+}
+```
+
+`quota` is non-retryable and means the provider reported a structured quota or
+billing-capacity failure. `rate_limit` remains retryable. Hosts should map both
+from `failure.code`; do not inspect `summary` or raw provider message text.
+
 Model failure codes currently distinguish `authentication`, `permission`,
-`rate_limit`, `request`, `transport`, `empty_response`, and `unknown`.
+`quota`, `rate_limit`, `request`, `transport`, `empty_response`, and `unknown`.

--- a/examples/sdk/05-hosted-agent/02-http-sse-api/contracts.ts
+++ b/examples/sdk/05-hosted-agent/02-http-sse-api/contracts.ts
@@ -42,6 +42,7 @@ const HostedAgentResultSchema = z.object({
     code: z.enum([
       'authentication',
       'permission',
+      'quota',
       'rate_limit',
       'request',
       'transport',

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -432,6 +432,33 @@ describe('conversation turn lifecycle', () => {
     expect(turnResult.failure).toEqual({ source: 'model', code: 'authentication' });
   });
 
+  it('returns the safe quota failure category and actionable summary to programmatic hosts', async () => {
+    const storage = createConversationTurnStorage();
+    vi.spyOn(agentLoopModule.AgentLoopRuntimeService, 'run').mockResolvedValue(createLoopResult({
+      workspaceRoot: storage.workspaceRoot,
+      prompt: 'Use a credential without quota.',
+      summary: 'LLM error: Model provider quota or billing limit reached',
+      outcome: 'error',
+      failure: { source: 'model', code: 'quota' },
+    }) as never);
+
+    const turnResult = await EngineConversationTurnService.run({
+      workspaceRoot: storage.workspaceRoot,
+      stateRoot: storage.stateRoot,
+      traceDir: join(storage.stateRoot, 'traces'),
+      sessionStoragePath: storage.sessionStoragePath,
+      sessionId: storage.sessionId,
+      prompt: 'Use a credential without quota.',
+      apiKey: 'quota-exhausted-key',
+      memoryMaintenanceMode: 'none',
+      artifactRoot: storage.artifactRoot,
+      artifactsEnabled: true,
+    });
+
+    expect(turnResult.failure).toEqual({ source: 'model', code: 'quota' });
+    expect(turnResult.summary).toContain('no usable provider quota or billing capacity');
+  });
+
   it('clears the session lease when the run loop fails', async () => {
     const storage = createConversationTurnStorage();
     vi.spyOn(agentLoopModule.AgentLoopRuntimeService, 'run').mockRejectedValue(new Error('loop failed'));

--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -156,6 +156,45 @@ describe('AgentLoopRuntimeService.run', () => {
     });
   });
 
+  it('propagates non-retryable quota failures through loop state and terminal activity', async () => {
+    const events: AgentLoopEvent[] = [];
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: false,
+          parallelToolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        throw Object.assign(new Error('provider quota response'), { code: 'insufficient_quota' });
+      },
+    };
+
+    const result = await AgentLoopRuntimeService.run({
+      goal: 'Use a credential without quota.',
+      llm: fakeLlm,
+      tools: [],
+      includeDefaultTools: false,
+      logger: silentLogger,
+      workspaceRoot: resolve('/tmp/heddle-loop-quota-failure-test'),
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(result.failure).toEqual({ source: 'model', code: 'quota' });
+    expect(result.state.failure).toEqual({ source: 'model', code: 'quota' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'loop.finished',
+      failure: { source: 'model', code: 'quota' },
+      state: {
+        failure: { source: 'model', code: 'quota' },
+      },
+    });
+  });
+
   it('emits assistant stream events through the programmatic event stream', async () => {
     const events: AgentHeartbeatEvent[] = [];
     const fakeLlm: LlmAdapter = {

--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -132,6 +132,39 @@ describe('AgentRunService.run', () => {
     expect(JSON.stringify(result)).not.toContain(providerSecret);
   });
 
+  it('finishes structured quota exhaustion without retrying or exposing provider details', async () => {
+    let calls = 0;
+    const providerSecret = 'provider-quota-sentinel';
+    const fakeLlm: LlmAdapter = {
+      async chat(): Promise<LlmResponse> {
+        calls += 1;
+        throw Object.assign(new Error(`Quota response: ${providerSecret}`), {
+          code: 'insufficient_quota',
+        });
+      },
+    };
+
+    const result = await AgentRunService.run({
+      goal: 'Handle quota exhaustion safely.',
+      llm: fakeLlm,
+      tools: [],
+      maxSteps: 1,
+      logger: silentLogger,
+    });
+
+    expect(result.outcome).toBe('error');
+    expect(result.summary).toBe('LLM error: Model provider quota or billing limit reached');
+    expect(result.failure).toEqual({ source: 'model', code: 'quota' });
+    expect(calls).toBe(1);
+    expect(result.trace.filter((event) => event.type === 'model.retry')).toEqual([]);
+    expect(result.trace.at(-1)).toMatchObject({
+      type: 'run.finished',
+      outcome: 'error',
+      failure: { source: 'model', code: 'quota' },
+    });
+    expect(JSON.stringify(result)).not.toContain(providerSecret);
+  });
+
   it('retries transient LLM transport errors before returning the assistant response', async () => {
     let calls = 0;
     const fakeLlm: LlmAdapter = {

--- a/src/__tests__/unit/core/agent-model-turn-retry-service.test.ts
+++ b/src/__tests__/unit/core/agent-model-turn-retry-service.test.ts
@@ -33,4 +33,33 @@ describe('AgentModelTurnRetryService', () => {
     expect(decision.message).not.toContain('secret-value');
     expect(JSON.stringify(decision.failure)).not.toContain('secret-value');
   });
+
+  it.each([undefined, 429])(
+    'classifies structured insufficient_quota as non-retryable before status %s',
+    (status) => {
+      const decision = AgentModelTurnRetryService.resolve({
+        kind: 'error',
+        error: Object.assign(new Error('provider message'), {
+          code: 'insufficient_quota',
+          ...(status === undefined ? {} : { status }),
+        }),
+      });
+
+      expect(decision).toEqual({
+        retryable: false,
+        failure: { source: 'model', code: 'quota' },
+        maxAttempts: 1,
+        message: 'Model provider quota or billing limit reached',
+      });
+    },
+  );
+
+  it('does not infer quota exhaustion from provider message text', () => {
+    const decision = AgentModelTurnRetryService.resolve({
+      kind: 'error',
+      error: new Error('You exceeded your current quota, please check your billing details.'),
+    });
+
+    expect(decision.failure).toEqual({ source: 'model', code: 'unknown' });
+  });
 });

--- a/src/__tests__/unit/core/conversation-turn-failure-messages.test.ts
+++ b/src/__tests__/unit/core/conversation-turn-failure-messages.test.ts
@@ -27,13 +27,19 @@ describe('ConversationTurnFailureMessages', () => {
     expect(ConversationTurnFailureMessages.shouldForceCompactionAfterFailure(formatted)).toBe(false);
   });
 
-  it('distinguishes OpenAI quota exhaustion from prompt-size issues', () => {
+  it('adds quota recovery guidance from the structured run failure', () => {
     const formatted = ConversationTurnFailureMessages.format(
-      'You exceeded your current quota, please check your plan and billing details.',
-      { model: 'gpt-5.4' },
+      'LLM error: Model provider quota or billing limit reached',
+      { model: 'gpt-5.4', failure: { source: 'model', code: 'quota' } },
     );
 
-    expect(formatted).toContain('quota or billing limit');
-    expect(formatted).toContain('not a transient prompt-size issue');
+    expect(formatted).toContain('no usable provider quota or billing capacity');
+    expect(formatted).toContain('switch credentials or providers');
+  });
+
+  it('does not infer quota recovery guidance from provider message text', () => {
+    const message = 'You exceeded your current quota, please check your plan and billing details.';
+
+    expect(ConversationTurnFailureMessages.format(message, { model: 'gpt-5.4' })).toBe(message);
   });
 });

--- a/src/__tests__/unit/sdk/hosted-react-ui.test.ts
+++ b/src/__tests__/unit/sdk/hosted-react-ui.test.ts
@@ -85,6 +85,29 @@ describe('hosted React UI example boundaries', () => {
       tone: 'running',
     }]);
   });
+
+  it('preserves the safe quota category through the hosted result contract', () => {
+    const event = HostedAgentRunProtocol.parseEvent({
+      kind: 'result',
+      runId: 'run-1',
+      sequence: 2,
+      timestamp: '2026-07-12T00:00:01.000Z',
+      result: {
+        outcome: 'error',
+        summary: 'Model provider quota or billing limit reached',
+        failure: { source: 'model', code: 'quota', providerMessage: 'must-not-cross-wire-boundary' },
+      },
+    });
+
+    expect(event).toMatchObject({
+      kind: 'result',
+      result: {
+        outcome: 'error',
+        failure: { source: 'model', code: 'quota' },
+      },
+    });
+    expect(JSON.stringify(event)).not.toContain('providerMessage');
+  });
 });
 
 class MemoryStorage implements Storage {

--- a/src/core/agent/model/README.md
+++ b/src/core/agent/model/README.md
@@ -10,6 +10,8 @@ usage accumulation, retry policy, and safe terminal failure classification.
   agent runs are never replayed by this service.
 - Converting provider status and transport signals into the stable
   host-facing `RunFailure` category.
+- Distinguishing structured provider quota exhaustion from transient rate
+  limiting so the runtime does not retry a request that cannot succeed.
 - Replacing raw provider diagnostics with a stable safe message before the
   value reaches logs, retry traces, or the human-readable run summary.
 
@@ -28,6 +30,13 @@ checkpoints, logs, live events, and remote API results.
 Provider-specific retry behavior belongs here when it can be derived from
 structured adapter errors. Product-specific copy and HTTP/API error mapping
 belong in the consuming host.
+
+Structured provider error codes take precedence over HTTP status when they
+carry more precise recovery semantics. For example, OpenAI's
+`insufficient_quota` is exposed as `{ source: 'model', code: 'quota' }` and is
+non-retryable, even if the provider also reports HTTP 429. An ordinary HTTP 429
+remains the retryable `rate_limit` category. Add future provider codes to this
+single classifier; never infer quota state from provider message text.
 
 ## Adjacent Owners
 

--- a/src/core/agent/model/model-turn-retry-service.ts
+++ b/src/core/agent/model/model-turn-retry-service.ts
@@ -26,6 +26,9 @@ const RETRY_MAX_DELAY_MS = 4_000;
 
 const RETRYABLE_STATUS_CODES = new Set([408, 409, 425, 429, 500, 502, 503, 504]);
 const NON_RETRYABLE_STATUS_CODES = new Set([400, 401, 403, 404, 422]);
+const MODEL_FAILURE_BY_PROVIDER_CODE = new Map<string, ModelRunFailureCode>([
+  ['insufficient_quota', 'quota'],
+]);
 const MODEL_FAILURE_BY_STATUS = new Map<number, ModelRunFailureCode>([
   [400, 'request'],
   [401, 'authentication'],
@@ -44,6 +47,7 @@ const MODEL_FAILURE_BY_STATUS = new Map<number, ModelRunFailureCode>([
 const MODEL_FAILURE_MESSAGE = new Map<ModelRunFailureCode, string>([
   ['authentication', 'Model authentication failed'],
   ['permission', 'Model access was denied'],
+  ['quota', 'Model provider quota or billing limit reached'],
   ['rate_limit', 'Model provider rate limit reached'],
   ['request', 'Model request was rejected'],
   ['transport', 'Model provider is temporarily unavailable'],
@@ -116,10 +120,15 @@ export class AgentModelTurnRetryService {
 
   private static resolveError(error: unknown): AgentModelTurnRetryDecision {
     const providerMessage = AgentModelTurnRetryService.formatErrorMessage(error);
+    const providerCode = AgentModelTurnRetryService.readProviderErrorCode(error);
     const status = AgentModelTurnRetryService.readStatusCode(error);
-    const failureCode = status === undefined ? 'unknown' : MODEL_FAILURE_BY_STATUS.get(status) ?? 'unknown';
+    const failureCode = AgentModelTurnRetryService.resolveFailureCode({ providerCode, status });
     const failure = AgentModelTurnRetryService.modelFailure(failureCode);
     const message = AgentModelTurnRetryService.safeMessage(failureCode);
+
+    if (failureCode === 'quota') {
+      return { retryable: false, failure, maxAttempts: 1, message };
+    }
 
     if (status !== undefined && NON_RETRYABLE_STATUS_CODES.has(status)) {
       return { retryable: false, failure, maxAttempts: 1, message };
@@ -147,6 +156,23 @@ export class AgentModelTurnRetryService {
     }
 
     return { retryable: false, failure, maxAttempts: 1, message };
+  }
+
+  private static resolveFailureCode(args: {
+    providerCode?: string;
+    status?: number;
+  }): ModelRunFailureCode {
+    const providerFailure = args.providerCode
+      ? MODEL_FAILURE_BY_PROVIDER_CODE.get(args.providerCode)
+      : undefined;
+    return providerFailure ?? (
+      args.status === undefined ? 'unknown' : MODEL_FAILURE_BY_STATUS.get(args.status) ?? 'unknown'
+    );
+  }
+
+  private static readProviderErrorCode(error: unknown): string | undefined {
+    const code: unknown = get(error, 'code') ?? get(error, 'error.code') ?? get(error, 'cause.code');
+    return isString(code) ? code.trim().toLowerCase() : undefined;
   }
 
   private static readStatusCode(error: unknown): number | undefined {

--- a/src/core/chat/engine/turns/failure/failure-message-formatter.ts
+++ b/src/core/chat/engine/turns/failure/failure-message-formatter.ts
@@ -5,6 +5,10 @@ import type { ConversationTurnFailureHintOptions } from './types.js';
  */
 export class ConversationTurnFailureMessages {
   static format(message: string, options: ConversationTurnFailureHintOptions): string {
+    if (options.failure?.source === 'model' && options.failure.code === 'quota') {
+      return `${message}\n\nThe active model account or credential has no usable provider quota or billing capacity. Check the provider account or switch credentials or providers before retrying.`;
+    }
+
     if (ConversationTurnFailureMessages.looksLikeContextWindowOverload(message)) {
       const sizeHint =
         typeof options.estimatedHistoryTokens === 'number' ?
@@ -19,10 +23,6 @@ export class ConversationTurnFailureMessages {
           ` Current session history is estimated at about ${options.estimatedHistoryTokens.toLocaleString()} tokens before the next request.`
         : '';
       return `${message}\n\nThis likely failed because the current prompt plus session history are too large for ${options.model}'s input-token-per-minute limit.${sizeHint} Try /compact, /clear, or /session new, then retry.`;
-    }
-
-    if (ConversationTurnFailureMessages.looksLikeOpenAiQuotaError(message)) {
-      return `${message}\n\nThis looks like an OpenAI quota or billing limit for the active key, not a transient prompt-size issue. Switch providers or check the OpenAI account quota and billing state.`;
     }
 
     return message;
@@ -51,14 +51,6 @@ export class ConversationTurnFailureMessages {
       normalized.includes('input tokens per minute')
       || (normalized.includes('reduce the prompt length') && normalized.includes('maximum tokens requested'))
       || (normalized.includes('rate_limit_error') && normalized.includes('tokens per minute'))
-    );
-  }
-
-  private static looksLikeOpenAiQuotaError(message: string): boolean {
-    const normalized = message.toLowerCase();
-    return (
-      normalized.includes('exceeded your current quota')
-      || (normalized.includes('billing details') && normalized.includes('quota'))
     );
   }
 }

--- a/src/core/chat/engine/turns/failure/types.ts
+++ b/src/core/chat/engine/turns/failure/types.ts
@@ -1,4 +1,7 @@
+import type { RunFailure } from '@/core/types.js';
+
 export type ConversationTurnFailureHintOptions = {
   model: string;
   estimatedHistoryTokens?: number;
+  failure?: RunFailure;
 };

--- a/src/core/chat/engine/turns/persistence/turn-artifacts.ts
+++ b/src/core/chat/engine/turns/persistence/turn-artifacts.ts
@@ -45,6 +45,7 @@ export class ConversationTurnArtifacts {
         ? ConversationTurnFailureMessages.format(args.result.summary, {
             model: compactionRuntime.model,
             estimatedHistoryTokens: ConversationCompactionService.estimateTokens(args.historyForTokenEstimate),
+            ...(args.result.failure ? { failure: args.result.failure } : {}),
           })
         : args.result.summary;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -64,6 +64,7 @@ export type StopReason = 'done' | 'max_steps' | 'error' | 'interrupted';
 export type ModelRunFailureCode =
   | 'authentication'
   | 'permission'
+  | 'quota'
   | 'rate_limit'
   | 'request'
   | 'transport'


### PR DESCRIPTION
## Summary

- add a stable, non-retryable `quota` model failure based on structured provider error codes
- keep ordinary HTTP 429 failures classified as retryable `rate_limit`
- propagate quota failures through conversation turn results, persisted artifacts, and hosted contracts
- document the public failure contract and its safe host-facing handling

## Root cause

A provider can return structured `insufficient_quota` without a numeric HTTP status. The existing status-first classifier therefore projected the failure as `unknown`, preventing hosts from giving an actionable billing or quota message.

The implementation checks structured error codes before status classification. It deliberately does not parse provider message text or expose raw provider diagnostics.

## Validation

- 87 focused model/turn/hosted-contract tests
- 679 unit tests
- 296 integration tests
- `yarn build`
- `yarn lint`
- `git diff --check`
