### PR TITLE
feat: add Kimi Platform provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ layers that match your product.
 - prepared MCP host extensions with curated exposure, overrides, and result
   artifact rules;
 - approval policy chains and host-owned approval decisions;
-- OpenAI, Anthropic, Ollama, and OpenAI-compatible provider profiles.
+- OpenAI, Anthropic, Kimi Platform, Ollama, and OpenAI-compatible provider
+  profiles.
 
 ### Hosted and remote runs
 

--- a/docs/reference/model-providers.md
+++ b/docs/reference/model-providers.md
@@ -13,6 +13,7 @@ For setup details, environment variables, and model-picker behavior, see
 | --- | --- | --- | --- | --- |
 | OpenAI | `gpt-*`, `o*` | OpenAI account sign-in or `OPENAI_API_KEY` | Built-in curated shortlist | Use a normal `heddle --model ... ask` run |
 | Anthropic Claude | `claude-*` | `ANTHROPIC_API_KEY` | Built-in curated shortlist | Use a normal `heddle --model ... ask` run |
+| Kimi Platform | `kimi/` or `kimi:` | `MOONSHOT_API_KEY` or `KIMI_PLATFORM_API_KEY` | Built-in K3 entry plus `/models` discovery | Use a normal `heddle --model kimi/kimi-k3 ask` run |
 | Ollama | `ollama/` or `ollama:` | Local endpoint, no hosted key required | Native Ollama `/api/tags` | `yarn smoke:ollama` |
 | LM Studio | `lmstudio/` | Local OpenAI-compatible endpoint | `/models` when the server is running | `yarn smoke:lmstudio` |
 | LiteLLM | `litellm/` | OpenAI-compatible gateway, optional gateway key | `/models` when the gateway is reachable | `yarn smoke:litellm` |
@@ -27,6 +28,7 @@ For setup details, environment variables, and model-picker behavior, see
 ```bash
 heddle --model gpt-5.4-mini ask "Summarize this repository"
 heddle --model claude-sonnet-4-6 ask "Summarize this repository"
+heddle --model kimi/kimi-k3 ask "Summarize this repository"
 heddle --model ollama/llama3.2:latest ask "Summarize this repository"
 heddle --model lmstudio/local-model ask "Summarize this repository"
 heddle --model openrouter/meta-llama/llama-3.3-70b-instruct ask "Summarize this repository"

--- a/docs/reference/providers-and-models.md
+++ b/docs/reference/providers-and-models.md
@@ -6,6 +6,7 @@ Heddle currently has working provider adapters for:
 
 - OpenAI
 - Anthropic
+- Kimi Platform
 - Ollama
 - LM Studio
 - LiteLLM
@@ -43,6 +44,17 @@ export ANTHROPIC_API_KEY=your_key_here
 
 Heddle does not support Anthropic consumer subscription OAuth. That path is intentionally deferred unless Anthropic documents or approves a third-party auth route.
 
+For Kimi Platform K3, use a Platform API key:
+
+```bash
+export MOONSHOT_API_KEY=your_key_here
+heddle --model kimi/kimi-k3 ask "Reply with exactly: ok"
+```
+
+`KIMI_PLATFORM_API_KEY` is also accepted. Heddle intentionally does not accept
+the ambiguous `KIMI_API_KEY` name or Kimi Code membership keys: Kimi Code has a
+separate endpoint and quota lifecycle from Kimi Platform.
+
 For Ollama, install and start Ollama locally, then select an installed model
 with the `ollama/` prefix:
 
@@ -77,6 +89,7 @@ Supported provider API-key environment variables:
 
 - `OPENAI_API_KEY` for OpenAI models
 - `ANTHROPIC_API_KEY` for Anthropic models
+- `MOONSHOT_API_KEY` or `KIMI_PLATFORM_API_KEY` for Kimi Platform models
 - `HF_TOKEN` or `HUGGINGFACE_API_KEY` for Hugging Face router models
 - `OPENROUTER_API_KEY` for OpenRouter models
 - `TOGETHER_API_KEY` for Together AI models
@@ -102,7 +115,9 @@ Supported hosted gateway endpoint overrides:
 - `OPENROUTER_OPENAI_BASE_URL` or `OPENROUTER_BASE_URL`; default `https://openrouter.ai/api/v1`
 - `TOGETHER_OPENAI_BASE_URL` or `TOGETHER_BASE_URL`; default `https://api.together.ai/v1`
 - `GROQ_OPENAI_BASE_URL` or `GROQ_BASE_URL`; default `https://api.groq.com/openai/v1`
+- `MOONSHOT_BASE_URL` or `KIMI_PLATFORM_BASE_URL`; default `https://api.moonshot.cn/v1`
 - `HUGGINGFACE_MODEL`, `OPENROUTER_MODEL`, `TOGETHER_MODEL`, or `GROQ_MODEL` for explicit provider defaults
+- `KIMI_MODEL` for an explicit Kimi Platform default
 
 For local development inside this repository, fallback env vars are also accepted:
 
@@ -123,6 +138,7 @@ Current defaults:
 
 - OpenAI: `gpt-5.4`
 - Anthropic: `claude-sonnet-4-6`
+- Kimi Platform: `kimi/kimi-k3`
 
 OpenAI-compatible profiles have no hardcoded default model because installed,
 served, and routed model names vary by machine and account. Select a model with
@@ -148,6 +164,15 @@ Anthropic models currently included in the built-in shortlist:
 - `claude-opus-4-1`, `claude-opus-4-0`, `claude-sonnet-4-0`
 - `claude-3-7-sonnet-latest`
 - `claude-3-5-sonnet-latest`, `claude-3-5-haiku-latest`
+
+Kimi Platform models currently included in the built-in shortlist:
+
+- `kimi/kimi-k3`
+
+Kimi K3 supports `low`, `high`, and `max` reasoning effort, with `max` as the
+default. Kimi's raw `reasoning_content` is private model-continuation state. It
+is replayed to Kimi when required by a tool turn, but is not exposed as Heddle
+reasoning summaries, commentary, logs, or traces.
 
 ### GPT-5.6 family
 
@@ -183,6 +208,7 @@ heddle --model gpt-5.4-mini
 heddle chat --model claude-3-5-haiku-latest
 heddle --model ollama/llama3.2:latest ask "Summarize this repository"
 heddle --model lmstudio/local-model ask "Summarize this repository"
+heddle --model kimi/kimi-k3 ask "Summarize this repository"
 heddle --model openrouter/meta-llama/llama-3.3-70b-instruct ask "Summarize this repository"
 ```
 
@@ -201,6 +227,7 @@ the selector, or type it directly with the provider prefix:
 ```text
 /model ollama/llama3.2:latest
 /model lmstudio/local-model
+/model kimi/kimi-k3
 /model openrouter/meta-llama/llama-3.3-70b-instruct
 ```
 
@@ -294,8 +321,11 @@ Use `OPENAI_API_KEY` for other OpenAI Platform models or features that require P
 
 - Provider selection is inferred from the model name prefix.
 - Ollama model names are recognized with `ollama/` or `ollama:` prefixes.
+- Kimi Platform model names are recognized with `kimi/` or `kimi:` prefixes.
 - OpenAI-compatible profile prefixes are `ollama/`, `lmstudio/`, `litellm/`,
-  `vllm/`, `huggingface/` or `hf/`, `openrouter/`, `together/`, and `groq/`.
+  `vllm/`, `huggingface/` or `hf/`, `openrouter/`, `together/`, `groq/`, and
+  `kimi/`. Kimi uses a specialized execution adapter because its continuation
+  replay semantics are provider-specific.
 - Gemini model names are recognized by provider inference, but a Google adapter is not wired yet.
 - You can pass another supported model name with `--model` if the relevant provider adapter can handle it.
 - Hosted web search and image viewing currently require Platform API-key mode for OpenAI.

--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -156,6 +156,69 @@ describe('AgentLoopRuntimeService.run', () => {
     });
   });
 
+  it('preserves provider-private continuation through tool and final assistant turns', async () => {
+    const seenMessages: ChatMessage[][] = [];
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'kimi',
+        model: 'kimi/kimi-k3',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: false,
+          parallelToolCalls: false,
+        },
+      },
+      async chat(messages): Promise<LlmResponse> {
+        seenMessages.push(messages);
+        return seenMessages.length === 1 ? {
+          toolCalls: [{ id: 'call-1', tool: 'echo_tool', input: { value: 'repo' } }],
+          providerContinuation: {
+            provider: 'kimi',
+            reasoningContent: 'Inspect before answering.',
+          },
+        } : {
+          content: 'Done.',
+          providerContinuation: {
+            provider: 'kimi',
+            reasoningContent: 'Answer from the result.',
+          },
+        };
+      },
+    };
+    const echoTool: ToolDefinition = {
+      name: 'echo_tool',
+      description: 'Echoes a value.',
+      parameters: { type: 'object', properties: { value: { type: 'string' } } },
+      execute: async (input) => ({ ok: true, output: input }),
+    };
+
+    const result = await AgentLoopRuntimeService.run({
+      goal: 'Use the echo tool.',
+      llm: fakeLlm,
+      tools: [echoTool],
+      includeDefaultTools: false,
+      maxSteps: 3,
+      logger: silentLogger,
+    });
+
+    expect(seenMessages[1]).toContainEqual(expect.objectContaining({
+      role: 'assistant',
+      providerContinuation: {
+        provider: 'kimi',
+        reasoningContent: 'Inspect before answering.',
+      },
+    }));
+    expect(result.transcript).toContainEqual({
+      role: 'assistant',
+      content: 'Done.',
+      providerContinuation: {
+        provider: 'kimi',
+        reasoningContent: 'Answer from the result.',
+      },
+    });
+  });
+
   it('propagates non-retryable quota failures through loop state and terminal activity', async () => {
     const events: AgentLoopEvent[] = [];
     const fakeLlm: LlmAdapter = {

--- a/src/__tests__/unit/core/chat-session-adapter-authoring-kit.test.ts
+++ b/src/__tests__/unit/core/chat-session-adapter-authoring-kit.test.ts
@@ -14,7 +14,18 @@ const createSessionRecord = () => ({
   }),
   createdAt: '2026-07-17T01:00:00.000Z',
   updatedAt: '2026-07-17T02:00:00.000Z',
-  history: [{ role: 'user' as const, content: 'Persist this record.' }],
+  history: [
+    { role: 'user' as const, content: 'Persist this record.' },
+    {
+      role: 'assistant' as const,
+      content: '',
+      toolCalls: [{ id: 'call-1', tool: 'inspect', input: {} }],
+      providerContinuation: {
+        provider: 'kimi' as const,
+        reasoningContent: 'Private continuation for exact Kimi replay.',
+      },
+    },
+  ],
   messages: [{ id: 'message-1', role: 'user' as const, text: 'Persist this record.' }],
   turns: [{
     id: 'turn-1',

--- a/src/__tests__/unit/core/conversation-compaction-token-estimator.test.ts
+++ b/src/__tests__/unit/core/conversation-compaction-token-estimator.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ConversationCompactionTokenEstimator } from '@/core/chat/engine/compaction/token-estimator.js';
+
+describe('ConversationCompactionTokenEstimator', () => {
+  it('counts provider-private continuation retained in model context', () => {
+    const withoutContinuation = ConversationCompactionTokenEstimator.estimateMessage({
+      role: 'assistant',
+      content: 'Done.',
+    });
+    const withContinuation = ConversationCompactionTokenEstimator.estimateMessage({
+      role: 'assistant',
+      content: 'Done.',
+      providerContinuation: {
+        provider: 'kimi',
+        reasoningContent: '12345678',
+      },
+    });
+
+    expect(withContinuation - withoutContinuation).toBe(2);
+  });
+});

--- a/src/__tests__/unit/core/kimi-adapter.test.ts
+++ b/src/__tests__/unit/core/kimi-adapter.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import { LlmAdapterService } from '@/core/llm/index.js';
+import type { LlmStreamEvent } from '@/core/llm/types.js';
+import type { ToolDefinition } from '@/core/types.js';
+
+describe('KimiAdapter', () => {
+  it('streams content, accumulates tool calls, and replays preserved thinking exactly', async () => {
+    const requests: Array<{ url: string; headers: Headers; body: Record<string, unknown> }> = [];
+    const responses = [
+      kimiSseResponse([
+        { choices: [{ delta: { reasoning_content: 'Inspect the ' } }] },
+        { choices: [{ delta: { reasoning_content: 'tool.' } }] },
+        {
+          choices: [{
+            delta: {
+              tool_calls: [{
+                index: 0,
+                id: 'call_1',
+                function: { name: 'add', arguments: '{"a":2,' },
+              }],
+            },
+          }],
+        },
+        {
+          choices: [{
+            delta: {
+              tool_calls: [{ index: 0, function: { arguments: '"b":3}' } }],
+            },
+          }],
+        },
+        {
+          choices: [],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 7,
+            total_tokens: 17,
+            prompt_tokens_details: { cached_tokens: 4 },
+            completion_tokens_details: { reasoning_tokens: 5 },
+          },
+        },
+      ], { fragmentSize: 17 }),
+      kimiSseResponse([
+        { choices: [{ delta: { reasoning_content: 'Use the result.' } }] },
+        { choices: [{ delta: { content: 'The answer is ' } }] },
+        { choices: [{ delta: { content: '5.' } }] },
+      ], { fragmentSize: 11 }),
+    ];
+    const fetchImpl = (async (url, init) => {
+      requests.push({
+        url: String(url),
+        headers: new Headers((init as RequestInit).headers),
+        body: JSON.parse(String((init as RequestInit).body)),
+      });
+      const response = responses.shift();
+      if (!response) {
+        throw new Error('Unexpected request.');
+      }
+      return response;
+    }) as typeof fetch;
+    const adapter = LlmAdapterService.create({
+      model: 'kimi/kimi-k3',
+      runtime: {
+        endpoint: {
+          baseUrl: 'https://kimi.test/v1/',
+          auth: { type: 'bearer', token: 'moonshot-key' },
+        },
+        reasoningEffort: 'high',
+        fetchImpl,
+      },
+    });
+    const events: LlmStreamEvent[] = [];
+    const tools: ToolDefinition[] = [addTool];
+
+    const toolRequest = await adapter.chat(
+      [{ role: 'user', content: 'Add 2 and 3.' }],
+      tools,
+      undefined,
+      (event) => events.push(event),
+    );
+
+    expect(toolRequest).toEqual({
+      content: undefined,
+      toolCalls: [{ id: 'call_1', tool: 'add', input: { a: 2, b: 3 } }],
+      providerContinuation: {
+        provider: 'kimi',
+        reasoningContent: 'Inspect the tool.',
+      },
+      usage: {
+        inputTokens: 10,
+        outputTokens: 7,
+        totalTokens: 17,
+        cachedInputTokens: 4,
+        reasoningTokens: 5,
+        requests: 1,
+      },
+    });
+    expect(events).toEqual([]);
+
+    const answer = await adapter.chat([
+      { role: 'user', content: 'Add 2 and 3.' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: toolRequest.toolCalls,
+        providerContinuation: toolRequest.providerContinuation,
+      },
+      { role: 'tool', content: '{"ok":true,"output":5}', toolCallId: 'call_1' },
+    ], tools, undefined, (event) => events.push(event));
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({
+      url: 'https://kimi.test/v1/chat/completions',
+      body: {
+        model: 'kimi-k3',
+        reasoning_effort: 'high',
+        stream: true,
+        stream_options: { include_usage: true },
+        tool_choice: 'auto',
+      },
+    });
+    expect(requests[0]?.headers.get('authorization')).toBe('Bearer moonshot-key');
+    expect(requests[0]?.body).toMatchObject({
+      tools: [{ function: { name: 'add', strict: false } }],
+    });
+    expect(requests[1]?.body).toMatchObject({
+      messages: [{ role: 'user' }, {
+        role: 'assistant',
+        content: null,
+        reasoning_content: 'Inspect the tool.',
+        tool_calls: [{ id: 'call_1' }],
+      }, { role: 'tool', tool_call_id: 'call_1' }],
+    });
+    expect(answer).toMatchObject({
+      content: 'The answer is 5.',
+      providerContinuation: {
+        provider: 'kimi',
+        reasoningContent: 'Use the result.',
+      },
+    });
+    expect(events).toEqual([
+      { type: 'content.delta', delta: 'The answer is ' },
+      { type: 'content.delta', delta: '5.' },
+      { type: 'content.done', content: 'The answer is 5.' },
+    ]);
+    expect(events.some((event) => event.type === 'reasoning_summary.delta')).toBe(false);
+  });
+
+  it('rejects unsupported explicit reasoning effort instead of silently changing it', () => {
+    expect(() => LlmAdapterService.create({
+      model: 'kimi/kimi-k3',
+      runtime: {
+        endpoint: {
+          baseUrl: 'https://api.moonshot.cn/v1',
+          auth: { type: 'bearer', token: 'moonshot-key' },
+        },
+        reasoningEffort: 'medium',
+      },
+    })).toThrow('Kimi K3 reasoning effort must be low, high, or max; received medium.');
+  });
+
+  it('rejects a truncated stream without returning a partial completion', async () => {
+    const adapter = LlmAdapterService.create({
+      model: 'kimi/kimi-k3',
+      runtime: {
+        endpoint: {
+          baseUrl: 'https://api.moonshot.cn/v1',
+          auth: { type: 'bearer', token: 'moonshot-key' },
+        },
+        fetchImpl: (async () => kimiSseResponse([
+          { choices: [{ delta: { content: 'partial' } }] },
+        ], { includeDone: false })) as typeof fetch,
+      },
+    });
+
+    await expect(adapter.chat([{ role: 'user', content: 'Hello' }], []))
+      .rejects.toThrow('Kimi Platform stream ended before the [DONE] marker.');
+  });
+});
+
+const addTool: ToolDefinition = {
+  name: 'add',
+  description: 'Add two numbers.',
+  parameters: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      a: { type: 'number' },
+      b: { type: 'number' },
+    },
+    required: ['a', 'b'],
+  },
+  execute: async () => ({ ok: true, output: 5 }),
+};
+
+function kimiSseResponse(
+  payloads: unknown[],
+  options: { fragmentSize?: number; includeDone?: boolean } = {},
+): Response {
+  const text = [
+    ...payloads.map((payload) => `data: ${JSON.stringify(payload)}\n\n`),
+    ...(options.includeDone === false ? [] : ['data: [DONE]\n\n']),
+  ].join('');
+  const encoded = new TextEncoder().encode(text);
+  const fragmentSize = options.fragmentSize ?? encoded.length;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let offset = 0; offset < encoded.length; offset += fragmentSize) {
+        controller.enqueue(encoded.slice(offset, offset + fragmentSize));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+  });
+}

--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -15,6 +15,7 @@ describe('llm adapter factory', () => {
     expect(LlmAdapterService.inferProvider('gpt-5.1-codex')).toBe('openai');
     expect(LlmAdapterService.inferProvider('claude-sonnet-4-6')).toBe('anthropic');
     expect(LlmAdapterService.inferProvider('gemini-2.5-pro')).toBe('google');
+    expect(LlmAdapterService.inferProvider('kimi/kimi-k3')).toBe('kimi');
     expect(LlmAdapterService.inferProvider('ollama/llama3.2:latest')).toBe('ollama');
     expect(LlmAdapterService.inferProvider('lmstudio/local-model')).toBe('lmstudio');
     expect(LlmAdapterService.inferProvider('hf/meta-llama/Llama-3.3-70B-Instruct')).toBe('huggingface');
@@ -355,6 +356,24 @@ describe('llm adapter factory', () => {
     expect(ModelCatalogService.isOpenAiAccountSignInModel('gpt-5.6-terra')).toBe(true);
     expect(ModelCatalogService.estimateOpenAiContextWindow('gpt-5.6-luna')).toBe(1_050_000);
     expect(ModelPolicyService.resolveDefaultReasoningEffort('gpt-5.6-sol')).toBe('medium');
+  });
+
+  it('supports Kimi K3 catalog and request policy without claiming reasoning summaries', () => {
+    expect(ModelCatalogService.isCommonBuiltInModel('kimi/kimi-k3')).toBe(true);
+    expect(ModelCatalogService.estimateBuiltInContextWindow('kimi/kimi-k3')).toBe(1_000_000);
+    expect(ModelPolicyService.supportedRequestReasoningEfforts('kimi/kimi-k3')).toEqual([
+      'low',
+      'high',
+      'max',
+    ]);
+    expect(ModelPolicyService.resolveDefaultReasoningEffort('kimi/kimi-k3')).toBe('max');
+    expect(ModelPolicyService.buildReasoningEffortOptions('kimi/kimi-k3')).toContainEqual({
+      id: 'max',
+      label: 'max',
+      description: 'Set explicit max effort',
+      disabled: false,
+      disabledReason: undefined,
+    });
   });
 
   it('owns reasoning-summary support independently from configurable effort', () => {

--- a/src/__tests__/unit/core/runtime-credentials.test.ts
+++ b/src/__tests__/unit/core/runtime-credentials.test.ts
@@ -125,6 +125,31 @@ describe('RuntimeCredentialService', () => {
     });
   });
 
+  it('uses only Kimi Platform credentials for Kimi models', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'openai-key');
+    vi.stubEnv('KIMI_API_KEY', 'kimi-code-key');
+    vi.stubEnv('MOONSHOT_API_KEY', '');
+    vi.stubEnv('KIMI_PLATFORM_API_KEY', '');
+
+    expect(RuntimeCredentialService.resolveCredentialSourceForModel('kimi/kimi-k3')).toEqual({
+      type: 'missing',
+      provider: 'kimi',
+    });
+
+    vi.stubEnv('MOONSHOT_API_KEY', 'moonshot-key');
+
+    expect(RuntimeCredentialService.resolveCredentialSourceForModel('kimi/kimi-k3')).toEqual({
+      type: 'env-api-key',
+      provider: 'kimi',
+    });
+    expect(RuntimeCredentialService.resolveOpenAiCompatibleEndpointRuntime('kimi')).toEqual({
+      baseUrl: 'https://api.moonshot.cn/v1',
+      auth: { type: 'bearer', token: 'moonshot-key' },
+    });
+    expect(RuntimeCredentialService.formatMissingCredentialMessage('kimi/kimi-k3'))
+      .toContain('Kimi Code membership keys use a separate service');
+  });
+
   it('resolves executable runtime endpoint auth for hosted OpenAI-compatible models', () => {
     vi.stubEnv('OPENROUTER_API_KEY', 'openrouter-key');
 
@@ -153,6 +178,8 @@ describe('RuntimeCredentialService', () => {
     vi.stubEnv('HUGGINGFACE_API_KEY', '');
     vi.stubEnv('TOGETHER_API_KEY', '');
     vi.stubEnv('GROQ_API_KEY', '');
+    vi.stubEnv('MOONSHOT_API_KEY', '');
+    vi.stubEnv('KIMI_PLATFORM_API_KEY', '');
 
     const sources = RuntimeCredentialService.resolveOpenAiCompatibleModelDiscoverySources();
 

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -21,6 +21,7 @@ export * from './index.js';
 export type {
   LlmAdapter,
   LlmAdapterCreateInput,
+  AssistantProviderContinuation,
   ChatMessage,
   LlmResponse,
   LlmProvider,
@@ -32,6 +33,10 @@ export type {
 export {
   AnthropicAdapter,
   AnthropicProviderAdapter,
+  KimiAdapter,
+  KimiChatCompletionsStreamDecoder,
+  KimiCodec,
+  KimiProviderAdapter,
   LlmAdapterService,
   LlmProviderRegistry,
   OpenAiAdapter,
@@ -47,6 +52,7 @@ export {
 } from './core/llm/index.js';
 export type {
   AnthropicAdapterOptions,
+  KimiAdapterOptions,
   LlmProviderAdapter,
   OpenAiAdapterOptions,
   OpenAiCompatibleAdapterOptions,

--- a/src/core/agent/finish/run-finisher.ts
+++ b/src/core/agent/finish/run-finisher.ts
@@ -39,7 +39,11 @@ export class AgentRunFinisher {
       step: context.state.step,
       timestamp: context.now(),
     });
-    context.messages.push({ role: 'assistant', content: response.content });
+    context.messages.push({
+      role: 'assistant',
+      content: response.content,
+      providerContinuation: response.providerContinuation,
+    });
 
     return AgentRunFinisher.finish(context, 'done', response.content, {
       logging: {

--- a/src/core/agent/tools/tool-turn-service.ts
+++ b/src/core/agent/tools/tool-turn-service.ts
@@ -33,6 +33,7 @@ export class AgentToolTurnService {
       role: 'assistant',
       content: response.content ?? '',
       toolCalls,
+      providerContinuation: response.providerContinuation,
     });
 
     for (const call of toolCalls) {

--- a/src/core/chat/engine/compaction/token-estimator.ts
+++ b/src/core/chat/engine/compaction/token-estimator.ts
@@ -39,11 +39,20 @@ export class ConversationCompactionTokenEstimator {
       case 'tool':
         return ConversationCompactionTokenEstimator.estimateText(message.content) + 12;
       case 'assistant':
-        return ConversationCompactionTokenEstimator.estimateText(message.content) + 12 + (message.toolCalls?.length ?? 0) * 24;
+        return ConversationCompactionTokenEstimator.estimateText(message.content)
+          + ConversationCompactionTokenEstimator.estimateProviderContinuation(message)
+          + 12
+          + (message.toolCalls?.length ?? 0) * 24;
     }
   }
 
   static estimateText(text: string): number {
     return Math.ceil(text.length / 4);
+  }
+
+  private static estimateProviderContinuation(message: Extract<ChatMessage, { role: 'assistant' }>): number {
+    return message.providerContinuation?.provider === 'kimi'
+      ? ConversationCompactionTokenEstimator.estimateText(message.providerContinuation.reasoningContent)
+      : 0;
   }
 }

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -22,6 +22,15 @@ const ToolCallSchema = z.object({
   input: z.unknown().describe('Raw structured input passed to the requested tool.'),
 });
 
+const AssistantProviderContinuationSchema = z.discriminatedUnion('provider', [
+  z.object({
+    provider: z.literal('kimi'),
+    reasoningContent: z.string().describe(
+      'Provider-private Kimi continuation replayed to Kimi for preserved thinking. It is not user-facing reasoning narration.',
+    ),
+  }),
+]);
+
 const ChatMessageSchema = z.union([
   z.object({
     role: z.literal('system').describe('Transcript role for host-provided system instructions.'),
@@ -36,6 +45,9 @@ const ChatMessageSchema = z.union([
     content: z.string().describe('Assistant text content returned by the model.'),
     toolCalls: z.array(ToolCallSchema)
       .describe('Tool calls requested by this assistant message.')
+      .optional(),
+    providerContinuation: AssistantProviderContinuationSchema
+      .describe('Provider-private assistant state retained only for durable model transcript replay.')
       .optional(),
   }),
   z.object({

--- a/src/core/llm/README.md
+++ b/src/core/llm/README.md
@@ -17,6 +17,8 @@ choosing providers themselves.
 - `adapters/openai-compatible/` owns the shared provider-profile family for
   `/chat/completions` services such as Ollama, LM Studio, LiteLLM, vLLM,
   Hugging Face, OpenRouter, Together, and Groq.
+- `adapters/kimi/` owns Kimi Platform's specialized chat-completions behavior,
+  including exact replay of provider-private reasoning continuation.
 - `models/` owns the curated model catalog and model policy decisions used by
   hosts.
 
@@ -26,6 +28,13 @@ request-scoped `oauth-access-token` is already resolved by the host/runtime;
 the adapter attaches it to requests, rejects it when expired, and never refreshes
 or persists it. Provider-backed tools must receive the same resolved credential
 as the main model so one run cannot silently change principals.
+
+Some providers require opaque continuation state to be carried between
+model-facing turns. That state belongs on the assistant message's
+`providerContinuation`; it is durable protocol data, not user-facing reasoning
+or commentary. Adapters must never render, trace, or log it. Kimi uses this
+boundary for the raw `reasoning_content` that its API requires callers to replay
+after tool calls.
 
 Provider adapters should follow the local pattern:
 

--- a/src/core/llm/adapters/kimi/README.md
+++ b/src/core/llm/adapters/kimi/README.md
@@ -1,0 +1,52 @@
+# Kimi Platform Adapter
+
+This package owns Heddle's Kimi Platform execution boundary. It translates the
+provider-neutral LLM port into Kimi's OpenAI-compatible chat-completions wire
+format while preserving the parts of Kimi's protocol that are not safely
+handled by the shared compatible adapter.
+
+## What This Adapter Owns
+
+- Kimi Platform authentication through `MOONSHOT_API_KEY` or
+  `KIMI_PLATFORM_API_KEY`;
+- the default `https://api.moonshot.cn/v1` endpoint and `kimi/kimi-k3` model;
+- K3 reasoning-effort validation (`low`, `high`, or `max`);
+- streamed text, tool calls, usage, and completion validation;
+- exact replay of Kimi's private `reasoning_content` between model-facing
+  turns.
+
+Kimi requires the complete assistant message, including `reasoning_content`,
+to be replayed after a tool call. Heddle stores that value as an opaque
+`providerContinuation` on the assistant transcript message. It is durable so a
+resumed session can continue correctly, but it is provider-private state:
+
+- do not expose it as a Heddle reasoning summary or assistant commentary;
+- do not render it in clients;
+- do not include it in logs or traces;
+- do not rewrite it into a provider-neutral field.
+
+Only the Kimi adapter may interpret the payload. Other providers ignore it.
+
+## Deliberate Exclusions
+
+This integration targets Kimi Platform API keys. Kimi Code membership keys and
+its separate endpoint/quota lifecycle are not accepted. The generic
+`KIMI_API_KEY` name is intentionally ignored because it does not identify which
+product issued the credential.
+
+The adapter does not claim support for provider-native web search, image input,
+or image generation.
+
+## Verification
+
+Fixture-backed tests cover fragmented streaming, tool-call assembly, usage,
+private continuation replay, invalid effort, and truncated streams. Before a
+release claims production support, also run a real K3 tool-calling turn with a
+Kimi Platform credential. This validates the live wire contract without
+weakening deterministic CI.
+
+Provider references:
+
+- <https://platform.kimi.com/docs/guide/kimi-k3-quickstart>
+- <https://platform.kimi.com/docs/guide/use-kimi-k2-thinking-model>
+- <https://platform.kimi.com/docs/api/chat>

--- a/src/core/llm/adapters/kimi/index.ts
+++ b/src/core/llm/adapters/kimi/index.ts
@@ -1,0 +1,5 @@
+export { KimiAdapter } from './kimi-adapter.js';
+export type { KimiAdapterOptions } from './kimi-adapter.js';
+export { KimiCodec } from './kimi-codec.js';
+export { KimiProviderAdapter } from './kimi-provider-adapter.js';
+export { KimiChatCompletionsStreamDecoder } from './kimi-stream-decoder.js';

--- a/src/core/llm/adapters/kimi/kimi-adapter.ts
+++ b/src/core/llm/adapters/kimi/kimi-adapter.ts
@@ -1,0 +1,160 @@
+import {
+  createParser,
+  type EventSourceMessage,
+} from 'eventsource-parser';
+import type {
+  ChatMessage,
+  LlmAdapter,
+  LlmAdapterCreateInput,
+  LlmResponse,
+  LlmStreamEvent,
+  ReasoningEffort,
+} from '@/core/llm/types.js';
+import { OpenAiCompatibleModelName } from '@/core/llm/adapters/openai-compatible/openai-compatible-model.js';
+import type { OpenAiCompatibleProviderProfile } from '@/core/llm/adapters/openai-compatible/types.js';
+import type { ToolDefinition } from '@/core/types.js';
+import { KimiCodec } from './kimi-codec.js';
+import { KimiChatCompletionsStreamDecoder } from './kimi-stream-decoder.js';
+
+export type KimiAdapterOptions = LlmAdapterCreateInput & {
+  provider: 'kimi';
+  model: string;
+  profile: OpenAiCompatibleProviderProfile;
+};
+
+const KIMI_REASONING_EFFORTS = new Set<ReasoningEffort>(['low', 'high', 'max']);
+
+/**
+ * Kimi Platform chat-completions adapter.
+ *
+ * Kimi's preserved-thinking protocol requires streaming and exact replay of
+ * `reasoning_content`, so it intentionally does not use the generic
+ * OpenAI-compatible adapter even though it shares the endpoint envelope.
+ */
+export class KimiAdapter implements LlmAdapter {
+  readonly info;
+
+  private readonly model: string;
+  private readonly endpointBaseUrl: string;
+  private readonly apiKey: string;
+  private readonly reasoningEffort?: 'low' | 'high' | 'max';
+  private readonly fetcher: (url: unknown, init?: unknown) => Promise<globalThis.Response>;
+
+  constructor(options: KimiAdapterOptions) {
+    const endpoint = options.runtime?.endpoint;
+    if (!endpoint) {
+      throw new Error('Missing Kimi Platform endpoint runtime. Resolve provider runtime before creating the adapter.');
+    }
+    if (endpoint.auth.type !== 'bearer' || !endpoint.auth.token.trim()) {
+      throw new Error('Kimi Platform endpoint requires bearer API-key auth.');
+    }
+
+    this.model = OpenAiCompatibleModelName.toProviderModel(options.profile, options.model);
+    this.endpointBaseUrl = endpoint.baseUrl.replace(/\/+$/, '');
+    this.apiKey = endpoint.auth.token;
+    this.reasoningEffort = KimiAdapter.resolveReasoningEffort(options.runtime?.reasoningEffort);
+    this.fetcher = options.runtime?.fetchImpl
+      ?? (fetch as (url: unknown, init?: unknown) => Promise<globalThis.Response>);
+    this.info = {
+      provider: 'kimi',
+      model: OpenAiCompatibleModelName.toHeddleModel(options.profile, this.model),
+      capabilities: options.profile.capabilities,
+    } satisfies LlmAdapter['info'];
+  }
+
+  async chat(
+    messages: ChatMessage[],
+    tools: ToolDefinition[],
+    signal?: AbortSignal,
+    onStreamEvent?: (event: LlmStreamEvent) => void,
+  ): Promise<LlmResponse> {
+    const response = await this.fetcher(`${this.endpointBaseUrl}/chat/completions`, {
+      method: 'POST',
+      signal,
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages: KimiCodec.toMessages(messages),
+        tools: tools.length > 0 ? KimiCodec.toTools(tools) : undefined,
+        tool_choice: tools.length > 0 ? 'auto' : undefined,
+        reasoning_effort: this.reasoningEffort,
+        stream: true,
+        stream_options: { include_usage: true },
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Kimi Platform chat-completions request failed: ${response.status} ${response.statusText}${text ? `: ${text}` : ''}`);
+    }
+    if (!response.body) {
+      throw new Error('Kimi Platform chat-completions response did not include a readable body.');
+    }
+    const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
+    if (contentType !== 'text/event-stream') {
+      throw new Error('Kimi Platform chat-completions response was not an SSE stream.');
+    }
+
+    return await KimiAdapter.consumeEventStream(response.body, onStreamEvent);
+  }
+
+  private static async consumeEventStream(
+    body: ReadableStream<Uint8Array>,
+    onStreamEvent?: (event: LlmStreamEvent) => void,
+  ): Promise<LlmResponse> {
+    const pending: EventSourceMessage[] = [];
+    const parser = createParser({
+      onEvent: (event) => pending.push(event),
+      onError: (error) => {
+        throw new Error('Kimi Platform returned invalid SSE framing.', { cause: error });
+      },
+    });
+    const stream = new KimiChatCompletionsStreamDecoder(onStreamEvent);
+    const reader = body.getReader();
+    const textDecoder = new TextDecoder();
+    let completed = false;
+
+    const flushPending = () => {
+      while (pending.length > 0) {
+        const message = pending.shift();
+        if (message) {
+          stream.accept(message.data);
+        }
+      }
+    };
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          parser.feed(textDecoder.decode());
+          parser.reset({ consume: true });
+          flushPending();
+          const result = stream.finish();
+          completed = true;
+          return result;
+        }
+        parser.feed(textDecoder.decode(value, { stream: true }));
+        flushPending();
+      }
+    } finally {
+      if (!completed) {
+        await reader.cancel().catch(() => undefined);
+      }
+      reader.releaseLock();
+    }
+  }
+
+  private static resolveReasoningEffort(effort: ReasoningEffort | undefined): 'low' | 'high' | 'max' | undefined {
+    if (effort === undefined) {
+      return undefined;
+    }
+    if (!KIMI_REASONING_EFFORTS.has(effort)) {
+      throw new Error(`Kimi K3 reasoning effort must be low, high, or max; received ${effort}.`);
+    }
+    return effort as 'low' | 'high' | 'max';
+  }
+}

--- a/src/core/llm/adapters/kimi/kimi-codec.ts
+++ b/src/core/llm/adapters/kimi/kimi-codec.ts
@@ -1,0 +1,161 @@
+import type {
+  ChatMessage,
+  LlmUsage,
+} from '@/core/llm/types.js';
+import type { ToolCall, ToolDefinition } from '@/core/types.js';
+
+type KimiChatCompletionMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  reasoning_content?: string;
+  tool_call_id?: string;
+  tool_calls?: KimiToolCall[];
+};
+
+type KimiToolCall = {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
+type KimiFunctionTool = {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+    strict: false;
+  };
+};
+
+export type KimiAccumulatedToolCall = {
+  index: number;
+  id: string;
+  name: string;
+  argumentsText: string;
+};
+
+/**
+ * Owns Kimi Platform wire translation, including preserved-thinking replay.
+ * Raw `reasoning_content` is provider-private continuation state; this codec
+ * never projects it into Heddle's user-facing reasoning-summary events.
+ */
+export class KimiCodec {
+  static toMessages(messages: ChatMessage[]): KimiChatCompletionMessage[] {
+    return messages.map((message) => {
+      if (message.role === 'assistant') {
+        return {
+          role: 'assistant',
+          content: message.content || null,
+          ...(message.providerContinuation?.provider === 'kimi' ? {
+            reasoning_content: message.providerContinuation.reasoningContent,
+          } : {}),
+          tool_calls: message.toolCalls?.map((call) => KimiCodec.toToolCall(call)),
+        };
+      }
+
+      if (message.role === 'tool') {
+        return {
+          role: 'tool',
+          content: message.content,
+          tool_call_id: message.toolCallId,
+        };
+      }
+
+      return {
+        role: message.role,
+        content: message.content,
+      };
+    });
+  }
+
+  static toTools(tools: ToolDefinition[]): KimiFunctionTool[] {
+    return tools.map((tool) => ({
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+        strict: false,
+      },
+    }));
+  }
+
+  static parseToolCalls(calls: KimiAccumulatedToolCall[]): ToolCall[] | undefined {
+    const parsed = calls
+      .sort((left, right) => left.index - right.index)
+      .map((call) => {
+        if (!call.id || !call.name) {
+          throw new Error(`Kimi Platform returned an incomplete tool call at index ${call.index}.`);
+        }
+
+        let input: unknown = {};
+        if (call.argumentsText.trim()) {
+          try {
+            input = JSON.parse(call.argumentsText);
+          } catch (error) {
+            throw new Error(`Kimi Platform returned invalid JSON arguments for tool ${call.name}.`, {
+              cause: error,
+            });
+          }
+        }
+
+        return {
+          id: call.id,
+          tool: call.name,
+          input,
+        } satisfies ToolCall;
+      });
+
+    return parsed.length > 0 ? parsed : undefined;
+  }
+
+  static extractUsage(value: unknown): LlmUsage | undefined {
+    if (!value || typeof value !== 'object') {
+      return undefined;
+    }
+
+    const usage = (value as { usage?: unknown }).usage;
+    if (!usage || typeof usage !== 'object') {
+      return undefined;
+    }
+
+    const inputTokens = KimiCodec.numberField(usage, 'prompt_tokens') ?? 0;
+    const outputTokens = KimiCodec.numberField(usage, 'completion_tokens') ?? 0;
+    const promptDetails = KimiCodec.objectField(usage, 'prompt_tokens_details');
+    const completionDetails = KimiCodec.objectField(usage, 'completion_tokens_details');
+
+    return {
+      inputTokens,
+      outputTokens,
+      totalTokens: KimiCodec.numberField(usage, 'total_tokens') ?? inputTokens + outputTokens,
+      cachedInputTokens: promptDetails ? KimiCodec.numberField(promptDetails, 'cached_tokens') : undefined,
+      reasoningTokens: completionDetails ? KimiCodec.numberField(completionDetails, 'reasoning_tokens') : undefined,
+      requests: 1,
+    };
+  }
+
+  private static toToolCall(call: ToolCall): KimiToolCall {
+    return {
+      id: call.id,
+      type: 'function',
+      function: {
+        name: call.tool,
+        arguments: JSON.stringify(call.input),
+      },
+    };
+  }
+
+  private static objectField(value: object, key: string): object | undefined {
+    const field = (value as Record<string, unknown>)[key];
+    return field && typeof field === 'object' ? field : undefined;
+  }
+
+  private static numberField(value: object, key: string): number | undefined {
+    const field = (value as Record<string, unknown>)[key];
+    return typeof field === 'number' ? field : undefined;
+  }
+}

--- a/src/core/llm/adapters/kimi/kimi-provider-adapter.ts
+++ b/src/core/llm/adapters/kimi/kimi-provider-adapter.ts
@@ -1,0 +1,31 @@
+import type { LlmAdapterCreateInput } from '@/core/llm/types.js';
+import { OpenAiCompatibleModelName } from '@/core/llm/adapters/openai-compatible/openai-compatible-model.js';
+import { OpenAiCompatibleProviderProfileService } from '@/core/llm/adapters/openai-compatible/openai-compatible-profiles.js';
+import { LlmProviderInference } from '@/core/llm/registry/provider-inference.js';
+import type { LlmProviderAdapter } from '@/core/llm/registry/types.js';
+import { KimiAdapter } from './kimi-adapter.js';
+
+const KIMI_PROFILE = OpenAiCompatibleProviderProfileService.get('kimi');
+
+/** Registers the Kimi-specific preserved-thinking adapter with Heddle. */
+export class KimiProviderAdapter implements LlmProviderAdapter {
+  readonly provider = 'kimi' as const;
+
+  inferModel(model: string): boolean {
+    return LlmProviderInference.matchesProviderModel('kimi', model);
+  }
+
+  defaultModel(): string {
+    return OpenAiCompatibleModelName.toHeddleModel(
+      KIMI_PROFILE,
+      process.env.KIMI_MODEL?.trim() || 'kimi-k3',
+    );
+  }
+
+  createAdapter(input: LlmAdapterCreateInput & { provider: 'kimi'; model: string }): KimiAdapter {
+    return new KimiAdapter({
+      ...input,
+      profile: KIMI_PROFILE,
+    });
+  }
+}

--- a/src/core/llm/adapters/kimi/kimi-stream-decoder.ts
+++ b/src/core/llm/adapters/kimi/kimi-stream-decoder.ts
@@ -1,0 +1,132 @@
+import type {
+  LlmResponse,
+  LlmStreamEvent,
+  LlmUsage,
+} from '@/core/llm/types.js';
+import {
+  KimiCodec,
+  type KimiAccumulatedToolCall,
+} from './kimi-codec.js';
+
+type KimiToolCallDelta = {
+  index?: unknown;
+  id?: unknown;
+  function?: {
+    name?: unknown;
+    arguments?: unknown;
+  };
+};
+
+/** Accumulates one streamed Kimi chat completion into Heddle's neutral response. */
+export class KimiChatCompletionsStreamDecoder {
+  private readonly contentParts: string[] = [];
+  private readonly reasoningParts: string[] = [];
+  private readonly toolCalls = new Map<number, KimiAccumulatedToolCall>();
+  private usage?: LlmUsage;
+  private done = false;
+
+  constructor(private readonly onStreamEvent?: (event: LlmStreamEvent) => void) {}
+
+  accept(data: string): void {
+    if (data.trim() === '[DONE]') {
+      this.done = true;
+      return;
+    }
+
+    let chunk: unknown;
+    try {
+      chunk = JSON.parse(data);
+    } catch (error) {
+      throw new Error('Kimi Platform stream contained invalid JSON.', { cause: error });
+    }
+
+    this.usage = KimiCodec.extractUsage(chunk) ?? this.usage;
+    const delta = KimiChatCompletionsStreamDecoder.firstDelta(chunk);
+    if (!delta) {
+      return;
+    }
+
+    if (typeof delta.reasoning_content === 'string') {
+      this.reasoningParts.push(delta.reasoning_content);
+    }
+    if (typeof delta.content === 'string' && delta.content.length > 0) {
+      this.contentParts.push(delta.content);
+      this.onStreamEvent?.({ type: 'content.delta', delta: delta.content });
+    }
+
+    if (Array.isArray(delta.tool_calls)) {
+      delta.tool_calls.forEach((call) => this.acceptToolCall(call));
+    }
+  }
+
+  finish(): LlmResponse {
+    if (!this.done) {
+      throw new Error('Kimi Platform stream ended before the [DONE] marker.');
+    }
+
+    const content = this.contentParts.join('') || undefined;
+    const reasoningContent = this.reasoningParts.join('') || undefined;
+    if (content) {
+      this.onStreamEvent?.({ type: 'content.done', content });
+    }
+
+    return {
+      content,
+      toolCalls: KimiCodec.parseToolCalls([...this.toolCalls.values()]),
+      ...(reasoningContent ? {
+        providerContinuation: {
+          provider: 'kimi',
+          reasoningContent,
+        },
+      } : {}),
+      usage: this.usage,
+    };
+  }
+
+  private acceptToolCall(value: unknown): void {
+    if (!value || typeof value !== 'object') {
+      throw new Error('Kimi Platform stream contained a malformed tool-call delta.');
+    }
+
+    const delta = value as KimiToolCallDelta;
+    if (!Number.isSafeInteger(delta.index) || Number(delta.index) < 0) {
+      throw new Error('Kimi Platform stream contained a tool-call delta without a valid index.');
+    }
+
+    const index = Number(delta.index);
+    const current = this.toolCalls.get(index) ?? {
+      index,
+      id: '',
+      name: '',
+      argumentsText: '',
+    };
+    this.toolCalls.set(index, {
+      index,
+      id: current.id + (typeof delta.id === 'string' ? delta.id : ''),
+      name: current.name + (typeof delta.function?.name === 'string' ? delta.function.name : ''),
+      argumentsText: current.argumentsText + (
+        typeof delta.function?.arguments === 'string' ? delta.function.arguments : ''
+      ),
+    });
+  }
+
+  private static firstDelta(value: unknown): Record<string, unknown> | undefined {
+    if (!value || typeof value !== 'object') {
+      throw new Error('Kimi Platform stream contained a non-object payload.');
+    }
+
+    const choices = (value as { choices?: unknown }).choices;
+    if (!Array.isArray(choices) || choices.length === 0) {
+      return undefined;
+    }
+
+    const delta = (choices[0] as { delta?: unknown } | undefined)?.delta;
+    if (delta === undefined || delta === null) {
+      return undefined;
+    }
+    if (typeof delta !== 'object') {
+      throw new Error('Kimi Platform stream contained a malformed choice delta.');
+    }
+    return delta as Record<string, unknown>;
+  }
+}

--- a/src/core/llm/adapters/openai-compatible/README.md
+++ b/src/core/llm/adapters/openai-compatible/README.md
@@ -18,6 +18,12 @@ to show. Runtime credential services resolve concrete endpoint/auth facts, and
 `src/core/llm/models/ModelOptionsService` aggregates discovered models for web
 and TUI pickers.
 
+Provider profiles may still use a specialized execution adapter when their wire
+contract has semantics the shared codec must not flatten. Kimi Platform is one
+such case: it uses the profile for endpoint and model discovery, but its adapter
+privately preserves and replays `reasoning_content` across tool turns. Do not add
+that provider-specific state to the shared compatible codec.
+
 When adding another OpenAI-compatible service, add one profile here first, then
 extend runtime credential tests and model-options discovery tests. Do not add
 provider-specific endpoint parsing to web components, TUI picker services, or

--- a/src/core/llm/adapters/openai-compatible/openai-compatible-profiles.ts
+++ b/src/core/llm/adapters/openai-compatible/openai-compatible-profiles.ts
@@ -10,6 +10,25 @@ const CHAT_COMPLETIONS_CAPABILITIES: LlmAdapterCapabilities = {
 
 export const OPENAI_COMPATIBLE_PROVIDER_PROFILES: readonly OpenAiCompatibleProviderProfile[] = [
   {
+    id: 'kimi',
+    label: 'Kimi Platform',
+    modelPrefix: 'kimi',
+    defaultModelEnvName: 'KIMI_MODEL',
+    endpoint: {
+      defaultBaseUrl: 'https://api.moonshot.cn/v1',
+      baseUrlEnvNames: ['MOONSHOT_BASE_URL', 'KIMI_PLATFORM_BASE_URL'],
+      apiKeyEnvNames: ['MOONSHOT_API_KEY', 'KIMI_PLATFORM_API_KEY'],
+      requiresApiKey: true,
+      local: false,
+    },
+    modelDiscovery: {
+      label: 'Kimi Platform · Available models',
+      mode: 'openai-models',
+      source: 'remote-discovered',
+    },
+    capabilities: CHAT_COMPLETIONS_CAPABILITIES,
+  },
+  {
     id: 'ollama',
     label: 'Ollama',
     modelPrefix: 'ollama',

--- a/src/core/llm/adapters/openai-compatible/types.ts
+++ b/src/core/llm/adapters/openai-compatible/types.ts
@@ -3,7 +3,7 @@ import type { ModelOptionSource } from '@/core/llm/models/model-catalog.js';
 
 export type OpenAiCompatibleProviderId = Extract<
   LlmProvider,
-  'ollama' | 'lmstudio' | 'litellm' | 'vllm' | 'huggingface' | 'openrouter' | 'together' | 'groq'
+  'kimi' | 'ollama' | 'lmstudio' | 'litellm' | 'vllm' | 'huggingface' | 'openrouter' | 'together' | 'groq'
 >;
 
 export type OpenAiCompatibleModelDiscoveryMode = 'ollama-tags' | 'openai-models';

--- a/src/core/llm/index.ts
+++ b/src/core/llm/index.ts
@@ -4,6 +4,13 @@ export type { AnthropicAdapterOptions } from './adapters/anthropic/index.js';
 export { OllamaAdapter, OllamaProviderAdapter } from './adapters/ollama/index.js';
 export type { OllamaAdapterOptions } from './adapters/ollama/index.js';
 export {
+  KimiAdapter,
+  KimiChatCompletionsStreamDecoder,
+  KimiCodec,
+  KimiProviderAdapter,
+} from './adapters/kimi/index.js';
+export type { KimiAdapterOptions } from './adapters/kimi/index.js';
+export {
   OpenAiCompatibleAdapter,
   OpenAiCompatibleModelDiscoveryService,
   OpenAiCompatibleModelName,
@@ -41,6 +48,7 @@ export type {
   LlmProviderRegistryInput,
 } from './registry/index.js';
 export type {
+  AssistantProviderContinuation,
   ChatMessage,
   LlmAdapter,
   LlmAdapterCapabilities,

--- a/src/core/llm/models/model-catalog.ts
+++ b/src/core/llm/models/model-catalog.ts
@@ -22,6 +22,10 @@ export const OPENAI_GPT_5_6_MODELS = [
 
 export const BUILT_IN_MODEL_GROUPS: BuiltInModelGroup[] = [
   {
+    label: 'Kimi Platform · K3',
+    models: ['kimi/kimi-k3'],
+  },
+  {
     label: 'OpenAI · GPT-5.6',
     models: [...OPENAI_GPT_5_6_MODELS],
   },
@@ -165,6 +169,10 @@ export class ModelCatalogService {
   }
 
   static inferContextWindowEstimate(model: string): number {
+    if (model === 'kimi/kimi-k3') {
+      return 1_000_000;
+    }
+
     if (model === OPENAI_GPT_5_6_ALIAS || model.startsWith(`${OPENAI_GPT_5_6_ALIAS}-`)) {
       return 1_050_000;
     }

--- a/src/core/llm/models/model-policy-service.ts
+++ b/src/core/llm/models/model-policy-service.ts
@@ -102,6 +102,12 @@ const DEFAULT_OPENAI_REASONING_EFFORT: Record<string, ReasoningEffort> = {
   'gpt-5.5': 'medium',
   'gpt-5.5-pro': 'medium',
 };
+const KIMI_REQUEST_REASONING_EFFORTS_BY_MODEL: Record<string, ReasoningEffort[]> = {
+  'kimi/kimi-k3': ['low', 'high', 'max'],
+};
+const DEFAULT_KIMI_REASONING_EFFORT: Record<string, ReasoningEffort> = {
+  'kimi/kimi-k3': 'max',
+};
 
 /**
  * Provider-neutral model policy facade. It centralizes model capability,
@@ -245,7 +251,8 @@ export class ModelPolicyService {
   }
 
   static supportsReasoningEffort(model: string): boolean {
-    return REASONING_EFFORT_CAPABLE_OPENAI_MODELS.includes(model as (typeof REASONING_EFFORT_CAPABLE_OPENAI_MODELS)[number]);
+    return ModelPolicyService.supportedRequestReasoningEfforts(model).length > 0
+      || REASONING_EFFORT_CAPABLE_OPENAI_MODELS.includes(model as (typeof REASONING_EFFORT_CAPABLE_OPENAI_MODELS)[number]);
   }
 
   static supportsOpenAiReasoningSummary(model: string): boolean {
@@ -272,7 +279,7 @@ export class ModelPolicyService {
   }
 
   static buildReasoningEffortOptions(model: string): ReasoningEffortOption[] {
-    const requestSupportedEfforts = new Set(ModelPolicyService.supportedOpenAiRequestReasoningEfforts(model));
+    const requestSupportedEfforts = new Set(ModelPolicyService.supportedRequestReasoningEfforts(model));
     const reasoningSupported = ModelPolicyService.supportsReasoningEffort(model);
     const defaultEffort = ModelPolicyService.resolveDefaultReasoningEffort(model);
     const disabledReason =
@@ -298,7 +305,12 @@ export class ModelPolicyService {
   }
 
   static resolveDefaultReasoningEffort(model: string): ReasoningEffort | undefined {
-    return DEFAULT_OPENAI_REASONING_EFFORT[model];
+    return DEFAULT_KIMI_REASONING_EFFORT[model] ?? DEFAULT_OPENAI_REASONING_EFFORT[model];
+  }
+
+  static supportedRequestReasoningEfforts(model: string): ReasoningEffort[] {
+    return KIMI_REQUEST_REASONING_EFFORTS_BY_MODEL[model]
+      ?? ModelPolicyService.supportedOpenAiRequestReasoningEfforts(model);
   }
 
   static formatOpenAiAccountSignInModels(): string {

--- a/src/core/llm/registry/builtin-llm-providers.ts
+++ b/src/core/llm/registry/builtin-llm-providers.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_LLM_PROVIDER } from '@/core/config.js';
 import { AnthropicProviderAdapter } from '../adapters/anthropic/index.js';
+import { KimiProviderAdapter } from '../adapters/kimi/index.js';
 import {
   OpenAiCompatibleProviderAdapter,
   OpenAiCompatibleProviderProfileService,
@@ -14,7 +15,10 @@ export class BuiltinLlmProviderRegistry {
       providers: [
         new OpenAiProviderAdapter(),
         new AnthropicProviderAdapter(),
-        ...OpenAiCompatibleProviderProfileService.list().map((profile) => new OpenAiCompatibleProviderAdapter(profile)),
+        new KimiProviderAdapter(),
+        ...OpenAiCompatibleProviderProfileService.list()
+          .filter((profile) => profile.id !== 'kimi')
+          .map((profile) => new OpenAiCompatibleProviderAdapter(profile)),
       ],
     });
   }

--- a/src/core/llm/registry/provider-inference.ts
+++ b/src/core/llm/registry/provider-inference.ts
@@ -48,6 +48,7 @@ export class LlmProviderInference {
       || value.startsWith('o4')],
     ['anthropic', (value) => value.startsWith('claude')],
     ['google', (value) => value.startsWith('gemini')],
+    ['kimi', (value) => value.startsWith('kimi/') || value.startsWith('kimi:')],
     ['ollama', (value) => value.startsWith('ollama/') || value.startsWith('ollama:')],
     ['lmstudio', (value) => value.startsWith('lmstudio/') || value.startsWith('lmstudio:')],
     ['litellm', (value) => value.startsWith('litellm/') || value.startsWith('litellm:')],

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -23,6 +23,7 @@ export type LlmProvider =
   | 'openai'
   | 'anthropic'
   | 'google'
+  | 'kimi'
   | 'ollama'
   | 'lmstudio'
   | 'litellm'
@@ -66,12 +67,27 @@ export type LlmUsage = {
 };
 
 /**
+ * Provider-private assistant state that must be replayed to the same provider.
+ *
+ * This state is part of the durable model-facing transcript, but it is not a
+ * user-facing reasoning summary. Hosts, traces, and presentation layers must
+ * not render or log it as assistant work narration.
+ */
+export type AssistantProviderContinuation =
+  | { provider: 'kimi'; reasoningContent: string };
+
+/**
  * A message in the chat transcript.
  */
 export type ChatMessage =
   | { role: 'system'; content: string }
   | { role: 'user'; content: string }
-  | { role: 'assistant'; content: string; toolCalls?: ToolCall[] }
+  | {
+    role: 'assistant';
+    content: string;
+    toolCalls?: ToolCall[];
+    providerContinuation?: AssistantProviderContinuation;
+  }
   | { role: 'tool'; content: string; toolCallId: string };
 
 /**
@@ -81,6 +97,7 @@ export type LlmResponse = {
   content?: string;
   diagnostics?: AssistantDiagnostics;
   toolCalls?: ToolCall[];
+  providerContinuation?: AssistantProviderContinuation;
   usage?: LlmUsage;
 };
 

--- a/src/core/runtime/credentials/service.ts
+++ b/src/core/runtime/credentials/service.ts
@@ -35,6 +35,7 @@ export class RuntimeCredentialService {
       case 'anthropic':
         return this.firstDefinedNonEmpty(process.env.ANTHROPIC_API_KEY, process.env.PERSONAL_ANTHROPIC_API_KEY);
       case 'google':
+      case 'kimi':
       case 'ollama':
       case 'lmstudio':
       case 'litellm':
@@ -217,6 +218,10 @@ export class RuntimeCredentialService {
 
     if (provider === 'anthropic') {
       return 'Missing Anthropic credential. Set ANTHROPIC_API_KEY for Anthropic models.';
+    }
+
+    if (provider === 'kimi') {
+      return 'Missing Kimi Platform credential. Set MOONSHOT_API_KEY (or KIMI_PLATFORM_API_KEY) to a Kimi Platform API key. Kimi Code membership keys use a separate service and are not supported by this provider.';
     }
 
     return `Missing provider credential for ${provider}.`;

--- a/src/core/tools/toolkits/external-context/view-image.ts
+++ b/src/core/tools/toolkits/external-context/view-image.ts
@@ -131,6 +131,7 @@ export function createViewImageTool(options: ViewImageToolOptions = {}): ToolDef
               ok: false,
               error: 'view_image is not wired for Google models yet.',
             };
+          case 'kimi':
           case 'ollama':
           case 'lmstudio':
           case 'litellm':

--- a/src/core/tools/toolkits/external-context/web-search.ts
+++ b/src/core/tools/toolkits/external-context/web-search.ts
@@ -86,6 +86,7 @@ export function createWebSearchTool(options: WebSearchToolOptions = {}): ToolDef
               ok: false,
               error: 'web_search is not wired for Google models yet.',
             };
+          case 'kimi':
           case 'ollama':
           case 'lmstudio':
           case 'litellm':

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -145,6 +145,9 @@ export const controlPlaneRouter = router({
         anthropic: ModelPolicyService.credentialModeFromSource(RuntimeCredentialService.resolveCredentialSourceForModel('claude-sonnet-4-6', {
           preferApiKey: ctx.preferApiKey,
         })),
+        kimi: ModelPolicyService.credentialModeFromSource(RuntimeCredentialService.resolveCredentialSourceForModel('kimi/kimi-k3', {
+          preferApiKey: ctx.preferApiKey,
+        })),
         ollama: 'api-key',
       },
       openAiCompatibleSources: RuntimeCredentialService.resolveOpenAiCompatibleModelDiscoverySources(),


### PR DESCRIPTION
## Summary

- add a first-class Kimi Platform K3 adapter with streamed text and tool-call handling
- preserve Kimi `reasoning_content` as opaque provider continuation across durable tool and multi-turn transcripts without surfacing private chain-of-thought
- wire Kimi credentials, model discovery, reasoning policy, documentation, and compaction accounting

## Boundary

- supports Kimi Platform through `MOONSHOT_API_KEY` or `KIMI_PLATFORM_API_KEY`
- does not accept Kimi Code membership keys or the ambiguous `KIMI_API_KEY`
- fixture verified; a real K3 tool-turn probe is still required before claiming live production compatibility

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test` (126 unit files / 748 tests; 34 integration files / 312 tests)
- `yarn build`

## References

- https://platform.kimi.com/docs/guide/kimi-k3-quickstart
- https://platform.kimi.com/docs/guide/use-kimi-k2-thinking-model
- https://platform.kimi.com/docs/api/chat
