### PR TITLE
fix: make conversation agent cleanup deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,23 @@ Then send a structured turn through a persisted conversation:
 import { ConversationAgentService } from '@roackb2/heddle'
 
 const agent = new ConversationAgentService()
-const result = await agent.send({
-  prompt: 'Summarize this project and identify the main verification path.',
-})
+try {
+  const result = await agent.send({
+    prompt: 'Summarize this project and identify the main verification path.',
+  })
 
-console.log(result.summary)
-console.log(result.activities)
+  console.log(result.summary)
+  console.log(result.activities)
+} finally {
+  await agent.close()
+}
 ```
 
 The headless service resolves the workspace, local state root, configured
 model, and credential; race-safely ensures one stable durable session; and
 returns structured activities plus Heddle's normal turn result. It does not
-choose a UI, transport, auth system, or product transaction.
+choose a UI, transport, auth system, or product transaction. One-shot hosts
+must await `close()`; long-running hosts should await it during shutdown.
 
 Run the corresponding repository example with:
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -63,18 +63,23 @@ npm install @roackb2/heddle
 import { ConversationAgentService } from '@roackb2/heddle'
 
 const agent = new ConversationAgentService()
-const result = await agent.send({
-  prompt: '整理這個專案，並指出主要的驗證路徑。',
-})
+try {
+  const result = await agent.send({
+    prompt: '整理這個專案，並指出主要的驗證路徑。',
+  })
 
-console.log(result.summary)
-console.log(result.activities)
+  console.log(result.summary)
+  console.log(result.activities)
+} finally {
+  await agent.close()
+}
 ```
 
 Headless service 會解析 workspace、本機 state root、已設定的 model 與
 credential，race-safe 地 ensure 一個穩定的 durable session，並回傳
 structured activities 與 Heddle 原本的 turn result。它不會替產品選擇 UI、
-transport、auth system 或 product transaction。
+transport、auth system 或 product transaction。One-shot host 必須 await
+`close()`；長時間運行的 host 則應在關閉應用程式時 await 它。
 
 在此 repository 中執行對應範例：
 

--- a/docs/guides/programmatic/quickstart.md
+++ b/docs/guides/programmatic/quickstart.md
@@ -16,19 +16,25 @@ the agent lifecycle yet:
 import { ConversationAgentService } from '@roackb2/heddle'
 
 const agent = new ConversationAgentService()
-const result = await agent.send({
-  prompt: 'Summarize this project and identify the main verification path.',
-})
+try {
+  const result = await agent.send({
+    prompt: 'Summarize this project and identify the main verification path.',
+  })
 
-console.log(result.summary)
-console.log(result.activities)
+  console.log(result.summary)
+  console.log(result.activities)
+} finally {
+  await agent.close()
+}
 ```
 
 This resolves the workspace, `.heddle` state root, configured model, and
 credential; race-safely ensures the stable `session-1`; and returns Heddle's
 structured turn result plus the ordered conversation activities observed during
 the turn. Repeated `send` calls continue the same durable conversation. Supply
-an explicit stable session ID for product scope:
+an explicit stable session ID for product scope. One-shot processes should
+close the service in `finally`; long-running hosts should close it during
+application shutdown:
 
 ```ts
 const agent = new ConversationAgentService({

--- a/docs/guides/programmatic/starter-recipes.md
+++ b/docs/guides/programmatic/starter-recipes.md
@@ -29,13 +29,19 @@ const agent = new ConversationAgentService({
   systemContext: 'Help the user operate this product.',
 })
 
-const result = await agent.send({ prompt: userPrompt })
+try {
+  const result = await agent.send({ prompt: userPrompt })
+  renderTrustedResult(result)
+} finally {
+  await agent.close()
+}
 ```
 
 This starts with local file-backed conversation state under `.heddle`; it does
 not require a database or web framework. The host owns where `userPrompt` came
 from and how the trusted result is rendered. Do not serialize `result` or its
-activities directly to an untrusted client.
+activities directly to an untrusted client. Long-running hosts may reuse the
+service across turns, but must await `close()` during application shutdown.
 
 Before shipping this shape, decide:
 

--- a/examples/sdk/01-headless-conversation.ts
+++ b/examples/sdk/01-headless-conversation.ts
@@ -9,13 +9,17 @@
 import { ConversationAgentService } from '../../src/index.js';
 
 const agent = new ConversationAgentService();
-const result = await agent.send({
-  prompt: process.argv.slice(2).join(' ').trim() || 'What does this project do?',
-});
+try {
+  const result = await agent.send({
+    prompt: process.argv.slice(2).join(' ').trim() || 'What does this project do?',
+  });
 
-console.log({
-  activityTypes: result.activities.map((activity) => activity.type),
-  outcome: result.outcome,
-  sessionId: result.session.id,
-  summary: result.summary,
-});
+  console.log({
+    activityTypes: result.activities.map((activity) => activity.type),
+    outcome: result.outcome,
+    sessionId: result.session.id,
+    summary: result.summary,
+  });
+} finally {
+  await agent.close();
+}

--- a/src/__tests__/fixtures/tool-execution-natural-exit.ts
+++ b/src/__tests__/fixtures/tool-execution-natural-exit.ts
@@ -1,0 +1,17 @@
+import { ToolExecutionService, ToolRegistry } from '@/core/tools/index.js';
+
+const registry = new ToolRegistry([{
+  name: 'fast_tool',
+  description: 'Completes immediately.',
+  parameters: { type: 'object', properties: {} },
+  execute: async () => ({ ok: true }),
+}]);
+
+const result = await ToolExecutionService.execute(
+  registry,
+  { id: 'call-1', tool: 'fast_tool', input: {} },
+);
+
+if (!result.ok) {
+  throw new Error(result.error ?? 'Fast tool failed.');
+}

--- a/src/__tests__/integration/core/tool-execution-process-lifecycle.test.ts
+++ b/src/__tests__/integration/core/tool-execution-process-lifecycle.test.ts
@@ -1,0 +1,41 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const CHILD_PATH = fileURLToPath(
+  new URL('../../fixtures/tool-execution-natural-exit.ts', import.meta.url),
+);
+
+describe('tool execution process lifecycle', () => {
+  it('lets a one-shot process exit naturally after a successful tool call', async () => {
+    const child = spawn(process.execPath, ['--import', 'tsx/esm', CHILD_PATH], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+
+    const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+      child.once('exit', (code, signal) => resolve({ code, signal }));
+    });
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(new Error('Child process remained alive after successful tool execution.'));
+      }, 5_000);
+    });
+
+    const result = await Promise.race([exit, timeout]).finally(() => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    });
+
+    expect(result).toEqual({ code: 0, signal: null });
+    expect(Buffer.concat(stdout).toString('utf8')).toBe('');
+    expect(Buffer.concat(stderr).toString('utf8')).toBe('');
+  }, 10_000);
+});

--- a/src/__tests__/unit/core/mcp-client-lifecycle.test.ts
+++ b/src/__tests__/unit/core/mcp-client-lifecycle.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { McpServerConfig } from '@/core/mcp/index.js';
+
+const mocks = vi.hoisted(() => ({
+  clientCallTool: vi.fn(),
+  clientClose: vi.fn(),
+  clientConnect: vi.fn(),
+  clientListTools: vi.fn(),
+  transportClose: vi.fn(),
+  transportCreated: vi.fn(),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    connect = mocks.clientConnect;
+    listTools = mocks.clientListTools;
+    callTool = mocks.clientCallTool;
+    close = mocks.clientClose;
+    getServerVersion = () => ({ name: 'fixture', version: '1.0.0' });
+    getInstructions = () => undefined;
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: class {
+    constructor() {
+      mocks.transportCreated('stdio');
+    }
+
+    close = () => mocks.transportClose('stdio');
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: class {
+    constructor() {
+      mocks.transportCreated('sse');
+    }
+
+    close = () => mocks.transportClose('sse');
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class {
+    constructor() {
+      mocks.transportCreated('http');
+    }
+
+    close = () => mocks.transportClose('http');
+  },
+}));
+
+import { McpClientService } from '@/core/mcp/client-service.js';
+
+const servers: McpServerConfig[] = [
+  {
+    id: 'stdio',
+    transport: 'stdio',
+    source: 'heddle',
+    command: 'fixture',
+    args: [],
+    env: {},
+  },
+  {
+    id: 'sse',
+    transport: 'sse',
+    source: 'heddle',
+    url: 'https://example.com/sse',
+    headers: {},
+  },
+  {
+    id: 'http',
+    transport: 'http',
+    source: 'heddle',
+    url: 'https://example.com/mcp',
+    headers: {},
+  },
+];
+
+describe('MCP client lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.clientConnect.mockResolvedValue(undefined);
+    mocks.clientListTools.mockResolvedValue({ tools: [] });
+    mocks.clientCallTool.mockResolvedValue({ content: [] });
+    mocks.clientClose.mockResolvedValue(undefined);
+    mocks.transportClose.mockResolvedValue(undefined);
+  });
+
+  it.each(servers)('closes client and $transport transport after successful discovery', async (server) => {
+    const signal = new AbortController().signal;
+
+    await expect(new McpClientService().listTools(server, signal)).resolves.toEqual(
+      expect.objectContaining({ tools: [] }),
+    );
+
+    expect(mocks.transportCreated).toHaveBeenCalledWith(server.transport);
+    expect(mocks.clientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ signal }),
+    );
+    expect(mocks.clientListTools).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ signal }),
+    );
+    expect(mocks.clientClose).toHaveBeenCalledTimes(1);
+    expect(mocks.transportClose).toHaveBeenCalledWith(server.transport);
+  });
+
+  it('closes HTTP resources when an MCP request fails', async () => {
+    mocks.clientListTools.mockRejectedValueOnce(new Error('catalog unavailable'));
+
+    await expect(new McpClientService().listTools(servers[2]!)).rejects.toThrow(
+      'catalog unavailable',
+    );
+
+    expect(mocks.clientClose).toHaveBeenCalledTimes(1);
+    expect(mocks.transportClose).toHaveBeenCalledWith('http');
+  });
+});

--- a/src/__tests__/unit/core/mcp-host-extension.test.ts
+++ b/src/__tests__/unit/core/mcp-host-extension.test.ts
@@ -224,7 +224,12 @@ describe('defineMcpHostExtension', () => {
     expect(result?.ok).toBe(true);
     // Execution went straight to the embedded server config via the client,
     // never through the stateRoot-backed McpService.
-    expect(clientCall).toHaveBeenCalledWith(resolved.server, 'create-deck', { title: 'Quarterly plan' });
+    expect(clientCall).toHaveBeenCalledWith(
+      resolved.server,
+      'create-deck',
+      { title: 'Quarterly plan' },
+      undefined,
+    );
     expect(stateCall).not.toHaveBeenCalled();
   });
 
@@ -357,9 +362,12 @@ describe('defineMcpHostExtension', () => {
     };
 
     expect(result.ok).toBe(true);
-    expect(McpService.prototype.callTool).toHaveBeenCalledWith('deck_service', 'create-deck', {
-      title: 'Quarterly plan',
-    });
+    expect(McpService.prototype.callTool).toHaveBeenCalledWith(
+      'deck_service',
+      'create-deck',
+      { title: 'Quarterly plan' },
+      undefined,
+    );
     expect(output.diagnostics).toEqual({ valid: true });
     expect(output.html).toEqual(expect.objectContaining({
       contentPath: ['html'],

--- a/src/__tests__/unit/sdk/conversation-agent.test.ts
+++ b/src/__tests__/unit/sdk/conversation-agent.test.ts
@@ -147,4 +147,40 @@ describe('ConversationAgentService', () => {
       credential,
     }));
   });
+
+  it('closes idempotently, aborts active turns, and rejects new work', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-conversation-agent-close-'));
+    let turnSignal: AbortSignal | undefined;
+    vi.mocked(EngineConversationTurnService.run).mockImplementationOnce(async (args) => {
+      turnSignal = args.abortSignal;
+      await new Promise<void>((resolve) => {
+        args.abortSignal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+      throw args.abortSignal?.reason;
+    });
+    const agent = new ConversationAgentService({
+      credentialPreflight: false,
+      env: {},
+      workspaceRoot,
+    });
+    const send = agent.send({ prompt: 'Wait for shutdown.' });
+    await vi.waitFor(() => expect(turnSignal).toBeDefined());
+
+    const firstClose = agent.close();
+    const secondClose = agent.close();
+
+    expect(secondClose).toBe(firstClose);
+    await expect(firstClose).resolves.toBeUndefined();
+    await expect(send).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'Conversation agent service was closed.',
+    });
+    expect(turnSignal?.aborted).toBe(true);
+    await expect(agent.send({ prompt: 'Too late.' })).rejects.toThrow(
+      'Conversation agent service is closed.',
+    );
+    await expect(agent.ensureSession()).rejects.toThrow(
+      'Conversation agent service is closed.',
+    );
+  });
 });

--- a/src/__tests__/unit/tools/tool-execution-lifecycle.test.ts
+++ b/src/__tests__/unit/tools/tool-execution-lifecycle.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ToolExecutionService, ToolRegistry } from '@/core/tools/index.js';
+import type { ToolDefinition } from '@/core/types.js';
+
+function registry(execute: ToolDefinition['execute']): ToolRegistry {
+  return new ToolRegistry([{
+    name: 'lifecycle_tool',
+    description: 'Exercise tool lifecycle behavior.',
+    parameters: { type: 'object', properties: {} },
+    execute,
+  }]);
+}
+
+describe('tool execution lifecycle', () => {
+  it('clears the timeout after successful execution', async () => {
+    vi.useFakeTimers();
+
+    try {
+      await expect(ToolExecutionService.execute(
+        registry(async () => ({ ok: true })),
+        { id: 'call-1', tool: 'lifecycle_tool', input: {} },
+      )).resolves.toEqual({ ok: true });
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('aborts the tool and clears the timeout when the owning run is cancelled', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    let toolSignal: AbortSignal | undefined;
+
+    try {
+      const execution = ToolExecutionService.execute(
+        registry(async (_input, context) => {
+          toolSignal = context?.signal;
+          await new Promise<void>((resolve) => {
+            context?.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return { ok: false, error: 'tool observed abort' };
+        }),
+        { id: 'call-1', tool: 'lifecycle_tool', input: {} },
+        { signal: controller.signal },
+      );
+
+      controller.abort(new Error('host cancelled the run'));
+
+      await expect(execution).resolves.toEqual({
+        ok: false,
+        error: 'host cancelled the run',
+      });
+      expect(toolSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('aborts the tool when its execution timeout elapses', async () => {
+    vi.useFakeTimers();
+    let toolSignal: AbortSignal | undefined;
+
+    try {
+      const execution = ToolExecutionService.execute(
+        registry(async (_input, context) => {
+          toolSignal = context?.signal;
+          await new Promise<void>((resolve) => {
+            context?.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return { ok: false, error: 'tool observed timeout' };
+        }),
+        { id: 'call-1', tool: 'lifecycle_tool', input: {} },
+        { timeoutMs: 100 },
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      await expect(execution).resolves.toEqual({
+        ok: false,
+        error: 'Tool "lifecycle_tool" timed out after 100ms',
+      });
+      expect(toolSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/__tests__/unit/tools/tool-policy-envelope.test.ts
+++ b/src/__tests__/unit/tools/tool-policy-envelope.test.ts
@@ -80,7 +80,10 @@ describe('tool policy envelope', () => {
       },
     })).resolves.toEqual({ ok: true, output: 'ok' });
 
-    expect(execute).toHaveBeenCalledWith({ path: 'README.md' });
+    expect(execute).toHaveBeenCalledWith(
+      { path: 'README.md' },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it('accepts an envelope with empty targetRoots for non-mutating tools', async () => {
@@ -103,7 +106,10 @@ describe('tool policy envelope', () => {
       },
     })).resolves.toEqual({ ok: true, output: 'ok' });
 
-    expect(execute).toHaveBeenCalledWith({ path: 'README.md' });
+    expect(execute).toHaveBeenCalledWith(
+      { path: 'README.md' },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it('rejects an envelope with empty roots for mutating operations', async () => {
@@ -153,7 +159,10 @@ describe('tool policy envelope', () => {
       },
     })).resolves.toEqual({ ok: true, output: 'ok' });
 
-    expect(execute).toHaveBeenCalledWith({ path: 'README.md' });
+    expect(execute).toHaveBeenCalledWith(
+      { path: 'README.md' },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it('rejects invalid policy envelope before execution', async () => {

--- a/src/core/agent/tools/tool-dispatcher.ts
+++ b/src/core/agent/tools/tool-dispatcher.ts
@@ -135,6 +135,7 @@ export class AgentToolDispatcher {
     seenToolCalls: Map<string, number>;
     approvalPolicies?: ToolApprovalPolicy[];
     approveToolCall: RunAgentOptions['approveToolCall'];
+    abortSignal?: AbortSignal;
     workspaceRoot?: string;
     live: AgentRunLiveRecorder;
     log: Logger;
@@ -210,6 +211,7 @@ export class AgentToolDispatcher {
       now: () => string;
       registry: ToolRegistry;
       seenToolCalls: Map<string, number>;
+      abortSignal?: AbortSignal;
       live: AgentRunLiveRecorder;
       log: Logger;
     },
@@ -244,7 +246,9 @@ export class AgentToolDispatcher {
     }
 
     const startedAt = Date.now();
-    const rawResult = await ToolExecutionService.execute(registry, call);
+    const rawResult = await ToolExecutionService.execute(registry, call, {
+      signal: args.abortSignal,
+    });
     const audit = AutonomyPostflightAuditService.shouldAudit(args.autonomyEvaluation)
       ? AutonomyPostflightAuditService.create({
         evaluation: args.autonomyEvaluation,

--- a/src/core/agent/tools/tool-turn-service.ts
+++ b/src/core/agent/tools/tool-turn-service.ts
@@ -75,6 +75,7 @@ export class AgentToolTurnService {
       now: context.now,
       registry: context.registry,
       seenToolCalls: context.seenToolCalls,
+      abortSignal: context.abortSignal,
       approveToolCall: context.approveToolCall,
       approvalPolicies: context.approvalPolicies,
       workspaceRoot: context.workspaceRoot,

--- a/src/core/chat/engine/mcp-host-extension/README.md
+++ b/src/core/chat/engine/mcp-host-extension/README.md
@@ -25,8 +25,9 @@ MCP config/catalog from `context.stateRoot`. This lets one prepared extension be
 reused across many cheap, per-request engines — e.g. a multi-tenant server that
 builds a fresh engine per request with a per-user API key and per-user storage,
 without any per-engine MCP prep or a per-user `.heddle/` directory. Tool
-execution stays stateless: each call spawns a fresh MCP subprocess via
-`McpClientService` from the embedded config and closes it.
+execution stays stateless: each call creates a fresh MCP client plus its
+configured transport (including a subprocess for stdio) and closes both.
+All three transport paths receive the owning tool execution's abort signal.
 
 A plain `defineMcpHostExtension(options)` with no embedded data keeps the
 original behavior: the toolkit reads the server + catalog from `stateRoot` at

--- a/src/core/chat/engine/mcp-host-extension/tool-definition-service.ts
+++ b/src/core/chat/engine/mcp-host-extension/tool-definition-service.ts
@@ -7,7 +7,7 @@ import {
 import { McpResultArtifactService } from './result-artifact-service.js';
 import { McpHostValueService } from './value-service.js';
 import type { McpCallToolResult, McpServerCatalogRecord, McpServerConfig } from '@/core/mcp/index.js';
-import type { ToolDefinition } from '@/core/types.js';
+import type { ToolDefinition, ToolExecutionContext } from '@/core/types.js';
 import type { ToolToolkit, ToolToolkitContext } from '@/core/tools/index.js';
 import type {
   DefineMcpHostExtensionOptions,
@@ -96,12 +96,17 @@ export class McpHostToolDefinitionService {
       description: override?.description ?? McpHostToolDefinitionService.describeTool(args.options, args.tool),
       capabilities: override?.capabilities ?? args.options.defaultCapabilities ?? ['mcp.unknown'],
       parameters: args.tool.inputSchema,
-      async execute(raw: unknown) {
+      async execute(raw: unknown, execution?: ToolExecutionContext) {
         const callArgs = McpHostValueService.isRecord(raw) ? raw : {};
         const result = args.resolved
-          ? await McpHostToolDefinitionService.callEmbedded(args.resolved.server, args.tool.name, callArgs)
+          ? await McpHostToolDefinitionService.callEmbedded(
+              args.resolved.server,
+              args.tool.name,
+              callArgs,
+              execution?.signal,
+            )
           : await McpHostToolDefinitionService.createMcpService(args.context)
-              .callTool(args.options.serverId, args.tool.name, callArgs);
+              .callTool(args.options.serverId, args.tool.name, callArgs, execution?.signal);
 
         return result.ok
           ? {
@@ -147,10 +152,11 @@ export class McpHostToolDefinitionService {
     server: McpServerConfig,
     toolName: string,
     args: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<McpCallToolResult> {
     if (!isToolAllowed(server, toolName)) {
       return { ok: false, error: `MCP tool is denied by Heddle config: ${server.id}/${toolName}` };
     }
-    return await new McpClientService().callTool(server, toolName, args);
+    return await new McpClientService().callTool(server, toolName, args, signal);
   }
 }

--- a/src/core/mcp/README.md
+++ b/src/core/mcp/README.md
@@ -90,7 +90,9 @@ work inside a synchronous toolkit.
   - owns the official `@modelcontextprotocol/sdk` client usage;
   - creates stdio, Streamable HTTP, or legacy SSE transports;
   - lists tools and calls tools;
-  - closes client and transport resources after each operation.
+  - forwards the owning run's abort signal to connection and request calls;
+  - closes client and transport resources after each operation, on both success
+    and failure.
 - `McpService`
   - owns Heddle-level semantics on top of repositories and SDK calls;
   - exposes config document read/create/save methods for control-plane hosts;
@@ -131,6 +133,16 @@ The runtime MCP toolkit exposes:
 The toolkit should stay an adapter. It should not parse config, manage
 enablement, launch servers, or decide policy beyond setting Heddle
 `ToolDefinition` metadata.
+
+## Connection Lifecycle
+
+MCP connections are operation-scoped rather than retained by `McpService`.
+Every discovery or tool call creates one official SDK client and transport,
+then closes both in `finally`. Agent-exposed MCP tools forward
+`ToolExecutionContext.signal`, so run cancellation and
+`ConversationAgentService.close()` can stop in-flight stdio, Streamable HTTP,
+and legacy SSE work before teardown. Do not introduce a persistent client pool
+without a separate ownership, health-check, reconnect, and shutdown design.
 
 ## Slash Commands And Web UI
 

--- a/src/core/mcp/client-service.ts
+++ b/src/core/mcp/client-service.ts
@@ -8,9 +8,12 @@ import type { McpCallToolResult, McpClientSessionInfo, McpServerConfig, McpToolD
 const DEFAULT_MCP_TIMEOUT_MS = 30_000;
 
 export class McpClientService {
-  async listTools(server: McpServerConfig): Promise<McpClientSessionInfo> {
+  async listTools(server: McpServerConfig, signal?: AbortSignal): Promise<McpClientSessionInfo> {
     return await this.withClient(server, async (client) => {
-      const tools = await client.listTools({}, { timeout: DEFAULT_MCP_TIMEOUT_MS });
+      const tools = await client.listTools({}, {
+        signal,
+        timeout: DEFAULT_MCP_TIMEOUT_MS,
+      });
       const serverVersion = client.getServerVersion();
 
       return {
@@ -19,26 +22,30 @@ export class McpClientService {
         instructions: client.getInstructions(),
         tools: tools.tools.map(toToolDescriptor),
       };
-    });
+    }, signal);
   }
 
   async callTool(
     server: McpServerConfig,
     toolName: string,
     args: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<McpCallToolResult> {
     try {
       return await this.withClient(server, async (client) => {
         const result = await client.callTool({
           name: toolName,
           arguments: args,
-        }, undefined, { timeout: DEFAULT_MCP_TIMEOUT_MS });
+        }, undefined, {
+          signal,
+          timeout: DEFAULT_MCP_TIMEOUT_MS,
+        });
 
         return {
           ok: true,
           output: normalizeToolResult(result),
         };
-      });
+      }, signal);
     } catch (error) {
       return {
         ok: false,
@@ -50,6 +57,7 @@ export class McpClientService {
   private async withClient<T>(
     server: McpServerConfig,
     callback: (client: Client) => Promise<T>,
+    signal?: AbortSignal,
   ): Promise<T> {
     const client = new Client({
       name: 'heddle',
@@ -58,7 +66,10 @@ export class McpClientService {
     const transport = createTransport(server);
 
     try {
-      await client.connect(transport, { timeout: DEFAULT_MCP_TIMEOUT_MS });
+      await client.connect(transport, {
+        signal,
+        timeout: DEFAULT_MCP_TIMEOUT_MS,
+      });
       return await callback(client);
     } finally {
       await client.close().catch(() => undefined);

--- a/src/core/mcp/service.ts
+++ b/src/core/mcp/service.ts
@@ -174,7 +174,12 @@ export class McpService {
     );
   }
 
-  async callTool(serverId: string, toolName: string, args: Record<string, unknown>): Promise<McpCallToolResult> {
+  async callTool(
+    serverId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<McpCallToolResult> {
     const config = this.configStore.read();
     const server = config.servers.find((candidate) => candidate.id === serverId);
     if (!server) {
@@ -194,7 +199,7 @@ export class McpService {
       return { ok: false, error: `MCP tool is denied by Heddle config: ${serverId}/${toolName}` };
     }
 
-    return await this.clientService.callTool(server, toolName, args);
+    return await this.clientService.callTool(server, toolName, args, signal);
   }
 
   private buildServerViews(servers: McpServerConfig[]): McpServerView[] {

--- a/src/core/tools/execute-tool.ts
+++ b/src/core/tools/execute-tool.ts
@@ -4,6 +4,11 @@ import { ToolPolicyEnvelopeInputService } from './policy-envelope/index.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+export type ToolExecutionOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
 /**
  * Executes tool calls against a registry with timeout/error normalization.
  */
@@ -11,7 +16,7 @@ export class ToolExecutionService {
   static async execute(
     registry: ToolRegistry,
     call: ToolCall,
-    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+    options: number | ToolExecutionOptions = {},
   ): Promise<ToolResult> {
     const tool = registry.get(call.tool);
     if (!tool) {
@@ -22,6 +27,14 @@ export class ToolExecutionService {
     }
 
     try {
+      const resolvedOptions = typeof options === 'number' ? { timeoutMs: options } : options;
+      const timeoutMs = resolvedOptions.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const timeoutController = new AbortController();
+      const signal = resolvedOptions.signal
+        ? AbortSignal.any([resolvedOptions.signal, timeoutController.signal])
+        : timeoutController.signal;
+      signal.throwIfAborted();
+
       const extraction = ToolPolicyEnvelopeInputService.extract(call.input);
       if (extraction.error) {
         return {
@@ -30,13 +43,29 @@ export class ToolExecutionService {
         };
       }
 
-      const result = await Promise.race([
-        tool.execute(extraction.toolInput),
-        new Promise<ToolResult>((_, reject) =>
-          setTimeout(() => reject(new Error(`Tool "${call.tool}" timed out after ${timeoutMs}ms`)), timeoutMs),
-        ),
-      ]);
-      return result;
+      const timeoutError = new Error(`Tool "${call.tool}" timed out after ${timeoutMs}ms`);
+      let rejectOnAbort: (() => void) | undefined;
+      const cancellation = new Promise<never>((_, reject) => {
+        rejectOnAbort = () => reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new Error(`Tool "${call.tool}" was aborted`),
+        );
+        signal.addEventListener('abort', rejectOnAbort, { once: true });
+      });
+      const timer = setTimeout(() => timeoutController.abort(timeoutError), timeoutMs);
+
+      try {
+        return await Promise.race([
+          tool.execute(extraction.toolInput, { signal }),
+          cancellation,
+        ]);
+      } finally {
+        clearTimeout(timer);
+        if (rejectOnAbort) {
+          signal.removeEventListener('abort', rejectOnAbort);
+        }
+      }
     } catch (err) {
       return {
         ok: false,

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -1,4 +1,5 @@
 export { ToolExecutionService } from './execute-tool.js';
+export type { ToolExecutionOptions } from './execute-tool.js';
 export { ToolRegistry } from './registry.js';
 export { ToolBundleComposer } from './toolkit.js';
 export type { ToolToolkit, ToolToolkitContext } from './toolkit.js';

--- a/src/core/tools/toolkits/mcp/toolkit.ts
+++ b/src/core/tools/toolkits/mcp/toolkit.ts
@@ -7,7 +7,7 @@ import {
   shouldMcpToolRequireApproval,
 } from '@/core/mcp/index.js';
 import type { McpServerConfig, McpToolDescriptor } from '@/core/mcp/index.js';
-import type { ToolDefinition, ToolResult } from '@/core/types.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from '@/core/types.js';
 import type { ToolToolkit } from '../../toolkit.js';
 
 const MCP_LIST_TOOLS_NAME = 'mcp_list_tools';
@@ -133,7 +133,7 @@ function createMcpCallToolTool(options: {
       },
       required: ['serverId', 'toolName', 'arguments'],
     },
-    async execute(raw: unknown): Promise<ToolResult> {
+    async execute(raw: unknown, execution?: ToolExecutionContext): Promise<ToolResult> {
       if (!isMcpCallInput(raw)) {
         return { ok: false, error: 'Invalid input for mcp_call_tool. Required fields: serverId, toolName, arguments.' };
       }
@@ -142,7 +142,12 @@ function createMcpCallToolTool(options: {
         return { ok: false, error: `MCP server is not available through default MCP tools: ${raw.serverId}` };
       }
 
-      const result = await mcpService(options).callTool(raw.serverId, raw.toolName, raw.arguments);
+      const result = await mcpService(options).callTool(
+        raw.serverId,
+        raw.toolName,
+        raw.arguments,
+        execution?.signal,
+      );
       return result.ok ? { ok: true, output: result.output } : { ok: false, error: result.error };
     },
   };
@@ -163,11 +168,12 @@ function createMcpServerTool(options: {
       'Calls external MCP capability through Heddle approval and trace boundaries.',
     ].join(' '),
     parameters: options.tool.inputSchema,
-    async execute(raw: unknown): Promise<ToolResult> {
+    async execute(raw: unknown, execution?: ToolExecutionContext): Promise<ToolResult> {
       const result = await mcpService(options).callTool(
         options.server.id,
         options.tool.name,
         isRecord(raw) ? raw : {},
+        execution?.signal,
       );
 
       return result.ok ? { ok: true, output: result.output } : { ok: false, error: result.error };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,13 +18,21 @@ export type RunInput = {
 /**
  * A tool the agent can invoke.
  */
+export type ToolExecutionContext = {
+  /**
+   * Aborted when the owning run is cancelled or the tool execution times out.
+   * Tool implementations should forward this signal to cancellable I/O.
+   */
+  signal?: AbortSignal;
+};
+
 export type ToolDefinition = {
   name: string;
   description: string;
   requiresApproval?: boolean;
   capabilities?: string[];
   parameters: Record<string, unknown>; // JSON Schema object
-  execute: (input: unknown) => Promise<ToolResult>;
+  execute: (input: unknown, context?: ToolExecutionContext) => Promise<ToolResult>;
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export type {
   RunResult,
   ModelRunFailureCode,
   ToolDefinition,
+  ToolExecutionContext,
   ToolCall,
   ToolResult,
   TraceEvent,

--- a/src/sdk/conversation/headless/README.md
+++ b/src/sdk/conversation/headless/README.md
@@ -7,6 +7,9 @@ This module owns Heddle's smallest structured in-process SDK adoption path.
 - `ConversationAgentService` constructs one conversation engine, ensures one
   stable durable session without a read/create race, submits turns, captures
   structured activities, and returns Heddle's normal structured turn result.
+- `close()` stops new service work, aborts active turns, and waits for their
+  operation-scoped resources, including MCP transports, to settle. It is
+  asynchronous and idempotent.
 - The underlying `engine` remains public so an adopter can progressively use
   full session, turn, artifact, persistence, and host-extension APIs without a
   rewrite.
@@ -40,9 +43,19 @@ const agent = new ConversationAgentService({
   session: { id: 'account-42:project-7', name: 'Project assistant' },
 })
 
-const result = await agent.send({
-  prompt: 'Summarize this project.',
-})
+try {
+  const result = await agent.send({
+    prompt: 'Summarize this project.',
+  })
 
-console.log(result.summary, result.activities)
+  console.log(result.summary, result.activities)
+} finally {
+  await agent.close()
+}
 ```
+
+One-shot processes should close the service in `finally`. Long-running hosts
+should keep one service for its intended scope and await `close()` during
+application shutdown. Once closing begins, the service rejects new sessions and
+turns. Direct use of the public `engine` has its own lifecycle and is not
+tracked by the headless service.

--- a/src/sdk/conversation/headless/service.ts
+++ b/src/sdk/conversation/headless/service.ts
@@ -27,9 +27,13 @@ export class ConversationAgentService {
   readonly engine: ConversationEngine;
   readonly runtime: ConversationAgentRuntimeContext;
 
+  private readonly activeSends = new Set<Promise<ConversationAgentTurnResult>>();
   private readonly defaultHost?: ConversationEngineHost;
+  private readonly lifecycleController = new AbortController();
   private readonly session: Required<Pick<ConversationAgentSessionOptions, 'id'>>
     & Omit<ConversationAgentSessionOptions, 'id'>;
+  private closePromise?: Promise<void>;
+  private closed = false;
 
   constructor(options: ConversationAgentOptions = {}) {
     const defaults = ConversationSdkRuntimeService.resolveDefaults(options);
@@ -71,10 +75,40 @@ export class ConversationAgentService {
   }
 
   async ensureSession(): Promise<EnsureConversationSessionResult> {
+    this.assertOpen();
     return await this.engine.sessions.ensure(this.session);
   }
 
   async send(input: ConversationAgentSendInput): Promise<ConversationAgentTurnResult> {
+    this.assertOpen();
+    const operation = this.sendOpen(input);
+    this.activeSends.add(operation);
+
+    try {
+      return await operation;
+    } finally {
+      this.activeSends.delete(operation);
+    }
+  }
+
+  /**
+   * Stops accepting work, aborts active turns, and waits for their
+   * operation-scoped resources (including MCP transports) to settle.
+   */
+  close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.closed = true;
+    const error = new Error('Conversation agent service was closed.');
+    error.name = 'AbortError';
+    this.lifecycleController.abort(error);
+    this.closePromise = Promise.allSettled(Array.from(this.activeSends)).then(() => undefined);
+    return this.closePromise;
+  }
+
+  private async sendOpen(input: ConversationAgentSendInput): Promise<ConversationAgentTurnResult> {
     const prompt = input.prompt.trim();
     if (!prompt) {
       throw new Error('Conversation agent prompt cannot be empty.');
@@ -88,6 +122,9 @@ export class ConversationAgentService {
       prompt,
       maxSteps: input.maxSteps ?? this.runtime.maxSteps,
       memoryMaintenanceMode: input.memoryMaintenanceMode ?? this.runtime.memoryMaintenanceMode,
+      abortSignal: input.abortSignal
+        ? AbortSignal.any([this.lifecycleController.signal, input.abortSignal])
+        : this.lifecycleController.signal,
       host: ConversationAgentService.captureActivities(
         input.host ?? this.defaultHost,
         activities,
@@ -99,6 +136,12 @@ export class ConversationAgentService {
       activities,
       sessionCreated: session.created,
     };
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error('Conversation agent service is closed.');
+    }
   }
 
   private static captureActivities(


### PR DESCRIPTION
## Summary

- clear successful tool-execution timeouts instead of retaining a 30-second event-loop handle
- add an async, idempotent `ConversationAgentService.close()` that rejects new work, aborts active turns, and waits for them to settle
- propagate run cancellation through `ToolExecutionContext` into MCP connect/request calls
- keep stdio, Streamable HTTP, and legacy SSE clients operation-scoped and close client plus transport in `finally`
- document one-shot and long-running host shutdown responsibilities

## Root cause

`ToolExecutionService` raced each tool against a 30-second timeout but never cleared that timeout after a successful tool result. A process could finish its real work in milliseconds and still remain alive until that timer fired.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` (126 files, 750 tests)
- `yarn test:integration` (35 files, 312 tests)
- `yarn build`
- child-process regression exits naturally in about 0.2 seconds and fails if the process remains live for 5 seconds

Closes #268