### PR TITLE
fix: keep run notifications concise

### DIFF
--- a/src/__tests__/unit/client-shared/notification-intent-service.test.ts
+++ b/src/__tests__/unit/client-shared/notification-intent-service.test.ts
@@ -175,6 +175,46 @@ describe('ClientSharedNotificationIntentService', () => {
     });
   });
 
+  it('projects long session results as concise notification previews', () => {
+    const longSummary = [
+      'I inspected the workspace and found the next implementation slice.',
+      '',
+      'This detail is intentionally repeated so the durable conversation keeps the complete answer. '.repeat(5),
+    ].join('\n');
+    const activity = ClientSharedNotificationIntentService.projectSessionActivity({
+      workspaceId: 'workspace-1',
+      sessionId: 'session-1',
+      activity: {
+        source: 'agent-loop',
+        type: 'loop.finished',
+        runId: 'run-1',
+        outcome: 'done',
+        summary: longSummary,
+        timestamp: '2026-06-12T00:01:00.000Z',
+      } as SessionActivity,
+    });
+    const terminal = ClientSharedNotificationIntentService.projectSessionRunTerminal({
+      workspaceId: 'workspace-1',
+      envelope: {
+        type: 'session.run.terminal',
+        sessionId: 'session-1',
+        timestamp: '2026-06-12T00:01:00.000Z',
+        terminal: {
+          kind: 'result',
+          runId: 'run-1',
+          sequence: 3,
+          timestamp: '2026-06-12T00:01:00.000Z',
+          result: { outcome: 'done', summary: longSummary },
+        },
+      },
+    });
+
+    expect(activity?.body).toBe(terminal.body);
+    expect(activity?.body).toHaveLength(160);
+    expect(activity?.body).not.toContain('\n');
+    expect(activity?.body).toMatch(/…$/);
+  });
+
   it('deduplicates notification intents by key', () => {
     const memory = new ClientSharedNotificationMemory();
     const intent = {

--- a/src/client-shared/services/notifications/README.md
+++ b/src/client-shared/services/notifications/README.md
@@ -23,6 +23,11 @@ adapter.
 - `heartbeat.task.finished` and `heartbeat.task.failed` become task-run
   notifications for the active workspace while a client is open.
 
+Session-completion bodies are short, whitespace-normalized previews. The full
+assistant result remains in the conversation and must not be copied into a
+notification intent, because browser and desktop notification surfaces are
+space-constrained and may appear outside the Heddle window.
+
 Each projected intent has a stable `key`. Hosts should pass intents through
 `ClientSharedNotificationMemory` before delivery so reconnects and refetches do
 not notify repeatedly for the same event.

--- a/src/client-shared/services/notifications/notification-intent-service.ts
+++ b/src/client-shared/services/notifications/notification-intent-service.ts
@@ -1,6 +1,7 @@
 import {
   ClientSharedSessionActivityService,
 } from '@/client-shared/services/session-activities/index.js';
+import truncate from 'lodash/truncate.js';
 import type {
   ClientSharedHeartbeatEventEnvelope,
   ClientSharedNotificationIntent,
@@ -35,6 +36,7 @@ type NotificationMemoryOptions = {
 };
 
 const DEFAULT_MAX_SEEN_KEYS = 200;
+const SESSION_COMPLETION_PREVIEW_LENGTH = 160;
 
 /**
  * Owns frontend-neutral notification intent projection from shared control-plane
@@ -70,7 +72,7 @@ export class ClientSharedNotificationIntentService {
           input.activity.runId,
         ].join(':'),
         title: 'Session run finished',
-        body: input.activity.summary || input.activity.outcome,
+        body: projectSessionCompletionPreview(input.activity.summary, input.activity.outcome),
         tone: ClientSharedSessionActivityService.resolveRunOutcomeTone(input.activity.outcome),
         timestamp: input.activity.timestamp,
         workspaceId: input.workspaceId,
@@ -184,9 +186,17 @@ function projectRunTerminalPresentation(
   }
   return {
     title: 'Session run finished',
-    body: terminal.result.summary ?? terminal.result.outcome,
+    body: projectSessionCompletionPreview(terminal.result.summary, terminal.result.outcome),
     tone: 'success',
   };
+}
+
+function projectSessionCompletionPreview(summary: string | undefined, outcome: string | undefined): string {
+  const content = (summary?.trim() || outcome?.trim() || 'Completed').replace(/\s+/g, ' ');
+  return truncate(content, {
+    length: SESSION_COMPLETION_PREVIEW_LENGTH,
+    omission: '…',
+  });
 }
 
 /**

--- a/src/web-v2/components/ui/toast.tsx
+++ b/src/web-v2/components/ui/toast.tsx
@@ -63,7 +63,11 @@ const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Description ref={ref} className={cn('v2-type-caption mt-1 text-slate-200/90', className)} {...props} />
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn('v2-type-caption mt-1 line-clamp-3 text-pretty text-slate-200/90', className)}
+    {...props}
+  />
 ))
 ToastDescription.displayName = ToastPrimitives.Description.displayName
 


### PR DESCRIPTION
## Summary

- limit successful session-completion notifications to a whitespace-normalized 160-character preview
- clamp web toast descriptions to three lines as a defensive presentation boundary
- keep the complete assistant result in the conversation instead of copying it into the notification surface

## Root cause

The shared notification projection passed the complete terminal assistant summary into browser and desktop notifications. Long Markdown answers therefore expanded the in-app toast across most of the control plane and could also leak excessive content into operating-system notification surfaces.

## Verification

- `yarn test` (124 unit files / 739 tests; 35 integration files / 316 tests)
- `yarn lint`
- `yarn build`
- `git diff --check`
