### PR TITLE
fix: preserve compaction credentials

### DIFF
--- a/src/__tests__/unit/core/chat-turn-persistence.test.ts
+++ b/src/__tests__/unit/core/chat-turn-persistence.test.ts
@@ -108,6 +108,12 @@ describe('chat turn persistence', () => {
     const repository = new FileChatSessionRepository({ sessionStoragePath });
     await seedChatSessionRepository(repository, [session]);
     const sessionService = createSessionService(stateRoot, sessionStoragePath, repository);
+    const summarizer = {
+      apiKey: 'user-byok-key',
+      credentialStorePath: join(stateRoot, 'auth.json'),
+      credentialSource: { type: 'explicit-api-key' as const },
+    };
+    const persistArtifacts = vi.spyOn(ConversationTurnArtifacts, 'persist');
 
     const result: AgentLoopResult = {
       outcome: 'done',
@@ -165,10 +171,11 @@ describe('chat turn persistence', () => {
       traceDir: join(stateRoot, 'traces'),
       toolNames: ['read_file'],
       historyForTokenEstimate: session.history,
-      credentialSource: { type: 'explicit-api-key' },
+      summarizer,
       host: {},
     });
 
+    expect(persistArtifacts).toHaveBeenCalledWith(expect.objectContaining({ summarizer }));
     const stored = await readStoredChatSession(repository, session.id);
     expect(stored?.id).toBe(session.id);
     expect(stored?.lastContinuePrompt).toBe('Persist this turn.');
@@ -209,7 +216,7 @@ describe('chat turn persistence', () => {
       traceDir: join(stateRoot, 'traces'),
       toolNames: ['read_file'],
       historyForTokenEstimate: session.history,
-      credentialSource: { type: 'explicit-api-key' },
+      summarizer: { credentialSource: { type: 'explicit-api-key' } },
       agentSnapshot,
       host: {},
     });
@@ -265,7 +272,7 @@ describe('chat turn persistence', () => {
       traceDir: join(stateRoot, 'traces'),
       toolNames: [],
       historyForTokenEstimate: session.history,
-      credentialSource: { type: 'explicit-api-key' },
+      summarizer: { credentialSource: { type: 'explicit-api-key' } },
       host: {},
     });
 

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -88,6 +88,11 @@ describe('chat turn preparation modules', () => {
     expect(runtime.provider).toBe('openai');
     expect(runtime.apiKey).toBe('explicit-key');
     expect(runtime.providerCredentialSource).toEqual({ type: 'explicit-api-key' });
+    expect(runtime.summarizer).toEqual({
+      apiKey: 'explicit-key',
+      credentialStorePath: undefined,
+      credentialSource: { type: 'explicit-api-key' },
+    });
     expect(runtime.memoryDir).toBe(join(stateRoot, 'memory'));
     expect(runtime.systemContext).toContain('System context');
     expect(runtime.systemContext).toContain('## Situation Awareness Domain');
@@ -181,6 +186,16 @@ describe('chat turn preparation modules', () => {
       provider: 'openai',
       accountId: 'account-123',
       expiresAt: Date.parse('2026-05-02T01:00:00.000Z'),
+    });
+    expect(runtime.summarizer).toEqual({
+      apiKey: undefined,
+      credentialStorePath,
+      credentialSource: {
+        type: 'oauth',
+        provider: 'openai',
+        accountId: 'account-123',
+        expiresAt: Date.parse('2026-05-02T01:00:00.000Z'),
+      },
     });
   });
 

--- a/src/__tests__/unit/core/conversation-compaction-credentials.test.ts
+++ b/src/__tests__/unit/core/conversation-compaction-credentials.test.ts
@@ -1,0 +1,105 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProviderCredentialRepository } from '@/core/auth/index.js';
+import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
+import { LlmAdapterService, type LlmAdapter } from '@/core/llm/index.js';
+
+describe('conversation compaction credentials', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('keeps compaction on the supplied BYOK key instead of a host key', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'host-openai-key');
+    vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');
+    const llm = summaryLlm('BYOK rolling summary');
+    const create = vi.spyOn(LlmAdapterService, 'create').mockReturnValue(llm);
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-compaction-byok-'));
+
+    const compacted = await ConversationCompactionService.compact({
+      history: history(),
+      runtime: { model: 'gpt-5.4', stateRoot },
+      session: { id: 'session-1' },
+      force: true,
+      summarizer: {
+        apiKey: 'user-byok-key',
+        credentialSource: { type: 'explicit-api-key' },
+      },
+    });
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'gpt-5.1-codex-mini',
+      credentials: {
+        apiKey: 'user-byok-key',
+        credentialStorePath: undefined,
+      },
+    }));
+    expect(compacted.archive.archives).toHaveLength(1);
+    expect(compacted.context.compaction?.status).toBe('idle');
+  });
+
+  it('keeps compaction on the selected OAuth store', async () => {
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');
+    const root = await mkdtemp(join(tmpdir(), 'heddle-compaction-oauth-'));
+    const credentialStorePath = join(root, 'auth.json');
+    const now = Date.now();
+    const timestamp = new Date(now).toISOString();
+    const expiresAt = now + 60 * 60 * 1_000;
+    new ProviderCredentialRepository({ storePath: credentialStorePath }).set({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt,
+      accountId: 'account-123',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    const llm = summaryLlm('OAuth rolling summary');
+    const create = vi.spyOn(LlmAdapterService, 'create').mockReturnValue(llm);
+
+    const compacted = await ConversationCompactionService.compact({
+      history: history(),
+      runtime: { model: 'gpt-5.4', stateRoot: join(root, '.heddle') },
+      session: { id: 'session-1' },
+      force: true,
+      summarizer: {
+        credentialStorePath,
+        credentialSource: {
+          type: 'oauth',
+          provider: 'openai',
+          accountId: 'account-123',
+          expiresAt,
+        },
+      },
+    });
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'gpt-5.4',
+      credentials: {
+        apiKey: undefined,
+        credentialStorePath,
+      },
+    }));
+    expect(compacted.archive.archives).toHaveLength(1);
+  });
+});
+
+function history() {
+  return [
+    { role: 'user' as const, content: 'Remember the durable marker.' },
+    { role: 'assistant' as const, content: 'Marker stored.' },
+    { role: 'user' as const, content: 'Continue the conversation.' },
+    { role: 'assistant' as const, content: 'Continuing.' },
+  ];
+}
+
+function summaryLlm(content: string): LlmAdapter {
+  return {
+    chat: vi.fn(async () => ({ content })),
+  };
+}

--- a/src/__tests__/unit/core/conversation-compaction-state-restoration.test.ts
+++ b/src/__tests__/unit/core/conversation-compaction-state-restoration.test.ts
@@ -54,7 +54,7 @@ describe('compaction infrastructure failure restoration', () => {
       traceDir: join(fixture.stateRoot, 'traces'),
       toolNames: [],
       historyForTokenEstimate: fixture.session.history,
-      credentialSource: { type: 'explicit-api-key' },
+      summarizer: { credentialSource: { type: 'explicit-api-key' } },
       host: {},
     })).rejects.toThrow('archive backend unavailable');
 

--- a/src/core/chat/engine/compaction/README.md
+++ b/src/core/chat/engine/compaction/README.md
@@ -14,6 +14,7 @@ adapter.
 - Building compacted summary messages for future turns.
 - Building persisted compaction context stats.
 - Estimating history and request-token pressure for compaction decisions.
+- Keeping summary generation on the active turn's resolved credential principal.
 
 ## Structure
 
@@ -33,6 +34,11 @@ Archive persistence itself belongs to
 and `summaryPath` values as opaque locators. Repository read/write failures are
 infrastructure failures and reject the compaction; summarizer failures retain
 the original history and produce a failed compaction result.
+
+Turn and control-plane callers must pass the concrete resolved API key or the
+selected credential-store path together with the credential source. Compaction
+may select a purpose-specific summary model, but it must not silently switch
+from a user's credential to a host environment or default auth-store credential.
 
 Avoid adding loose exported functions for compaction-domain behavior. If the
 behavior is part of compaction semantics, put it on `ConversationCompactionService`

--- a/src/core/chat/engine/compaction/summarizer/service.ts
+++ b/src/core/chat/engine/compaction/summarizer/service.ts
@@ -41,16 +41,19 @@ export class ConversationArchiveSummarizer {
           activeModel: options.runtime.model,
           explicitApiKey: options.summarizer?.apiKey,
           credentialSource: options.summarizer?.credentialSource,
+          credentialStorePath: options.summarizer?.credentialStorePath,
         }),
       });
     const providerRuntime = LlmProviderRuntimeService.resolve({
       model,
       apiKey: options.summarizer?.apiKey,
+      credentialStorePath: options.summarizer?.credentialStorePath,
     });
     const apiKey = options.summarizer?.apiKey ?? providerRuntime.apiKey;
     const summarizerCredentialRuntime: ApiKeyRuntime = {
       apiKey,
       apiKeyProvider: options.summarizer?.apiKey ? 'explicit' : apiKey ? provider : undefined,
+      credentialStorePath: options.summarizer?.credentialStorePath,
     };
     if (providerRuntime.credentialSource.type === 'missing' || !RuntimeCredentialService.hasCredentialForModel(model, summarizerCredentialRuntime)) {
       return { model };
@@ -60,7 +63,10 @@ export class ConversationArchiveSummarizer {
       model,
       llm: LlmAdapterService.create({
         model,
-        credentials: { apiKey },
+        credentials: {
+          apiKey,
+          credentialStorePath: options.summarizer?.credentialStorePath,
+        },
         runtime: providerRuntime.llmRuntime,
       }),
     };

--- a/src/core/chat/engine/compaction/types.ts
+++ b/src/core/chat/engine/compaction/types.ts
@@ -9,6 +9,7 @@ export type ConversationCompactionSummarizerOptions = {
   provider?: 'openai' | 'anthropic' | 'active';
   model?: string;
   apiKey?: string;
+  credentialStorePath?: string;
   llm?: LlmAdapter;
   credentialSource?: ProviderCredentialSource;
 };

--- a/src/core/chat/engine/direct-shell/service.ts
+++ b/src/core/chat/engine/direct-shell/service.ts
@@ -140,9 +140,7 @@ export class ConversationDirectShellService {
         toolNames: [chosenCall.tool],
         goal: shellDisplay,
       },
-      summarizer: {
-        credentialSource: input.credentialSource,
-      },
+      summarizer: input.summarizer,
       onStatusChange: input.onCompactionStatus,
     });
 

--- a/src/core/chat/engine/direct-shell/types.ts
+++ b/src/core/chat/engine/direct-shell/types.ts
@@ -1,8 +1,8 @@
 import type { ConversationActivity, ConversationCompactionStatus } from '@/core/live/index.js';
-import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { ConversationDirectShellLineResult } from '@/core/chat/types.js';
 import type { ConversationSessionService } from '../types.js';
 import type { ChatArchiveRepository } from '../sessions/archives/index.js';
+import type { ConversationCompactionOptions } from '../compaction/index.js';
 
 export type DirectShellToolName = 'run_shell_inspect' | 'run_shell_mutate';
 
@@ -25,7 +25,7 @@ export type ConversationDirectShellInput = {
   stateRoot: string;
   archiveRepository?: ChatArchiveRepository;
   systemContext?: string;
-  credentialSource?: ProviderCredentialSource;
+  summarizer: ConversationCompactionOptions['summarizer'];
   sessions: ConversationSessionService;
   abortSignal?: AbortSignal;
   onActivity?: (activity: ConversationActivity) => void;

--- a/src/core/chat/engine/turns/persistence/turn-persistence-service.ts
+++ b/src/core/chat/engine/turns/persistence/turn-persistence-service.ts
@@ -18,7 +18,7 @@ export class ConversationTurnPersistenceService {
     try {
       persisted = await ConversationTurnArtifacts.persist({
         ...artifactInput,
-        summarizer: { credentialSource: args.credentialSource },
+        summarizer: args.summarizer,
         createTurnId: () => `server-turn-${Date.now()}`,
         onCompactionStatus: async (event) => {
           args.host.onCompactionStatus?.(event, 'final');

--- a/src/core/chat/engine/turns/persistence/types.ts
+++ b/src/core/chat/engine/turns/persistence/types.ts
@@ -2,7 +2,6 @@ import type { AgentLoopResult } from '@/core/runtime/loop/index.js';
 import type { RunResult } from '@/core/types.js';
 import type { ChatMessage } from '@/core/llm/types.js';
 import type { ConversationCompactionStatus } from '@/core/live/index.js';
-import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { TraceSummaryService } from '@/core/observability/index.js';
 import type { ChatSession, TurnSummary } from '@/core/chat/types.js';
 import type { ConversationSessionService } from '@/core/chat/engine/types.js';
@@ -76,7 +75,7 @@ export type PersistCompletedChatTurnBase = {
 
 export type PersistCompletedChatTurnArgs = PersistCompletedChatTurnBase & {
   sessionService: ConversationSessionService;
-  credentialSource: ProviderCredentialSource;
+  summarizer: ConversationCompactionOptions['summarizer'];
   host: Pick<ChatTurnHostPort, 'onCompactionStatus'>;
 };
 

--- a/src/core/chat/engine/turns/runtime/runtime-resolver.ts
+++ b/src/core/chat/engine/turns/runtime/runtime-resolver.ts
@@ -48,6 +48,11 @@ export class ConversationTurnRuntimeResolver {
       provider: providerRuntime.provider,
       apiKey,
       providerCredentialSource: providerRuntime.credentialSource,
+      summarizer: {
+        apiKey,
+        credentialStorePath: config.credentialStorePath,
+        credentialSource: providerRuntime.credentialSource,
+      },
       memoryDir,
       systemContext: appendAwarenessDomainSystemContext(domainSystemContext),
       reasoningEffort: session.reasoningEffort,

--- a/src/core/chat/engine/turns/runtime/types.ts
+++ b/src/core/chat/engine/turns/runtime/types.ts
@@ -1,6 +1,7 @@
 import type { LlmAdapter, LlmProvider, ReasoningEffort } from '@/core/llm/types.js';
 import type { ApiKeyRuntime, ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { ChatSession } from '@/core/chat/types.js';
+import type { ConversationCompactionOptions } from '@/core/chat/engine/compaction/index.js';
 
 export type ChatTurnRuntime = {
   model: string;
@@ -8,6 +9,7 @@ export type ChatTurnRuntime = {
   provider: LlmProvider;
   apiKey: string | undefined;
   providerCredentialSource: ProviderCredentialSource;
+  summarizer: ConversationCompactionOptions['summarizer'];
   memoryDir: string;
   systemContext: string | undefined;
   llm: LlmAdapter;

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -112,7 +112,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
         model: runtime.model,
         systemContext: runtime.systemContext,
         toolNames,
-        summarizer: { credentialSource: runtime.providerCredentialSource },
+        summarizer: runtime.summarizer,
         leaseOwner,
         host,
       });
@@ -163,7 +163,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
         systemContext: runtime.systemContext,
         toolNames,
         historyForTokenEstimate: session.history,
-        credentialSource: runtime.providerCredentialSource,
+        summarizer: runtime.summarizer,
         host,
         agentSnapshot,
       });

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -249,6 +249,12 @@ export class ControlPlaneChatSessionsController {
 
           await sessions.markCompactionRunning(sessionId, { sourceHistory: session.history });
           const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
+          const providerRuntime = LlmProviderRuntimeService.resolve({
+            model,
+            apiKey: args.apiKey,
+            credentialStorePath: args.credentialStorePath,
+            preferApiKey: args.preferApiKey,
+          });
           const compacted = await ConversationCompactionService.compact({
             history: session.history,
             runtime: {
@@ -260,11 +266,9 @@ export class ControlPlaneChatSessionsController {
             archiveRepository: args.archiveRepository,
             force,
             summarizer: {
-              credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(model, {
-                apiKey: args.apiKey,
-                credentialStorePath: args.credentialStorePath,
-                preferApiKey: args.preferApiKey,
-              }),
+              apiKey: providerRuntime.apiKey,
+              credentialStorePath: args.credentialStorePath,
+              credentialSource: providerRuntime.credentialSource,
             },
             onStatusChange: publisher.publishActivity,
           });
@@ -667,17 +671,28 @@ export class ControlPlaneChatSessionsController {
         await sessions.acquireLease(args.sessionId, args.leaseOwner);
 
         try {
+          const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
+          const providerRuntime = LlmProviderRuntimeService.resolve({
+            model,
+            apiKey: args.apiKey,
+            credentialStorePath: args.credentialStorePath,
+            preferApiKey: args.preferApiKey,
+          });
           const result = await ConversationDirectShellService.execute({
             sessionId: args.sessionId,
             runId: run.runId,
             command: args.command,
-            model: session.model ?? args.model ?? DEFAULT_OPENAI_MODEL,
+            model,
             workspaceRoot: args.workspaceRoot,
             stateRoot: args.stateRoot,
             archiveRepository: args.archiveRepository,
             systemContext: args.systemContext,
             riskAccepted: args.riskAccepted,
-            credentialSource: RuntimeCredentialService.resolveCredentialSourceForModel(session.model ?? args.model ?? DEFAULT_OPENAI_MODEL, args),
+            summarizer: {
+              apiKey: providerRuntime.apiKey,
+              credentialStorePath: args.credentialStorePath,
+              credentialSource: providerRuntime.credentialSource,
+            },
             sessions,
             abortSignal: run.controller.signal,
             onActivity: publisher.publishActivity,


### PR DESCRIPTION
## Summary

- carry the resolved turn API key or OAuth credential-store path into preflight and final compaction
- preserve the selected credential principal for manual and direct-shell compaction
- add BYOK host-isolation and custom OAuth-store regression coverage

## Root cause

Compaction received only a credential-source label. Its purpose-specific summarizer resolved credentials again, so a caller-supplied key could be lost and replaced by a host credential or reported missing.

## Behavior after this change

Compaction retains its purpose-specific model policy while using the same resolved credential principal as the active conversation.

## Validation

- `yarn vitest run src/__tests__/unit/core/conversation-compaction-credentials.test.ts src/__tests__/unit/core/chat-turn-runtime.test.ts src/__tests__/unit/core/chat-turn-persistence.test.ts src/__tests__/unit/core/conversation-compaction-state-restoration.test.ts src/__tests__/integration/control-plane/session-lifecycle.test.ts`
- `yarn lint`
- `yarn typecheck`
- `yarn test` (719 unit, 310 integration)
- `yarn build`
