### PR TITLE
feat: add conversation persistence capability

### DIFF
--- a/docs/architecture/durable-state.md
+++ b/docs/architecture/durable-state.md
@@ -8,8 +8,8 @@ questions for each state surface:
 3. Which storage boundary can a programmatic host replace today?
 4. What corruption, atomicity, retention, or security constraints still apply?
 
-The inventory describes the `v5.1.0` implementation. Update it when adding a
-production writer, changing a persisted schema, or widening a repository
+The inventory describes the post-`v5.1.0` implementation. Update it when adding
+a production writer, changing a persisted schema, or widening a repository
 contract.
 
 For the shorter adopter-facing decision guide, see the
@@ -70,8 +70,7 @@ storage contract. The current extension surface is:
 
 | Domain | Injected surface | I/O and consistency shape | Current remote posture |
 | --- | --- | --- | --- |
-| Sessions | `ChatSessionRepository` on the conversation engine | Async CRUD, optimistic revisions, stable pagination, strict corruption behavior, and a conformance suite | **Remote-ready** when the host binds authenticated scope and operations |
-| Archives | `ChatArchiveRepository` on the conversation engine | Async read/append; one append atomically owns messages, summary, and manifest | **Remote-ready** when paired with the session repository's authenticated scope |
+| Conversations | `persistence.conversations`, containing `ChatSessionRepository` plus `ChatArchiveRepository` | Revisioned session CRUD/pagination plus atomic archive content/summary/manifest append | **Remote-ready as one capability** when the host binds both ports to the same authenticated scope and completes the readiness checks |
 | Artifacts | `ArtifactRepository` on the conversation engine | Synchronous catalog and text-content calls; no atomic catalog/content commit | **Host-replaceable**, not remote-ready |
 | Heartbeat | `HeartbeatTaskStore` passed to `runDueTasks` or `runLoop` | Async tasks/checkpoints/runs, but no revisions, distributed lease, multi-record transaction, or conformance suite; built-in `start` constructs the file service | **Host-replaceable scheduler primitive**, not a distributed durability promise |
 | MCP | `McpConfigStorePort`, `McpActivationStorePort`, and `McpCatalogStorePort` | Synchronous whole-document stores; activation/config authority differs from rebuildable discovery cache | **Host-replaceable for an in-process host**, not remote-ready |
@@ -79,6 +78,17 @@ storage contract. The current extension surface is:
 | All other rows | No general injected persistence port | Domain-specific files, diagnostics, secrets, or process coordination | Local/machine/process semantics remain authoritative |
 
 ## Remote-Ready Conversation State
+
+[`ConversationPersistence`](../../src/core/chat/engine/persistence/types.ts) groups sessions
+and compacted archives as one configuration capability. The engine resolves the
+pair once and exposes it at `engine.persistence.conversations` with a readiness
+report. The report catches missing or ambiguous configuration and enumerates
+the host-owned checks; it does not query or certify the database, auth, tenant
+scope, migrations, backup, or product finalization.
+
+The separate engine repository options remain as deprecated compatibility
+inputs. A partial legacy configuration can continue operating, but it is not a
+complete completed-conversation durability configuration.
 
 ### Sessions
 

--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -59,17 +59,19 @@ split between Heddle and the host explicit for developers and coding agents.
      state surfaces must follow a replica.
    - [Result artifacts](result-artifacts.md): save large generated values as
      reusable artifacts.
-   - Artifact, session, and compacted-history storage are injectable: implement
-     `ArtifactRepository` / `ChatSessionRepository` /
-     `ChatArchiveRepository` and pass them as `artifactRepository` /
-     `sessionRepository` / `archiveRepository` (see
+   - Artifact and conversation storage are injectable: implement
+     `ArtifactRepository`, plus the paired `ChatSessionRepository` and
+     `ChatArchiveRepository`. Pass artifacts independently and group the two
+     conversation ports under `persistence.conversations` (see
      [Conversation engine → Bring your own artifact storage](conversation-engine.md#bring-your-own-artifact-storage)
      and [Durable session storage](session-storage.md) for local JSON and
      PostgreSQL adapter guidance). The
      [runnable PostgreSQL + Drizzle reference](../../../examples/sdk/06-postgres-drizzle-storage/README.md)
      includes migrations, both repository implementations, public conformance,
      and fresh-service recovery.
-     Traces and memory still persist under a local state root. They have
+     The engine exposes a lightweight conversation-readiness report; real
+     infrastructure verification remains with the host. Traces and memory still
+     persist under a local state root. They have
      different authority and lifecycle requirements and are not implied by
      session/archive repository injection.
 

--- a/docs/guides/programmatic/conversation-engine.md
+++ b/docs/guides/programmatic/conversation-engine.md
@@ -181,11 +181,12 @@ family, and MCP host-extension result-artifact capture. `contentKey` owns
 content addressing — return whatever key your storage understands; it is stored
 as `RuntimeArtifact.path`.
 
-## Bring your own session storage
+## Bring your own conversation storage
 
 Sessions use an async, revisioned `ChatSessionRepository` port. Local products
 can keep the zero-configuration file adapter; hosted products can inject a
-record-oriented database adapter.
+record-oriented database adapter. A hosted completed-conversation promise must
+also inject the archive repository through the same conversation capability.
 
 ```ts
 import { createConversationEngine, type ChatSessionRepository } from '@roackb2/heddle'
@@ -197,16 +198,9 @@ const sessionRepository: ChatSessionRepository = {
   update: async (input) => compareAndSwapSession(input),
   delete: async (input) => compareAndSwapSessionDelete(input),
 }
-
-const engine = createConversationEngine({
-  workspaceRoot,
-  stateRoot,
-  model: 'gpt-5.4',
-  sessionRepository,
-})
 ```
 
-The injected repository is resolved once at the engine boundary and used for
+The session repository is used for
 session create/read/update/rename, turn preflight and persistence, lease
 acquisition/release, and background memory-maintenance writes. Session policy
 (leases, records, compaction state) stays inside Heddle — the repository only
@@ -216,12 +210,13 @@ silently lose a concurrent write.
 See [Durable session storage](session-storage.md) for the default JSON layout,
 the exact compare-and-swap behavior, and a PostgreSQL table/query shape.
 
-## Bring your own compacted-history storage
+### Complete the capability with compacted-history storage
 
 Long conversations archive exact messages and a cumulative rolling summary
-through the async `ChatArchiveRepository`. Hosted services should inject this
-beside `ChatSessionRepository`; otherwise the active session can reopen on a
-new replica while its compacted history still points at local files.
+through the async `ChatArchiveRepository`. Hosted services configure both
+repositories under `persistence.conversations`; otherwise the active session
+can reopen on a new replica while its compacted history still points at local
+files.
 
 ```ts
 import {
@@ -239,16 +234,23 @@ const engine = createConversationEngine({
   workspaceRoot,
   stateRoot,
   model: 'gpt-5.4',
-  sessionRepository,
-  archiveRepository,
+  persistence: {
+    conversations: {
+      sessions: sessionRepository,
+      archives: archiveRepository,
+    },
+  },
 })
 ```
 
 Bind both repositories to the same server-authenticated account/tenant scope.
-`append` must atomically expose the raw messages, summary, and returned
+The resolved pair and its non-certifying host checklist are available at
+`engine.persistence.conversations`. `append` must atomically expose the raw
+messages, summary, and returned
 manifest; Heddle will not persist compacted session state until it succeeds.
 See [Durable session storage](session-storage.md) for the complete contract,
 codec helpers, and a PostgreSQL shape.
 
-Traces and memory still persist under the state root today. Making them
-injectable follows the same port-per-domain pattern.
+Traces and memory still persist under the state root today. Any future
+persistence capability keeps its own domain contract rather than sharing a
+universal storage interface with conversations.

--- a/docs/guides/programmatic/durability-support.md
+++ b/docs/guides/programmatic/durability-support.md
@@ -13,7 +13,7 @@ contributor-facing [durable-state inventory](../../architecture/durable-state.md
 | Level | User-visible promise | Current Heddle support |
 | --- | --- | --- |
 | **Local durable** | Completed conversations survive browser refresh and process restart on one host | Supported by the default file repositories when `stateRoot` is on a persistent local filesystem |
-| **Completed-conversation durable** | After a turn finishes, another process or replica can reopen the conversation and continue with the same compacted context | Supported when the host injects remote `ChatSessionRepository` and `ChatArchiveRepository` implementations and durably commits any product-owned result before reporting success |
+| **Completed-conversation durable** | After a turn finishes, another process or replica can reopen the conversation and continue with the same compacted context | Supported when the host configures remote session and archive repositories together through `persistence.conversations` and durably commits any product-owned result before reporting success |
 | **Durable in-flight execution** | A run, approval wait, cancellation handle, and event replay survive the executor process dying | **Not provided.** Active runs, pending approvals, cancellation, and replay buffers are process-local; this requires host-selected queue/orchestration infrastructure and idempotent execution design |
 
 The completed-conversation level is a valid production boundary. A product does
@@ -46,24 +46,28 @@ from the last completed durable state.
 To promise that a user can return to a completed conversation and continue it
 after a server replacement, a host needs all of the following:
 
-1. **Remote session records.** Bind `ChatSessionRepository` to a trusted
+1. **One conversation persistence capability.** Configure
+   `persistence.conversations` with both repositories. Heddle exposes a
+   readiness report that detects incomplete/legacy configuration and enumerates
+   the remaining host checks; it does not certify infrastructure.
+2. **Remote session records.** Bind `ChatSessionRepository` to a trusted
    server-side identity scope and pass the repository conformance suite in the
    host's integration environment.
-2. **Remote compaction archives.** Bind `ChatArchiveRepository` to the same
+3. **Remote compaction archives.** Bind `ChatArchiveRepository` to the same
    identity scope and make each archive append transactional. This is required
    whenever a conversation may compact; session JSON alone cannot reconstruct
    removed exact history or the rolling summary.
-3. **Durable product truth.** If a turn changes host-owned domain state, persist
+4. **Durable product truth.** If a turn changes host-owned domain state, persist
    the canonical result before publishing terminal success. A durable
    conversation that claims an output changed while the product still stores
    the old value is not a successful durability design.
-4. **Durable user-facing projection when needed.** If the UI exposes a catalog
+5. **Durable user-facing projection when needed.** If the UI exposes a catalog
    or safe transcript, persist that product view separately instead of treating
    Heddle's complete model/tool record as a stable browser contract.
-5. **Identity, deletion, and operations.** Enforce tenant isolation in the
+6. **Identity, deletion, and operations.** Enforce tenant isolation in the
    adapter factory and database, define cascade/retention behavior, and own
    migrations, backups, monitoring, and disaster recovery.
-6. **Truthful interruption behavior.** If the executor dies before finalization,
+7. **Truthful interruption behavior.** If the executor dies before finalization,
    report the run as interrupted or failed. Do not reconstruct and replay a
    pending tool call or approval from partial evidence.
 

--- a/docs/guides/programmatic/session-storage.md
+++ b/docs/guides/programmatic/session-storage.md
@@ -7,9 +7,10 @@ them. Compacted raw transcripts and rolling summaries use a separate
 `ChatArchiveRepository` because their append-only lifecycle is different from
 revisioned active-session records.
 
-Use the default JSON adapters for one-machine/local-first products. Inject
-`ChatSessionRepository` and `ChatArchiveRepository` for hosted or multi-process
-products that already have a database.
+Use the default JSON adapters for one-machine/local-first products. For hosted
+or multi-process products, inject both repositories through the
+`persistence.conversations` capability so the completed-conversation boundary
+cannot be mistaken for a session-only configuration.
 
 For the exact boundary between local durability, completed-conversation
 durability, and durable in-flight execution, see the
@@ -35,19 +36,20 @@ To choose the catalog location explicitly:
 
 ```ts
 import { join } from 'node:path'
-import {
-  createConversationEngine,
-  FileChatSessionRepository,
-} from '@roackb2/heddle'
+import { createConversationEngine } from '@roackb2/heddle'
 
 const sessionStoragePath = join(dataDir, 'agent-sessions.catalog.json')
 const engine = createConversationEngine({
   workspaceRoot,
   stateRoot: dataDir,
   model: 'gpt-5.4',
-  sessionRepository: new FileChatSessionRepository({ sessionStoragePath }),
+  sessionStoragePath,
 })
 ```
+
+The separate `sessionRepository` and `archiveRepository` options remain for
+compatibility. New hosted integrations should use the complete conversation
+capability shown below.
 
 The file adapter serializes writers across processes and uses immutable session
 bodies plus atomic catalog replacement. Keep the directory on a filesystem
@@ -72,18 +74,11 @@ const sessionRepository: ChatSessionRepository = {
   update: async (input) => compareAndSwapSession(input),
   delete: async (input) => compareAndSwapSessionDelete(input),
 }
-
-const engine = createConversationEngine({
-  workspaceRoot,
-  stateRoot,
-  model: 'gpt-5.4',
-  sessionRepository,
-})
 ```
 
-For a hosted service, session storage alone is not complete durability. Inject
-the companion archive repository as well, bound to the same trusted server-side
-identity scope:
+For a hosted service, session storage alone is not complete durability. Build
+the companion archive repository from the same trusted server-side identity
+scope, then inject the pair as one capability:
 
 ```ts
 import {
@@ -127,10 +122,44 @@ const engine = createConversationEngine({
   workspaceRoot,
   stateRoot,
   model: 'gpt-5.4',
-  sessionRepository,
-  archiveRepository,
+  persistence: {
+    conversations: {
+      sessions: sessionRepository,
+      archives: archiveRepository,
+    },
+  },
 })
 ```
+
+The engine exposes the resolved repositories and a non-certifying readiness
+report at `engine.persistence.conversations`. To inspect a configuration before
+constructing the engine:
+
+```ts
+import { ConversationPersistenceService } from '@roackb2/heddle'
+
+const readiness = ConversationPersistenceService.assess({
+  persistence: {
+    conversations: {
+      sessions: sessionRepository,
+      archives: archiveRepository,
+    },
+  },
+})
+
+if (!readiness.configurationComplete) {
+  throw new Error(readiness.issues.map((issue) => issue.message).join('\n'))
+}
+
+for (const check of readiness.requiredHostChecks) {
+  console.log(`${check.id}: ${check.description}`)
+}
+```
+
+This report confirms configuration shape and identifies the focused host checks
+needed for the selected durability level. It does not query the database or
+certify auth/RLS, scope binding, migrations, backup, load, or disaster
+recovery. Keep those checks in the host or maintained adapter.
 
 `append` is the durability boundary: the exact messages, rolling summary, and
 returned manifest must become visible in one transaction. If it rejects,
@@ -363,8 +392,9 @@ the exact session adapter boundary and file-layout details. The archive port's
 separate ownership and atomicity rules are in its
 [`README.md`](../../../src/core/chat/engine/sessions/archives/README.md).
 
-The session conformance suite does not yet certify a custom archive adapter.
-Keep host integration tests for transactional append, malformed manifest
-rejection, fresh-instance rolling-summary recovery, missing summary content,
-and storage-failure propagation. The default file adapter exercises those same
-invariants in Heddle's integration suite.
+The session conformance suite does not certify a custom archive adapter. Keep a
+small set of host integration checks for transactional append, malformed
+manifest rejection, fresh-instance rolling-summary recovery, missing summary
+content, and storage-failure propagation. Add broader provider scenarios only
+when a real adapter exposes a portable correctness risk or a public support
+claim requires the evidence.

--- a/docs/project-posture.md
+++ b/docs/project-posture.md
@@ -7,10 +7,15 @@ small enough to route agents here instead of duplicating this document.
 
 ## Identity
 
-Heddle is a local-first TypeScript agent runtime and developer tool for durable
-coding-agent work. It combines a reusable execution loop, local tools,
-approvals, traces, saved sessions, memory, heartbeat tasks, and a browser
-control plane.
+Heddle builds composable building blocks that let product teams create their
+own trustworthy agentic experiences. An adopter should be able to start with a
+small working conversation agent, then progressively own more policy,
+persistence, tools, interfaces, and operations without replacing the runtime.
+
+The current implementation is a local-first TypeScript agent runtime and
+developer tool for durable coding-agent work. It combines a reusable execution
+loop, local tools, approvals, traces, saved sessions, memory, heartbeat tasks,
+and a browser control plane.
 
 The current proving ground is single-agent coding work. The broader direction
 is a general host framework for useful agent systems: environment access,
@@ -19,6 +24,9 @@ tooling, approval policy, memory, situation awareness, traces, and evaluation.
 ## Product Posture
 
 - Keep Heddle minimal, trace-first, and operator-controlled.
+- Make first adoption dead simple, then reveal coherent customization
+  boundaries as the host needs them; do not require product teams to assemble
+  low-level subsystems before their first useful agent turn.
 - Prefer observable state and explicit tools over hidden magic.
 - Let agents use intelligence to explain intent, but keep policy decisions in
   runtime/operator control.
@@ -63,7 +71,9 @@ tooling, approval policy, memory, situation awareness, traces, and evaluation.
   checkpoint reuse, and heartbeat task/run views.
 - `src/core/chat/engine/` owns persisted conversation sessions, turns,
   compaction, leases, approvals, traces, user-facing conversation activities,
-  and package-level programmatic use.
+  package-level programmatic use, and domain-specific persistence capability
+  composition/readiness. Its `persistence/` subdomain does not define one
+  universal storage or CRUD abstraction across domains.
 - `src/core/chat/` defines the shared chat boundary above the engine. It should
   stay small.
 - `src/core/tools/` owns tool definitions, registries, execution, and toolkits.
@@ -137,6 +147,8 @@ scope.
 - Control plane: `src/server/routes/`, `src/server/controllers/`,
   `src/server/services/`, and `src/web-v2/`.
 - Memory: `src/core/tools/toolkits/knowledge/`, `src/core/memory/`.
+- Conversation persistence capabilities and readiness:
+  `src/core/chat/engine/persistence/`.
 - Architecture boundaries: `docs/architecture/core-layering.md`,
   `docs/architecture/chat-layering.md`,
   `docs/architecture/durable-state.md`.

--- a/examples/sdk/06-postgres-drizzle-storage/README.md
+++ b/examples/sdk/06-postgres-drizzle-storage/README.md
@@ -106,10 +106,19 @@ const engine = createConversationEngine({
   workspaceRoot,
   stateRoot,
   model,
-  sessionRepository,
-  archiveRepository,
+  persistence: {
+    conversations: {
+      sessions: sessionRepository,
+      archives: archiveRepository,
+    },
+  },
 })
 ```
+
+`engine.persistence.conversations.readiness` confirms that the complete Heddle
+conversation boundary is configured and lists the remaining host-owned checks.
+It does not certify this scope, database, migrations, backup, or deployment;
+the verification script below exercises the provider-specific invariants.
 
 When copying these files into another project, replace the relative imports
 from `../../../src/index.js` with `@roackb2/heddle` and declare the dependencies

--- a/examples/sdk/06-postgres-drizzle-storage/verify.ts
+++ b/examples/sdk/06-postgres-drizzle-storage/verify.ts
@@ -159,8 +159,12 @@ async function verifyFreshServiceRecovery(
         stateRoot: firstStateRoot,
         model: 'gpt-5.4',
         memoryMaintenanceMode: 'none',
-        sessionRepository,
-        archiveRepository,
+        persistence: {
+          conversations: {
+            sessions: sessionRepository,
+            archives: archiveRepository,
+          },
+        },
       });
 
       const created = await engine.sessions.create({
@@ -214,8 +218,12 @@ async function verifyFreshServiceRecovery(
         stateRoot: secondStateRoot,
         model: 'gpt-5.4',
         memoryMaintenanceMode: 'none',
-        sessionRepository,
-        archiveRepository,
+        persistence: {
+          conversations: {
+            sessions: sessionRepository,
+            archives: archiveRepository,
+          },
+        },
       });
 
       assert.deepEqual(

--- a/examples/sdk/README.md
+++ b/examples/sdk/README.md
@@ -114,10 +114,12 @@ yarn example:postgres-storage:verify
 
 **Assumption:** the host already owns a PostgreSQL service and derives a trusted
 tenant/account scope from server authentication. The reference implements both
-Heddle repository ports, applies checked-in migrations, runs the public session
-conformance suite, and proves session plus archive recovery through fresh
-connection pools and engine instances. It is deliberately an example rather
-than an official adapter package.
+Heddle repository ports as one conversation persistence capability, applies
+checked-in migrations, runs the public session conformance suite, and proves
+session plus archive recovery through fresh connection pools and engine
+instances. The engine readiness report identifies the remaining host-owned
+checks. This is deliberately an example rather than an official adapter
+package.
 
 Read the [storage reference boundary](06-postgres-drizzle-storage/README.md)
 before copying it. This stage can be combined with any stage-05 transport or UI;

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -15,7 +15,10 @@ import {
   type StoredChatSession,
 } from '../../../core/chat/engine/sessions/repository/index.js';
 import type { ChatSession } from '../../../core/chat/types.js';
-import type { ChatArchiveRepository } from '../../../core/chat/engine/sessions/archives/index.js';
+import {
+  FileChatArchiveRepository,
+  type ChatArchiveRepository,
+} from '../../../core/chat/engine/sessions/archives/index.js';
 import {
   listChatSessionCatalog,
   readStoredChatSession,
@@ -212,6 +215,57 @@ describe('createConversationEngine', () => {
       archiveRepository,
       sessionId: session.id,
     }));
+  });
+
+  it('resolves a complete conversation persistence capability once for sessions and turns', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-engine-conversation-persistence-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const sessionStoragePath = join(workspaceRoot, 'hosted', 'sessions.catalog.json');
+    const sessionRepository = new FileChatSessionRepository({ sessionStoragePath });
+    const archiveRepository = new FileChatArchiveRepository({
+      stateRoot: join(workspaceRoot, 'hosted'),
+    });
+    const engine = createConversationEngine({
+      workspaceRoot,
+      stateRoot,
+      model: 'gpt-5.4',
+      apiKeyPresent: true,
+      persistence: {
+        conversations: {
+          sessions: sessionRepository,
+          archives: archiveRepository,
+        },
+      },
+    });
+
+    expect(engine.persistence.conversations).toEqual(expect.objectContaining({
+      sessions: sessionRepository,
+      archives: archiveRepository,
+      readiness: expect.objectContaining({
+        source: 'conversation-capability',
+        targetLevel: 'completed-conversation',
+        configurationComplete: true,
+      }),
+    }));
+
+    const session = await engine.sessions.create({
+      id: 'session-capability',
+      name: 'Conversation capability',
+    });
+    await engine.turns.submit({
+      sessionId: session.id,
+      prompt: 'Continue with the paired repositories',
+    });
+
+    await expect(sessionRepository.read(session.id)).resolves.toEqual(expect.objectContaining({
+      session: expect.objectContaining({ id: session.id }),
+    }));
+    expect(EngineConversationTurnService.run).toHaveBeenCalledWith(expect.objectContaining({
+      sessionRepository,
+      archiveRepository,
+      sessionId: session.id,
+    }));
+    expect(existsSync(join(stateRoot, 'chat-sessions.catalog.json'))).toBe(false);
   });
 
   it('roots the artifacts reader at a custom host-extension artifacts root', async () => {

--- a/src/__tests__/unit/core/conversation-persistence.test.ts
+++ b/src/__tests__/unit/core/conversation-persistence.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
+import type { ChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
+import {
+  ConversationPersistenceService,
+} from '@/core/chat/engine/persistence/index.js';
+
+describe('ConversationPersistenceService', () => {
+  it('describes the default file capability as a complete local configuration', () => {
+    expect(ConversationPersistenceService.assess()).toEqual({
+      source: 'default-files',
+      targetLevel: 'local',
+      configurationComplete: true,
+      issues: [],
+      requiredHostChecks: [
+        expect.objectContaining({ id: 'persistent-state-root' }),
+        expect.objectContaining({ id: 'backup-and-restore' }),
+      ],
+    });
+  });
+
+  it('describes a complete conversation capability without certifying the host', () => {
+    const readiness = ConversationPersistenceService.assess({
+      persistence: {
+        conversations: {
+          sessions: createSessionRepository(),
+          archives: createArchiveRepository(),
+        },
+      },
+    });
+
+    expect(readiness).toEqual(expect.objectContaining({
+      source: 'conversation-capability',
+      targetLevel: 'completed-conversation',
+      configurationComplete: true,
+      issues: [],
+    }));
+    expect(readiness.requiredHostChecks.map((check) => check.id)).toEqual([
+      'same-authenticated-scope',
+      'session-revision-conflicts',
+      'atomic-archive-append',
+      'fresh-instance-compaction-recovery',
+      'identity-isolation-and-deletion',
+      'product-finalization-before-success',
+    ]);
+  });
+
+  it('reports a partial legacy configuration without breaking compatibility', () => {
+    const readiness = ConversationPersistenceService.assess({
+      sessionRepository: createSessionRepository(),
+    });
+
+    expect(readiness).toEqual(expect.objectContaining({
+      source: 'legacy-repositories',
+      targetLevel: 'completed-conversation',
+      configurationComplete: false,
+    }));
+    expect(readiness.issues).toEqual([
+      expect.objectContaining({
+        code: 'legacy-repository-options',
+        severity: 'warning',
+      }),
+      expect.objectContaining({
+        code: 'archive-repository-missing',
+        severity: 'error',
+      }),
+    ]);
+  });
+
+  it('rejects mixing the coherent capability with legacy repository options', () => {
+    const sessions = createSessionRepository();
+    const archives = createArchiveRepository();
+
+    expect(() => ConversationPersistenceService.assess({
+      persistence: {
+        conversations: { sessions, archives },
+      },
+      sessionRepository: sessions,
+    })).toThrow(
+      'persistence.conversations cannot be combined with the deprecated sessionRepository or archiveRepository options.',
+    );
+  });
+});
+
+function createSessionRepository(): ChatSessionRepository {
+  return {
+    list: async () => ({ items: [] }),
+    read: async () => undefined,
+    create: async (session) => ({ session, revision: 1 }),
+    update: async () => undefined,
+    delete: async () => false,
+  };
+}
+
+function createArchiveRepository(): ChatArchiveRepository {
+  return {
+    loadManifest: async (sessionId) => ({ version: 1, sessionId, archives: [] }),
+    readSummary: async () => undefined,
+    append: async () => {
+      throw new Error('Not used by readiness assessment.');
+    },
+  };
+}

--- a/src/__tests__/unit/core/import-boundaries.test.ts
+++ b/src/__tests__/unit/core/import-boundaries.test.ts
@@ -28,6 +28,7 @@ const FORBIDDEN_PRODUCTION_TOKENS = [
 ];
 
 const PUBLIC_EXPORT_EXPECTATIONS = [
+  'ConversationPersistenceService',
   'createConversationEngine',
   'defineHostExtension',
   'EngineConversationTurnService',

--- a/src/__tests__/unit/core/quickstart-conversation-cli-runner.test.ts
+++ b/src/__tests__/unit/core/quickstart-conversation-cli-runner.test.ts
@@ -9,6 +9,8 @@ import {
   resolveQuickstartConversationCliDefaults,
   runQuickstartConversationCli,
 } from '@/core/chat/engine/index.js';
+import { FileChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
+import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
 
 class CaptureOutput extends Writable {
   private readonly chunks: string[] = [];
@@ -161,6 +163,32 @@ describe('runQuickstartConversationCli', () => {
     await run;
 
     expect(output.text()).toContain(`Session: ${session.id}`);
+  });
+
+  it('passes a complete conversation persistence capability into the quickstart engine', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-quickstart-cli-persistence-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const hostedStateRoot = join(workspaceRoot, 'hosted');
+    const sessions = new FileChatSessionRepository({
+      sessionStoragePath: join(hostedStateRoot, 'sessions.catalog.json'),
+    });
+    const archives = new FileChatArchiveRepository({ stateRoot: hostedStateRoot });
+
+    await runQuickstartConversationCli({
+      prompts: ['/exit'],
+      credentialPreflight: false,
+      model: 'gpt-test',
+      output: new CaptureOutput(),
+      persistence: {
+        conversations: { sessions, archives },
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+
+    await expect(sessions.list({ limit: 10 })).resolves.toEqual(expect.objectContaining({
+      items: [expect.objectContaining({ name: 'Heddle SDK interactive chat' })],
+    }));
   });
 
   it('prints a generic credential status before entering the loop', async () => {

--- a/src/core/chat/engine/config.ts
+++ b/src/core/chat/engine/config.ts
@@ -1,7 +1,6 @@
 import { join, resolve } from 'node:path';
 import { FileArtifactRepository } from '@/core/artifacts/index.js';
 import type { ArtifactRepository } from '@/core/artifacts/index.js';
-import { FileChatSessionRepository } from './sessions/repository/index.js';
 import type { ChatSessionRepository } from './sessions/repository/index.js';
 import type { ChatArchiveRepository } from './sessions/archives/index.js';
 import type { ToolApprovalPolicy } from '../../approvals/types.js';
@@ -12,6 +11,12 @@ import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
 import { ConversationEngineHostExtensionService } from './host-extension.js';
 import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
+import {
+  ConversationPersistenceService,
+} from './persistence/conversation-persistence.js';
+import type {
+  ResolvedHeddlePersistenceCapabilities,
+} from './persistence/index.js';
 
 export type NormalizedConversationEngineConfig = {
   workspaceRoot: string;
@@ -34,7 +39,8 @@ export type NormalizedConversationEngineConfig = {
   artifactsEnabled: boolean;
   sessionStoragePath: string;
   sessionRepository: ChatSessionRepository;
-  archiveRepository?: ChatArchiveRepository;
+  archiveRepository: ChatArchiveRepository;
+  persistence: ResolvedHeddlePersistenceCapabilities;
   memoryDir: string;
   traceDir: string;
   workspaceId?: string;
@@ -45,9 +51,16 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
   const workspaceRoot = resolve(config.workspaceRoot);
   const stateRoot = resolve(config.stateRoot);
   const sessionStoragePath = resolve(config.sessionStoragePath ?? join(stateRoot, 'chat-sessions.catalog.json'));
-  // Resolve session persistence once at the engine boundary; session and turn
-  // services receive this instance instead of re-deriving storage from paths.
-  const sessionRepository = config.sessionRepository ?? new FileChatSessionRepository({ sessionStoragePath });
+  // Resolve conversation persistence once at the engine boundary. New hosts
+  // configure the coherent capability; older separate options remain a
+  // compatibility path and receive an explicit readiness disposition.
+  const persistence = ConversationPersistenceService.resolve({
+    persistence: config.persistence,
+    sessionRepository: config.sessionRepository,
+    archiveRepository: config.archiveRepository,
+    sessionStoragePath,
+    stateRoot,
+  });
   const memoryDir = resolve(config.memoryDir ?? join(stateRoot, 'memory'));
   const traceDir = resolve(join(stateRoot, 'traces'));
   const hostExtensions = ConversationEngineHostExtensionService.compose(config.hostExtensions);
@@ -85,8 +98,9 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     artifactRepository,
     artifactsEnabled: hostExtensions?.artifacts?.enabled ?? true,
     sessionStoragePath,
-    sessionRepository,
-    archiveRepository: config.archiveRepository,
+    sessionRepository: persistence.conversations.sessions,
+    archiveRepository: persistence.conversations.archives,
+    persistence,
     memoryDir,
     traceDir,
     workspaceId: config.workspaceId,

--- a/src/core/chat/engine/conversation-engine.ts
+++ b/src/core/chat/engine/conversation-engine.ts
@@ -10,6 +10,7 @@ export function createConversationEngine(config: ConversationEngineConfig): Conv
   return {
     sessions: new FileConversationSessionService(normalizedConfig),
     turns: new EngineConversationTurnService(normalizedConfig),
+    persistence: normalizedConfig.persistence,
     artifacts: new ArtifactService({ repository: normalizedConfig.artifactRepository }),
   };
 }

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -1,4 +1,19 @@
 export { createConversationEngine } from './conversation-engine.js';
+export { ConversationPersistenceService } from './persistence/index.js';
+export type {
+  ConversationPersistence,
+  ConversationPersistenceConfiguration,
+  ConversationPersistenceReadinessCheck,
+  ConversationPersistenceReadinessCheckId,
+  ConversationPersistenceReadinessIssue,
+  ConversationPersistenceReadinessIssueCode,
+  ConversationPersistenceReadinessReport,
+  ConversationPersistenceReadinessSource,
+  ConversationPersistenceTargetLevel,
+  HeddlePersistenceCapabilities,
+  ResolvedConversationPersistence,
+  ResolvedHeddlePersistenceCapabilities,
+} from './persistence/index.js';
 export {
   QuickstartConversationCliRunnerService,
   resolveQuickstartConversationCliDefaults,

--- a/src/core/chat/engine/persistence/README.md
+++ b/src/core/chat/engine/persistence/README.md
@@ -1,0 +1,41 @@
+# Persistence Capability Composition
+
+This service boundary composes Heddle-owned persistence domains without
+pretending that they share one storage contract.
+
+## Ownership
+
+- A domain capability groups ports that must be configured and reasoned about
+  together for one user-facing promise.
+- `ConversationPersistence` groups the revisioned session repository and the
+  append-only compaction archive repository. Heddle owns their domain semantics
+  and default local implementations.
+- A host owns authenticated scope, database transactions, schema/migrations,
+  retention, backup/restore, and any canonical product result.
+
+`HeddlePersistenceCapabilities` is a discoverable composition map. It is not a
+universal CRUD interface. Future artifact, trace, or other capabilities must
+retain their own identities, consistency, data-size, retention, and security
+semantics.
+
+## Readiness boundary
+
+`ConversationPersistenceService.assess(...)` reports whether the Heddle
+conversation boundary is configured completely and returns the small set of
+host checks needed to support the selected durability level. It does not run
+database writes and does not certify authentication, deployment topology,
+backups, or disaster recovery.
+
+Add another automated readiness scenario only when a real adapter exposes a
+portable correctness risk or a public support claim needs that evidence. Keep
+provider-specific load, migration, RLS, and recovery tests with the maintained
+binding or host service.
+
+## Compatibility
+
+Heddle 5.1's separate `sessionRepository` and `archiveRepository` engine options
+remain as deprecated compatibility inputs. New hosts should configure
+`persistence.conversations`; the capability form requires both repositories and
+cannot be mixed with the older options. A legacy partial configuration remains
+operational for compatibility but readiness reports it as incomplete for a
+completed-conversation durability promise.

--- a/src/core/chat/engine/persistence/conversation-persistence.ts
+++ b/src/core/chat/engine/persistence/conversation-persistence.ts
@@ -1,0 +1,186 @@
+import { FileChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
+import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
+import type {
+  ConversationPersistence,
+  ConversationPersistenceConfiguration,
+  ConversationPersistenceReadinessCheck,
+  ConversationPersistenceReadinessIssue,
+  ConversationPersistenceReadinessReport,
+  ResolvedHeddlePersistenceCapabilities,
+} from './types.js';
+
+const LOCAL_HOST_CHECKS: ConversationPersistenceReadinessCheck[] = [
+  {
+    id: 'persistent-state-root',
+    description: 'Keep stateRoot on a persistent local filesystem with normal locking and atomic rename semantics.',
+  },
+  {
+    id: 'backup-and-restore',
+    description: 'Verify backup and restore for the complete local stateRoot before relying on it as user-owned durable state.',
+  },
+];
+
+const COMPLETED_CONVERSATION_HOST_CHECKS: ConversationPersistenceReadinessCheck[] = [
+  {
+    id: 'same-authenticated-scope',
+    description: 'Construct both repositories from the same trusted server-side identity scope.',
+  },
+  {
+    id: 'session-revision-conflicts',
+    description: 'Verify that concurrent session writers cannot silently overwrite a newer revision.',
+  },
+  {
+    id: 'atomic-archive-append',
+    description: 'Verify that archive content, rolling summary, and manifest become visible atomically.',
+  },
+  {
+    id: 'fresh-instance-compaction-recovery',
+    description: 'Force compaction and continue from the recovered session and rolling summary in a fresh process or replica.',
+  },
+  {
+    id: 'identity-isolation-and-deletion',
+    description: 'Verify cross-identity isolation plus documented deletion, retention, migration, and backup behavior.',
+  },
+  {
+    id: 'product-finalization-before-success',
+    description: 'Commit any host-owned canonical result before publishing terminal success.',
+  },
+];
+
+type ResolveConversationPersistenceInput = ConversationPersistenceConfiguration & {
+  sessionStoragePath: string;
+  stateRoot: string;
+};
+
+/**
+ * Owns conversation persistence capability validation, compatibility
+ * resolution, local defaults, and non-certifying readiness evidence.
+ */
+export class ConversationPersistenceService {
+  static assess(
+    configuration: ConversationPersistenceConfiguration = {},
+  ): ConversationPersistenceReadinessReport {
+    const conversations = configuration.persistence?.conversations;
+    ConversationPersistenceService.assertValidCapability(conversations);
+    ConversationPersistenceService.assertUnambiguousConfiguration(configuration);
+
+    if (conversations) {
+      return {
+        source: 'conversation-capability',
+        targetLevel: 'completed-conversation',
+        configurationComplete: true,
+        issues: [],
+        requiredHostChecks: ConversationPersistenceService.cloneChecks(
+          COMPLETED_CONVERSATION_HOST_CHECKS,
+        ),
+      };
+    }
+
+    const hasSessionRepository = Boolean(configuration.sessionRepository);
+    const hasArchiveRepository = Boolean(configuration.archiveRepository);
+    if (!hasSessionRepository && !hasArchiveRepository) {
+      return {
+        source: 'default-files',
+        targetLevel: 'local',
+        configurationComplete: true,
+        issues: [],
+        requiredHostChecks: ConversationPersistenceService.cloneChecks(LOCAL_HOST_CHECKS),
+      };
+    }
+
+    return {
+      source: 'legacy-repositories',
+      targetLevel: 'completed-conversation',
+      configurationComplete: hasSessionRepository && hasArchiveRepository,
+      issues: ConversationPersistenceService.legacyIssues({
+        hasArchiveRepository,
+        hasSessionRepository,
+      }),
+      requiredHostChecks: ConversationPersistenceService.cloneChecks(
+        COMPLETED_CONVERSATION_HOST_CHECKS,
+      ),
+    };
+  }
+
+  static resolve(
+    input: ResolveConversationPersistenceInput,
+  ): ResolvedHeddlePersistenceCapabilities {
+    const readiness = ConversationPersistenceService.assess(input);
+    const conversations = input.persistence?.conversations
+      ?? ConversationPersistenceService.resolveCompatibilityRepositories(input);
+
+    return {
+      conversations: {
+        ...conversations,
+        readiness,
+      },
+    };
+  }
+
+  private static legacyIssues(args: {
+    hasArchiveRepository: boolean;
+    hasSessionRepository: boolean;
+  }): ConversationPersistenceReadinessIssue[] {
+    return [
+      {
+        code: 'legacy-repository-options',
+        severity: 'warning',
+        message: 'Configure persistence.conversations for new hosts; separate repository options remain for compatibility.',
+      },
+      ...(!args.hasSessionRepository ? [{
+        code: 'session-repository-missing' as const,
+        severity: 'error' as const,
+        message: 'A custom archive repository without its paired session repository cannot support completed-conversation durability.',
+      }] : []),
+      ...(!args.hasArchiveRepository ? [{
+        code: 'archive-repository-missing' as const,
+        severity: 'error' as const,
+        message: 'A custom session repository without its paired archive repository cannot support completed-conversation durability after compaction.',
+      }] : []),
+    ];
+  }
+
+  private static resolveCompatibilityRepositories(
+    input: ResolveConversationPersistenceInput,
+  ): ConversationPersistence {
+    return {
+      sessions: input.sessionRepository ?? new FileChatSessionRepository({
+        sessionStoragePath: input.sessionStoragePath,
+      }),
+      archives: input.archiveRepository ?? new FileChatArchiveRepository({
+        stateRoot: input.stateRoot,
+      }),
+    };
+  }
+
+  private static assertValidCapability(
+    conversations: ConversationPersistence | undefined,
+  ): void {
+    if (!conversations) {
+      return;
+    }
+
+    if (!conversations.sessions || !conversations.archives) {
+      throw new Error('persistence.conversations requires both sessions and archives repositories.');
+    }
+  }
+
+  private static assertUnambiguousConfiguration(
+    configuration: ConversationPersistenceConfiguration,
+  ): void {
+    if (
+      configuration.persistence?.conversations
+      && (configuration.sessionRepository || configuration.archiveRepository)
+    ) {
+      throw new Error(
+        'persistence.conversations cannot be combined with the deprecated sessionRepository or archiveRepository options.',
+      );
+    }
+  }
+
+  private static cloneChecks(
+    checks: ConversationPersistenceReadinessCheck[],
+  ): ConversationPersistenceReadinessCheck[] {
+    return checks.map((check) => ({ ...check }));
+  }
+}

--- a/src/core/chat/engine/persistence/index.ts
+++ b/src/core/chat/engine/persistence/index.ts
@@ -1,0 +1,17 @@
+export {
+  ConversationPersistenceService,
+} from './conversation-persistence.js';
+export type {
+  ConversationPersistence,
+  ConversationPersistenceConfiguration,
+  ConversationPersistenceReadinessCheck,
+  ConversationPersistenceReadinessCheckId,
+  ConversationPersistenceReadinessIssue,
+  ConversationPersistenceReadinessIssueCode,
+  ConversationPersistenceReadinessReport,
+  ConversationPersistenceReadinessSource,
+  ConversationPersistenceTargetLevel,
+  HeddlePersistenceCapabilities,
+  ResolvedConversationPersistence,
+  ResolvedHeddlePersistenceCapabilities,
+} from './types.js';

--- a/src/core/chat/engine/persistence/types.ts
+++ b/src/core/chat/engine/persistence/types.ts
@@ -1,0 +1,88 @@
+import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
+import type { ChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
+
+/**
+ * Complete persistence boundary for one conversation domain.
+ *
+ * Session records and compacted archives have different storage contracts but
+ * must be configured together for a truthful completed-conversation promise.
+ */
+export type ConversationPersistence = {
+  sessions: ChatSessionRepository;
+  archives: ChatArchiveRepository;
+};
+
+/**
+ * Discoverable persistence capabilities configured for a Heddle runtime.
+ *
+ * Future domains may add their own capability without sharing a CRUD contract
+ * with conversations. This map is composition, not a universal storage port.
+ */
+export type HeddlePersistenceCapabilities = {
+  conversations?: ConversationPersistence;
+};
+
+export type ConversationPersistenceConfiguration = {
+  persistence?: HeddlePersistenceCapabilities;
+  /** Compatibility input for Heddle 5.1 and earlier hosts. */
+  sessionRepository?: ChatSessionRepository;
+  /** Compatibility input for Heddle 5.1 and earlier hosts. */
+  archiveRepository?: ChatArchiveRepository;
+};
+
+export type ConversationPersistenceReadinessSource =
+  | 'default-files'
+  | 'conversation-capability'
+  | 'legacy-repositories';
+
+export type ConversationPersistenceTargetLevel =
+  | 'local'
+  | 'completed-conversation';
+
+export type ConversationPersistenceReadinessIssueCode =
+  | 'legacy-repository-options'
+  | 'session-repository-missing'
+  | 'archive-repository-missing';
+
+export type ConversationPersistenceReadinessIssue = {
+  code: ConversationPersistenceReadinessIssueCode;
+  severity: 'warning' | 'error';
+  message: string;
+};
+
+export type ConversationPersistenceReadinessCheckId =
+  | 'persistent-state-root'
+  | 'backup-and-restore'
+  | 'same-authenticated-scope'
+  | 'session-revision-conflicts'
+  | 'atomic-archive-append'
+  | 'fresh-instance-compaction-recovery'
+  | 'identity-isolation-and-deletion'
+  | 'product-finalization-before-success';
+
+export type ConversationPersistenceReadinessCheck = {
+  id: ConversationPersistenceReadinessCheckId;
+  description: string;
+};
+
+/**
+ * Configuration evidence only—not a database, auth, or disaster-recovery
+ * certification. `configurationComplete` confirms that the selected Heddle
+ * domain boundary is present; the host checks still require real deployment
+ * evidence.
+ */
+export type ConversationPersistenceReadinessReport = {
+  source: ConversationPersistenceReadinessSource;
+  targetLevel: ConversationPersistenceTargetLevel;
+  configurationComplete: boolean;
+  issues: ConversationPersistenceReadinessIssue[];
+  requiredHostChecks: ConversationPersistenceReadinessCheck[];
+};
+
+export type ResolvedConversationPersistence = ConversationPersistence & {
+  readiness: ConversationPersistenceReadinessReport;
+};
+
+export type ResolvedHeddlePersistenceCapabilities = {
+  conversations: ResolvedConversationPersistence;
+};

--- a/src/core/chat/engine/quickstart-cli/service.ts
+++ b/src/core/chat/engine/quickstart-cli/service.ts
@@ -62,6 +62,7 @@ export class QuickstartConversationCliRunnerService {
       tools: options.tools,
       hostExtensions: options.hostExtensions,
       artifactRepository: options.artifactRepository,
+      persistence: options.persistence,
       sessionRepository: options.sessionRepository,
       archiveRepository: options.archiveRepository,
     });

--- a/src/core/chat/engine/quickstart-cli/types.ts
+++ b/src/core/chat/engine/quickstart-cli/types.ts
@@ -10,6 +10,7 @@ import type { ConversationEngine } from '../types.js';
 import type { ChatSession } from '../../types.js';
 import type { ConversationTurnResultSummary } from '../turn-result.js';
 import type { ConversationEngineHost, ConversationEngineHostExtension } from '../types.js';
+import type { HeddlePersistenceCapabilities } from '../persistence/index.js';
 
 export type QuickstartConversationCliMemoryMaintenanceMode = 'none' | 'background' | 'inline';
 
@@ -71,7 +72,10 @@ export type QuickstartConversationCliRunnerOptions = {
   tools?: ToolDefinition[];
   hostExtensions?: ConversationEngineHostExtension[];
   artifactRepository?: ArtifactRepository;
+  persistence?: HeddlePersistenceCapabilities;
+  /** @deprecated Use `persistence.conversations.sessions`. */
   sessionRepository?: ChatSessionRepository;
+  /** @deprecated Use `persistence.conversations.archives`. */
   archiveRepository?: ChatArchiveRepository;
   host?: ConversationEngineHost;
   localCommands?: QuickstartConversationCliLocalCommand[];

--- a/src/core/chat/engine/sessions/archives/README.md
+++ b/src/core/chat/engine/sessions/archives/README.md
@@ -24,9 +24,15 @@ lifecycle, authenticated tenant/session scope, transaction, schema, retention,
 backup, and restore.
 
 The host must bind `ChatSessionRepository` and `ChatArchiveRepository` to the
-same authenticated identity scope. Heddle intentionally does not accept a user
-or tenant id on individual archive operations; trusting caller-provided scope
+same authenticated identity scope and configure them together through
+`persistence.conversations`. Heddle intentionally does not accept a user or
+tenant id on individual archive operations; trusting caller-provided scope
 would weaken the storage boundary.
+
+The capability readiness report confirms only that both Heddle ports are
+present and lists the host checks still required. It cannot prove that two
+arbitrary adapters use the same scope, transaction system, migration, backup,
+or deletion policy.
 
 ## File adapter durability
 

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -24,6 +24,10 @@ import type { ConversationTurnResultSummary } from './turn-result.js';
 import type { ConversationCompactionResult } from '@/core/chat/engine/compaction/index.js';
 import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
 import type {
+  HeddlePersistenceCapabilities,
+  ResolvedHeddlePersistenceCapabilities,
+} from './persistence/index.js';
+import type {
   ConversationEngineHostExtension,
   ConversationEngineHostExtensionBundle,
   ConversationEngineHostExtensionInput,
@@ -60,15 +64,27 @@ export type ConversationEngineConfig = {
    */
   artifactRepository?: ArtifactRepository;
   /**
+   * Domain persistence capabilities configured as coherent units. New hosted
+   * conversation integrations should provide both session and archive
+   * repositories through `persistence.conversations`.
+   */
+  persistence?: HeddlePersistenceCapabilities;
+  /**
    * Custom session persistence for hosted services. When set, session
    * create/read/update, turn preflight/persistence, leases, and background
    * memory-maintenance writes all flow through this repository instead of the
    * file catalog under the state root.
+   *
+   * @deprecated Use `persistence.conversations.sessions` together with the
+   * paired archive repository.
    */
   sessionRepository?: ChatSessionRepository;
   /**
    * Durable storage for compacted raw transcripts, rolling summaries, and
    * archive manifests. Locators remain server-side and repository-owned.
+   *
+   * @deprecated Use `persistence.conversations.archives` together with the
+   * paired session repository.
    */
   archiveRepository?: ChatArchiveRepository;
 };
@@ -80,6 +96,8 @@ export type { ConversationEngineHostExtension };
 export type ConversationEngine = {
   sessions: ConversationSessionService;
   turns: ConversationTurnService;
+  /** Resolved domain persistence capabilities and readiness evidence. */
+  persistence: ResolvedHeddlePersistenceCapabilities;
   /**
    * Read/inspect artifacts saved during turns (e.g. for a host `/artifacts`
    * review command) without reconstructing the on-disk artifact root. Backed by

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export type {
   QuickstartConversationCliTurnContext,
 } from './core/chat/engine/quickstart-cli/index.js';
 export { createConversationEngine } from './core/chat/engine/conversation-engine.js';
+export { ConversationPersistenceService } from './core/chat/engine/persistence/index.js';
 export { DEFAULT_OPENAI_MODEL, DEFAULT_ANTHROPIC_MODEL } from './core/config.js';
 
 // ---------------------------------------------------------------------------
@@ -203,6 +204,20 @@ export type {
   SubmitConversationTurnResult,
   UpdateConversationSessionSettingsInput,
 } from './core/chat/engine/types.js';
+export type {
+  ConversationPersistence,
+  ConversationPersistenceConfiguration,
+  ConversationPersistenceReadinessCheck,
+  ConversationPersistenceReadinessCheckId,
+  ConversationPersistenceReadinessIssue,
+  ConversationPersistenceReadinessIssueCode,
+  ConversationPersistenceReadinessReport,
+  ConversationPersistenceReadinessSource,
+  ConversationPersistenceTargetLevel,
+  HeddlePersistenceCapabilities,
+  ResolvedConversationPersistence,
+  ResolvedHeddlePersistenceCapabilities,
+} from './core/chat/engine/persistence/index.js';
 export { EngineConversationTurnService } from './core/chat/engine/turns/service.js';
 export type { RuntimeToolSelectionProfile, ToolCapability } from './core/runtime/tools/index.js';
 export type {


### PR DESCRIPTION
## Summary

- add a coherent `persistence.conversations` capability that groups the revisioned session repository with the compaction archive repository
- expose the resolved capability and a lightweight, non-certifying readiness report from the conversation engine
- preserve the Heddle 5.1 separate repository options as deprecated compatibility inputs while detecting incomplete or ambiguous configurations
- carry the capability through the SDK quickstart and update the PostgreSQL + Drizzle recovery reference
- record the progressive-adoption mission and the boundary against a universal storage abstraction in public project guidance

## Why

A host can only promise that a completed conversation survives process or replica replacement when sessions and compacted archives follow the same authenticated durability boundary. Configuring the ports independently made it easy to build a session-only integration that looked complete until compaction.

The readiness surface intentionally stays small: it checks Heddle configuration shape and lists the focused evidence a host still owns. It does not attempt to certify a database, auth/RLS, migrations, backup, load, or disaster recovery.

## Compatibility

- Existing `sessionRepository` and `archiveRepository` inputs continue to work.
- Default file persistence remains zero-configuration.
- A legacy partial configuration remains operational, but readiness reports it as incomplete for completed-conversation durability.
- New capability configuration cannot be mixed with the deprecated options.

## Verification

- `yarn test:unit` — 119 files, 709 tests
- `yarn test:integration` — 34 files, 310 tests
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- built-root export smoke for `ConversationPersistenceService`
- PostgreSQL + Drizzle migration and reference verification, including fresh-engine compaction recovery
