### PR TITLE
feat: support request-scoped OAuth credentials

### DIFF
--- a/docs/guides/programmatic/quickstart.md
+++ b/docs/guides/programmatic/quickstart.md
@@ -41,6 +41,27 @@ Creation fields never overwrite an existing session with that ID. A hosted
 service must derive the ID and repository scope from trusted server-side
 identity; Heddle does not provide authentication or tenant mapping.
 
+If the host already acquired an OpenAI account access token, it can keep the
+token request-scoped instead of writing it to Heddle's credential store:
+
+```ts
+const agent = new ConversationAgentService({
+  model: 'gpt-5.4',
+  credential: {
+    type: 'oauth-access-token',
+    provider: 'openai',
+    accessToken,
+    expiresAt,
+    accountId,
+  },
+})
+```
+
+Heddle never refreshes or persists this credential. The host must acquire it,
+send it over an authenticated transport, keep it out of logs and durable state,
+and require sign-in again after expiry or host refresh. The same token is used
+for the turn, compaction, and OpenAI-backed tools.
+
 The result and activities are trusted in-process host data; they may include
 tool input/output, local paths, or other internal details. Do not serialize them
 directly to an untrusted browser. Use a host-owned public projection and the

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -90,6 +90,7 @@ describe('chat turn preparation modules', () => {
     expect(runtime.providerCredentialSource).toEqual({ type: 'explicit-api-key' });
     expect(runtime.summarizer).toEqual({
       apiKey: 'explicit-key',
+      credential: undefined,
       credentialStorePath: undefined,
       credentialSource: { type: 'explicit-api-key' },
     });
@@ -189,6 +190,12 @@ describe('chat turn preparation modules', () => {
     });
     expect(runtime.summarizer).toEqual({
       apiKey: undefined,
+      credential: expect.objectContaining({
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        accountId: 'account-123',
+      }),
       credentialStorePath,
       credentialSource: {
         type: 'oauth',
@@ -196,6 +203,42 @@ describe('chat turn preparation modules', () => {
         accountId: 'account-123',
         expiresAt: Date.parse('2026-05-02T01:00:00.000Z'),
       },
+    });
+  });
+
+  it('threads one request-scoped access token through turn and compaction runtime', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'host-openai-key');
+    const root = mkdtempSync(join(tmpdir(), 'heddle-turn-runtime-oauth-'));
+    const credential = {
+      type: 'oauth-access-token' as const,
+      provider: 'openai' as const,
+      accessToken: 'request-access-token',
+      expiresAt: Date.now() + 60 * 60_000,
+      accountId: 'account-123',
+    };
+
+    const runtime = ConversationTurnRuntimeResolver.resolve({
+      config: {
+        stateRoot: join(root, '.heddle'),
+        credential,
+        preferApiKey: true,
+      },
+      session: { model: 'gpt-5.4' },
+    });
+
+    expect(runtime.apiKey).toBeUndefined();
+    expect(runtime.credential).toBe(credential);
+    expect(runtime.providerCredentialSource).toEqual({
+      type: 'oauth-access-token',
+      provider: 'openai',
+      accountId: 'account-123',
+      expiresAt: credential.expiresAt,
+    });
+    expect(runtime.summarizer).toEqual({
+      apiKey: undefined,
+      credential,
+      credentialStorePath: undefined,
+      credentialSource: runtime.providerCredentialSource,
     });
   });
 

--- a/src/__tests__/unit/core/conversation-compaction-credentials.test.ts
+++ b/src/__tests__/unit/core/conversation-compaction-credentials.test.ts
@@ -34,6 +34,7 @@ describe('conversation compaction credentials', () => {
       model: 'gpt-5.1-codex-mini',
       credentials: {
         apiKey: 'user-byok-key',
+        credential: undefined,
         credentialStorePath: undefined,
       },
     }));
@@ -82,7 +83,55 @@ describe('conversation compaction credentials', () => {
       model: 'gpt-5.4',
       credentials: {
         apiKey: undefined,
+        credential: expect.objectContaining({
+          type: 'oauth',
+          provider: 'openai',
+          accessToken: 'access-token',
+          accountId: 'account-123',
+        }),
         credentialStorePath,
+      },
+    }));
+    expect(compacted.archive.archives).toHaveLength(1);
+  });
+
+  it('keeps compaction on the request-scoped access token', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'host-openai-key');
+    vi.stubEnv('PERSONAL_OPENAI_API_KEY', '');
+    const stateRoot = await mkdtemp(join(tmpdir(), 'heddle-compaction-runtime-oauth-'));
+    const credential = {
+      type: 'oauth-access-token' as const,
+      provider: 'openai' as const,
+      accessToken: 'request-access-token',
+      expiresAt: Date.now() + 60 * 60_000,
+      accountId: 'account-123',
+    };
+    const create = vi.spyOn(LlmAdapterService, 'create').mockReturnValue(
+      summaryLlm('Request OAuth rolling summary'),
+    );
+
+    const compacted = await ConversationCompactionService.compact({
+      history: history(),
+      runtime: { model: 'gpt-5.4', stateRoot },
+      session: { id: 'session-1' },
+      force: true,
+      summarizer: {
+        credential,
+        credentialSource: {
+          type: 'oauth-access-token',
+          provider: 'openai',
+          accountId: 'account-123',
+          expiresAt: credential.expiresAt,
+        },
+      },
+    });
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'gpt-5.4',
+      credentials: {
+        apiKey: undefined,
+        credential,
+        credentialStorePath: undefined,
       },
     }));
     expect(compacted.archive.archives).toHaveLength(1);

--- a/src/__tests__/unit/core/external-context-runtime-credentials.test.ts
+++ b/src/__tests__/unit/core/external-context-runtime-credentials.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OPENAI_CODEX_RESPONSES_ENDPOINT } from '../../../core/auth/openai-oauth.js';
+import { createWebSearchTool } from '../../../core/tools/toolkits/external-context/web-search.js';
+
+describe('external-context runtime credentials', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the request-scoped OpenAI access token for web search', async () => {
+    const requests: Array<{ url: string; headers: Headers }> = [];
+    vi.stubGlobal('fetch', (async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({
+        url: String(url),
+        headers: new Headers(init?.headers),
+      });
+      return new Response([
+        'data: {"type":"response.output_text.done","text":"Runtime credential search result."}',
+        '',
+      ].join('\n'));
+    }) as typeof fetch);
+
+    const credential = {
+      type: 'oauth-access-token',
+      provider: 'openai',
+      accessToken: 'request-access-token',
+      expiresAt: Date.now() + 120_000,
+      accountId: 'account-123',
+    } as const;
+    const tool = createWebSearchTool({
+      model: 'gpt-5.4',
+      credential,
+      providerCredentialSource: {
+        type: 'oauth-access-token',
+        provider: 'openai',
+        expiresAt: credential.expiresAt,
+        accountId: credential.accountId,
+      },
+    });
+
+    await expect(tool.execute({ query: 'Heddle runtime credentials' })).resolves.toMatchObject({
+      ok: true,
+      output: {
+        provider: 'openai',
+        model: 'gpt-5.4',
+        summary: 'Runtime credential search result.',
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe(OPENAI_CODEX_RESPONSES_ENDPOINT);
+    expect(requests[0]?.headers.get('authorization')).toBe('Bearer request-access-token');
+    expect(requests[0]?.headers.get('ChatGPT-Account-Id')).toBe('account-123');
+  });
+});

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -186,6 +186,54 @@ describe('OpenAI OAuth helpers', () => {
     expect(requests[1]?.url).toBe(OPENAI_CODEX_RESPONSES_ENDPOINT);
     expect(requests[1]?.headers.get('authorization')).toBe('Bearer new-access-token');
     expect(requests[1]?.headers.get('ChatGPT-Account-Id')).toBe('account-123');
+  });
+
+  it('routes a request-scoped access token without refreshing or persisting it', async () => {
+    const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-runtime-oauth-fetch-')), 'auth.json');
+    const requests: Array<{ url: string; headers: Headers }> = [];
+    const oauthFetch = OpenAiOAuthFetchService.create({
+      type: 'oauth-access-token',
+      provider: 'openai',
+      accessToken: 'request-access-token',
+      expiresAt: Date.now() + 120_000,
+      accountId: 'account-123',
+    }, {
+      storePath,
+      fetchImpl: (async (url, init) => {
+        requests.push({
+          url: String(url),
+          headers: new Headers(init?.headers),
+        });
+        return new Response('ok');
+      }) as typeof fetch,
+    });
+
+    await oauthFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { authorization: 'Bearer placeholder' },
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe(OPENAI_CODEX_RESPONSES_ENDPOINT);
+    expect(requests[0]?.headers.get('authorization')).toBe('Bearer request-access-token');
+    expect(requests[0]?.headers.get('ChatGPT-Account-Id')).toBe('account-123');
+    expect(existsSync(storePath)).toBe(false);
+  });
+
+  it('rejects an expired request-scoped token before any provider request', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const oauthFetch = OpenAiOAuthFetchService.create({
+      type: 'oauth-access-token',
+      provider: 'openai',
+      accessToken: 'expired-access-token',
+      expiresAt: Date.now() - 1_000,
+    }, { fetchImpl });
+
+    await expect(oauthFetch('https://api.openai.com/v1/responses')).rejects.toMatchObject({
+      code: 'oauth_access_token_expired',
+      status: 401,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it('fails clearly for account sign-in with a model outside the known Codex set', async () => {

--- a/src/__tests__/unit/core/runtime-credentials.test.ts
+++ b/src/__tests__/unit/core/runtime-credentials.test.ts
@@ -44,6 +44,12 @@ describe('RuntimeCredentialService', () => {
       accountId: 'account-123',
     })).toBe('openai OAuth account account-123');
     expect(RuntimeCredentialService.formatCredentialSource({
+      type: 'oauth-access-token',
+      provider: 'openai',
+      accountId: 'account-123',
+      expiresAt: Date.parse('2026-07-20T02:00:00.000Z'),
+    })).toBe('openai request-scoped OAuth account account-123');
+    expect(RuntimeCredentialService.formatCredentialSource({
       type: 'local-endpoint',
       provider: 'ollama',
       baseUrl: 'http://localhost:11434/v1',
@@ -212,5 +218,48 @@ describe('RuntimeCredentialService', () => {
       type: 'env-api-key',
       provider: 'openai',
     });
+  });
+
+  it('resolves a request-scoped access token without falling back to an environment key', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'host-openai-key');
+    const credential = {
+      type: 'oauth-access-token' as const,
+      provider: 'openai' as const,
+      accessToken: 'request-access-token',
+      expiresAt: Date.now() + 60 * 60_000,
+      accountId: 'account-123',
+    };
+
+    expect(RuntimeCredentialService.resolveForModel('gpt-5.4', {
+      credential,
+      preferApiKey: true,
+    })).toEqual({
+      provider: 'openai',
+      credential,
+      source: {
+        type: 'oauth-access-token',
+        provider: 'openai',
+        accountId: 'account-123',
+        expiresAt: credential.expiresAt,
+      },
+    });
+  });
+
+  it('rejects ambiguous or provider-mismatched runtime credentials', () => {
+    const credential = {
+      type: 'oauth-access-token' as const,
+      provider: 'openai' as const,
+      accessToken: 'request-access-token',
+      expiresAt: Date.now() + 60 * 60_000,
+    };
+
+    expect(() => RuntimeCredentialService.resolveForModel('gpt-5.4', {
+      apiKey: 'api-key',
+      apiKeyProvider: 'explicit',
+      credential,
+    })).toThrow('Provide either apiKey or credential');
+    expect(() => RuntimeCredentialService.resolveForModel('claude-sonnet-4-6', {
+      credential,
+    })).toThrow('Runtime credential provider openai does not match model provider anthropic.');
   });
 });

--- a/src/__tests__/unit/sdk/conversation-agent.test.ts
+++ b/src/__tests__/unit/sdk/conversation-agent.test.ts
@@ -10,6 +10,7 @@ import { ConversationAgentService } from '@/sdk/conversation/headless/index.js';
 describe('ConversationAgentService', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     vi.spyOn(EngineConversationTurnService, 'run').mockImplementation(async (args) => {
       const event: AgentLoopEvent = {
         source: 'agent-loop',
@@ -115,5 +116,35 @@ describe('ConversationAgentService', () => {
       'Conversation agent prompt cannot be empty.',
     );
     await expect(agent.engine.sessions.listExisting()).resolves.toEqual([]);
+  });
+
+  it('accepts a request-scoped access token without selecting a host API key', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'host-openai-key');
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-conversation-agent-oauth-'));
+    const credential = {
+      type: 'oauth-access-token' as const,
+      provider: 'openai' as const,
+      accessToken: 'request-access-token',
+      expiresAt: Date.now() + 60 * 60_000,
+      accountId: 'account-123',
+    };
+    const agent = new ConversationAgentService({
+      credential,
+      model: 'gpt-5.4',
+      workspaceRoot,
+    });
+
+    await agent.send({ prompt: 'Use this account for one turn.' });
+
+    expect(agent.runtime.credential?.source).toEqual({
+      type: 'oauth-access-token',
+      provider: 'openai',
+      accountId: 'account-123',
+      expiresAt: credential.expiresAt,
+    });
+    expect(EngineConversationTurnService.run).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: undefined,
+      credential,
+    }));
   });
 });

--- a/src/cli-v2/services/status/runtime-status-service.ts
+++ b/src/cli-v2/services/status/runtime-status-service.ts
@@ -37,6 +37,8 @@ export class RuntimeStatusService {
         return `auth=${source.provider}-key`;
       case 'oauth':
         return `auth=${source.provider}-oauth`;
+      case 'oauth-access-token':
+        return `auth=${source.provider}-request-oauth`;
       case 'local-endpoint':
         return `auth=${source.provider}-local`;
       case 'missing':

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -11,5 +11,7 @@ export type {
   PkceCodes,
   ProviderCredentialStore,
   ProviderCredentialSummary,
+  ResolvedProviderCredential,
+  RuntimeProviderCredential,
   StoredProviderCredential,
 } from './types.js';

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -29,6 +29,23 @@ export type StoredProviderCredential =
       label?: string;
     };
 
+/**
+ * A provider credential supplied only for the lifetime of one runtime/engine.
+ * It intentionally excludes refresh material and persistence metadata.
+ */
+export type RuntimeProviderCredential = {
+  type: 'oauth-access-token';
+  provider: 'openai';
+  accessToken: string;
+  /** Unix epoch timestamp in milliseconds. */
+  expiresAt: number;
+  accountId?: string;
+};
+
+export type ResolvedProviderCredential =
+  | RuntimeProviderCredential
+  | Extract<StoredProviderCredential, { type: 'oauth' }>;
+
 export type ProviderCredentialStore = {
   version: 1;
   credentials: Partial<Record<LlmProvider, StoredProviderCredential>>;

--- a/src/core/chat/engine/README.md
+++ b/src/core/chat/engine/README.md
@@ -10,6 +10,9 @@ not each invent their own version.
 ## Owns
 
 - Normalized engine config and derived paths in `config.ts`.
+- Request-scoped runtime credential propagation across the main turn,
+  compaction, and provider-backed tools. Token acquisition, refresh, and host
+  transport remain outside the engine.
 - File-backed session persistence, migration, lease rules, titles, archives, and
   conversation-line projection plus session execution-preference policy under
   `sessions/`.
@@ -83,6 +86,8 @@ Use this pattern when it fits the domain:
 ## Common Changes
 
 - Put normalized config, path defaults, and engine-wide defaults in `config.ts`.
+- Accept a transient provider access token through `credential`; never put it
+  into session metadata, archives, traces, or the provider credential store.
 - Put persisted session lifecycle behavior in `sessions/service.ts` and related
   `sessions/*` modules.
 - Runtime and compaction events should already use the shared

--- a/src/core/chat/engine/compaction/summarizer/service.ts
+++ b/src/core/chat/engine/compaction/summarizer/service.ts
@@ -47,12 +47,18 @@ export class ConversationArchiveSummarizer {
     const providerRuntime = LlmProviderRuntimeService.resolve({
       model,
       apiKey: options.summarizer?.apiKey,
+      credential: options.summarizer?.credential?.type === 'oauth-access-token' ?
+          options.summarizer.credential
+        : undefined,
       credentialStorePath: options.summarizer?.credentialStorePath,
     });
     const apiKey = options.summarizer?.apiKey ?? providerRuntime.apiKey;
     const summarizerCredentialRuntime: ApiKeyRuntime = {
       apiKey,
       apiKeyProvider: options.summarizer?.apiKey ? 'explicit' : apiKey ? provider : undefined,
+      credential: options.summarizer?.credential?.type === 'oauth-access-token' ?
+          options.summarizer.credential
+        : undefined,
       credentialStorePath: options.summarizer?.credentialStorePath,
     };
     if (providerRuntime.credentialSource.type === 'missing' || !RuntimeCredentialService.hasCredentialForModel(model, summarizerCredentialRuntime)) {
@@ -65,6 +71,7 @@ export class ConversationArchiveSummarizer {
         model,
         credentials: {
           apiKey,
+          credential: providerRuntime.credential,
           credentialStorePath: options.summarizer?.credentialStorePath,
         },
         runtime: providerRuntime.llmRuntime,

--- a/src/core/chat/engine/compaction/types.ts
+++ b/src/core/chat/engine/compaction/types.ts
@@ -1,7 +1,10 @@
 import type { ChatArchiveRecord, ChatContextStats, ChatSession } from '@/core/chat/types.js';
 import type { ConversationCompactionStatus } from '@/core/live/index.js';
 import type { ChatMessage, LlmAdapter, LlmUsage } from '@/core/llm/types.js';
-import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
+import type {
+  ProviderCredentialSource,
+  ResolvedProviderCredential,
+} from '@/core/runtime/credentials/index.js';
 import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
 export type { ConversationCompactionStatus } from '@/core/live/index.js';
 
@@ -9,6 +12,7 @@ export type ConversationCompactionSummarizerOptions = {
   provider?: 'openai' | 'anthropic' | 'active';
   model?: string;
   apiKey?: string;
+  credential?: ResolvedProviderCredential;
   credentialStorePath?: string;
   llm?: LlmAdapter;
   credentialSource?: ProviderCredentialSource;

--- a/src/core/chat/engine/config.ts
+++ b/src/core/chat/engine/config.ts
@@ -11,6 +11,7 @@ import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
 import { ConversationEngineHostExtensionService } from './host-extension.js';
 import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
+import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
 import {
   ConversationPersistenceService,
 } from './persistence/conversation-persistence.js';
@@ -24,6 +25,7 @@ export type NormalizedConversationEngineConfig = {
   model: string;
   reasoningEffort?: ReasoningEffort;
   apiKey?: string;
+  credential?: RuntimeProviderCredential;
   preferApiKey?: boolean;
   credentialStorePath?: string;
   systemContext?: string;
@@ -84,6 +86,7 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     model: config.model,
     reasoningEffort: config.reasoningEffort,
     apiKey: config.apiKey,
+    credential: config.credential,
     preferApiKey: config.preferApiKey,
     credentialStorePath,
     systemContext,
@@ -104,6 +107,6 @@ export function normalizeConversationEngineConfig(config: ConversationEngineConf
     memoryDir,
     traceDir,
     workspaceId: config.workspaceId,
-    apiKeyPresent: config.apiKeyPresent ?? Boolean(config.apiKey),
+    apiKeyPresent: config.apiKeyPresent ?? Boolean(config.apiKey || config.credential),
   };
 }

--- a/src/core/chat/engine/turns/context/types.ts
+++ b/src/core/chat/engine/turns/context/types.ts
@@ -7,6 +7,7 @@ import type { ConversationSessionService } from '@/core/chat/engine/types.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import type { ChatTurnRuntime } from '../runtime/index.js';
 import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
+import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
 
 export type PrepareConversationTurnContextArgs = {
   workspaceRoot: string;
@@ -14,6 +15,7 @@ export type PrepareConversationTurnContextArgs = {
   sessionService: ConversationSessionService;
   sessionId: string;
   apiKey?: string;
+  credential?: RuntimeProviderCredential;
   preferApiKey?: boolean;
   credentialStorePath?: string;
   systemContext?: string;
@@ -33,6 +35,7 @@ export type PrepareConversationTurnContextArgs = {
 export type ConversationTurnToolContextArgs = Pick<
   PrepareConversationTurnContextArgs,
   | 'workspaceRoot'
+  | 'credential'
   | 'credentialStorePath'
   | 'searchIgnoreDirs'
   | 'includePlanTool'
@@ -49,7 +52,7 @@ export type ConversationTurnToolContextArgs = Pick<
 
 export type ConversationTurnToolRuntimeArgs = Pick<
   ChatTurnRuntime,
-  'model' | 'apiKey' | 'providerCredentialSource' | 'memoryDir'
+  'model' | 'apiKey' | 'credential' | 'providerCredentialSource' | 'memoryDir'
 >;
 
 export type ConversationTurnContext = {

--- a/src/core/chat/engine/turns/runtime/runtime-resolver.ts
+++ b/src/core/chat/engine/turns/runtime/runtime-resolver.ts
@@ -47,9 +47,11 @@ export class ConversationTurnRuntimeResolver {
       model,
       provider: providerRuntime.provider,
       apiKey,
+      credential: providerRuntime.credential,
       providerCredentialSource: providerRuntime.credentialSource,
       summarizer: {
         apiKey,
+        credential: providerRuntime.credential,
         credentialStorePath: config.credentialStorePath,
         credentialSource: providerRuntime.credentialSource,
       },
@@ -60,6 +62,7 @@ export class ConversationTurnRuntimeResolver {
         model,
         credentials: {
           apiKey,
+          credential: providerRuntime.credential,
           credentialStorePath: config.credentialStorePath,
         },
         runtime: {
@@ -74,6 +77,7 @@ export class ConversationTurnRuntimeResolver {
     return {
       apiKey: config.apiKey,
       apiKeyProvider: config.apiKey ? 'explicit' : undefined,
+      credential: config.credential,
       credentialStorePath: config.credentialStorePath,
       preferApiKey: config.preferApiKey,
     };

--- a/src/core/chat/engine/turns/runtime/types.ts
+++ b/src/core/chat/engine/turns/runtime/types.ts
@@ -1,5 +1,9 @@
 import type { LlmAdapter, LlmProvider, ReasoningEffort } from '@/core/llm/types.js';
-import type { ApiKeyRuntime, ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
+import type {
+  ApiKeyRuntime,
+  ProviderCredentialSource,
+  ResolvedProviderCredential,
+} from '@/core/runtime/credentials/index.js';
 import type { ChatSession } from '@/core/chat/types.js';
 import type { ConversationCompactionOptions } from '@/core/chat/engine/compaction/index.js';
 
@@ -8,6 +12,7 @@ export type ChatTurnRuntime = {
   reasoningEffort?: ReasoningEffort;
   provider: LlmProvider;
   apiKey: string | undefined;
+  credential: ResolvedProviderCredential | undefined;
   providerCredentialSource: ProviderCredentialSource;
   summarizer: ConversationCompactionOptions['summarizer'];
   memoryDir: string;

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -125,6 +125,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
         goal: args.prompt,
         model: runtime.model,
         apiKey: runtime.apiKey,
+        credential: runtime.credential?.type === 'oauth-access-token' ? runtime.credential : undefined,
         stateDir: args.stateRoot,
         memoryDir: runtime.memoryDir,
         llm: runtime.llm,

--- a/src/core/chat/engine/turns/types.ts
+++ b/src/core/chat/engine/turns/types.ts
@@ -12,6 +12,7 @@ import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
 import type { ConversationTurnResultSummary } from '../turn-result.js';
 import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
+import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
 
 export type RunConversationTurnArgs = {
   workspaceRoot: string;
@@ -23,6 +24,7 @@ export type RunConversationTurnArgs = {
   sessionId: string;
   prompt: string;
   apiKey?: string;
+  credential?: RuntimeProviderCredential;
   preferApiKey?: boolean;
   credentialStorePath?: string;
   systemContext?: string;
@@ -58,6 +60,7 @@ export type TurnRuntimeConfigInput = Pick<
   | 'sessionRepository'
   | 'archiveRepository'
   | 'apiKey'
+  | 'credential'
   | 'preferApiKey'
   | 'credentialStorePath'
   | 'systemContext'

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -22,6 +22,7 @@ import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js
 import type { ChatTurnHostPort } from './turns/host/index.js';
 import type { ConversationTurnResultSummary } from './turn-result.js';
 import type { ConversationCompactionResult } from '@/core/chat/engine/compaction/index.js';
+import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
 import type { RuntimeToolSelectionProfile } from '@/core/runtime/tools/index.js';
 import type {
   HeddlePersistenceCapabilities,
@@ -39,6 +40,11 @@ export type ConversationEngineConfig = {
   model: string;
   reasoningEffort?: ReasoningEffort;
   apiKey?: string;
+  /**
+   * Request-scoped provider credential. It stays in memory, is never refreshed
+   * or persisted, and must not be combined with `apiKey`.
+   */
+  credential?: RuntimeProviderCredential;
   preferApiKey?: boolean;
   credentialStorePath?: string;
   systemContext?: string;

--- a/src/core/llm/README.md
+++ b/src/core/llm/README.md
@@ -20,6 +20,13 @@ choosing providers themselves.
 - `models/` owns the curated model catalog and model policy decisions used by
   hosts.
 
+The OpenAI adapter accepts two account-sign-in lifecycles. Stored OAuth
+credentials may refresh through Heddle's credential repository. A
+request-scoped `oauth-access-token` is already resolved by the host/runtime;
+the adapter attaches it to requests, rejects it when expired, and never refreshes
+or persists it. Provider-backed tools must receive the same resolved credential
+as the main model so one run cannot silently change principals.
+
 Provider adapters should follow the local pattern:
 
 - expose a class for the provider adapter and concrete LLM adapter;

--- a/src/core/llm/adapters/openai/openai-adapter.ts
+++ b/src/core/llm/adapters/openai/openai-adapter.ts
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import OpenAI from 'openai';
+import dayjs from 'dayjs';
 import type {
   Response as OpenAiResponse,
   ResponseStreamEvent,
@@ -18,6 +19,7 @@ import {
 import {
   ProviderCredentialRepository,
   type OpenAiOAuthCredential,
+  type RuntimeProviderCredential,
   type StoredProviderCredential,
 } from '@/core/auth/index.js';
 import { ModelPolicyService } from '@/core/llm/models/index.js';
@@ -26,6 +28,7 @@ import { OpenAiCodec } from './openai-codec.js';
 export type OpenAiAdapterOptions = LlmAdapterCreateInput;
 
 export type CompatibleFetch = (url: unknown, init?: unknown) => Promise<globalThis.Response>;
+export type OpenAiAccountCredential = OpenAiOAuthCredential | RuntimeProviderCredential;
 
 /**
  * OpenAI implementation of the LLM port. It owns OpenAI Responses streaming,
@@ -43,13 +46,15 @@ export class OpenAiAdapter implements LlmAdapter {
 
   private readonly client: OpenAI;
   private readonly model: string;
-  private readonly oauthCredential?: StoredProviderCredential;
+  private readonly oauthCredential?: OpenAiAccountCredential;
   private readonly reasoningEffort?: ReasoningEffort;
 
   constructor(options: OpenAiAdapterOptions = {}) {
     const credentials = options.credentials;
     const runtime = options.runtime;
-    this.oauthCredential = credentials?.credential?.type === 'oauth' ? credentials.credential : undefined;
+    this.oauthCredential = OpenAiOAuthFetchService.isAccountCredential(credentials?.credential) ?
+        credentials.credential
+      : undefined;
     this.model = options.model ?? DEFAULT_OPENAI_MODEL;
     this.reasoningEffort = runtime?.reasoningEffort;
     this.client = new OpenAI({
@@ -227,12 +232,12 @@ export type OpenAiOAuthFetchOptions = {
 };
 
 /**
- * Builds the OpenAI OAuth fetch implementation and refreshes stored account
- * credentials before expiry.
+ * Builds the OpenAI account-mode fetch implementation. Stored credentials may
+ * refresh and persist; request-scoped access tokens never do either.
  */
 export class OpenAiOAuthFetchService {
   static create(
-    initialCredential: OpenAiOAuthCredential,
+    initialCredential: OpenAiAccountCredential,
     options: OpenAiOAuthFetchOptions = {},
   ): OpenAiFetch {
     let credential = initialCredential;
@@ -240,7 +245,11 @@ export class OpenAiOAuthFetchService {
     const refreshBeforeMs = options.refreshBeforeMs ?? 60_000;
 
     const oauthFetch: CompatibleFetch = async (requestInput, init) => {
-      if (credential.expiresAt <= Date.now() + refreshBeforeMs) {
+      if (!dayjs(credential.expiresAt).isAfter(dayjs().add(refreshBeforeMs, 'millisecond'))) {
+        if (credential.type === 'oauth-access-token') {
+          throw OpenAiOAuthFetchService.expiredRuntimeCredentialError();
+        }
+
         credential = await OpenAiOAuthService.refreshCredential(credential, { fetchImpl: fetcher as typeof fetch });
         new ProviderCredentialRepository({ storePath: options.storePath }).set(credential);
       }
@@ -267,6 +276,12 @@ export class OpenAiOAuthFetchService {
     return oauthFetch as unknown as OpenAiFetch;
   }
 
+  static isAccountCredential(
+    credential: StoredProviderCredential | RuntimeProviderCredential | undefined,
+  ): credential is OpenAiAccountCredential {
+    return credential?.type === 'oauth' || credential?.type === 'oauth-access-token';
+  }
+
   private static normalizeRequestUrl(requestInput: unknown): URL {
     if (requestInput instanceof URL) {
       return requestInput;
@@ -279,6 +294,13 @@ export class OpenAiOAuthFetchService {
 
   private static shouldRouteToCodexResponses(url: URL): boolean {
     return url.pathname.endsWith('/responses') || url.pathname.endsWith('/chat/completions');
+  }
+
+  private static expiredRuntimeCredentialError(): Error {
+    return Object.assign(
+      new Error('OpenAI OAuth access token expired. Sign in again and retry.'),
+      { code: 'oauth_access_token_expired', status: 401 },
+    );
   }
 }
 

--- a/src/core/llm/models/model-policy-service.ts
+++ b/src/core/llm/models/model-policy-service.ts
@@ -92,7 +92,7 @@ const DEFAULT_OPENAI_REASONING_EFFORT: Record<string, ReasoningEffort> = {
  */
 export class ModelPolicyService {
   static credentialModeFromSource(source: ProviderCredentialSource | undefined): ModelCredentialMode {
-    if (source?.type === 'oauth') {
+    if (source?.type === 'oauth' || source?.type === 'oauth-access-token') {
       return 'oauth';
     }
 

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -3,7 +3,10 @@
 // ---------------------------------------------------------------------------
 
 import type { AssistantDiagnostics, ToolCall, ToolDefinition } from '../types.js';
-import type { StoredProviderCredential } from '@/core/auth/index.js';
+import type {
+  RuntimeProviderCredential,
+  StoredProviderCredential,
+} from '@/core/auth/index.js';
 
 export type LlmStreamEvent =
   | { type: 'content.delta'; delta: string }
@@ -83,7 +86,7 @@ export interface LlmAdapter {
 
 export type LlmCredentialContext = {
   apiKey?: string;
-  credential?: StoredProviderCredential;
+  credential?: StoredProviderCredential | RuntimeProviderCredential;
   credentialStorePath?: string;
 };
 

--- a/src/core/runtime/credentials/README.md
+++ b/src/core/runtime/credentials/README.md
@@ -4,9 +4,27 @@ Runtime credentials own provider credential source selection for generic agent
 execution.
 
 `RuntimeCredentialService` decides whether a model will use an explicit API key,
-an environment API key, a stored OAuth credential, a local no-auth endpoint, or
-no available credential. Callers should resolve this once at their owning
-runtime boundary and pass the concrete result downward.
+an environment API key, a stored OAuth credential, a request-scoped OAuth access
+token, a local no-auth endpoint, or no available credential. Callers should
+resolve this once at their owning runtime boundary and pass the concrete result
+downward.
+
+## Credential lifecycles
+
+- Stored credentials may contain refresh material and are owned by
+  `ProviderCredentialRepository`. The OpenAI adapter may refresh and persist
+  them.
+- A `RuntimeProviderCredential` is supplied by the embedding host for one
+  engine/runtime instance. It contains only an access token and expiry. Heddle
+  uses it for the main turn, compaction, and provider-backed tools, but never
+  refreshes or writes it to the credential repository.
+
+Hosts must acquire request-scoped tokens outside Heddle and send them only over
+an authenticated transport. They remain responsible for tenant authorization,
+redaction, and re-authentication after expiry or process/browser refresh.
+
+Do not combine `apiKey` and `credential` for one runtime. The ambiguity is
+rejected during resolution instead of relying on an implicit precedence rule.
 
 Local providers are not "missing credentials." For example, Ollama resolves to a
 `local-endpoint` source with the OpenAI-compatible base URL. Adapter creation

--- a/src/core/runtime/credentials/index.ts
+++ b/src/core/runtime/credentials/index.ts
@@ -1,2 +1,8 @@
 export { RuntimeCredentialService } from './service.js';
-export type { ApiKeyRuntime, ProviderCredentialSource } from './types.js';
+export type {
+  ApiKeyRuntime,
+  ProviderCredentialResolution,
+  ProviderCredentialSource,
+  ResolvedProviderCredential,
+  RuntimeProviderCredential,
+} from './types.js';

--- a/src/core/runtime/credentials/service.ts
+++ b/src/core/runtime/credentials/service.ts
@@ -9,7 +9,12 @@ import {
   type OpenAiCompatibleProviderProfile,
 } from '@/core/llm/index.js';
 import type { LlmProvider, LlmProviderEndpointRuntime } from '@/core/llm/types.js';
-import type { ApiKeyRuntime, ProviderCredentialSource } from './types.js';
+import type {
+  ApiKeyRuntime,
+  ProviderCredentialResolution,
+  ProviderCredentialSource,
+  RuntimeProviderCredential,
+} from './types.js';
 
 /**
  * Resolves runtime credential sources for provider-backed agent execution.
@@ -43,23 +48,7 @@ export class RuntimeCredentialService {
   }
 
   static resolveApiKeyForModel(model: string, runtime?: ApiKeyRuntime): string | undefined {
-    const source = this.resolveCredentialSourceForModel(model, runtime);
-
-    if (source.type === 'local-endpoint') {
-      return undefined;
-    }
-
-    if (source.type === 'explicit-api-key') {
-      return runtime?.apiKey;
-    }
-
-    if (source.type === 'env-api-key') {
-      return runtime?.apiKey && runtime.apiKeyProvider === source.provider ?
-          runtime.apiKey
-        : this.resolveProviderApiKey(source.provider);
-    }
-
-    return undefined;
+    return this.resolveForModel(model, runtime).apiKey;
   }
 
   static resolveOAuthCredentialForModel(
@@ -75,54 +64,107 @@ export class RuntimeCredentialService {
     model: string,
     runtime?: ApiKeyRuntime & { credentialStorePath?: string },
   ): boolean {
-    return this.resolveCredentialSourceForModel(model, runtime).type !== 'missing';
+    return this.resolveForModel(model, runtime).source.type !== 'missing';
   }
 
   static resolveCredentialSourceForModel(
     model: string,
     runtime?: ApiKeyRuntime,
   ): ProviderCredentialSource {
+    return this.resolveForModel(model, runtime).source;
+  }
+
+  /** Resolves one concrete credential principal for a model-backed runtime. */
+  static resolveForModel(
+    model: string,
+    runtime?: ApiKeyRuntime,
+  ): ProviderCredentialResolution {
     const provider = LlmAdapterService.inferProvider(model);
+    RuntimeCredentialService.assertRuntimeCredential({
+      apiKey: runtime?.apiKey,
+      credential: runtime?.credential,
+      provider,
+    });
     const localEndpointSource = this.resolveLocalEndpointCredentialSource(provider);
     if (localEndpointSource) {
-      return localEndpointSource;
+      return { provider, source: localEndpointSource };
+    }
+
+    if (runtime?.credential) {
+      return {
+        provider,
+        credential: runtime.credential,
+        source: {
+          type: 'oauth-access-token',
+          provider: runtime.credential.provider,
+          accountId: runtime.credential.accountId,
+          expiresAt: runtime.credential.expiresAt,
+        },
+      };
     }
 
     if (runtime?.apiKey && runtime.apiKeyProvider === 'explicit') {
-      return { type: 'explicit-api-key' };
+      return {
+        provider,
+        apiKey: runtime.apiKey,
+        source: { type: 'explicit-api-key' },
+      };
     }
 
     if (runtime?.preferApiKey) {
       if (runtime.apiKey && runtime.apiKeyProvider === provider) {
-        return { type: 'env-api-key', provider };
+        return {
+          provider,
+          apiKey: runtime.apiKey,
+          source: { type: 'env-api-key', provider },
+        };
       }
 
       const preferredApiKey = this.resolveProviderApiKey(provider);
       if (preferredApiKey) {
-        return { type: 'env-api-key', provider };
+        return {
+          provider,
+          apiKey: preferredApiKey,
+          source: { type: 'env-api-key', provider },
+        };
       }
     }
 
     const oauthCredential = this.resolveOAuthCredentialForModel(model, { storePath: runtime?.credentialStorePath });
     if (oauthCredential) {
       return {
-        type: 'oauth',
-        provider: oauthCredential.provider,
-        accountId: oauthCredential.accountId,
-        expiresAt: oauthCredential.expiresAt,
+        provider,
+        credential: oauthCredential,
+        source: {
+          type: 'oauth',
+          provider: oauthCredential.provider,
+          accountId: oauthCredential.accountId,
+          expiresAt: oauthCredential.expiresAt,
+        },
       };
     }
 
     if (runtime?.apiKey && runtime.apiKeyProvider === provider) {
-      return { type: 'env-api-key', provider };
+      return {
+        provider,
+        apiKey: runtime.apiKey,
+        source: { type: 'env-api-key', provider },
+      };
     }
 
     const apiKey = this.resolveProviderApiKey(provider);
     if (apiKey) {
-      return { type: 'env-api-key', provider };
+      return {
+        provider,
+        apiKey,
+        source: { type: 'env-api-key', provider },
+      };
     }
 
-    return { type: 'missing', provider };
+    return {
+      provider,
+      source: { type: 'missing', provider },
+    };
   }
 
   static resolveLocalEndpointCredentialSource(provider: LlmProvider): Extract<ProviderCredentialSource, { type: 'local-endpoint' }> | undefined {
@@ -188,6 +230,8 @@ export class RuntimeCredentialService {
         return `${source.provider} API key from environment`;
       case 'oauth':
         return source.accountId ? `${source.provider} OAuth account ${source.accountId}` : `${source.provider} OAuth account`;
+      case 'oauth-access-token':
+        return source.accountId ? `${source.provider} request-scoped OAuth account ${source.accountId}` : `${source.provider} request-scoped OAuth access token`;
       case 'local-endpoint':
         return `${source.provider} local endpoint ${source.baseUrl}`;
       case 'missing':
@@ -217,6 +261,29 @@ export class RuntimeCredentialService {
     }
 
     return RuntimeCredentialService.resolveProviderApiKey(provider);
+  }
+
+  private static assertRuntimeCredential(args: {
+    apiKey?: string;
+    credential?: RuntimeProviderCredential;
+    provider: LlmProvider;
+  }): void {
+    if (!args.credential) {
+      return;
+    }
+
+    if (args.apiKey?.trim()) {
+      throw new Error('Provide either apiKey or credential for one runtime, not both.');
+    }
+    if (args.credential.provider !== args.provider) {
+      throw new Error(`Runtime credential provider ${args.credential.provider} does not match model provider ${args.provider}.`);
+    }
+    if (!args.credential.accessToken.trim()) {
+      throw new Error('Runtime OAuth access token cannot be empty.');
+    }
+    if (!Number.isFinite(args.credential.expiresAt)) {
+      throw new Error('Runtime OAuth access token expiry must be a finite Unix timestamp in milliseconds.');
+    }
   }
 
   private static resolveOpenAiCompatibleBaseUrl(profile: OpenAiCompatibleProviderProfile): string {

--- a/src/core/runtime/credentials/types.ts
+++ b/src/core/runtime/credentials/types.ts
@@ -1,15 +1,33 @@
 import type { LlmProvider } from '@/core/llm/types.js';
+import type {
+  ResolvedProviderCredential,
+  RuntimeProviderCredential,
+} from '@/core/auth/index.js';
 
 export type ApiKeyRuntime = {
   apiKey?: string;
   apiKeyProvider?: LlmProvider | 'explicit';
+  credential?: RuntimeProviderCredential;
   credentialStorePath?: string;
   preferApiKey?: boolean;
+};
+
+export type ProviderCredentialResolution = {
+  provider: LlmProvider;
+  apiKey?: string;
+  credential?: ResolvedProviderCredential;
+  source: ProviderCredentialSource;
 };
 
 export type ProviderCredentialSource =
   | { type: 'explicit-api-key' }
   | { type: 'env-api-key'; provider: LlmProvider }
   | { type: 'oauth'; provider: LlmProvider; accountId?: string; expiresAt?: number }
+  | { type: 'oauth-access-token'; provider: 'openai'; accountId?: string; expiresAt: number }
   | { type: 'local-endpoint'; provider: LlmProvider; baseUrl: string }
   | { type: 'missing'; provider: LlmProvider };
+
+export type {
+  ResolvedProviderCredential,
+  RuntimeProviderCredential,
+};

--- a/src/core/runtime/loop/service.ts
+++ b/src/core/runtime/loop/service.ts
@@ -9,7 +9,10 @@ import { LlmAdapterService } from '@/core/llm/index.js';
 import type { LlmAdapter, LlmRuntimeContext, ReasoningEffort } from '@/core/llm/types.js';
 import type { ToolDefinition } from '@/core/types.js';
 import { createLogger } from '@/core/utils/logger.js';
-import type { ProviderCredentialSource } from '../credentials/index.js';
+import type {
+  ProviderCredentialSource,
+  ResolvedProviderCredential,
+} from '../credentials/index.js';
 import { LlmProviderRuntimeService } from '../provider-runtime/index.js';
 import { RuntimeToolService } from '../tools/index.js';
 import { AgentLoopCheckpointService } from './checkpoint.js';
@@ -27,6 +30,7 @@ export class AgentLoopRuntimeService {
     const providerRuntime = LlmProviderRuntimeService.resolve({
       model,
       apiKey: options.apiKey,
+      credential: options.credential,
       credentialStorePath,
       reasoningEffort: options.reasoningEffort,
     });
@@ -37,6 +41,7 @@ export class AgentLoopRuntimeService {
     const llm = options.llm ?? await this.createLoopLlmAdapter({
       model,
       apiKey,
+      credential: providerRuntime.credential,
       credentialStorePath,
       reasoningEffort: options.reasoningEffort,
       runtime: providerRuntime.llmRuntime,
@@ -45,6 +50,7 @@ export class AgentLoopRuntimeService {
     const tools = this.resolveTools(options, {
       model,
       apiKey,
+      credential: providerRuntime.credential,
       providerCredentialSource: providerRuntime.credentialSource,
       workspaceRoot,
       credentialStorePath,
@@ -167,6 +173,7 @@ export class AgentLoopRuntimeService {
   private static async createLoopLlmAdapter(options: {
     model: string;
     apiKey?: string;
+    credential?: ResolvedProviderCredential;
     credentialStorePath?: string;
     reasoningEffort?: ReasoningEffort;
     runtime: LlmRuntimeContext;
@@ -175,6 +182,7 @@ export class AgentLoopRuntimeService {
       model: options.model,
       credentials: {
         apiKey: options.apiKey,
+        credential: options.credential,
         credentialStorePath: options.credentialStorePath,
       },
       runtime: {
@@ -189,6 +197,7 @@ export class AgentLoopRuntimeService {
     runtime: {
       model: string;
       apiKey?: string;
+      credential?: ResolvedProviderCredential;
       providerCredentialSource?: ProviderCredentialSource;
       workspaceRoot: string;
       credentialStorePath?: string;
@@ -204,6 +213,7 @@ export class AgentLoopRuntimeService {
       ...RuntimeToolService.createDefaultAgentTools({
         model: runtime.model,
         apiKey: runtime.apiKey,
+        credential: runtime.credential,
         providerCredentialSource: runtime.providerCredentialSource,
         credentialStorePath: runtime.credentialStorePath,
         workspaceRoot: runtime.workspaceRoot,

--- a/src/core/runtime/loop/types.ts
+++ b/src/core/runtime/loop/types.ts
@@ -15,6 +15,7 @@ import type {
 } from '@/core/live/index.js';
 import type { ChatMessage, LlmAdapter, LlmProvider, LlmUsage, ReasoningEffort } from '@/core/llm/types.js';
 import type { RunFailure, RunResult, StopReason, ToolCall, ToolDefinition, TraceEvent } from '@/core/types.js';
+import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
 
 export type AgentLoopStatus = 'finished';
 
@@ -80,6 +81,7 @@ export type RunAgentLoopOptions = {
   model?: string;
   reasoningEffort?: ReasoningEffort;
   apiKey?: string;
+  credential?: RuntimeProviderCredential;
   maxSteps?: number;
   workspaceRoot?: string;
   stateDir?: string;

--- a/src/core/runtime/provider-runtime/service.ts
+++ b/src/core/runtime/provider-runtime/service.ts
@@ -1,4 +1,3 @@
-import { LlmAdapterService } from '@/core/llm/index.js';
 import {
   RuntimeCredentialService,
 } from '../credentials/index.js';
@@ -12,23 +11,21 @@ import type { LlmProviderRuntimeInput, LlmProviderRuntimeResolution } from './ty
  */
 export class LlmProviderRuntimeService {
   static resolve(input: LlmProviderRuntimeInput): LlmProviderRuntimeResolution {
-    const provider = LlmAdapterService.inferProvider(input.model);
     const credentialRuntime = LlmProviderRuntimeService.credentialRuntime(input);
-    const apiKey = RuntimeCredentialService.resolveApiKeyForModel(input.model, credentialRuntime);
-    const credentialSource = RuntimeCredentialService.resolveCredentialSourceForModel(input.model, {
-      ...credentialRuntime,
-      apiKey,
-      apiKeyProvider: input.apiKey ? 'explicit' : apiKey ? provider : undefined,
-    });
+    const resolution = RuntimeCredentialService.resolveForModel(input.model, credentialRuntime);
 
     return {
       model: input.model,
-      provider,
-      apiKey,
-      credentialSource,
+      provider: resolution.provider,
+      apiKey: resolution.apiKey,
+      credential: resolution.credential,
+      credentialSource: resolution.source,
       llmRuntime: {
         reasoningEffort: input.reasoningEffort,
-        endpoint: RuntimeCredentialService.resolveOpenAiCompatibleEndpointRuntime(provider, credentialRuntime),
+        endpoint: RuntimeCredentialService.resolveOpenAiCompatibleEndpointRuntime(
+          resolution.provider,
+          credentialRuntime,
+        ),
       },
     };
   }
@@ -43,6 +40,7 @@ export class LlmProviderRuntimeService {
     return {
       apiKey: input.apiKey,
       apiKeyProvider: input.apiKey ? 'explicit' : undefined,
+      credential: input.credential,
       credentialStorePath: input.credentialStorePath,
       preferApiKey: input.preferApiKey,
     };

--- a/src/core/runtime/provider-runtime/types.ts
+++ b/src/core/runtime/provider-runtime/types.ts
@@ -1,5 +1,9 @@
 import type { LlmProvider, LlmRuntimeContext, ReasoningEffort } from '@/core/llm/types.js';
-import type { ApiKeyRuntime, ProviderCredentialSource } from '../credentials/index.js';
+import type {
+  ApiKeyRuntime,
+  ProviderCredentialSource,
+  ResolvedProviderCredential,
+} from '../credentials/index.js';
 
 export type LlmProviderRuntimeInput = ApiKeyRuntime & {
   model: string;
@@ -10,6 +14,7 @@ export type LlmProviderRuntimeResolution = {
   model: string;
   provider: LlmProvider;
   apiKey: string | undefined;
+  credential: ResolvedProviderCredential | undefined;
   credentialSource: ProviderCredentialSource;
   llmRuntime: LlmRuntimeContext;
 };

--- a/src/core/runtime/tools/service.ts
+++ b/src/core/runtime/tools/service.ts
@@ -44,6 +44,7 @@ export class RuntimeToolService {
           sessionId: options.sessionId,
           model: options.model,
           apiKey: options.apiKey,
+          credential: options.credential,
           providerCredentialSource: options.providerCredentialSource,
           credentialStorePath: options.credentialStorePath,
           memoryDir,

--- a/src/core/runtime/tools/types.ts
+++ b/src/core/runtime/tools/types.ts
@@ -1,5 +1,8 @@
 import type { ArtifactRepository } from '@/core/artifacts/index.js';
-import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
+import type {
+  ProviderCredentialSource,
+  ResolvedProviderCredential,
+} from '@/core/runtime/credentials/index.js';
 import type { RuntimeToolSelectionProfile } from './profiles/index.js';
 import type { ToolDefinition } from '@/core/types.js';
 import type { ToolToolkit } from '@/core/tools/index.js';
@@ -7,6 +10,7 @@ import type { ToolToolkit } from '@/core/tools/index.js';
 export type DefaultAgentToolsOptions = {
   model: string;
   apiKey?: string;
+  credential?: ResolvedProviderCredential;
   providerCredentialSource?: ProviderCredentialSource;
   credentialStorePath?: string;
   workspaceRoot?: string;

--- a/src/core/tools/toolkit.ts
+++ b/src/core/tools/toolkit.ts
@@ -9,6 +9,7 @@ export type ToolToolkitContext = {
   sessionId?: string;
   model: string;
   apiKey?: string;
+  credential?: import('../runtime/credentials/index.js').ResolvedProviderCredential;
   providerCredentialSource?: import('../runtime/credentials/index.js').ProviderCredentialSource;
   credentialStorePath?: string;
   memoryDir: string;

--- a/src/core/tools/toolkits/external-context/toolkit.ts
+++ b/src/core/tools/toolkits/external-context/toolkit.ts
@@ -9,12 +9,14 @@ export const externalContextToolkit: ToolToolkit = {
       createWebSearchTool({
         model: context.model,
         apiKey: context.apiKey,
+        credential: context.credential,
         providerCredentialSource: context.providerCredentialSource,
         credentialStorePath: context.credentialStorePath,
       }),
       createViewImageTool({
         model: context.model,
         apiKey: context.apiKey,
+        credential: context.credential,
         providerCredentialSource: context.providerCredentialSource,
         credentialStorePath: context.credentialStorePath,
         workspaceRoot: context.workspaceRoot,

--- a/src/core/tools/toolkits/external-context/view-image.ts
+++ b/src/core/tools/toolkits/external-context/view-image.ts
@@ -18,7 +18,11 @@ import {
 import { ModelPolicyService } from '../../../llm/models/index.js';
 import type { LlmProvider } from '../../../llm/types.js';
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from '../../../config.js';
-import { RuntimeCredentialService, type ProviderCredentialSource } from '../../../runtime/credentials/index.js';
+import {
+  RuntimeCredentialService,
+  type ProviderCredentialSource,
+  type ResolvedProviderCredential,
+} from '../../../runtime/credentials/index.js';
 
 type ViewImageInput = {
   path?: string;
@@ -36,6 +40,7 @@ export type ViewImageToolOptions = {
   model?: string;
   provider?: LlmProvider;
   apiKey?: string;
+  credential?: ResolvedProviderCredential;
   providerCredentialSource?: ProviderCredentialSource;
   credentialStorePath?: string;
   workspaceRoot?: string;
@@ -156,14 +161,19 @@ async function executeOpenAiImageView(args: {
 }): Promise<ToolResult> {
   const model = args.options.model ?? DEFAULT_OPENAI_MODEL;
   const oauthCredential =
-    args.options.providerCredentialSource?.type === 'oauth' ?
+    OpenAiOAuthFetchService.isAccountCredential(args.options.credential) ? args.options.credential
+    : args.options.providerCredentialSource?.type === 'oauth' ?
       RuntimeCredentialService.resolveOAuthCredentialForModel(model, { storePath: args.options.credentialStorePath })
     : undefined;
 
-  if (args.options.providerCredentialSource?.type === 'oauth' && !oauthCredential) {
+  const expectsOAuth = args.options.providerCredentialSource?.type === 'oauth'
+    || args.options.providerCredentialSource?.type === 'oauth-access-token';
+  if (expectsOAuth && !oauthCredential) {
     return {
       ok: false,
-      error: 'view_image could not load the stored OpenAI account sign-in credential for this workspace. Sign in again with `heddle auth login openai`, or set OPENAI_API_KEY to use Platform API-key mode.',
+      error: args.options.providerCredentialSource?.type === 'oauth-access-token' ?
+          'view_image did not receive the request-scoped OpenAI access token for this run. Sign in again and retry.'
+        : 'view_image could not load the stored OpenAI account sign-in credential for this workspace. Sign in again with `heddle auth login openai`, or set OPENAI_API_KEY to use Platform API-key mode.',
     };
   }
 

--- a/src/core/tools/toolkits/external-context/web-search.ts
+++ b/src/core/tools/toolkits/external-context/web-search.ts
@@ -24,6 +24,7 @@ import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from '../../../config.j
 import {
   RuntimeCredentialService,
   type ProviderCredentialSource,
+  type ResolvedProviderCredential,
 } from '../../../runtime/credentials/index.js';
 
 type WebSearchInput = {
@@ -35,6 +36,7 @@ export type WebSearchToolOptions = {
   model?: string;
   provider?: LlmProvider;
   apiKey?: string;
+  credential?: ResolvedProviderCredential;
   providerCredentialSource?: ProviderCredentialSource;
   credentialStorePath?: string;
 };
@@ -110,14 +112,19 @@ export function createWebSearchTool(options: WebSearchToolOptions = {}): ToolDef
 async function executeOpenAiWebSearch(input: WebSearchInput, options: WebSearchToolOptions): Promise<ToolResult> {
   const model = options.model ?? process.env.OPENAI_WEB_SEARCH_MODEL ?? DEFAULT_OPENAI_MODEL;
   const oauthCredential =
-    options.providerCredentialSource?.type === 'oauth' ?
+    OpenAiOAuthFetchService.isAccountCredential(options.credential) ? options.credential
+    : options.providerCredentialSource?.type === 'oauth' ?
       RuntimeCredentialService.resolveOAuthCredentialForModel(model, { storePath: options.credentialStorePath })
     : undefined;
 
-  if (options.providerCredentialSource?.type === 'oauth' && !oauthCredential) {
+  const expectsOAuth = options.providerCredentialSource?.type === 'oauth'
+    || options.providerCredentialSource?.type === 'oauth-access-token';
+  if (expectsOAuth && !oauthCredential) {
     return {
       ok: false,
-      error: 'web_search could not load the stored OpenAI account sign-in credential for this workspace. Sign in again with `heddle auth login openai`, or set OPENAI_API_KEY to use Platform API-key mode.',
+      error: options.providerCredentialSource?.type === 'oauth-access-token' ?
+          'web_search did not receive the request-scoped OpenAI access token for this run. Sign in again and retry.'
+        : 'web_search could not load the stored OpenAI account sign-in credential for this workspace. Sign in again with `heddle auth login openai`, or set OPENAI_API_KEY to use Platform API-key mode.',
     };
   }
 
@@ -165,7 +172,7 @@ async function executeOpenAiWebSearch(input: WebSearchInput, options: WebSearchT
 async function executeOpenAiOAuthWebSearch(
   input: WebSearchInput,
   options: WebSearchToolOptions & { model: string },
-  oauthCredential: NonNullable<ReturnType<typeof RuntimeCredentialService.resolveOAuthCredentialForModel>>,
+  oauthCredential: Parameters<typeof OpenAiOAuthFetchService.create>[0],
 ): Promise<ToolResult> {
   const oauthFetch = OpenAiOAuthFetchService.create(oauthCredential, { storePath: options.credentialStorePath });
   const sseText = await OpenAiCodexSseService.execute({

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,4 +335,8 @@ export type {
   ChatSession,
 } from './core/chat/types.js';
 export { RuntimeCredentialService } from './core/runtime/credentials/index.js';
-export type { ApiKeyRuntime, ProviderCredentialSource } from './core/runtime/credentials/index.js';
+export type {
+  ApiKeyRuntime,
+  ProviderCredentialSource,
+  RuntimeProviderCredential,
+} from './core/runtime/credentials/index.js';

--- a/src/sdk/conversation/README.md
+++ b/src/sdk/conversation/README.md
@@ -25,6 +25,30 @@ headless returns structured results to caller-owned input/output, while console
 owns readline, text rendering, and local commands. Their shared runtime module
 prevents defaults and credential policy from drifting.
 
+## Host-supplied account access tokens
+
+An embedding host may pass an already-acquired OpenAI account access token as a
+`RuntimeProviderCredential`:
+
+```ts
+const agent = new ConversationAgentService({
+  model: 'gpt-5.4',
+  credential: {
+    type: 'oauth-access-token',
+    provider: 'openai',
+    accessToken,
+    expiresAt,
+    accountId,
+  },
+})
+```
+
+Heddle uses that token consistently for the main model call, compaction, and
+OpenAI-backed external-context tools. It does not store or refresh the token.
+The host owns sign-in, authenticated delivery to its server, in-memory lifetime,
+and asking the user to sign in again after expiry. Use `apiKey` instead when the
+host is supplying a Platform API key; supplying both is invalid.
+
 ## Product Boundary
 
 These services are not Heddle product applications. `src/cli-v2` owns the

--- a/src/sdk/conversation/console/service.ts
+++ b/src/sdk/conversation/console/service.ts
@@ -50,6 +50,7 @@ export class QuickstartConversationCliRunnerService {
       model: defaults.model,
       reasoningEffort: defaults.reasoningEffort,
       apiKey: options.apiKey,
+      credential: options.credential,
       preferApiKey: options.preferApiKey,
       credentialStorePath: options.credentialStorePath,
       systemContext: options.systemContext,
@@ -222,6 +223,7 @@ export class QuickstartConversationCliRunnerService {
     const preflight = QuickstartConversationCliRunnerService.resolveCredentialPreflight(input.options.credentialPreflight);
     const context = ConversationSdkRuntimeService.preflightCredentials({
       apiKey: input.options.apiKey,
+      credential: input.options.credential,
       credentialStorePath: input.options.credentialStorePath,
       defaults: input.defaults,
       preferApiKey: input.options.preferApiKey,

--- a/src/sdk/conversation/console/types.ts
+++ b/src/sdk/conversation/console/types.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/core/chat/engine/types.js';
 import type { ChatSession } from '@/core/chat/types.js';
 import type { ToolDefinition } from '@/core/types.js';
+import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
 import type {
   ConversationSdkCredentialContext,
   ConversationSdkCredentialPreflightOptions,
@@ -65,6 +66,7 @@ export type QuickstartConversationCliRunnerOptions = {
   maxSteps?: number;
   reasoningEffort?: ConversationSdkRuntimeDefaultsInput['reasoningEffort'];
   apiKey?: string;
+  credential?: RuntimeProviderCredential;
   preferApiKey?: boolean;
   credentialStorePath?: string;
   credentialPreflight?: boolean | QuickstartConversationCliCredentialPreflightOptions;

--- a/src/sdk/conversation/headless/service.ts
+++ b/src/sdk/conversation/headless/service.ts
@@ -35,6 +35,7 @@ export class ConversationAgentService {
     const defaults = ConversationSdkRuntimeService.resolveDefaults(options);
     const credential = ConversationSdkRuntimeService.preflightCredentials({
       apiKey: options.apiKey,
+      credential: options.credential,
       credentialStorePath: options.credentialStorePath,
       defaults,
       preferApiKey: options.preferApiKey,

--- a/src/sdk/conversation/runtime/service.ts
+++ b/src/sdk/conversation/runtime/service.ts
@@ -3,6 +3,7 @@ import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import type { ReasoningEffort } from '@/core/llm/types.js';
 import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
+import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
 import type {
   ConversationSdkCredentialContext,
   ConversationSdkCredentialPreflightOptions,
@@ -39,6 +40,7 @@ export class ConversationSdkRuntimeService {
 
   static preflightCredentials(input: {
     apiKey?: string;
+    credential?: RuntimeProviderCredential;
     credentialStorePath?: string;
     defaults: ConversationSdkRuntimeDefaults;
     preferApiKey?: boolean;
@@ -51,6 +53,7 @@ export class ConversationSdkRuntimeService {
 
     const resolution = LlmProviderRuntimeService.resolve({
       apiKey: input.apiKey,
+      credential: input.credential,
       credentialStorePath: input.credentialStorePath,
       model: input.defaults.model,
       preferApiKey: input.preferApiKey,


### PR DESCRIPTION
## Summary

- Add a public request-scoped OpenAI access-token credential for embedded runtimes.
- Resolve one concrete credential principal and keep it consistent across the main turn, compaction, and provider-backed tools.
- Preserve stored OAuth refresh behavior while ensuring runtime tokens are never refreshed or persisted.
- Reject ambiguous API-key plus runtime-token configuration and expired runtime tokens with a stable 401-class error.
- Document the adopter and host lifecycle and SDK usage.

## Boundary

This PR consumes an access token that the embedding host already acquired. It does not implement browser sign-in, an OAuth redirect endpoint, refresh-token storage, or tenant authentication.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` — 123 files, 727 tests
- `yarn build`
- All six GitHub checks pass.

Focused coverage includes credential precedence and validation, OpenAI request rewriting and no-persistence behavior, expiry, conversation SDK propagation, compaction, and external-context web search.
