### PR TITLE
feat: add async conversation archive repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ YOUR PRODUCT
   run identity, ordered activity, replay, cancel, approvals
           |
   ConversationEngine
-  sessions, turns, compaction, traces, artifacts
+  sessions, turns, compaction, archives, traces, artifacts
           |
   models, tools, host extensions, MCP
 ```
@@ -153,7 +153,7 @@ YOUR PRODUCT
 | Approvals | Request/resolution lifecycle and run integration | Who may approve, approval policy, and approval UI |
 | Active runs | Run IDs, ordered sequences, bounded replay, cancellation, and terminal settlement | Process lifetime, routing, draining, and multi-process delivery |
 | Remote clients | Runtime envelope validation, cursor/duplicate/gap rules, terminal detection, and reconnect calculation | Public payload schemas, timers, UI state, retry UX, and result presentation |
-| Persistence | File-backed defaults and injectable session/artifact repository boundaries | Production adapters, retention, encryption, backup, tenancy, and product records |
+| Persistence | File-backed defaults and injectable session/archive/artifact repository boundaries | Production adapters, retention, encryption, backup, tenancy, and product records |
 | API and UI | Optional Node HTTP/SSE and browser transport mechanics | Server framework, routes, auth, CORS, limits, errors, and every visual decision |
 
 The full ownership model lives in
@@ -315,12 +315,11 @@ Heddle is designed to make assumptions and limitations visible:
   active-run handles and replay are process-local and bounded;
 - multi-process routing and durable in-flight delivery require infrastructure
   selected by the host;
-- session and artifact repositories are injectable, but production retention,
-  encryption, backup, tenancy, and adapter operations remain host
-  responsibilities;
-- traces, compaction archives, memory, and some supporting state remain
-  local/path-oriented unless the host deliberately provides another
-  integration path;
+- session, compacted-history archive, and artifact repositories are injectable,
+  but production retention, encryption, backup, tenancy, and adapter operations
+  remain host responsibilities;
+- traces, memory, and some supporting state remain local/path-oriented unless
+  the host deliberately provides another integration path;
 - HTTP/SSE helpers own wire correctness, not route registration,
   authentication, authorization, CORS, limits, billing, or deployment;
 - `@roackb2/heddle-remote` validates the run protocol but does not own product

--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -56,9 +56,10 @@ split between Heddle and the host explicit for developers and coding agents.
 5. **Advanced: storage** — back Heddle with your own persistence.
    - [Result artifacts](result-artifacts.md): save large generated values as
      reusable artifacts.
-   - Artifact and session storage are injectable: implement
-     `ArtifactRepository` / `ChatSessionRepository` and pass them as
-     `artifactRepository` / `sessionRepository` (see
+   - Artifact, session, and compacted-history storage are injectable: implement
+     `ArtifactRepository` / `ChatSessionRepository` /
+     `ChatArchiveRepository` and pass them as `artifactRepository` /
+     `sessionRepository` / `archiveRepository` (see
      [Conversation engine → Bring your own artifact storage](conversation-engine.md#bring-your-own-artifact-storage)
      and [Durable session storage](session-storage.md) for local JSON and
      PostgreSQL adapter guidance).

--- a/docs/guides/programmatic/conversation-engine.md
+++ b/docs/guides/programmatic/conversation-engine.md
@@ -216,5 +216,39 @@ silently lose a concurrent write.
 See [Durable session storage](session-storage.md) for the default JSON layout,
 the exact compare-and-swap behavior, and a PostgreSQL table/query shape.
 
+## Bring your own compacted-history storage
+
+Long conversations archive exact messages and a cumulative rolling summary
+through the async `ChatArchiveRepository`. Hosted services should inject this
+beside `ChatSessionRepository`; otherwise the active session can reopen on a
+new replica while its compacted history still points at local files.
+
+```ts
+import {
+  createConversationEngine,
+  type ChatArchiveRepository,
+} from '@roackb2/heddle'
+
+const archiveRepository: ChatArchiveRepository = {
+  loadManifest: async (sessionId) => loadManifest(sessionId),
+  readSummary: async (summaryLocator) => loadSummary(summaryLocator),
+  append: async (input) => appendArchiveTransaction(input),
+}
+
+const engine = createConversationEngine({
+  workspaceRoot,
+  stateRoot,
+  model: 'gpt-5.4',
+  sessionRepository,
+  archiveRepository,
+})
+```
+
+Bind both repositories to the same server-authenticated account/tenant scope.
+`append` must atomically expose the raw messages, summary, and returned
+manifest; Heddle will not persist compacted session state until it succeeds.
+See [Durable session storage](session-storage.md) for the complete contract,
+codec helpers, and a PostgreSQL shape.
+
 Traces and memory still persist under the state root today. Making them
 injectable follows the same port-per-domain pattern.

--- a/docs/guides/programmatic/integration-layers.md
+++ b/docs/guides/programmatic/integration-layers.md
@@ -45,7 +45,7 @@ not transport infrastructure.
 | Approvals | Approval request/resolution lifecycle and run integration | Whether an action is allowed, authenticated approver, and approval UI/policy |
 | Active runs | Run ID, ordered sequence, process-local replay, subscription, cancellation, and terminal result | Lifetime of the run service, address scope, process routing, draining, and multi-process delivery |
 | Remote consumption | Cursor advancement, duplicate suppression, sequence-gap failure, terminal detection, bounded reconnect timing, and runtime envelope validation | Public activity/result schemas, actual transport timer/handle, and error UX |
-| Persistence | File-backed defaults plus injectable session/artifact repository ports | Production repository implementations, retention, encryption, backup, and tenancy |
+| Persistence | File-backed defaults plus injectable session/archive/artifact repository ports | Production repository implementations, retention, encryption, backup, and tenancy |
 | Identity and authorization | No identity-provider assumption | Authentication, tenant/user mapping, authorization for start/subscribe/cancel |
 | Transport/API | Optional fetch/SSE client and Node SSE streaming correctness when that preset is selected | Framework, routes/procedures, wire schemas, auth, errors, limits, CORS, and rate limiting |
 | Client experience | Semantic activities, terminal run events, and remote cursor/retry calculations | Messages, tool rendering, UI state, transport timers, retry UX, notifications, and product-specific result presentation |

--- a/docs/guides/programmatic/session-storage.md
+++ b/docs/guides/programmatic/session-storage.md
@@ -3,11 +3,13 @@
 Heddle owns conversation-session semantics: messages, turns, leases, queued
 prompts, compaction metadata, and optimistic mutation coordination. A host owns
 where those records live and how an authenticated product user is scoped to
-them.
+them. Compacted raw transcripts and rolling summaries use a separate
+`ChatArchiveRepository` because their append-only lifecycle is different from
+revisioned active-session records.
 
-Use the default JSON adapter for one-machine/local-first products. Inject a
-`ChatSessionRepository` for hosted or multi-process products that already have
-a database.
+Use the default JSON adapters for one-machine/local-first products. Inject
+`ChatSessionRepository` and `ChatArchiveRepository` for hosted or multi-process
+products that already have a database.
 
 ## Local JSON: zero configuration
 
@@ -74,6 +76,64 @@ const engine = createConversationEngine({
   sessionRepository,
 })
 ```
+
+For a hosted service, session storage alone is not complete durability. Inject
+the companion archive repository as well, bound to the same trusted server-side
+identity scope:
+
+```ts
+import {
+  ChatArchivePersistenceCodec,
+  createConversationEngine,
+  type ChatArchiveRepository,
+} from '@roackb2/heddle'
+
+const archiveRepository: ChatArchiveRepository = {
+  loadManifest: async (sessionId) => {
+    const stored = await readArchiveManifest(sessionId)
+    return stored
+      ? ChatArchivePersistenceCodec.parseManifest(stored, sessionId)
+      : ChatArchivePersistenceCodec.emptyManifest(sessionId)
+  },
+  readSummary: async (summaryLocator) => readArchiveSummary(summaryLocator),
+  append: async (input) => database.transaction(async (tx) => {
+    const currentValue = await tx.readArchiveManifestForUpdate(input.sessionId)
+    const current = currentValue
+      ? ChatArchivePersistenceCodec.parseManifest(currentValue, input.sessionId)
+      : ChatArchivePersistenceCodec.emptyManifest(input.sessionId)
+    const archive = {
+      ...input.archive,
+      path: `db://conversation-archives/${input.archive.id}/messages`,
+      summaryPath: `db://conversation-archives/${input.archive.id}/summary`,
+    }
+    const manifest = ChatArchivePersistenceCodec.appendArchive(current, archive)
+
+    await tx.insertArchive({
+      sessionId: input.sessionId,
+      archive,
+      messages: input.messages,
+      summary: input.summary,
+    })
+    await tx.writeArchiveManifest(input.sessionId, manifest)
+    return { archive, manifest }
+  }),
+}
+
+const engine = createConversationEngine({
+  workspaceRoot,
+  stateRoot,
+  model: 'gpt-5.4',
+  sessionRepository,
+  archiveRepository,
+})
+```
+
+`append` is the durability boundary: the exact messages, rolling summary, and
+returned manifest must become visible in one transaction. If it rejects,
+Heddle keeps the exact active transcript and does not persist compacted session
+state that points at incomplete content. The legacy `path` and `summaryPath`
+field names are repository-owned opaque locators; only the default file adapter
+promises filesystem paths.
 
 ### Reuse Heddle's adapter-authoring primitives
 
@@ -193,6 +253,44 @@ where (
 
 Apply tenant, workspace, and archive filters before the cursor predicate.
 
+### PostgreSQL archive shape
+
+Keep archive content separate from the hot session row. One practical JSONB
+shape uses an immutable content row plus one locked manifest/head row:
+
+```sql
+create table agent_conversation_archives (
+  tenant_id uuid not null,
+  session_id text not null,
+  archive_id text not null,
+  archive_record jsonb not null,
+  messages jsonb not null,
+  summary text not null,
+  created_at timestamptz not null,
+  primary key (tenant_id, session_id, archive_id)
+);
+
+create table agent_conversation_archive_heads (
+  tenant_id uuid not null,
+  session_id text not null,
+  manifest jsonb not null,
+  updated_at timestamptz not null,
+  primary key (tenant_id, session_id)
+);
+```
+
+In `append`, create or lock the head row with `SELECT ... FOR UPDATE`, validate
+its JSONB with `ChatArchivePersistenceCodec.parseManifest`, insert the immutable
+archive row, and update the head in the same transaction. Enforce the composite
+tenant/session key in every query. A Drizzle adapter can map the JSONB columns
+to TypeScript shapes, but it must still run the Heddle codec when data crosses
+the storage boundary; TypeScript generics do not validate stored JSON.
+
+For large transcripts, replace `messages jsonb` with an object-store key. Write
+the immutable object before committing the manifest transaction. A failed
+transaction may leave an unreferenced object for a retention job to remove, but
+the committed manifest must never reference a missing object.
+
 ## Required behavior
 
 Before using a custom adapter in production, run Heddle's reusable conformance
@@ -242,4 +340,12 @@ host's normal integration-test runner produces better diagnostics.
 
 See the repository's local
 [`README.md`](../../../src/core/chat/engine/sessions/repository/README.md) for
-the exact adapter boundary and file-layout details.
+the exact session adapter boundary and file-layout details. The archive port's
+separate ownership and atomicity rules are in its
+[`README.md`](../../../src/core/chat/engine/sessions/archives/README.md).
+
+The session conformance suite does not yet certify a custom archive adapter.
+Keep host integration tests for transactional append, malformed manifest
+rejection, fresh-instance rolling-summary recovery, missing summary content,
+and storage-failure propagation. The default file adapter exercises those same
+invariants in Heddle's integration suite.

--- a/src/__tests__/integration/chat/chat-archive-storage.test.ts
+++ b/src/__tests__/integration/chat/chat-archive-storage.test.ts
@@ -1,0 +1,122 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  ChatArchiveStorageCorruptionError,
+  FileChatArchiveRepository,
+} from '@/core/chat/engine/sessions/archives/index.js';
+
+describe('file chat archive repository', () => {
+  it('persists exact messages, summaries, and a valid v1 manifest for a fresh repository instance', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-chat-archives-'));
+    const writer = new FileChatArchiveRepository({ stateRoot });
+
+    const appended = await writer.append({
+      sessionId: 'session-1',
+      archive: {
+        id: 'archive-1',
+        shortDescription: 'Investigated the storage boundary',
+        messageCount: 2,
+        createdAt: '2026-07-17T00:00:00.000Z',
+        summaryModel: 'gpt-5.4',
+      },
+      messages: [
+        { role: 'user', content: 'Inspect the repository.' },
+        { role: 'assistant', content: 'The storage boundary is here.' },
+      ],
+      summary: '# Rolling summary\n\nStorage boundary inspected.',
+    });
+
+    const reopened = new FileChatArchiveRepository({ stateRoot });
+    const manifest = await reopened.loadManifest('session-1');
+    const paths = reopened.deriveStoragePaths('session-1');
+
+    expect(appended.archive).toEqual(expect.objectContaining({
+      id: 'archive-1',
+      path: '.heddle/chat-sessions/session-1/archives/archive-1.jsonl',
+      summaryPath: '.heddle/chat-sessions/session-1/archives/archive-1.summary.md',
+    }));
+    expect(manifest).toEqual(appended.manifest);
+    await expect(reopened.readSummary(appended.archive.summaryPath)).resolves.toContain('Storage boundary inspected.');
+    expect(await readFile(join(paths.archivesDir, 'archive-1.jsonl'), 'utf8')).toContain(
+      '"content":"Inspect the repository."',
+    );
+  });
+
+  it('serializes concurrent appends across repository instances without losing an archive', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-chat-archive-race-'));
+    const first = new FileChatArchiveRepository({ stateRoot });
+    const second = new FileChatArchiveRepository({ stateRoot });
+
+    await Promise.all([
+      first.append(appendInput('archive-a', 'First summary')),
+      second.append(appendInput('archive-b', 'Second summary')),
+    ]);
+
+    const manifest = await new FileChatArchiveRepository({ stateRoot }).loadManifest('session-1');
+    expect(manifest.archives.map((archive) => archive.id).sort()).toEqual(['archive-a', 'archive-b']);
+    expect(manifest.currentSummaryPath).toMatch(/archive-(a|b)\.summary\.md$/);
+  });
+
+  it('fails loudly for malformed or session-mismatched manifests', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-chat-archive-corrupt-'));
+    const repository = new FileChatArchiveRepository({ stateRoot });
+    const paths = repository.deriveStoragePaths('session-1');
+    await mkdir(paths.archivesDir, { recursive: true });
+    await writeFile(paths.manifestPath, JSON.stringify({
+      version: 1,
+      sessionId: 'another-session',
+      archives: [],
+    }));
+
+    await expect(repository.loadManifest('session-1'))
+      .rejects.toBeInstanceOf(ChatArchiveStorageCorruptionError);
+
+    await writeFile(paths.manifestPath, '{not-json');
+    await expect(repository.loadManifest('session-1'))
+      .rejects.toBeInstanceOf(ChatArchiveStorageCorruptionError);
+  });
+
+  it('keeps host-provided session and archive ids inside the archive root', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-chat-archive-path-safety-'));
+    const repository = new FileChatArchiveRepository({ stateRoot });
+
+    const appended = await repository.append({
+      ...appendInput('../archive', 'Safe summary'),
+      sessionId: '../session',
+    });
+
+    expect(appended.archive.path).toBe(
+      '.heddle/chat-sessions/..%2Fsession/archives/..%2Farchive.jsonl',
+    );
+    await expect(readFile(
+      join(stateRoot, 'chat-sessions', '..%2Fsession', 'archives', '..%2Farchive.jsonl'),
+      'utf8',
+    )).resolves.toContain('../archive');
+  });
+
+  it('rejects summary locators outside the configured state root', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-chat-archive-locator-safety-'));
+    const repository = new FileChatArchiveRepository({ stateRoot });
+
+    await expect(repository.readSummary('/tmp/untrusted-summary.md'))
+      .rejects.toBeInstanceOf(ChatArchiveStorageCorruptionError);
+    await expect(repository.readSummary('.heddle/../../untrusted-summary.md'))
+      .rejects.toBeInstanceOf(ChatArchiveStorageCorruptionError);
+  });
+});
+
+function appendInput(archiveId: string, summary: string) {
+  return {
+    sessionId: 'session-1',
+    archive: {
+      id: archiveId,
+      messageCount: 1,
+      createdAt: '2026-07-17T00:00:00.000Z',
+      summaryModel: 'gpt-5.4',
+    },
+    messages: [{ role: 'user' as const, content: archiveId }],
+    summary,
+  };
+}

--- a/src/__tests__/unit/core/chat-archive-adapter-authoring-kit.test.ts
+++ b/src/__tests__/unit/core/chat-archive-adapter-authoring-kit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { ChatArchivePersistenceCodec } from '../../../index.js';
+
+describe('chat archive adapter-authoring primitives', () => {
+  it('builds and strictly round-trips a canonical manifest', () => {
+    const empty = ChatArchivePersistenceCodec.emptyManifest('session-1');
+    const manifest = ChatArchivePersistenceCodec.appendArchive(empty, {
+      id: 'archive-1',
+      path: 'db://conversation-archives/archive-1/messages',
+      summaryPath: 'db://conversation-archives/archive-1/summary',
+      messageCount: 3,
+      createdAt: '2026-07-17T00:00:00.000Z',
+      summaryModel: 'gpt-5.4',
+    });
+
+    expect(ChatArchivePersistenceCodec.parseManifest(
+      JSON.parse(ChatArchivePersistenceCodec.serializeManifest(manifest)) as unknown,
+      'session-1',
+    )).toEqual(manifest);
+  });
+
+  it('rejects session mismatches, unknown manifest state, and duplicate archive ids', () => {
+    const empty = ChatArchivePersistenceCodec.emptyManifest('session-1');
+    const archive = {
+      id: 'archive-1',
+      path: 'db://conversation-archives/archive-1/messages',
+      summaryPath: 'db://conversation-archives/archive-1/summary',
+      messageCount: 3,
+      createdAt: '2026-07-17T00:00:00.000Z',
+    };
+    const manifest = ChatArchivePersistenceCodec.appendArchive(empty, archive);
+
+    expect(() => ChatArchivePersistenceCodec.parseManifest(manifest, 'session-2'))
+      .toThrow('archive manifest session mismatch');
+    expect(() => ChatArchivePersistenceCodec.parseManifest({
+      ...manifest,
+      tenantId: 'scope-must-stay-in-the-host-adapter',
+    }, 'session-1')).toThrow();
+    expect(() => ChatArchivePersistenceCodec.appendArchive(manifest, archive))
+      .toThrow('conversation archive already exists');
+  });
+});

--- a/src/__tests__/unit/core/conversation-compaction-archive-repository.test.ts
+++ b/src/__tests__/unit/core/conversation-compaction-archive-repository.test.ts
@@ -1,0 +1,219 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
+import {
+  ChatArchivePersistenceCodec,
+  ChatArchiveRepositoryError,
+  ChatArchiveSummaryNotFoundError,
+  FileChatArchiveRepository,
+  type AppendChatArchiveInput,
+  type AppendChatArchiveResult,
+  type ChatArchiveRepository,
+} from '@/core/chat/engine/sessions/archives/index.js';
+import type { ChatArchiveManifest } from '@/core/chat/types.js';
+import type { ChatMessage, LlmAdapter } from '@/core/llm/types.js';
+
+describe('conversation compaction archive repository', () => {
+  it('preserves the zero-configuration local archive layout', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-local-archive-compaction-'));
+
+    const compacted = await ConversationCompactionService.compact({
+      history: history('local'),
+      runtime: { model: 'gpt-5.4', stateRoot },
+      session: { id: 'session-1' },
+      force: true,
+      summarizer: {
+        model: 'gpt-5.4',
+        llm: { chat: async () => ({ content: 'Local rolling summary' }) },
+      },
+    });
+
+    const manifest = await new FileChatArchiveRepository({ stateRoot }).loadManifest('session-1');
+    expect(manifest).toEqual(expect.objectContaining({
+      archives: compacted.archive.archives,
+      currentSummaryPath: compacted.archive.currentSummaryPath,
+    }));
+    expect(manifest.archives[0]?.path).toMatch(
+      /^\.heddle\/chat-sessions\/session-1\/archives\/archive-/,
+    );
+  });
+
+  it('continues a rolling summary from a fresh repository instance without shared archive files', async () => {
+    const backend = new InMemoryArchiveBackend();
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-remote-archive-compaction-'));
+    const prompts: ChatMessage[][] = [];
+    const summaries = ['First durable rolling summary', 'Second durable rolling summary'];
+    const llm: LlmAdapter = {
+      chat: vi.fn(async (messages) => {
+        prompts.push(messages);
+        return { content: summaries[prompts.length - 1] };
+      }),
+    };
+
+    const first = await ConversationCompactionService.compact({
+      history: history('first'),
+      runtime: { model: 'gpt-5.4', stateRoot },
+      session: { id: 'session-1' },
+      archiveRepository: backend.createRepository(),
+      force: true,
+      summarizer: { llm, model: 'gpt-5.4' },
+    });
+    const second = await ConversationCompactionService.compact({
+      history: [
+        ...first.history,
+        { role: 'user', content: 'second user 1' },
+        { role: 'assistant', content: 'second assistant 1' },
+        { role: 'user', content: 'second user 2' },
+        { role: 'assistant', content: 'second assistant 2' },
+      ],
+      runtime: { model: 'gpt-5.4', stateRoot },
+      session: { id: 'session-1' },
+      archiveRepository: backend.createRepository(),
+      force: true,
+      summarizer: { llm, model: 'gpt-5.4' },
+    });
+
+    expect(first.archive.archives).toHaveLength(1);
+    expect(second.archive.archives).toHaveLength(2);
+    expect(second.archive.currentSummaryPath).toMatch(/^memory:\/\/session-1\//);
+    expect(prompts[1]?.find((message) => message.role === 'user')?.content)
+      .toContain('First durable rolling summary');
+    expect(second.history[0]).toEqual(expect.objectContaining({
+      role: 'system',
+      content: expect.stringContaining('Second durable rolling summary'),
+    }));
+  });
+
+  it('rejects archive infrastructure failures after emitting a failed status', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-archive-failure-'));
+    const statuses: string[] = [];
+    const repository: ChatArchiveRepository = {
+      loadManifest: async (sessionId) => ChatArchivePersistenceCodec.emptyManifest(sessionId),
+      readSummary: async () => undefined,
+      append: async () => {
+        throw new Error('archive backend unavailable');
+      },
+    };
+
+    await expect(ConversationCompactionService.compact({
+      history: history('failure'),
+      runtime: { model: 'gpt-5.4', stateRoot },
+      session: { id: 'session-1' },
+      archiveRepository: repository,
+      force: true,
+      summarizer: {
+        model: 'gpt-5.4',
+        llm: { chat: async () => ({ content: 'Summary completed before storage failed' }) },
+      },
+      onStatusChange: (event) => {
+        statuses.push(event.status);
+      },
+    })).rejects.toThrow('archive backend unavailable');
+
+    expect(statuses).toEqual(['running', 'failed']);
+  });
+
+  it('rejects a manifest whose current summary locator cannot be reconstructed', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-archive-missing-summary-'));
+    const repository: ChatArchiveRepository = {
+      loadManifest: async () => ({
+        version: 1,
+        sessionId: 'session-1',
+        currentSummaryPath: 'remote://archive-1/summary',
+        archives: [{
+          id: 'archive-1',
+          path: 'remote://archive-1/messages',
+          summaryPath: 'remote://archive-1/summary',
+          messageCount: 2,
+          createdAt: '2026-07-17T00:00:00.000Z',
+        }],
+      }),
+      readSummary: async () => undefined,
+      append: async () => {
+        throw new Error('append should not run');
+      },
+    };
+
+    const pending = ConversationCompactionService.compact({
+      history: history('missing'),
+      runtime: { model: 'gpt-5.4', stateRoot },
+      session: { id: 'session-1' },
+      archiveRepository: repository,
+      force: true,
+      summarizer: {
+        model: 'gpt-5.4',
+        llm: { chat: async () => ({ content: 'Must not run' }) },
+      },
+    });
+
+    await expect(pending).rejects.toMatchObject({
+      operation: 'read_summary',
+      cause: expect.any(ChatArchiveSummaryNotFoundError),
+    } satisfies Partial<ChatArchiveRepositoryError>);
+  });
+});
+
+type InMemoryArchiveState = {
+  manifest: ChatArchiveManifest;
+  summaries: Map<string, string>;
+};
+
+class InMemoryArchiveBackend {
+  private readonly sessions = new Map<string, InMemoryArchiveState>();
+
+  createRepository(): ChatArchiveRepository {
+    return {
+      loadManifest: async (sessionId) => structuredClone(this.readState(sessionId).manifest),
+      readSummary: async (summaryLocator) => {
+        for (const state of this.sessions.values()) {
+          const summary = state.summaries.get(summaryLocator);
+          if (summary !== undefined) {
+            return summary;
+          }
+        }
+        return undefined;
+      },
+      append: async (input) => this.append(input),
+    };
+  }
+
+  private append(input: AppendChatArchiveInput): AppendChatArchiveResult {
+    const state = this.readState(input.sessionId);
+    const archive = {
+      ...input.archive,
+      path: `memory://${input.sessionId}/${input.archive.id}.jsonl`,
+      summaryPath: `memory://${input.sessionId}/${input.archive.id}.summary.md`,
+    };
+    const manifest = ChatArchivePersistenceCodec.appendArchive(state.manifest, archive);
+    state.manifest = manifest;
+    state.summaries.set(archive.summaryPath, input.summary);
+    return structuredClone({ archive, manifest });
+  }
+
+  private readState(sessionId: string): InMemoryArchiveState {
+    const existing = this.sessions.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+
+    const created = {
+      manifest: ChatArchivePersistenceCodec.emptyManifest(sessionId),
+      summaries: new Map<string, string>(),
+    };
+    this.sessions.set(sessionId, created);
+    return created;
+  }
+}
+
+function history(prefix: string): ChatMessage[] {
+  return [
+    { role: 'user', content: `${prefix} user 1` },
+    { role: 'assistant', content: `${prefix} assistant 1` },
+    { role: 'user', content: `${prefix} user 2` },
+    { role: 'assistant', content: `${prefix} assistant 2` },
+    { role: 'user', content: `${prefix} user 3` },
+    { role: 'assistant', content: `${prefix} assistant 3` },
+  ];
+}

--- a/src/__tests__/unit/core/conversation-compaction-state-restoration.test.ts
+++ b/src/__tests__/unit/core/conversation-compaction-state-restoration.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
+import { ChatArchiveRepositoryError } from '@/core/chat/engine/sessions/archives/index.js';
+import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
+import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
+import { FileConversationSessionService } from '@/core/chat/engine/sessions/service.js';
+import { ConversationTurnPreflightService } from '@/core/chat/engine/turns/preflight/index.js';
+import { ConversationTurnPersistenceService } from '@/core/chat/engine/turns/persistence/index.js';
+import type { AgentLoopResult } from '@/core/runtime/loop/index.js';
+
+describe('compaction infrastructure failure restoration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('restores preflight compaction metadata after an archive backend exception', async () => {
+    const fixture = await createFixture('preflight');
+    failCompactionAfterRunning();
+
+    await expect(ConversationTurnPreflightService.prepare({
+      sessionService: fixture.sessions,
+      sessionId: fixture.session.id,
+      fallbackHistory: fixture.session.history,
+      prompt: 'Continue the investigation',
+      model: 'gpt-5.4',
+      stateRoot: fixture.stateRoot,
+      toolNames: [],
+      summarizer: {},
+      leaseOwner: { ownerKind: 'daemon', ownerId: 'daemon-test' },
+      host: {},
+    })).rejects.toThrow('archive backend unavailable');
+
+    const restored = await fixture.sessions.require(fixture.session.id);
+    expect(restored.context).toEqual(fixture.session.context);
+    expect(restored.archives).toEqual(fixture.session.archives);
+    expect(restored.history).toEqual(fixture.session.history);
+  });
+
+  it('keeps the exact completed transcript but restores prior archive metadata after a final append failure', async () => {
+    const fixture = await createFixture('final');
+    failCompactionAfterRunning();
+    const result = completedResult(fixture.stateRoot);
+
+    await expect(ConversationTurnPersistenceService.persistCompleted({
+      result,
+      prompt: 'Continue the investigation',
+      session: fixture.session,
+      sessionService: fixture.sessions,
+      model: 'gpt-5.4',
+      stateRoot: fixture.stateRoot,
+      traceDir: join(fixture.stateRoot, 'traces'),
+      toolNames: [],
+      historyForTokenEstimate: fixture.session.history,
+      credentialSource: { type: 'explicit-api-key' },
+      host: {},
+    })).rejects.toThrow('archive backend unavailable');
+
+    const restored = await fixture.sessions.require(fixture.session.id);
+    expect(restored.context).toEqual(fixture.session.context);
+    expect(restored.archives).toEqual(fixture.session.archives);
+    expect(restored.history).toEqual(result.transcript);
+  });
+});
+
+function failCompactionAfterRunning(): void {
+  vi.spyOn(ConversationCompactionService, 'compact').mockImplementation(async (options) => {
+    await options.onStatusChange?.({
+      source: 'compaction',
+      type: 'compaction.running',
+      status: 'running',
+    });
+    throw new ChatArchiveRepositoryError('append', new Error('archive backend unavailable'));
+  });
+}
+
+async function createFixture(suffix: string) {
+  const stateRoot = await mkdtemp(join(tmpdir(), `heddle-compaction-restore-${suffix}-`));
+  const sessionStoragePath = join(stateRoot, 'chat-sessions.catalog.json');
+  const repository = new FileChatSessionRepository({ sessionStoragePath });
+  const session = {
+    ...ChatSessionRecords.create({ id: 'session-1', name: 'Session' }),
+    history: [
+      { role: 'user' as const, content: 'Inspect the repository.' },
+      { role: 'assistant' as const, content: 'Inspection started.' },
+    ],
+    context: {
+      estimatedHistoryTokens: 12,
+      compaction: { status: 'idle' as const },
+      archive: { currentSummaryPath: 'memory://session-1/archive-1.summary.md' },
+    },
+    archives: [{
+      id: 'archive-1',
+      path: 'memory://session-1/archive-1.jsonl',
+      summaryPath: 'memory://session-1/archive-1.summary.md',
+      messageCount: 2,
+      createdAt: '2026-07-17T00:00:00.000Z',
+    }],
+  };
+  await repository.create(session);
+  return {
+    stateRoot,
+    session,
+    sessions: new FileConversationSessionService({
+      workspaceRoot: stateRoot,
+      stateRoot,
+      sessionStoragePath,
+      sessionRepository: repository,
+      model: 'gpt-5.4',
+    }),
+  };
+}
+
+function completedResult(stateRoot: string): AgentLoopResult {
+  return {
+    outcome: 'done',
+    summary: 'Investigation complete.',
+    trace: [],
+    transcript: [
+      { role: 'user', content: 'Inspect the repository.' },
+      { role: 'assistant', content: 'Inspection started.' },
+      { role: 'user', content: 'Continue the investigation' },
+      { role: 'assistant', content: 'Investigation complete.' },
+    ],
+    model: 'gpt-5.4',
+    provider: 'openai',
+    workspaceRoot: stateRoot,
+  };
+}

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -15,6 +15,7 @@ import {
   type StoredChatSession,
 } from '../../../core/chat/engine/sessions/repository/index.js';
 import type { ChatSession } from '../../../core/chat/types.js';
+import type { ChatArchiveRepository } from '../../../core/chat/engine/sessions/archives/index.js';
 import {
   listChatSessionCatalog,
   readStoredChatSession,
@@ -186,6 +187,31 @@ describe('createConversationEngine', () => {
     expect(stored.get('session-hosted')?.session.name).toBe('Renamed hosted');
     // Nothing was written to the default on-disk session catalog.
     expect(existsSync(join(stateRoot, 'chat-sessions.catalog.json'))).toBe(false);
+  });
+
+  it('passes an injected archive repository through submitted turns', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-archive-repo-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const archiveRepository: ChatArchiveRepository = {
+      loadManifest: vi.fn(async (sessionId) => ({ version: 1, sessionId, archives: [] })),
+      readSummary: vi.fn(async () => undefined),
+      append: vi.fn(),
+    };
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      apiKeyPresent: true,
+      archiveRepository,
+    });
+    const session = await engine.sessions.create({ id: 'session-1', name: 'Hosted archives' });
+
+    await engine.turns.submit({ sessionId: session.id, prompt: 'Continue remotely' });
+
+    expect(EngineConversationTurnService.run).toHaveBeenCalledWith(expect.objectContaining({
+      archiveRepository,
+      sessionId: session.id,
+    }));
   });
 
   it('roots the artifacts reader at a custom host-extension artifacts root', async () => {

--- a/src/core/chat/engine/compaction/README.md
+++ b/src/core/chat/engine/compaction/README.md
@@ -10,7 +10,7 @@ adapter.
 
 - Deciding whether history needs compaction.
 - Choosing the archived slice versus recent active history.
-- Writing archived transcript files and rolling summaries.
+- Ordering durable archive writes after successful rolling-summary generation.
 - Building compacted summary messages for future turns.
 - Building persisted compaction context stats.
 - Estimating history and request-token pressure for compaction decisions.
@@ -27,6 +27,12 @@ adapter.
   context assembly.
 - `transcript-renderer.ts` owns archive transcript rendering for summarization.
 - `context-builder.ts` owns persisted compaction context stats.
+
+Archive persistence itself belongs to
+`sessions/archives/ChatArchiveRepository`. Compaction treats returned `path`
+and `summaryPath` values as opaque locators. Repository read/write failures are
+infrastructure failures and reject the compaction; summarizer failures retain
+the original history and produce a failed compaction result.
 
 Avoid adding loose exported functions for compaction-domain behavior. If the
 behavior is part of compaction semantics, put it on `ConversationCompactionService`

--- a/src/core/chat/engine/compaction/service.ts
+++ b/src/core/chat/engine/compaction/service.ts
@@ -1,5 +1,13 @@
+import { randomUUID } from 'node:crypto';
 import { ModelCatalogService } from '@/core/llm/models/index.js';
-import type { ChatArchiveRecord } from '@/core/chat/types.js';
+import type { ChatArchiveManifest } from '@/core/chat/types.js';
+import {
+  ChatArchiveSummaryNotFoundError,
+  ChatArchiveRepositoryError,
+  FileChatArchiveRepository,
+  type ChatArchiveRecordDraft,
+  type ChatArchiveRepository,
+} from '@/core/chat/engine/sessions/archives/index.js';
 import {
   DEFAULT_CONTEXT_WINDOW_ESTIMATE,
   MAX_HISTORY_RATIO,
@@ -12,7 +20,6 @@ import { ConversationArchiveSummarizer } from './summarizer/index.js';
 import { ConversationCompactionSplitPolicy } from './split-policy.js';
 import { ConversationCompactionSummaryMessage } from './summary-message.js';
 import { ConversationCompactionTokenEstimator } from './token-estimator.js';
-import { FileChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
 import type {
   BuildSessionCompactionRunningContextOptions,
   ConversationCompactionArchiveState,
@@ -40,7 +47,7 @@ export class ConversationCompactionService {
       || (Boolean(options.force) && ConversationCompactionTokenEstimator.countNonCompactedMessages(options.history) > 0);
 
     if (!needsCompaction) {
-      return ConversationCompactionService.buildUnchangedResult(options);
+      return await ConversationCompactionService.buildUnchangedResult(options);
     }
 
     const splitIndex = ConversationCompactionSplitPolicy.findSplit(options.history, {
@@ -49,7 +56,7 @@ export class ConversationCompactionService {
       stopAtPreferredMessages: Boolean(options.force),
     });
     if (splitIndex <= 0 || splitIndex >= options.history.length) {
-      return ConversationCompactionService.buildUnchangedResult(options);
+      return await ConversationCompactionService.buildUnchangedResult(options);
     }
 
     return await ConversationCompactionService.compactArchivedSlice({ options, splitIndex });
@@ -67,9 +74,16 @@ export class ConversationCompactionService {
     return ConversationCompactionContextBuilder.buildSessionRunning(options);
   }
 
-  private static buildUnchangedResult(options: ConversationCompactionOptions): ConversationCompactionResult {
-    const archiveRepository = ConversationCompactionService.createArchiveRepository(options);
-    const manifest = archiveRepository.loadManifest();
+  private static async buildUnchangedResult(
+    options: ConversationCompactionOptions,
+  ): Promise<ConversationCompactionResult> {
+    let manifest: ChatArchiveManifest;
+    try {
+      manifest = await ConversationCompactionService.createArchiveRepository(options)
+        .loadManifest(options.session.id);
+    } catch (error) {
+      throw ConversationCompactionService.repositoryError('load_manifest', error);
+    }
     const archive: ConversationCompactionArchiveState = {
       archives: manifest.archives,
       currentSummaryPath: manifest.currentSummaryPath,
@@ -94,107 +108,138 @@ export class ConversationCompactionService {
     const archivedMessages = options.history.slice(0, splitIndex);
     const recentMessages = options.history.slice(splitIndex);
     const archiveRepository = ConversationCompactionService.createArchiveRepository(options);
-    const manifest = archiveRepository.loadManifest();
-    const previousRollingSummary =
-      (manifest.currentSummaryPath ? archiveRepository.readSummaryMarkdown(manifest.currentSummaryPath) : undefined)
-      ?? ConversationCompactionSummaryMessage.extractPriorSummary(options.history);
+    let manifest: ChatArchiveManifest;
+    let previousRollingSummary: string | undefined;
 
-    const archiveId = FileChatArchiveRepository.createArchiveId();
-    const archivePath = archiveRepository.writeMessagesJsonl(archiveId, archivedMessages);
+    try {
+      manifest = await archiveRepository.loadManifest(options.session.id);
+    } catch (error) {
+      const repositoryError = ConversationCompactionService.repositoryError('load_manifest', error);
+      await ConversationCompactionService.emitFailure(options, repositoryError);
+      throw repositoryError;
+    }
+
+    try {
+      previousRollingSummary = await ConversationCompactionService.readPreviousRollingSummary({
+        archiveRepository,
+        manifest,
+        history: options.history,
+      });
+    } catch (error) {
+      const repositoryError = ConversationCompactionService.repositoryError('read_summary', error);
+      await ConversationCompactionService.emitFailure(options, repositoryError);
+      throw repositoryError;
+    }
+
+    const archiveId = ConversationCompactionService.createArchiveId();
     await options.onStatusChange?.({
       source: 'compaction',
       type: 'compaction.running',
       status: 'running',
-      archivePath,
     });
 
+    let rollingSummary: string;
+    let summaryModel: string;
     try {
       const summarizer = ConversationArchiveSummarizer.resolve(options);
       if (!summarizer.llm) {
         throw new Error(`Missing provider API key for ${summarizer.model}`);
       }
-
-      const rollingSummary = await ConversationArchiveSummarizer.summarizeArchive({
+      summaryModel = summarizer.model;
+      rollingSummary = await ConversationArchiveSummarizer.summarizeArchive({
         runtime: { llm: summarizer.llm, model: summarizer.model },
         summaryModel: summarizer.model,
         sessionId: options.session.id,
-        archivePath,
+        archiveId,
         manifest,
         previousRollingSummary,
         archivedMessages,
       });
-      const summaryPath = archiveRepository.writeSummaryMarkdown(archiveId, rollingSummary);
-      const archiveRecord = ConversationCompactionService.buildArchiveRecord({
-        archiveId,
-        archivePath,
-        summaryPath,
-        rollingSummary,
-        archivedMessagesCount: ConversationCompactionTokenEstimator.countNonCompactedMessages(archivedMessages),
-        summaryModel: summarizer.model,
-      });
-      const nextManifest = FileChatArchiveRepository.appendManifestArchive(manifest, archiveRecord);
-      archiveRepository.saveManifest(nextManifest);
-
-      const compactedHistory = [
-        ConversationCompactionSummaryMessage.buildArchivedSummaryMessage({
-          sessionId: options.session.id,
-          rollingSummary,
-          archives: nextManifest.archives,
-        }),
-        ...recentMessages,
-      ];
-
-      await options.onStatusChange?.({
-        source: 'compaction',
-        type: 'compaction.finished',
-        status: 'finished',
-        archivePath: archiveRecord.path,
-        summaryPath: archiveRecord.summaryPath,
-      });
-
-      return ConversationCompactionService.buildCompactedResult({
-        options,
-        compactedHistory,
-        archiveRecord,
-        archive: {
-          archives: nextManifest.archives,
-          currentSummaryPath: nextManifest.currentSummaryPath,
-          lastArchivePath: archiveRecord.path,
-        },
-      });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      await options.onStatusChange?.({
-        source: 'compaction',
-        type: 'compaction.failed',
-        status: 'failed',
-        archivePath,
-        error: message,
-      });
+      const message = await ConversationCompactionService.emitFailure(options, error);
       return ConversationCompactionService.buildFailedResult({
         options,
         message,
-        archive: {
-          archives: manifest.archives,
-          currentSummaryPath: manifest.currentSummaryPath,
-          lastArchivePath: archivePath,
-        },
+        archive: ConversationCompactionService.archiveStateFromManifest(manifest),
       });
     }
+
+    const archiveDraft = ConversationCompactionService.buildArchiveRecordDraft({
+      archiveId,
+      rollingSummary,
+      archivedMessagesCount: ConversationCompactionTokenEstimator.countNonCompactedMessages(archivedMessages),
+      summaryModel,
+    });
+    let appended: Awaited<ReturnType<ChatArchiveRepository['append']>>;
+    try {
+      appended = await archiveRepository.append({
+        sessionId: options.session.id,
+        archive: archiveDraft,
+        messages: archivedMessages,
+        summary: rollingSummary,
+      });
+    } catch (error) {
+      const repositoryError = ConversationCompactionService.repositoryError('append', error);
+      await ConversationCompactionService.emitFailure(options, repositoryError);
+      throw repositoryError;
+    }
+
+    const compactedHistory = [
+      ConversationCompactionSummaryMessage.buildArchivedSummaryMessage({
+        rollingSummary,
+        archives: appended.manifest.archives,
+      }),
+      ...recentMessages,
+    ];
+
+    await options.onStatusChange?.({
+      source: 'compaction',
+      type: 'compaction.finished',
+      status: 'finished',
+      archivePath: appended.archive.path,
+      summaryPath: appended.archive.summaryPath,
+    });
+
+    return ConversationCompactionService.buildCompactedResult({
+      options,
+      compactedHistory,
+      archiveRecord: appended.archive,
+      archive: {
+        archives: appended.manifest.archives,
+        currentSummaryPath: appended.manifest.currentSummaryPath,
+        lastArchivePath: appended.archive.path,
+      },
+    });
   }
 
-  private static buildArchiveRecord(args: {
+  private static async readPreviousRollingSummary(args: {
+    archiveRepository: ChatArchiveRepository;
+    manifest: ChatArchiveManifest;
+    history: ConversationCompactionOptions['history'];
+  }): Promise<string | undefined> {
+    if (!args.manifest.currentSummaryPath) {
+      return ConversationCompactionSummaryMessage.extractPriorSummary(args.history);
+    }
+
+    const summary = await args.archiveRepository.readSummary(args.manifest.currentSummaryPath);
+    if (summary === undefined) {
+      throw new ChatArchiveSummaryNotFoundError(args.manifest.currentSummaryPath);
+    }
+    return summary;
+  }
+
+  private static createArchiveId(now = new Date()): string {
+    return `archive-${now.toISOString().replaceAll(':', '-')}-${randomUUID()}`;
+  }
+
+  private static buildArchiveRecordDraft(args: {
     archiveId: string;
-    archivePath: string;
-    summaryPath: string;
     rollingSummary: string;
     archivedMessagesCount: number;
     summaryModel: string;
-  }): ChatArchiveRecord {
+  }): ChatArchiveRecordDraft {
     return {
       id: args.archiveId,
-      path: args.archivePath,
-      summaryPath: args.summaryPath,
       shortDescription: ConversationArchiveSummarizer.deriveShortDescription(args.rollingSummary),
       messageCount: args.archivedMessagesCount,
       createdAt: new Date().toISOString(),
@@ -202,10 +247,41 @@ export class ConversationCompactionService {
     };
   }
 
+  private static archiveStateFromManifest(manifest: ChatArchiveManifest): ConversationCompactionArchiveState {
+    return {
+      archives: manifest.archives,
+      currentSummaryPath: manifest.currentSummaryPath,
+      lastArchivePath: manifest.archives.at(-1)?.path,
+    };
+  }
+
+  private static async emitFailure(
+    options: ConversationCompactionOptions,
+    error: unknown,
+  ): Promise<string> {
+    const message = error instanceof Error ? error.message : String(error);
+    await options.onStatusChange?.({
+      source: 'compaction',
+      type: 'compaction.failed',
+      status: 'failed',
+      error: message,
+    });
+    return message;
+  }
+
+  private static repositoryError(
+    operation: ConstructorParameters<typeof ChatArchiveRepositoryError>[0],
+    error: unknown,
+  ): ChatArchiveRepositoryError {
+    return error instanceof ChatArchiveRepositoryError
+      ? error
+      : new ChatArchiveRepositoryError(operation, error);
+  }
+
   private static buildCompactedResult(args: {
     options: ConversationCompactionOptions;
     compactedHistory: ConversationCompactionResult['history'];
-    archiveRecord: ChatArchiveRecord;
+    archiveRecord: Awaited<ReturnType<ChatArchiveRepository['append']>>['archive'];
     archive: ConversationCompactionArchiveState;
   }): ConversationCompactionResult {
     return {
@@ -246,10 +322,9 @@ export class ConversationCompactionService {
     };
   }
 
-  private static createArchiveRepository(options: ConversationCompactionOptions): FileChatArchiveRepository {
-    return new FileChatArchiveRepository({
+  private static createArchiveRepository(options: ConversationCompactionOptions): ChatArchiveRepository {
+    return options.archiveRepository ?? new FileChatArchiveRepository({
       stateRoot: options.runtime.stateRoot,
-      sessionId: options.session.id,
     });
   }
 }

--- a/src/core/chat/engine/compaction/summarizer/context-builder.ts
+++ b/src/core/chat/engine/compaction/summarizer/context-builder.ts
@@ -19,7 +19,7 @@ export class ConversationArchiveSummarizerContextBuilder {
         role: 'user',
         content: [
           `Session: ${context.sessionId}`,
-          `New archive path: ${context.archivePath}`,
+          `New archive id: ${context.archiveId}`,
           '',
           'Previous rolling summary:',
           context.previousRollingSummary?.trim() || '(none)',

--- a/src/core/chat/engine/compaction/summarizer/types.ts
+++ b/src/core/chat/engine/compaction/summarizer/types.ts
@@ -8,7 +8,7 @@ export type ConversationArchiveSummarizerRuntime = {
 
 export type ConversationArchiveSummaryContext = {
   sessionId: string;
-  archivePath: string;
+  archiveId: string;
   manifest: ChatArchiveManifest;
   previousRollingSummary?: string;
   archivedMessages: ChatMessage[];

--- a/src/core/chat/engine/compaction/summary-message.ts
+++ b/src/core/chat/engine/compaction/summary-message.ts
@@ -1,5 +1,4 @@
 import type { ChatArchiveRecord } from '@/core/chat/types.js';
-import { FileChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
 import type { ChatMessage } from '@/core/llm/types.js';
 import { COMPACTED_HISTORY_MARKER } from './constants.js';
 import { CompactionText } from './text.js';
@@ -27,7 +26,6 @@ export class ConversationCompactionSummaryMessage {
   }
 
   static buildArchivedSummaryMessage(options: {
-    sessionId: string;
     rollingSummary: string;
     archives: ChatArchiveRecord[];
   }): ChatMessage {
@@ -38,15 +36,13 @@ export class ConversationCompactionSummaryMessage {
     const content = [
       COMPACTED_HISTORY_MARKER,
       '',
-      `Archive root: ${FileChatArchiveRepository.derivePaths('.', options.sessionId).displayArchivesDir}`,
-      '',
       'Current rolling summary:',
       CompactionText.truncateSummary(options.rollingSummary),
       '',
-      'Archive index:',
+      'Archive locators (resolved by the configured archive repository):',
       ...(archivePaths.length > 0 ? archivePaths : ['- No archive records found.']),
       '',
-      'If exact wording, tool output, or earlier rationale matters, inspect the archive files with normal file tools before relying on this summary.',
+      'If exact wording, tool output, or earlier rationale matters, retrieve the archive through the host capability for the configured repository. Local file-adapter locators can be read with normal file tools.',
     ].join('\n');
 
     return {

--- a/src/core/chat/engine/compaction/transcript-renderer.ts
+++ b/src/core/chat/engine/compaction/transcript-renderer.ts
@@ -26,7 +26,7 @@ export class CompactionTranscriptRenderer {
     );
     const lines: string[] = [
       `Summarizer transcript note: raw archive contains ${messages.length} complete messages.`,
-      `Each message below is condensed to fit the summarizer request. Read the archive file when exact wording or full tool output matters.`,
+      'Each message below is condensed to fit the summarizer request. After a successful compaction, use the configured repository retrieval capability when exact wording or full tool output matters.',
       `Summarizer input budget: about ${Math.floor(transcriptCharBudget / 4).toLocaleString()} estimated text tokens.`,
     ];
     let totalChars = lines.join('\n').length;
@@ -35,7 +35,7 @@ export class CompactionTranscriptRenderer {
       const rendered = `## Message ${index + 1}\n${CompactionTranscriptRenderer.renderMessage(message, perMessageBudget)}`;
       const separator = lines.length > 0 ? '\n\n' : '';
       if (totalChars + separator.length + rendered.length > transcriptCharBudget) {
-        lines.push(`\n\nOmitted ${messages.length - index} additional archived messages from summarizer input to stay within request budget. Inspect the raw archive for full detail.`);
+        lines.push(`\n\nOmitted ${messages.length - index} additional archived messages from summarizer input to stay within request budget. Retrieve the raw archive through the configured repository for full detail.`);
         break;
       }
 

--- a/src/core/chat/engine/compaction/types.ts
+++ b/src/core/chat/engine/compaction/types.ts
@@ -2,6 +2,7 @@ import type { ChatArchiveRecord, ChatContextStats, ChatSession } from '@/core/ch
 import type { ConversationCompactionStatus } from '@/core/live/index.js';
 import type { ChatMessage, LlmAdapter, LlmUsage } from '@/core/llm/types.js';
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
+import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
 export type { ConversationCompactionStatus } from '@/core/live/index.js';
 
 export type ConversationCompactionSummarizerOptions = {
@@ -51,6 +52,7 @@ export type ConversationCompactionOptions = {
   history: ChatMessage[];
   runtime: ConversationCompactionRuntime;
   session: Pick<ChatSession, 'id'>;
+  archiveRepository?: ChatArchiveRepository;
   request?: ConversationCompactionRequest;
   force?: boolean;
   summarizer?: ConversationCompactionSummarizerOptions;

--- a/src/core/chat/engine/config.ts
+++ b/src/core/chat/engine/config.ts
@@ -3,6 +3,7 @@ import { FileArtifactRepository } from '@/core/artifacts/index.js';
 import type { ArtifactRepository } from '@/core/artifacts/index.js';
 import { FileChatSessionRepository } from './sessions/repository/index.js';
 import type { ChatSessionRepository } from './sessions/repository/index.js';
+import type { ChatArchiveRepository } from './sessions/archives/index.js';
 import type { ToolApprovalPolicy } from '../../approvals/types.js';
 import type { ReasoningEffort } from '../../llm/types.js';
 import type { TraceSummaryService } from '@/core/observability/index.js';
@@ -33,6 +34,7 @@ export type NormalizedConversationEngineConfig = {
   artifactsEnabled: boolean;
   sessionStoragePath: string;
   sessionRepository: ChatSessionRepository;
+  archiveRepository?: ChatArchiveRepository;
   memoryDir: string;
   traceDir: string;
   workspaceId?: string;
@@ -84,6 +86,7 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     artifactsEnabled: hostExtensions?.artifacts?.enabled ?? true,
     sessionStoragePath,
     sessionRepository,
+    archiveRepository: config.archiveRepository,
     memoryDir,
     traceDir,
     workspaceId: config.workspaceId,

--- a/src/core/chat/engine/direct-shell/service.ts
+++ b/src/core/chat/engine/direct-shell/service.ts
@@ -135,6 +135,7 @@ export class ConversationDirectShellService {
         systemContext: input.systemContext,
       },
       session,
+      archiveRepository: input.archiveRepository,
       request: {
         toolNames: [chosenCall.tool],
         goal: shellDisplay,

--- a/src/core/chat/engine/direct-shell/types.ts
+++ b/src/core/chat/engine/direct-shell/types.ts
@@ -2,6 +2,7 @@ import type { ConversationActivity, ConversationCompactionStatus } from '@/core/
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { ConversationDirectShellLineResult } from '@/core/chat/types.js';
 import type { ConversationSessionService } from '../types.js';
+import type { ChatArchiveRepository } from '../sessions/archives/index.js';
 
 export type DirectShellToolName = 'run_shell_inspect' | 'run_shell_mutate';
 
@@ -22,6 +23,7 @@ export type ConversationDirectShellInput = {
   model: string;
   workspaceRoot: string;
   stateRoot: string;
+  archiveRepository?: ChatArchiveRepository;
   systemContext?: string;
   credentialSource?: ProviderCredentialSource;
   sessions: ConversationSessionService;

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -53,6 +53,22 @@ export type {
 } from './mcp-host-extension.js';
 export { EngineConversationTurnService } from './turns/service.js';
 export type { RunConversationTurnArgs, RunConversationTurnResult } from './turns/types.js';
+export {
+  ChatArchivePersistenceCodec,
+  ChatArchiveStorageCorruptionError,
+  ChatArchiveSummaryNotFoundError,
+  ChatArchiveRepositoryError,
+  FileChatArchiveRepository,
+} from './sessions/archives/index.js';
+export type {
+  AppendChatArchiveInput,
+  AppendChatArchiveResult,
+  ChatArchiveRecordDraft,
+  ChatArchiveRepository,
+  ChatArchiveStoragePaths,
+  FileChatArchiveRepositoryOptions,
+  ChatArchiveRepositoryOperation,
+} from './sessions/archives/index.js';
 export type {
   ConversationActivity,
   ConversationActivityCorrelation,

--- a/src/core/chat/engine/quickstart-cli/service.ts
+++ b/src/core/chat/engine/quickstart-cli/service.ts
@@ -63,6 +63,7 @@ export class QuickstartConversationCliRunnerService {
       hostExtensions: options.hostExtensions,
       artifactRepository: options.artifactRepository,
       sessionRepository: options.sessionRepository,
+      archiveRepository: options.archiveRepository,
     });
     let session = await QuickstartConversationCliRunnerService.resolveSession({ engine, options });
     const textHost = createConversationTextHost({

--- a/src/core/chat/engine/quickstart-cli/types.ts
+++ b/src/core/chat/engine/quickstart-cli/types.ts
@@ -1,6 +1,7 @@
 import type { Readable, Writable } from 'node:stream';
 import type { ArtifactRepository } from '@/core/artifacts/index.js';
 import type { ChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
+import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
 import type { ReasoningEffort } from '@/core/llm/types.js';
 import type { LlmProvider } from '@/core/llm/types.js';
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
@@ -71,6 +72,7 @@ export type QuickstartConversationCliRunnerOptions = {
   hostExtensions?: ConversationEngineHostExtension[];
   artifactRepository?: ArtifactRepository;
   sessionRepository?: ChatSessionRepository;
+  archiveRepository?: ChatArchiveRepository;
   host?: ConversationEngineHost;
   localCommands?: QuickstartConversationCliLocalCommand[];
   formatPrompt?: (prompt: string) => string;

--- a/src/core/chat/engine/sessions/archives/README.md
+++ b/src/core/chat/engine/sessions/archives/README.md
@@ -1,0 +1,50 @@
+# Conversation Archive Repository
+
+This folder owns durable storage for compacted conversation history. It is a
+separate boundary from active `ChatSessionRepository` records, generated
+artifacts, traces, and memory.
+
+## Contract
+
+`ChatArchiveRepository` is async and host-injectable. It loads the manifest,
+reads the current rolling summary, and atomically appends one archive unit:
+exact messages, summary text, and the next manifest. A successful append must
+never return a manifest whose locators cannot be read.
+
+The legacy `path` and `summaryPath` field names are retained for stored-session
+compatibility. Treat their values as repository-owned opaque locators. The
+default file adapter returns `.heddle/...` paths; a database/blob adapter can
+return stable keys meaningful only to that adapter.
+
+## Ownership boundary
+
+Heddle owns archive record semantics, manifest validation, compaction ordering,
+and the default local file implementation. A host adapter owns its connection
+lifecycle, authenticated tenant/session scope, transaction, schema, retention,
+backup, and restore.
+
+The host must bind `ChatSessionRepository` and `ChatArchiveRepository` to the
+same authenticated identity scope. Heddle intentionally does not accept a user
+or tenant id on individual archive operations; trusting caller-provided scope
+would weaken the storage boundary.
+
+## File adapter durability
+
+`FileChatArchiveRepository` preserves the v1 layout under
+`.heddle/chat-sessions/<session-id>/archives`. It writes immutable content files
+before atomically replacing the manifest and serializes appends with
+`proper-lockfile`. A crash may leave unreferenced orphan content, but readers
+will see either the previous complete manifest or the next complete manifest.
+Malformed or session-mismatched manifests raise
+`ChatArchiveStorageCorruptionError`; they are never treated as empty history.
+During compaction, adapter exceptions are surfaced as
+`ChatArchiveRepositoryError` with the operation and original `cause` intact so
+hosts can log database details without interpreting a false success.
+
+## Deliberate limits
+
+- This port does not define SQL tables, an ORM, or object-store credentials.
+- It does not make traces, memory, or generated artifacts durable.
+- It does not add a model-visible raw-archive reader. Remote hosts that need
+  exact retrieval should expose a scoped host tool backed by their repository.
+- Active-run and streaming coordination remain process-local.

--- a/src/core/chat/engine/sessions/archives/errors.ts
+++ b/src/core/chat/engine/sessions/archives/errors.ts
@@ -1,0 +1,39 @@
+/** Raised when persisted archive metadata cannot be trusted or reconstructed. */
+export class ChatArchiveStorageCorruptionError extends Error {
+  readonly code = 'CHAT_ARCHIVE_STORAGE_CORRUPTION';
+
+  constructor(readonly storageLocator: string, detail: string) {
+    super(`Invalid chat archive storage at ${storageLocator}: ${detail}`);
+    this.name = 'ChatArchiveStorageCorruptionError';
+  }
+}
+
+/** Raised when a manifest references a rolling summary the repository cannot read. */
+export class ChatArchiveSummaryNotFoundError extends Error {
+  readonly code = 'CHAT_ARCHIVE_SUMMARY_NOT_FOUND';
+
+  constructor(readonly summaryLocator: string) {
+    super(`Chat archive summary not found: ${summaryLocator}`);
+    this.name = 'ChatArchiveSummaryNotFoundError';
+  }
+}
+
+export type ChatArchiveRepositoryOperation = 'load_manifest' | 'read_summary' | 'append';
+
+/**
+ * Identifies an infrastructure failure raised while compaction is using a
+ * local or host-provided archive repository. The original adapter error is
+ * retained as `cause` for logging and database diagnostics.
+ */
+export class ChatArchiveRepositoryError extends Error {
+  readonly code = 'CHAT_ARCHIVE_REPOSITORY_ERROR';
+
+  constructor(
+    readonly operation: ChatArchiveRepositoryOperation,
+    cause: unknown,
+  ) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(`Chat archive repository ${operation} failed: ${detail}`, { cause });
+    this.name = 'ChatArchiveRepositoryError';
+  }
+}

--- a/src/core/chat/engine/sessions/archives/file-chat-archive-repository.ts
+++ b/src/core/chat/engine/sessions/archives/file-chat-archive-repository.ts
@@ -1,176 +1,229 @@
 /**
- * File-backed chat archive repository.
+ * Async file-backed conversation archive repository.
  *
- * Owns archive paths, manifest persistence, archived transcript files, and
- * rolling-summary markdown files for one chat session. Compaction policy stays
- * in the history module; archive file layout stays here.
+ * Exact transcript and summary files are written before an atomically replaced
+ * manifest references them. `proper-lockfile` serializes manifest appends
+ * across repository instances/processes; orphan files may remain after an
+ * interrupted append, but a manifest never points at incomplete content.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import type { ChatMessage } from '@/core/llm/types.js';
-import type { ChatArchiveManifest, ChatArchiveRecord } from '@/core/chat/types.js';
-import type { ChatArchivePaths, ChatArchiveRepository } from './types.js';
-
-const ARCHIVE_MANIFEST_VERSION = 1;
+import { randomUUID } from 'node:crypto';
+import {
+  mkdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import { Mutex } from 'async-mutex';
+import { lock } from 'proper-lockfile';
+import type { ChatArchiveRecord } from '@/core/chat/types.js';
+import { ChatArchiveStorageCorruptionError } from './errors.js';
+import { ChatArchivePersistenceCodec } from './persistence-codec.js';
+import type {
+  AppendChatArchiveInput,
+  AppendChatArchiveResult,
+  ChatArchiveRepository,
+  ChatArchiveStoragePaths,
+  FileChatArchiveRepositoryOptions,
+} from './types.js';
 
 export class FileChatArchiveRepository implements ChatArchiveRepository {
   private readonly stateRoot: string;
-  private readonly sessionId: string;
-  private readonly paths: ChatArchivePaths;
+  private readonly mutex = new Mutex();
 
-  constructor(args: { stateRoot: string; sessionId: string }) {
-    this.stateRoot = args.stateRoot;
-    this.sessionId = args.sessionId;
-    this.paths = FileChatArchiveRepository.derivePaths(args.stateRoot, args.sessionId);
+  constructor(options: FileChatArchiveRepositoryOptions) {
+    this.stateRoot = resolve(options.stateRoot);
   }
 
-  derivePaths(): ChatArchivePaths {
-    return this.paths;
+  async loadManifest(sessionId: string) {
+    return await FileChatArchiveRepository.readManifestFile(
+      this.deriveStoragePaths(sessionId),
+      sessionId,
+    );
   }
 
-  ensureArchiveDir(): ChatArchivePaths {
-    mkdirSync(this.paths.archivesDir, { recursive: true });
-    return this.paths;
+  async readSummary(summaryLocator: string): Promise<string | undefined> {
+    return await FileChatArchiveRepository.readOptionalFile(
+      FileChatArchiveRepository.resolveDisplayPath(summaryLocator, this.stateRoot),
+    );
   }
 
-  loadManifest(): ChatArchiveManifest {
-    if (!existsSync(this.paths.manifestPath)) {
-      return FileChatArchiveRepository.emptyManifest(this.sessionId);
-    }
+  async append(input: AppendChatArchiveInput): Promise<AppendChatArchiveResult> {
+    return await this.withWriteLock(input.sessionId, async (paths) => {
+      const manifest = await FileChatArchiveRepository.readManifestFile(paths, input.sessionId);
+      const archiveFileStem = FileChatArchiveRepository.encodePathSegment(input.archive.id);
+      const rawLocator = `${paths.displayArchivesDir}/${archiveFileStem}.jsonl`;
+      const summaryLocator = `${paths.displayArchivesDir}/${archiveFileStem}.summary.md`;
+      const archive: ChatArchiveRecord = {
+        ...input.archive,
+        path: rawLocator,
+        summaryPath: summaryLocator,
+      };
+      const nextManifest = ChatArchivePersistenceCodec.appendArchive(manifest, archive);
 
-    try {
-      const parsed = JSON.parse(readFileSync(this.paths.manifestPath, 'utf8')) as unknown;
-      return FileChatArchiveRepository.parseManifest(parsed, this.sessionId);
-    } catch {
-      return FileChatArchiveRepository.emptyManifest(this.sessionId);
-    }
+      await writeFile(
+        join(paths.archivesDir, `${archiveFileStem}.jsonl`),
+        FileChatArchiveRepository.serializeMessages(input.messages),
+        { flag: 'wx' },
+      );
+      await writeFile(
+        join(paths.archivesDir, `${archiveFileStem}.summary.md`),
+        input.summary.endsWith('\n') ? input.summary : `${input.summary}\n`,
+        { flag: 'wx' },
+      );
+      await FileChatArchiveRepository.replaceManifest(paths.manifestPath, nextManifest);
+
+      return {
+        archive,
+        manifest: nextManifest,
+      };
+    });
   }
 
-  saveManifest(manifest: ChatArchiveManifest): void {
-    const paths = this.ensureArchiveDir();
-    writeFileSync(paths.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  deriveStoragePaths(sessionId: string): ChatArchiveStoragePaths {
+    return FileChatArchiveRepository.deriveStoragePaths(this.stateRoot, sessionId);
   }
 
-  writeMessagesJsonl(archiveId: string, messages: ChatMessage[]): string {
-    const paths = this.ensureArchiveDir();
-    const displayPath = `${paths.displayArchivesDir}/${archiveId}.jsonl`;
-    const filePath = join(paths.archivesDir, `${archiveId}.jsonl`);
-    const body = messages.map((message, index) => JSON.stringify({
-      index,
-      ...message,
-    })).join('\n');
-    writeFileSync(filePath, body ? `${body}\n` : '', 'utf8');
-    return displayPath;
-  }
-
-  writeSummaryMarkdown(archiveId: string, summary: string): string {
-    const paths = this.ensureArchiveDir();
-    const displayPath = `${paths.displayArchivesDir}/${archiveId}.summary.md`;
-    const filePath = join(paths.archivesDir, `${archiveId}.summary.md`);
-    writeFileSync(filePath, summary.endsWith('\n') ? summary : `${summary}\n`, 'utf8');
-    return displayPath;
-  }
-
-  readSummaryMarkdown(path: string): string | undefined {
-    const filePath = FileChatArchiveRepository.resolveDisplayPath(path, this.stateRoot);
-    if (!existsSync(filePath)) {
-      return undefined;
-    }
-
-    try {
-      return readFileSync(filePath, 'utf8');
-    } catch {
-      return undefined;
-    }
-  }
-
-  static derivePaths(stateRoot: string, sessionId: string): ChatArchivePaths {
-    const sessionDir = join(stateRoot, 'chat-sessions', sessionId);
+  static deriveStoragePaths(stateRoot: string, sessionId: string): ChatArchiveStoragePaths {
+    const sessionPathSegment = FileChatArchiveRepository.encodePathSegment(sessionId);
+    const sessionDir = join(stateRoot, 'chat-sessions', sessionPathSegment);
     const archivesDir = join(sessionDir, 'archives');
     return {
       sessionDir,
       archivesDir,
       manifestPath: join(archivesDir, 'manifest.json'),
-      displaySessionDir: `.heddle/chat-sessions/${sessionId}`,
-      displayArchivesDir: `.heddle/chat-sessions/${sessionId}/archives`,
+      displaySessionDir: `.heddle/chat-sessions/${sessionPathSegment}`,
+      displayArchivesDir: `.heddle/chat-sessions/${sessionPathSegment}/archives`,
     };
   }
 
-  static createArchiveId(now = new Date()): string {
-    return `archive-${now.toISOString().replaceAll(':', '-')}`;
+  private async withWriteLock<T>(
+    sessionId: string,
+    operation: (paths: ChatArchiveStoragePaths) => Promise<T>,
+  ): Promise<T> {
+    return await this.mutex.runExclusive(async () => {
+      const paths = this.deriveStoragePaths(sessionId);
+      await mkdir(paths.archivesDir, { recursive: true });
+      const release = await lock(paths.archivesDir, {
+        lockfilePath: `${paths.manifestPath}.lock`,
+        realpath: false,
+        stale: 30_000,
+        update: 10_000,
+        retries: {
+          retries: 20,
+          factor: 1.5,
+          minTimeout: 10,
+          maxTimeout: 500,
+          randomize: true,
+        },
+      });
+
+      try {
+        return await operation(paths);
+      } finally {
+        await release();
+      }
+    });
   }
 
-  static appendManifestArchive(
-    current: ChatArchiveManifest,
-    archive: ChatArchiveRecord,
-  ): ChatArchiveManifest {
-    return {
-      version: ARCHIVE_MANIFEST_VERSION,
-      sessionId: current.sessionId,
-      currentSummaryPath: archive.summaryPath,
-      archives: [...current.archives, archive],
-    };
-  }
-
-  private static emptyManifest(sessionId: string): ChatArchiveManifest {
-    return {
-      version: ARCHIVE_MANIFEST_VERSION,
-      sessionId,
-      archives: [],
-    };
-  }
-
-  private static parseManifest(value: unknown, sessionId: string): ChatArchiveManifest {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return FileChatArchiveRepository.emptyManifest(sessionId);
+  private static async readManifestFile(
+    paths: ChatArchiveStoragePaths,
+    sessionId: string,
+  ) {
+    const contents = await FileChatArchiveRepository.readOptionalFile(paths.manifestPath);
+    if (contents === undefined) {
+      return ChatArchivePersistenceCodec.emptyManifest(sessionId);
     }
 
-    const candidate = value as Partial<ChatArchiveManifest> & { archives?: unknown };
-    const archives =
-      Array.isArray(candidate.archives) ?
-        candidate.archives.flatMap((archive) => FileChatArchiveRepository.parseArchiveRecord(archive))
-      : [];
-
-    return {
-      version: ARCHIVE_MANIFEST_VERSION,
-      sessionId: typeof candidate.sessionId === 'string' ? candidate.sessionId : sessionId,
-      currentSummaryPath: typeof candidate.currentSummaryPath === 'string' ? candidate.currentSummaryPath : undefined,
-      archives,
-    };
+    try {
+      return ChatArchivePersistenceCodec.parseManifest(JSON.parse(contents) as unknown, sessionId);
+    } catch (error) {
+      throw new ChatArchiveStorageCorruptionError(
+        paths.manifestPath,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
   }
 
-  private static parseArchiveRecord(value: unknown): ChatArchiveRecord[] {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return [];
-    }
+  private static serializeMessages(messages: AppendChatArchiveInput['messages']): string {
+    const body = messages.map((message, index) => JSON.stringify({
+      index,
+      ...message,
+    })).join('\n');
+    return body ? `${body}\n` : '';
+  }
 
-    const candidate = value as Partial<ChatArchiveRecord>;
-    if (
-      typeof candidate.id !== 'string'
-      || typeof candidate.path !== 'string'
-      || typeof candidate.summaryPath !== 'string'
-      || typeof candidate.messageCount !== 'number'
-      || typeof candidate.createdAt !== 'string'
-    ) {
-      return [];
+  private static async replaceManifest(
+    manifestPath: string,
+    manifest: AppendChatArchiveResult['manifest'],
+  ): Promise<void> {
+    const temporaryPath = `${manifestPath}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(
+        temporaryPath,
+        ChatArchivePersistenceCodec.serializeManifest(manifest),
+        { flag: 'wx' },
+      );
+      await rename(temporaryPath, manifestPath);
+    } finally {
+      await FileChatArchiveRepository.removeFileIfPresent(temporaryPath);
     }
+  }
 
-    return [{
-      id: candidate.id,
-      path: candidate.path,
-      summaryPath: candidate.summaryPath,
-      shortDescription: typeof candidate.shortDescription === 'string' ? candidate.shortDescription : undefined,
-      messageCount: candidate.messageCount,
-      createdAt: candidate.createdAt,
-      summaryModel: typeof candidate.summaryModel === 'string' ? candidate.summaryModel : undefined,
-    }];
+  private static async readOptionalFile(path: string): Promise<string | undefined> {
+    try {
+      return await readFile(path, 'utf8');
+    } catch (error) {
+      if (FileChatArchiveRepository.isMissingFileError(error)) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  private static async removeFileIfPresent(path: string): Promise<void> {
+    try {
+      await unlink(path);
+    } catch (error) {
+      if (!FileChatArchiveRepository.isMissingFileError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  private static isMissingFileError(error: unknown): boolean {
+    return Boolean(
+      error
+      && typeof error === 'object'
+      && 'code' in error
+      && error.code === 'ENOENT',
+    );
+  }
+
+  private static encodePathSegment(value: string): string {
+    const encoded = encodeURIComponent(value);
+    return encoded === '.' || encoded === '..'
+      ? encoded.replaceAll('.', '%2E')
+      : encoded;
   }
 
   private static resolveDisplayPath(displayPath: string, stateRoot: string): string {
-    if (displayPath.startsWith('.heddle/')) {
-      return join(stateRoot, displayPath.slice('.heddle/'.length));
+    if (!displayPath.startsWith('.heddle/')) {
+      throw new ChatArchiveStorageCorruptionError(
+        displayPath,
+        'file archive summary locator must start with .heddle/',
+      );
     }
 
-    return displayPath;
+    const filePath = resolve(stateRoot, displayPath.slice('.heddle/'.length));
+    const relativePath = relative(stateRoot, filePath);
+    if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+      throw new ChatArchiveStorageCorruptionError(
+        displayPath,
+        'file archive summary locator escapes the configured state root',
+      );
+    }
+    return filePath;
   }
 }

--- a/src/core/chat/engine/sessions/archives/index.ts
+++ b/src/core/chat/engine/sessions/archives/index.ts
@@ -1,2 +1,17 @@
 export { FileChatArchiveRepository } from './file-chat-archive-repository.js';
-export type { ChatArchivePaths, ChatArchiveRepository } from './types.js';
+export { ChatArchivePersistenceCodec } from './persistence-codec.js';
+export {
+  ChatArchiveStorageCorruptionError,
+  ChatArchiveSummaryNotFoundError,
+  ChatArchiveRepositoryError,
+} from './errors.js';
+export type { ChatArchiveRepositoryOperation } from './errors.js';
+export { ChatArchiveManifestSchema, ChatArchiveRecordSchema } from './schemas.js';
+export type {
+  AppendChatArchiveInput,
+  AppendChatArchiveResult,
+  ChatArchiveRecordDraft,
+  ChatArchiveRepository,
+  ChatArchiveStoragePaths,
+  FileChatArchiveRepositoryOptions,
+} from './types.js';

--- a/src/core/chat/engine/sessions/archives/persistence-codec.ts
+++ b/src/core/chat/engine/sessions/archives/persistence-codec.ts
@@ -1,0 +1,46 @@
+import type { ChatArchiveManifest, ChatArchiveRecord } from '@/core/chat/types.js';
+import { ChatArchiveManifestSchema } from './schemas.js';
+
+/**
+ * Strict database-neutral validation and manifest projection for archive
+ * repository adapters. File and remote adapters should share these invariants.
+ */
+export class ChatArchivePersistenceCodec {
+  static emptyManifest(sessionId: string): ChatArchiveManifest {
+    return ChatArchiveManifestSchema.parse({
+      version: 1,
+      sessionId,
+      archives: [],
+    });
+  }
+
+  static parseManifest(value: unknown, expectedSessionId: string): ChatArchiveManifest {
+    const manifest = ChatArchiveManifestSchema.parse(value);
+    if (manifest.sessionId !== expectedSessionId) {
+      throw new Error(
+        `archive manifest session mismatch: expected ${expectedSessionId}, found ${manifest.sessionId}`,
+      );
+    }
+    return manifest;
+  }
+
+  static appendArchive(
+    manifest: ChatArchiveManifest,
+    archive: ChatArchiveRecord,
+  ): ChatArchiveManifest {
+    if (manifest.archives.some((candidate) => candidate.id === archive.id)) {
+      throw new Error(`conversation archive already exists: ${archive.id}`);
+    }
+
+    return ChatArchiveManifestSchema.parse({
+      version: 1,
+      sessionId: manifest.sessionId,
+      currentSummaryPath: archive.summaryPath,
+      archives: [...manifest.archives, archive],
+    });
+  }
+
+  static serializeManifest(manifest: ChatArchiveManifest): string {
+    return `${JSON.stringify(ChatArchiveManifestSchema.parse(manifest), null, 2)}\n`;
+  }
+}

--- a/src/core/chat/engine/sessions/archives/schemas.ts
+++ b/src/core/chat/engine/sessions/archives/schemas.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const ChatArchiveRecordSchema = z.object({
+  id: z.string().min(1).describe('Stable identifier for this conversation archive.'),
+  path: z.string().min(1).describe('Repository-owned locator for the exact archived conversation history.'),
+  summaryPath: z.string().min(1).describe('Repository-owned locator for the rolling archive summary.'),
+  shortDescription: z.string()
+    .describe('Short human-readable description of the archived conversation slice.')
+    .optional(),
+  messageCount: z.number().int().nonnegative().describe('Number of messages stored in this archive.'),
+  createdAt: z.string().describe('Timestamp when this archive was created.'),
+  summaryModel: z.string()
+    .describe('Model used to generate the archive summary, when available.')
+    .optional(),
+});
+
+export const ChatArchiveManifestSchema = z.object({
+  version: z.literal(1).describe('Conversation archive manifest schema version.'),
+  sessionId: z.string().min(1).describe('Session whose compacted history this manifest indexes.'),
+  currentSummaryPath: z.string().min(1)
+    .describe('Repository-owned locator for the current cumulative summary.')
+    .optional(),
+  archives: z.array(ChatArchiveRecordSchema).describe('Archives in append order.'),
+}).strict();

--- a/src/core/chat/engine/sessions/archives/types.ts
+++ b/src/core/chat/engine/sessions/archives/types.ts
@@ -1,7 +1,14 @@
 import type { ChatMessage } from '@/core/llm/types.js';
-import type { ChatArchiveManifest } from '@/core/chat/types.js';
+import type {
+  ChatArchiveManifest,
+  ChatArchiveRecord,
+} from '@/core/chat/types.js';
 
-export type ChatArchivePaths = {
+export type FileChatArchiveRepositoryOptions = {
+  stateRoot: string;
+};
+
+export type ChatArchiveStoragePaths = {
   sessionDir: string;
   archivesDir: string;
   manifestPath: string;
@@ -9,12 +16,34 @@ export type ChatArchivePaths = {
   displayArchivesDir: string;
 };
 
+export type ChatArchiveRecordDraft = Omit<ChatArchiveRecord, 'path' | 'summaryPath'>;
+
+export type AppendChatArchiveInput = {
+  sessionId: string;
+  archive: ChatArchiveRecordDraft;
+  messages: ChatMessage[];
+  summary: string;
+};
+
+export type AppendChatArchiveResult = {
+  archive: ChatArchiveRecord;
+  manifest: ChatArchiveManifest;
+};
+
+/**
+ * Host-provided durable storage for compacted conversation history.
+ *
+ * `path` and `summaryPath` on returned records are repository-owned opaque
+ * locators. File adapters return inspectable `.heddle/...` paths; remote
+ * adapters may return database or object-store keys.
+ */
 export type ChatArchiveRepository = {
-  derivePaths(): ChatArchivePaths;
-  ensureArchiveDir(): ChatArchivePaths;
-  loadManifest(): ChatArchiveManifest;
-  saveManifest(manifest: ChatArchiveManifest): void;
-  writeMessagesJsonl(archiveId: string, messages: ChatMessage[]): string;
-  writeSummaryMarkdown(archiveId: string, summary: string): string;
-  readSummaryMarkdown(path: string): string | undefined;
+  loadManifest(sessionId: string): Promise<ChatArchiveManifest>;
+  readSummary(summaryLocator: string): Promise<string | undefined>;
+  /**
+   * Makes raw messages, their rolling summary, and the returned manifest
+   * visible as one durable append. A rejected call must never leave a manifest
+   * that references missing content; unreferenced orphan content is allowed.
+   */
+  append(input: AppendChatArchiveInput): Promise<AppendChatArchiveResult>;
 };

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -6,6 +6,7 @@
  */
 import { z } from 'zod';
 import { ConversationDirectShellLineResultSchema } from '@/core/chat/engine/direct-shell/result-schema.js';
+import { ChatArchiveRecordSchema } from '@/core/chat/engine/sessions/archives/schemas.js';
 import { ConversationTurnPresentationSchema } from '@/core/chat/engine/turns/presentation/index.js';
 import { CustomAgentExecutionSnapshotSchema } from '@/core/custom-agents/index.js';
 
@@ -160,26 +161,12 @@ const ChatContextStatsSchema = z.object({
       .describe('Number of archive records currently associated with the session.')
       .optional(),
     currentSummaryPath: z.string()
-      .describe('Path to the active compacted summary used for context reconstruction.')
+      .describe('Repository-owned locator for the active compacted summary used for context reconstruction.')
       .optional(),
     lastArchivePath: z.string()
-      .describe('Path to the most recently written conversation archive.')
+      .describe('Repository-owned locator for the most recently written conversation archive.')
       .optional(),
-  }).describe('Archive metadata used to reconnect compacted history with persisted files.').optional(),
-});
-
-const ChatArchiveRecordSchema = z.object({
-  id: z.string().describe('Stable identifier for this conversation archive.'),
-  path: z.string().describe('Path to the archived raw conversation history.'),
-  summaryPath: z.string().describe('Path to the compacted summary generated for this archive.'),
-  shortDescription: z.string()
-    .describe('Short human-readable description of the archived conversation slice.')
-    .optional(),
-  messageCount: z.number().describe('Number of messages stored in this archive.'),
-  createdAt: z.string().describe('Timestamp when this archive was created.'),
-  summaryModel: z.string()
-    .describe('Model used to generate the archive summary, when available.')
-    .optional(),
+  }).describe('Archive metadata used to reconnect compacted history with durable repository content.').optional(),
 });
 
 const ChatArchiveRecordsSchema = z.array(z.unknown())

--- a/src/core/chat/engine/turns/persistence/turn-artifacts.ts
+++ b/src/core/chat/engine/turns/persistence/turn-artifacts.ts
@@ -26,6 +26,7 @@ export class ConversationTurnArtifacts {
       history: sourceHistory,
       runtime: compactionRuntime,
       session: args.session,
+      archiveRepository: args.archiveRepository,
       request: compactionRequest,
       force: ConversationTurnFailureMessages.shouldForceCompactionAfterFailure(args.result.summary),
       summarizer: args.summarizer,

--- a/src/core/chat/engine/turns/persistence/turn-persistence-service.ts
+++ b/src/core/chat/engine/turns/persistence/turn-persistence-service.ts
@@ -1,4 +1,5 @@
 import { ConversationTurnArtifacts } from './turn-artifacts.js';
+import { ChatArchiveRepositoryError } from '@/core/chat/engine/sessions/archives/index.js';
 import type {
   PersistCompletedChatTurnBase,
   PersistChatTurnResult,
@@ -12,20 +13,33 @@ import type {
 export class ConversationTurnPersistenceService {
   static async persistCompleted(args: PersistCompletedChatTurnArgs): Promise<PersistChatTurnResult> {
     const artifactInput: PersistCompletedChatTurnBase = args;
-    const persisted = await ConversationTurnArtifacts.persist({
-      ...artifactInput,
-      summarizer: { credentialSource: args.credentialSource },
-      createTurnId: () => `server-turn-${Date.now()}`,
-      onCompactionStatus: async (event) => {
-        args.host.onCompactionStatus?.(event, 'final');
-        if (event.status === 'running') {
-          await ConversationTurnPersistenceService.persistFinalCompactionRunningSeed({
-            ...args,
-            archivePath: event.archivePath,
-          });
-        }
-      },
-    });
+    let persisted: PersistChatTurnResult;
+    let runningSeedPersisted = false;
+    try {
+      persisted = await ConversationTurnArtifacts.persist({
+        ...artifactInput,
+        summarizer: { credentialSource: args.credentialSource },
+        createTurnId: () => `server-turn-${Date.now()}`,
+        onCompactionStatus: async (event) => {
+          args.host.onCompactionStatus?.(event, 'final');
+          if (event.status === 'running') {
+            await ConversationTurnPersistenceService.persistFinalCompactionRunningSeed({
+              ...args,
+              archivePath: event.archivePath,
+            });
+            runningSeedPersisted = true;
+          }
+        },
+      });
+    } catch (error) {
+      if (runningSeedPersisted && error instanceof ChatArchiveRepositoryError) {
+        await args.sessionService.restoreCompactionState(args.session.id, {
+          context: args.session.context,
+          archives: args.session.archives,
+        });
+      }
+      throw error;
+    }
 
     const session = await args.sessionService.update(args.session.id, (latestSession) => ({
         ...persisted.session,

--- a/src/core/chat/engine/turns/persistence/types.ts
+++ b/src/core/chat/engine/turns/persistence/types.ts
@@ -7,6 +7,7 @@ import type { TraceSummaryService } from '@/core/observability/index.js';
 import type { ChatSession, TurnSummary } from '@/core/chat/types.js';
 import type { ConversationSessionService } from '@/core/chat/engine/types.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
+import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
 import type { ChatTurnHostPort } from '../host/index.js';
 import type {
   ConversationCompactionResult,
@@ -21,6 +22,7 @@ export type PersistChatTurnResultArgs = {
   session: ChatSession;
   model: string;
   stateRoot: string;
+  archiveRepository?: ChatArchiveRepository;
   traceDir: string;
   systemContext?: string;
   toolNames: string[];
@@ -63,6 +65,7 @@ export type PersistCompletedChatTurnBase = {
   session: ChatSession;
   model: string;
   stateRoot: string;
+  archiveRepository?: ChatArchiveRepository;
   traceDir: string;
   systemContext?: string;
   toolNames: string[];

--- a/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
+++ b/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
@@ -1,5 +1,7 @@
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
 import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
+import type { ConversationCompactionResult } from '@/core/chat/engine/compaction/index.js';
+import { ChatArchiveRepositoryError } from '@/core/chat/engine/sessions/archives/index.js';
 import type {
   PersistPreflightRunningSeedArgs,
   PersistPreparedChatSessionTurnArgs,
@@ -35,23 +37,37 @@ export class ConversationTurnPreflightService {
       toolNames: args.toolNames,
       goal: args.prompt,
     };
-    const preflightCompacted = await ConversationCompactionService.compact({
-      history: initialHistory,
-      runtime: compactionRuntime,
-      session: { id: args.sessionId },
-      request: compactionRequest,
-      summarizer: args.summarizer,
-      onStatusChange: async (event) => {
-        args.host.onCompactionStatus?.(event, 'preflight');
-        if (event.status === 'running' && leasedSession) {
-          await ConversationTurnPreflightService.persistRunningSeed({
-            ...args,
-            leasedSession,
-            archivePath: event.archivePath,
-          });
-        }
-      },
-    });
+    let preflightCompacted: ConversationCompactionResult;
+    let runningSeedPersisted = false;
+    try {
+      preflightCompacted = await ConversationCompactionService.compact({
+        history: initialHistory,
+        runtime: compactionRuntime,
+        session: { id: args.sessionId },
+        archiveRepository: args.archiveRepository,
+        request: compactionRequest,
+        summarizer: args.summarizer,
+        onStatusChange: async (event) => {
+          args.host.onCompactionStatus?.(event, 'preflight');
+          if (event.status === 'running' && leasedSession) {
+            await ConversationTurnPreflightService.persistRunningSeed({
+              ...args,
+              leasedSession,
+              archivePath: event.archivePath,
+            });
+            runningSeedPersisted = true;
+          }
+        },
+      });
+    } catch (error) {
+      if (leasedSession && runningSeedPersisted && error instanceof ChatArchiveRepositoryError) {
+        await args.sessionService.restoreCompactionState(args.sessionId, {
+          context: leasedSession.context,
+          archives: leasedSession.archives,
+        });
+      }
+      throw error;
+    }
 
     return await ConversationTurnPreflightService.persistPrepared({
       ...args,

--- a/src/core/chat/engine/turns/preflight/types.ts
+++ b/src/core/chat/engine/turns/preflight/types.ts
@@ -3,6 +3,7 @@ import type { ChatSession } from '@/core/chat/types.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import type { ConversationCompactionStatus } from '@/core/live/index.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
+import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
 import type { ConversationSessionService } from '@/core/chat/engine/types.js';
 import type { ChatTurnHostPort } from '../host/index.js';
 import type {
@@ -19,6 +20,7 @@ export type PrepareChatSessionTurnArgs = {
   prompt: string;
   model: string;
   stateRoot: string;
+  archiveRepository?: ChatArchiveRepository;
   systemContext?: string;
   toolNames: string[];
   summarizer: ConversationCompactionOptions['summarizer'];

--- a/src/core/chat/engine/turns/types.ts
+++ b/src/core/chat/engine/turns/types.ts
@@ -6,6 +6,7 @@ import type { TraceSummaryService } from '@/core/observability/index.js';
 import type { RunAgentLoopOptions } from '@/core/runtime/loop/index.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import type { ChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
+import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
 import type { ChatTurnHostPort } from './host/index.js';
 import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
@@ -18,6 +19,7 @@ export type RunConversationTurnArgs = {
   sessionStoragePath: string;
   /** Custom session persistence. Defaults to the file catalog at `sessionStoragePath`. */
   sessionRepository?: ChatSessionRepository;
+  archiveRepository?: ChatArchiveRepository;
   sessionId: string;
   prompt: string;
   apiKey?: string;
@@ -54,6 +56,7 @@ export type TurnRuntimeConfigInput = Pick<
   | 'stateRoot'
   | 'sessionStoragePath'
   | 'sessionRepository'
+  | 'archiveRepository'
   | 'apiKey'
   | 'preferApiKey'
   | 'credentialStorePath'
@@ -91,7 +94,7 @@ export type TurnHostInput = Pick<
 
 export type TurnPreflightInput = Pick<
   RunConversationTurnArgs,
-  'stateRoot' | 'prompt'
+  'stateRoot' | 'archiveRepository' | 'prompt'
 >;
 
 export type AgentLoopTurnInput = Pick<
@@ -101,7 +104,7 @@ export type AgentLoopTurnInput = Pick<
 
 export type TurnPersistenceInput = Pick<
   RunConversationTurnArgs,
-  'stateRoot' | 'traceDir' | 'traceSummarizerRegistry' | 'prompt'
+  'stateRoot' | 'archiveRepository' | 'traceDir' | 'traceSummarizerRegistry' | 'prompt'
 >;
 
 export type RunConversationTurnResult = ConversationTurnResultSummary;

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -11,6 +11,7 @@ import type { AgentLoopEvent, RunAgentLoopOptions } from '../../runtime/loop/ind
 import type { ChatMessage, LlmAdapter, ReasoningEffort } from '../../llm/types.js';
 import type { ToolDefinition, TraceEvent } from '../../types.js';
 import type { ChatSessionLeaseOwner } from './sessions/leases/index.js';
+import type { ChatArchiveRepository } from './sessions/archives/index.js';
 import type {
   ChatSessionCatalogPage,
   ChatSessionRepository,
@@ -65,6 +66,11 @@ export type ConversationEngineConfig = {
    * file catalog under the state root.
    */
   sessionRepository?: ChatSessionRepository;
+  /**
+   * Durable storage for compacted raw transcripts, rolling summaries, and
+   * archive manifests. Locators remain server-side and repository-owned.
+   */
+  archiveRepository?: ChatArchiveRepository;
 };
 
 export type ConversationEngineHostExtensions = ConversationEngineHostExtensionBundle;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@
 //   2. Add capabilities      — your own tools, MCP servers, skills
 //   3. Shape input/output    — render streaming activity / text, read results
 //   4. Advanced: lifecycle   — drive the engine, sessions, and approvals
-//   5. Advanced: storage     — back artifacts/credentials with your own store
+//   5. Advanced: storage     — back sessions/archives/artifacts with your store
 //
 // Remote-hosting assumptions are explicit peer entrypoints:
 // `@roackb2/heddle/hosted` and the lightweight `@roackb2/heddle-remote`
@@ -239,15 +239,10 @@ export type {
 // ---------------------------------------------------------------------------
 // 5. Advanced: storage — back Heddle with your own persistence
 // ---------------------------------------------------------------------------
-// Heddle defaults to local file-backed stores. Artifacts and sessions are
-// injectable today: implement `ArtifactRepository` / `ChatSessionRepository`
-// and pass them as `artifactRepository` / `sessionRepository` to
-// `createConversationEngine(...)` (or the quickstart runner) to persist
-// through your own storage — session lifecycle, turn preflight/persistence,
-// leases, the engine artifact reader, turn results, and artifact tools all
-// flow through the injected instances. Traces and memory remain path-oriented
-// (stateRoot) for now; making them injectable follows the same pattern (see
-// SDK posture, rung 5).
+// Heddle defaults to local file-backed stores. Artifacts, sessions, and
+// compacted conversation archives are injectable: implement the corresponding
+// repository and pass it to `createConversationEngine(...)` (or the quickstart
+// runner). Traces and memory remain path-oriented (`stateRoot`) for now.
 export { ArtifactService, FileArtifactRepository } from './core/artifacts/index.js';
 export type {
   ArtifactCurrentPointers,
@@ -287,6 +282,26 @@ export type {
   StoredChatSession,
   UpdateChatSessionInput,
 } from './core/chat/engine/sessions/repository/index.js';
-export type { ChatSession } from './core/chat/types.js';
+export {
+  ChatArchivePersistenceCodec,
+  ChatArchiveStorageCorruptionError,
+  ChatArchiveSummaryNotFoundError,
+  ChatArchiveRepositoryError,
+  FileChatArchiveRepository,
+} from './core/chat/engine/sessions/archives/index.js';
+export type {
+  AppendChatArchiveInput,
+  AppendChatArchiveResult,
+  ChatArchiveRecordDraft,
+  ChatArchiveRepository,
+  ChatArchiveStoragePaths,
+  FileChatArchiveRepositoryOptions,
+  ChatArchiveRepositoryOperation,
+} from './core/chat/engine/sessions/archives/index.js';
+export type {
+  ChatArchiveManifest,
+  ChatArchiveRecord,
+  ChatSession,
+} from './core/chat/types.js';
 export { RuntimeCredentialService } from './core/runtime/credentials/index.js';
 export type { ApiKeyRuntime, ProviderCredentialSource } from './core/runtime/credentials/index.js';

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -257,6 +257,7 @@ export class ControlPlaneChatSessionsController {
               systemContext: args.systemContext,
             },
             session,
+            archiveRepository: args.archiveRepository,
             force,
             summarizer: {
               credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(model, {
@@ -673,6 +674,7 @@ export class ControlPlaneChatSessionsController {
             model: session.model ?? args.model ?? DEFAULT_OPENAI_MODEL,
             workspaceRoot: args.workspaceRoot,
             stateRoot: args.stateRoot,
+            archiveRepository: args.archiveRepository,
             systemContext: args.systemContext,
             riskAccepted: args.riskAccepted,
             credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(session.model ?? args.model ?? DEFAULT_OPENAI_MODEL, args),


### PR DESCRIPTION
## Summary

- add an async, host-injected `ChatArchiveRepository` for compacted raw transcripts, rolling summaries, and manifests
- make compaction save through one durable append boundary before session state can reference the archive
- upgrade the default file adapter to async I/O, serialized appends, atomic manifest replacement, strict corruption handling, and path-safe locators
- propagate the repository through the engine, quickstart runner, turn preflight/persistence, direct shell, and control-plane compaction
- export strict adapter-authoring codecs/errors and document a PostgreSQL/Drizzle-friendly storage shape

## Why

A remote `ChatSessionRepository` could reopen active session state on another replica, but compacted history still referenced local archive files. This gives hosts a separate archive persistence port while preserving the zero-configuration local layout and keeping SQL, identity, tenancy, and object-store choices outside Heddle.

## Reliability semantics

- summarization completes before archive storage is mutated
- `append` makes raw messages, summary text, and the returned manifest visible as one repository operation
- repository failures reject the turn/manual compaction and restore any temporary running metadata; exact active history is retained
- valid v1 local manifests remain readable, while malformed, mismatched, missing-summary, and escaping-locator state fails loudly
- `path` and `summaryPath` stay backward-compatible field names but are now documented as repository-owned opaque locators

## Verification

- `yarn lint`
- `yarn typecheck`
- `yarn test` — 703 unit and 310 integration tests passed
- `yarn build`

The build only reports the existing Vite chunk-size warnings.

## Deliberate boundaries

- no database/ORM/object-store dependency in Heddle
- no model-visible remote raw-archive reader in this slice
- traces, memory, and active-run/SSE coordination remain outside this storage port
