### PR TITLE
feat: stream assistant progress commentary

### DIFF
--- a/docs/architecture/live-events.md
+++ b/docs/architecture/live-events.md
@@ -33,8 +33,8 @@ The ownership split is:
 
 `ConversationActivity` describes user-facing progress. Current sources include:
 
-- `agent-loop`: `loop.started`, `reasoning.summary`, `assistant.stream`, tool
-  activity, approvals, plans, and `loop.finished`;
+- `agent-loop`: `loop.started`, `assistant.commentary`, `reasoning.summary`,
+  `assistant.stream`, tool activity, approvals, plans, and `loop.finished`;
 - `compaction`: compaction progress and outcomes;
 - `direct-shell`: direct-shell lifecycle and results.
 
@@ -53,6 +53,33 @@ includes encrypted reasoning content so the Codex transport can emit summary
 events. The provider may still omit a summary for a trivial turn; hosts should
 keep their generic in-progress state until another activity or the terminal
 result arrives.
+
+`assistant.commentary` is assistant-authored, user-facing narration of ongoing
+work before or between tool calls. It is not inferred from message wording and
+is not hidden model chain-of-thought. For OpenAI Codex-account responses, the
+source output message is identified by its `phase` field:
+
+```json
+{
+  "id": "msg_123",
+  "type": "message",
+  "role": "assistant",
+  "phase": "commentary",
+  "content": [
+    { "type": "output_text", "text": "I found the loader and am checking its callers." }
+  ]
+}
+```
+
+The discriminator is `phase: "commentary"`; `output_text` by itself does not
+mean commentary. During streaming, Codex sends the message ID and phase on
+`response.output_item.added` or `response.output_item.done`, then sends text on
+`response.output_text.delta` and `response.output_text.done` with a matching
+`item_id`. The OpenAI adapter joins those events by ID and emits Heddle
+`assistant.commentary` activities. A message with `phase: "final_answer"` is
+the terminal-answer stream instead. Standard Responses API message output may
+omit `phase`, which Heddle treats as the normal final-output fallback rather
+than guessing a phase.
 
 `assistant.stream` is the cumulative assistant response draft. Embedding hosts
 may intentionally withhold it when an incomplete response could expose source
@@ -182,7 +209,7 @@ Run discovery:
 }
 ```
 
-Ordered assistant activity:
+Ordered terminal-answer stream activity:
 
 ```json
 {
@@ -195,9 +222,30 @@ Ordered assistant activity:
     "type": "assistant.stream",
     "runId": "run-123",
     "step": 1,
-    "text": "I am checking the session loader now...",
+    "text": "I updated the session loader and verified its callers.",
     "done": false,
     "timestamp": "2026-07-11T01:20:01.000Z"
+  }
+}
+```
+
+Ordered assistant-commentary activity:
+
+```json
+{
+  "kind": "activity",
+  "runId": "run-123",
+  "sequence": 3,
+  "timestamp": "2026-07-11T01:20:02.000Z",
+  "activity": {
+    "source": "agent-loop",
+    "type": "assistant.commentary",
+    "runId": "run-123",
+    "step": 1,
+    "messageId": "msg_123",
+    "text": "I found the loader and am checking its callers.",
+    "done": false,
+    "timestamp": "2026-07-11T01:20:02.000Z"
   }
 }
 ```
@@ -208,8 +256,8 @@ Ordered reasoning-summary activity:
 {
   "kind": "activity",
   "runId": "run-123",
-  "sequence": 3,
-  "timestamp": "2026-07-11T01:20:02.000Z",
+  "sequence": 4,
+  "timestamp": "2026-07-11T01:20:03.000Z",
   "activity": {
     "source": "agent-loop",
     "type": "reasoning.summary",
@@ -217,7 +265,7 @@ Ordered reasoning-summary activity:
     "step": 1,
     "text": "Inspecting the session loader before choosing a change.",
     "done": false,
-    "timestamp": "2026-07-11T01:20:02.000Z"
+    "timestamp": "2026-07-11T01:20:03.000Z"
   }
 }
 ```

--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -440,6 +440,52 @@ describe('AgentRunService.run', () => {
     });
   });
 
+  it('delivers assistant commentary as a distinct user-facing activity', async () => {
+    const events: AgentRunEvent[] = [];
+    const fakeLlm: LlmAdapter = {
+      async chat(_messages, _tools, _signal, onStreamEvent): Promise<LlmResponse> {
+        onStreamEvent?.({
+          type: 'commentary.delta',
+          messageId: 'commentary-1',
+          delta: 'I’m checking the repository ',
+        });
+        onStreamEvent?.({
+          type: 'commentary.done',
+          messageId: 'commentary-1',
+          text: 'I’m checking the repository before answering.',
+        });
+        onStreamEvent?.({ type: 'content.done', content: 'Done.' });
+        return { content: 'Done.' };
+      },
+    };
+
+    await AgentRunService.run({
+      goal: 'Inspect this repo.',
+      llm: fakeLlm,
+      tools: [],
+      maxSteps: 1,
+      logger: silentLogger,
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(events.filter((event) => event.type === 'assistant.commentary')).toEqual([
+      expect.objectContaining({
+        type: 'assistant.commentary',
+        step: 1,
+        messageId: 'commentary-1',
+        text: 'I’m checking the repository ',
+        done: false,
+      }),
+      expect.objectContaining({
+        type: 'assistant.commentary',
+        step: 1,
+        messageId: 'commentary-1',
+        text: 'I’m checking the repository before answering.',
+        done: true,
+      }),
+    ]);
+  });
+
   it('allows one repeated identical tool call, then blocks excessive repetition', async () => {
     const seenMessages: ChatMessage[][] = [];
     const fakeLlm: LlmAdapter = {

--- a/src/__tests__/unit/client-shared/session-activity-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-activity-service.test.ts
@@ -144,6 +144,42 @@ describe('ClientSharedSessionActivityService', () => {
     });
   });
 
+  it('delivers assistant commentary separately from reasoning and final text', () => {
+    let commentary: {
+      messageId: string;
+      text: string;
+      done: boolean;
+      liveStatus: string | undefined;
+    } | undefined;
+
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'assistant.commentary',
+      runId: 'run-1',
+      source: 'agent-loop',
+      step: 1,
+      messageId: 'commentary-1',
+      text: 'I’m checking the repository before making changes.',
+      done: false,
+      timestamp: '2026-06-03T00:00:00.000Z',
+    } as ControlPlaneSessionActivity, {
+      onAssistantCommentary: (activity, liveStatus) => {
+        commentary = {
+          messageId: activity.messageId,
+          text: activity.text,
+          done: activity.done,
+          liveStatus,
+        };
+      },
+    });
+
+    expect(commentary).toEqual({
+      messageId: 'commentary-1',
+      text: 'I’m checking the repository before making changes.',
+      done: false,
+      liveStatus: 'Working...',
+    });
+  });
+
   it('projects recent edit diffs from successful edit_file completions', () => {
     const diffs: string[] = [];
 

--- a/src/__tests__/unit/control-plane/session-message-service.test.ts
+++ b/src/__tests__/unit/control-plane/session-message-service.test.ts
@@ -65,6 +65,45 @@ describe('ClientSharedSessionMessageService', () => {
     ]);
   });
 
+  it('keeps commentary messages distinct until the final answer starts', () => {
+    const current = sessionWithMessages([
+      { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
+      { id: 'live-reasoning', role: 'assistant', text: 'Thinking: Inspecting files' },
+    ]);
+    const withCommentary = ClientSharedSessionMessageService.upsertLiveCommentaryMessage(
+      current,
+      'commentary-1',
+      'I’m checking the relevant files now.',
+      true,
+    );
+
+    expect(withCommentary?.messages).toEqual([
+      { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
+      {
+        id: 'live-commentary:commentary-1',
+        role: 'assistant',
+        text: 'I’m checking the relevant files now.',
+        isStreaming: false,
+        isPending: true,
+      },
+    ]);
+
+    expect(ClientSharedSessionMessageService.upsertLiveAssistantMessage(
+      withCommentary,
+      'Final answer.',
+      true,
+    )?.messages).toEqual([
+      { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },
+      {
+        id: 'live-assistant',
+        role: 'assistant',
+        text: 'Final answer.',
+        isPending: false,
+        isStreaming: false,
+      },
+    ]);
+  });
+
   it('does not preserve other transient message ids during stale snapshot merges', () => {
     const current = sessionWithMessages([
       { id: 'persisted-assistant', role: 'assistant', text: 'Previous answer.' },

--- a/src/__tests__/unit/core/conversation-text-host.test.ts
+++ b/src/__tests__/unit/core/conversation-text-host.test.ts
@@ -27,6 +27,26 @@ describe('createConversationTextHost', () => {
     });
     textHost.host.events?.onActivity?.({
       source: 'agent-loop',
+      type: 'assistant.commentary',
+      runId: 'run-1',
+      step: 1,
+      messageId: 'commentary-1',
+      text: 'I’m checking',
+      done: false,
+      timestamp: '2026-07-02T00:00:00.600Z',
+    });
+    textHost.host.events?.onActivity?.({
+      source: 'agent-loop',
+      type: 'assistant.commentary',
+      runId: 'run-1',
+      step: 1,
+      messageId: 'commentary-1',
+      text: 'I’m checking the files now.',
+      done: true,
+      timestamp: '2026-07-02T00:00:00.700Z',
+    });
+    textHost.host.events?.onActivity?.({
+      source: 'agent-loop',
       type: 'assistant.stream',
       runId: 'run-1',
       step: 1,
@@ -58,6 +78,9 @@ describe('createConversationTextHost', () => {
     expect(write.mock.calls.map((call) => call[0])).toEqual([
       'Thinking: Inspecting',
       ' the request.',
+      '\n',
+      'Working: I’m checking',
+      ' the files now.',
       '\n',
       'Hello',
       ' world',

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -344,7 +344,8 @@ describe('OpenAI OAuth helpers', () => {
     expect(body.store).toBe(false);
     expect(body.reasoning?.summary).toBe('detailed');
     expect(body.include).toEqual(['reasoning.encrypted_content']);
-    expect(body.instructions).toBe('You are Heddle. Reply with OK only.');
+    expect(body.instructions).toContain('You are Heddle. Reply with OK only.');
+    expect(body.instructions).toContain('brief, concrete commentary messages');
     expect(body.input).toEqual([
       { type: 'message', role: 'user', content: 'hello' },
     ]);
@@ -525,6 +526,72 @@ describe('OpenAI OAuth helpers', () => {
       { type: 'reasoning_summary.delta', delta: 'Inspecting ' },
       { type: 'reasoning_summary.delta', delta: 'the repo.' },
       { type: 'reasoning_summary.done', text: 'Inspecting the repo.' },
+      { type: 'content.done', content: 'Done.' },
+    ]);
+    expect(result.content).toBe('Done.');
+  });
+
+  it('separates assistant commentary from the final-answer stream by message phase', async () => {
+    const adapter = createOpenAiTestAdapter({
+      model: 'gpt-5.4',
+      credential: {
+        type: 'oauth',
+        provider: 'openai',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 120_000,
+        accountId: 'account-123',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      },
+      fetchImpl: (async () => {
+        const body = [
+          'event: response.created',
+          'data: {"type":"response.created","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"in_progress","model":"gpt-5.4","output":[]}}',
+          '',
+          'event: response.output_item.added',
+          'data: {"type":"response.output_item.added","item":{"id":"msg_commentary","type":"message","status":"in_progress","role":"assistant","content":[{"type":"output_text","text":"","annotations":[]}],"phase":"commentary"},"output_index":0,"sequence_number":2}',
+          '',
+          'event: response.output_text.delta',
+          'data: {"type":"response.output_text.delta","delta":"I’m checking ","content_index":0,"item_id":"msg_commentary","output_index":0,"sequence_number":3}',
+          '',
+          'event: response.output_text.delta',
+          'data: {"type":"response.output_text.delta","delta":"the repository now.","content_index":0,"item_id":"msg_commentary","output_index":0,"sequence_number":4}',
+          '',
+          'event: response.output_text.done',
+          'data: {"type":"response.output_text.done","text":"I’m checking the repository now.","content_index":0,"item_id":"msg_commentary","output_index":0,"sequence_number":5}',
+          '',
+          'event: response.output_item.added',
+          'data: {"type":"response.output_item.added","item":{"id":"msg_final","type":"message","status":"in_progress","role":"assistant","content":[{"type":"output_text","text":"","annotations":[]}],"phase":"final_answer"},"output_index":1,"sequence_number":6}',
+          '',
+          'event: response.output_text.delta',
+          'data: {"type":"response.output_text.delta","delta":"Done.","content_index":0,"item_id":"msg_final","output_index":1,"sequence_number":7}',
+          '',
+          'event: response.output_text.done',
+          'data: {"type":"response.output_text.done","text":"Done.","content_index":0,"item_id":"msg_final","output_index":1,"sequence_number":8}',
+          '',
+          'event: response.completed',
+          'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"completed","completed_at":1777301835,"model":"gpt-5.4","output_text":"I’m checking the repository now.\nDone.","output":[{"id":"msg_commentary","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"I’m checking the repository now.","annotations":[]}],"phase":"commentary"},{"id":"msg_final","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Done.","annotations":[]}],"phase":"final_answer"}],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":20}}}',
+          '',
+        ].join('\n');
+
+        return new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }) as typeof fetch,
+    });
+    const streamEvents: unknown[] = [];
+
+    const result = await adapter.chat([{ role: 'user', content: 'Inspect the repo.' }], [], undefined, (event) => {
+      streamEvents.push(event);
+    });
+
+    expect(streamEvents).toEqual([
+      { type: 'commentary.delta', messageId: 'msg_commentary', delta: 'I’m checking ' },
+      { type: 'commentary.delta', messageId: 'msg_commentary', delta: 'the repository now.' },
+      { type: 'commentary.done', messageId: 'msg_commentary', text: 'I’m checking the repository now.' },
+      { type: 'content.delta', delta: 'Done.' },
       { type: 'content.done', content: 'Done.' },
     ]);
     expect(result.content).toBe('Done.');

--- a/src/cli-v2/state/control-plane-live-event-reducer.ts
+++ b/src/cli-v2/state/control-plane-live-event-reducer.ts
@@ -91,6 +91,17 @@ export class ControlPlaneLiveEventReducer {
           done: streamActivity.done,
         });
       },
+      onAssistantCommentary: (commentaryActivity, liveStatus) => {
+        this.options.assistantStreamBuffer.push({
+          workspaceId,
+          sessionId,
+          text: commentaryActivity.text,
+          done: false,
+        });
+        if (liveStatus !== undefined) {
+          this.options.state.patch({ liveStatus });
+        }
+      },
       onReasoningSummary: (summaryActivity, liveStatus) => {
         this.options.assistantStreamBuffer.push({
           workspaceId,

--- a/src/client-shared/services/session-activities/README.md
+++ b/src/client-shared/services/session-activities/README.md
@@ -9,6 +9,8 @@ after they receive API-provided live events.
 - Mapping each API activity type to shared client effects.
 - Shared live status copy for activity progress.
 - Shared derived labels for tool-related activities.
+- Shared effects for final-answer, commentary, and reasoning-summary streams;
+  each remains a distinct activity so clients can present them independently.
 - Active plan lifetime at the client edge: `plan.updated` sets the visible plan,
   `loop.started` and `loop.finished` clear it.
 

--- a/src/client-shared/services/session-activities/session-activity-service.ts
+++ b/src/client-shared/services/session-activities/session-activity-service.ts
@@ -57,6 +57,7 @@ type SessionActivityEffectHandlers = {
 
 export type ClientSharedSessionActivityEffects = {
   onAssistantStream?: (activity: ActivityOf<'assistant.stream'>, liveStatus: string | undefined) => void;
+  onAssistantCommentary?: (activity: ActivityOf<'assistant.commentary'>, liveStatus: string | undefined) => void;
   onReasoningSummary?: (activity: ActivityOf<'reasoning.summary'>, liveStatus: string | undefined) => void;
   onRunStarted?: (activity: ActivityOf<'loop.started'> | ActivityOf<'direct_shell.started'>, liveStatus: string | undefined) => void;
   onRunFinished?: (activity: ActivityOf<'loop.finished'> | ActivityOf<'direct_shell.completed'>, liveStatus: string | undefined) => void;
@@ -87,6 +88,9 @@ export class ClientSharedSessionActivityService {
     'assistant.stream': (activity, effects) => {
       effects.onAssistantStream?.(activity, activity.done ? undefined : 'Receiving assistant response...');
       effects.onCurrentActivityChanged?.(undefined);
+    },
+    'assistant.commentary': (activity, effects) => {
+      effects.onAssistantCommentary?.(activity, 'Working...');
     },
     'reasoning.summary': (activity, effects) => {
       effects.onReasoningSummary?.(activity, 'Thinking...');

--- a/src/client-shared/services/session-messages/session-message-service.ts
+++ b/src/client-shared/services/session-messages/session-message-service.ts
@@ -16,15 +16,68 @@ export class ClientSharedSessionMessageService {
       return session;
     }
 
-    const messages = session.messages.filter((message) => (
-      message.id !== 'live-run-status' && message.id !== 'live-assistant'
-    ));
+    const messages = session.messages.filter((message) => !ClientSharedSessionMessageService.isTransientActivityMessage(message.id));
 
     return {
       ...session,
       messages: [
         ...messages,
         ClientSharedSessionMessageService.createLiveAssistantMessage(text, done),
+      ],
+    };
+  }
+
+  static upsertLiveCommentaryMessage(
+    session: ControlPlaneSessionDetail,
+    messageId: string,
+    text: string,
+    done: boolean,
+  ): ControlPlaneSessionDetail {
+    if (!session) {
+      return session;
+    }
+
+    const id = `live-commentary:${messageId}`;
+    return {
+      ...session,
+      messages: [
+        ...session.messages.filter((message) => (
+          message.id !== id
+          && message.id !== 'live-reasoning'
+          && message.id !== 'live-run-status'
+        )),
+        {
+          id,
+          role: 'assistant',
+          text,
+          isStreaming: !done,
+          isPending: true,
+        },
+      ],
+    };
+  }
+
+  static upsertLiveReasoningMessage(
+    session: ControlPlaneSessionDetail,
+    text: string,
+  ): ControlPlaneSessionDetail {
+    if (!session) {
+      return session;
+    }
+
+    return {
+      ...session,
+      messages: [
+        ...session.messages.filter((message) => (
+          message.id !== 'live-reasoning' && message.id !== 'live-run-status'
+        )),
+        {
+          id: 'live-reasoning',
+          role: 'assistant',
+          text,
+          isStreaming: true,
+          isPending: true,
+        },
       ],
     };
   }
@@ -39,7 +92,7 @@ export class ClientSharedSessionMessageService {
 
     const nextMessageIds = new Set(next.messages.map((message) => message.id));
     const transientMessages = current.messages.filter((message) => (
-      message.id === 'live-assistant' &&
+      ClientSharedSessionMessageService.isPreservedLiveMessage(message.id) &&
       !nextMessageIds.has(message.id) &&
       !next.messages.some((persisted) => persisted.role === message.role && persisted.text === message.text)
     ));
@@ -51,6 +104,19 @@ export class ClientSharedSessionMessageService {
         ...transientMessages,
       ],
     } : next;
+  }
+
+  private static isTransientActivityMessage(id: string): boolean {
+    return id === 'live-run-status'
+      || id === 'live-assistant'
+      || id === 'live-reasoning'
+      || id.startsWith('live-commentary:');
+  }
+
+  private static isPreservedLiveMessage(id: string): boolean {
+    return id === 'live-assistant'
+      || id === 'live-reasoning'
+      || id.startsWith('live-commentary:');
   }
 
   private static createLiveAssistantMessage(text: string, done: boolean | undefined): ControlPlaneSessionMessage {

--- a/src/core/agent/model/model-turn-service.ts
+++ b/src/core/agent/model/model-turn-service.ts
@@ -72,6 +72,7 @@ export class AgentModelTurnService {
     const { context } = args;
     const streamState = {
       content: '',
+      commentary: new Map<string, { text: string; lastStreamEmitAt: number }>(),
       reasoningSummary: '',
       lastStreamEmitAt: 0,
     };
@@ -121,6 +122,7 @@ export class AgentModelTurnService {
     event: LlmStreamEvent;
     streamState: {
       content: string;
+      commentary: Map<string, { text: string; lastStreamEmitAt: number }>;
       reasoningSummary: string;
       lastStreamEmitAt: number;
     };
@@ -143,6 +145,47 @@ export class AgentModelTurnService {
       streamState.content = event.content;
       streamState.lastStreamEmitAt = Date.now();
       context.live.activity({ type: HeddleEventType.assistantStream, step: context.state.step, text: streamState.content, done: true });
+      return;
+    }
+
+    if (event.type === 'commentary.delta') {
+      const commentary = streamState.commentary.get(event.messageId) ?? {
+        text: '',
+        lastStreamEmitAt: 0,
+      };
+      commentary.text += event.delta;
+      streamState.commentary.set(event.messageId, commentary);
+      if (!AgentModelTurnService.shouldEmitStreamUpdate(commentary, Date.now())) {
+        return;
+      }
+      context.live.activity({
+        type: HeddleEventType.assistantCommentary,
+        step: context.state.step,
+        messageId: event.messageId,
+        text: commentary.text,
+        done: false,
+      });
+      return;
+    }
+
+    if (event.type === 'commentary.done') {
+      const commentary = streamState.commentary.get(event.messageId) ?? {
+        text: '',
+        lastStreamEmitAt: 0,
+      };
+      commentary.text = event.text;
+      commentary.lastStreamEmitAt = Date.now();
+      streamState.commentary.set(event.messageId, commentary);
+      if (!commentary.text.trim()) {
+        return;
+      }
+      context.live.activity({
+        type: HeddleEventType.assistantCommentary,
+        step: context.state.step,
+        messageId: event.messageId,
+        text: commentary.text,
+        done: true,
+      });
       return;
     }
 

--- a/src/core/chat/engine/text-host/service.ts
+++ b/src/core/chat/engine/text-host/service.ts
@@ -27,6 +27,7 @@ export class ConversationTextHostService {
   private readonly compactionMode: Exclude<ConversationTextHostMode, 'verbose'>;
   private readonly resultMode: Exclude<ConversationTextHostMode, 'verbose'>;
   private streamedAssistantText = '';
+  private readonly streamedCommentaryText = new Map<string, string>();
   private streamedReasoningSummaryText = '';
 
   constructor(options: ConversationTextHostOptions = {}) {
@@ -76,6 +77,7 @@ export class ConversationTextHostService {
     if (
       this.activityMode === 'off'
       || activity.type === 'assistant.stream'
+      || activity.type === 'assistant.commentary'
       || activity.type === 'reasoning.summary'
     ) {
       return undefined;
@@ -159,6 +161,20 @@ export class ConversationTextHostService {
         this.writer.write(nextText);
       }
       this.streamedAssistantText = activity.text;
+      return;
+    }
+
+    if (activity.type === 'assistant.commentary') {
+      const previousText = this.streamedCommentaryText.get(activity.messageId) ?? '';
+      const nextText = activity.text.slice(previousText.length);
+      if (nextText) {
+        this.writer.write(`${previousText ? '' : 'Working: '}${nextText}`);
+      }
+      this.streamedCommentaryText.set(activity.messageId, activity.text);
+      if (activity.done) {
+        this.writer.write('\n');
+        this.streamedCommentaryText.delete(activity.messageId);
+      }
       return;
     }
 

--- a/src/core/event-types.ts
+++ b/src/core/event-types.ts
@@ -8,6 +8,7 @@ export const HeddleEventType = {
   runStarted: 'run.started',
   assistantTurn: 'assistant.turn',
   assistantStream: 'assistant.stream',
+  assistantCommentary: 'assistant.commentary',
   reasoningSummary: 'reasoning.summary',
   modelRetry: 'model.retry',
   hostWarning: 'host.warning',

--- a/src/core/live/README.md
+++ b/src/core/live/README.md
@@ -14,6 +14,21 @@ tool progress, run lifecycle, or compaction progress. Add structured fields to
 the activity type that owns the behavior, then let interfaces decide how to
 present those fields.
 
+## Assistant Text Activities
+
+Assistant text has three separate user-visible meanings:
+
+- `assistant.commentary` is assistant-authored progress narration produced
+  before or between tool calls. It may be streamed and is safe to show, but it
+  is not the final answer.
+- `reasoning.summary` is a provider-generated summary of model reasoning. It is
+  not hidden chain-of-thought and may be as short as a heading.
+- `assistant.stream` is the draft and completion stream for the terminal answer.
+
+Core emits raw text for all three activities. Presentation layers own labels
+such as "Working" or "Thinking" and must not relabel final-answer drafts as
+reasoning.
+
 ## Plan Activity
 
 Agent planning uses the same live activity lane. The agent domain owns the

--- a/src/core/live/index.ts
+++ b/src/core/live/index.ts
@@ -6,6 +6,7 @@ export type {
   ConversationActivityDerived,
   ConversationActivityHandlerMap,
   ConversationActivityOf,
+  ConversationAssistantCommentaryActivity,
   ConversationAssistantStreamActivity,
   ConversationCompactionActivity,
   ConversationCompactionFailedActivity,

--- a/src/core/live/types.ts
+++ b/src/core/live/types.ts
@@ -53,6 +53,21 @@ export type ConversationAssistantStreamActivity = {
 };
 
 /**
+ * Assistant-authored, user-facing progress narration emitted during a turn.
+ * This is distinct from provider reasoning summaries and the final response.
+ */
+export type ConversationAssistantCommentaryActivity = {
+  source: 'agent-loop';
+  type: typeof HeddleEventType.assistantCommentary;
+  runId: string;
+  step: number;
+  messageId: string;
+  text: string;
+  done: boolean;
+  timestamp: string;
+};
+
+/**
  * Provider-generated reasoning summary intended for user-visible progress.
  * This is not hidden model chain-of-thought or assistant response draft text.
  */
@@ -147,6 +162,7 @@ export type ConversationLoopFinishedActivity = {
 export type ConversationAgentLoopActivity =
   | ConversationLoopStartedActivity
   | ConversationAssistantStreamActivity
+  | ConversationAssistantCommentaryActivity
   | ConversationReasoningSummaryActivity
   | ConversationToolApprovalRequestedActivity
   | ConversationToolApprovalResolvedActivity

--- a/src/core/llm/adapters/openai/openai-adapter.ts
+++ b/src/core/llm/adapters/openai/openai-adapter.ts
@@ -99,6 +99,11 @@ export class OpenAiAdapter implements LlmAdapter {
     }, { signal });
 
     let streamedContent = '';
+    // Codex sends the assistant message classifier on
+    // `response.output_item.{added,done}` as `event.item.phase`, while token
+    // text arrives separately on `response.output_text.{delta,done}`. The
+    // shared message/item ID is the join key. Do not classify output text as
+    // commentary from its wording, event order, or content type.
     const assistantMessagePhases = new Map<string, 'commentary' | 'final_answer'>();
     const streamedToolCalls = new Map<string, { id: string; tool: string; argumentsText: string }>();
     let completedResponse: OpenAiResponse | undefined;

--- a/src/core/llm/adapters/openai/openai-adapter.ts
+++ b/src/core/llm/adapters/openai/openai-adapter.ts
@@ -99,17 +99,36 @@ export class OpenAiAdapter implements LlmAdapter {
     }, { signal });
 
     let streamedContent = '';
+    const assistantMessagePhases = new Map<string, 'commentary' | 'final_answer'>();
     const streamedToolCalls = new Map<string, { id: string; tool: string; argumentsText: string }>();
     let completedResponse: OpenAiResponse | undefined;
     try {
       for await (const event of stream as AsyncIterable<ResponseStreamEvent>) {
         if (event.type === 'response.output_text.delta' && event.delta) {
+          if (assistantMessagePhases.get(event.item_id) === 'commentary') {
+            onStreamEvent?.({
+              type: 'commentary.delta',
+              messageId: event.item_id,
+              delta: event.delta,
+            });
+            continue;
+          }
+
           streamedContent += event.delta;
           onStreamEvent?.({ type: 'content.delta', delta: event.delta });
           continue;
         }
 
         if (event.type === 'response.output_text.done') {
+          if (assistantMessagePhases.get(event.item_id) === 'commentary') {
+            onStreamEvent?.({
+              type: 'commentary.done',
+              messageId: event.item_id,
+              text: event.text,
+            });
+            continue;
+          }
+
           streamedContent = event.text;
           onStreamEvent?.({ type: 'content.done', content: event.text });
           continue;
@@ -140,6 +159,10 @@ export class OpenAiAdapter implements LlmAdapter {
 
         if (event.type === 'response.output_item.added' || event.type === 'response.output_item.done') {
           const item = event.item;
+          const message = OpenAiCodec.readAssistantMessageMetadata(item);
+          if (message?.phase) {
+            assistantMessagePhases.set(message.messageId, message.phase);
+          }
           if (
             item.type === 'function_call'
             && typeof item.id === 'string'

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -23,6 +23,27 @@ const OPENAI_ACCOUNT_COMMENTARY_INSTRUCTIONS = `During substantial multi-step wo
  * OpenAI Responses API payloads/events.
  */
 export class OpenAiCodec {
+  /**
+   * Reads the Responses/Codex assistant-message discriminator.
+   *
+   * A completed assistant output item has this relevant shape:
+   *
+   * ```ts
+   * {
+   *   id: 'msg_123',
+   *   type: 'message',
+   *   role: 'assistant',
+   *   phase: 'commentary' | 'final_answer',
+   *   content: [{ type: 'output_text', text: '...' }],
+   * }
+   * ```
+   *
+   * `phase` is the classifier: `phase: 'commentary'` means user-facing work
+   * narration, not hidden chain-of-thought and not the final answer. The text
+   * still lives in `content[].output_text.text`. Standard Responses API output
+   * may omit `phase`; preserving `undefined` lets callers use the normal final
+   * output fallback without guessing from message wording or ordering.
+   */
   static readAssistantMessageMetadata(item: unknown): OpenAiAssistantMessageMetadata | undefined {
     if (!item || typeof item !== 'object' || Array.isArray(item)) {
       return undefined;

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -10,11 +10,41 @@ import { ModelPolicyService } from '@/core/llm/models/index.js';
 import type { ChatMessage, LlmUsage, ReasoningEffort } from '@/core/llm/types.js';
 import type { AssistantDiagnostics, ToolCall, ToolDefinition } from '@/core/types.js';
 
+export type OpenAiAssistantMessagePhase = 'commentary' | 'final_answer';
+export type OpenAiAssistantMessageMetadata = {
+  messageId: string;
+  phase?: OpenAiAssistantMessagePhase;
+};
+
+const OPENAI_ACCOUNT_COMMENTARY_INSTRUCTIONS = `During substantial multi-step work, keep the user informed with brief, concrete commentary messages before tool calls and between major phases. Describe progress and the next action without revealing hidden chain-of-thought. Skip commentary for simple one-step answers.`;
+
 /**
  * Provider-owned codec for translating between Heddle LLM port types and the
  * OpenAI Responses API payloads/events.
  */
 export class OpenAiCodec {
+  static readAssistantMessageMetadata(item: unknown): OpenAiAssistantMessageMetadata | undefined {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      return undefined;
+    }
+
+    const candidate = item as { id?: unknown; type?: unknown; role?: unknown; phase?: unknown };
+    if (
+      candidate.type !== 'message'
+      || candidate.role !== 'assistant'
+      || typeof candidate.id !== 'string'
+    ) {
+      return undefined;
+    }
+
+    return {
+      messageId: candidate.id,
+      ...(candidate.phase === 'commentary' || candidate.phase === 'final_answer'
+        ? { phase: candidate.phase }
+        : {}),
+    };
+  }
+
   static parseStreamedToolCalls(
     streamedToolCalls: Map<string, { id: string; tool: string; argumentsText: string }>,
   ): ToolCall[] {
@@ -49,29 +79,30 @@ export class OpenAiCodec {
   }
 
   static extractAssistantContent(response: OpenAiResponse, preferToolCalls: boolean): string | undefined {
-    const text = response.output_text?.trim();
-    if (text) {
-      return text;
-    }
+    const output = Array.isArray(response.output) ? response.output : [];
+    const messages = output.flatMap((item) => {
+      const metadata = OpenAiCodec.readAssistantMessageMetadata(item);
+      if (!metadata || item.type !== 'message') {
+        return [];
+      }
+
+      const text = (Array.isArray(item.content) ? item.content : [])
+        .flatMap((part) => part.type === 'output_text' && part.text.trim() ? [part.text.trim()] : [])
+        .join('\n\n');
+      return text ? [{ ...metadata, text }] : [];
+    });
 
     if (preferToolCalls) {
-      return undefined;
+      const progressText = messages
+        .filter((message) => message.phase !== 'final_answer')
+        .map((message) => message.text)
+        .join('\n\n');
+      return progressText || undefined;
     }
 
-    const output = Array.isArray(response.output) ? response.output : [];
-    for (const item of output) {
-      if (item.type !== 'message') {
-        continue;
-      }
-
-      const content = Array.isArray(item.content) ? item.content : [];
-      const segment = content.find((part) => part.type === 'output_text');
-      if (segment?.text?.trim()) {
-        return segment.text.trim();
-      }
-    }
-
-    return undefined;
+    const finalText = messages.find((message) => message.phase === 'final_answer')?.text
+      ?? messages.find((message) => message.phase === undefined)?.text;
+    return finalText ?? (response.output_text?.trim() || undefined);
   }
 
   static extractAssistantDiagnostics(
@@ -135,9 +166,11 @@ export class OpenAiCodec {
   } {
     const systemMessages = options.oauthMode ? messages.filter((message): message is Extract<ChatMessage, { role: 'system' }> => message.role === 'system') : [];
     const inputMessages = options.oauthMode ? messages.filter((message) => message.role !== 'system') : messages;
-    const instructions =
-      options.oauthMode ?
-        systemMessages.map((message) => message.content.trim()).filter(Boolean).join('\n\n')
+    const instructions = options.oauthMode
+      ? [
+          ...systemMessages.map((message) => message.content.trim()).filter(Boolean),
+          OPENAI_ACCOUNT_COMMENTARY_INSTRUCTIONS,
+        ].join('\n\n')
       : undefined;
     const reasoningEffort = OpenAiCodec.resolveRequestReasoningEffort({
       model: options.model,

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -11,6 +11,8 @@ import type {
 export type LlmStreamEvent =
   | { type: 'content.delta'; delta: string }
   | { type: 'content.done'; content: string }
+  | { type: 'commentary.delta'; messageId: string; delta: string }
+  | { type: 'commentary.done'; messageId: string; text: string }
   | { type: 'reasoning_summary.delta'; delta: string }
   | { type: 'reasoning_summary.done'; text: string };
 

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -11,6 +11,9 @@ import type {
 export type LlmStreamEvent =
   | { type: 'content.delta'; delta: string }
   | { type: 'content.done'; content: string }
+  // User-facing assistant work narration. Provider adapters must derive this
+  // from an explicit provider discriminator (OpenAI/Codex uses message
+  // `phase: 'commentary'`), never from the text itself.
   | { type: 'commentary.delta'; messageId: string; delta: string }
   | { type: 'commentary.done'; messageId: string; text: string }
   | { type: 'reasoning_summary.delta'; delta: string }

--- a/src/core/runtime/loop/types.ts
+++ b/src/core/runtime/loop/types.ts
@@ -3,6 +3,7 @@ import type { AutonomyEvaluation } from '@/core/approvals/autonomy/index.js';
 import type { ToolApprovalDecision, ToolApprovalPolicy } from '@/core/approvals/types.js';
 import { HeddleEventType } from '@/core/event-types.js';
 import type {
+  ConversationAssistantCommentaryActivity,
   ConversationAssistantStreamActivity,
   ConversationLoopFinishedActivity,
   ConversationLoopStartedActivity,
@@ -54,6 +55,7 @@ export type AgentLoopEvent =
       timestamp: string;
     }
   | ConversationAssistantStreamActivity
+  | ConversationAssistantCommentaryActivity
   | ConversationReasoningSummaryActivity
   | ConversationToolApprovalRequestedActivity
   | ConversationToolApprovalResolvedActivity

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
@@ -314,12 +314,22 @@ function applySessionActivity(activity: ControlPlaneSessionActivity, context: Se
         context.setLiveStatus(liveStatus);
       }
     },
+    onAssistantCommentary: (commentaryActivity, liveStatus) => {
+      context.updateSession((current) => (
+        ClientSharedSessionMessageService.upsertLiveCommentaryMessage(
+          current,
+          commentaryActivity.messageId,
+          commentaryActivity.text,
+          commentaryActivity.done,
+        )
+      ));
+      context.setLiveStatus(liveStatus);
+    },
     onReasoningSummary: (summaryActivity, liveStatus) => {
       context.updateSession((current) => (
-        ClientSharedSessionMessageService.upsertLiveAssistantMessage(
+        ClientSharedSessionMessageService.upsertLiveReasoningMessage(
           current,
           `Thinking: ${summaryActivity.text}`,
-          false,
         )
       ));
       context.setLiveStatus(liveStatus);


### PR DESCRIPTION
## Summary

- preserve OpenAI assistant message phases and stream `commentary` separately from provider reasoning summaries and the final answer
- expose `assistant.commentary` through Heddle's live activity protocol, shared clients, web control plane, CLI, and text host
- prompt Codex-account runs to provide brief user-facing progress updates during substantial multi-step work

## Boundary

This is user-facing progress narration, not hidden chain-of-thought. Provider `reasoning.summary`, assistant `commentary`, tool activity, and the terminal assistant response remain distinct channels. Core events carry raw text; presentation layers own labels such as “Working” or “Thinking”.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` — 124 files, 738 tests
- `yarn test:integration` — 34 files, 311 tests
- `yarn build`
- live Heddle Web verification with a Codex subscription
