### PR TITLE
docs: define durable state support boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ framework, or deployment platform.
 - [Host extensions](docs/guides/programmatic/host-extensions.md)
 - [MCP host extensions](docs/guides/programmatic/mcp-host-extensions.md)
 - [Remote conversation runs](docs/guides/programmatic/remote-runs.md)
+- [Durability support matrix](docs/guides/programmatic/durability-support.md)
 - [Result artifacts](docs/guides/programmatic/result-artifacts.md)
 - [Runnable SDK examples](examples/sdk/README.md)
 

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ framework, or deployment platform.
 - [Project posture](docs/project-posture.md)
 - [Development guide](docs/guides/development.md)
 - [Core layering](docs/architecture/core-layering.md)
+- [Durable state](docs/architecture/durable-state.md)
 - [Framework vision](docs/strategy/framework-vision.md)
 
 ## Development

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ Contributor-facing architecture boundaries:
 
 - [Core Layering](architecture/core-layering.md)
 - [Chat Layering](architecture/chat-layering.md)
+- [Durable State](architecture/durable-state.md)
 - [Live Events](architecture/live-events.md)
 
 ## Project Context

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ Task-oriented guides:
 - [Semantic drift](guides/semantic-drift.md)
 - [Heartbeat](guides/heartbeat.md)
 - [Programmatic hosts](guides/programmatic/README.md)
+- [Durability support matrix](guides/programmatic/durability-support.md)
 - [Development and contributing](guides/development.md)
 - [Debugging](guides/debugging.md)
 - [Release convention](releases/README.md)
@@ -130,8 +131,9 @@ Evaluation:
 ### I want to build on Heddle programmatically
 
 1. [Programmatic hosts](guides/programmatic/README.md) for the conversation engine alpha, persisted sessions, and turn submission
-2. [Capabilities and tools](reference/capabilities.md)
-3. [Providers and models](reference/providers-and-models.md)
+2. [Durability support matrix](guides/programmatic/durability-support.md) before choosing local or remote storage boundaries
+3. [Capabilities and tools](reference/capabilities.md)
+4. [Providers and models](reference/providers-and-models.md)
 
 ### I want to contribute or develop locally
 

--- a/docs/architecture/durable-state.md
+++ b/docs/architecture/durable-state.md
@@ -1,0 +1,373 @@
+# Durable State
+
+This document inventories Heddle's durable state boundaries. It answers four
+questions for each state surface:
+
+1. Which domain owns its persisted meaning?
+2. What survives a browser refresh, process restart, or host replacement?
+3. Which storage boundary can a programmatic host replace today?
+4. What corruption, atomicity, retention, or security constraints still apply?
+
+The inventory describes the `v5.1.0` implementation. Update it when adding a
+production writer, changing a persisted schema, or widening a repository
+contract.
+
+## Terms
+
+The labels in this document are deliberately narrower than "persistent":
+
+- **Remote-ready**: Heddle exposes an asynchronous, host-injectable repository
+  contract whose semantics are defined independently of the default file
+  adapter. A remote adapter still owns authentication, tenant scope, schema,
+  migrations, transactions, backups, and operations.
+- **Host-replaceable**: a host can inject another implementation, but the
+  current contract is synchronous or otherwise shaped around local storage.
+  This is not a remote-storage guarantee.
+- **Workspace-local**: files belong to one workspace or state root. They survive
+  a process restart when that filesystem survives, but do not follow a new
+  replica unless the workspace storage is mounted or copied.
+- **Machine-local**: data represents one machine's credentials, paths, browser
+  profile, or process discovery state. It should not be copied to another host
+  by a generic persistence layer.
+- **Diagnostic**: durable evidence or developer output, not authoritative
+  product recovery state.
+- **Process-local**: coordination held only in memory. Losing it interrupts the
+  operation even when related durable records remain.
+
+"Host replacement" below means a new process on a different machine or
+ephemeral replica without the old local filesystem. A shared volume counts as
+the same storage, not as remote portability.
+
+## Lifecycle Matrix
+
+| State surface | Current class | Browser refresh | Same-filesystem process restart | Host replacement | Delete and retention behavior |
+| --- | --- | --- | --- | --- | --- |
+| Conversation sessions | **Remote-ready** | Reloaded from the repository | Survives; stale local leases can be recovered | Survives when the host supplies the same remote repository and authenticated scope | Session delete is revision-checked; default files retain superseded and interrupted revision bodies |
+| Conversation archives | **Remote-ready** | Reloaded through the session manifest | Survives | Survives when the host supplies the same remote archive repository and scope | Append-only today; default files can retain orphan content and have no archive GC policy |
+| Result artifacts | **Host-replaceable** | Reloaded from catalog and content keys | Survives with the same artifact root | Only if a custom synchronous repository reaches shared storage; not a remote-ready promise | No public delete, retention, or orphan cleanup contract |
+| Raw turn traces | **Workspace-local diagnostic** | Existing trace files remain | Survives | Does not follow the session unless state storage is shared or copied | No retention or GC policy; session summaries can retain a local-only `traceFile` locator |
+| Memory notes and maintenance records | **Workspace-local** | Reloaded from `.heddle/memory` | Survives | Only when the workspace files are mounted, copied, or intentionally synchronized | Human-editable notes plus append-only maintenance JSONL; no general retention policy |
+| Remembered approvals and project config | **Workspace-local security policy** | Reloaded from the state root | Survives | Only with the workspace; copying changes the receiving host's policy | Approval rules can be replaced by the owning service; there is no cross-domain cascade |
+| MCP config, activation, and discovery catalog | **Host-replaceable (sync); workspace-local default** | Reloaded; catalog is a cache | Survives | Only with the workspace; the catalog may be rebuilt | No universal cleanup; discovery catalog is disposable, config and activation are authoritative |
+| Skill activation | **Host-replaceable (sync); workspace-local default** | Reloaded | Survives | Only with the state root; referenced user skill paths may not exist | No generic pruning of stale source paths |
+| Custom-agent definitions | **Workspace or machine source config** | Rediscovered from source files | Survives | Project definitions follow copied project files; user definitions do not | Project definitions have explicit create/delete; accepted turns persist an immutable execution snapshot |
+| Heartbeat tasks, checkpoints, and run records | **Host-replaceable async scheduler store; workspace-local built-in** | Reloaded through the control plane | Survives; scheduler execution itself restarts | Only a custom store can follow a new host, and Heddle defines no distributed scheduler guarantee | Deleting a file-backed task removes its task, checkpoint, and matching run-record files; no age-based retention |
+| Browser settings and profiles | **Machine-bound workspace state** | Reloaded; an open window remains server-owned | Settings and profile files survive, open windows and locks do not | Not portable by contract; browser profile data and local CDP endpoints are machine-specific | No profile/evidence retention policy |
+| Runtime workspace catalog | **Machine-local** | Reloaded | Survives | Not portable: records contain absolute local paths | No automatic pruning of moved or deleted workspaces |
+| Daemon registry | **Machine-local process discovery** | Reloaded | Survives as a registry file, but liveness is re-evaluated by timestamp and PID | Must not be copied; endpoints and PIDs are local facts | Live server registration is cleared by owner; known workspace records are not automatically pruned |
+| Provider credentials | **Machine-local secret store** | Server-side store is unaffected | Survives with mode `0600` | Must be re-provisioned or supplied explicitly; never migrate through generic state sync | Per-provider removal exists; malformed storage fails to an empty store |
+| Session image uploads | **Workspace-local input files** | Existing absolute paths remain usable on the same host | Survives | Does not follow a remote session unless separately copied | No session-delete cascade or retention policy today |
+| Logs, layout snapshots, browser evidence, and eval output | **Diagnostic** | Files remain, but are not UI recovery state | Files survive | No portability contract | Eval output has explicit cleanup; other diagnostics have no shared retention policy |
+| Active runs, replay buffers, subscribers, pending approvals, browser windows, and scheduler handles | **Process-local** | Browser clients can reconnect only while the owning server still has the run | Lost and treated as interrupted | Lost | Removed when the process/run closes; there is no durable in-flight recovery |
+
+## Current Extension Surfaces
+
+An injected TypeScript interface is not automatically a production remote
+storage contract. The current extension surface is:
+
+| Domain | Injected surface | I/O and consistency shape | Current remote posture |
+| --- | --- | --- | --- |
+| Sessions | `ChatSessionRepository` on the conversation engine | Async CRUD, optimistic revisions, stable pagination, strict corruption behavior, and a conformance suite | **Remote-ready** when the host binds authenticated scope and operations |
+| Archives | `ChatArchiveRepository` on the conversation engine | Async read/append; one append atomically owns messages, summary, and manifest | **Remote-ready** when paired with the session repository's authenticated scope |
+| Artifacts | `ArtifactRepository` on the conversation engine | Synchronous catalog and text-content calls; no atomic catalog/content commit | **Host-replaceable**, not remote-ready |
+| Heartbeat | `HeartbeatTaskStore` passed to `runDueTasks` or `runLoop` | Async tasks/checkpoints/runs, but no revisions, distributed lease, multi-record transaction, or conformance suite; built-in `start` constructs the file service | **Host-replaceable scheduler primitive**, not a distributed durability promise |
+| MCP | `McpConfigStorePort`, `McpActivationStorePort`, and `McpCatalogStorePort` | Synchronous whole-document stores; activation/config authority differs from rebuildable discovery cache | **Host-replaceable for an in-process host**, not remote-ready |
+| Skill activation | `AgentSkillActivationStorePort` | Synchronous consent metadata containing source paths | **Host-replaceable for an in-process host**, not portable skill storage |
+| All other rows | No general injected persistence port | Domain-specific files, diagnostics, secrets, or process coordination | Local/machine/process semantics remain authoritative |
+
+## Remote-Ready Conversation State
+
+### Sessions
+
+[`ChatSessionRepository`](../../src/core/chat/engine/sessions/repository/types.ts)
+is the authoritative active-session boundary. It is asynchronous and uses
+optimistic revisions for create, update, and delete. Catalog ordering and cursor
+pagination are part of the contract, including scope isolation and stable
+ordering ties. A host binds a repository instance to an authenticated scope;
+individual operations intentionally do not accept caller-provided tenant IDs.
+
+The default
+[`FileChatSessionRepository`](../../src/core/chat/engine/sessions/repository/file-chat-session-repository.ts)
+stores an atomic catalog plus immutable revision bodies. It serializes writes
+within a process and across processes, writes a new body before replacing the
+catalog, and surfaces malformed referenced state as a storage-corruption error.
+Readers therefore see either the previous complete revision or the next one.
+
+Current limits:
+
+- superseded and crash-orphaned revision bodies are retained;
+- the repository conformance suite verifies Heddle semantics, not a host's
+  authentication, row-level policy, migrations, query plans, backups, or
+  disaster recovery;
+- a host must keep session and archive repositories in the same identity scope.
+
+See the repository's
+[`README`](../../src/core/chat/engine/sessions/repository/README.md) for the full
+contract and conformance boundary.
+
+### Compaction archives
+
+[`ChatArchiveRepository`](../../src/core/chat/engine/sessions/archives/types.ts)
+owns compacted exact messages, rolling summaries, and archive manifests. One
+successful append must make all three readable together. Locators are opaque to
+the engine: the file adapter returns `.heddle/...` paths, while a database/blob
+adapter can return stable repository keys.
+
+The default
+[`FileChatArchiveRepository`](../../src/core/chat/engine/sessions/archives/file-chat-archive-repository.ts)
+writes immutable content first and atomically replaces the manifest under a
+cross-process lock. A crash can leave unreferenced content, but cannot publish a
+manifest that points to an incomplete append. Invalid or session-mismatched
+manifests raise a corruption error instead of becoming empty history.
+
+This boundary deliberately excludes raw trace storage, artifacts, memory, and
+active streaming coordination. See the archive
+[`README`](../../src/core/chat/engine/sessions/archives/README.md).
+
+## Replaceable But Not Remote-Ready
+
+### Result artifacts
+
+[`ArtifactService`](../../src/core/artifacts/service.ts) owns artifact IDs,
+catalog shape, content keys, and current-workspace/current-session pointers.
+[`ArtifactRepository`](../../src/core/artifacts/types.ts) is injectable, and
+custom repositories may use opaque content keys, but its API is synchronous.
+The default file repository stores `artifacts.json` and text-like content under
+`files/`.
+
+Important gaps in the current file implementation:
+
+- content and catalog/current-pointer changes are not one atomic commit;
+- catalog replacement has no file or process lock, so concurrent writers can
+  lose updates;
+- a malformed catalog is treated as an empty store, hiding corruption;
+- content is written before the catalog, so interruption can leave orphan
+  files;
+- there is no delete, retention, garbage-collection, large-blob, or streaming
+  contract.
+
+Artifacts are the strongest candidate for the next focused storage boundary.
+That work should define asynchronous metadata and content operations, opaque
+stable addresses, commit/current-pointer atomicity, and cleanup semantics. It
+should not introduce a universal storage provider shared by unrelated domains.
+
+## Workspace-Local Product State
+
+### Memory
+
+[`src/core/memory`](../../src/core/memory/README.md) owns human-readable durable
+knowledge under `.heddle/memory`, including catalog files, notes, append-only
+candidate/run records, and a maintenance lock. This is workspace knowledge, not
+a transcript or application database.
+
+Maintenance combines an in-process queue with an exclusive lock file. Invalid
+JSONL entries are skipped during tolerant reads, and a process failure may leave
+pending candidates or a lock until stale-lock recovery. Memory explicitly must
+not contain credentials or secrets. Remote knowledge synchronization, if ever
+needed, should be a separate product boundary with conflict and authority rules;
+it should not be inferred from the conversation repository contract.
+
+### Approval policy and project configuration
+
+Remembered project approvals live in `command-approvals.json` through
+[`FileProjectApprovalRuleRepository`](../../src/core/approvals/remembered-rules/repository.ts).
+Malformed files fail closed to no remembered rules and log an error. Writes
+replace the whole file without an atomic rename or cross-process lock.
+
+Project settings live in `.heddle/config.json` through
+[`ProjectConfigService`](../../src/core/project-config/service.ts). They include
+model/runtime defaults and security-relevant autonomy policy. Missing or invalid
+config resolves to an empty configuration before defaults are applied. Writes
+also replace the whole file without locking. These files should move only with
+an operator-controlled workspace because copying them changes execution policy.
+
+Pending approval promises are not part of this durable state. They remain
+process-local by design; a restart interrupts the waiting run. See the approvals
+domain [`README`](../../src/core/approvals/README.md).
+
+### MCP, skills, and custom agents
+
+The MCP domain owns three different files with different authority:
+
+- `mcp.json` is user-authored configuration and may reference environment
+  variables, but must not contain resolved secrets or tokens;
+- `mcp/activation.json` records operator activation decisions;
+- `mcp/catalog.json` caches discovered tool metadata and may be rebuilt.
+
+The file repositories report invalid MCP configuration as issues; invalid
+activation or catalog stores fall back to empty state. All writes replace whole
+files without atomic rename or locking. `McpService` can accept synchronous
+store ports for all three, but their different authority and cache semantics
+remain; this is not one remote MCP database contract. See
+[`src/core/mcp`](../../src/core/mcp/README.md).
+
+Skill definitions remain at their project, user, or built-in source paths.
+[`FileAgentSkillActivationRepository`](../../src/core/skills/activation-repository.ts)
+persists only activation/consent metadata under `skills/activation.json` and
+falls back to empty state on invalid input. `AgentSkillService` accepts another
+synchronous activation store, but the records still refer to project, user, or
+built-in definition sources rather than storing the skill content.
+
+Custom-agent definitions similarly remain under project or user `.agents`
+directories. Project definitions have explicit create/delete behavior. An
+accepted conversation turn stores an immutable execution snapshot, so later
+definition edits do not change the meaning of persisted history. See
+[`src/core/custom-agents`](../../src/core/custom-agents/README.md).
+
+### Heartbeat
+
+[`FileHeartbeatTaskService`](../../src/core/heartbeat/tasks/service.ts) is the
+domain boundary for `heartbeat/tasks`, `heartbeat/checkpoints`, and
+`heartbeat/runs`. Task deletion removes all three kinds of matching records.
+The repository validates writes and skips unreadable task, checkpoint, or run
+files during reads. One-off stored heartbeat usage has a separate
+[`FileHeartbeatCheckpointRepository`](../../src/core/heartbeat/checkpoint/repository.ts)
+for a caller-selected checkpoint path under the same heartbeat domain.
+
+The exported asynchronous `HeartbeatTaskStore` can be supplied to
+`HeartbeatSchedulerService.runDueTasks` and `runLoop`. It does not define
+compare-and-swap task revisions, distributed execution leases, or an atomic
+task/checkpoint/run transaction, and the built-in `start` path always creates
+the file service. A hosted store is therefore possible for custom scheduler
+code, but is not currently a remote-ready or exactly-once scheduler contract.
+
+Writes replace individual files without atomic rename or cross-process locking.
+Run filenames use a timestamp plus task ID and have no explicit collision or
+age-retention policy. Scheduler handles and the currently executing cycle stay
+process-local even though the task and last checkpoint are durable. See the
+heartbeat [`README`](../../src/core/heartbeat/README.md).
+
+### Browser settings, profiles, and evidence
+
+[`src/core/browser`](../../src/core/browser/README.md) owns:
+
+- `browser/settings.json` for the selected backend, profile, channel, display
+  mode, and local CDP endpoint;
+- `browser-profiles/` and `native-chrome-profiles/` for browser-managed user
+  data such as authenticated cookies;
+- per-run `events.jsonl`, snapshots, and screenshots when evidence recording is
+  enabled.
+
+Profile directories and loopback CDP endpoints are intentionally machine-bound
+and can contain sensitive authenticated browser state. They must not be moved by
+a generic workspace database adapter. Settings writes are whole-file writes;
+evidence appends and snapshot writes do not define retention or remote lookup.
+Open windows and profile leases are in-process coordination and disappear on
+restart.
+
+### Session image uploads
+
+The control plane stores validated image uploads under
+`uploads/sessions/<session-id>/` through
+[`ChatSessionImageUploadService`](../../src/server/services/control-plane/chat-session-image-uploads.ts).
+The current session/runtime consumes absolute local paths. Uploads therefore do
+not become remotely available merely because the session repository is remote,
+and session deletion does not currently cascade to uploaded files.
+
+## Machine-Local State
+
+### Provider credentials
+
+[`ProviderCredentialRepository`](../../src/core/auth/provider-credentials.ts)
+stores provider keys, bearer tokens, and OAuth tokens at `~/.heddle/auth.json`
+by default. The file is forced to mode `0600`; malformed input becomes an empty
+store. Explicit per-run credentials and environment variables remain separate
+host inputs.
+
+This is a secret-management boundary, not application persistence. Hosted
+deployments should inject credentials through their own secret manager or
+request scope. Heddle must never copy this file into a conversation database,
+workspace catalog, artifact store, or diagnostic bundle.
+
+### Workspace and daemon catalogs
+
+[`RuntimeWorkspaceService`](../../src/core/runtime/workspaces/service.ts) owns
+`workspaces.catalog.json`. Records include absolute workspace and state-root
+paths, so the catalog describes one local installation. The file repository
+performs whole-file writes without atomic rename or locking. Schema-invalid
+catalogs normalize to a default catalog, while malformed JSON fails before that
+normalization step.
+
+[`RuntimeDaemonRegistryService`](../../src/core/runtime/daemon/registry-service.ts)
+owns `~/.heddle/daemon-registry.json`: the current local server endpoint/PID and
+known local workspaces. Server liveness is re-evaluated from the heartbeat age
+and PID. Invalid schema normalizes to an empty registry, although malformed JSON
+still fails in the repository read before normalization. The registry is local
+discovery data and must not be replicated.
+
+## Diagnostic State
+
+- [`TraceWriter`](../../src/core/chat/engine/turns/trace/trace-writer.ts) writes
+  completed-turn traces under `traces/`. A session stores a summary plus the
+  local `traceFile` path. Memory maintenance can later rewrite that trace to add
+  maintenance events; an unreadable trace is treated as empty before that
+  rewrite. The legacy control-plane one-shot ask controller also writes directly
+  into the same trace root. There is no repository port, atomic replacement,
+  lock, redaction boundary, retention policy, or stable remote locator. Trace
+  semantics and ordering must be designed before adding remote trace storage.
+- [`createLogger`](../../src/core/utils/logger.ts) writes asynchronous Pino logs,
+  normally to `logs/server.log`. Logs are operational evidence, not recovery
+  state, and need host-owned rotation/redaction in production.
+- [`ControlPlaneLayoutSnapshotsController`](../../src/server/controllers/trpc/control-plane/layout-snapshots.ts)
+  writes JSON/PNG debugging snapshots under `debug/dom-snapshots`.
+- [`BrowserEvidenceService`](../../src/core/browser/evidence/service.ts) writes
+  per-run browser events, snapshots, and screenshots.
+- [`src/core/eval`](../../src/core/eval/README.md) creates disposable workspaces
+  and gitignored reports under `evals/results` by default. The eval cleanup
+  command owns deletion. These are developer-tool outputs, not runtime state.
+
+## Process-Local Coordination
+
+[`ConversationRunService`](../../src/core/chat/runs/service.ts) owns active runs,
+bounded replay buffers, stream subscribers, abort controllers, and pending
+approval resolvers in memory. Control-plane event buses, browser windows,
+profile leases, cached loggers, and heartbeat scheduler handles are also
+process-local.
+
+Persisted session leases protect accepted conversation state across competing
+clients, but they do not make an in-flight model/tool execution resumable. A
+process restart must be represented as interruption; replaying a pending tool
+call or approval from partial durable evidence would be unsafe.
+
+## Explicitly Excluded Writers
+
+The production writer sweep also found file operations that are not Heddle
+durable-state domains:
+
+| Writer | Why it is excluded from storage portability |
+| --- | --- |
+| `src/core/tools/toolkits/coding-files` | These tools intentionally mutate user-owned workspace files. Git/filesystem semantics, not Heddle persistence, are authoritative. |
+| Project/user skill and custom-agent definition services | The files are operator-authored source configuration. Their discovery and snapshot rules are inventoried above, but they are not copied into a Heddle state repository. |
+| Browser driver screenshot/profile writes | The browser runtime writes into the browser evidence/profile roots owned above; the driver is not a second persistence domain. |
+| Eval fixture setup and cleanup | These are bounded developer-harness workspaces and reports, not a production recovery surface. |
+| Read-only awareness, file-view, and session-watch code | Filesystem access without durable writes does not create another state owner. |
+
+Any new production writer under `src/core` or `src/server` must either join an
+owner above, define a new owner and lifecycle here, or be explicitly excluded
+with the same level of reasoning.
+
+## Ranked Follow-Up
+
+1. **Publish the adopter support matrix.** Distill this inventory into the
+   programmatic-host docs: sessions and archives are remote-ready; artifacts
+   are synchronously replaceable; traces, memory, approvals, heartbeat,
+   credentials, browser state, and runtime catalogs are not implied by those
+   contracts.
+2. **Design the artifact boundary only if the next host needs it.** Define an
+   asynchronous metadata/content split, stable opaque addresses, atomic content
+   plus current-pointer semantics, size/streaming limits, and explicit deletion
+   and orphan cleanup. Add an adapter only against that domain contract.
+3. **Harden local writers by domain and risk.** Use atomic replacement,
+   domain-appropriate locks, and explicit corruption behavior for state whose
+   concurrent loss changes user-visible truth. Do not hide this work behind a
+   generic file repository wrapper.
+4. **Specify trace semantics before trace portability.** Decide event ordering,
+   redaction, partial-run visibility, retention, session linkage, and stable
+   addressing before creating a trace port.
+5. **Keep machine/security state local.** Credentials, browser profiles,
+   daemon discovery, and absolute-path workspace catalogs should remain outside
+   general remote persistence. Memory synchronization also requires its own
+   authority/conflict design rather than reuse of the session repository.
+
+The result is intentionally several domain-owned storage boundaries, not one
+universal persistence abstraction.

--- a/docs/architecture/durable-state.md
+++ b/docs/architecture/durable-state.md
@@ -12,6 +12,9 @@ The inventory describes the `v5.1.0` implementation. Update it when adding a
 production writer, changing a persisted schema, or widening a repository
 contract.
 
+For the shorter adopter-facing decision guide, see the
+[durability support matrix](../guides/programmatic/durability-support.md).
+
 ## Terms
 
 The labels in this document are deliberately narrower than "persistent":
@@ -348,11 +351,10 @@ with the same level of reasoning.
 
 ## Ranked Follow-Up
 
-1. **Publish the adopter support matrix.** Distill this inventory into the
-   programmatic-host docs: sessions and archives are remote-ready; artifacts
-   are synchronously replaceable; traces, memory, approvals, heartbeat,
-   credentials, browser state, and runtime catalogs are not implied by those
-   contracts.
+1. **Keep the adopter support matrix current.** The
+   [durability support matrix](../guides/programmatic/durability-support.md)
+   now distinguishes local, completed-conversation, and durable in-flight
+   promises. Update it whenever an extension surface or support level changes.
 2. **Design the artifact boundary only if the next host needs it.** Define an
    asynchronous metadata/content split, stable opaque addresses, atomic content
    plus current-pointer semantics, size/streaming limits, and explicit deletion

--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -54,6 +54,9 @@ split between Heddle and the host explicit for developers and coding agents.
      a transport-neutral run service, Express/SSE API, browser client, and
      optional React reference product while keeping each layer replaceable.
 5. **Advanced: storage** — back Heddle with your own persistence.
+   - [Durability support matrix](durability-support.md): choose between local,
+     completed-conversation, and durable in-flight promises, and see which
+     state surfaces must follow a replica.
    - [Result artifacts](result-artifacts.md): save large generated values as
      reusable artifacts.
    - Artifact, session, and compacted-history storage are injectable: implement
@@ -66,8 +69,9 @@ split between Heddle and the host explicit for developers and coding agents.
      [runnable PostgreSQL + Drizzle reference](../../../examples/sdk/06-postgres-drizzle-storage/README.md)
      includes migrations, both repository implementations, public conformance,
      and fresh-service recovery.
-     Traces and memory still persist under a local state root; making them
-     injectable follows the same pattern.
+     Traces and memory still persist under a local state root. They have
+     different authority and lifecycle requirements and are not implied by
+     session/archive repository injection.
 
 Runnable versions of the first few rungs live in
 [`examples/sdk/`](../../../examples/sdk/README.md).

--- a/docs/guides/programmatic/durability-support.md
+++ b/docs/guides/programmatic/durability-support.md
@@ -1,0 +1,117 @@
+# Durability Support Matrix
+
+Heddle does not make every runtime surface durable across replicas. A host
+should choose the smallest durability promise its users need, then persist only
+the state required to keep that promise truthful.
+
+This guide is the adopter-facing support matrix. For implementation ownership,
+file behavior, corruption handling, and known atomicity/retention gaps, read the
+contributor-facing [durable-state inventory](../../architecture/durable-state.md).
+
+## Promise Levels
+
+| Level | User-visible promise | Current Heddle support |
+| --- | --- | --- |
+| **Local durable** | Completed conversations survive browser refresh and process restart on one host | Supported by the default file repositories when `stateRoot` is on a persistent local filesystem |
+| **Completed-conversation durable** | After a turn finishes, another process or replica can reopen the conversation and continue with the same compacted context | Supported when the host injects remote `ChatSessionRepository` and `ChatArchiveRepository` implementations and durably commits any product-owned result before reporting success |
+| **Durable in-flight execution** | A run, approval wait, cancellation handle, and event replay survive the executor process dying | **Not provided.** Active runs, pending approvals, cancellation, and replay buffers are process-local; this requires host-selected queue/orchestration infrastructure and idempotent execution design |
+
+The completed-conversation level is a valid production boundary. A product does
+not need durable in-flight execution merely because it runs more than one
+replica. It must instead report process loss honestly and let the user retry
+from the last completed durable state.
+
+## State Surface Matrix
+
+| Surface | Default behavior | Host extension today | Same-host restart | New replica or machine | Supported posture |
+| --- | --- | --- | --- | --- | --- |
+| Conversation sessions | Atomic local catalog with immutable revision bodies | Async `ChatSessionRepository` with revisions, stable pagination, strict records, and conformance scenarios | Yes, with persistent `stateRoot` | Yes, with a scope-bound remote repository | **Remote-ready** |
+| Compaction archives | Locked, atomic local manifest append with immutable content | Async `ChatArchiveRepository`; one append owns exact messages, rolling summary, and manifest | Yes, with persistent `stateRoot` | Yes, with a scope-bound remote repository paired with the session repository | **Remote-ready** |
+| Product catalog, transcript, and canonical result | Outside Heddle ownership | The host persists its user-facing view and domain result | Host-defined | Host-defined | **Host responsibility** for a truthful product success promise |
+| Result artifacts | Local catalog, text content, and current pointers | Synchronous `ArtifactRepository` | Yes, with the same artifact root | Not guaranteed; a custom synchronous store is not a remote-ready contract | **Host-replaceable, local-biased** |
+| Raw turn traces | Local files referenced by a local path | No general persistence port | Files survive on the same storage | No | **Local diagnostic evidence** |
+| Memory notes and maintenance | Workspace files and JSONL under the state root | No general persistence port | Yes | Only when the workspace itself is copied or mounted | **Workspace-local by design** |
+| Remembered approvals and project config | Workspace policy files | No general persistence port | Yes | Only with operator-controlled workspace state | **Workspace-local security policy** |
+| Heartbeat tasks and checkpoints | Local task, checkpoint, and run files | Async `HeartbeatTaskStore` for custom scheduler calls, without revisions or distributed leases | Yes | Not guaranteed; the built-in scheduler is not a distributed exactly-once service | **Host-replaceable scheduler primitive** |
+| MCP and skill activation | Local config, consent metadata, source paths, and a rebuildable MCP catalog | Synchronous MCP and skill activation stores | Yes | Not generally portable because records can refer to local sources | **In-process host-replaceable** |
+| Custom-agent definitions | Project, user, and built-in source files; accepted turns retain a snapshot | No generic definition store | Yes | Project definitions only when project files follow the host; user definitions remain machine-local | **Source configuration** |
+| Session image uploads | Local files addressed by absolute paths | No general upload repository | Yes, with the same state root | No | **Host must add object storage** if uploaded inputs must follow a replica |
+| Provider credentials and browser profiles | Protected machine files and browser user-data directories | Explicit credentials may be supplied per run | Yes, on the same machine | No; re-provision credentials and browser state deliberately | **Machine-local secret/session state** |
+| Runtime workspace and daemon catalogs | Absolute paths, local endpoint, PID, and liveness facts | No general persistence port | Yes, but liveness is re-evaluated | No; these records describe one machine | **Machine-local discovery** |
+| Logs, layout snapshots, browser evidence, and eval output | Local diagnostic files | Host-selected logging/diagnostic infrastructure | Files survive on the same storage | No Heddle portability promise | **Diagnostic** |
+| Active runs, SSE replay, cancellation, pending approvals, browser windows, and scheduler handles | In-memory coordination | No durable execution port | No | No | **Process-local** |
+
+## Minimum Hosted Conversation Promise
+
+To promise that a user can return to a completed conversation and continue it
+after a server replacement, a host needs all of the following:
+
+1. **Remote session records.** Bind `ChatSessionRepository` to a trusted
+   server-side identity scope and pass the repository conformance suite in the
+   host's integration environment.
+2. **Remote compaction archives.** Bind `ChatArchiveRepository` to the same
+   identity scope and make each archive append transactional. This is required
+   whenever a conversation may compact; session JSON alone cannot reconstruct
+   removed exact history or the rolling summary.
+3. **Durable product truth.** If a turn changes host-owned domain state, persist
+   the canonical result before publishing terminal success. A durable
+   conversation that claims an output changed while the product still stores
+   the old value is not a successful durability design.
+4. **Durable user-facing projection when needed.** If the UI exposes a catalog
+   or safe transcript, persist that product view separately instead of treating
+   Heddle's complete model/tool record as a stable browser contract.
+5. **Identity, deletion, and operations.** Enforce tenant isolation in the
+   adapter factory and database, define cascade/retention behavior, and own
+   migrations, backups, monitoring, and disaster recovery.
+6. **Truthful interruption behavior.** If the executor dies before finalization,
+   report the run as interrupted or failed. Do not reconstruct and replay a
+   pending tool call or approval from partial evidence.
+
+For implementation guidance, see [durable session storage](session-storage.md)
+and the runnable
+[PostgreSQL + Drizzle reference](../../../examples/sdk/06-postgres-drizzle-storage/README.md).
+
+## What This Promise Does Not Require
+
+A completed-conversation promise does not by itself require:
+
+- remote Heddle artifacts when the product already persists the canonical
+  user-owned result;
+- raw trace portability or cross-replica log lookup;
+- remote Heddle memory notes;
+- durable approval waits, SSE replay, cancellation, or active-run recovery;
+- replicated MCP/skill activation, browser profiles, or provider credentials;
+- distributed heartbeat scheduling; or
+- one universal storage abstraction for unrelated domains.
+
+Add one of those only when it becomes user-facing product state, an operational
+requirement, or a repeated host need. Its contract should stay with the owning
+domain rather than being folded into conversation storage.
+
+## Choosing A Deployment Posture
+
+| Product need | Recommended setup | Honest limitation |
+| --- | --- | --- |
+| Local tool or single durable server | Default file repositories on a persistent local volume with backup | A new machine needs the same restored volume |
+| Hosted product where completed work must follow users | Remote session and archive repositories plus host-owned product persistence | An executor death can interrupt the current run |
+| Product requiring uninterrupted jobs across executor death | External durable queue/workflow engine, idempotent tool effects, durable approvals/cancellation, and result finalization designed by the host | This is a larger distributed-execution system, not enabled by repository injection alone |
+
+## Acceptance Checklist
+
+Before claiming completed-conversation durability, verify:
+
+- refresh restores the selected conversation, user-facing projection, and
+  canonical product result;
+- a fresh server process can continue the same conversation;
+- a different replica can continue it using only authenticated durable state;
+- forced compaction survives a fresh process and restores the rolling summary;
+- two writers cannot silently overwrite a newer session or product result;
+- a failed archive or product commit cannot publish terminal success;
+- another identity cannot list, read, mutate, or delete the conversation;
+- deletion removes or intentionally retains every user-owned record according
+  to documented policy; and
+- executor death is presented as interruption, not as completed durable work.
+
+Once this checklist passes, durability is sufficient for the
+completed-conversation promise. Improving unrelated local state can continue
+as Heddle core work without blocking the host product.

--- a/docs/guides/programmatic/session-storage.md
+++ b/docs/guides/programmatic/session-storage.md
@@ -11,6 +11,10 @@ Use the default JSON adapters for one-machine/local-first products. Inject
 `ChatSessionRepository` and `ChatArchiveRepository` for hosted or multi-process
 products that already have a database.
 
+For the exact boundary between local durability, completed-conversation
+durability, and durable in-flight execution, see the
+[durability support matrix](durability-support.md).
+
 ## Local JSON: zero configuration
 
 `createConversationEngine` uses `FileChatSessionRepository` by default. Point

--- a/docs/project-posture.md
+++ b/docs/project-posture.md
@@ -94,7 +94,8 @@ review. A good service boundary should make it obvious:
 
 For core dependency direction, use
 `docs/architecture/core-layering.md`. For chat-specific placement, use
-`docs/architecture/chat-layering.md`.
+`docs/architecture/chat-layering.md`. For persistence ownership and lifecycle,
+use `docs/architecture/durable-state.md`.
 
 For host-heavy areas, prefer an MVC-like split that stays easy to reason about:
 
@@ -137,7 +138,8 @@ scope.
   `src/server/services/`, and `src/web-v2/`.
 - Memory: `src/core/tools/toolkits/knowledge/`, `src/core/memory/`.
 - Architecture boundaries: `docs/architecture/core-layering.md`,
-  `docs/architecture/chat-layering.md`.
+  `docs/architecture/chat-layering.md`,
+  `docs/architecture/durable-state.md`.
 - Project direction: `docs/strategy/project-purpose.md`,
   `docs/strategy/framework-vision.md`.
 


### PR DESCRIPTION
## Summary

- inventory every production durable-state writer under src/core and src/server, with explicit exclusions for user workspace mutations and developer harness output
- define adopter-facing durability levels and a support matrix for refresh, process replacement, and replica replacement
- document completed-conversation durability as a valid production boundary without claiming durable in-flight execution
- link the architecture inventory and support matrix from the main documentation paths

## Supported production boundary

A hosted adopter can make completed conversations durable by providing remote ChatSessionRepository and ChatArchiveRepository implementations, plus committing any product-owned canonical result before reporting terminal success.

This does not require remote traces, memory, artifacts when the product already owns the canonical result, approvals, cancellation, SSE replay, MCP and skill activation, browser state, credentials, or a universal storage abstraction. Interrupted in-flight work must be reported honestly and retried from the last completed durable state.

## Key findings

- conversation sessions and compaction archives are the only remote-ready durable repositories today
- artifacts are host-replaceable but synchronous and lack atomic metadata/content/current-pointer semantics
- heartbeat, MCP, and skill activation expose narrower host-replaceable stores but do not promise distributed or remote durability
- traces need ordering, redaction, partial-failure, retention, and stable-address semantics before a remote port
- credentials, browser profiles, daemon discovery, and absolute-path workspace catalogs should remain machine-local
- active runs, pending approvals, cancellation ownership, and live stream replay remain process-local
- no universal storage abstraction or new adapter is introduced

## Validation

- yarn lint
- git diff --check
- all local links in the architecture inventory and support matrix resolve
- public diff contains no private integration names or schemas

Documentation-only change; no runtime code or generated index changed.