### PR TITLE
docs: reposition Heddle around the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,645 +2,368 @@
 
 [English](README.md) | [繁體中文](README.zh-TW.md)
 
-Heddle is an open-source AI coding agent runtime and terminal-first workspace for shipping features, fixing bugs, and operating software with reviewable agent help.
+**Build agentic experiences into your product—without giving up control of your
+architecture.**
+
+Heddle is an open-source TypeScript agent runtime and SDK for durable
+conversations, tool and MCP execution, approvals, artifacts, traceable
+activity, and reconnectable hosted runs.
+
+Your product keeps control of identity, data relationships, API policy,
+deployment, transport, and UI. Start with a working conversation, then adopt
+only the Heddle layers your product needs.
+
+Want to see the runtime working before embedding it? Heddle's local coding
+agent, terminal UI, and browser control plane are built on the same
+conversation and run foundations exposed through the SDK.
 
 Official website: [heddleagent.com](https://heddleagent.com)
 
-> **Terminal UI v2 is now the default.** Run `heddle` or `heddle chat` to use the API-backed terminal experience. Messages, run events, and agent response streams flow through the shared control-plane path, so terminal, browser, and mobile clients can follow the same work at the same time.
+Start here:
+[SDK quickstart](docs/guides/programmatic/quickstart.md) ·
+[choose an integration layer](docs/guides/programmatic/integration-layers.md) ·
+[runnable SDK examples](examples/sdk/README.md) ·
+[try the coding agent](#try-heddle-as-a-coding-agent)
 
-## Agenda
+## Why Heddle
 
-- [What Heddle Can Do](#what-heddle-can-do)
-- [See It In Action](#see-it-in-action)
-- [Quick Start](#quick-start)
-- [Core Workflows](#core-workflows)
-  - [Terminal Coding](#terminal-coding)
-  - [Model Providers](#model-providers)
-  - [Browser Control Plane](#browser-control-plane)
-  - [Sessions And Continuity](#sessions-and-continuity)
-  - [Project Instructions](#project-instructions)
-  - [Knowledge Persistence](#knowledge-persistence)
-  - [Agent Skills](#agent-skills)
-  - [Custom Agents](#custom-agents)
-  - [Browser Automation](#browser-automation)
-  - [MCP Integrations](#mcp-integrations)
-  - [Heartbeat](#heartbeat)
-  - [Programmatic Runtime](#programmatic-runtime)
-  - [Semantic Drift](#semantic-drift)
-- [Install](#install)
-- [Requirements](#requirements)
-- [Optional CyberLoop Integration](#optional-cyberloop-integration)
-- [Documentation](#documentation)
-- [Project Status](#project-status)
-- [Development](#development)
-- [License](#license)
+Calling a model and registering a tool is only the beginning of an agentic
+product. The harder product work starts when a conversation must survive
+multiple turns, expose understandable activity, pause for approval, outlive one
+HTTP request, reconnect after a browser refresh, and apply results without
+leaking internal state.
 
-## What Heddle Can Do
+Heddle owns those reusable runtime mechanics while leaving product decisions in
+the product:
 
-Heddle is for engineers, maintainers, and side-project builders who want an AI coding assistant that can help with day-to-day software work while keeping local continuity and reviewable execution.
+- persisted multi-turn conversations, continuation, compaction, and leases;
+- native tools, Agent Skills, and curated MCP-backed host extensions;
+- approval requests, semantic activity, traces, artifacts, and typed turn
+  results;
+- addressable active runs with ordered events, bounded replay, cancellation,
+  approval resolution, and one terminal outcome;
+- runtime-validated remote envelopes, cursor progression, duplicate and gap
+  handling, and bounded reconnect calculation;
+- file-backed local defaults plus explicit extension points for host
+  capabilities, storage, output, policy, and transport.
 
-It is a good fit when you want to:
+Heddle is a good fit for TypeScript teams building document agents, research
+assistants, internal copilots, operational agents, or other product experiences
+where inspectability and host control matter more than a one-shot chat
+endpoint.
 
-- inspect and understand unfamiliar repositories
-- develop new product features for work or side projects
-- build frontend pages, backend services, CLIs, docs, and tests
-- fix bugs, investigate regressions, and explain unfamiliar code paths
-- refactor existing modules while preserving reviewable diffs
-- run bounded verification such as builds, tests, and repo review
-- keep multi-step implementation work going across saved sessions
-- review file diffs, commands, approvals, traces, and semantic activity before accepting changes
-- switch between local workspaces from a browser control plane
-- let the agent learn durable project knowledge over time
-- activate standard Agent Skills only when a workspace should expose them
-- define custom agents for turn-scoped roles such as ask, code, review, docs writing, or release operations
-- connect configured MCP servers such as Notion, Anytype, GitHub, or other tools
-- opt into Browser Automation for rendered page inspection and user-requested web workflows
-- run against hosted models, local Ollama, and OpenAI-compatible providers through Heddle's provider adapters
-- build custom hosts on top of Heddle's runtime APIs
+## Start Building
 
-Heddle is probably not the right fit if you only want a very simple one-shot prompt runner and do not care about sessions, persistence, observability, or operator control.
+### Fastest SDK evaluation
 
-## See It In Action
+Install the Node runtime package:
 
-Terminal, browser, and mobile surfaces can observe the same live session at once:
+```bash
+npm install @roackb2/heddle
+```
 
-![Heddle streams the same session across terminal, browser, and mobile](docs/images/heddle-cross-device-stream.gif)
+Then start a persisted interactive conversation:
 
-Review and approve sensitive actions from the control plane while the agent run stays visible:
+```ts
+import { runQuickstartConversationCli } from '@roackb2/heddle'
 
-![Heddle request approval flow in the browser control plane](docs/images/heddle-request-approval.gif)
+await runQuickstartConversationCli()
+```
 
-Inspect workspace diffs from browser and mobile while the same conversation continues:
+The quickstart resolves the workspace, local state root, configured model, and
+credential before opening the prompt loop. It is intentionally smaller than
+Heddle's product CLI and is the shortest path for evaluating the SDK.
 
-![Heddle diff review across browser and mobile](docs/images/heddle-diff-view.gif)
+Run the corresponding repository example with:
 
-Heddle also works as a terminal-first coding agent with live progress, tool activity, plans, and review output:
+```bash
+yarn example:sdk:interactive
+```
 
-![Heddle terminal coding workflow](docs/images/terminal-active-run.png)
+See the [SDK quickstart](docs/guides/programmatic/quickstart.md) for model,
+credential, prompt, command, and host-extension options.
 
-Terminal chat/dev workflow showing file edits, inline diff output, and verification-oriented follow-through:
+### Own presentation and turn lifecycle
 
-![Heddle terminal change review](docs/images/terminal-change-review.png)
+Move to `createConversationEngine` when your product owns rendering, commands,
+approvals, or session browsing:
 
-The default local control plane is the web-v2 browser client served by `heddle daemon`:
+```ts
+import { join } from 'node:path'
+import {
+  createConversationEngine,
+  createConversationTextHost,
+} from '@roackb2/heddle'
 
-![Heddle web-v2 control plane](docs/images/control-plane-v2.png)
+const workspaceRoot = process.cwd()
 
-The task workbench covers recurring heartbeat tasks, live run state, and run result review:
+const engine = createConversationEngine({
+  workspaceRoot,
+  stateRoot: join(workspaceRoot, '.heddle'),
+  model: process.env.HEDDLE_MODEL ?? 'gpt-5.4',
+})
 
-![Heddle web-v2 heartbeat task workbench](docs/images/control-plane-v2-heartbeat-task.png)
+const session = await engine.sessions.create({
+  name: 'Product assistant',
+})
 
-The same control plane supports mobile layouts, with the session list, workbench, and diff preview exposed as focused panels:
+const textHost = createConversationTextHost({
+  output: (text) => process.stdout.write(text),
+})
 
-<p>
-  <img src="docs/images/control-plane-v2-session-list.PNG" alt="Heddle web-v2 mobile session list" width="220">
-  <img src="docs/images/control-plane-v2-workbench.PNG" alt="Heddle web-v2 mobile workbench" width="220">
-  <img src="docs/images/control-plane-v2-diff-view.PNG" alt="Heddle web-v2 mobile diff preview" width="220">
-</p>
+const result = await engine.turns.submit({
+  sessionId: session.id,
+  prompt: 'Summarize this workspace and identify the main verification path.',
+  host: textHost.host,
+})
 
-## Quick Start
+textHost.renderTurnResult(result)
+```
 
-1. Install Heddle:
+The text host supplies a working output surface. Replace it with your product's
+activity, approval, telemetry, and result handlers when you own the UI. If a
+turn must outlive a request or support remote reconnection, continue to the
+[hosted agent stack](examples/sdk/05-hosted-agent/README.md).
+
+## Reuse the Runtime, Keep the Product
+
+Heddle is intentionally not a full application framework:
+
+```text
+YOUR PRODUCT
+  UI state and result application
+          |
+  @roackb2/heddle-remote + optional HTTP/SSE client
+          |
+  your API, authentication, public schemas, and product state
+========================= HEDDLE SDK =========================
+  ConversationRunService
+  run identity, ordered activity, replay, cancel, approvals
+          |
+  ConversationEngine
+  sessions, turns, compaction, traces, artifacts
+          |
+  models, tools, host extensions, MCP
+```
+
+| Concern | Heddle owns | Your product owns |
+| --- | --- | --- |
+| Conversation | Messages, turns, continuation, compaction, leases, and persisted session behavior | Stable product conversation IDs, access rules, and product relationships |
+| Execution | Model/tool loop, tool execution, host extensions, traces, activities, and artifacts | Product tools, system context, model choice, credentials, and capability policy |
+| Approvals | Request/resolution lifecycle and run integration | Who may approve, approval policy, and approval UI |
+| Active runs | Run IDs, ordered sequences, bounded replay, cancellation, and terminal settlement | Process lifetime, routing, draining, and multi-process delivery |
+| Remote clients | Runtime envelope validation, cursor/duplicate/gap rules, terminal detection, and reconnect calculation | Public payload schemas, timers, UI state, retry UX, and result presentation |
+| Persistence | File-backed defaults and injectable session/artifact repository boundaries | Production adapters, retention, encryption, backup, tenancy, and product records |
+| API and UI | Optional Node HTTP/SSE and browser transport mechanics | Server framework, routes, auth, CORS, limits, errors, and every visual decision |
+
+The full ownership model lives in
+[Choose a Programmatic Integration Layer](docs/guides/programmatic/integration-layers.md).
+
+## Choose Your Integration Depth
+
+Heddle's public entry points make assumptions explicit. Use the lowest layer
+that already owns the mechanics your host needs:
+
+| Host need | Start with | What it adds |
+| --- | --- | --- |
+| A working local conversation | `runQuickstartConversationCli` | Prompt loop, persisted session, credentials, and text output |
+| Custom output, tools, or session UX | `@roackb2/heddle` | Conversation engine, host extensions, tools, MCP, approvals, artifacts, and turn results |
+| A server, worker, or Electron backend | `@roackb2/heddle/hosted` | Addressable process-local runs, replay, cancellation, and approval resolution |
+| Conventional Node HTTP/SSE | `@roackb2/heddle/hosted/http-sse` | Replay cursor parsing, SSE framing, backpressure, and disconnect cleanup |
+| A remote browser or client | `@roackb2/heddle-remote` | Browser-safe protocol validation and transport-neutral run consumption |
+| Conventional browser REST/SSE | `@roackb2/heddle-remote/http-sse` | Authenticated fetch, incremental SSE parsing, and transport validation |
+| Lower-level runtime assembly | `@roackb2/heddle/advanced` | Model adapters, individual tools, trace, memory, heartbeat, and core runtime services |
+
+Existing tRPC, Fastify, Hono, Nest, WebSocket, IPC, queue, React, or other stacks
+should normally keep those choices and adapt the closest neutral Heddle layer.
+Do not install Express or React merely because a reference example uses them.
+
+## Progressive SDK Examples
+
+The runnable examples teach customization in small steps:
+
+1. [Interactive chat](examples/sdk/01-interactive-chat.ts) — start a persisted
+   conversation.
+2. [Add a tool](examples/sdk/02-add-a-tool.ts) — expose native product
+   behavior.
+3. [Add an MCP server](examples/sdk/03-add-an-mcp-server.ts) — prepare curated
+   MCP-backed capabilities without copying schemas.
+4. [Custom output](examples/sdk/04-custom-output.ts) — keep conversation
+   semantics while replacing presentation.
+5. [Hosted agent stack](examples/sdk/05-hosted-agent/README.md) — progress from
+   a transport-neutral service to an optional HTTP/SSE API, browser client, and
+   React reference.
+
+Each stage states its assumptions and responsibility boundary. Copy only the
+layers that match your product.
+
+## Core Capabilities
+
+### Conversations and results
+
+- persisted sessions with create, resume, continue, rename, archive, and
+  compaction paths;
+- structured conversation activity for text, tools, approvals, lifecycle, and
+  progress;
+- turn summaries with traces, tool outcomes, artifacts, and safe typed model
+  failures;
+- artifact capture for generated documents and large tool results, including
+  mirror workflows for stateless MCP tools.
+
+### Capabilities and control
+
+- host-owned `ToolDefinition` capabilities and reusable tool registries;
+- Agent Skills with workspace activation and progressive disclosure;
+- prepared MCP host extensions with curated exposure, overrides, and result
+  artifact rules;
+- approval policy chains and host-owned approval decisions;
+- OpenAI, Anthropic, Ollama, and OpenAI-compatible provider profiles.
+
+### Hosted and remote runs
+
+- one active run per host-defined conversation address;
+- stable run IDs, ordered event sequences, bounded replay, explicit
+  cancellation, and approval resolution;
+- awaited product result projection before a success terminal becomes visible;
+- safe public error projection that keeps provider and persistence diagnostics
+  on the host;
+- a lightweight browser package that excludes Heddle's Node runtime, CLI,
+  model providers, server, and control plane.
+
+See the [programmatic guide index](docs/guides/programmatic/README.md) for the
+complete ladder.
+
+## Try Heddle as a Coding Agent
+
+The coding agent is the fastest way to experience Heddle's runtime as a
+complete product host.
+
+Install the CLI:
 
 ```bash
 npm install -g @roackb2/heddle
 ```
 
-2. Configure provider access.
-
-For OpenAI, you can either sign in with your own ChatGPT/Codex account:
-
-```bash
-heddle auth login openai
-```
-
-Or use a Platform API key:
+Configure one provider. For OpenAI, either use a Platform API key:
 
 ```bash
 export OPENAI_API_KEY=your_key_here
 ```
 
-If you keep both a stored OpenAI OAuth credential and an API key around for testing, you can explicitly prefer the API key for a run:
+Or opt into experimental OpenAI account sign-in:
 
 ```bash
-heddle --prefer-api-key
-heddle --prefer-api-key ask "Summarize this repository"
-heddle --prefer-api-key daemon
+heddle auth login openai
 ```
 
-For Anthropic, use an API key:
-
-```bash
-export ANTHROPIC_API_KEY=your_key_here
-```
-
-For local models, install and start [Ollama](https://ollama.com), then select one of your installed chat models with the `ollama/` prefix:
-
-```bash
-ollama list
-heddle --model ollama/llama3.2:latest ask "Reply with exactly: ok"
-```
-
-Ollama does not require a hosted provider API key. Heddle uses Ollama's local OpenAI-compatible endpoint at `http://127.0.0.1:11434/v1` by default. Heddle also supports OpenAI-compatible providers such as LM Studio, LiteLLM, vLLM, Hugging Face, OpenRouter, Together AI, and Groq; see [Model Providers](#model-providers).
-
-OpenAI account sign-in is an experimental, user-selected transport for Heddle. It is not official OpenAI support, and Heddle is not affiliated with, endorsed by, or sponsored by OpenAI. Use of OpenAI services remains subject to OpenAI's terms and policies.
-
-3. Move into any repository you want to inspect:
+Then open any repository:
 
 ```bash
 cd /path/to/project
-```
-
-4. Start chat:
-
-```bash
 heddle
 ```
 
-5. Try a prompt like:
+Try:
 
 ```text
-Summarize this repository, show me the main build/test commands, and point out the likely entrypoints.
+Summarize this repository, identify its main entrypoints, and show me the
+commands used to build and test it.
 ```
 
-6. If you want the browser oversight UI too:
+For a one-shot saved run:
+
+```bash
+heddle ask "Review the current repository and identify the highest-risk change."
+```
+
+For browser and mobile oversight of the same conversations:
 
 ```bash
 heddle daemon
 ```
 
-Open the browser control plane from the daemon output. From there you can use `Sessions`, `Tasks`, and `Settings` to inspect the active workspace, continue saved sessions, review changes, inspect memory status, and switch to another local project.
-
-For a one-shot run instead of interactive chat:
-
-```bash
-heddle ask "Summarize this repository"
-```
-
-`ask` exits after one prompt, but it records the run as a one-off saved session under `.heddle/` so traces, memory maintenance, and later inspection use the same persisted conversation path as normal sessions.
-
-### Try The Learning Loop
-
-Heddle gets more useful when it learns a reusable preference and applies it later. In chat, teach it a ticket format:
-
-```text
-Whenever I ask you to create a ticket, use these sections: problem statement, proposed approach, considered alternatives, conclusion.
-```
-
-Then start a fresh session and ask:
-
-```text
-Create a ticket for maintaining doc consistency after feature updates.
-```
-
-Heddle should recover the preference from its local memory catalog and produce the ticket in that structure. You can inspect what it learned with:
-
-```bash
-heddle memory status
-heddle memory list
-heddle memory search ticket
-```
-
-## Core Workflows
-
-### Terminal Coding
-
-The main way to use Heddle is interactive chat in a repository:
-
-```bash
-heddle
-```
-
-From there, Heddle can inspect files, search with ignore-aware fallbacks, explain code, make edits, run shell commands with the right approval model, and carry a task through multiple turns.
-
-The terminal composer supports multiline prompts, prompt undo/redo, prompt history navigation, model picking with `/model set`, and reasoning-effort picking with `/reasoning set`. During a run, Heddle streams visible activity so you can see whether it is thinking, searching, calling tools, updating a plan, or waiting for approval.
-
-More: [Chat and sessions guide](docs/guides/chat-and-sessions.md)
-
-### Model Providers
-
-Heddle is not tied to one model vendor. It supports hosted frontier models, local models, and OpenAI-compatible gateways through provider adapters. This lets you choose the right tradeoff for each run: strongest hosted model, private local model, self-hosted inference server, or a routing gateway.
-
-Supported provider families:
-
-- OpenAI, including OpenAI account sign-in and Platform API-key mode
-- Anthropic Claude via API key
-- Ollama local models with the `ollama/` prefix
-- LM Studio local server models with the `lmstudio/` prefix
-- LiteLLM gateway models with the `litellm/` prefix
-- vLLM self-hosted OpenAI-compatible models with the `vllm/` prefix
-- Hugging Face router models with the `huggingface/` or `hf/` prefix
-- OpenRouter models with the `openrouter/` prefix
-- Together AI models with the `together/` prefix
-- Groq models with the `groq/` prefix
-
-Start Ollama, pull or install a chat-capable model, then choose it with the `ollama/` model prefix:
-
-```bash
-ollama list
-heddle --model ollama/llama3.2:latest ask "Summarize this repository"
-heddle chat --model ollama/llama3.2:latest
-```
-
-For other OpenAI-compatible providers, select models with their profile prefix:
-
-```bash
-heddle --model lmstudio/local-model ask "Reply with exactly: ok"
-heddle --model openrouter/meta-llama/llama-3.3-70b-instruct ask "Summarize this repository"
-```
-
-Inside terminal chat, use `/model set <query>` to search available models. The terminal picker and browser model selector use the same model-options service: Ollama is discovered from the local Ollama API, and other OpenAI-compatible profiles are discovered from `/models` when their local server is running or their hosted API key is configured.
-
-```text
-/model set llama
-/model ollama/llama3.2:latest
-```
-
-Local and gateway model quality varies. Some smaller, older, or provider-routed models are not reliable at tool calling, may ignore tool results, or may produce confident but wrong repository answers. Use manual review, keep approval prompts enabled for risky work, and prefer stronger models for edits that matter.
-
-More: [Model providers](docs/reference/model-providers.md) and [Providers and models](docs/reference/providers-and-models.md)
-
-### Browser Control Plane
-
-The control plane is Heddle's local browser UI:
-
-```bash
-heddle daemon
-```
-
-It gives you a browser-based view into workspaces, saved conversations, live assistant streaming, tool progress, approvals, current workspace diffs, heartbeat tasks, memory health, and settings.
-
-While the control plane is open, Heddle can notify you when any session in the open workspace needs approval or finishes, and when heartbeat task runs finish for the open workspace. Enable browser notifications from `Settings > General`; Heddle also keeps an in-app toast and marks the browser tab title so the event remains visible even when the operating system suppresses the browser banner.
-
-The workspace switcher and `Settings > Workspace` page let you register local projects, switch the control plane between them, rename workspace entries, and pick a project folder from the browser UI. The `Sessions` section is built around current work first: review starts from the live Git working tree, with changed files, structured read-only diffs, and a larger full-diff viewer when the side panel is too tight.
-
-Session rows in the browser control plane support right-click actions for common session management: pin or unpin important conversations, rename a session inline, or archive a session so it is hidden from normal session lists. Archiving is reversible immediately from the toast undo action.
-
-If terminal chat is the execution surface, the control plane is the oversight surface.
-
-More: [Control plane guide](docs/guides/control-plane.md)
-
-### Sessions And Continuity
-
-Heddle keeps saved sessions under `.heddle/` so longer work does not have to reset every time. Current versions store the session catalog at `.heddle/chat-sessions.catalog.json` and per-session bodies under `.heddle/chat-sessions/`.
-
-Typical session commands include:
-
-```text
-/session list
-/session choose <query>
-/session new [name]
-/session switch <id>
-/session continue <id>
-/session rename <name>
-/session pin
-/session unpin
-/continue
-/compact
-/model set
-/reasoning set
-```
-
-The browser control plane adds right-click session actions for pinning, inline rename, and archiving. Archived sessions are hidden from the normal session list; the archive toast includes an undo action right after archiving.
-
-More: [Chat and sessions guide](docs/guides/chat-and-sessions.md)
-
-### Project Instructions
-
-Heddle can load a short project instruction file at startup so a fresh session starts with the repository's operating context. By default it loads the first non-empty file found in this order: `HEDDLE.md`, `AGENTS.md`, `CLAUDE.md`.
-
-Only one default file is loaded to preserve context space. If a project needs a different path or intentionally wants multiple files, set `agentContextPaths` in `.heddle/config.json`.
-
-More: [Project config](docs/reference/config.md)
-
-### Knowledge Persistence
-
-Heddle can learn durable project knowledge while it works with you.
-
-When the agent notices reusable information such as a preferred ticket format, a canonical verification command, an operational convention, a recurring repo quirk, or a stable workflow pattern, it can record a memory candidate and let a dedicated maintainer path fold that knowledge into cataloged markdown notes under `.heddle/memory/`.
-
-The goal is practical recall: future sessions should know where to look instead of rediscovering the same context from scratch. Heddle does this through explicit catalogs, readable local notes, maintenance logs, and memory visibility commands rather than opaque retrieval.
-
-More: [Knowledge persistence](docs/guides/knowledge-persistence.md)
-
-### Agent Skills
-
-Heddle supports the standard Agent Skills folder format for reusable, opt-in agent workflows. Put project skills under `.agents/skills/<name>/SKILL.md` or user skills under `~/.agents/skills/<name>/SKILL.md`, then manage workspace activation from chat:
-
-```text
-/skills
-/skills enable <name>
-/skills disable <name>
-```
-
-Heddle also ships built-in skills for Heddle-owned capabilities. Capability settings can activate those built-ins without asking users to install separate skill files.
-
-Only active skills are shown to the agent. Heddle initially exposes a compact catalog with each active skill's name and description, then the agent can call `read_agent_skill` to fetch the full `SKILL.md` body when a skill is relevant. Activation state is stored under `.heddle/skills/activation.json`; skill definitions stay in their original folders.
-
-Skills are instructions, not permissions. They do not bypass Heddle's approval policy or tool safety checks, so users remain responsible for which project or user skills they enable.
-
-More: [Agent Skills guide](docs/guides/agent-skills.md)
-
-### Custom Agents
-
-Custom agents let you choose the role Heddle should use for a specific turn.
-Heddle ships built-in Ask, Code, and Review modes as custom agents, and you can
-define your own project or user agents for specialized work such as repository
-review, docs writing, release operation, or incident investigation.
-
-A custom agent is a named runtime profile:
-
-- prompt appendix: extra instructions appended to Heddle's default system prompt
-- tool profile: which tools the model can see for that turn
-- approval profile: whether the agent is read-only, asks interactively, or uses auto-approved trusted actions
-- runtime defaults: optional defaults such as `maxSteps`, model, or reasoning effort
-
-Agent selection is turn-scoped, not session-scoped. In the same saved session,
-you can ask a question with Ask, switch to Code for implementation, then switch
-to Review for feedback.
-
-Project agents live under `.agents/agents/<id>/AGENT.md`; user agents live under
-`~/.agents/agents/<id>/AGENT.md`. The file starts with YAML frontmatter and the
-markdown body becomes the prompt appendix:
-
-```md
----
-schemaVersion: 1
-id: repo-reviewer
-name: Repo Reviewer
-description: Review repository changes without applying fixes.
-modeAlias: review
-runtime:
-  maxSteps: 80
-tools:
-  preset: inspect
-approval:
-  preset: read_only
----
-
-You are a repository review agent. Prioritize correctness, reliability, missing
-tests, and maintainability. Do not edit files or run mutation commands.
-```
-
-Use Settings -> Agents in the browser control plane to create or inspect project
-agents. In chat, use the composer plus menu to choose Ask, Code, Review, or a
-custom agent for the next prompt. For one-shot terminal usage:
-
-```bash
-heddle ask --agent repo-reviewer "Review the current workspace changes"
-heddle ask --mode review "Review the current diff"
-```
-
-Custom agents are role profiles; Agent Skills are reusable instructions the
-agent may load when relevant. A custom agent can still use active skills when
-its tool profile includes `read_agent_skill`.
-
-More: [Custom Agents guide](docs/guides/custom-agents.md)
-
-### Browser Automation
-
-Browser Automation is an opt-in capability for tasks where the agent should see or operate real web pages instead of relying only on code inspection, tests, or plain web search.
-
-Use it when you want Heddle to:
-
-- visually inspect a frontend after local UI changes
-- capture page snapshots or screenshots as evidence
-- interact with a website the user asked it to browse
-- compare visible product/listing pages
-- use rendered DOM state that is not available from static files or APIs
-
-Browser Automation is off by default. Enable it from Settings -> Browser Automation or chat:
-
-```text
-/browser
-/browser enable
-/browser disable
-/browser headed
-/browser headless
-/browser profile <id>
-/browser backend <playwright|native-chrome>
-/browser endpoint <url>
-/browser launch-native [url]
-/browser check-native
-/browser channel <chromium|chrome|msedge>
-/browser open-profile [url]
-/browser close-profile
-```
-
-Enabling Browser Automation activates Heddle's package-owned `browser-automation` Agent Skill and adds these tools to future default agent turns:
-
-```text
-browser_open
-browser_snapshot
-browser_click
-browser_type
-browser_screenshot
-browser_close
-```
-
-The built-in skill teaches the agent when browser automation is appropriate and when `web_search` is only useful for discovering a starting URL. Browser policy still remains authoritative: unsafe actions, off-domain navigation, and ambiguous JavaScript-only clicks can be blocked or require approval.
-
-For normal work, ask the task in chat. Use the composer plus menu -> Use browser
-when you want to nudge the next message toward browser inspection or website
-interaction. This does not enable the workspace capability by itself; it only
-adds task-level context for the next agent turn.
-
-Current behavior:
-
-- if no explicit domain allowlist is configured, the first `browser_open` URL establishes the same-domain browsing boundary for that browser session
-- a later `browser_open` to a different domain starts a fresh derived browser run instead of reusing the previous site's boundary
-- if the first `browser_open` redirects to a regional/canonical domain, that final loaded domain becomes part of the derived boundary
-- snapshots return scoped refs for safe `browser_click` calls
-- `browser_type` can type into editable snapshot refs and optionally submit with Enter for search/navigation
-- screenshots and browser evidence are stored under Heddle state
-- Settings -> Browser Automation and `/browser profile <id>` select a Heddle-owned profile under `.heddle/browser-profiles/`
-- Settings -> Browser Automation and `/browser channel <chromium|chrome|msedge>` select the Playwright browser channel for future agent runs and manual profile windows
-- `/browser headed` opens future runs in a visible Playwright window so you can prepare a logged-in session; `/browser headless` reuses that profile without showing the window
-- Settings -> Browser Automation and `/browser open-profile [url]` can open the selected profile in a visible manual window for login/session management; close it with `/browser close-profile` before asking an agent to use the same profile
-- Settings -> Browser Automation and `/browser launch-native [url]` can launch locally installed Chrome with a Heddle-owned profile and CDP endpoint; keep that Chrome window open, then verify it with `/browser check-native`
-- when the backend is native Chrome and the configured CDP endpoint is not reachable, the first agent `browser_open` can launch local Chrome with the task URL rather than a diagnostic page
-- logged-in sites require the selected browser profile to already have a valid session
-
-Browser Automation agenda:
-
-- add richer form actions such as select, checkbox, and press-key helpers
-- surface browser evidence and screenshots in the control plane
-- design a live browser preview path, likely screenshot/CDP screencast based rather than embedding Playwright's native headed window
-- add richer policy and approval flows for harmless same-origin UI clicks and cart-like actions
-
-### MCP Integrations
-
-Heddle can connect to user-configured Model Context Protocol servers so the agent can use ecosystem tools such as Notion, Anytype, GitHub, or other MCP integrations through Heddle's approval and trace path.
-
-Configure servers by pasting a standard `mcpServers` JSON document into Settings -> MCP, editing `.heddle/mcp.json` directly, or opening that file from chat with `/mcp config`. Server config is separate from workspace activation: after saving config, explicitly enable and refresh the server before future agent turns can see its cached tools.
-
-```text
-/mcp
-/mcp config
-/mcp enable <server>
-/mcp refresh <server>
-/mcp disable <server>
-```
-
-Refreshing an enabled server caches its tool catalog under `.heddle/mcp/`. Future agent turns can inspect MCP tools with `mcp_list_tools` and call them through approval-gated MCP tool adapters.
-
-More: [MCP integrations](docs/reference/mcp.md)
-
-### Heartbeat
-
-Heartbeat is Heddle's model for bounded autonomous wake cycles.
-
-Instead of only running when a human types a prompt, a heartbeat task lets Heddle wake up on a schedule, do a limited amount of work, checkpoint the result, and decide whether to continue, pause, complete, or escalate.
-
-Example commands:
-
-```bash
-heddle heartbeat start --every 30m
-heddle heartbeat task add --id repo-gardener --task "Check for safe maintenance work" --every 1h
-heddle heartbeat task list
-```
-
-Why this exists: some agent work is not a single interactive chat. You may want periodic repo inspection, recurring maintenance checks, scheduled summaries, or a host that can resume work in bounded steps.
-
-More: [Heartbeat guide](docs/guides/heartbeat.md)
-
-### Programmatic Runtime
-
-Heddle is not only a CLI. The npm package exposes explicit programmatic layers:
-
-- `createConversationEngine`: an alpha API for persisted multi-turn sessions with session storage, compaction, approvals, traces, semantic activity, and custom frontends or local hosts
-- `@roackb2/heddle/hosted`: process-local run identity, ordered activity, bounded replay, cancellation, and approval resolution for reconnectable hosted conversations
-- `@roackb2/heddle/hosted/http-sse`: optional Node HTTP/SSE framing, cursor, backpressure, and subscriber-disconnect correctness without choosing a server framework
-- `@roackb2/heddle-remote`: independently installable runtime-validated run envelopes plus shared cursor, duplicate, gap, terminal, and reconnect correctness for remote clients
-- `@roackb2/heddle-remote/http-sse`: optional browser-safe fetch/SSE transport for the conventional REST run resource
-- `AgentLoopRuntimeService.run(...)`: a lower-level single-run execution loop for hosts that do not need persisted chat or session behavior
-
-Advanced hosts can also reuse lower-level class APIs such as `ToolRegistry`, `ToolExecutionService`, `TraceRecorder`, `TraceConsoleFormatter`, and `ReviewDiffParser` when they intentionally assemble custom runtime or review surfaces.
-
-Other exported primitives include `HeartbeatRunnerAgent.run`, `HeartbeatSchedulerService.runDueTasks`, and `FileHeartbeatTaskService` for scheduled or custom host workflows.
-
-More: [Programmatic hosts](docs/guides/programmatic/README.md),
-[choosing an integration layer](docs/guides/programmatic/integration-layers.md),
-[remote conversation runs](docs/guides/programmatic/remote-runs.md),
-and the runnable
-[hosted service → HTTP/SSE → browser client → React reference](examples/sdk/05-hosted-agent/README.md).
-
-### Semantic Drift
-
-Semantic drift is optional telemetry that helps you see whether the assistant's responses appear to be moving away from the recent semantic trajectory of the conversation.
-
-With optional [CyberLoop](https://www.npmjs.com/package/cyberloop) integration installed, Heddle can surface drift levels such as:
-
-- `drift=unknown`
-- `drift=low`
-- `drift=medium`
-- `drift=high`
-
-This is an observability feature, not a correctness guarantee. It is meant to help operators notice when a run may be getting less aligned with its recent direction.
-
-More: [Semantic drift](docs/guides/semantic-drift.md)
-
-## Install
-
-Global install:
-
-```bash
-npm install -g @roackb2/heddle
-```
-
-Run without a global install:
-
-```bash
-npx @roackb2/heddle
-```
-
-The installed CLI command is `heddle`.
-
-## Requirements
-
-- Node.js 20+
-- access to at least one supported provider:
-  - OpenAI account sign-in with `heddle auth login openai`, or `OPENAI_API_KEY`
-  - `ANTHROPIC_API_KEY` for Anthropic models
-  - a local Ollama, LM Studio, LiteLLM, or vLLM server for local OpenAI-compatible models
-  - a hosted gateway API key such as `HF_TOKEN`, `OPENROUTER_API_KEY`, `TOGETHER_API_KEY`, or `GROQ_API_KEY`
-
-Heddle intentionally does not support Anthropic consumer subscription OAuth. Use Anthropic API-key access unless Anthropic provides an approved third-party auth route.
-
-## Optional CyberLoop Integration
-
-If you want semantic drift telemetry in chat, install `cyberloop` in the same environment as Heddle:
-
-```bash
-npm install -g cyberloop
-# or for project-local usage
-npm install cyberloop
-```
-
-For one-off usage without a global install:
-
-```bash
-npx -p @roackb2/heddle -p cyberloop heddle
-```
+![Heddle streams the same session across terminal, browser, and mobile](docs/images/heddle-cross-device-stream.gif)
+
+The reference product also includes saved sessions, reviewable diffs,
+workspace memory, Agent Skills, custom agents, MCP integrations, heartbeat
+tasks, and opt-in Browser Automation. These are useful product features and
+dogfood for the same reusable runtime boundaries.
+
+More:
+
+- [Chat and sessions](docs/guides/chat-and-sessions.md)
+- [Control plane](docs/guides/control-plane.md)
+- [Providers and models](docs/reference/providers-and-models.md)
+- [Capabilities and Browser Automation](docs/reference/capabilities.md)
+- [Agent Skills](docs/guides/agent-skills.md)
+- [Custom agents](docs/guides/custom-agents.md)
+- [Knowledge persistence](docs/guides/knowledge-persistence.md)
+- [Heartbeat](docs/guides/heartbeat.md)
+- [MCP integrations](docs/reference/mcp.md)
+
+OpenAI account sign-in is an experimental, user-selected transport for Heddle.
+It is not official OpenAI support, and Heddle is not affiliated with, endorsed
+by, or sponsored by OpenAI. Use of OpenAI services remains subject to OpenAI's
+terms and policies.
+
+## Production Posture
+
+Heddle is designed to make assumptions and limitations visible:
+
+- the curated SDK targets Node.js 20+ TypeScript/ESM hosts;
+- conversation state is durable through the configured repositories, while
+  active-run handles and replay are process-local and bounded;
+- multi-process routing and durable in-flight delivery require infrastructure
+  selected by the host;
+- session and artifact repositories are injectable, but production retention,
+  encryption, backup, tenancy, and adapter operations remain host
+  responsibilities;
+- traces, compaction archives, memory, and some supporting state remain
+  local/path-oriented unless the host deliberately provides another
+  integration path;
+- HTTP/SSE helpers own wire correctness, not route registration,
+  authentication, authorization, CORS, limits, billing, or deployment;
+- `@roackb2/heddle-remote` validates the run protocol but does not own product
+  messages, UI state, authentication, or result rendering;
+- the SDK is actively evolving, so review
+  [release notes](docs/releases/README.md) before upgrading public APIs.
+
+Heddle is not a hosted agent SaaS and does not require your product to adopt a
+particular identity provider, database, server framework, transport, UI
+framework, or deployment platform.
 
 ## Documentation
 
-Start here:
+### Build with the SDK
+
+- [Programmatic hosts](docs/guides/programmatic/README.md)
+- [SDK quickstart](docs/guides/programmatic/quickstart.md)
+- [Integration-layer chooser](docs/guides/programmatic/integration-layers.md)
+- [Conversation engine](docs/guides/programmatic/conversation-engine.md)
+- [Host extensions](docs/guides/programmatic/host-extensions.md)
+- [MCP host extensions](docs/guides/programmatic/mcp-host-extensions.md)
+- [Remote conversation runs](docs/guides/programmatic/remote-runs.md)
+- [Result artifacts](docs/guides/programmatic/result-artifacts.md)
+- [Runnable SDK examples](examples/sdk/README.md)
+
+### Use Heddle locally
 
 - [Documentation hub](docs/README.md)
 - [Runtime host model](docs/guides/runtime-host-model.md)
-- [Chat and sessions guide](docs/guides/chat-and-sessions.md)
-- [Providers and models](docs/reference/providers-and-models.md)
-- [CLI reference](docs/reference/cli.md)
-
-Feature guides:
-
+- [Chat and sessions](docs/guides/chat-and-sessions.md)
 - [Control plane](docs/guides/control-plane.md)
-- [Heartbeat](docs/guides/heartbeat.md)
-- [Agent Skills](docs/guides/agent-skills.md)
-- [Custom Agents](docs/guides/custom-agents.md)
-- Browser Automation: see the Browser Automation section above
-- [MCP integrations](docs/reference/mcp.md)
-- [Knowledge persistence](docs/guides/knowledge-persistence.md)
-- [Semantic drift](docs/guides/semantic-drift.md)
-- [Programmatic hosts](docs/guides/programmatic/README.md)
+- [CLI reference](docs/reference/cli.md)
+- [Project configuration](docs/reference/config.md)
 
-Contributors:
+### Contribute
 
 - [Agent context](docs/agent-context.md)
 - [Project posture](docs/project-posture.md)
-- [Development and contributing](docs/guides/development.md)
-- [Release convention](docs/releases/README.md)
-- [Framework Vision](docs/strategy/framework-vision.md)
-- [Coding Agent Roadmap](docs/strategy/coding-agent-roadmap.md)
-
-## Project Status
-
-Heddle is already useful for real coding-agent workflows, but it is still evolving.
-
-Current strengths include:
-
-- terminal-first coding and repository workflows
-- autonomous, catalog-backed workspace memory that helps the agent learn from normal usage
-- standard Agent Skills support with workspace-level activation and progressive disclosure
-- custom agents for turn-scoped role, tool, approval, and runtime profiles
-- opt-in Browser Automation with browser snapshots, screenshots, policy checks, and a published next-step agenda
-- MCP integration support for user-configured ecosystem tools
-- explicit traces, approval previews, diff review, and local workspace state
-- browser-based oversight and workspace switching through the control plane
-- local-first heartbeat primitives for scheduled agent work
-- practical programmatic hooks for custom hosts
-
-Current limitations include:
-
-- the browser control plane is read-only for file review; it is not yet an editable IDE-like diff environment
-- Browser Automation still needs profile management, form-safe actions, and richer browser evidence surfaces
-- some advanced workflows remain better documented in source and examples than in polished product UX
-- the project surface is still changing as the runtime matures
+- [Development guide](docs/guides/development.md)
+- [Core layering](docs/architecture/core-layering.md)
+- [Framework vision](docs/strategy/framework-vision.md)
 
 ## Development
-
-If you want to work on Heddle itself:
 
 ```bash
 git clone https://github.com/roackb2/heddle.git
@@ -650,9 +373,8 @@ yarn build
 yarn test
 ```
 
-`yarn test` runs the default unit and integration suites. Browser integration coverage lives under `src/__tests__/browser-integration` and runs on PRs; run it locally with `yarn test:browser-integration`.
-
-See [Development and contributing](docs/guides/development.md) for the fuller contributor workflow.
+`yarn test` runs the default unit and integration suites. Browser integration
+coverage lives under `src/__tests__/browser-integration`.
 
 ## License
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,618 +2,354 @@
 
 [English](README.md) | [繁體中文](README.zh-TW.md)
 
-Heddle 是開源 AI 程式開發代理執行環境，也是以終端機為優先，協助你開發功能、修正錯誤、維護軟體，並保留可審查代理執行過程的工作區。
+**把 agentic experience 帶進你的產品，同時保有架構主導權。**
+
+Heddle 是開源的 TypeScript agent runtime 與 SDK，提供可持久化對話、tool
+與 MCP 執行、approval、artifact、可追蹤的 activity，以及可重新連線的
+hosted run。
+
+你的產品仍掌控 identity、資料關係、API policy、部署、transport 與 UI。
+可以先建立一個可運作的對話，再依產品需求逐層採用 Heddle。
+
+想先看看 runtime 實際如何運作，再決定是否嵌入產品？Heddle 的本機 coding
+agent、terminal UI 與 browser control plane，都建立在 SDK 對外提供的同一套
+conversation 與 run 基礎之上。
 
 官方網站：[heddleagent.com](https://heddleagent.com)
 
-> **Terminal UI v2 現在是預設介面。** 執行 `heddle` 或 `heddle chat` 會進入 API-backed 終端機體驗。訊息、執行事件、代理回應串流會走同一條 shared control-plane path，讓終端機、瀏覽器、行動端可以同時追蹤同一個工作。
+從這裡開始：
+[SDK 快速入門](docs/guides/programmatic/quickstart.md) ·
+[選擇整合層級](docs/guides/programmatic/integration-layers.md) ·
+[可執行的 SDK 範例](examples/sdk/README.md) ·
+[試用 coding agent](#將-heddle-當作-coding-agent-試用)
 
-## 目錄
+## 為什麼選 Heddle
 
-- [Heddle 能做什麼](#heddle-能做什麼)
-- [實際運作畫面](#實際運作畫面)
-- [快速開始](#快速開始)
-- [核心工作流程](#核心工作流程)
-  - [終端機程式開發](#終端機程式開發)
-  - [模型供應商](#模型供應商)
-  - [瀏覽器控制平面](#瀏覽器控制平面)
-  - [工作階段與連續性](#工作階段與連續性)
-  - [專案指令](#專案指令)
-  - [知識持久化](#知識持久化)
-  - [Agent Skills](#agent-skills)
-  - [自訂代理](#自訂代理)
-  - [瀏覽器自動化](#瀏覽器自動化)
-  - [MCP 整合](#mcp-整合)
-  - [心跳任務](#心跳任務)
-  - [程式化執行環境](#程式化執行環境)
-  - [語意漂移](#語意漂移)
-- [安裝](#安裝)
-- [需求](#需求)
-- [選用 CyberLoop 整合](#選用-cyberloop-整合)
-- [文件](#文件)
-- [專案狀態](#專案狀態)
-- [開發](#開發)
-- [授權](#授權)
+呼叫模型並註冊一個 tool，只是 agentic product 的起點。真正困難的產品工程，
+通常從對話必須跨多個 turn、顯示可理解的 activity、等待 approval、跨越單一
+HTTP request 的生命週期、在瀏覽器重新整理後重新連線，並在不洩漏內部狀態的
+前提下套用結果開始。
 
-## Heddle 能做什麼
+Heddle 負責這些可重用的 runtime mechanics，同時把產品決策留在產品內：
 
-Heddle 適合想讓 AI 程式開發助理參與日常軟體開發，同時保留本地工作脈絡與可審查執行過程的工程師、維護者、個人專案開發者。
+- 可持久化的多輪對話、continuation、compaction 與 lease；
+- 原生 tool、Agent Skills，以及經過挑選的 MCP-backed host extension；
+- approval request、semantic activity、trace、artifact 與 typed turn result；
+- 可定址的 active run、排序過的 event、bounded replay、cancellation、
+  approval resolution，以及唯一 terminal outcome；
+- runtime-validated remote envelope、cursor 推進、duplicate/gap handling，
+  與 bounded reconnect calculation；
+- file-backed 本機預設值，以及 host capability、storage、output、policy 與
+  transport 的明確擴充點。
 
-它適合用來：
+Heddle 適合以 TypeScript 建置文件 agent、研究助理、內部 copilot、營運 agent
+或其他產品體驗的團隊，尤其是重視可檢查性與 host control，而不只需要一次性
+chat endpoint 的情境。
 
-- 檢查與理解陌生程式碼庫
-- 為工作或個人專案開發新的產品功能
-- 建立前端頁面、後端服務、CLI 工具、文件與測試
-- 修正錯誤、調查退化問題，並解釋陌生程式路徑
-- 重構既有模組，同時保留可審查的差異
-- 執行有界驗證，例如建置、測試、程式碼庫審查
-- 讓多步驟實作工作跨已儲存的工作階段持續進行
-- 在接受變更前審查檔案差異、命令、核准、追蹤紀錄與語意活動
-- 從瀏覽器控制平面切換本地工作區
-- 讓代理隨著實際工作學習持久專案知識
-- 只在工作區需要時啟用標準 Agent Skills
-- 定義自訂代理，讓不同回合使用 Ask、Code、Review、文件撰寫、發版操作等角色
-- 連接使用者設定的 MCP 伺服器，例如 Notion、Anytype、GitHub 或其他工具
-- 選擇性啟用瀏覽器自動化，用於渲染後頁面檢查與使用者要求的網頁流程
-- 透過 Heddle 的供應商轉接器使用託管模型、本地 Ollama 與 OpenAI-compatible 供應商
-- 基於 Heddle 執行環境 API 建立自訂主機
+## 開始建置
 
-如果你只需要非常簡單的單次提示執行工具，而且不在意 sessions、持久化、可觀測性或操作員控制，Heddle 可能不是最適合的工具。
+### 最快的 SDK 評估方式
 
-## 實際運作畫面
+安裝 Node runtime package：
 
-終端機、瀏覽器、行動端介面可以同時觀察同一個即時 session：
+```bash
+npm install @roackb2/heddle
+```
 
-![Heddle streams the same session across terminal, browser, and mobile](docs/images/heddle-cross-device-stream.gif)
+接著啟動一個可持久化的互動式對話：
 
-你可以在控制平面裡審查與核准敏感操作，同時代理執行仍然保持可見：
+```ts
+import { runQuickstartConversationCli } from '@roackb2/heddle'
 
-![Heddle 在瀏覽器控制平面中的請求核准流程](docs/images/heddle-request-approval.gif)
+await runQuickstartConversationCli()
+```
 
-瀏覽器與行動端可以檢查工作區差異，而同一個 conversation 仍然持續：
+Quickstart 會在開啟 prompt loop 前，解析 workspace、本機 state root、已設定的
+model 與 credential。它刻意比 Heddle 完整產品 CLI 更小，是評估 SDK 最短的
+路徑。
 
-![Heddle 在瀏覽器與行動端審查差異](docs/images/heddle-diff-view.gif)
+在此 repository 中執行對應範例：
 
-Heddle 也可以作為終端機優先的程式開發代理，顯示即時進度、工具活動、計畫與審查輸出：
+```bash
+yarn example:sdk:interactive
+```
 
-![Heddle 終端機程式開發工作流程](docs/images/terminal-active-run.png)
+Model、credential、prompt、command 與 host extension 選項，請參考
+[SDK 快速入門](docs/guides/programmatic/quickstart.md)。
 
-終端機聊天與開發工作流程展示檔案編輯、行內差異輸出與以驗證為導向的後續處理：
+### 掌控 presentation 與 turn lifecycle
 
-![Heddle 終端機變更審查](docs/images/terminal-change-review.png)
+當產品需要自行掌控 rendering、command、approval 或 session browsing 時，
+改用 `createConversationEngine`：
 
-預設的本地控制平面是由 `heddle daemon` 提供的 web-v2 瀏覽器客戶端：
+```ts
+import { join } from 'node:path'
+import {
+  createConversationEngine,
+  createConversationTextHost,
+} from '@roackb2/heddle'
 
-![Heddle web-v2 控制平面](docs/images/control-plane-v2.png)
+const workspaceRoot = process.cwd()
 
-Task workbench 支援週期性 heartbeat tasks、即時執行狀態與執行結果審查：
+const engine = createConversationEngine({
+  workspaceRoot,
+  stateRoot: join(workspaceRoot, '.heddle'),
+  model: process.env.HEDDLE_MODEL ?? 'gpt-5.4',
+})
 
-![Heddle web-v2 heartbeat task workbench](docs/images/control-plane-v2-heartbeat-task.png)
+const session = await engine.sessions.create({
+  name: 'Product assistant',
+})
 
-同一個控制平面也支援行動版版面，提供工作階段列表、工作區與差異預覽的聚焦面板：
+const textHost = createConversationTextHost({
+  output: (text) => process.stdout.write(text),
+})
 
-<p>
-  <img src="docs/images/control-plane-v2-session-list.PNG" alt="Heddle web-v2 mobile session list" width="220">
-  <img src="docs/images/control-plane-v2-workbench.PNG" alt="Heddle web-v2 mobile workbench" width="220">
-  <img src="docs/images/control-plane-v2-diff-view.PNG" alt="Heddle web-v2 mobile diff preview" width="220">
-</p>
+const result = await engine.turns.submit({
+  sessionId: session.id,
+  prompt: 'Summarize this workspace and identify the main verification path.',
+  host: textHost.host,
+})
 
-## 快速開始
+textHost.renderTurnResult(result)
+```
 
-1. 安裝 Heddle：
+Text host 提供一個可運作的 output surface。當產品擁有自己的 UI 時，可將它
+替換成產品的 activity、approval、telemetry 與 result handler。若 turn 必須
+超過單一 request 的生命週期，或支援 remote reconnect，請繼續閱讀
+[hosted agent stack](examples/sdk/05-hosted-agent/README.md)。
+
+## 重用 Runtime，產品仍由你掌控
+
+Heddle 刻意不是一個完整 application framework：
+
+```text
+你的產品
+  UI state 與 result application
+          |
+  @roackb2/heddle-remote + optional HTTP/SSE client
+          |
+  你的 API、authentication、public schema 與 product state
+========================= HEDDLE SDK =========================
+  ConversationRunService
+  run identity、ordered activity、replay、cancel、approvals
+          |
+  ConversationEngine
+  sessions、turns、compaction、traces、artifacts
+          |
+  models、tools、host extensions、MCP
+```
+
+| 關注點 | Heddle 負責 | 你的產品負責 |
+| --- | --- | --- |
+| Conversation | Message、turn、continuation、compaction、lease 與 persisted session behavior | 穩定的 product conversation ID、access rule 與產品資料關係 |
+| Execution | Model/tool loop、tool execution、host extension、trace、activity 與 artifact | Product tool、system context、model choice、credential 與 capability policy |
+| Approvals | Request/resolution lifecycle 與 run integration | 誰能批准、approval policy 與 approval UI |
+| Active runs | Run ID、ordered sequence、bounded replay、cancellation 與 terminal settlement | Process lifetime、routing、draining 與 multi-process delivery |
+| Remote clients | Runtime envelope validation、cursor/duplicate/gap rule、terminal detection 與 reconnect calculation | Public payload schema、timer、UI state、retry UX 與 result presentation |
+| Persistence | File-backed 預設值與可注入的 session/artifact repository boundary | Production adapter、retention、encryption、backup、tenancy 與 product record |
+| API 與 UI | 選用的 Node HTTP/SSE 與 browser transport mechanics | Server framework、route、auth、CORS、limit、error 與所有視覺決策 |
+
+完整的責任邊界請參考
+[選擇 Programmatic Integration Layer](docs/guides/programmatic/integration-layers.md)。
+
+## 選擇整合深度
+
+Heddle 的 public entry point 會明確表達各層假設。選擇已經涵蓋 host 所需
+mechanics 的最低層即可：
+
+| Host 需求 | 從這裡開始 | 增加的能力 |
+| --- | --- | --- |
+| 可運作的本機對話 | `runQuickstartConversationCli` | Prompt loop、persisted session、credential 與 text output |
+| 自訂 output、tool 或 session UX | `@roackb2/heddle` | Conversation engine、host extension、tool、MCP、approval、artifact 與 turn result |
+| Server、worker 或 Electron backend | `@roackb2/heddle/hosted` | 可定址的 process-local run、replay、cancellation 與 approval resolution |
+| 一般 Node HTTP/SSE | `@roackb2/heddle/hosted/http-sse` | Replay cursor parsing、SSE framing、backpressure 與 disconnect cleanup |
+| Remote browser 或 client | `@roackb2/heddle-remote` | Browser-safe protocol validation 與 transport-neutral run consumption |
+| 一般 browser REST/SSE | `@roackb2/heddle-remote/http-sse` | Authenticated fetch、incremental SSE parsing 與 transport validation |
+| 更底層的 runtime 組裝 | `@roackb2/heddle/advanced` | Model adapter、individual tool、trace、memory、heartbeat 與 core runtime service |
+
+既有的 tRPC、Fastify、Hono、Nest、WebSocket、IPC、queue、React 或其他技術棧，
+通常應保留原本的選擇，再銜接最接近的 transport-neutral Heddle layer。不要
+只因 reference example 使用 Express 或 React，就在產品中加入它們。
+
+## 漸進式 SDK 範例
+
+可執行的範例會以小步驟教你逐層客製：
+
+1. [Interactive chat](examples/sdk/01-interactive-chat.ts) — 啟動可持久化對話。
+2. [Add a tool](examples/sdk/02-add-a-tool.ts) — 暴露產品原生能力。
+3. [Add an MCP server](examples/sdk/03-add-an-mcp-server.ts) — 不複製 schema，
+   直接準備經過挑選的 MCP-backed capability。
+4. [Custom output](examples/sdk/04-custom-output.ts) — 保留 conversation
+   semantics，同時替換 presentation。
+5. [Hosted agent stack](examples/sdk/05-hosted-agent/README.md) — 從
+   transport-neutral service，逐步走到選用的 HTTP/SSE API、browser client
+   與 React reference。
+
+每個階段都會說明假設與責任邊界。只複製符合產品架構的 layer。
+
+## 核心能力
+
+### 對話與結果
+
+- 可持久化 session，包含 create、resume、continue、rename、archive 與
+  compaction path；
+- text、tool、approval、lifecycle 與 progress 的 structured conversation
+  activity；
+- 包含 trace、tool outcome、artifact 與安全 typed model failure 的 turn
+  summary；
+- 產出文件與大型 tool result 的 artifact capture，包含 stateless MCP tool
+  的 mirror workflow。
+
+### 能力與控制
+
+- Host-owned `ToolDefinition` capability 與可重用 tool registry；
+- 支援 workspace activation 與 progressive disclosure 的 Agent Skills；
+- 支援 curated exposure、override 與 result-artifact rule 的 prepared MCP
+  host extension；
+- approval policy chain 與 host-owned approval decision；
+- OpenAI、Anthropic、Ollama 與 OpenAI-compatible provider profile。
+
+### Hosted 與 remote runs
+
+- 每個 host-defined conversation address 僅有一個 active run；
+- stable run ID、ordered event sequence、bounded replay、explicit
+  cancellation 與 approval resolution；
+- 在 success terminal 對外可見前，等待 product result projection 完成；
+- 安全的 public error projection，讓 provider 與 persistence diagnostic 留在
+  host；
+- 輕量 browser package，不帶入 Heddle 的 Node runtime、CLI、model
+  provider、server 與 control plane。
+
+完整內容請參考
+[programmatic guide index](docs/guides/programmatic/README.md)。
+
+## 將 Heddle 當作 Coding Agent 試用
+
+Coding agent 是把 Heddle runtime 當成完整 product host 體驗的最快方式。
+
+安裝 CLI：
 
 ```bash
 npm install -g @roackb2/heddle
 ```
 
-2. 設定 provider 存取權。
-
-OpenAI 可以使用自己的 ChatGPT/Codex account 登入：
-
-```bash
-heddle auth login openai
-```
-
-也可以使用 Platform API key：
+設定一個 provider。使用 OpenAI Platform API key：
 
 ```bash
 export OPENAI_API_KEY=your_key_here
 ```
 
-如果你同時保留 OpenAI OAuth credential 和 API key 用於測試，可以明確要求某次執行優先使用 API key：
+或選擇實驗性的 OpenAI account sign-in：
 
 ```bash
-heddle --prefer-api-key
-heddle --prefer-api-key ask "Summarize this repository"
-heddle --prefer-api-key daemon
+heddle auth login openai
 ```
 
-Anthropic 使用 API key：
-
-```bash
-export ANTHROPIC_API_KEY=your_key_here
-```
-
-本地模型可安裝並啟動 [Ollama](https://ollama.com)，再用 `ollama/` prefix 選擇已安裝的 chat model：
-
-```bash
-ollama list
-heddle --model ollama/llama3.2:latest ask "Reply with exactly: ok"
-```
-
-Ollama 不需要 hosted provider API key。Heddle 預設使用 Ollama 的本地 OpenAI-compatible endpoint：`http://127.0.0.1:11434/v1`。
-
-OpenAI account sign-in 是 Heddle 提供的實驗性、由使用者選擇的傳輸方式。這不是 OpenAI 官方支援，Heddle 與 OpenAI 沒有 affiliation、endorsement 或 sponsorship。使用 OpenAI 服務仍受 OpenAI terms and policies 約束。
-
-3. 進入你想檢查的程式碼庫：
+接著開啟任何 repository：
 
 ```bash
 cd /path/to/project
-```
-
-4. 啟動 chat：
-
-```bash
 heddle
 ```
 
-5. 試一個提示：
+試著輸入：
 
 ```text
-Summarize this repository, show me the main build/test commands, and point out the likely entrypoints.
+Summarize this repository, identify its main entrypoints, and show me the
+commands used to build and test it.
 ```
 
-6. 如果也想使用瀏覽器監督 UI：
+執行一次性的 saved run：
+
+```bash
+heddle ask "Review the current repository and identify the highest-risk change."
+```
+
+從 browser 與 mobile 監看同一組對話：
 
 ```bash
 heddle daemon
 ```
 
-從 daemon output 開啟瀏覽器控制平面。你可以在裡面使用 `Sessions`、`Tasks`、`Settings` 檢查目前工作區、繼續已儲存的工作階段、審查變更、檢查記憶狀態，或切換到其他本地專案。
-
-如果想執行一次性 run，而不是進入互動式 chat：
-
-```bash
-heddle ask "Summarize this repository"
-```
-
-`ask` 會在一個提示後結束，但它仍會把執行記錄為 `.heddle/` 底下的一次性已儲存工作階段，讓追蹤紀錄、記憶維護與後續檢查都使用和一般工作階段相同的持久化對話路徑。
-
-### 試試 Learning Loop
-
-當 Heddle 學會可重用偏好並在之後套用時，它會變得更有用。你可以在 chat 裡教它 ticket 格式：
-
-```text
-Whenever I ask you to create a ticket, use these sections: problem statement, proposed approach, considered alternatives, conclusion.
-```
-
-然後開一個新的 session 並詢問：
-
-```text
-Create a ticket for maintaining doc consistency after feature updates.
-```
-
-Heddle 應該會從本地 memory catalog 取回這個偏好，並用該結構產生 ticket。你可以用以下指令檢查它學到了什麼：
-
-```bash
-heddle memory status
-heddle memory list
-heddle memory search ticket
-```
-
-## 核心工作流程
-
-### 終端機程式開發
-
-Heddle 的主要使用方式是在程式碼庫裡開啟互動式聊天：
-
-```bash
-heddle
-```
-
-在聊天裡，Heddle 可以檢查檔案、使用遵守忽略規則的備援搜尋、解釋程式碼、進行編輯、用正確核准模型執行 shell 命令，並讓任務跨多個回合持續前進。
-
-終端機輸入框支援多行提示、提示復原與重做、提示歷史瀏覽、透過 `/model set` 選模型，以及透過 `/reasoning set` 選推理強度。執行時，Heddle 會串流可見活動，讓你知道它是在思考、搜尋、呼叫工具、更新計畫，還是在等待核准。
-
-更多：[聊天與工作階段指南](docs/guides/chat-and-sessions.md)
-
-### 模型供應商
-
-Heddle 不綁定單一模型供應商。它透過供應商轉接器支援託管前沿模型、本地模型與 OpenAI-compatible 閘道，讓你可以依照每次工作選擇最合適的取捨：能力最強的託管模型、私有本地模型、自架推論伺服器，或路由閘道。
-
-支援的供應商家族：
-
-- OpenAI，包含 OpenAI account sign-in 與 Platform API-key mode
-- Anthropic Claude API key
-- Ollama 本地模型，使用 `ollama/` 前綴
-- LM Studio 本地伺服器模型，使用 `lmstudio/` 前綴
-- LiteLLM 閘道模型，使用 `litellm/` 前綴
-- vLLM 自架 OpenAI-compatible 模型，使用 `vllm/` 前綴
-- Hugging Face router 模型，使用 `huggingface/` 或 `hf/` 前綴
-- OpenRouter 模型，使用 `openrouter/` 前綴
-- Together AI 模型，使用 `together/` 前綴
-- Groq 模型，使用 `groq/` 前綴
-
-先啟動 Ollama，pull 或安裝支援聊天的模型，然後用 `ollama/` 模型前綴選擇它：
-
-```bash
-ollama list
-heddle --model ollama/llama3.2:latest ask "Summarize this repository"
-heddle chat --model ollama/llama3.2:latest
-```
-
-其他 OpenAI-compatible 供應商則用對應設定檔前綴選擇模型：
-
-```bash
-heddle --model lmstudio/local-model ask "Reply with exactly: ok"
-heddle --model openrouter/meta-llama/llama-3.3-70b-instruct ask "Summarize this repository"
-```
-
-在終端機聊天裡，可以用 `/model set <query>` 搜尋可用模型。終端機選擇器與瀏覽器模型選擇器使用同一個模型選項服務：Ollama 會從本地 Ollama API 發現模型，其他 OpenAI-compatible 設定檔會在本地伺服器正在執行或託管 API key 已設定時從 `/models` 發現模型。
-
-```text
-/model set llama
-/model ollama/llama3.2:latest
-```
-
-本地與閘道模型的品質差異很大。有些較小、較舊或經由供應商路由的模型不擅長工具呼叫，可能忽略工具結果，或給出有信心但錯誤的程式碼庫答案。請保留人工審查，對高風險工作維持核准提示，重要修改建議使用能力較強的模型。
-
-更多：[模型供應商](docs/reference/model-providers.md) 與 [供應商與模型](docs/reference/providers-and-models.md)
-
-### 瀏覽器控制平面
-
-控制平面是 Heddle 的本地瀏覽器 UI：
-
-```bash
-heddle daemon
-```
-
-它提供瀏覽器介面，用來查看工作區、已儲存對話、即時助理串流、工具進度、核准、目前工作區差異、心跳任務、記憶健康狀態與設定。
-
-工作區切換器與 `Settings > Workspace` 頁面讓你註冊本地專案、在控制平面裡切換專案、重新命名工作區項目，並從瀏覽器 UI 選擇專案資料夾。`Sessions` 區塊以目前工作為核心：審查從作用中工作區的即時 Git 工作樹開始，包含已變更檔案、結構化唯讀差異，以及當側邊面板太窄時使用的較大完整差異檢視器。
-
-如果終端機聊天是執行介面，那控制平面就是監督介面。
-
-更多：[控制平面指南](docs/guides/control-plane.md)
-
-### 工作階段與連續性
-
-Heddle 會把已儲存的工作階段放在 `.heddle/`，所以較長的工作不需要每次重新開始。目前版本把工作階段目錄存在 `.heddle/chat-sessions.catalog.json`，並把每個工作階段的內容存在 `.heddle/chat-sessions/`。
-
-常用工作階段指令：
-
-```text
-/session list
-/session switch <id>
-/continue
-/compact
-/model set
-/reasoning set
-```
-
-更多：[聊天與工作階段指南](docs/guides/chat-and-sessions.md)
-
-### 專案指令
-
-Heddle 可以在啟動時載入短的專案指令檔，讓新的工作階段一開始就有程式碼庫的操作脈絡。預設會依序尋找第一個非空檔案：`HEDDLE.md`、`AGENTS.md`、`CLAUDE.md`。
-
-為了保留 context 空間，預設只載入一個檔案。如果專案需要不同路徑，或刻意想載入多個檔案，可以在 `.heddle/config.json` 設定 `agentContextPaths`。
-
-更多：[Project config](docs/reference/config.md)
-
-### 知識持久化
-
-Heddle 可以在工作過程中學習持久專案知識。
-
-當代理注意到可重用資訊，例如偏好的 ticket 格式、標準驗證命令、操作慣例、反覆出現的程式碼庫特性或穩定工作流程，它可以記錄記憶候選項，並讓專門的維護流程把這些知識整理進 `.heddle/memory/` 底下的目錄化 Markdown 筆記。
-
-目標是實用回想：未來的工作階段應該知道要去哪裡找，而不是每次從頭重新探索相同脈絡。Heddle 透過明確目錄、可讀的本地筆記、維護記錄與記憶檢視指令達成，而不是不透明的擷取。
-
-更多：[知識持久化指南](docs/guides/knowledge-persistence.md)
-
-### Agent Skills
-
-Heddle 支援標準 Agent Skills 資料夾格式，用於可重用、選用的代理工作流程。你可以把專案 skills 放在 `.agents/skills/<name>/SKILL.md`，或把使用者 skills 放在 `~/.agents/skills/<name>/SKILL.md`，然後從聊天管理工作區啟用狀態：
-
-```text
-/skills
-/skills enable <name>
-/skills disable <name>
-```
-
-Heddle 也會內建一些由 Heddle 擁有能力對應的 built-in skills。能力設定可以啟用這些 built-ins，不需要使用者另外安裝 skill files。
-
-只有啟用中的 skills 會顯示給代理。Heddle 一開始只暴露精簡目錄，包含每個啟用中 skill 的名稱與描述；當某個 skill 相關時，代理可以呼叫 `read_agent_skill` 取得完整 `SKILL.md` 內容。啟用狀態存在 `.heddle/skills/activation.json`；skill 定義仍留在原本的資料夾。
-
-Skills 是指令，不是權限。它們不會繞過 Heddle 的核准政策或工具安全檢查，所以使用者仍需要對自己啟用哪些專案或使用者 skills 負責。
-
-更多：[Agent Skills 指南](docs/guides/agent-skills.md)
-
-### 自訂代理
-
-自訂代理讓你替特定回合選擇 Heddle 應該使用的角色。Heddle 內建的
-Ask、Code、Review 模式本身就是自訂代理；你也可以定義自己的專案代理或使用者代理，
-用於程式碼庫審查、文件撰寫、發版操作、事件調查等專門工作。
-
-一個自訂代理是一個具名的執行設定檔：
-
-- 提示詞附錄：附加在 Heddle 預設系統提示詞後面的額外指令
-- 工具設定：該回合中模型可以看見哪些工具
-- 核准設定：代理是唯讀、需要互動式核准，或使用可信任的自動核准動作
-- 執行預設值：選用預設值，例如 `maxSteps`、模型或推理強度
-
-代理選擇是以回合為範圍，不是以整個工作階段為範圍。在同一個已儲存工作階段裡，
-你可以先用 Ask 問問題，再切到 Code 實作，最後切到 Review 做審查回饋。
-
-專案代理放在 `.agents/agents/<id>/AGENT.md`；使用者代理放在
-`~/.agents/agents/<id>/AGENT.md`。檔案以 YAML frontmatter 區塊開頭，Markdown 內文
-會成為提示詞附錄：
-
-```md
----
-schemaVersion: 1
-id: repo-reviewer
-name: Repo Reviewer
-description: Review repository changes without applying fixes.
-modeAlias: review
-runtime:
-  maxSteps: 80
-tools:
-  preset: inspect
-approval:
-  preset: read_only
----
-
-You are a repository review agent. Prioritize correctness, reliability, missing
-tests, and maintainability. Do not edit files or run mutation commands.
-```
-
-在瀏覽器控制平面裡，可以用 Settings -> Agents 建立或檢視專案代理。
-在聊天輸入框的加號選單中，可以為下一個提示選擇 Ask、Code、Review 或自訂代理。
-一次性的終端機使用方式：
-
-```bash
-heddle ask --agent repo-reviewer "Review the current workspace changes"
-heddle ask --mode review "Review the current diff"
-```
-
-自訂代理是角色設定檔；Agent Skills 則是代理在相關任務中可以載入的可重用指令。
-當自訂代理的工具設定包含 `read_agent_skill` 時，它仍然可以使用已啟用的 Agent Skills。
-
-更多：[自訂代理指南](docs/guides/custom-agents.md)
-
-### 瀏覽器自動化
-
-瀏覽器自動化是選用功能，用於代理需要看見或操作真實網頁，而不能只依賴程式碼檢查、測試或一般網路搜尋的任務。
-
-適合在你希望 Heddle 做這些事時使用：
-
-- 在本地 UI 變更後目視檢查前端
-- 擷取頁面快照或截圖作為證據
-- 與使用者指定的網站互動
-- 比較可見的商品頁或列表頁
-- 使用靜態檔案或 API 看不到的渲染後 DOM 狀態
-
-瀏覽器自動化預設關閉。可以從 Settings -> Browser Automation 或聊天中啟用：
-
-```text
-/browser
-/browser enable
-/browser disable
-/browser headed
-/browser headless
-/browser profile <id>
-/browser backend <playwright|native-chrome>
-/browser endpoint <url>
-/browser launch-native [url]
-/browser check-native
-/browser channel <chromium|chrome|msedge>
-/browser open-profile [url]
-/browser close-profile
-```
-
-啟用瀏覽器自動化會啟用 Heddle 套件內建的 `browser-automation` Agent Skill，並把以下工具加入未來預設的代理回合：
-
-```text
-browser_open
-browser_snapshot
-browser_click
-browser_type
-browser_screenshot
-browser_close
-```
-
-內建 skill 會教代理什麼時候適合使用瀏覽器自動化，以及什麼時候 `web_search` 只適合用來發現起始 URL。瀏覽器政策仍然是最終邊界：不安全操作、跨網域導覽、語意不明的 JavaScript-only 點擊可能被阻擋或要求核准。
-
-一般工作時，直接在聊天中描述任務即可。當你希望下一則訊息偏向瀏覽器檢查或網站互動，可以在 composer 的加號選單選擇「使用瀏覽器」。這不會自行啟用工作區能力，只會為下一個代理回合加入任務層級的脈絡提示。
-
-目前行為：
-
-- 如果沒有明確的網域允許清單，第一個 `browser_open` URL 會建立該瀏覽器工作階段的同網域瀏覽邊界
-- 之後若 `browser_open` 指向不同網域，會開始新的衍生瀏覽器執行，而不是沿用上一個網站的邊界
-- 如果第一個 `browser_open` 重新導向到地區或正式網域，最後載入的網域也會納入衍生邊界
-- 快照會回傳作用範圍限定的 refs，供安全的 `browser_click` 呼叫使用
-- `browser_type` 可以輸入到可編輯的快照 ref，並可選擇按 Enter 送出搜尋或導覽
-- 截圖與瀏覽器證據會存放在 Heddle 狀態目錄
-- Settings -> Browser Automation 與 `/browser profile <id>` 可選擇 Heddle 管理的瀏覽器設定檔，位置在 `.heddle/browser-profiles/`
-- Settings -> Browser Automation 與 `/browser channel <chromium|chrome|msedge>` 可選擇之後代理執行與手動設定檔視窗使用的 Playwright 瀏覽器通道
-- `/browser headed` 會讓之後的瀏覽器執行顯示 Playwright 視窗，方便你先手動登入；`/browser headless` 則會在不顯示視窗的狀態下重用該設定檔
-- Settings -> Browser Automation 與 `/browser open-profile [url]` 可用可見的手動視窗開啟選定設定檔，供你登入或管理工作階段；請在要求代理使用同一設定檔前，用 `/browser close-profile` 關閉它
-- Settings -> Browser Automation 與 `/browser launch-native [url]` 可用 Heddle 管理的設定檔與 CDP endpoint 啟動本機安裝的 Chrome；請保持該 Chrome 視窗開啟，並用 `/browser check-native` 檢查連線
-- 後端為原生 Chrome 且設定的 CDP endpoint 尚未連上時，代理第一次 `browser_open` 可以用任務 URL 啟動本機 Chrome，而不是開啟診斷頁
-- 需要登入的網站要求目前選定的瀏覽器設定檔已經有有效的登入狀態
-
-瀏覽器自動化待辦方向：
-
-- 增加更完整的表單操作，例如選單、核取方塊與按鍵輔助工具
-- 在控制平面顯示瀏覽器證據與截圖
-- 設計即時瀏覽器預覽路徑，較可能基於截圖或 CDP screencast，而不是嵌入 Playwright 原生可見視窗
-- 為無害的同源 UI 點擊與加入購物車這類動作加上更完整的政策與核准流程
-
-### MCP 整合
-
-Heddle 可以連接使用者設定的 Model Context Protocol 伺服器，讓代理透過 Heddle 的核准與追蹤路徑使用生態系工具，例如 Notion、Anytype、GitHub 或其他 MCP 整合。
-
-你可以把標準 `mcpServers` JSON 文件貼到 Settings -> MCP、直接編輯 `.heddle/mcp.json`，或在聊天裡用 `/mcp config` 開啟該檔案。伺服器設定與工作區啟用狀態是分開的：儲存設定後，仍需要明確啟用並重新整理伺服器，未來代理回合才能看到已快取的工具。
-
-```text
-/mcp
-/mcp config
-/mcp enable <server>
-/mcp refresh <server>
-/mcp disable <server>
-```
-
-重新整理已啟用的伺服器會把工具目錄快取到 `.heddle/mcp/`。未來代理回合可以透過 `mcp_list_tools` 檢查 MCP 工具，並透過需要核准的 MCP 工具轉接器呼叫它們。
-
-更多：[MCP 整合](docs/reference/mcp.md)
-
-### 心跳任務
-
-Heartbeat 是 Heddle 的有界自主喚醒週期模型。
-
-不只是在人類輸入提示時執行，心跳任務讓 Heddle 可以依照排程喚醒、做有限範圍的工作、建立檢查點結果，並決定要繼續、暫停、完成或升級處理。
-
-範例指令：
-
-```bash
-heddle heartbeat start --every 30m
-heddle heartbeat task add --id repo-gardener --task "Check for safe maintenance work" --every 1h
-heddle heartbeat task list
-```
-
-它存在的理由是：有些代理工作不是單一互動式聊天。你可能需要週期性程式碼庫檢查、定期維護檢查、排程摘要，或能在有限步驟中恢復工作的主機。
-
-更多：[心跳任務指南](docs/guides/heartbeat.md)
-
-### 程式化執行環境
-
-Heddle 不只是 CLI。npm 套件暴露兩個主要程式化層級：
-
-- `createConversationEngine`：alpha API，用於持久化的多回合工作階段，包含工作階段儲存、壓縮、核准、追蹤紀錄、語意活動，以及自訂前端或本地主機
-- `AgentLoopRuntimeService.run(...)`：較低階的單次執行迴圈，適合不需要持久化聊天或工作階段行為的主機
-
-進階主機也可以重用較低階的 class API，例如 `ToolRegistry`、`ToolExecutionService`、`TraceRecorder`、`TraceConsoleFormatter`、`ReviewDiffParser`，在需要時組裝自訂執行環境或審查介面。
-
-其他匯出的基礎能力包含 `HeartbeatRunnerAgent.run`、`HeartbeatSchedulerService.runDueTasks` 與 `FileHeartbeatTaskService`，用於排程或自訂主機工作流程。
-
-更多：[程式化使用指南](docs/guides/programmatic-use.md)
-
-### 語意漂移
-
-語意漂移是選用遙測，用來幫助你觀察助理回應是否似乎偏離對話最近的語意軌跡。
-
-搭配 optional [CyberLoop](https://www.npmjs.com/package/cyberloop) integration 時，Heddle 可以顯示 drift levels，例如：
-
-- `drift=unknown`
-- `drift=low`
-- `drift=medium`
-- `drift=high`
-
-這是可觀測性功能，不是正確性保證。它的目的，是讓操作員注意到執行可能變得比較不貼近最近的方向。
-
-更多：[語意漂移](docs/guides/semantic-drift.md)
-
-## 安裝
-
-Global install：
-
-```bash
-npm install -g @roackb2/heddle
-```
-
-不安裝 global package 也可以執行：
-
-```bash
-npx @roackb2/heddle
-```
-
-安裝後的 CLI command 是 `heddle`。
-
-## 需求
-
-- Node.js 20+
-- 至少一個 supported provider：
-  - OpenAI account sign-in：`heddle auth login openai`，或 `OPENAI_API_KEY`
-  - Anthropic models 使用 `ANTHROPIC_API_KEY`
-  - 本地 Ollama server，用於 `ollama/<model>` models
-
-Heddle 不支援 Anthropic consumer subscription OAuth。除非 Anthropic 提供 approved third-party auth route，請使用 Anthropic API-key access。
-
-## 選用 CyberLoop 整合
-
-如果你想在 chat 裡使用 semantic drift telemetry，請在和 Heddle 相同的 environment 安裝 `cyberloop`：
-
-```bash
-npm install -g cyberloop
-# or for project-local usage
-npm install cyberloop
-```
-
-如果只想一次性使用而不 global install：
-
-```bash
-npx -p @roackb2/heddle -p cyberloop heddle
-```
+![Heddle 在 terminal、browser 與 mobile 同步串流同一個 session](docs/images/heddle-cross-device-stream.gif)
+
+Reference product 也包含 saved session、reviewable diff、workspace memory、
+Agent Skills、custom agent、MCP integration、heartbeat task，以及 opt-in
+Browser Automation。它們既是實用產品功能，也會持續驗證同一套可重用 runtime
+boundary。
+
+延伸閱讀：
+
+- [Chat 與 session](docs/guides/chat-and-sessions.md)
+- [Control plane](docs/guides/control-plane.md)
+- [Provider 與 model](docs/reference/providers-and-models.md)
+- [Capability 與 Browser Automation](docs/reference/capabilities.md)
+- [Agent Skills](docs/guides/agent-skills.md)
+- [Custom agents](docs/guides/custom-agents.md)
+- [Knowledge persistence](docs/guides/knowledge-persistence.md)
+- [Heartbeat](docs/guides/heartbeat.md)
+- [MCP integration](docs/reference/mcp.md)
+
+OpenAI account sign-in 是 Heddle 實驗性、由使用者主動選擇的 transport。它不
+代表 OpenAI 官方支援；Heddle 與 OpenAI 無隸屬、背書或贊助關係。使用 OpenAI
+服務仍須遵守 OpenAI 的條款與政策。
+
+## Production 使用邊界
+
+Heddle 刻意讓假設與限制保持可見：
+
+- Curated SDK 的目標 host 為 Node.js 20+ TypeScript/ESM；
+- conversation state 會透過設定的 repository 持久化，但 active-run handle
+  與 replay 為 process-local 且有界；
+- multi-process routing 與 durable in-flight delivery，需要由 host 選擇並
+  提供基礎設施；
+- session 與 artifact repository 可注入，但 production retention、
+  encryption、backup、tenancy 與 adapter operation 仍由 host 負責；
+- trace、compaction archive、memory 與部分 supporting state 仍是
+  local/path-oriented，除非 host 明確提供其他 integration path；
+- HTTP/SSE helper 負責 wire correctness，不負責 route registration、
+  authentication、authorization、CORS、limit、billing 或 deployment；
+- `@roackb2/heddle-remote` 會驗證 run protocol，但不負責 product
+  message、UI state、authentication 或 result rendering；
+- SDK 仍持續演進，升級 public API 前請先閱讀
+  [release notes](docs/releases/README.md)。
+
+Heddle 不是 hosted agent SaaS，也不要求產品採用特定 identity provider、
+database、server framework、transport、UI framework 或 deployment platform。
 
 ## 文件
 
-從這裡開始：
+### 使用 SDK 建置
 
-- [文件總覽](docs/README.md)
-- [執行環境主機模型](docs/guides/runtime-host-model.md)
-- [聊天與工作階段指南](docs/guides/chat-and-sessions.md)
-- [供應商與模型](docs/reference/providers-and-models.md)
-- [CLI 參考](docs/reference/cli.md)
+- [Programmatic hosts](docs/guides/programmatic/README.md)
+- [SDK 快速入門](docs/guides/programmatic/quickstart.md)
+- [Integration-layer chooser](docs/guides/programmatic/integration-layers.md)
+- [Conversation engine](docs/guides/programmatic/conversation-engine.md)
+- [Host extensions](docs/guides/programmatic/host-extensions.md)
+- [MCP host extensions](docs/guides/programmatic/mcp-host-extensions.md)
+- [Remote conversation runs](docs/guides/programmatic/remote-runs.md)
+- [Result artifacts](docs/guides/programmatic/result-artifacts.md)
+- [可執行的 SDK 範例](examples/sdk/README.md)
 
-功能指南：
+### 在本機使用 Heddle
 
-- [控制平面](docs/guides/control-plane.md)
-- [心跳任務](docs/guides/heartbeat.md)
-- [Agent Skills](docs/guides/agent-skills.md)
-- [自訂代理](docs/guides/custom-agents.md)
-- 瀏覽器自動化：請看上方瀏覽器自動化章節
-- [MCP 整合](docs/reference/mcp.md)
-- [知識持久化](docs/guides/knowledge-persistence.md)
-- [語意漂移](docs/guides/semantic-drift.md)
-- [程式化使用方式](docs/guides/programmatic-use.md)
+- [文件入口](docs/README.md)
+- [Runtime host model](docs/guides/runtime-host-model.md)
+- [Chat 與 session](docs/guides/chat-and-sessions.md)
+- [Control plane](docs/guides/control-plane.md)
+- [CLI reference](docs/reference/cli.md)
+- [Project configuration](docs/reference/config.md)
 
-貢獻者：
+### 參與貢獻
 
-- [代理開發脈絡](docs/agent-context.md)
-- [專案定位](docs/project-posture.md)
-- [開發與貢獻](docs/guides/development.md)
-- [發版慣例](docs/releases/README.md)
-- [框架願景](docs/strategy/framework-vision.md)
-- [程式開發代理路線圖](docs/strategy/coding-agent-roadmap.md)
-
-## 專案狀態
-
-Heddle 已經能用於真實程式開發代理工作流程，但仍在演進。
-
-目前強項包含：
-
-- 終端機優先的程式開發與程式碼庫工作流程
-- 自主、以目錄管理的工作區記憶，讓代理從一般使用中學習
-- 標準 Agent Skills 支援，包含工作區層級啟用與漸進式揭露
-- 自訂代理，用於以回合為範圍的角色、工具、核准與執行設定
-- 選用瀏覽器自動化，包含瀏覽器快照、截圖、政策檢查與公開的下一步清單
-- MCP 整合支援，可連接使用者設定的生態系工具
-- 明確的追蹤紀錄、核准預覽、差異審查與本地工作區狀態
-- 透過控制平面進行瀏覽器監督與工作區切換
-- 本機優先的心跳任務基礎能力，用於排程代理工作
-- 可用於自訂主機的實用程式化 hooks
-
-目前限制包含：
-
-- 瀏覽器控制平面對檔案審查仍是唯讀；尚未是可編輯的 IDE-like 差異環境
-- 瀏覽器自動化仍需要設定檔管理、表單安全操作與更完整的瀏覽器證據介面
-- 有些進階工作流程在原始碼與範例中已有記錄，但產品 UX 文件仍需要打磨
-- 隨著執行環境成熟，專案介面仍在變動
+- [Agent context](docs/agent-context.md)
+- [Project posture](docs/project-posture.md)
+- [開發指南](docs/guides/development.md)
+- [Core layering](docs/architecture/core-layering.md)
+- [Framework vision](docs/strategy/framework-vision.md)
 
 ## 開發
-
-如果你想開發 Heddle 本身：
 
 ```bash
 git clone https://github.com/roackb2/heddle.git
@@ -623,10 +359,9 @@ yarn build
 yarn test
 ```
 
-`yarn test` 會執行預設 unit 與 integration suites。Browser integration coverage 位於 `src/__tests__/browser-integration`，並會在 PRs 中執行；本地可以用 `yarn test:browser-integration` 執行。
-
-完整貢獻流程請見 [開發與貢獻](docs/guides/development.md)。
+`yarn test` 會執行預設 unit 與 integration suites。Browser integration
+coverage 位於 `src/__tests__/browser-integration`。
 
 ## 授權
 
-Heddle 使用 MIT License。詳見 [LICENSE](LICENSE)。
+Heddle 採用 MIT License。詳見 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary

- Reframe Heddle as an SDK for building agentic experiences inside products, with the local coding agent presented as the reference host and fastest evaluation path.
- Add progressive onboarding from running Heddle, to embedding the SDK, to owning models, tools, policy, persistence, UI, and transport.
- Document ownership boundaries, customization depth, core capabilities, and production posture in both English and Traditional Chinese.

## Why

The root README was centered on the local coding-agent experience, which made Heddle's broader programmatic value difficult to discover. This rewrite makes the SDK the primary product story while preserving the CLI as a concrete way to learn the runtime.

## Impact

- Product builders can identify the right SDK entry point and understand how far Heddle can be customized.
- CLI users keep a clear quick-start path and can graduate naturally into embedding Heddle.
- Documentation only; there are no runtime or API behavior changes.

## Validation

- `git diff --check`
- Parsed both README files with Remark and GFM
- Verified all 92 local README links resolve