### PR TITLE
feat: stream reasoning summaries as activities

### DIFF
--- a/docs/architecture/live-events.md
+++ b/docs/architecture/live-events.md
@@ -33,13 +33,24 @@ The ownership split is:
 
 `ConversationActivity` describes user-facing progress. Current sources include:
 
-- `agent-loop`: `loop.started`, `assistant.stream`, tool activity, approvals,
-  plans, and `loop.finished`;
+- `agent-loop`: `loop.started`, `reasoning.summary`, `assistant.stream`, tool
+  activity, approvals, plans, and `loop.finished`;
 - `compaction`: compaction progress and outcomes;
 - `direct-shell`: direct-shell lifecycle and results.
 
 Activities contain enough structured information for each host to choose its
 own presentation. They do not carry delivery ordering by themselves.
+
+`reasoning.summary` is the provider-generated, user-visible summary of model
+progress. It streams cumulative `text` updates and ends with `done: true`.
+Heddle core does not prefix or otherwise present that text; each host decides
+whether to label it as "Thinking", place it beside tool activity, or omit it.
+It is not hidden model chain-of-thought.
+
+`assistant.stream` is the cumulative assistant response draft. Embedding hosts
+may intentionally withhold it when an incomplete response could expose source
+material or conflict with a product-owned terminal result. They can still show
+`reasoning.summary` and structured tool activity independently.
 
 `ConversationRunStreamItem<Result>` is the ordered run envelope:
 
@@ -180,6 +191,26 @@ Ordered assistant activity:
     "text": "I am checking the session loader now...",
     "done": false,
     "timestamp": "2026-07-11T01:20:01.000Z"
+  }
+}
+```
+
+Ordered reasoning-summary activity:
+
+```json
+{
+  "kind": "activity",
+  "runId": "run-123",
+  "sequence": 3,
+  "timestamp": "2026-07-11T01:20:02.000Z",
+  "activity": {
+    "source": "agent-loop",
+    "type": "reasoning.summary",
+    "runId": "run-123",
+    "step": 1,
+    "text": "Inspecting the session loader before choosing a change.",
+    "done": false,
+    "timestamp": "2026-07-11T01:20:02.000Z"
   }
 }
 ```

--- a/docs/architecture/live-events.md
+++ b/docs/architecture/live-events.md
@@ -47,6 +47,13 @@ Heddle core does not prefix or otherwise present that text; each host decides
 whether to label it as "Thinking", place it beside tool activity, or omit it.
 It is not hidden model chain-of-thought.
 
+Heddle requests detailed summaries from supported OpenAI reasoning models. In
+Codex account mode, the request also identifies Heddle as the originator and
+includes encrypted reasoning content so the Codex transport can emit summary
+events. The provider may still omit a summary for a trivial turn; hosts should
+keep their generic in-progress state until another activity or the terminal
+result arrives.
+
 `assistant.stream` is the cumulative assistant response draft. Embedding hosts
 may intentionally withhold it when an incomplete response could expose source
 material or conflict with a product-owned terminal result. They can still show

--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -289,7 +289,7 @@ Use browser_snapshot before making claims.
     expect(systemMessage).not.toContain('Use browser_snapshot before making claims.');
   });
 
-  it('emits streamed reasoning summaries as assistant progress events', async () => {
+  it('emits provider reasoning summaries through a distinct cumulative stream', async () => {
     const events: AgentLoopEvent[] = [];
     const fakeLlm: LlmAdapter = {
       info: {
@@ -319,12 +319,18 @@ Use browser_snapshot before making claims.
       onEvent: (event) => events.push(event),
     });
 
-    expect(events).toContainEqual(expect.objectContaining({
-      type: 'assistant.stream',
+    const summaries = events.filter((event) => event.type === 'reasoning.summary');
+    expect(summaries).toHaveLength(2);
+    expect(summaries[0]).toMatchObject({
       step: 1,
-      text: 'Thinking: Inspecting the request before choosing tools.',
+      text: '**Inspecting the request**',
       done: false,
-    }));
+    });
+    expect(summaries[1]).toMatchObject({
+      step: 1,
+      text: '**Inspecting the request** before choosing tools.',
+      done: true,
+    });
   });
 
   it('does not treat the workspace state directory as the OAuth credential store', async () => {

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -762,6 +762,42 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('presents streamed reasoning summaries without changing the core event text', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    fixture.emitRunActivity({
+      source: 'agent-loop',
+      type: 'loop.started',
+      runId: 'run-1',
+      goal: 'Inspect the project.',
+      model: 'gpt-test',
+      provider: 'openai',
+      workspaceRoot: '/repo',
+      timestamp: new Date().toISOString(),
+    });
+    fixture.emitRunActivity({
+      source: 'agent-loop',
+      type: 'reasoning.summary',
+      runId: 'run-1',
+      step: 1,
+      text: 'Inspecting the project structure.',
+      done: false,
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(store.getSnapshot().activeSession?.messages.at(-1)).toEqual({
+      id: 'live-assistant',
+      role: 'assistant',
+      text: 'Thinking: Inspecting the project structure.',
+      isStreaming: true,
+      isPending: true,
+    });
+    expect(store.getSnapshot().liveStatus).toBe('Thinking...');
+    store.dispose();
+  });
+
   it('coalesces rapid live assistant stream events to the newest text', async () => {
     vi.useFakeTimers();
     try {

--- a/src/__tests__/unit/client-shared/session-activity-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-activity-service.test.ts
@@ -120,6 +120,30 @@ describe('ClientSharedSessionActivityService', () => {
     expect(effects).toEqual(['Implement']);
   });
 
+  it('delivers raw reasoning-summary progress for each frontend to present', () => {
+    let summary: { text: string; done: boolean; liveStatus: string | undefined } | undefined;
+
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'reasoning.summary',
+      runId: 'run-1',
+      source: 'agent-loop',
+      step: 1,
+      text: 'Inspecting the project structure.',
+      done: false,
+      timestamp: '2026-06-03T00:00:00.000Z',
+    } as ControlPlaneSessionActivity, {
+      onReasoningSummary: (activity, liveStatus) => {
+        summary = { text: activity.text, done: activity.done, liveStatus };
+      },
+    });
+
+    expect(summary).toEqual({
+      text: 'Inspecting the project structure.',
+      done: false,
+      liveStatus: 'Thinking...',
+    });
+  });
+
   it('projects recent edit diffs from successful edit_file completions', () => {
     const diffs: string[] = [];
 

--- a/src/__tests__/unit/core/conversation-activity.test.ts
+++ b/src/__tests__/unit/core/conversation-activity.test.ts
@@ -25,6 +25,24 @@ describe('conversation activity', () => {
     });
   });
 
+  it('keeps provider reasoning summaries separate from assistant response drafts', () => {
+    const activity: ConversationActivity = {
+      source: 'agent-loop',
+      type: 'reasoning.summary',
+      runId: 'run-1',
+      step: 1,
+      text: 'Inspecting the workspace before choosing a tool.',
+      done: false,
+      timestamp: '2026-05-02T00:00:00.000Z',
+    };
+
+    expect(activity).toMatchObject({
+      type: 'reasoning.summary',
+      text: 'Inspecting the workspace before choosing a tool.',
+      done: false,
+    });
+  });
+
   it('keeps compaction activity in the final conversation activity shape', () => {
     const running: ConversationActivity = {
       source: 'compaction',

--- a/src/__tests__/unit/core/conversation-text-host.test.ts
+++ b/src/__tests__/unit/core/conversation-text-host.test.ts
@@ -9,6 +9,24 @@ describe('createConversationTextHost', () => {
 
     textHost.host.events?.onActivity?.({
       source: 'agent-loop',
+      type: 'reasoning.summary',
+      runId: 'run-1',
+      step: 1,
+      text: 'Inspecting',
+      done: false,
+      timestamp: '2026-07-02T00:00:00.000Z',
+    });
+    textHost.host.events?.onActivity?.({
+      source: 'agent-loop',
+      type: 'reasoning.summary',
+      runId: 'run-1',
+      step: 1,
+      text: 'Inspecting the request.',
+      done: true,
+      timestamp: '2026-07-02T00:00:00.500Z',
+    });
+    textHost.host.events?.onActivity?.({
+      source: 'agent-loop',
       type: 'assistant.stream',
       runId: 'run-1',
       step: 1,
@@ -38,6 +56,9 @@ describe('createConversationTextHost', () => {
     });
 
     expect(write.mock.calls.map((call) => call[0])).toEqual([
+      'Thinking: Inspecting',
+      ' the request.',
+      '\n',
       'Hello',
       ' world',
       '[activity] tool create_report:ok\n',

--- a/src/__tests__/unit/core/openai-codec.test.ts
+++ b/src/__tests__/unit/core/openai-codec.test.ts
@@ -48,6 +48,7 @@ describe('OpenAiCodec.buildResponsesRequest reasoning parameter', () => {
     });
 
     expect(request.reasoning).toEqual(expect.objectContaining({ summary: 'detailed' }));
+    expect(request.include).toEqual(['reasoning.encrypted_content']);
   });
 
   it('keeps summaries for Codex API-key models without a Heddle-managed effort', () => {
@@ -58,6 +59,7 @@ describe('OpenAiCodec.buildResponsesRequest reasoning parameter', () => {
     });
 
     expect(request.reasoning).toEqual({ summary: 'detailed' });
+    expect(request.include).toBeUndefined();
   });
 
   it('omits reasoning for unknown API-key models', () => {
@@ -78,5 +80,6 @@ describe('OpenAiCodec.buildResponsesRequest reasoning parameter', () => {
     });
 
     expect(request.reasoning).toEqual({ summary: 'detailed' });
+    expect(request.include).toEqual(['reasoning.encrypted_content']);
   });
 });

--- a/src/__tests__/unit/core/openai-codec.test.ts
+++ b/src/__tests__/unit/core/openai-codec.test.ts
@@ -40,14 +40,14 @@ describe('OpenAiCodec.buildResponsesRequest reasoning parameter', () => {
     expect(request.reasoning).toEqual({ summary: 'detailed' });
   });
 
-  it('keeps summary auto in OAuth mode', () => {
+  it('requests a detailed summary in OAuth mode', () => {
     const request = OpenAiCodec.buildResponsesRequest(messages, {
       model: 'gpt-5.4',
       tools: [],
       oauthMode: true,
     });
 
-    expect(request.reasoning).toEqual(expect.objectContaining({ summary: 'auto' }));
+    expect(request.reasoning).toEqual(expect.objectContaining({ summary: 'detailed' }));
   });
 
   it('keeps summaries for Codex API-key models without a Heddle-managed effort', () => {
@@ -77,6 +77,6 @@ describe('OpenAiCodec.buildResponsesRequest reasoning parameter', () => {
       oauthMode: true,
     });
 
-    expect(request.reasoning).toEqual({ summary: 'auto' });
+    expect(request.reasoning).toEqual({ summary: 'detailed' });
   });
 });

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -339,7 +339,7 @@ describe('OpenAI OAuth helpers', () => {
     };
     expect(body.model).toBe('gpt-5.4');
     expect(body.store).toBe(false);
-    expect(body.reasoning?.summary).toBe('auto');
+    expect(body.reasoning?.summary).toBe('detailed');
     expect(body.instructions).toBe('You are Heddle. Reply with OK only.');
     expect(body.input).toEqual([
       { type: 'message', role: 'user', content: 'hello' },

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -185,6 +185,7 @@ describe('OpenAI OAuth helpers', () => {
     expect(requests[0]?.url).toBe(`${OPENAI_AUTH_ISSUER}/oauth/token`);
     expect(requests[1]?.url).toBe(OPENAI_CODEX_RESPONSES_ENDPOINT);
     expect(requests[1]?.headers.get('authorization')).toBe('Bearer new-access-token');
+    expect(requests[1]?.headers.get('originator')).toBe('heddle');
     expect(requests[1]?.headers.get('ChatGPT-Account-Id')).toBe('account-123');
   });
 
@@ -216,6 +217,7 @@ describe('OpenAI OAuth helpers', () => {
     expect(requests).toHaveLength(1);
     expect(requests[0]?.url).toBe(OPENAI_CODEX_RESPONSES_ENDPOINT);
     expect(requests[0]?.headers.get('authorization')).toBe('Bearer request-access-token');
+    expect(requests[0]?.headers.get('originator')).toBe('heddle');
     expect(requests[0]?.headers.get('ChatGPT-Account-Id')).toBe('account-123');
     expect(existsSync(storePath)).toBe(false);
   });
@@ -334,12 +336,14 @@ describe('OpenAI OAuth helpers', () => {
       model?: string;
       store?: boolean;
       reasoning?: { summary?: string };
+      include?: string[];
       instructions?: string;
       input?: Array<{ type?: string; role?: string; content?: string }>;
     };
     expect(body.model).toBe('gpt-5.4');
     expect(body.store).toBe(false);
     expect(body.reasoning?.summary).toBe('detailed');
+    expect(body.include).toEqual(['reasoning.encrypted_content']);
     expect(body.instructions).toBe('You are Heddle. Reply with OK only.');
     expect(body.input).toEqual([
       { type: 'message', role: 'user', content: 'hello' },

--- a/src/cli-v2/state/control-plane-live-event-reducer.ts
+++ b/src/cli-v2/state/control-plane-live-event-reducer.ts
@@ -91,6 +91,17 @@ export class ControlPlaneLiveEventReducer {
           done: streamActivity.done,
         });
       },
+      onReasoningSummary: (summaryActivity, liveStatus) => {
+        this.options.assistantStreamBuffer.push({
+          workspaceId,
+          sessionId,
+          text: `Thinking: ${summaryActivity.text}`,
+          done: false,
+        });
+        if (liveStatus !== undefined) {
+          this.options.state.patch({ liveStatus });
+        }
+      },
       onRunStarted: (runActivity, liveStatus) => {
         this.options.state.patch({
           running: true,

--- a/src/client-shared/services/session-activities/session-activity-service.ts
+++ b/src/client-shared/services/session-activities/session-activity-service.ts
@@ -57,6 +57,7 @@ type SessionActivityEffectHandlers = {
 
 export type ClientSharedSessionActivityEffects = {
   onAssistantStream?: (activity: ActivityOf<'assistant.stream'>, liveStatus: string | undefined) => void;
+  onReasoningSummary?: (activity: ActivityOf<'reasoning.summary'>, liveStatus: string | undefined) => void;
   onRunStarted?: (activity: ActivityOf<'loop.started'> | ActivityOf<'direct_shell.started'>, liveStatus: string | undefined) => void;
   onRunFinished?: (activity: ActivityOf<'loop.finished'> | ActivityOf<'direct_shell.completed'>, liveStatus: string | undefined) => void;
   onRecentEditDiff?: (diff: ClientSharedRecentEditDiff, activity: ActivityOf<'tool.completed'>) => void;
@@ -86,6 +87,9 @@ export class ClientSharedSessionActivityService {
     'assistant.stream': (activity, effects) => {
       effects.onAssistantStream?.(activity, activity.done ? undefined : 'Receiving assistant response...');
       effects.onCurrentActivityChanged?.(undefined);
+    },
+    'reasoning.summary': (activity, effects) => {
+      effects.onReasoningSummary?.(activity, 'Thinking...');
     },
     'loop.started': (activity, effects) => {
       effects.onPlanCleared?.();

--- a/src/core/agent/model/model-turn-service.ts
+++ b/src/core/agent/model/model-turn-service.ts
@@ -151,10 +151,14 @@ export class AgentModelTurnService {
       if (streamState.content || !AgentModelTurnService.shouldEmitStreamUpdate(streamState, Date.now())) {
         return;
       }
+      const text = streamState.reasoningSummary;
+      if (!text.trim()) {
+        return;
+      }
       context.live.activity({
-        type: HeddleEventType.assistantStream,
+        type: HeddleEventType.reasoningSummary,
         step: context.state.step,
-        text: AgentModelTurnService.formatReasoningSummary(streamState.reasoningSummary),
+        text,
         done: false,
       });
       return;
@@ -163,12 +167,16 @@ export class AgentModelTurnService {
     if (event.type === 'reasoning_summary.done') {
       streamState.reasoningSummary = event.text;
       if (!streamState.content) {
+        const text = streamState.reasoningSummary;
+        if (!text.trim()) {
+          return;
+        }
         streamState.lastStreamEmitAt = Date.now();
         context.live.activity({
-          type: HeddleEventType.assistantStream,
+          type: HeddleEventType.reasoningSummary,
           step: context.state.step,
-          text: AgentModelTurnService.formatReasoningSummary(streamState.reasoningSummary),
-          done: false,
+          text,
+          done: true,
         });
       }
     }
@@ -207,17 +215,5 @@ export class AgentModelTurnService {
       reasoningTokens: reasoningTokens || undefined,
       requests: requests || undefined,
     };
-  }
-
-  private static formatReasoningSummary(text: string): string {
-    const trimmed = AgentModelTurnService.stripReasoningSummaryMarkdown(text.trim());
-    return trimmed ? `Thinking: ${trimmed}` : 'Thinking...';
-  }
-
-  private static stripReasoningSummaryMarkdown(text: string): string {
-    return text
-      .replace(/\*\*([^*]+)\*\*/g, '$1')
-      .replace(/__([^_]+)__/g, '$1')
-      .replace(/([.!?])([A-Z][A-Za-z ]{2,}:?)/g, '$1 $2');
   }
 }

--- a/src/core/auth/openai-oauth.ts
+++ b/src/core/auth/openai-oauth.ts
@@ -16,6 +16,7 @@ import type {
 export const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 export const OPENAI_AUTH_ISSUER = 'https://auth.openai.com';
 export const OPENAI_CODEX_RESPONSES_ENDPOINT = 'https://chatgpt.com/backend-api/codex/responses';
+export const OPENAI_OAUTH_ORIGINATOR = 'heddle';
 export const OPENAI_OAUTH_CALLBACK_PATH = '/auth/callback';
 export const DEFAULT_OPENAI_OAUTH_PORT = 1455;
 
@@ -50,7 +51,7 @@ export class OpenAiOAuthService {
       id_token_add_organizations: 'true',
       codex_cli_simplified_flow: 'true',
       state: args.state,
-      originator: args.originator ?? 'heddle',
+      originator: args.originator ?? OPENAI_OAUTH_ORIGINATOR,
     });
 
     return `${OPENAI_AUTH_ISSUER}/oauth/authorize?${params.toString()}`;

--- a/src/core/chat/engine/text-host/service.ts
+++ b/src/core/chat/engine/text-host/service.ts
@@ -27,6 +27,7 @@ export class ConversationTextHostService {
   private readonly compactionMode: Exclude<ConversationTextHostMode, 'verbose'>;
   private readonly resultMode: Exclude<ConversationTextHostMode, 'verbose'>;
   private streamedAssistantText = '';
+  private streamedReasoningSummaryText = '';
 
   constructor(options: ConversationTextHostOptions = {}) {
     this.writer = ConversationTextHostService.normalizeWriter(options.output);
@@ -72,7 +73,11 @@ export class ConversationTextHostService {
   }
 
   formatActivity(activity: ConversationActivity): string | undefined {
-    if (this.activityMode === 'off' || activity.type === 'assistant.stream') {
+    if (
+      this.activityMode === 'off'
+      || activity.type === 'assistant.stream'
+      || activity.type === 'reasoning.summary'
+    ) {
       return undefined;
     }
 
@@ -154,6 +159,19 @@ export class ConversationTextHostService {
         this.writer.write(nextText);
       }
       this.streamedAssistantText = activity.text;
+      return;
+    }
+
+    if (activity.type === 'reasoning.summary') {
+      const nextText = activity.text.slice(this.streamedReasoningSummaryText.length);
+      if (nextText) {
+        this.writer.write(`${this.streamedReasoningSummaryText ? '' : 'Thinking: '}${nextText}`);
+      }
+      this.streamedReasoningSummaryText = activity.text;
+      if (activity.done) {
+        this.writer.write('\n');
+        this.streamedReasoningSummaryText = '';
+      }
       return;
     }
 

--- a/src/core/event-types.ts
+++ b/src/core/event-types.ts
@@ -8,6 +8,7 @@ export const HeddleEventType = {
   runStarted: 'run.started',
   assistantTurn: 'assistant.turn',
   assistantStream: 'assistant.stream',
+  reasoningSummary: 'reasoning.summary',
   modelRetry: 'model.retry',
   hostWarning: 'host.warning',
   autonomyDecision: 'autonomy.decision',

--- a/src/core/live/index.ts
+++ b/src/core/live/index.ts
@@ -18,6 +18,7 @@ export type {
   ConversationLoopFinishedActivity,
   ConversationLoopStartedActivity,
   ConversationPlanUpdatedActivity,
+  ConversationReasoningSummaryActivity,
   ConversationToolApprovalRequestedActivity,
   ConversationToolApprovalResolvedActivity,
   ConversationToolFallbackActivity,

--- a/src/core/live/types.ts
+++ b/src/core/live/types.ts
@@ -52,6 +52,20 @@ export type ConversationAssistantStreamActivity = {
   timestamp: string;
 };
 
+/**
+ * Provider-generated reasoning summary intended for user-visible progress.
+ * This is not hidden model chain-of-thought or assistant response draft text.
+ */
+export type ConversationReasoningSummaryActivity = {
+  source: 'agent-loop';
+  type: typeof HeddleEventType.reasoningSummary;
+  runId: string;
+  step: number;
+  text: string;
+  done: boolean;
+  timestamp: string;
+};
+
 export type ConversationToolApprovalRequestedActivity = {
   source: 'agent-loop';
   type: typeof HeddleEventType.toolApprovalRequested;
@@ -133,6 +147,7 @@ export type ConversationLoopFinishedActivity = {
 export type ConversationAgentLoopActivity =
   | ConversationLoopStartedActivity
   | ConversationAssistantStreamActivity
+  | ConversationReasoningSummaryActivity
   | ConversationToolApprovalRequestedActivity
   | ConversationToolApprovalResolvedActivity
   | ConversationToolFallbackActivity

--- a/src/core/llm/adapters/openai/openai-adapter.ts
+++ b/src/core/llm/adapters/openai/openai-adapter.ts
@@ -14,6 +14,7 @@ import type { ToolDefinition, ToolCall } from '@/core/types.js';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import {
   OPENAI_CODEX_RESPONSES_ENDPOINT,
+  OPENAI_OAUTH_ORIGINATOR,
   OpenAiOAuthService,
 } from '@/core/auth/openai-oauth.js';
 import {
@@ -260,6 +261,7 @@ export class OpenAiOAuthFetchService {
       headers.delete('authorization');
       headers.delete('Authorization');
       headers.set('authorization', `Bearer ${credential.accessToken}`);
+      headers.set('originator', OPENAI_OAUTH_ORIGINATOR);
       if (credential.accountId) {
         headers.set('ChatGPT-Account-Id', credential.accountId);
       }

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -1,6 +1,7 @@
 import type {
   FunctionTool,
   Response as OpenAiResponse,
+  ResponseIncludable,
   ResponseInputItem,
   ResponseReasoningItem,
 } from 'openai/resources/responses/responses.js';
@@ -128,6 +129,7 @@ export class OpenAiCodec {
     input: ResponseInputItem[];
     tools?: FunctionTool[];
     store: boolean;
+    include?: ResponseIncludable[];
     reasoning?: { summary: 'auto' | 'detailed'; effort?: OpenAiReasoningEffort };
     instructions?: string;
   } {
@@ -155,6 +157,11 @@ export class OpenAiCodec {
       input: OpenAiCodec.toResponseInput(inputMessages),
       tools: options.tools.length > 0 ? options.tools.map((tool) => OpenAiCodec.toResponseTool(tool)) : undefined,
       store: false,
+      ...(options.oauthMode && includeReasoning ? {
+        // Codex account-mode summary events require the encrypted reasoning
+        // item to be requested alongside the user-visible summary.
+        include: ['reasoning.encrypted_content' as const],
+      } : {}),
       ...(includeReasoning ? {
         reasoning: {
           // Request a summary explicitly for every supported credential path.

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -157,7 +157,10 @@ export class OpenAiCodec {
       store: false,
       ...(includeReasoning ? {
         reasoning: {
-          summary: options.oauthMode ? 'auto' as const : 'detailed' as const,
+          // Request a summary explicitly for every supported credential path.
+          // `auto` may return no user-visible summary even when the model spent
+          // reasoning tokens, which leaves embedded hosts with no live progress.
+          summary: 'detailed' as const,
           ...(reasoningEffort ? { effort: reasoningEffort } : {}),
         },
       } : {}),

--- a/src/core/runtime/loop/types.ts
+++ b/src/core/runtime/loop/types.ts
@@ -12,6 +12,7 @@ import type {
   ConversationToolCallingActivity,
   ConversationToolCompletedActivity,
   ConversationPlanUpdatedActivity,
+  ConversationReasoningSummaryActivity,
 } from '@/core/live/index.js';
 import type { ChatMessage, LlmAdapter, LlmProvider, LlmUsage, ReasoningEffort } from '@/core/llm/types.js';
 import type { RunFailure, RunResult, StopReason, ToolCall, ToolDefinition, TraceEvent } from '@/core/types.js';
@@ -53,6 +54,7 @@ export type AgentLoopEvent =
       timestamp: string;
     }
   | ConversationAssistantStreamActivity
+  | ConversationReasoningSummaryActivity
   | ConversationToolApprovalRequestedActivity
   | ConversationToolApprovalResolvedActivity
   | ConversationToolFallbackActivity

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
@@ -314,6 +314,16 @@ function applySessionActivity(activity: ControlPlaneSessionActivity, context: Se
         context.setLiveStatus(liveStatus);
       }
     },
+    onReasoningSummary: (summaryActivity, liveStatus) => {
+      context.updateSession((current) => (
+        ClientSharedSessionMessageService.upsertLiveAssistantMessage(
+          current,
+          `Thinking: ${summaryActivity.text}`,
+          false,
+        )
+      ));
+      context.setLiveStatus(liveStatus);
+    },
     onRunStarted: (_runActivity, liveStatus) => {
       context.setLiveStatus(liveStatus);
     },


### PR DESCRIPTION
## Summary

- add a dedicated `reasoning.summary` live activity for provider-generated reasoning summaries
- stream cumulative raw summary text with `done: false` updates and a final `done: true` item
- keep `assistant.stream` reserved for assistant response drafts
- preserve the current `Thinking:` presentation in Heddle web, CLI, and text hosts while leaving embedded hosts free to present or omit summaries
- request detailed summaries on supported OpenAI reasoning models
- align Codex account requests with the required `originator` header and encrypted-reasoning include
- document that reasoning summaries are user-visible provider output, not hidden chain-of-thought

## Contract

Heddle core emits provider summary text without presentation prefixes or Markdown rewriting. Hosts can distinguish it from incomplete assistant response text and structured tool activity.

The provider may omit summaries for trivial turns. Hosts retain their generic in-progress state until another activity or the terminal result arrives.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` (124 files / 735 tests)
- `yarn test` on the activity checkpoint (124 unit files / 735 tests; 34 integration files / 310 tests)
- `yarn build`
- real Codex-account probe observed `response.reasoning_summary_text.delta` events on a substantive reasoning turn
