### PR TITLE
feat: add session adapter authoring primitives

### DIFF
--- a/docs/guides/programmatic/session-storage.md
+++ b/docs/guides/programmatic/session-storage.md
@@ -75,6 +75,44 @@ const engine = createConversationEngine({
 })
 ```
 
+### Reuse Heddle's adapter-authoring primitives
+
+Remote adapters should not maintain a second validator or invent a cursor wire
+format. Heddle exports the database-neutral parts of the contract:
+
+```ts
+import {
+  ChatSessionCatalogPagination,
+  ChatSessionPersistenceCodec,
+} from '@roackb2/heddle'
+
+// Fail loudly if JSON/JSONB cannot reconstruct one complete Heddle session.
+const session = ChatSessionPersistenceCodec.parseRecord(row.session)
+
+// Reuse the canonical browser-safe/indexed projection on create and update.
+const catalog = ChatSessionPersistenceCodec.projectCatalogEntry(
+  session,
+  Number(row.revision),
+)
+
+ChatSessionCatalogPagination.validatePageLimit(input.limit)
+const cursor = input.cursor
+  ? ChatSessionCatalogPagination.decodeCursor(input.cursor)
+  : undefined
+
+// After a query returns limit + 1 rows, encode the last included row.
+const nextCursor = hasNextPage && lastIncluded
+  ? ChatSessionCatalogPagination.encodeCursor(lastIncluded)
+  : undefined
+```
+
+`decodeCursor(...)` supplies `(pinned, updatedAt, id)` for the database
+predicate shown below. Express that predicate and order in SQL; do not fetch an
+entire tenant catalog merely to call the in-process comparator. Translate
+database constraint/CAS failures to Heddle's exported repository errors, and
+wrap record-validation failures only to add row/storage context—never continue
+with a partial session.
+
 Construct the adapter with trusted server-side identity/scope. Do not accept a
 tenant or account ID from the browser and then trust it inside repository
 methods. Heddle deliberately leaves product account IDs and row-level-security

--- a/src/__tests__/integration/chat/chat-storage.test.ts
+++ b/src/__tests__/integration/chat/chat-storage.test.ts
@@ -44,6 +44,7 @@ describe('chat session storage layout', () => {
       sessions: Array<Record<string, unknown>>;
     };
     const body = JSON.parse(readFileSync(join(dir, 'chat-sessions', 'session-1.1.json'), 'utf8')) as Record<string, unknown>;
+    const reread = (await repository.read('session-1'))?.session;
 
     expect(stored.revision).toBe(1);
     expect(catalog.version).toBe(1);
@@ -64,7 +65,7 @@ describe('chat session storage layout', () => {
       id: 'session-1',
       messages: [{ id: 'm1', role: 'assistant', text: 'hello there' }],
     }));
-    expect((await repository.read('session-1'))?.session).toEqual(expect.objectContaining({
+    expect(reread).toEqual(expect.objectContaining({
       id: 'session-1',
       workspaceId: 'workspace-1',
       pinned: true,
@@ -72,6 +73,7 @@ describe('chat session storage layout', () => {
       history: [],
       turns: [expect.objectContaining({ id: 't1', summary: 'said hello' })],
     }));
+    expect(reread).not.toHaveProperty('revision');
   });
 
   it('uses expected revisions to prevent lost updates across repository instances', async () => {

--- a/src/__tests__/unit/core/chat-session-adapter-authoring-kit.test.ts
+++ b/src/__tests__/unit/core/chat-session-adapter-authoring-kit.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ChatSessionCatalogPagination,
+  ChatSessionPersistenceCodec,
+  InvalidChatSessionCursorError,
+} from '../../../index.js';
+import { ChatSessionRecords } from '../../../core/chat/engine/sessions/records/index.js';
+
+const createSessionRecord = () => ({
+  ...ChatSessionRecords.create({
+    id: 'session-1',
+    name: 'Adapter authoring',
+    workspaceId: 'workspace-1',
+  }),
+  createdAt: '2026-07-17T01:00:00.000Z',
+  updatedAt: '2026-07-17T02:00:00.000Z',
+  history: [{ role: 'user' as const, content: 'Persist this record.' }],
+  messages: [{ id: 'message-1', role: 'user' as const, text: 'Persist this record.' }],
+  turns: [{
+    id: 'turn-1',
+    prompt: 'Persist this record.',
+    outcome: 'done',
+    summary: 'Persisted the record.',
+    steps: 1,
+    traceFile: '/var/lib/agent/traces/turn-1.json',
+    events: ['completed'],
+  }],
+});
+
+describe('chat session adapter-authoring primitives', () => {
+  it('strictly round-trips a complete opaque session record', () => {
+    const record = createSessionRecord();
+
+    expect(ChatSessionPersistenceCodec.parseRecord(record)).toEqual(record);
+  });
+
+  it.each([
+    ['invalid model history', (record: ReturnType<typeof createSessionRecord>) => ({
+      ...record,
+      history: [{ role: 'assistant', content: 42 }],
+    })],
+    ['invalid context metadata', (record: ReturnType<typeof createSessionRecord>) => ({
+      ...record,
+      context: { estimatedHistoryTokens: '42' },
+    })],
+    ['missing queue state', (record: ReturnType<typeof createSessionRecord>) => {
+      const { queuedPrompts: _queuedPrompts, ...withoutQueue } = record;
+      return withoutQueue;
+    }],
+    ['unknown top-level state', (record: ReturnType<typeof createSessionRecord>) => ({
+      ...record,
+      undocumentedState: true,
+    })],
+  ])('rejects %s instead of degrading it', (_name, mutate) => {
+    expect(() => ChatSessionPersistenceCodec.parseRecord(mutate(createSessionRecord()))).toThrow();
+  });
+
+  it('projects only catalog-safe fields and validates the revision', () => {
+    const entry = ChatSessionPersistenceCodec.projectCatalogEntry(createSessionRecord(), 3);
+
+    expect(entry).toMatchObject({
+      id: 'session-1',
+      revision: 3,
+      name: 'Adapter authoring',
+      workspaceId: 'workspace-1',
+      pinned: false,
+      updatedAt: '2026-07-17T02:00:00.000Z',
+    });
+    expect(entry).not.toHaveProperty('history');
+    expect(entry).not.toHaveProperty('messages');
+    expect(entry).not.toHaveProperty('turns');
+    expect(entry).not.toHaveProperty('queuedPrompts');
+    expect(() => ChatSessionPersistenceCodec.projectCatalogEntry(createSessionRecord(), 0)).toThrow();
+  });
+
+  it('uses one stable order for pinned groups, timestamps, and tied ids', () => {
+    const entries = [
+      { id: 'regular-new', pinned: false, updatedAt: '2026-07-17T03:00:00.000Z' },
+      { id: 'a', pinned: true, updatedAt: '2026-07-17T02:00:00.000Z' },
+      { id: 'Z', pinned: true, updatedAt: '2026-07-17T02:00:00.000Z' },
+      { id: 'regular-old', pinned: false, updatedAt: '2026-07-17T01:00:00.000Z' },
+    ].sort(ChatSessionCatalogPagination.compare);
+
+    expect(entries.map((entry) => entry.id)).toEqual(['Z', 'a', 'regular-new', 'regular-old']);
+    expect(ChatSessionCatalogPagination.isAfterCursor(entries[2]!, entries[1]!)).toBe(true);
+    expect(ChatSessionCatalogPagination.isAfterCursor(entries[0]!, entries[1]!)).toBe(false);
+  });
+
+  it('matches UTF-8 binary database collation for non-ASCII tied ids', () => {
+    const privateUse = { id: '\uE000', pinned: false, updatedAt: '2026-07-17T01:00:00.000Z' };
+    const emoji = { id: '😀', pinned: false, updatedAt: '2026-07-17T01:00:00.000Z' };
+
+    expect(ChatSessionCatalogPagination.compare(privateUse, emoji)).toBeLessThan(0);
+    expect([emoji, privateUse].sort(ChatSessionCatalogPagination.compare)).toEqual([
+      privateUse,
+      emoji,
+    ]);
+  });
+
+  it('round-trips opaque cursors and rejects malformed cursor state', () => {
+    const entry = ChatSessionPersistenceCodec.projectCatalogEntry(createSessionRecord(), 3);
+    const cursor = ChatSessionCatalogPagination.encodeCursor(entry);
+
+    expect(ChatSessionCatalogPagination.decodeCursor(cursor)).toEqual({
+      id: entry.id,
+      pinned: entry.pinned,
+      updatedAt: entry.updatedAt,
+    });
+    expect(() => ChatSessionCatalogPagination.decodeCursor('not-a-cursor'))
+      .toThrow(InvalidChatSessionCursorError);
+
+    const unexpectedField = Buffer.from(JSON.stringify({
+      id: entry.id,
+      pinned: entry.pinned,
+      updatedAt: entry.updatedAt,
+      tenantId: 'must-not-enter-the-generic-cursor',
+    }), 'utf8').toString('base64url');
+    expect(() => ChatSessionCatalogPagination.decodeCursor(unexpectedField))
+      .toThrow(InvalidChatSessionCursorError);
+  });
+
+  it.each([0, 201, 1.5, Number.NaN])('rejects invalid page limit %s', (limit) => {
+    expect(() => ChatSessionCatalogPagination.validatePageLimit(limit)).toThrow(RangeError);
+  });
+
+  it.each([1, 200])('accepts supported page limit %s', (limit) => {
+    expect(() => ChatSessionCatalogPagination.validatePageLimit(limit)).not.toThrow();
+  });
+});

--- a/src/core/chat/engine/sessions/repository/README.md
+++ b/src/core/chat/engine/sessions/repository/README.md
@@ -9,9 +9,14 @@ service; adapters only own durable record I/O.
 - the `ChatSessionRepository` async adapter contract
 - optimistic revisions and compare-and-swap mutation errors
 - deterministic, cursor-paginated catalog reads
+- database-neutral strict record validation and catalog projection through
+  `ChatSessionPersistenceCodec`
+- canonical in-process ordering, opaque cursors, and page validation through
+  `ChatSessionCatalogPagination`
 - the default catalog and immutable per-session revision file layout
 - persisted JSON contract in `chat-session-schemas.ts`
-- serialization/deserialization behavior through `ChatSessionCodec`
+- legacy file serialization/deserialization behavior through the private
+  `ChatSessionCodec`
 - legacy revision-one file compatibility
 
 ## Does Not Own
@@ -29,6 +34,11 @@ service; adapters only own durable record I/O.
 - hosts should not call it directly when a core session service can own the flow
 - disk-shape validation belongs in `chat-session-schemas.ts`, not in ad hoc
   repository type guards
+- remote adapters should parse opaque records and project catalog columns with
+  `ChatSessionPersistenceCodec`; do not copy Heddle's record shape into another
+  hand-maintained validator
+- adapters should use `ChatSessionCatalogPagination` for cursor wire behavior
+  and mirror its documented order exactly in database queries
 - do not add wrapper-only repository files; this folder earns its place by
   owning real file persistence mechanics
 
@@ -46,6 +56,13 @@ Every adapter must:
   predicate, so page boundaries cannot skip or repeat records;
 - scope all operations to the authenticated product boundary chosen by the
   host. Heddle's record does not invent product-specific account or RLS fields.
+
+The authoring primitives deliberately do not own SQL, transactions, connection
+pooling, migrations, identity, tenant filters, RLS, or database error codes.
+Those stay in the host adapter. `ChatSessionPersistenceCodec.parseRecord(...)`
+throws on malformed complete records instead of using the tolerant legacy-file
+read behavior; catch that failure only to add storage-specific context, never
+to return a partial conversation.
 
 The session service retries a small, bounded number of optimistic update
 conflicts by rereading the latest record and reapplying the update. A generic
@@ -84,7 +101,9 @@ the revision in the same statement or transaction. If no row is changed,
 distinguish a missing record from a revision conflict and return/throw the
 contract result accordingly.
 
-For cursor pages, use a composite cursor matching the query order (pinned
-first, then `updatedAt` descending, then ID ascending) and make the final ID
-comparison use a stable binary/C collation. Do not load and rewrite the whole
-collection for one record mutation.
+For cursor pages, decode/encode with `ChatSessionCatalogPagination` and use a
+composite database predicate matching its query order (pinned first, then
+`updatedAt` descending, then ID ascending). Make the final ID comparison use a
+stable binary/C collation. The helper's comparator is for in-process adapters
+and tests; a database adapter must express the same order in SQL rather than
+loading and rewriting the whole collection.

--- a/src/core/chat/engine/sessions/repository/chat-session-catalog-pagination.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-catalog-pagination.ts
@@ -1,0 +1,73 @@
+/**
+ * Canonical ordering and opaque cursor behavior for chat-session catalogs.
+ *
+ * Database adapters must use the equivalent order and predicate in SQL:
+ * pinned descending, updatedAt descending, then id ascending with binary/C
+ * collation. These helpers own the in-process form and cursor wire format.
+ */
+import { z } from 'zod';
+import { InvalidChatSessionCursorError } from './errors.js';
+import type { ChatSessionCatalogEntry } from './types.js';
+
+export type ChatSessionCatalogCursor = Pick<
+  ChatSessionCatalogEntry,
+  'id' | 'pinned' | 'updatedAt'
+>;
+
+const ChatSessionCatalogCursorSchema = z.object({
+  id: z.string(),
+  pinned: z.boolean(),
+  updatedAt: z.string(),
+}).strict();
+
+export class ChatSessionCatalogPagination {
+  static compare(
+    left: ChatSessionCatalogCursor,
+    right: ChatSessionCatalogCursor,
+  ): number {
+    if (left.pinned !== right.pinned) {
+      return left.pinned ? -1 : 1;
+    }
+
+    const updatedAtOrder = ChatSessionCatalogPagination.compareText(
+      right.updatedAt,
+      left.updatedAt,
+    );
+    return updatedAtOrder || ChatSessionCatalogPagination.compareText(left.id, right.id);
+  }
+
+  static isAfterCursor(
+    entry: ChatSessionCatalogCursor,
+    cursor: ChatSessionCatalogCursor,
+  ): boolean {
+    return ChatSessionCatalogPagination.compare(entry, cursor) > 0;
+  }
+
+  static encodeCursor(entry: ChatSessionCatalogCursor): string {
+    const cursor = ChatSessionCatalogCursorSchema.parse({
+      id: entry.id,
+      pinned: entry.pinned,
+      updatedAt: entry.updatedAt,
+    });
+    return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+  }
+
+  static decodeCursor(cursor: string): ChatSessionCatalogCursor {
+    try {
+      const value = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as unknown;
+      return ChatSessionCatalogCursorSchema.parse(value);
+    } catch {
+      throw new InvalidChatSessionCursorError();
+    }
+  }
+
+  static validatePageLimit(limit: number): void {
+    if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+      throw new RangeError('Chat session page limit must be an integer between 1 and 200.');
+    }
+  }
+
+  private static compareText(left: string, right: string): number {
+    return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'));
+  }
+}

--- a/src/core/chat/engine/sessions/repository/chat-session-codec.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-codec.ts
@@ -2,14 +2,12 @@
  * Codec service for current chat session persistence.
  *
  * The schema file owns the JSON contract. This class owns the read/write
- * behavior around that contract: graceful read degradation, strict write
- * validation, catalog projection, and compatibility cleanup for legacy visible
- * welcome messages.
+ * behavior around that contract: graceful read degradation, strict file-write
+ * validation, and compatibility cleanup for legacy visible welcome messages.
  */
 import type { ChatSession } from '@/core/chat/types.js';
 import {
   CatalogEntryReadSchema,
-  CatalogEntryWriteSchema,
   CatalogReadSchema,
   CatalogWriteSchema,
   SessionBodyReadSchema,
@@ -40,23 +38,16 @@ export class ChatSessionCodec {
     if (!parsed.success) {
       return [];
     }
+    const { revision: _revision, ...entry } = args.entry;
 
     return [{
       ...parsed.data,
-      ...args.entry,
+      ...entry,
       history: parsed.data.history ?? [],
       messages: ChatSessionCodec.resolveMessages(parsed.data.messages),
       turns: parsed.data.turns ?? [],
       queuedPrompts: parsed.data.queuedPrompts ?? [],
     }];
-  }
-
-  static projectCatalogEntry(session: ChatSession, revision: number): ChatSessionCatalogEntry {
-    const parsed = CatalogEntryWriteSchema.parse({ ...session, revision });
-    return {
-      ...parsed,
-      pinned: parsed.pinned ?? false,
-    };
   }
 
   static serializeCatalog(catalog: ChatSessionCatalog): string {

--- a/src/core/chat/engine/sessions/repository/chat-session-persistence-codec.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-persistence-codec.ts
@@ -1,0 +1,35 @@
+/**
+ * Database-neutral validation and catalog projection for session adapters.
+ *
+ * This codec is deliberately stricter than Heddle's private legacy-file read
+ * path. A remote adapter must fail a malformed opaque record rather than
+ * silently drop model history, turns, queue state, or compaction metadata.
+ */
+import type { ChatSession } from '@/core/chat/types.js';
+import {
+  CatalogEntryWriteSchema,
+  ChatSessionRecordSchema,
+} from './chat-session-schemas.js';
+import type { ChatSessionCatalogEntry } from './types.js';
+
+export class ChatSessionPersistenceCodec {
+  /** Parse and normalize one complete opaque record read from durable storage. */
+  static parseRecord(value: unknown): ChatSession {
+    return ChatSessionRecordSchema.parse(value);
+  }
+
+  /**
+   * Project the columns needed for catalog queries without exposing transcript
+   * or tool payloads to the host's browser-facing catalog.
+   */
+  static projectCatalogEntry(
+    session: ChatSession,
+    revision: number,
+  ): ChatSessionCatalogEntry {
+    return CatalogEntryWriteSchema.parse({
+      ...session,
+      pinned: session.pinned ?? false,
+      revision,
+    });
+  }
+}

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -68,6 +68,17 @@ const ConversationLinesSchema = z.array(z.unknown())
     return parsed.success ? [parsed.data] : [];
   }));
 
+const ChatTurnAgentSchema = z.object({
+  id: z.string().describe('Custom agent id used for this turn.'),
+  name: z.string().describe('Custom agent display name used for this turn.'),
+  modeAlias: z.enum(['ask', 'code', 'review'])
+    .describe('Built-in mode alias for this custom agent, when present.')
+    .optional(),
+  source: z.enum(['project', 'user', 'built-in'])
+    .describe('Definition source for the custom agent used for this turn.'),
+  definitionHash: z.string().describe('Hash of the custom-agent definition snapshot used for this turn.'),
+});
+
 const TurnSummarySchema = z.object({
   id: z.string().describe('Stable identifier for this completed turn summary.'),
   prompt: z.string().describe('User prompt that started the turn.'),
@@ -78,29 +89,24 @@ const TurnSummarySchema = z.object({
   events: z.array(z.string()).describe('Compact event summaries extracted from the turn trace.'),
   presentation: ConversationTurnPresentationSchema
     .describe('Compact non-transcript tool activity metadata for conversation timeline presentation.')
-    .optional()
-    .catch(undefined),
-  agent: z.object({
-    id: z.string().describe('Custom agent id used for this turn.'),
-    name: z.string().describe('Custom agent display name used for this turn.'),
-    modeAlias: z.enum(['ask', 'code', 'review'])
-      .describe('Built-in mode alias for this custom agent, when present.')
-      .optional(),
-    source: z.enum(['project', 'user', 'built-in'])
-      .describe('Definition source for the custom agent used for this turn.'),
-    definitionHash: z.string().describe('Hash of the custom-agent definition snapshot used for this turn.'),
-  }).describe('Compact custom-agent metadata for this completed turn.')
-    .optional()
-    .catch(undefined),
+    .optional(),
+  agent: ChatTurnAgentSchema
+    .describe('Compact custom-agent metadata for this completed turn.')
+    .optional(),
   agentSnapshot: CustomAgentExecutionSnapshotSchema
     .describe('Resolved custom-agent execution snapshot used by this completed turn.')
-    .optional()
-    .catch(undefined),
+    .optional(),
+});
+
+const TurnSummaryReadSchema = TurnSummarySchema.extend({
+  presentation: ConversationTurnPresentationSchema.optional().catch(undefined),
+  agent: ChatTurnAgentSchema.optional().catch(undefined),
+  agentSnapshot: CustomAgentExecutionSnapshotSchema.optional().catch(undefined),
 });
 
 const TurnSummariesSchema = z.array(z.unknown())
   .transform((turns) => turns.flatMap((turn) => {
-    const parsed = TurnSummarySchema.safeParse(turn);
+    const parsed = TurnSummaryReadSchema.safeParse(turn);
     return parsed.success ? [parsed.data] : [];
   }));
 
@@ -200,8 +206,7 @@ const QueuedConversationPromptSchema = z.object({
     .optional(),
   agentSnapshot: CustomAgentExecutionSnapshotSchema
     .describe('Resolved custom-agent execution snapshot selected when this prompt entered the queue.')
-    .optional()
-    .catch(undefined),
+    .optional(),
   systemContext: z.string()
     .describe('Optional runtime context that should be applied when this queued prompt runs.')
     .optional(),
@@ -209,9 +214,13 @@ const QueuedConversationPromptSchema = z.object({
   updatedAt: z.string().describe('Timestamp when this queued prompt was last edited.'),
 });
 
+const QueuedConversationPromptReadSchema = QueuedConversationPromptSchema.extend({
+  agentSnapshot: CustomAgentExecutionSnapshotSchema.optional().catch(undefined),
+});
+
 const QueuedConversationPromptsSchema = z.array(z.unknown())
   .transform((prompts) => prompts.flatMap((prompt) => {
-    const parsed = QueuedConversationPromptSchema.safeParse(prompt);
+    const parsed = QueuedConversationPromptReadSchema.safeParse(prompt);
     return parsed.success ? [parsed.data] : [];
   }));
 
@@ -272,10 +281,15 @@ export const CatalogEntryReadSchema = z.object({
     .catch(undefined),
 });
 
-export const CatalogEntryWriteSchema = CatalogEntryReadSchema.required({
-  revision: true,
-  createdAt: true,
-  updatedAt: true,
+export const CatalogEntryWriteSchema = CatalogEntryReadSchema.extend({
+  revision: z.number()
+    .int()
+    .positive()
+    .describe('Monotonic revision used for optimistic concurrency.'),
+  pinned: z.boolean()
+    .describe('Whether this session should be grouped above unpinned sessions in session lists.'),
+  createdAt: z.string().describe('Timestamp when the session was created.'),
+  updatedAt: z.string().describe('Timestamp when the session was last changed.'),
 });
 
 export const CatalogReadSchema = z.object({
@@ -359,6 +373,30 @@ export const SessionBodyWriteSchema = z.object({
     .describe('FIFO user prompts accepted while the session has earlier work to finish.')
     .default([]),
 });
+
+/**
+ * Strict database-neutral shape for a complete opaque Heddle session record.
+ *
+ * Legacy file reads intentionally use the tolerant read schemas above. Remote
+ * adapters should use this schema through `ChatSessionPersistenceCodec` so a
+ * malformed database record fails loudly instead of silently losing history.
+ */
+export const ChatSessionRecordSchema = CatalogEntryWriteSchema
+  .omit({ revision: true })
+  .extend({
+    retention: ChatSessionRetentionSchema.optional(),
+    pinned: z.boolean(),
+    reasoningEffort: ReasoningEffortSchema.optional(),
+    driftEnabled: z.boolean().optional(),
+    context: ChatContextStatsSchema.optional(),
+    archives: z.array(ChatArchiveRecordSchema).optional(),
+    lease: ChatSessionLeaseSchema.optional(),
+    history: z.array(ChatMessageSchema),
+    messages: z.array(ConversationLineSchema),
+    turns: z.array(TurnSummarySchema),
+    queuedPrompts: z.array(QueuedConversationPromptSchema),
+  })
+  .strict();
 
 export type CatalogEntryRead = z.infer<typeof CatalogEntryReadSchema>;
 export type ConversationLineValue = z.infer<typeof ConversationLineSchema>;

--- a/src/core/chat/engine/sessions/repository/file-chat-session-repository.ts
+++ b/src/core/chat/engine/sessions/repository/file-chat-session-repository.ts
@@ -19,12 +19,13 @@ import { basename, dirname, join } from 'node:path';
 import { Mutex } from 'async-mutex';
 import { lock } from 'proper-lockfile';
 import type { ChatSession } from '@/core/chat/types.js';
+import { ChatSessionCatalogPagination } from './chat-session-catalog-pagination.js';
 import { ChatSessionCodec } from './chat-session-codec.js';
+import { ChatSessionPersistenceCodec } from './chat-session-persistence-codec.js';
 import {
   ChatSessionAlreadyExistsError,
   ChatSessionRevisionConflictError,
   ChatSessionStorageCorruptionError,
-  InvalidChatSessionCursorError,
 } from './errors.js';
 import type {
   ChatSessionCatalog,
@@ -38,8 +39,6 @@ import type {
   UpdateChatSessionInput,
 } from './types.js';
 
-type FileChatSessionCursor = Pick<ChatSessionCatalogEntry, 'id' | 'pinned' | 'updatedAt'>;
-
 export class FileChatSessionRepository implements ChatSessionRepository {
   private readonly sessionStoragePath: string;
   private readonly storagePaths: SessionStoragePaths;
@@ -52,23 +51,23 @@ export class FileChatSessionRepository implements ChatSessionRepository {
 
   async list(input: ListChatSessionsInput): Promise<ChatSessionCatalogPage> {
     return await this.mutex.runExclusive(async () => {
-      FileChatSessionRepository.validatePageLimit(input.limit);
+      ChatSessionCatalogPagination.validatePageLimit(input.limit);
       const catalog = await FileChatSessionRepository.readCatalogFile(this.storagePaths.catalogPath);
       const cursor = input.cursor
-        ? FileChatSessionRepository.decodeCursor(input.cursor)
+        ? ChatSessionCatalogPagination.decodeCursor(input.cursor)
         : undefined;
       const filtered = catalog.sessions
         .filter((entry) => input.workspaceId === undefined || entry.workspaceId === input.workspaceId)
         .filter((entry) => input.archived === undefined || Boolean(entry.archivedAt) === input.archived)
-        .filter((entry) => !cursor || FileChatSessionRepository.compareSessionOrder(entry, cursor) > 0)
-        .sort(FileChatSessionRepository.compareSessionOrder);
+        .filter((entry) => !cursor || ChatSessionCatalogPagination.isAfterCursor(entry, cursor))
+        .sort(ChatSessionCatalogPagination.compare);
       const items = filtered.slice(0, input.limit);
       const last = items.at(-1);
 
       return {
         items,
         nextCursor: filtered.length > input.limit && last
-          ? FileChatSessionRepository.encodeCursor(last)
+          ? ChatSessionCatalogPagination.encodeCursor(last)
           : undefined,
       };
     });
@@ -101,9 +100,9 @@ export class FileChatSessionRepository implements ChatSessionRepository {
       const nextCatalog: ChatSessionCatalog = {
         version: 1,
         sessions: [
-          ChatSessionCodec.projectCatalogEntry(session, revision),
+          ChatSessionPersistenceCodec.projectCatalogEntry(session, revision),
           ...catalog.sessions,
-        ].sort(FileChatSessionRepository.compareSessionOrder),
+        ].sort(ChatSessionCatalogPagination.compare),
       };
       await FileChatSessionRepository.replaceCatalog(this.storagePaths.catalogPath, nextCatalog);
       return { session, revision };
@@ -135,9 +134,9 @@ export class FileChatSessionRepository implements ChatSessionRepository {
         version: 1,
         sessions: catalog.sessions
           .map((entry) => entry.id === input.session.id
-            ? ChatSessionCodec.projectCatalogEntry(input.session, revision)
+            ? ChatSessionPersistenceCodec.projectCatalogEntry(input.session, revision)
             : entry)
-          .sort(FileChatSessionRepository.compareSessionOrder),
+          .sort(ChatSessionCatalogPagination.compare),
       };
       await FileChatSessionRepository.replaceCatalog(this.storagePaths.catalogPath, nextCatalog);
       return { session: input.session, revision };
@@ -230,7 +229,7 @@ export class FileChatSessionRepository implements ChatSessionRepository {
       }
       return {
         ...catalog,
-        sessions: catalog.sessions.sort(FileChatSessionRepository.compareSessionOrder),
+        sessions: catalog.sessions.sort(ChatSessionCatalogPagination.compare),
       };
     } catch (error) {
       throw new ChatSessionStorageCorruptionError(
@@ -327,60 +326,6 @@ export class FileChatSessionRepository implements ChatSessionRepository {
       && 'code' in error
       && error.code === 'ENOENT',
     );
-  }
-
-  private static compareSessionOrder(
-    left: Pick<ChatSessionCatalogEntry, 'id' | 'pinned' | 'updatedAt'>,
-    right: Pick<ChatSessionCatalogEntry, 'id' | 'pinned' | 'updatedAt'>,
-  ): number {
-    if (left.pinned !== right.pinned) {
-      return left.pinned ? -1 : 1;
-    }
-
-    const updatedAtOrder = FileChatSessionRepository.compareText(right.updatedAt, left.updatedAt);
-    return updatedAtOrder || FileChatSessionRepository.compareText(left.id, right.id);
-  }
-
-  private static compareText(left: string, right: string): number {
-    return left === right ? 0 : left < right ? -1 : 1;
-  }
-
-  private static encodeCursor(entry: FileChatSessionCursor): string {
-    return Buffer.from(JSON.stringify({
-      id: entry.id,
-      pinned: entry.pinned,
-      updatedAt: entry.updatedAt,
-    }), 'utf8').toString('base64url');
-  }
-
-  private static decodeCursor(cursor: string): FileChatSessionCursor {
-    try {
-      const value = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as unknown;
-      if (
-        !value
-        || typeof value !== 'object'
-        || !('id' in value)
-        || !('pinned' in value)
-        || !('updatedAt' in value)
-        || typeof value.id !== 'string'
-        || typeof value.pinned !== 'boolean'
-        || typeof value.updatedAt !== 'string'
-      ) {
-        throw new InvalidChatSessionCursorError();
-      }
-      return value as FileChatSessionCursor;
-    } catch (error) {
-      if (error instanceof InvalidChatSessionCursorError) {
-        throw error;
-      }
-      throw new InvalidChatSessionCursorError();
-    }
-  }
-
-  private static validatePageLimit(limit: number): void {
-    if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
-      throw new RangeError('Chat session page limit must be an integer between 1 and 200.');
-    }
   }
 
   private static sessionRevisionPath(sessionsDir: string, sessionId: string, revision: number): string {

--- a/src/core/chat/engine/sessions/repository/index.ts
+++ b/src/core/chat/engine/sessions/repository/index.ts
@@ -1,3 +1,5 @@
+export { ChatSessionCatalogPagination } from './chat-session-catalog-pagination.js';
+export { ChatSessionPersistenceCodec } from './chat-session-persistence-codec.js';
 export { FileChatSessionRepository } from './file-chat-session-repository.js';
 export {
   ChatSessionAlreadyExistsError,
@@ -5,6 +7,9 @@ export {
   ChatSessionStorageCorruptionError,
   InvalidChatSessionCursorError,
 } from './errors.js';
+export type {
+  ChatSessionCatalogCursor,
+} from './chat-session-catalog-pagination.js';
 export type {
   ChatSessionCatalog,
   ChatSessionCatalogPage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,7 +262,9 @@ export type {
   SaveTextArtifactInput,
 } from './core/artifacts/index.js';
 export {
+  ChatSessionCatalogPagination,
   ChatSessionAlreadyExistsError,
+  ChatSessionPersistenceCodec,
   ChatSessionRevisionConflictError,
   ChatSessionStorageCorruptionError,
   FileChatSessionRepository,
@@ -270,6 +272,7 @@ export {
 } from './core/chat/engine/sessions/repository/index.js';
 export type {
   ChatSessionCatalog,
+  ChatSessionCatalogCursor,
   ChatSessionCatalogEntry,
   ChatSessionCatalogPage,
   ChatSessionRepository,


### PR DESCRIPTION
## Summary

- export a strict, database-neutral `ChatSessionPersistenceCodec` for complete opaque records and catalog projection
- export canonical `ChatSessionCatalogPagination` ordering, cursor, and page-limit behavior
- refactor the file adapter to consume those projection/pagination primitives while preserving tolerant legacy file reads
- document the host/database boundary and add focused public-API coverage

## Why

The first production database adapter had to duplicate Heddle's record validation, catalog projection, stable ordering, cursor encoding, and page validation. This slice makes those session-domain mechanics reusable without adding a database, ORM, tenancy, or RLS dependency to Heddle core.

The strict remote-record parser remains separate from the compatibility-oriented file codec. During verification this also exposed and fixed an undeclared `revision` property leaking from file catalog metadata into returned `ChatSession` values.

## Deliberate boundary

This PR does not add a PostgreSQL/MySQL adapter or conformance runner. Hosts still own SQL, migrations, transactions, connection pooling, identity scope, tenant filters, RLS, and database error translation. A reusable repository conformance kit is the next slice; async archive persistence comes before claiming full multi-replica durability.

## Verification

- focused adapter/file tests: 21 passed
- full unit suite: 694 passed
- full integration suite: 295 passed
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- built-package public export smoke
