### PR TITLE
feat: add headless conversation agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,26 +62,34 @@ Install the Node runtime package:
 npm install @roackb2/heddle
 ```
 
-Then start a persisted interactive conversation:
+Then send a structured turn through a persisted conversation:
 
 ```ts
-import { runQuickstartConversationCli } from '@roackb2/heddle'
+import { ConversationAgentService } from '@roackb2/heddle'
 
-await runQuickstartConversationCli()
+const agent = new ConversationAgentService()
+const result = await agent.send({
+  prompt: 'Summarize this project and identify the main verification path.',
+})
+
+console.log(result.summary)
+console.log(result.activities)
 ```
 
-The quickstart resolves the workspace, local state root, configured model, and
-credential before opening the prompt loop. It is intentionally smaller than
-Heddle's product CLI and is the shortest path for evaluating the SDK.
+The headless service resolves the workspace, local state root, configured
+model, and credential; race-safely ensures one stable durable session; and
+returns structured activities plus Heddle's normal turn result. It does not
+choose a UI, transport, auth system, or product transaction.
 
 Run the corresponding repository example with:
 
 ```bash
-yarn example:sdk:interactive
+yarn example:sdk:headless "What does this project do?"
 ```
 
-See the [SDK quickstart](docs/guides/programmatic/quickstart.md) for model,
-credential, prompt, command, and host-extension options.
+Use `runQuickstartConversationCli()` when you also want Heddle to provide a
+temporary terminal prompt loop and text rendering. See the
+[SDK quickstart](docs/guides/programmatic/quickstart.md) for both paths.
 
 ### Own presentation and turn lifecycle
 
@@ -166,7 +174,8 @@ that already owns the mechanics your host needs:
 
 | Host need | Start with | What it adds |
 | --- | --- | --- |
-| A working local conversation | `runQuickstartConversationCli` | Prompt loop, persisted session, credentials, and text output |
+| A structured local conversation | `ConversationAgentService` | Runtime defaults, stable session ensure, structured activities, and turn result |
+| A terminal SDK evaluation | `runQuickstartConversationCli` | Prompt loop, persisted session, credentials, and text output |
 | Custom output, tools, or session UX | `@roackb2/heddle` | Conversation engine, host extensions, tools, MCP, approvals, artifacts, and turn results |
 | A server, worker, or Electron backend | `@roackb2/heddle/hosted` | Addressable process-local runs, replay, cancellation, and approval resolution |
 | Conventional Node HTTP/SSE | `@roackb2/heddle/hosted/http-sse` | Replay cursor parsing, SSE framing, backpressure, and disconnect cleanup |
@@ -182,8 +191,9 @@ Do not install Express or React merely because a reference example uses them.
 
 The runnable examples teach customization in small steps:
 
-1. [Interactive chat](examples/sdk/01-interactive-chat.ts) — start a persisted
-   conversation.
+1. [Headless conversation](examples/sdk/01-headless-conversation.ts) — send a
+   structured turn through a persisted session; or use
+   [interactive chat](examples/sdk/01-interactive-chat.ts) for a terminal loop.
 2. [Add a tool](examples/sdk/02-add-a-tool.ts) — expose native product
    behavior.
 3. [Add an MCP server](examples/sdk/03-add-an-mcp-server.ts) — prepare curated

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -56,25 +56,33 @@ chat endpoint 的情境。
 npm install @roackb2/heddle
 ```
 
-接著啟動一個可持久化的互動式對話：
+接著透過可持久化對話送出一個 structured turn：
 
 ```ts
-import { runQuickstartConversationCli } from '@roackb2/heddle'
+import { ConversationAgentService } from '@roackb2/heddle'
 
-await runQuickstartConversationCli()
+const agent = new ConversationAgentService()
+const result = await agent.send({
+  prompt: '整理這個專案，並指出主要的驗證路徑。',
+})
+
+console.log(result.summary)
+console.log(result.activities)
 ```
 
-Quickstart 會在開啟 prompt loop 前，解析 workspace、本機 state root、已設定的
-model 與 credential。它刻意比 Heddle 完整產品 CLI 更小，是評估 SDK 最短的
-路徑。
+Headless service 會解析 workspace、本機 state root、已設定的 model 與
+credential，race-safe 地 ensure 一個穩定的 durable session，並回傳
+structured activities 與 Heddle 原本的 turn result。它不會替產品選擇 UI、
+transport、auth system 或 product transaction。
 
 在此 repository 中執行對應範例：
 
 ```bash
-yarn example:sdk:interactive
+yarn example:sdk:headless "What does this project do?"
 ```
 
-Model、credential、prompt、command 與 host extension 選項，請參考
+如果還希望 Heddle 暫時提供 terminal prompt loop 與 text rendering，可使用
+`runQuickstartConversationCli()`。兩條路徑請參考
 [SDK 快速入門](docs/guides/programmatic/quickstart.md)。
 
 ### 掌控 presentation 與 turn lifecycle
@@ -160,7 +168,8 @@ mechanics 的最低層即可：
 
 | Host 需求 | 從這裡開始 | 增加的能力 |
 | --- | --- | --- |
-| 可運作的本機對話 | `runQuickstartConversationCli` | Prompt loop、persisted session、credential 與 text output |
+| Structured 本機對話 | `ConversationAgentService` | Runtime defaults、stable session ensure、structured activities 與 turn result |
+| Terminal SDK 評估 | `runQuickstartConversationCli` | Prompt loop、persisted session、credential 與 text output |
 | 自訂 output、tool 或 session UX | `@roackb2/heddle` | Conversation engine、host extension、tool、MCP、approval、artifact 與 turn result |
 | Server、worker 或 Electron backend | `@roackb2/heddle/hosted` | 可定址的 process-local run、replay、cancellation 與 approval resolution |
 | 一般 Node HTTP/SSE | `@roackb2/heddle/hosted/http-sse` | Replay cursor parsing、SSE framing、backpressure 與 disconnect cleanup |
@@ -176,7 +185,9 @@ mechanics 的最低層即可：
 
 可執行的範例會以小步驟教你逐層客製：
 
-1. [Interactive chat](examples/sdk/01-interactive-chat.ts) — 啟動可持久化對話。
+1. [Headless conversation](examples/sdk/01-headless-conversation.ts) — 透過
+   persisted session 送出 structured turn；需要 terminal loop 時則使用
+   [interactive chat](examples/sdk/01-interactive-chat.ts)。
 2. [Add a tool](examples/sdk/02-add-a-tool.ts) — 暴露產品原生能力。
 3. [Add an MCP server](examples/sdk/03-add-an-mcp-server.ts) — 不複製 schema，
    直接準備經過挑選的 MCP-backed capability。

--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -33,8 +33,9 @@ host stacks to the smallest useful Heddle boundary and makes the responsibility
 split between Heddle and the host explicit for developers and coding agents.
 
 1. **Start here** — stand up a conversation agent.
-   - [Quickstart](quickstart.md): a minimal persisted conversation with default
-     text output, in a few lines.
+   - [Quickstart](quickstart.md): a headless persisted conversation with
+     structured activities/results in a few lines, plus an optional terminal
+     loop.
 2. **Add capabilities** — give the agent your own tools, MCP servers, skills.
    - [Host extensions](host-extensions.md): add generic product or domain tools.
    - [MCP host extensions](mcp-host-extensions.md): expose MCP servers as curated

--- a/docs/guides/programmatic/conversation-engine.md
+++ b/docs/guides/programmatic/conversation-engine.md
@@ -7,7 +7,7 @@ daemon wrappers, or products that want Heddle to own the agent runtime plumbing.
 Use it when you want:
 
 - persisted sessions under a host-controlled state root;
-- session create/read/list/rename/delete operations;
+- session create/ensure/read/list/rename/delete operations;
 - turn submission and continue behavior;
 - automatic conversation compaction;
 - approval handling through host callbacks;
@@ -39,6 +39,22 @@ session ids and storage paths. For new hosts, prefer `createConversationEngine`.
 Use `engine.sessions.readExisting(id)` when checking whether a persisted session
 already exists. Unlike `read(id)`, it does not materialize Heddle's host-facing
 fallback session in an empty repository.
+
+When a host maps a stable product conversation to Heddle, avoid a separate
+read-then-create sequence. Use the race-safe ensure operation:
+
+```ts
+const { session, created } = await engine.sessions.ensure({
+  id: trustedProductConversationId,
+  name: 'Product assistant',
+})
+```
+
+If another process creates the same ID first, `ensure` reads and returns the
+winner. Creation fields apply only to a new record; they never rename or change
+the model/settings of an existing session. Repository adapters must surface
+create collisions as `ChatSessionAlreadyExistsError`, as required by the public
+session repository contract.
 
 ## Control model-visible tools
 

--- a/docs/guides/programmatic/integration-layers.md
+++ b/docs/guides/programmatic/integration-layers.md
@@ -59,7 +59,8 @@ disconnect as implicit cancellation.
 
 | What the host already has | Heddle entrypoint | Example to follow |
 | --- | --- | --- |
-| Nothing beyond a TypeScript process | `runQuickstartConversationCli` | [`01-interactive-chat.ts`](../../../examples/sdk/01-interactive-chat.ts) |
+| A TypeScript process that owns input/output | `ConversationAgentService` | [`01-headless-conversation.ts`](../../../examples/sdk/01-headless-conversation.ts) |
+| A terminal evaluation with no host loop | `runQuickstartConversationCli` | [`01-interactive-chat.ts`](../../../examples/sdk/01-interactive-chat.ts) |
 | A local loop that needs product tools or MCP | Quickstart plus tools/host extensions | [`02-add-a-tool.ts`](../../../examples/sdk/02-add-a-tool.ts), [`03-add-an-mcp-server.ts`](../../../examples/sdk/03-add-an-mcp-server.ts) |
 | Its own output sink or local UI | `createConversationEngine` + `createConversationTextHost` or host callbacks | [`04-custom-output.ts`](../../../examples/sdk/04-custom-output.ts) |
 | A server/worker that owns transport | `@roackb2/heddle` + `@roackb2/heddle/hosted` | [`05-hosted-agent/01-hosted-service`](../../../examples/sdk/05-hosted-agent/01-hosted-service) |
@@ -76,12 +77,18 @@ copying Express-specific code.
 
 ## Layer-by-layer assumptions
 
+### Headless conversation agent
+
+Use `ConversationAgentService` when the host owns input/output but wants Heddle
+to resolve runtime defaults, ensure one stable session, capture structured
+activities, and return the normal turn result. The underlying engine remains
+available for progressive customization.
+
 ### Quickstart runner
 
 Use `runQuickstartConversationCli` when Heddle may own the prompt loop and
 plain-text terminal experience. The host supplies configuration and optional
-capabilities. Move deeper when the product needs its own presentation or
-lifecycle.
+capabilities. It adds a terminal host around the same generic starter defaults.
 
 ### Conversation engine
 

--- a/docs/guides/programmatic/quickstart.md
+++ b/docs/guides/programmatic/quickstart.md
@@ -5,9 +5,54 @@ This is rung 1 of the programmatic ladder — the smallest working agent. See th
 shape output → lifecycle → storage), and [`examples/sdk/`](../../../examples/sdk/README.md)
 for runnable versions.
 
-If your product already owns a server, transport, or UI, use the
+Start with the headless service when your product owns its input/output but not
+the agent lifecycle yet:
+
+```ts
+import { ConversationAgentService } from '@roackb2/heddle'
+
+const agent = new ConversationAgentService()
+const result = await agent.send({
+  prompt: 'Summarize this project and identify the main verification path.',
+})
+
+console.log(result.summary)
+console.log(result.activities)
+```
+
+This resolves the workspace, `.heddle` state root, configured model, and
+credential; race-safely ensures the stable `session-1`; and returns Heddle's
+structured turn result plus the ordered conversation activities observed during
+the turn. Repeated `send` calls continue the same durable conversation. Supply
+an explicit stable session ID for product scope:
+
+```ts
+const agent = new ConversationAgentService({
+  session: { id: trustedProductConversationId, name: 'Product assistant' },
+  systemContext: 'Help the user work with this product.',
+})
+```
+
+Creation fields never overwrite an existing session with that ID. A hosted
+service must derive the ID and repository scope from trusted server-side
+identity; Heddle does not provide authentication or tenant mapping.
+
+The result and activities are trusted in-process host data; they may include
+tool input/output, local paths, or other internal details. Do not serialize them
+directly to an untrusted browser. Use a host-owned public projection and the
+[remote run contracts](remote-runs.md) when crossing a network boundary.
+
+Run the headless repository example:
+
+```bash
+yarn example:sdk:headless "What does this project do?"
+```
+
+If your product already owns a server or remote transport, use the
 [integration-layer chooser](integration-layers.md) to skip directly to the
-lowest matching boundary instead of copying the terminal quickstart stack.
+lowest matching hosting boundary.
+
+## Optional terminal loop
 
 Use `runQuickstartConversationCli` when you want a working interactive conversation loop
 before building a custom UI:
@@ -26,10 +71,11 @@ Heddle's built-in OpenAI default. It resolves credentials before starting the
 session and prints the selected model and credential source. If the model has no
 usable credential, it fails early with Heddle's standard setup message.
 
-This quickstart runner is intentionally smaller than Heddle's product CLI/TUI.
-Use it to get an SDK conversation working quickly, then move to
-`createConversationEngine` when your product needs custom UI state, rendering,
-approval screens, session browsers, or control-plane lifecycle.
+This runner adds readline, text rendering, and local commands around the same
+generic runtime defaults. It is intentionally smaller than Heddle's product
+CLI/TUI. Use `ConversationAgentService` for structured headless output, or move
+to `createConversationEngine` when your product needs full session and turn
+lifecycle control.
 
 Run the local SDK example:
 
@@ -113,7 +159,7 @@ const engine = createConversationEngine({
   reasoningEffort: 'medium',
 })
 
-const session = engine.sessions.create({ name: 'Project assistant' })
+const session = await engine.sessions.create({ name: 'Project assistant' })
 const textHost = createConversationTextHost()
 
 const result = await engine.turns.submit({

--- a/docs/project-posture.md
+++ b/docs/project-posture.md
@@ -73,7 +73,9 @@ tooling, approval policy, memory, situation awareness, traces, and evaluation.
   compaction, leases, approvals, traces, user-facing conversation activities,
   package-level programmatic use, and domain-specific persistence capability
   composition/readiness. Its `persistence/` subdomain does not define one
-  universal storage or CRUD abstraction across domains.
+  universal storage or CRUD abstraction across domains. Its
+  `conversation-agent/` subdomain owns the smallest structured headless
+  adoption path without absorbing host UI, transport, auth, or product policy.
 - `src/core/chat/` defines the shared chat boundary above the engine. It should
   stay small.
 - `src/core/tools/` owns tool definitions, registries, execution, and toolkits.
@@ -149,6 +151,7 @@ scope.
 - Memory: `src/core/tools/toolkits/knowledge/`, `src/core/memory/`.
 - Conversation persistence capabilities and readiness:
   `src/core/chat/engine/persistence/`.
+- Headless conversation starter: `src/core/chat/engine/conversation-agent/`.
 - Architecture boundaries: `docs/architecture/core-layering.md`,
   `docs/architecture/chat-layering.md`,
   `docs/architecture/durable-state.md`.

--- a/examples/sdk/01-headless-conversation.ts
+++ b/examples/sdk/01-headless-conversation.ts
@@ -1,0 +1,21 @@
+/**
+ * Stage 01: the smallest structured, persisted conversation agent.
+ *
+ * Prerequisite: a configured Heddle model credential.
+ * Assumption: agent execution happens in this TypeScript process; the host
+ * still owns any UI, transport, authentication, and product transactions.
+ * Run: yarn example:sdk:headless "What does this project do?"
+ */
+import { ConversationAgentService } from '../../src/index.js';
+
+const agent = new ConversationAgentService();
+const result = await agent.send({
+  prompt: process.argv.slice(2).join(' ').trim() || 'What does this project do?',
+});
+
+console.log({
+  activityTypes: result.activities.map((activity) => activity.type),
+  outcome: result.outcome,
+  sessionId: result.session.id,
+  summary: result.summary,
+});

--- a/examples/sdk/README.md
+++ b/examples/sdk/README.md
@@ -26,7 +26,8 @@ platform, an identity provider, or a database.
 
 | Your current host | Start with | New host responsibility |
 | --- | --- | --- |
-| No agent loop or UI yet | [`01-interactive-chat.ts`](01-interactive-chat.ts) | Configuration and prompts only |
+| A TypeScript process that owns input/output | [`01-headless-conversation.ts`](01-headless-conversation.ts) | Configuration and prompts only |
+| A terminal evaluation with no host loop | [`01-interactive-chat.ts`](01-interactive-chat.ts) | Configuration and prompts only |
 | A local chat that needs product capabilities | [`02-add-a-tool.ts`](02-add-a-tool.ts) or [`03-add-an-mcp-server.ts`](03-add-an-mcp-server.ts) | Tool implementation or MCP server selection |
 | A process that already owns output/rendering | [`04-custom-output.ts`](04-custom-output.ts) | Output sink and presentation policy |
 | A server, worker, Electron backend, or custom transport | [`05-hosted-agent/01-hosted-service`](05-hosted-agent/01-hosted-service) | Identity scope, durable session IDs, engine composition, and process lifetime |
@@ -41,14 +42,26 @@ Do not introduce Express merely to copy the example.
 
 ## Follow the customization ladder
 
-### 01 Interactive Chat — working conversation
+### 01 Headless or Interactive — working conversation
+
+For structured in-process output:
+
+```bash
+yarn example:sdk:headless "What does this repository do?"
+```
+
+**Assumption:** the host owns input/output while Heddle owns runtime defaults,
+stable session ensure, and turn execution. The result contains the normal turn
+summary plus ordered structured activities.
+
+For a temporary terminal prompt loop:
 
 ```bash
 yarn example:sdk:interactive
 ```
 
 **Assumption:** Heddle can own the local prompt loop, persisted session, and
-plain-text output. This is the smallest file to copy for an SDK evaluation.
+plain-text output. Both stage-01 paths use the same generic starter defaults.
 
 ### 02 Add a Tool — native host capability
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "chat:dev:anthropic": "ANTHROPIC_API_KEY=\"$PERSONAL_ANTHROPIC_API_KEY\" tsx --no-cache src/cli-v2/main.ts chat",
     "chat:dev:v2:anthropic": "ANTHROPIC_API_KEY=\"$PERSONAL_ANTHROPIC_API_KEY\" tsx --no-cache src/cli-v2/main.ts chat-v2",
     "example:repo-investigator": "tsx --no-cache examples/repo-investigator.ts",
+    "example:sdk:headless": "tsx --no-cache examples/sdk/01-headless-conversation.ts",
     "example:sdk:interactive": "tsx --no-cache examples/sdk/01-interactive-chat.ts",
     "example:sdk:add-tool": "tsx --no-cache examples/sdk/02-add-a-tool.ts",
     "example:sdk:add-mcp": "tsx --no-cache examples/sdk/03-add-an-mcp-server.ts",

--- a/src/__tests__/unit/core/conversation-agent.test.ts
+++ b/src/__tests__/unit/core/conversation-agent.test.ts
@@ -1,0 +1,119 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
+import { ConversationAgentService } from '@/core/chat/engine/conversation-agent/index.js';
+import { EngineConversationTurnService } from '@/core/chat/engine/turns/service.js';
+import type { AgentLoopEvent } from '@/core/runtime/loop/index.js';
+
+describe('ConversationAgentService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(EngineConversationTurnService, 'run').mockImplementation(async (args) => {
+      const event: AgentLoopEvent = {
+        source: 'agent-loop',
+        type: 'assistant.stream',
+        runId: 'run-1',
+        step: 1,
+        text: 'structured partial',
+        done: false,
+        timestamp: '2026-07-19T00:00:00.000Z',
+      };
+      args.host?.onEvent(event);
+      const session = await args.sessionRepository?.read(args.sessionId);
+
+      return {
+        outcome: 'done',
+        summary: 'Structured answer',
+        session: session?.session,
+        artifacts: [],
+        toolResults: [],
+      } as Awaited<ReturnType<typeof EngineConversationTurnService.run>>;
+    });
+  });
+
+  it('owns defaults, stable session ensure, activity capture, and structured turn output', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-conversation-agent-'));
+    const onActivity = vi.fn();
+    const agent = new ConversationAgentService({
+      credentialPreflight: false,
+      env: {},
+      host: { events: { onActivity } },
+      maxSteps: 7,
+      model: 'gpt-test',
+      session: {
+        id: 'project-assistant',
+        name: 'Project assistant',
+      },
+      workspaceRoot,
+    });
+
+    const first = await agent.send({ prompt: '  Summarize this project.  ' });
+    const second = await agent.send({ prompt: 'Continue.' });
+
+    expect(agent.runtime).toEqual(expect.objectContaining({
+      maxSteps: 7,
+      memoryMaintenanceMode: 'none',
+      model: 'gpt-test',
+      stateRoot: join(workspaceRoot, '.heddle'),
+      workspaceRoot,
+    }));
+    expect(first).toEqual(expect.objectContaining({
+      outcome: 'done',
+      summary: 'Structured answer',
+      sessionCreated: true,
+      session: expect.objectContaining({
+        id: 'project-assistant',
+        name: 'Project assistant',
+      }),
+      activities: [expect.objectContaining({
+        type: 'assistant.stream',
+        text: 'structured partial',
+      })],
+    }));
+    expect(second.sessionCreated).toBe(false);
+    expect(onActivity).toHaveBeenCalledTimes(2);
+    expect(EngineConversationTurnService.run).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        maxSteps: 7,
+        memoryMaintenanceMode: 'none',
+        prompt: 'Summarize this project.',
+        sessionId: 'project-assistant',
+      }),
+    );
+  });
+
+  it('uses the same generic defaults as the CLI starter', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-conversation-agent-defaults-'));
+    const agent = new ConversationAgentService({
+      credentialPreflight: false,
+      env: {},
+      workspaceRoot,
+    });
+
+    expect(agent.runtime).toEqual({
+      memoryMaintenanceMode: 'none',
+      model: DEFAULT_OPENAI_MODEL,
+      reasoningEffort: undefined,
+      stateRoot: join(workspaceRoot, '.heddle'),
+      workspaceRoot,
+    });
+  });
+
+  it('rejects an empty prompt before creating the default session', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-conversation-agent-empty-'));
+    const agent = new ConversationAgentService({
+      credentialPreflight: false,
+      env: {},
+      model: 'gpt-test',
+      workspaceRoot,
+    });
+
+    await expect(agent.send({ prompt: '   ' })).rejects.toThrow(
+      'Conversation agent prompt cannot be empty.',
+    );
+    await expect(agent.engine.sessions.listExisting()).resolves.toEqual([]);
+  });
+});

--- a/src/__tests__/unit/core/conversation-session-ensure.test.ts
+++ b/src/__tests__/unit/core/conversation-session-ensure.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createConversationEngine } from '@/core/chat/engine/index.js';
+
+describe('ConversationSessionService.ensure', () => {
+  it('resolves two first-writer attempts to one stable session', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-session-ensure-race-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const firstEngine = createConversationEngine({
+      model: 'gpt-test',
+      stateRoot,
+      workspaceRoot,
+    });
+    const secondEngine = createConversationEngine({
+      model: 'gpt-test',
+      stateRoot,
+      workspaceRoot,
+    });
+
+    const resolutions = await Promise.all([
+      firstEngine.sessions.ensure({ id: 'stable-session', name: 'First contender' }),
+      secondEngine.sessions.ensure({ id: 'stable-session', name: 'Second contender' }),
+    ]);
+
+    expect(resolutions.filter((resolution) => resolution.created)).toHaveLength(1);
+    expect(new Set(resolutions.map((resolution) => resolution.session.id))).toEqual(
+      new Set(['stable-session']),
+    );
+    expect(new Set(resolutions.map((resolution) => resolution.session.name)).size).toBe(1);
+  });
+
+  it('does not overwrite an existing session with creation defaults', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-session-ensure-existing-'));
+    const engine = createConversationEngine({
+      model: 'gpt-default',
+      stateRoot: join(workspaceRoot, '.heddle'),
+      workspaceRoot,
+    });
+    const created = await engine.sessions.ensure({
+      id: 'stable-session',
+      model: 'gpt-original',
+      name: 'Original name',
+    });
+
+    const resumed = await engine.sessions.ensure({
+      id: 'stable-session',
+      model: 'gpt-replacement',
+      name: 'Replacement name',
+    });
+
+    expect(created.created).toBe(true);
+    expect(resumed).toEqual({
+      created: false,
+      session: expect.objectContaining({
+        id: 'stable-session',
+        model: 'gpt-original',
+        name: 'Original name',
+      }),
+    });
+  });
+
+  it('rejects an empty stable session id', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-session-ensure-empty-'));
+    const engine = createConversationEngine({
+      model: 'gpt-test',
+      stateRoot: join(workspaceRoot, '.heddle'),
+      workspaceRoot,
+    });
+
+    await expect(engine.sessions.ensure({ id: '   ' })).rejects.toThrow(
+      'Conversation session ensure requires a non-empty id.',
+    );
+  });
+});

--- a/src/__tests__/unit/core/import-boundaries.test.ts
+++ b/src/__tests__/unit/core/import-boundaries.test.ts
@@ -28,6 +28,7 @@ const FORBIDDEN_PRODUCTION_TOKENS = [
 ];
 
 const PUBLIC_EXPORT_EXPECTATIONS = [
+  'ConversationAgentService',
   'ConversationPersistenceService',
   'createConversationEngine',
   'defineHostExtension',

--- a/src/core/chat/engine/conversation-agent/README.md
+++ b/src/core/chat/engine/conversation-agent/README.md
@@ -1,0 +1,46 @@
+# Headless Conversation Agent
+
+This domain owns Heddle's smallest structured in-process adoption path.
+
+## Ownership
+
+- `ConversationAgentRuntimeService` resolves the model, workspace/state roots,
+  reasoning effort, memory-maintenance default, and early credential evidence
+  shared by SDK starters.
+- `ConversationAgentService` constructs one conversation engine, ensures one
+  stable durable session without a read/create race, submits turns, captures
+  structured activities, and returns Heddle's normal structured turn result.
+- The underlying `engine` remains public so an adopter can progressively use
+  full session, turn, artifact, persistence, and host-extension APIs without a
+  rewrite.
+
+## Boundary
+
+The service is headless and in-process. It does not own terminal rendering,
+HTTP, authentication, tenant mapping, public result projection, canonical
+product transactions, or durable in-flight execution. A per-turn host callback
+overrides the service default when approval or event handling is request-scoped.
+
+Returned activities and turn results are trusted host data, not a browser-safe
+wire contract. They may contain tool input/output, trace paths, artifacts, or
+other internal details. Remote hosts must project an explicit public result and
+activity schema before serialization.
+
+The default stable session is `session-1`. Hosted or multi-user code must supply
+an identity derived from trusted server-side scope, and must construct the
+engine with appropriately scoped repositories. Heddle never derives tenant
+identity from an unverified browser field.
+
+## Example
+
+```ts
+const agent = new ConversationAgentService({
+  session: { id: 'account-42:project-7', name: 'Project assistant' },
+})
+
+const result = await agent.send({
+  prompt: 'Summarize this project.',
+})
+
+console.log(result.summary, result.activities)
+```

--- a/src/core/chat/engine/conversation-agent/index.ts
+++ b/src/core/chat/engine/conversation-agent/index.ts
@@ -1,0 +1,14 @@
+export { ConversationAgentService } from './service.js';
+export { ConversationAgentRuntimeService } from './runtime-service.js';
+export type {
+  ConversationAgentCredentialContext,
+  ConversationAgentCredentialPreflightOptions,
+  ConversationAgentMemoryMaintenanceMode,
+  ConversationAgentOptions,
+  ConversationAgentRuntimeContext,
+  ConversationAgentRuntimeDefaults,
+  ConversationAgentRuntimeDefaultsInput,
+  ConversationAgentSendInput,
+  ConversationAgentSessionOptions,
+  ConversationAgentTurnResult,
+} from './types.js';

--- a/src/core/chat/engine/conversation-agent/runtime-service.ts
+++ b/src/core/chat/engine/conversation-agent/runtime-service.ts
@@ -1,0 +1,135 @@
+import { join } from 'node:path';
+import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
+import type { ReasoningEffort } from '@/core/llm/types.js';
+import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
+import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
+import type {
+  ConversationAgentCredentialContext,
+  ConversationAgentCredentialPreflightOptions,
+  ConversationAgentRuntimeDefaults,
+  ConversationAgentRuntimeDefaultsInput,
+} from './types.js';
+
+const DEFAULT_MEMORY_MAINTENANCE_MODE = 'none';
+const SUPPORTED_REASONING_EFFORTS = new Set<ReasoningEffort>([
+  'low',
+  'medium',
+  'high',
+  'ultrahigh',
+]);
+
+/** Owns the environment-derived defaults and credential preflight shared by headless and CLI SDK starters. */
+export class ConversationAgentRuntimeService {
+  static resolveDefaults(
+    options: ConversationAgentRuntimeDefaultsInput = {},
+  ): ConversationAgentRuntimeDefaults {
+    const workspaceRoot = options.workspaceRoot ?? process.cwd();
+
+    return {
+      ...(options.maxSteps === undefined ? {} : { maxSteps: options.maxSteps }),
+      memoryMaintenanceMode: options.memoryMaintenanceMode ?? DEFAULT_MEMORY_MAINTENANCE_MODE,
+      model: ConversationAgentRuntimeService.resolveModel(options),
+      reasoningEffort: ConversationAgentRuntimeService.resolveReasoningEffort(
+        options.reasoningEffort,
+      ),
+      stateRoot: options.stateRoot ?? join(workspaceRoot, '.heddle'),
+      workspaceRoot,
+    };
+  }
+
+  static preflightCredentials(input: {
+    apiKey?: string;
+    credentialStorePath?: string;
+    defaults: ConversationAgentRuntimeDefaults;
+    preferApiKey?: boolean;
+    preflight?: boolean | ConversationAgentCredentialPreflightOptions;
+  }): ConversationAgentCredentialContext | undefined {
+    const preflight = ConversationAgentRuntimeService.resolveCredentialPreflight(input.preflight);
+    if (!preflight.enabled) {
+      return undefined;
+    }
+
+    const resolution = LlmProviderRuntimeService.resolve({
+      apiKey: input.apiKey,
+      credentialStorePath: input.credentialStorePath,
+      model: input.defaults.model,
+      preferApiKey: input.preferApiKey,
+      reasoningEffort: input.defaults.reasoningEffort,
+    });
+    const context = {
+      model: resolution.model,
+      preferApiKey: input.preferApiKey,
+      provider: resolution.provider,
+      source: resolution.credentialSource,
+    } satisfies ConversationAgentCredentialContext;
+
+    if (resolution.credentialSource.type === 'missing') {
+      throw new Error([
+        RuntimeCredentialService.formatMissingCredentialMessage(resolution.model),
+        ConversationAgentRuntimeService.resolveMissingCredentialHint({
+          context,
+          missingCredentialHint: preflight.missingCredentialHint,
+        }),
+      ].filter(Boolean).join(' '));
+    }
+
+    return context;
+  }
+
+  private static resolveCredentialPreflight(
+    input: boolean | ConversationAgentCredentialPreflightOptions | undefined,
+  ): Required<Pick<ConversationAgentCredentialPreflightOptions, 'enabled'>>
+    & Pick<ConversationAgentCredentialPreflightOptions, 'missingCredentialHint'> {
+    if (input === false) {
+      return { enabled: false };
+    }
+
+    if (input === true || input === undefined) {
+      return { enabled: true };
+    }
+
+    return {
+      enabled: input.enabled ?? true,
+      missingCredentialHint: input.missingCredentialHint,
+    };
+  }
+
+  private static resolveMissingCredentialHint(input: {
+    context: ConversationAgentCredentialContext;
+    missingCredentialHint: ConversationAgentCredentialPreflightOptions['missingCredentialHint'];
+  }): string | undefined {
+    const hint = typeof input.missingCredentialHint === 'function'
+      ? input.missingCredentialHint(input.context)
+      : input.missingCredentialHint;
+
+    return hint?.trim() || undefined;
+  }
+
+  private static resolveModel(options: ConversationAgentRuntimeDefaultsInput): string {
+    const env = options.env ?? process.env;
+    return [
+      options.model,
+      env.HEDDLE_MODEL,
+      env.HEDDLE_EXAMPLE_MODEL,
+      env.OPENAI_MODEL,
+      env.ANTHROPIC_MODEL,
+      DEFAULT_OPENAI_MODEL,
+    ].map((candidate) => candidate?.trim())
+      .find((candidate): candidate is string => Boolean(candidate)) ?? DEFAULT_OPENAI_MODEL;
+  }
+
+  private static resolveReasoningEffort(
+    input: ConversationAgentRuntimeDefaultsInput['reasoningEffort'],
+  ): ReasoningEffort | undefined {
+    const value = input?.trim();
+    if (!value) {
+      return undefined;
+    }
+
+    if (SUPPORTED_REASONING_EFFORTS.has(value as ReasoningEffort)) {
+      return value as ReasoningEffort;
+    }
+
+    throw new Error(`Unsupported reasoning effort: ${value}. Use one of low, medium, high, ultrahigh.`);
+  }
+}

--- a/src/core/chat/engine/conversation-agent/service.ts
+++ b/src/core/chat/engine/conversation-agent/service.ts
@@ -1,0 +1,118 @@
+import omit from 'lodash/omit.js';
+import { createConversationEngine } from '../conversation-engine.js';
+import type {
+  ConversationEngine,
+  ConversationEngineConfig,
+  ConversationEngineHost,
+  EnsureConversationSessionResult,
+} from '../types.js';
+import { ConversationAgentRuntimeService } from './runtime-service.js';
+import type {
+  ConversationAgentOptions,
+  ConversationAgentRuntimeContext,
+  ConversationAgentSendInput,
+  ConversationAgentSessionOptions,
+  ConversationAgentTurnResult,
+} from './types.js';
+
+const DEFAULT_SESSION_ID = 'session-1';
+const DEFAULT_SESSION_NAME = 'Heddle SDK conversation';
+
+/**
+ * Owns the smallest headless conversation lifecycle: runtime defaults,
+ * credential preflight, stable session ensure, structured activities, and one
+ * turn result. Full lifecycle control remains available through `engine`.
+ */
+export class ConversationAgentService {
+  readonly engine: ConversationEngine;
+  readonly runtime: ConversationAgentRuntimeContext;
+
+  private readonly defaultHost?: ConversationEngineHost;
+  private readonly session: Required<Pick<ConversationAgentSessionOptions, 'id'>>
+    & Omit<ConversationAgentSessionOptions, 'id'>;
+
+  constructor(options: ConversationAgentOptions = {}) {
+    const defaults = ConversationAgentRuntimeService.resolveDefaults(options);
+    const credential = ConversationAgentRuntimeService.preflightCredentials({
+      apiKey: options.apiKey,
+      credentialStorePath: options.credentialStorePath,
+      defaults,
+      preferApiKey: options.preferApiKey,
+      preflight: options.credentialPreflight,
+    });
+    const engineConfig = {
+      ...omit(options, [
+        'credentialPreflight',
+        'env',
+        'host',
+        'maxSteps',
+        'memoryMaintenanceMode',
+        'model',
+        'reasoningEffort',
+        'session',
+        'stateRoot',
+        'workspaceRoot',
+      ]),
+      ...omit(defaults, ['maxSteps']),
+    } satisfies ConversationEngineConfig;
+
+    this.engine = createConversationEngine(engineConfig);
+    this.runtime = {
+      ...defaults,
+      ...(credential ? { credential } : {}),
+    };
+    this.defaultHost = options.host;
+    this.session = {
+      ...options.session,
+      id: options.session?.id ?? DEFAULT_SESSION_ID,
+      name: options.session?.name ?? DEFAULT_SESSION_NAME,
+    };
+  }
+
+  async ensureSession(): Promise<EnsureConversationSessionResult> {
+    return await this.engine.sessions.ensure(this.session);
+  }
+
+  async send(input: ConversationAgentSendInput): Promise<ConversationAgentTurnResult> {
+    const prompt = input.prompt.trim();
+    if (!prompt) {
+      throw new Error('Conversation agent prompt cannot be empty.');
+    }
+
+    const session = await this.ensureSession();
+    const activities: ConversationAgentTurnResult['activities'] = [];
+    const result = await this.engine.turns.submit({
+      ...omit(input, ['prompt']),
+      sessionId: session.session.id,
+      prompt,
+      maxSteps: input.maxSteps ?? this.runtime.maxSteps,
+      memoryMaintenanceMode: input.memoryMaintenanceMode ?? this.runtime.memoryMaintenanceMode,
+      host: ConversationAgentService.captureActivities(
+        input.host ?? this.defaultHost,
+        activities,
+      ),
+    });
+
+    return {
+      ...result,
+      activities,
+      sessionCreated: session.created,
+    };
+  }
+
+  private static captureActivities(
+    host: ConversationEngineHost | undefined,
+    activities: ConversationAgentTurnResult['activities'],
+  ): ConversationEngineHost {
+    return {
+      ...host,
+      events: {
+        ...host?.events,
+        onActivity(activity) {
+          activities.push(activity);
+          host?.events?.onActivity?.(activity);
+        },
+      },
+    };
+  }
+}

--- a/src/core/chat/engine/conversation-agent/types.ts
+++ b/src/core/chat/engine/conversation-agent/types.ts
@@ -1,0 +1,77 @@
+import type { ConversationActivity } from '@/core/live/index.js';
+import type { LlmProvider, ReasoningEffort } from '@/core/llm/types.js';
+import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
+import type {
+  ConversationEngineConfig,
+  ConversationEngineHost,
+  EnsureConversationSessionInput,
+  SubmitConversationTurnInput,
+} from '../types.js';
+import type { ConversationTurnResultSummary } from '../turn-result.js';
+
+export type ConversationAgentMemoryMaintenanceMode =
+  NonNullable<ConversationEngineConfig['memoryMaintenanceMode']>;
+
+export type ConversationAgentCredentialContext = {
+  model: string;
+  preferApiKey?: boolean;
+  provider: LlmProvider;
+  source: ProviderCredentialSource;
+};
+
+export type ConversationAgentCredentialPreflightOptions = {
+  enabled?: boolean;
+  missingCredentialHint?: string | ((context: ConversationAgentCredentialContext) => string | undefined);
+};
+
+export type ConversationAgentRuntimeDefaultsInput = {
+  model?: string;
+  workspaceRoot?: string;
+  stateRoot?: string;
+  maxSteps?: number;
+  reasoningEffort?: ReasoningEffort | string;
+  memoryMaintenanceMode?: ConversationAgentMemoryMaintenanceMode;
+  env?: Pick<
+    NodeJS.ProcessEnv,
+    'ANTHROPIC_MODEL' | 'HEDDLE_EXAMPLE_MODEL' | 'HEDDLE_MODEL' | 'OPENAI_MODEL'
+  >;
+};
+
+export type ConversationAgentRuntimeDefaults = {
+  model: string;
+  workspaceRoot: string;
+  stateRoot: string;
+  maxSteps?: number;
+  reasoningEffort?: ReasoningEffort;
+  memoryMaintenanceMode: ConversationAgentMemoryMaintenanceMode;
+};
+
+export type ConversationAgentSessionOptions = Omit<EnsureConversationSessionInput, 'id'> & {
+  /** Stable durable identity. Defaults to `session-1`. */
+  id?: string;
+};
+
+export type ConversationAgentOptions = Omit<
+  ConversationEngineConfig,
+  'memoryMaintenanceMode' | 'model' | 'reasoningEffort' | 'stateRoot' | 'workspaceRoot'
+> & ConversationAgentRuntimeDefaultsInput & {
+  credentialPreflight?: boolean | ConversationAgentCredentialPreflightOptions;
+  host?: ConversationEngineHost;
+  session?: ConversationAgentSessionOptions;
+};
+
+export type ConversationAgentRuntimeContext = ConversationAgentRuntimeDefaults & {
+  credential?: ConversationAgentCredentialContext;
+};
+
+export type ConversationAgentSendInput = Omit<
+  SubmitConversationTurnInput,
+  'prompt' | 'sessionId'
+> & {
+  prompt: string;
+};
+
+export type ConversationAgentTurnResult = ConversationTurnResultSummary & {
+  activities: ConversationActivity[];
+  sessionCreated: boolean;
+};

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -1,4 +1,17 @@
 export { createConversationEngine } from './conversation-engine.js';
+export { ConversationAgentService } from './conversation-agent/index.js';
+export type {
+  ConversationAgentCredentialContext,
+  ConversationAgentCredentialPreflightOptions,
+  ConversationAgentMemoryMaintenanceMode,
+  ConversationAgentOptions,
+  ConversationAgentRuntimeContext,
+  ConversationAgentRuntimeDefaults,
+  ConversationAgentRuntimeDefaultsInput,
+  ConversationAgentSendInput,
+  ConversationAgentSessionOptions,
+  ConversationAgentTurnResult,
+} from './conversation-agent/index.js';
 export { ConversationPersistenceService } from './persistence/index.js';
 export type {
   ConversationPersistence,
@@ -108,6 +121,8 @@ export type {
   ConversationTurnService,
   CreateConversationSessionInput,
   ContinueConversationTurnInput,
+  EnsureConversationSessionInput,
+  EnsureConversationSessionResult,
   SubmitConversationTurnInput,
   SubmitConversationTurnResult,
   UpdateConversationSessionSettingsInput,

--- a/src/core/chat/engine/quickstart-cli/README.md
+++ b/src/core/chat/engine/quickstart-cli/README.md
@@ -14,9 +14,8 @@ conversation easier, smaller, or more predictable.
 `QuickstartConversationCliRunnerService` owns:
 
 - creating a persisted conversation engine and session;
-- resolving generic SDK defaults for workspace root, state root, model, and
-  memory maintenance mode;
-- resolving model credentials before a session starts;
+- consuming the headless agent domain's generic workspace/state/model/memory
+  defaults and credential preflight;
 - printing default model and credential status;
 - resuming a caller-selected session;
 - running a one-shot prompt when the caller does not want an interactive loop;
@@ -46,6 +45,11 @@ It does not own:
 ## Relationship To TUI
 
 Both this module and the TUI run from a terminal, but they are different hosts.
+
+For a non-terminal starter, use `ConversationAgentService`. It owns the shared
+runtime defaults, stable session ensure, structured activity capture, and turn
+result. This module adds readline, text rendering, commands, and CLI hooks; it
+must not become a parallel implementation of those generic mechanics.
 
 ```text
 src/core/chat/engine/quickstart-cli/

--- a/src/core/chat/engine/quickstart-cli/service.ts
+++ b/src/core/chat/engine/quickstart-cli/service.ts
@@ -1,14 +1,11 @@
 import { createInterface } from 'node:readline/promises';
-import { join } from 'node:path';
 import { stdin, stdout } from 'node:process';
 import type { Writable } from 'node:stream';
-import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
-import type { ReasoningEffort } from '@/core/llm/types.js';
 import {
   RuntimeCredentialService,
 } from '@/core/runtime/credentials/index.js';
-import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
 import { createConversationEngine } from '../conversation-engine.js';
+import { ConversationAgentRuntimeService } from '../conversation-agent/index.js';
 import { createConversationTextHost } from '../text-host/index.js';
 import type { ChatSession } from '../../types.js';
 import type { ConversationTurnResultSummary } from '../turn-result.js';
@@ -24,8 +21,6 @@ import type {
 } from './types.js';
 
 const DEFAULT_PROMPT_LABEL = 'heddle> ';
-const DEFAULT_MEMORY_MAINTENANCE_MODE = 'none';
-const SUPPORTED_REASONING_EFFORTS = new Set<ReasoningEffort>(['low', 'medium', 'high', 'ultrahigh']);
 const BUILT_IN_COMMANDS = [
   { command: '/session', description: 'print the active session id' },
   { command: '/help', description: 'print available local commands' },
@@ -217,16 +212,7 @@ export class QuickstartConversationCliRunnerService {
   }
 
   static resolveDefaults(options: QuickstartConversationCliRunnerDefaultsInput = {}): QuickstartConversationCliRunnerDefaults {
-    const workspaceRoot = options.workspaceRoot ?? process.cwd();
-
-    return {
-      ...(options.maxSteps === undefined ? {} : { maxSteps: options.maxSteps }),
-      memoryMaintenanceMode: options.memoryMaintenanceMode ?? DEFAULT_MEMORY_MAINTENANCE_MODE,
-      model: QuickstartConversationCliRunnerService.resolveModel(options),
-      reasoningEffort: QuickstartConversationCliRunnerService.resolveReasoningEffort(options.reasoningEffort),
-      stateRoot: options.stateRoot ?? join(workspaceRoot, '.heddle'),
-      workspaceRoot,
-    };
+    return ConversationAgentRuntimeService.resolveDefaults(options);
   }
 
   private static preflightCredentials(input: {
@@ -234,33 +220,16 @@ export class QuickstartConversationCliRunnerService {
     options: QuickstartConversationCliRunnerOptions;
   }): QuickstartConversationCliCredentialContext | undefined {
     const preflight = QuickstartConversationCliRunnerService.resolveCredentialPreflight(input.options.credentialPreflight);
-    if (!preflight.enabled) {
-      return undefined;
-    }
-
-    const resolution = LlmProviderRuntimeService.resolve({
+    const context = ConversationAgentRuntimeService.preflightCredentials({
       apiKey: input.options.apiKey,
       credentialStorePath: input.options.credentialStorePath,
-      model: input.defaults.model,
+      defaults: input.defaults,
       preferApiKey: input.options.preferApiKey,
-      reasoningEffort: input.defaults.reasoningEffort,
+      preflight: {
+        enabled: preflight.enabled,
+        missingCredentialHint: preflight.missingCredentialHint,
+      },
     });
-    const context = {
-      model: resolution.model,
-      preferApiKey: input.options.preferApiKey,
-      provider: resolution.provider,
-      source: resolution.credentialSource,
-    } satisfies QuickstartConversationCliCredentialContext;
-
-    if (resolution.credentialSource.type === 'missing') {
-      throw new Error([
-        RuntimeCredentialService.formatMissingCredentialMessage(resolution.model),
-        QuickstartConversationCliRunnerService.resolveMissingCredentialHint({
-          context,
-          missingCredentialHint: preflight.missingCredentialHint,
-        }),
-      ].filter(Boolean).join(' '));
-    }
 
     return preflight.status === 'status' ? context : undefined;
   }
@@ -288,17 +257,6 @@ export class QuickstartConversationCliRunnerService {
       missingCredentialHint: input.missingCredentialHint,
       status: input.status ?? 'status',
     };
-  }
-
-  private static resolveMissingCredentialHint(input: {
-    context: QuickstartConversationCliCredentialContext;
-    missingCredentialHint: QuickstartConversationCliCredentialPreflightOptions['missingCredentialHint'];
-  }): string | undefined {
-    const hint = typeof input.missingCredentialHint === 'function'
-      ? input.missingCredentialHint(input.context)
-      : input.missingCredentialHint;
-
-    return hint?.trim() || undefined;
   }
 
   private static writeRuntimeStatus(input: {
@@ -496,31 +454,6 @@ export class QuickstartConversationCliRunnerService {
     ].join(', ');
   }
 
-  private static resolveModel(options: QuickstartConversationCliRunnerDefaultsInput): string {
-    const env = options.env ?? process.env;
-    return [
-      options.model,
-      env.HEDDLE_MODEL,
-      env.HEDDLE_EXAMPLE_MODEL,
-      env.OPENAI_MODEL,
-      env.ANTHROPIC_MODEL,
-      DEFAULT_OPENAI_MODEL,
-    ].map((candidate) => candidate?.trim())
-      .find((candidate): candidate is string => Boolean(candidate)) ?? DEFAULT_OPENAI_MODEL;
-  }
-
-  private static resolveReasoningEffort(input: QuickstartConversationCliRunnerDefaultsInput['reasoningEffort']): ReasoningEffort | undefined {
-    const value = input?.trim();
-    if (!value) {
-      return undefined;
-    }
-
-    if (SUPPORTED_REASONING_EFFORTS.has(value as ReasoningEffort)) {
-      return value as ReasoningEffort;
-    }
-
-    throw new Error(`Unsupported reasoning effort: ${value}. Use one of low, medium, high, ultrahigh.`);
-  }
 }
 
 type ResolvedLocalCommand =

--- a/src/core/chat/engine/quickstart-cli/types.ts
+++ b/src/core/chat/engine/quickstart-cli/types.ts
@@ -2,17 +2,21 @@ import type { Readable, Writable } from 'node:stream';
 import type { ArtifactRepository } from '@/core/artifacts/index.js';
 import type { ChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
 import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
-import type { ReasoningEffort } from '@/core/llm/types.js';
-import type { LlmProvider } from '@/core/llm/types.js';
-import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { ToolDefinition } from '@/core/types.js';
 import type { ConversationEngine } from '../types.js';
 import type { ChatSession } from '../../types.js';
 import type { ConversationTurnResultSummary } from '../turn-result.js';
 import type { ConversationEngineHost, ConversationEngineHostExtension } from '../types.js';
 import type { HeddlePersistenceCapabilities } from '../persistence/index.js';
+import type {
+  ConversationAgentCredentialContext,
+  ConversationAgentCredentialPreflightOptions,
+  ConversationAgentMemoryMaintenanceMode,
+  ConversationAgentRuntimeDefaults,
+  ConversationAgentRuntimeDefaultsInput,
+} from '../conversation-agent/index.js';
 
-export type QuickstartConversationCliMemoryMaintenanceMode = 'none' | 'background' | 'inline';
+export type QuickstartConversationCliMemoryMaintenanceMode = ConversationAgentMemoryMaintenanceMode;
 
 export type QuickstartConversationCliLocalCommandContext = {
   command: string;
@@ -39,18 +43,12 @@ export type QuickstartConversationCliTurnContext = {
   workspaceRoot: string;
 };
 
-export type QuickstartConversationCliCredentialContext = {
-  model: string;
-  preferApiKey?: boolean;
-  provider: LlmProvider;
-  source: ProviderCredentialSource;
-};
+export type QuickstartConversationCliCredentialContext = ConversationAgentCredentialContext;
 
-export type QuickstartConversationCliCredentialPreflightOptions = {
-  enabled?: boolean;
-  missingCredentialHint?: string | ((context: QuickstartConversationCliCredentialContext) => string | undefined);
-  status?: 'off' | 'status';
-};
+export type QuickstartConversationCliCredentialPreflightOptions =
+  ConversationAgentCredentialPreflightOptions & {
+    status?: 'off' | 'status';
+  };
 
 export type QuickstartConversationCliRunnerOptions = {
   model?: string;
@@ -62,7 +60,7 @@ export type QuickstartConversationCliRunnerOptions = {
   oncePrompt?: string;
   prompts?: string[];
   maxSteps?: number;
-  reasoningEffort?: ReasoningEffort | string;
+  reasoningEffort?: ConversationAgentRuntimeDefaultsInput['reasoningEffort'];
   apiKey?: string;
   preferApiKey?: boolean;
   credentialStorePath?: string;
@@ -88,21 +86,6 @@ export type QuickstartConversationCliRunnerOptions = {
   output?: Writable;
 };
 
-export type QuickstartConversationCliRunnerDefaultsInput = Pick<
-  QuickstartConversationCliRunnerOptions,
-  'maxSteps' | 'memoryMaintenanceMode' | 'model' | 'reasoningEffort' | 'stateRoot' | 'workspaceRoot'
-> & {
-  env?: Pick<
-    NodeJS.ProcessEnv,
-    'ANTHROPIC_MODEL' | 'HEDDLE_EXAMPLE_MODEL' | 'HEDDLE_MODEL' | 'OPENAI_MODEL'
-  >;
-};
+export type QuickstartConversationCliRunnerDefaultsInput = ConversationAgentRuntimeDefaultsInput;
 
-export type QuickstartConversationCliRunnerDefaults = {
-  maxSteps?: number;
-  memoryMaintenanceMode: QuickstartConversationCliMemoryMaintenanceMode;
-  model: string;
-  reasoningEffort?: ReasoningEffort;
-  stateRoot: string;
-  workspaceRoot: string;
-};
+export type QuickstartConversationCliRunnerDefaults = ConversationAgentRuntimeDefaults;

--- a/src/core/chat/engine/sessions/README.md
+++ b/src/core/chat/engine/sessions/README.md
@@ -14,6 +14,7 @@ or future hosts, it belongs here rather than in host-side code.
   a session already has earlier work to finish.
 - New-session inheritance rules.
 - Session-level default resolution at the engine boundary.
+- Race-safe create-or-read for a host-provided stable session identity.
 - Storage-independent session mutation coordination and bounded optimistic
   update retries.
 
@@ -68,7 +69,7 @@ session policy.
 The service API should cover ordinary host needs directly:
 
 - use `list`, `read`, `require`, and `latest` for session lookup;
-- use `create`, `rename`, and `delete` for lifecycle changes;
+- use `create`, `ensure`, `rename`, and `delete` for lifecycle changes;
 - use `updateSettings` for shared model, reasoning-effort, and drift settings;
 - reserve generic `update` for persisted session changes that are not yet
   expressed as a named service operation. Its updater may be reapplied after a

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -41,6 +41,8 @@ import type {
   ApplyConversationCompactionResultInput,
   ConversationSessionService,
   CreateConversationSessionInput,
+  EnsureConversationSessionInput,
+  EnsureConversationSessionResult,
   MarkAcceptedConversationUserMessageFailedInput,
   MarkAcceptedConversationUserMessageInput,
   MarkConversationCompactionRunningInput,
@@ -118,16 +120,52 @@ export class FileConversationSessionService implements ConversationSessionServic
   }
 
   async create(input?: CreateConversationSessionInput): Promise<ChatSession> {
-    const existing = await this.loadCatalogEntries();
+    const requestedName = input?.name?.trim();
+    const existing = requestedName ? [] : await this.loadCatalogEntries();
     const session = ChatSessionRecords.create({
       id: input?.id?.trim() || `session-${randomUUID()}`,
-      name: input?.name?.trim() || `Session ${FileConversationSessionService.getNextSessionNumber(existing)}`,
+      name: requestedName || `Session ${FileConversationSessionService.getNextSessionNumber(existing)}`,
       model: input?.model ?? this.config.model,
       reasoningEffort: input?.reasoningEffort ?? this.config.reasoningEffort,
       workspaceId: input?.workspaceId ?? this.config.workspaceId,
       retention: input?.retention,
     });
     return (await this.repository.create(session)).session;
+  }
+
+  /**
+   * Reads an existing stable ID or creates it once. If another process wins the
+   * create race, the repository's uniqueness error becomes a successful read;
+   * existing settings are never overwritten by ensure input.
+   */
+  async ensure(input: EnsureConversationSessionInput): Promise<EnsureConversationSessionResult> {
+    const id = input.id.trim();
+    if (!id) {
+      throw new Error('Conversation session ensure requires a non-empty id.');
+    }
+
+    const existing = await this.repository.read(id);
+    if (existing) {
+      return { session: existing.session, created: false };
+    }
+
+    try {
+      return {
+        session: await this.create({ ...input, id }),
+        created: true,
+      };
+    } catch (error) {
+      if (!(error instanceof ChatSessionAlreadyExistsError)) {
+        throw error;
+      }
+
+      const raced = await this.repository.read(id);
+      if (!raced) {
+        throw error;
+      }
+
+      return { session: raced.session, created: false };
+    }
   }
 
   async createOneOff(input?: CreateConversationSessionInput): Promise<ChatSession> {

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -121,6 +121,7 @@ export type ConversationSessionService = {
 
   // Lifecycle
   create(input?: CreateConversationSessionInput): Promise<ChatSession>;
+  ensure(input: EnsureConversationSessionInput): Promise<EnsureConversationSessionResult>;
   createOneOff(input?: CreateConversationSessionInput): Promise<ChatSession>;
   rename(id: string, name: string): Promise<ChatSession>;
   setPinned(id: string, pinned: boolean): Promise<ChatSession>;
@@ -170,6 +171,19 @@ export type CreateConversationSessionInput = {
   reasoningEffort?: ReasoningEffort;
   workspaceId?: string;
   retention?: ChatSessionRetention;
+};
+
+/**
+ * Stable session identity to read or create without a read-then-create race.
+ * Creation fields apply only when the session does not already exist.
+ */
+export type EnsureConversationSessionInput = Omit<CreateConversationSessionInput, 'id'> & {
+  id: string;
+};
+
+export type EnsureConversationSessionResult = {
+  session: ChatSession;
+  created: boolean;
 };
 
 export type AutoRenameConversationSessionInput = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,22 @@
 // ---------------------------------------------------------------------------
 // 1. Start here — stand up a conversation agent
 // ---------------------------------------------------------------------------
-// `runQuickstartConversationCli()` is the smallest working agent. Drop to
-// `createConversationEngine(...)` when you want to own the turn loop / UI.
+// `ConversationAgentService` is the smallest headless structured agent;
+// `runQuickstartConversationCli()` adds a terminal loop. Drop to
+// `createConversationEngine(...)` when you want full lifecycle control.
+export { ConversationAgentService } from './core/chat/engine/conversation-agent/index.js';
+export type {
+  ConversationAgentCredentialContext,
+  ConversationAgentCredentialPreflightOptions,
+  ConversationAgentMemoryMaintenanceMode,
+  ConversationAgentOptions,
+  ConversationAgentRuntimeContext,
+  ConversationAgentRuntimeDefaults,
+  ConversationAgentRuntimeDefaultsInput,
+  ConversationAgentSendInput,
+  ConversationAgentSessionOptions,
+  ConversationAgentTurnResult,
+} from './core/chat/engine/conversation-agent/index.js';
 export {
   QuickstartConversationCliRunnerService,
   resolveQuickstartConversationCliDefaults,
@@ -200,6 +214,8 @@ export type {
   ConversationTurnService,
   CreateConversationSessionInput,
   ContinueConversationTurnInput,
+  EnsureConversationSessionInput,
+  EnsureConversationSessionResult,
   SubmitConversationTurnInput,
   SubmitConversationTurnResult,
   UpdateConversationSessionSettingsInput,


### PR DESCRIPTION
## Stack

- base: #253 (`codex/conversation-persistence-capability`)
- this PR contains only SDK-13 headless onboarding and session-lifecycle changes
- merge #253 first, then rebase this branch onto `main`

## Summary

- add `ConversationAgentService` as the smallest structured, in-process conversation entrypoint
- add race-safe `engine.sessions.ensure({ id })` with create-or-read semantics across competing service instances
- return Heddle's normal structured turn result plus ordered captured activities and `sessionCreated`
- expose the underlying engine so adopters can progressively move to full session, turn, artifact, extension, and persistence control without rewriting
- share model/path/reasoning/memory defaults and credential preflight with the existing terminal quickstart, deleting its duplicated resolution logic
- add a runnable headless example and lead the English/Traditional Chinese onboarding docs with the new beginner path

## Boundary

The service is deliberately headless and process-local. It does not own HTTP, authentication, tenant mapping, browser-safe projection, canonical product transactions, or durable in-flight execution. Returned turn data is trusted host data and must be projected before crossing an untrusted network boundary.

The default stable ID is `session-1`. Hosted/multi-user code must supply a trusted product-derived ID and scoped repositories. Ensure creation fields never overwrite an existing session.

## Verification

- `yarn test` — 121 unit files / 715 tests; 34 integration files / 310 tests
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- built-package import + stable ensure smoke
- 149 relative Markdown links resolved across changed docs
- real OpenAI first turn through `ConversationAgentService`: completed with 8 captured activities
- fresh service instance against the same state: resumed the original session, preserved its name, reported `sessionCreated: false`, reached 2 persisted turns, and recalled the first-turn phrase
