### PR TITLE
feat: support OpenAI GPT-5.6 models

### DIFF
--- a/docs/reference/providers-and-models.md
+++ b/docs/reference/providers-and-models.md
@@ -133,6 +133,7 @@ a provider default.
 
 OpenAI models currently included in the built-in shortlist:
 
+- `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
 - `gpt-5.5`, `gpt-5.5-pro`
 - `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`
 - `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, `gpt-5-nano`
@@ -147,6 +148,31 @@ Anthropic models currently included in the built-in shortlist:
 - `claude-opus-4-1`, `claude-opus-4-0`, `claude-sonnet-4-0`
 - `claude-3-7-sonnet-latest`
 - `claude-3-5-sonnet-latest`, `claude-3-5-haiku-latest`
+
+### GPT-5.6 family
+
+Heddle exposes the three explicit GPT-5.6 tiers in model pickers:
+
+- `gpt-5.6-sol` for the highest-capability tier
+- `gpt-5.6-terra` for the balanced tier
+- `gpt-5.6-luna` for cost-sensitive, high-volume work
+
+The provider alias `gpt-5.6` is also accepted and routes to Sol, but Heddle
+shows the explicit tier names so the selected cost/capability posture is clear.
+All three tiers have a 1,050,000-token context window and a 128,000-token
+maximum output. Heddle keeps `gpt-5.4` as the default; GPT-5.6 selection is
+opt-in.
+
+GPT-5.6 supports `none`, `low`, `medium`, `high`, `xhigh`, and `max` reasoning
+effort, with `medium` as the default. Heddle retains the existing persisted
+value `ultrahigh` for backward compatibility and translates it to OpenAI's
+wire value `xhigh` in the OpenAI adapter. The web and terminal clients render
+only the effort levels enabled by the selected model's shared runtime policy.
+
+See OpenAI's official model pages for
+[Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol),
+[Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra), and
+[Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna).
 
 ## Choosing A Model
 
@@ -247,6 +273,10 @@ In the browser control plane, the same auth indicator appears in the session com
 
 OpenAI account sign-in is routed through the ChatGPT/Codex transport path and is limited to models Heddle has explicitly allowed for that path:
 
+- `gpt-5.6` (Sol alias)
+- `gpt-5.6-sol`
+- `gpt-5.6-terra`
+- `gpt-5.6-luna`
 - `gpt-5.1-codex`
 - `gpt-5.1-codex-max`
 - `gpt-5.1-codex-mini`

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "marked-terminal": "^6.3.0",
     "monaco-editor": "^0.55.1",
     "multer": "^2.1.1",
-    "openai": "^4.86.2",
+    "openai": "^6.48.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "proper-lockfile": "^4.1.2",

--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -8,7 +8,7 @@ import {
 import { ProviderCredentialRepository } from '../../../core/auth/index.js';
 import { AnthropicAdapter } from '../../../core/llm/adapters/anthropic/index.js';
 import { LlmAdapterService } from '../../../core/llm/index.js';
-import { ModelPolicyService } from '../../../core/llm/models/index.js';
+import { ModelCatalogService, ModelPolicyService } from '../../../core/llm/models/index.js';
 
 describe('llm adapter factory', () => {
   it('infers provider from known model prefixes', () => {
@@ -63,8 +63,11 @@ describe('llm adapter factory', () => {
             'event: response.created',
             'data: {"type":"response.created","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"in_progress","model":"gpt-5.4","output":[]}}',
             '',
+            'event: response.output_item.added',
+            'data: {"type":"response.output_item.added","item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant","content":[{"type":"output_text","text":"","annotations":[]}]},"output_index":0,"sequence_number":2}',
+            '',
             'event: response.output_text.done',
-            'data: {"type":"response.output_text.done","text":"Done.","content_index":0,"item_id":"msg_1","output_index":0,"sequence_number":2}',
+            'data: {"type":"response.output_text.done","text":"Done.","content_index":0,"item_id":"msg_1","output_index":0,"sequence_number":3}',
             '',
             'event: response.completed',
             'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"completed","completed_at":1777301835,"model":"gpt-5.4","output_text":"Done.","output":[],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":15}}}',
@@ -328,6 +331,30 @@ describe('llm adapter factory', () => {
       disabled: false,
       disabledReason: undefined,
     });
+
+    expect(ModelPolicyService.supportedOpenAiRequestReasoningEfforts('gpt-5.6-sol')).toEqual([
+      'none',
+      'low',
+      'medium',
+      'high',
+      'ultrahigh',
+      'max',
+    ]);
+    expect(ModelPolicyService.buildReasoningEffortOptions('gpt-5.6-terra')).toContainEqual({
+      id: 'max',
+      label: 'max',
+      description: 'Set explicit max effort',
+      disabled: false,
+      disabledReason: undefined,
+    });
+  });
+
+  it('supports the GPT-5.6 family across catalog and account sign-in policy', () => {
+    expect(ModelCatalogService.isCommonBuiltInModel('gpt-5.6-sol')).toBe(true);
+    expect(ModelCatalogService.isOpenAiAccountSignInModel('gpt-5.6')).toBe(true);
+    expect(ModelCatalogService.isOpenAiAccountSignInModel('gpt-5.6-terra')).toBe(true);
+    expect(ModelCatalogService.estimateOpenAiContextWindow('gpt-5.6-luna')).toBe(1_050_000);
+    expect(ModelPolicyService.resolveDefaultReasoningEffort('gpt-5.6-sol')).toBe('medium');
   });
 
   it('owns reasoning-summary support independently from configurable effort', () => {

--- a/src/__tests__/unit/core/openai-codec.test.ts
+++ b/src/__tests__/unit/core/openai-codec.test.ts
@@ -30,6 +30,37 @@ describe('OpenAiCodec.buildResponsesRequest reasoning parameter', () => {
     expect(request.reasoning).toEqual({ summary: 'detailed', effort: 'medium' });
   });
 
+  it('uses GPT-5.6 defaults and canonical provider effort values', () => {
+    const defaultRequest = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'gpt-5.6-sol',
+      tools: [],
+      oauthMode: false,
+    });
+    const noneRequest = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'gpt-5.6-terra',
+      tools: [],
+      oauthMode: false,
+      reasoningEffort: 'none',
+    });
+    const extraHighRequest = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'gpt-5.6-luna',
+      tools: [],
+      oauthMode: false,
+      reasoningEffort: 'ultrahigh',
+    });
+    const maxRequest = OpenAiCodec.buildResponsesRequest(messages, {
+      model: 'gpt-5.6-sol',
+      tools: [],
+      oauthMode: false,
+      reasoningEffort: 'max',
+    });
+
+    expect(defaultRequest.reasoning).toEqual({ summary: 'detailed', effort: 'medium' });
+    expect(noneRequest.reasoning).toEqual({ summary: 'detailed', effort: 'none' });
+    expect(extraHighRequest.reasoning).toEqual({ summary: 'detailed', effort: 'xhigh' });
+    expect(maxRequest.reasoning).toEqual({ summary: 'detailed', effort: 'max' });
+  });
+
   it('keeps summaries for o-series models without a Heddle-managed effort', () => {
     const request = OpenAiCodec.buildResponsesRequest(messages, {
       model: 'o4-mini',

--- a/src/__tests__/unit/core/openai-oauth.test.ts
+++ b/src/__tests__/unit/core/openai-oauth.test.ts
@@ -400,7 +400,7 @@ describe('OpenAI OAuth helpers', () => {
 
     await expect(adapter.chat([{ role: 'user', content: 'hello' }], [])).rejects.toThrow();
     const body = JSON.parse(requests[0]?.body ?? '{}') as { reasoning?: { effort?: string } };
-    expect(body.reasoning?.effort).toBe('ultrahigh');
+    expect(body.reasoning?.effort).toBe('xhigh');
   });
 
   it('reconstructs tool calls from streamed Codex OAuth events when final response output is empty', async () => {
@@ -493,20 +493,26 @@ describe('OpenAI OAuth helpers', () => {
           'event: response.created',
           'data: {"type":"response.created","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"in_progress","model":"gpt-5.4","output":[]}}',
           '',
-          'event: response.reasoning_summary_text.delta',
-          'data: {"type":"response.reasoning_summary_text.delta","delta":"Inspecting ","item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":2}',
+          'event: response.output_item.added',
+          'data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning","status":"in_progress","summary":[{"type":"summary_text","text":""}]},"output_index":0,"sequence_number":2}',
           '',
           'event: response.reasoning_summary_text.delta',
-          'data: {"type":"response.reasoning_summary_text.delta","delta":"the repo.","item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":3}',
+          'data: {"type":"response.reasoning_summary_text.delta","delta":"Inspecting ","item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":3}',
+          '',
+          'event: response.reasoning_summary_text.delta',
+          'data: {"type":"response.reasoning_summary_text.delta","delta":"the repo.","item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":4}',
           '',
           'event: response.reasoning_summary_text.done',
-          'data: {"type":"response.reasoning_summary_text.done","text":"Inspecting the repo.","item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":4}',
+          'data: {"type":"response.reasoning_summary_text.done","text":"Inspecting the repo.","item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":5}',
+          '',
+          'event: response.output_item.added',
+          'data: {"type":"response.output_item.added","item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant","content":[{"type":"output_text","text":"","annotations":[]}]},"output_index":1,"sequence_number":6}',
           '',
           'event: response.output_text.done',
-          'data: {"type":"response.output_text.done","text":"Done.","content_index":0,"item_id":"msg_1","output_index":1,"sequence_number":5}',
+          'data: {"type":"response.output_text.done","text":"Done.","content_index":0,"item_id":"msg_1","output_index":1,"sequence_number":7}',
           '',
           'event: response.completed',
-          'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"completed","completed_at":1777301835,"model":"gpt-5.4","output_text":"Done.","output":[],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":1},"total_tokens":15}}}',
+          'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"completed","completed_at":1777301835,"model":"gpt-5.4","output_text":"Done.","output":[{"id":"rs_1","type":"reasoning","status":"completed","summary":[{"type":"summary_text","text":"Inspecting the repo."}]},{"id":"msg_1","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Done.","annotations":[]}]}],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":1},"total_tokens":15}}}',
           '',
         ].join('\n');
 
@@ -615,8 +621,11 @@ describe('OpenAI OAuth helpers', () => {
           'event: response.created',
           'data: {"type":"response.created","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"in_progress","model":"gpt-5.4","output":[]}}',
           '',
+          'event: response.output_item.added',
+          'data: {"type":"response.output_item.added","item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant","content":[{"type":"output_text","text":"","annotations":[]}]},"output_index":0,"sequence_number":2}',
+          '',
           'event: response.output_text.done',
-          'data: {"type":"response.output_text.done","text":"Done.","content_index":0,"item_id":"msg_1","output_index":0,"sequence_number":2}',
+          'data: {"type":"response.output_text.done","text":"Done.","content_index":0,"item_id":"msg_1","output_index":0,"sequence_number":3}',
           '',
           'event: response.completed',
           'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1777301834,"status":"completed","completed_at":1777301835,"model":"gpt-5.4","output_text":"Done.","output":[{"id":"msg_1","type":"message","status":"completed","role":"assistant"}],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":15}}}',

--- a/src/__tests__/unit/sdk/quickstart-conversation-cli-runner.test.ts
+++ b/src/__tests__/unit/sdk/quickstart-conversation-cli-runner.test.ts
@@ -131,7 +131,7 @@ describe('runQuickstartConversationCli', () => {
     expect(() => resolveQuickstartConversationCliDefaults({
       env: {},
       reasoningEffort: 'extreme',
-    })).toThrow('Unsupported reasoning effort: extreme. Use one of low, medium, high, ultrahigh.');
+    })).toThrow('Unsupported reasoning effort: extreme. Use one of none, low, medium, high, ultrahigh, max.');
   });
 
   it('can resume an existing session without owning the caller loop', async () => {

--- a/src/__tests__/unit/web-v2/composer-execution-menu.test.tsx
+++ b/src/__tests__/unit/web-v2/composer-execution-menu.test.tsx
@@ -1,12 +1,14 @@
 /** @vitest-environment jsdom */
 
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ControlPlaneModelOptions } from '@/client-shared/api/types.js';
 import { ComposerExecutionMenu } from '../../../web-v2/components/conversation/ComposerExecutionMenu.js';
 import { I18nProvider } from '../../../web-v2/i18n/I18nProvider.js';
 
 describe('web-v2 ComposerExecutionMenu', () => {
+  afterEach(cleanup);
+
   it('renders discovered Ollama models from shared model options', () => {
     const modelOptions: ControlPlaneModelOptions = {
       groups: [
@@ -33,9 +35,32 @@ describe('web-v2 ComposerExecutionMenu', () => {
       </I18nProvider>,
     );
 
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5.4/i }));
 
     expect(screen.getByText('Ollama · Installed local models')).toBeTruthy();
     expect(screen.getByText('llama3.2:latest')).toBeTruthy();
+  });
+
+  it('renders model-owned GPT-5.6 reasoning levels and disabled states', () => {
+    render(
+      <I18nProvider>
+        <ComposerExecutionMenu
+          model="gpt-5.6-sol"
+          reasoningEffort="medium"
+          reasoningOptions={[
+            { id: 'default', label: 'default', description: 'Use model default', disabled: false },
+            { id: 'none', label: 'none', description: 'Set explicit none effort', disabled: false },
+            { id: 'medium', label: 'medium', description: 'Set explicit medium effort', disabled: false },
+            { id: 'max', label: 'max', description: 'Set explicit max effort', disabled: true, disabledReason: 'Unavailable' },
+          ]}
+          onUpdateReasoningEffort={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5.6-sol/i }));
+
+    expect((screen.getByRole('menuitemradio', { name: 'None' }) as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByRole('menuitemradio', { name: /Max/ }) as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -9,8 +9,9 @@ import { ConversationDirectShellLineResultSchema } from '@/core/chat/engine/dire
 import { ChatArchiveRecordSchema } from '@/core/chat/engine/sessions/archives/schemas.js';
 import { ConversationTurnPresentationSchema } from '@/core/chat/engine/turns/presentation/index.js';
 import { CustomAgentExecutionSnapshotSchema } from '@/core/custom-agents/index.js';
+import { REASONING_EFFORTS } from '@/core/llm/types.js';
 
-const ReasoningEffortSchema = z.enum(['low', 'medium', 'high', 'ultrahigh']);
+const ReasoningEffortSchema = z.enum(REASONING_EFFORTS);
 const ChatSessionRetentionSchema = z.enum(['reusable', 'one_off']);
 const ChatSessionLeaseOwnerSchema = z.enum(['tui', 'daemon', 'ask']);
 const CompactionStatusSchema = z.enum(['idle', 'running', 'failed']);

--- a/src/core/commands/slash/modules/model/model-commands.ts
+++ b/src/core/commands/slash/modules/model/model-commands.ts
@@ -8,7 +8,7 @@ import {
   ModelPolicyService,
 } from '../../../../llm/models/index.js';
 import { LlmAdapterService } from '../../../../llm/index.js';
-import type { ReasoningEffort } from '../../../../llm/types.js';
+import { REASONING_EFFORTS, type ReasoningEffort } from '../../../../llm/types.js';
 import {
   formatSessionReasoningEffortStatus,
   resolveEffectiveReasoningEffort,
@@ -159,7 +159,7 @@ async function setReasoningEffort(
   }
 
   if (!isReasoningEffort(selected)) {
-    return slashMessageResult('Usage: /reasoning set <query> or /reasoning <low|medium|high|default>');
+    return slashMessageResult('Usage: /reasoning set <query> or /reasoning <none|low|medium|high|ultrahigh|max|default>');
   }
 
   if (!ModelPolicyService.supportsReasoningEffort(context.model.active())) {
@@ -174,5 +174,5 @@ async function setReasoningEffort(
   return slashMessageResult(`Set reasoning effort to ${selected} for ${context.model.active()}.`);
 }
 function isReasoningEffort(value: string): value is ReasoningEffort {
-  return value === 'low' || value === 'medium' || value === 'high' || value === 'ultrahigh';
+  return REASONING_EFFORTS.includes(value as ReasoningEffort);
 }

--- a/src/core/custom-agents/schemas.ts
+++ b/src/core/custom-agents/schemas.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
+import { REASONING_EFFORTS } from '@/core/llm/types.js';
 
 export const CustomAgentModeAliasSchema = z.enum(['ask', 'code', 'review']);
 export const CustomAgentSourceKindSchema = z.enum(['project', 'user', 'built-in']);
 export const CustomAgentToolPresetSchema = z.enum(['default', 'inspect', 'none', 'custom']);
 export const CustomAgentApprovalPresetSchema = z.enum(['interactive', 'read_only', 'auto', 'custom']);
-export const CustomAgentReasoningEffortSchema = z.enum(['low', 'medium', 'high', 'ultrahigh']);
+export const CustomAgentReasoningEffortSchema = z.enum(REASONING_EFFORTS);
 export const CustomAgentMemoryModeSchema = z.enum(['none', 'read-and-record', 'maintainer', 'legacy-full']);
 export const ToolCapabilitySchema = z.enum([
   'workspace.read',

--- a/src/core/llm/adapters/openai/openai-adapter.ts
+++ b/src/core/llm/adapters/openai/openai-adapter.ts
@@ -2,13 +2,12 @@
 // LLM Adapter — OpenAI implementation
 // ---------------------------------------------------------------------------
 
-import OpenAI from 'openai';
+import OpenAI, { type ClientOptions } from 'openai';
 import dayjs from 'dayjs';
 import type {
   Response as OpenAiResponse,
   ResponseStreamEvent,
 } from 'openai/resources/responses/responses.js';
-import type { Fetch as OpenAiFetch } from 'openai/core.js';
 import type { LlmAdapter, ChatMessage, LlmResponse, LlmAdapterCapabilities, LlmStreamEvent, ReasoningEffort, LlmAdapterCreateInput } from '@/core/llm/types.js';
 import type { ToolDefinition, ToolCall } from '@/core/types.js';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
@@ -30,6 +29,11 @@ export type OpenAiAdapterOptions = LlmAdapterCreateInput;
 
 export type CompatibleFetch = (url: unknown, init?: unknown) => Promise<globalThis.Response>;
 export type OpenAiAccountCredential = OpenAiOAuthCredential | RuntimeProviderCredential;
+type OpenAiFetch = NonNullable<ClientOptions['fetch']>;
+type LegacyOpenAiReasoningSummaryEvent =
+  | { type: 'response.reasoning_summary.delta'; delta: unknown }
+  | { type: 'response.reasoning_summary.done'; text: string };
+type OpenAiStreamEvent = ResponseStreamEvent | LegacyOpenAiReasoningSummaryEvent;
 
 /**
  * OpenAI implementation of the LLM port. It owns OpenAI Responses streaming,
@@ -108,7 +112,10 @@ export class OpenAiAdapter implements LlmAdapter {
     const streamedToolCalls = new Map<string, { id: string; tool: string; argumentsText: string }>();
     let completedResponse: OpenAiResponse | undefined;
     try {
-      for await (const event of stream as AsyncIterable<ResponseStreamEvent>) {
+      // The public API stream uses the SDK union. Codex account mode can also
+      // emit the two legacy summary event names retained below, so Heddle owns
+      // that narrow transport extension at this adapter boundary.
+      for await (const event of stream as AsyncIterable<OpenAiStreamEvent>) {
         if (event.type === 'response.output_text.delta' && event.delta) {
           if (assistantMessagePhases.get(event.item_id) === 'commentary') {
             onStreamEvent?.({
@@ -303,7 +310,7 @@ export class OpenAiOAuthFetchService {
         headers,
       });
     };
-    return oauthFetch as unknown as OpenAiFetch;
+    return oauthFetch as OpenAiFetch;
   }
 
   static isAccountCredential(

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -249,7 +249,10 @@ export class OpenAiCodec {
   }
 
   private static toOpenAiReasoningEffort(value: ReasoningEffort): OpenAiReasoningEffort {
-    return value as OpenAiReasoningEffort;
+    // Heddle persisted `ultrahigh` before OpenAI standardized the provider
+    // wire value as `xhigh`. Keep the product value backward compatible and
+    // translate only at this provider-owned boundary.
+    return value === 'ultrahigh' ? 'xhigh' : value;
   }
 
   private static toResponseInput(messages: ChatMessage[]): ResponseInputItem[] {

--- a/src/core/llm/models/README.md
+++ b/src/core/llm/models/README.md
@@ -54,3 +54,21 @@ Provider adapters can still translate an already-approved Heddle policy value
 into the provider wire format. If translation discovers a provider limitation,
 move that limitation back into `ModelPolicyService` so every interface sees the
 same behavior before a request is made.
+
+## GPT-5.6 Contract
+
+The GPT-5.6 product boundary is intentionally additive:
+
+- the curated picker exposes `gpt-5.6-sol`, `gpt-5.6-terra`, and
+  `gpt-5.6-luna`;
+- the `gpt-5.6` Sol alias and all three explicit tiers are allowed through both
+  Platform API-key and OpenAI account-sign-in paths;
+- the catalog owns the 1,050,000-token context estimate;
+- `ModelPolicyService` owns the supported `none` through `max` effort levels
+  and the `medium` default;
+- the OpenAI adapter translates Heddle's backward-compatible persisted
+  `ultrahigh` value to the provider wire value `xhigh`.
+
+Do not repeat this policy in a host UI. Clients receive concrete reasoning
+options from the session runtime context so unsupported levels are disabled
+before a request starts.

--- a/src/core/llm/models/index.ts
+++ b/src/core/llm/models/index.ts
@@ -7,6 +7,8 @@ export {
   type ModelOptionGroup,
   type ModelOptionSource,
   OPENAI_ACCOUNT_SIGN_IN_MODELS,
+  OPENAI_GPT_5_6_ALIAS,
+  OPENAI_GPT_5_6_MODELS,
   OPENAI_MODEL_GROUPS,
 } from './model-catalog.js';
 export type { BuiltInModelGroup } from './model-catalog.js';

--- a/src/core/llm/models/model-catalog.ts
+++ b/src/core/llm/models/model-catalog.ts
@@ -13,7 +13,18 @@ export type BuiltInModelGroup = {
   models: string[];
 };
 
+export const OPENAI_GPT_5_6_ALIAS = 'gpt-5.6';
+export const OPENAI_GPT_5_6_MODELS = [
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
+] as const;
+
 export const BUILT_IN_MODEL_GROUPS: BuiltInModelGroup[] = [
+  {
+    label: 'OpenAI · GPT-5.6',
+    models: [...OPENAI_GPT_5_6_MODELS],
+  },
   {
     label: 'OpenAI · GPT-5.5',
     models: ['gpt-5.5', 'gpt-5.5-pro'],
@@ -67,6 +78,8 @@ export const OPENAI_MODEL_GROUPS: BuiltInModelGroup[] = BUILT_IN_MODEL_GROUPS.fi
 export const COMMON_BUILT_IN_MODELS = BUILT_IN_MODEL_GROUPS.flatMap((group) => group.models);
 export const COMMON_OPENAI_MODELS = OPENAI_MODEL_GROUPS.flatMap((group) => group.models);
 export const OPENAI_ACCOUNT_SIGN_IN_MODELS = [
+  OPENAI_GPT_5_6_ALIAS,
+  ...OPENAI_GPT_5_6_MODELS,
   'gpt-5.5',
   'gpt-5.4',
   'gpt-5.4-mini',
@@ -152,6 +165,10 @@ export class ModelCatalogService {
   }
 
   static inferContextWindowEstimate(model: string): number {
+    if (model === OPENAI_GPT_5_6_ALIAS || model.startsWith(`${OPENAI_GPT_5_6_ALIAS}-`)) {
+      return 1_050_000;
+    }
+
     if (model.startsWith('gpt-5.5')) {
       return 400_000;
     }

--- a/src/core/llm/models/model-policy-service.ts
+++ b/src/core/llm/models/model-policy-service.ts
@@ -1,7 +1,12 @@
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import type { LlmProvider, ReasoningEffort } from '@/core/llm/types.js';
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
-import { ModelCatalogService, OPENAI_ACCOUNT_SIGN_IN_MODELS } from './model-catalog.js';
+import {
+  ModelCatalogService,
+  OPENAI_ACCOUNT_SIGN_IN_MODELS,
+  OPENAI_GPT_5_6_ALIAS,
+  OPENAI_GPT_5_6_MODELS,
+} from './model-catalog.js';
 
 export type SystemModelPurpose = 'chat-compaction' | 'session-title';
 export type ModelCredentialMode = 'api-key' | 'oauth' | 'missing';
@@ -31,6 +36,8 @@ const OPENAI_OAUTH_IMAGE_MODEL_PREFERENCES = ['gpt-5.4', 'gpt-5.4-mini'];
 // Keep this explicit and aligned with the curated reasoning models in
 // model-catalog.ts so unknown/non-reasoning models never receive this parameter.
 const OPENAI_REASONING_SUMMARY_CAPABLE_MODELS = [
+  OPENAI_GPT_5_6_ALIAS,
+  ...OPENAI_GPT_5_6_MODELS,
   'gpt-5.5',
   'gpt-5.5-pro',
   'gpt-5.4',
@@ -56,6 +63,8 @@ const OPENAI_REASONING_SUMMARY_CAPABLE_MODELS = [
   'o4-mini',
 ] as const;
 const REASONING_EFFORT_CAPABLE_OPENAI_MODELS = [
+  OPENAI_GPT_5_6_ALIAS,
+  ...OPENAI_GPT_5_6_MODELS,
   'gpt-5.4',
   'gpt-5.4-pro',
   'gpt-5.4-mini',
@@ -64,6 +73,8 @@ const REASONING_EFFORT_CAPABLE_OPENAI_MODELS = [
   'gpt-5.5-pro',
 ] as const;
 const OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS = [
+  OPENAI_GPT_5_6_ALIAS,
+  ...OPENAI_GPT_5_6_MODELS,
   'gpt-5.4',
   'gpt-5.4-pro',
   'gpt-5.4-mini',
@@ -71,6 +82,10 @@ const OPENAI_REQUEST_REASONING_EFFORT_COMPATIBLE_MODELS = [
   'gpt-5.5-pro',
 ] as const;
 const OPENAI_REQUEST_REASONING_EFFORTS_BY_MODEL: Record<string, ReasoningEffort[]> = {
+  [OPENAI_GPT_5_6_ALIAS]: ['none', 'low', 'medium', 'high', 'ultrahigh', 'max'],
+  ...Object.fromEntries(
+    OPENAI_GPT_5_6_MODELS.map((model) => [model, ['none', 'low', 'medium', 'high', 'ultrahigh', 'max']]),
+  ),
   'gpt-5.4': ['low', 'medium', 'high'],
   'gpt-5.4-pro': ['low', 'medium', 'high'],
   'gpt-5.4-mini': ['low', 'medium', 'high'],
@@ -78,6 +93,8 @@ const OPENAI_REQUEST_REASONING_EFFORTS_BY_MODEL: Record<string, ReasoningEffort[
   'gpt-5.5-pro': ['low', 'medium', 'high', 'ultrahigh'],
 };
 const DEFAULT_OPENAI_REASONING_EFFORT: Record<string, ReasoningEffort> = {
+  [OPENAI_GPT_5_6_ALIAS]: 'medium',
+  ...Object.fromEntries(OPENAI_GPT_5_6_MODELS.map((model) => [model, 'medium'])),
   'gpt-5.4': 'medium',
   'gpt-5.4-pro': 'medium',
   'gpt-5.4-mini': 'medium',
@@ -270,7 +287,7 @@ export class ModelPolicyService {
         description: defaultEffort ? `Use ${model} default (${defaultEffort})` : `Do not send reasoning effort for ${model}`,
         disabled: false,
       },
-      ...(['low', 'medium', 'high', 'ultrahigh'] as const).map((effort) => ({
+      ...(['none', 'low', 'medium', 'high', 'ultrahigh', 'max'] as const).map((effort) => ({
         id: effort,
         label: effort,
         description: `Set explicit ${effort} effort`,

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -32,7 +32,16 @@ export type LlmProvider =
   | 'together'
   | 'groq';
 
-export type ReasoningEffort = 'low' | 'medium' | 'high' | 'ultrahigh';
+export const REASONING_EFFORTS = [
+  'none',
+  'low',
+  'medium',
+  'high',
+  'ultrahigh',
+  'max',
+] as const;
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
 
 export type LlmAdapterCapabilities = {
   toolCalls: boolean;

--- a/src/core/tools/toolkits/external-context/web-search.ts
+++ b/src/core/tools/toolkits/external-context/web-search.ts
@@ -158,7 +158,7 @@ async function executeOpenAiWebSearch(input: WebSearchInput, options: WebSearchT
     model,
     input: input.query,
     tools: [{
-      type: 'web_search_preview',
+      type: 'web_search',
       search_context_size: input.contextSize ?? 'medium',
     } satisfies WebSearchTool],
   });

--- a/src/sdk/conversation/runtime/service.ts
+++ b/src/sdk/conversation/runtime/service.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
-import type { ReasoningEffort } from '@/core/llm/types.js';
+import { REASONING_EFFORTS, type ReasoningEffort } from '@/core/llm/types.js';
 import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
@@ -12,12 +12,7 @@ import type {
 } from './types.js';
 
 const DEFAULT_MEMORY_MAINTENANCE_MODE = 'none';
-const SUPPORTED_REASONING_EFFORTS = new Set<ReasoningEffort>([
-  'low',
-  'medium',
-  'high',
-  'ultrahigh',
-]);
+const SUPPORTED_REASONING_EFFORTS = new Set<ReasoningEffort>(REASONING_EFFORTS);
 
 /** Owns environment-derived defaults and credential preflight shared by SDK conversation hosts. */
 export class ConversationSdkRuntimeService {
@@ -133,6 +128,6 @@ export class ConversationSdkRuntimeService {
       return value as ReasoningEffort;
     }
 
-    throw new Error(`Unsupported reasoning effort: ${value}. Use one of low, medium, high, ultrahigh.`);
+    throw new Error(`Unsupported reasoning effort: ${value}. Use one of ${REASONING_EFFORTS.join(', ')}.`);
   }
 }

--- a/src/server/controllers/trpc/control-plane/chat-session-presenter.ts
+++ b/src/server/controllers/trpc/control-plane/chat-session-presenter.ts
@@ -1,5 +1,5 @@
 import type { ChatSession, ConversationDirectShellLineResult } from '@/core/chat/types.js';
-import type { ReasoningEffort } from '@/core/llm/types.js';
+import { REASONING_EFFORTS, type ReasoningEffort } from '@/core/llm/types.js';
 import { ConversationDirectShellLineResultSchema } from '@/core/chat/engine/direct-shell/result-schema.js';
 import { ConversationTurnPresentationService } from '@/core/chat/engine/turns/presentation/index.js';
 import type {
@@ -271,7 +271,9 @@ export class ControlPlaneChatSessionPresenter {
   }
 
   private static readReasoningEffort(value: unknown): ReasoningEffort | undefined {
-    return value === 'low' || value === 'medium' || value === 'high' || value === 'ultrahigh' ? value : undefined;
+    return typeof value === 'string' && REASONING_EFFORTS.includes(value as ReasoningEffort)
+      ? value as ReasoningEffort
+      : undefined;
   }
 }
 

--- a/src/server/routes/trpc/schema.ts
+++ b/src/server/routes/trpc/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { REASONING_EFFORTS } from '@/core/llm/types.js';
 import { AUTONOMY_PERMISSION_MODES } from '@/core/approvals/index.js';
 import {
   CustomAgentApprovalPresetSchema,
@@ -171,7 +172,7 @@ export const sessionSettingsInputSchema = z.object({
   id: z.string().min(1),
   workspaceId: z.string().min(1).optional(),
   model: z.string().min(1).optional(),
-  reasoningEffort: z.enum(['low', 'medium', 'high', 'ultrahigh']).optional().nullable(),
+  reasoningEffort: z.enum(REASONING_EFFORTS).optional().nullable(),
   driftEnabled: z.boolean().optional(),
 });
 

--- a/src/web-v2/components/conversation/ComposerExecutionMenu.tsx
+++ b/src/web-v2/components/conversation/ComposerExecutionMenu.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { Check, ChevronDown, Search } from 'lucide-react';
-import type { ControlPlaneModelOptions } from '@web/api/client';
+import type { ControlPlaneModelOptions, ControlPlaneSessionRuntimeContext } from '@web/api/client';
 import { Button } from '@web/components/ui/button';
 import {
   Popover,
@@ -14,28 +14,37 @@ import { useI18n } from '@web/i18n';
 import { cn } from '@web/lib/utils';
 
 export type ComposerReasoningEffortSelection = Exclude<ControlPlaneReasoningEffortSelection, 'default'>;
+type ComposerReasoningOption = NonNullable<ControlPlaneSessionRuntimeContext['reasoningOptions']>[number];
 
 type ComposerExecutionMenuProps = {
   model?: string;
   modelOptions?: ControlPlaneModelOptions;
   reasoningEffort: ComposerReasoningEffortSelection;
+  reasoningOptions?: ControlPlaneSessionRuntimeContext['reasoningOptions'];
   disabled?: boolean;
   settingsUpdating?: boolean;
   onUpdateModel?: (model: string) => Promise<void>;
   onUpdateReasoningEffort?: (value: ControlPlaneReasoningEffortSelection) => Promise<void>;
 };
 
-const reasoningEfforts = [
-  { value: 'low', labelKey: 'composer.reasoning.low' },
-  { value: 'medium', labelKey: 'composer.reasoning.medium' },
-  { value: 'high', labelKey: 'composer.reasoning.high' },
-  { value: 'ultrahigh', labelKey: 'composer.reasoning.ultrahigh' },
-] as const satisfies Array<{ value: ComposerReasoningEffortSelection; labelKey: I18nMessageKey }>;
+const reasoningLabelKeys = {
+  none: 'composer.reasoning.none',
+  low: 'composer.reasoning.low',
+  medium: 'composer.reasoning.medium',
+  high: 'composer.reasoning.high',
+  ultrahigh: 'composer.reasoning.ultrahigh',
+  max: 'composer.reasoning.max',
+} as const satisfies Record<ComposerReasoningEffortSelection, I18nMessageKey>;
+
+const isConcreteReasoningOption = (
+  option: ComposerReasoningOption,
+): option is ComposerReasoningOption & { id: ComposerReasoningEffortSelection } => option.id !== 'default';
 
 export function ComposerExecutionMenu({
   model,
   modelOptions,
   reasoningEffort,
+  reasoningOptions,
   disabled,
   settingsUpdating,
   onUpdateModel,
@@ -65,7 +74,13 @@ export function ComposerExecutionMenu({
       }))
       .filter((group) => group.options.length)
     : modelGroups;
-  const reasoningLabel = t(reasoningEfforts.find((option) => option.value === reasoningEffort)?.labelKey ?? 'composer.reasoning.medium');
+  const concreteReasoningOptions = reasoningOptions?.filter(isConcreteReasoningOption) ?? [{
+    id: reasoningEffort,
+    label: reasoningEffort,
+    description: '',
+    disabled: false,
+  }];
+  const reasoningLabel = t(reasoningLabelKeys[reasoningEffort]);
   const modelLabel = model ?? t('composer.model');
   const triggerLabel = `${modelLabel} · ${reasoningLabel}`;
   const triggerDisabled = disabled || settingsUpdating || (!onUpdateModel && !onUpdateReasoningEffort);
@@ -100,17 +115,18 @@ export function ComposerExecutionMenu({
             {t('composer.reasoningEffort')}
           </p>
           <div className="v2-composer-menu-options">
-            {reasoningEfforts.map((option) => (
+            {concreteReasoningOptions.map((option) => (
               <ComposerMenuOption
-                key={option.value}
+                key={option.id}
                 compact
-                selected={reasoningEffort === option.value}
-                disabled={!onUpdateReasoningEffort || settingsUpdating}
+                selected={reasoningEffort === option.id}
+                disabled={!onUpdateReasoningEffort || settingsUpdating || option.disabled}
+                description={option.disabledReason}
                 onSelect={() => {
-                  void onUpdateReasoningEffort?.(option.value);
+                  void onUpdateReasoningEffort?.(option.id);
                 }}
               >
-                {t(option.labelKey)}
+                {t(reasoningLabelKeys[option.id])}
               </ComposerMenuOption>
             ))}
           </div>

--- a/src/web-v2/components/conversation/ConversationComposer.tsx
+++ b/src/web-v2/components/conversation/ConversationComposer.tsx
@@ -39,6 +39,7 @@ export function ConversationComposer({
   model,
   modelOptions,
   reasoningEffort,
+  reasoningOptions,
   agents,
   settingsUpdating,
   settingsError,
@@ -62,6 +63,7 @@ export function ConversationComposer({
   model?: string;
   modelOptions?: ControlPlaneModelOptions;
   reasoningEffort?: ComposerReasoningEffortSelection;
+  reasoningOptions?: ControlPlaneSessionRuntimeContext['reasoningOptions'];
   agents?: ControlPlaneCustomAgents;
   settingsUpdating?: boolean;
   settingsError?: string;
@@ -248,6 +250,7 @@ export function ConversationComposer({
             model={model}
             modelOptions={modelOptions}
             reasoningEffort={effectiveReasoningEffort}
+            reasoningOptions={reasoningOptions}
             onUpdateModel={onUpdateModel}
             onUpdateReasoningEffort={onUpdateReasoningEffort}
           />

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -208,7 +208,8 @@ export function ConversationThread({
           permissionModeOptions={runtimeContext?.permissionModeOptions}
           model={session.model}
           modelOptions={modelOptions}
-          reasoningEffort={session.reasoningEffort}
+          reasoningEffort={runtimeContext?.effectiveReasoningEffort ?? session.reasoningEffort}
+          reasoningOptions={runtimeContext?.reasoningOptions}
           agents={agents}
           settingsUpdating={settingsUpdating}
           settingsError={settingsError}

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -139,8 +139,10 @@
       "default": "Default",
       "high": "High",
       "low": "Low",
+      "max": "Max",
       "medium": "Medium",
-      "ultrahigh": "Ultra high"
+      "none": "None",
+      "ultrahigh": "Extra high"
     },
     "reasoningEffort": "Reasoning effort",
     "noModelMatches": "No matching models",

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -139,7 +139,9 @@
       "default": "默认",
       "high": "高",
       "low": "低",
+      "max": "最大",
       "medium": "中",
+      "none": "无",
       "ultrahigh": "超高"
     },
     "reasoningEffort": "推理强度",

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -139,7 +139,9 @@
       "default": "預設",
       "high": "高",
       "low": "低",
+      "max": "最大",
       "medium": "中",
+      "none": "無",
       "ultrahigh": "超高"
     },
     "reasoningEffort": "推理強度",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,27 +2400,12 @@
   dependencies:
     "@types/express" "*"
 
-"@types/node-fetch@^2.6.4":
-  version "2.6.13"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.13.tgz#e0c9b7b5edbdb1b50ce32c127e85e880872d56ee"
-  integrity sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==
-  dependencies:
-    "@types/node" "*"
-    form-data "^4.0.4"
-
 "@types/node@*":
   version "25.3.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.3.5.tgz#beccb5915561f7a9970ace547ad44d6cdbf39b46"
   integrity sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==
   dependencies:
     undici-types "~7.18.0"
-
-"@types/node@^18.11.18":
-  version "18.19.130"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.130.tgz#da4c6324793a79defb7a62cba3947ec5add00d59"
-  integrity sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==
-  dependencies:
-    undici-types "~5.26.4"
 
 "@types/node@^22.13.10":
   version "22.19.15"
@@ -2706,13 +2691,6 @@
     convert-source-map "^2.0.0"
     tinyrainbow "^3.1.0"
 
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
-
 accepts@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
@@ -2730,13 +2708,6 @@ acorn@^8.16.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
-
-agentkeepalive@^4.2.1:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.6.0.tgz#35f73e94b3f40bf65f105219c623ad19c136ea6a"
-  integrity sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==
-  dependencies:
-    humanize-ms "^1.2.1"
 
 ajv-formats@^3.0.1:
   version "3.0.1"
@@ -2868,11 +2839,6 @@ async-mutex@^0.5.0:
   integrity sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==
   dependencies:
     tslib "^2.4.0"
-
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 atomic-sleep@^1.0.0:
   version "1.0.0"
@@ -3168,13 +3134,6 @@ colorette@^2.0.7:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
-
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
 
 comma-separated-tokens@^2.0.0:
   version "2.0.3"
@@ -3659,11 +3618,6 @@ delaunator@5:
   dependencies:
     robust-predicates "^3.0.2"
 
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
-
 depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -3827,16 +3781,6 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
-
-es-set-tostringtag@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
-  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
-  dependencies:
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.6"
-    has-tostringtag "^1.0.2"
-    hasown "^2.0.2"
 
 es-toolkit@^1.39.10:
   version "1.45.1"
@@ -4124,11 +4068,6 @@ etag@^1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
-
 eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
@@ -4316,30 +4255,6 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
-form-data-encoder@1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
-  integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
-
-form-data@^4.0.4:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
-  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
-    mime-types "^2.1.12"
-
-formdata-node@^4.3.2:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/formdata-node/-/formdata-node-4.4.1.tgz#23f6a5cb9cb55315912cbec4ff7b0f59bbd191e2"
-  integrity sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==
-  dependencies:
-    node-domexception "1.0.0"
-    web-streams-polyfill "4.0.0-beta.3"
-
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
@@ -4380,7 +4295,7 @@ get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.1, get-east-asian-width@^
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz#ce7008fe345edcf5497a6f557cfa54bc318a9ce7"
   integrity sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -4484,17 +4399,10 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.3, has-symbols@^1.1.0:
+has-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
-
-has-tostringtag@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
-  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
-  dependencies:
-    has-symbols "^1.0.3"
 
 hasown@^2.0.2:
   version "2.0.2"
@@ -4663,13 +4571,6 @@ http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
     setprototypeof "~1.2.0"
     statuses "~2.0.2"
     toidentifier "~1.0.1"
-
-humanize-ms@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
-  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
-  dependencies:
-    ms "^2.0.0"
 
 iconv-lite@0.6:
   version "0.6.3"
@@ -5730,19 +5631,19 @@ mime-db@^1.54.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.12, mime-types@~2.1.24:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
-
 mime-types@^3.0.0, mime-types@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
   integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
   dependencies:
     mime-db "^1.54.0"
+
+mime-types@~2.1.24:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -5800,7 +5701,7 @@ monaco-editor@^0.55.1:
     dompurify "3.2.7"
     marked "14.0.0"
 
-ms@^2.0.0, ms@^2.1.3:
+ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -5844,11 +5745,6 @@ negotiator@^1.0.0:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
-node-domexception@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
 node-emoji@^2.1.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-2.2.0.tgz#1d000e3c76e462577895be1b436f4aa2d6760eb0"
@@ -5858,13 +5754,6 @@ node-emoji@^2.1.3:
     char-regex "^1.0.2"
     emojilib "^2.4.0"
     skin-tone "^2.0.0"
-
-node-fetch@^2.6.7:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
 
 node-releases@^2.0.36:
   version "2.0.37"
@@ -5917,23 +5806,15 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-openai@^4.86.2:
-  version "4.104.0"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-4.104.0.tgz#c489765dc051b95019845dab64b0e5207cae4d30"
-  integrity sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==
-  dependencies:
-    "@types/node" "^18.11.18"
-    "@types/node-fetch" "^2.6.4"
-    abort-controller "^3.0.0"
-    agentkeepalive "^4.2.1"
-    form-data-encoder "1.7.2"
-    formdata-node "^4.3.2"
-    node-fetch "^2.6.7"
-
 openai@^5.20.2:
   version "5.23.2"
   resolved "https://registry.yarnpkg.com/openai/-/openai-5.23.2.tgz#f13e2dc2ef6b88aab6a9b97cdc68d41a1d083c68"
   integrity sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==
+
+openai@^6.48.0:
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-6.48.0.tgz#4cabd2a68a123c1b2c2d6fac59fd19c327aab7ad"
+  integrity sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -7085,11 +6966,6 @@ tr46@^6.0.0:
   dependencies:
     punycode "^2.3.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 trim-lines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
@@ -7202,11 +7078,6 @@ undici-types@^7.21.0:
   version "7.25.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.25.0.tgz#c5f8feb61c70d8954e05beb5f1c786c7ff95458a"
   integrity sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==
-
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici-types@~6.21.0:
   version "6.21.0"
@@ -7414,16 +7285,6 @@ web-namespaces@^2.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
-web-streams-polyfill@4.0.0-beta.3:
-  version "4.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz#2898486b74f5156095e473efe989dcf185047a38"
-  integrity sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==
-
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
 webidl-conversions@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-8.0.1.tgz#0657e571fe6f06fcb15ca50ed1fdbcb495cd1686"
@@ -7442,14 +7303,6 @@ whatwg-url@^16.0.0, whatwg-url@^16.0.1:
     "@exodus/bytes" "^1.11.0"
     tr46 "^6.0.0"
     webidl-conversions "^8.0.1"
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
## Summary

- add `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to Heddle's curated model catalog, while accepting the `gpt-5.6` Sol alias
- support GPT-5.6 through both API-key and OpenAI account-sign-in paths
- expose the family-owned `none` through `max` reasoning options and translate Heddle's persisted `ultrahigh` value to OpenAI's `xhigh` wire value
- render model-owned reasoning options and disabled states in the Heddle web composer
- upgrade the OpenAI SDK to 6.48.0 and adapt the Responses stream and web-search types without changing the adapter boundary
- document the model-family contract and official limits

## Product boundary

- `gpt-5.4` remains Heddle's default model; GPT-5.6 is opt-in
- pickers show explicit Sol, Terra, and Luna names so users choose the cost/capability tier intentionally
- the `gpt-5.6` alias is accepted for configuration compatibility but is not duplicated in pickers
- Codex Ultra is not modeled as an API reasoning effort; Heddle keeps its existing `ultrahigh` persistence value and maps it to the provider's `xhigh` effort

## Verification

- `yarn test:unit` — 124 files, 742 tests
- `yarn test:integration` — 34 files, 311 tests
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- focused GPT-5.6/OpenAI/Web regression set — 45 tests

## References

- https://developers.openai.com/api/docs/models/gpt-5.6-sol
- https://developers.openai.com/api/docs/models/gpt-5.6-terra
- https://developers.openai.com/api/docs/models/gpt-5.6-luna
