### PR TITLE
feat: land hosted OpenAI device login on main

### DIFF
--- a/docs/guides/programmatic/quickstart.md
+++ b/docs/guides/programmatic/quickstart.md
@@ -62,6 +62,18 @@ send it over an authenticated transport, keep it out of logs and durable state,
 and require sign-in again after expiry or host refresh. The same token is used
 for the turn, compaction, and OpenAI-backed tools.
 
+For a hosted product that cannot receive Codex's loopback browser callback,
+`OpenAiDeviceCodeAuthService` provides a stateless device-code handshake. Its
+`requestCode()` result contains the verification URL, one-time user code,
+expiry, and minimum polling interval. Call `poll()` no faster than
+`intervalMs`; an approved result contains the access-token-only
+`RuntimeProviderCredential` shown above. Heddle discards the refresh token.
+
+Protect both host routes with product authentication and rate limits, warn
+users not to share device codes, and keep the challenge and resulting
+credential out of durable storage and logs. This Codex account-sign-in binding
+is experimental and is not a generic third-party OpenAI OAuth integration.
+
 The result and activities are trusted in-process host data; they may include
 tool input/output, local paths, or other internal details. Do not serialize them
 directly to an untrusted browser. Use a host-owned public projection and the

--- a/src/__tests__/unit/core/import-boundaries.test.ts
+++ b/src/__tests__/unit/core/import-boundaries.test.ts
@@ -33,6 +33,7 @@ const PUBLIC_EXPORT_EXPECTATIONS = [
   'createConversationEngine',
   'defineHostExtension',
   'EngineConversationTurnService',
+  'OpenAiDeviceCodeAuthService',
 ];
 
 describe('core import boundaries', () => {

--- a/src/__tests__/unit/core/openai-device-code-auth.test.ts
+++ b/src/__tests__/unit/core/openai-device-code-auth.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  OpenAiDeviceCodeAuthService,
+} from '../../../core/auth/index.js';
+import type { OpenAiDeviceCodeChallenge } from '../../../core/auth/index.js';
+import {
+  OPENAI_AUTH_ISSUER,
+  OPENAI_CODEX_CLIENT_ID,
+} from '../../../core/auth/openai-oauth.js';
+
+describe('OpenAI device-code auth', () => {
+  it('requests and validates a provider device-code challenge', async () => {
+    const expiresAt = new Date(Date.now() + 15 * 60_000).toISOString();
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(Response.json({
+      device_auth_id: 'device-auth-123',
+      user_code: 'ABCD-1234',
+      interval: '5',
+      expires_at: expiresAt,
+    }));
+
+    await expect(OpenAiDeviceCodeAuthService.requestCode({ fetchImpl })).resolves.toEqual({
+      deviceAuthId: 'device-auth-123',
+      userCode: 'ABCD-1234',
+      verificationUrl: `${OPENAI_AUTH_ISSUER}/codex/device`,
+      intervalMs: 5_000,
+      expiresAt: Date.parse(expiresAt),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(String(url)).toBe(`${OPENAI_AUTH_ISSUER}/api/accounts/deviceauth/usercode`);
+    expect(JSON.parse(String(init?.body))).toEqual({ client_id: OPENAI_CODEX_CLIENT_ID });
+  });
+
+  it('reports a pending device-code authorization without exchanging tokens', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 403 }));
+
+    await expect(OpenAiDeviceCodeAuthService.poll(challenge(), { fetchImpl })).resolves.toEqual({
+      status: 'pending',
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('reports an expired challenge without contacting OpenAI', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(OpenAiDeviceCodeAuthService.poll({
+      ...challenge(),
+      expiresAt: Date.now() - 1,
+    }, { fetchImpl })).resolves.toEqual({ status: 'expired' });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed round-tripped challenges before contacting OpenAI', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(OpenAiDeviceCodeAuthService.poll({
+      ...challenge(),
+      deviceAuthId: ' ',
+    }, { fetchImpl })).rejects.toThrow('missing its authorization identifiers');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('exchanges an approved device code for a non-persistable runtime credential', async () => {
+    const accessToken = createJwt({ chatgpt_account_id: 'account-123' });
+    const requests: Array<{ url: string; body: string }> = [];
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async (url, init) => {
+      requests.push({ url: String(url), body: String(init?.body ?? '') });
+      if (String(url).endsWith('/deviceauth/token')) {
+        return Response.json({
+          authorization_code: 'authorization-code',
+          code_challenge: 'code-challenge',
+          code_verifier: 'code-verifier',
+        });
+      }
+      return Response.json({
+        access_token: accessToken,
+        refresh_token: 'discarded-refresh-token',
+        expires_in: 120,
+      });
+    });
+    const before = Date.now();
+
+    const result = await OpenAiDeviceCodeAuthService.poll(challenge(), { fetchImpl });
+
+    expect(result).toMatchObject({
+      status: 'authorized',
+      credential: {
+        type: 'oauth-access-token',
+        provider: 'openai',
+        accessToken,
+        accountId: 'account-123',
+      },
+    });
+    if (result.status !== 'authorized') {
+      throw new Error('Expected an authorized device-code result.');
+    }
+    expect(result.credential.expiresAt).toBeGreaterThanOrEqual(before + 120_000);
+    expect(result.credential).not.toHaveProperty('refreshToken');
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.url).toBe(`${OPENAI_AUTH_ISSUER}/api/accounts/deviceauth/token`);
+    expect(JSON.parse(requests[0]?.body ?? '{}')).toEqual({
+      device_auth_id: 'device-auth-123',
+      user_code: 'ABCD-1234',
+    });
+    expect(requests[1]?.url).toBe(`${OPENAI_AUTH_ISSUER}/oauth/token`);
+    const exchange = new URLSearchParams(requests[1]?.body);
+    expect(exchange.get('code')).toBe('authorization-code');
+    expect(exchange.get('code_verifier')).toBe('code-verifier');
+    expect(exchange.get('redirect_uri')).toBe(`${OPENAI_AUTH_ISSUER}/deviceauth/callback`);
+  });
+});
+
+function challenge(): OpenAiDeviceCodeChallenge {
+  return {
+    deviceAuthId: 'device-auth-123',
+    userCode: 'ABCD-1234',
+    verificationUrl: `${OPENAI_AUTH_ISSUER}/codex/device`,
+    intervalMs: 5_000,
+    expiresAt: Date.now() + 15 * 60_000,
+  };
+}
+
+function createJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+}

--- a/src/core/auth/README.md
+++ b/src/core/auth/README.md
@@ -8,11 +8,20 @@ The boundary is intentionally small:
   deserialization, writes, private file permissions, summaries, and redaction.
 - `OpenAiOAuthService` owns the OpenAI OAuth browser flow, token exchange,
   refresh, account-id extraction, and platform-specific browser launching.
+- `OpenAiDeviceCodeAuthService` owns the stateless hosted/device-code handshake.
+  It validates the provider payload, reports pending/expired states, exchanges
+  an approved code, and returns only a `RuntimeProviderCredential`. It must not
+  expose or persist the refresh token from the exchange.
 - `ProviderCredentialCommandService` owns shared credential command semantics
   such as status, OAuth login, and logout. Terminal and control-plane hosts may
   call it, but they still own their own rendering and invocation flow.
 - Runtime and LLM services may ask auth for credentials, but auth should not
   own model policy, adapter selection, tool behavior, or UI formatting.
+
+Device-code login is an experimental OpenAI Codex binding, not a generic OAuth
+server. A host owns its authenticated routes, rate limits, anti-phishing UX,
+and the browser's in-memory credential lifetime. Respect the challenge's
+`intervalMs`; do not create a server-side polling loop or persist the challenge.
 
 When adding another persisted auth format, add schema fields in `schemas.ts` and
 repository methods on `ProviderCredentialRepository`. Avoid loose one-off

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -1,8 +1,13 @@
 export { ProviderCredentialRepository } from './provider-credentials.js';
 export { OpenAiOAuthService } from './openai-oauth.js';
+export { OpenAiDeviceCodeAuthService } from './openai-device-code-auth.js';
 export { ProviderCredentialCommandService } from './command-service.js';
 export type { ProviderCredentialCommandOptions } from './command-service.js';
 export type {
+  OpenAiDeviceCodeChallenge,
+  OpenAiDeviceCodePollOptions,
+  OpenAiDeviceCodePollResult,
+  OpenAiDeviceCodeRequestOptions,
   OpenAiIdTokenClaims,
   OpenAiOAuthCredential,
   OpenAiOAuthLoginOptions,

--- a/src/core/auth/openai-device-code-auth.ts
+++ b/src/core/auth/openai-device-code-auth.ts
@@ -1,0 +1,143 @@
+import dayjs from 'dayjs';
+import { z } from 'zod';
+import {
+  OPENAI_AUTH_ISSUER,
+  OPENAI_CODEX_CLIENT_ID,
+  OpenAiOAuthService,
+} from './openai-oauth.js';
+import type {
+  OpenAiDeviceCodeChallenge,
+  OpenAiDeviceCodePollOptions,
+  OpenAiDeviceCodePollResult,
+  OpenAiDeviceCodeRequestOptions,
+} from './types.js';
+
+const OPENAI_DEVICE_AUTH_API_BASE_URL = `${OPENAI_AUTH_ISSUER}/api/accounts/deviceauth`;
+const OPENAI_DEVICE_AUTH_CALLBACK_URI = `${OPENAI_AUTH_ISSUER}/deviceauth/callback`;
+const OPENAI_DEVICE_VERIFICATION_URL = `${OPENAI_AUTH_ISSUER}/codex/device`;
+
+const deviceCodeResponseSchema = z.object({
+  device_auth_id: z.string().trim().min(1),
+  expires_at: z.string().trim().min(1),
+  interval: z.coerce.number().int().positive(),
+  user_code: z.string().trim().min(1).optional(),
+  usercode: z.string().trim().min(1).optional(),
+}).refine((value) => Boolean(value.user_code ?? value.usercode), {
+  message: 'Device-code response did not include a user code.',
+});
+
+const deviceAuthorizationResponseSchema = z.object({
+  authorization_code: z.string().trim().min(1),
+  code_challenge: z.string().trim().min(1),
+  code_verifier: z.string().trim().min(1),
+});
+
+/**
+ * Owns the stateless OpenAI Codex device-code handshake for hosted adopters.
+ * It returns an access-token-only runtime credential and never persists or
+ * exposes the refresh token received during the final exchange.
+ */
+export class OpenAiDeviceCodeAuthService {
+  static async requestCode(
+    options: OpenAiDeviceCodeRequestOptions = {},
+  ): Promise<OpenAiDeviceCodeChallenge> {
+    const response = await (options.fetchImpl ?? fetch)(`${OPENAI_DEVICE_AUTH_API_BASE_URL}/usercode`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_id: OPENAI_CODEX_CLIENT_ID }),
+      signal: options.signal,
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error('OpenAI device-code login is not enabled for this Codex client.');
+      }
+      throw new Error(`OpenAI device-code request failed: ${response.status}`);
+    }
+
+    const parsed = deviceCodeResponseSchema.safeParse(
+      await OpenAiDeviceCodeAuthService.readJson(response, 'device-code'),
+    );
+    if (!parsed.success) {
+      throw new Error('OpenAI device-code response was invalid.');
+    }
+
+    const expiresAt = dayjs(parsed.data.expires_at);
+    if (!expiresAt.isValid() || !expiresAt.isAfter(dayjs())) {
+      throw new Error('OpenAI device-code response included an invalid expiry.');
+    }
+
+    return {
+      deviceAuthId: parsed.data.device_auth_id,
+      userCode: parsed.data.user_code ?? parsed.data.usercode!,
+      verificationUrl: OPENAI_DEVICE_VERIFICATION_URL,
+      intervalMs: parsed.data.interval * 1000,
+      expiresAt: expiresAt.valueOf(),
+    };
+  }
+
+  static async poll(
+    challenge: OpenAiDeviceCodeChallenge,
+    options: OpenAiDeviceCodePollOptions = {},
+  ): Promise<OpenAiDeviceCodePollResult> {
+    OpenAiDeviceCodeAuthService.assertChallenge(challenge);
+    if (!dayjs(challenge.expiresAt).isAfter(dayjs())) {
+      return { status: 'expired' };
+    }
+
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const response = await fetchImpl(`${OPENAI_DEVICE_AUTH_API_BASE_URL}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        device_auth_id: challenge.deviceAuthId.trim(),
+        user_code: challenge.userCode.trim(),
+      }),
+      signal: options.signal,
+    });
+
+    if (response.status === 403 || response.status === 404) {
+      return { status: 'pending' };
+    }
+    if (!response.ok) {
+      throw new Error(`OpenAI device-code poll failed: ${response.status}`);
+    }
+
+    const parsed = deviceAuthorizationResponseSchema.safeParse(
+      await OpenAiDeviceCodeAuthService.readJson(response, 'device-code authorization'),
+    );
+    if (!parsed.success) {
+      throw new Error('OpenAI device-code authorization response was invalid.');
+    }
+
+    const tokens = await OpenAiOAuthService.exchangeCode({
+      code: parsed.data.authorization_code,
+      redirectUri: OPENAI_DEVICE_AUTH_CALLBACK_URI,
+      codeVerifier: parsed.data.code_verifier,
+      fetchImpl,
+      signal: options.signal,
+    });
+
+    return {
+      status: 'authorized',
+      credential: OpenAiOAuthService.createRuntimeCredential(tokens),
+    };
+  }
+
+  private static async readJson(response: Response, label: string): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch {
+      throw new Error(`OpenAI ${label} response was not valid JSON.`);
+    }
+  }
+
+  private static assertChallenge(challenge: OpenAiDeviceCodeChallenge): void {
+    if (!challenge.deviceAuthId.trim() || !challenge.userCode.trim()) {
+      throw new Error('OpenAI device-code challenge is missing its authorization identifiers.');
+    }
+    if (!Number.isFinite(challenge.expiresAt)) {
+      throw new Error('OpenAI device-code challenge expiry must be a finite Unix timestamp in milliseconds.');
+    }
+  }
+}

--- a/src/core/auth/openai-oauth.ts
+++ b/src/core/auth/openai-oauth.ts
@@ -10,6 +10,7 @@ import type {
   OpenAiOAuthRefreshOptions,
   OpenAiOAuthTokenResponse,
   PkceCodes,
+  RuntimeProviderCredential,
 } from './types.js';
 
 export const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
@@ -162,6 +163,20 @@ export class OpenAiOAuthService {
       createdAt: timestamp,
       updatedAt: timestamp,
       label: 'ChatGPT/Codex OAuth',
+    };
+  }
+
+  /** Converts OAuth tokens to an access-token-only, non-persistable runtime credential. */
+  static createRuntimeCredential(
+    tokens: OpenAiOAuthTokenResponse,
+    now = Date.now(),
+  ): RuntimeProviderCredential {
+    return {
+      type: 'oauth-access-token',
+      provider: 'openai',
+      accessToken: tokens.access_token,
+      expiresAt: now + (tokens.expires_in ?? 3600) * 1000,
+      accountId: OpenAiOAuthService.extractAccountId(tokens),
     };
   }
 

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -74,6 +74,28 @@ export type OpenAiOAuthTokenResponse = {
   expires_in?: number;
 };
 
+export type OpenAiDeviceCodeChallenge = {
+  deviceAuthId: string;
+  userCode: string;
+  verificationUrl: string;
+  /** Minimum polling interval requested by OpenAI. */
+  intervalMs: number;
+  /** Unix epoch timestamp in milliseconds. */
+  expiresAt: number;
+};
+
+export type OpenAiDeviceCodePollResult =
+  | { status: 'pending' }
+  | { status: 'expired' }
+  | { status: 'authorized'; credential: RuntimeProviderCredential };
+
+export type OpenAiDeviceCodeRequestOptions = {
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+};
+
+export type OpenAiDeviceCodePollOptions = OpenAiDeviceCodeRequestOptions;
+
 export type OpenAiOAuthCredential = Extract<StoredProviderCredential, { type: 'oauth' }>;
 
 export type OpenAiOAuthLoginOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,16 @@ export type {
   StopReason,
 } from './core/types.js';
 
+// Provider-specific credential acquisition remains opt-in. The device-code
+// service is useful to hosted adopters that cannot receive a loopback callback.
+export { OpenAiDeviceCodeAuthService } from './core/auth/index.js';
+export type {
+  OpenAiDeviceCodeChallenge,
+  OpenAiDeviceCodePollOptions,
+  OpenAiDeviceCodePollResult,
+  OpenAiDeviceCodeRequestOptions,
+} from './core/auth/index.js';
+
 // ---------------------------------------------------------------------------
 // 2. Add capabilities — tools, MCP servers, skills
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Land the hosted OpenAI Codex device-code service that was reviewed in #260 onto Heddle `main`.
- Preserve the stateless request/poll contract, explicit pending and expired outcomes, access-token-only runtime credential, and refresh-token discard.
- Restore the public exports, documentation, and unit coverage from the original feature commit without unrelated changes.

## Root cause

PR #260 remained based on `codex/request-scoped-runtime-credentials` after #259 merged. GitHub therefore merged #260 into that feature branch, not `main`; the merged badge did not mean the device-code API was releaseable from Heddle `main`.

This branch starts at current `origin/main` (`9ea5bc67`) and cherry-picks only the missing feature commit (`e1bb5db7`).

## Verification

- `yarn install --frozen-lockfile` — includes a successful production build
- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` — 124 files, 732 tests
- `git diff --check origin/main...HEAD`

## Target

`roackb2/heddle:main` ← `codex/land-openai-device-code-auth`
