### PR TITLE
fix: make MCP policy provenance host-owned

### DIFF
--- a/src/__tests__/unit/core/autonomy-policy-service.test.ts
+++ b/src/__tests__/unit/core/autonomy-policy-service.test.ts
@@ -239,6 +239,192 @@ describe('AutonomyPolicyService', () => {
     }));
   });
 
+  it('uses host-owned MCP transport and environment while retaining the model proposal', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-mcp-read',
+          tool: 'search_slides',
+          input: {
+            query: 'roadmap',
+            policy: {
+              operations: ['read', 'network'],
+              intent: 'read slides through Streamable HTTP',
+              targetRoots: [],
+              expectedEffects: ['return matching slides'],
+              maxDestructiveScope: 'none',
+              environment: 'production',
+              confidence: 'high',
+            },
+          },
+        },
+        tool: {
+          name: 'search_slides',
+          description: 'search slides',
+          requiresApproval: true,
+          parameters: {},
+          hostPolicy: {
+            authority: {
+              kind: 'mcp',
+              serverId: 'slides',
+              toolName: 'search-slides',
+              tenantId: 'tenant-1',
+            },
+            transport: {
+              kind: 'http',
+              network: true,
+            },
+            environment: 'local',
+            operations: ['read'],
+          },
+          execute: async () => ({ ok: true }),
+        },
+      }),
+      profile,
+    });
+
+    expect(evaluation.decision).toEqual(expect.objectContaining({
+      type: 'allow',
+      reason: 'allowed by autopilot profile and declared policy envelope',
+    }));
+    expect(evaluation.envelope).toEqual(expect.objectContaining({
+      operations: ['read'],
+      environment: 'local',
+    }));
+    expect(evaluation.policy).toEqual(expect.objectContaining({
+      modelProposed: expect.objectContaining({
+        operations: ['read', 'network'],
+        environment: 'production',
+      }),
+      hostOwned: expect.objectContaining({
+        authority: {
+          kind: 'mcp',
+          serverId: 'slides',
+          toolName: 'search-slides',
+          tenantId: 'tenant-1',
+        },
+        transport: {
+          kind: 'http',
+          network: true,
+        },
+        environment: 'local',
+        operations: ['read'],
+      }),
+      ownership: {
+        hostOwned: ['authority', 'transport', 'environment', 'operations'],
+        modelProposed: expect.arrayContaining(['operations', 'environment', 'intent']),
+      },
+    }));
+    expect(evaluation.facts.claimMismatches).toEqual([
+      expect.stringContaining('host targets "local"'),
+      expect.stringContaining('host-owned transport provenance'),
+      expect.stringContaining('host classifies this tool as [read]'),
+    ]);
+  });
+
+  it('applies host-owned development and production environments', () => {
+    const evaluateEnvironment = (environment: 'dev' | 'production') =>
+      AutonomyPolicyService.evaluate({
+        context: context({
+          call: {
+            id: `call-mcp-${environment}`,
+            tool: 'search_slides',
+            input: {
+              query: 'roadmap',
+              policy: {
+                operations: ['read'],
+                intent: 'read slides',
+                targetRoots: [],
+                expectedEffects: ['return matching slides'],
+                environment: 'local',
+                confidence: 'high',
+              },
+            },
+          },
+          tool: {
+            name: 'search_slides',
+            description: 'search slides',
+            requiresApproval: true,
+            parameters: {},
+            hostPolicy: {
+              authority: {
+                kind: 'mcp',
+                serverId: 'slides',
+                toolName: 'search-slides',
+              },
+              transport: {
+                kind: 'http',
+                network: true,
+              },
+              environment,
+              operations: ['read'],
+            },
+            execute: async () => ({ ok: true }),
+          },
+        }),
+        profile,
+      });
+
+    expect(evaluateEnvironment('dev').decision.type).toBe('allow');
+    expect(evaluateEnvironment('production').decision).toEqual(expect.objectContaining({
+      type: 'request',
+      reason: 'environment is not allowed for unattended execution',
+    }));
+  });
+
+  it('does not let a model downgrade a host-classified remote mutation to a read', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-mcp-write',
+          tool: 'update_slide',
+          input: {
+            title: 'Updated',
+            policy: {
+              operations: ['read'],
+              intent: 'read a slide',
+              targetRoots: [],
+              expectedEffects: ['read slide'],
+              environment: 'local',
+              confidence: 'high',
+            },
+          },
+        },
+        tool: {
+          name: 'update_slide',
+          description: 'updates a remote slide',
+          requiresApproval: true,
+          parameters: {},
+          hostPolicy: {
+            authority: {
+              kind: 'mcp',
+              serverId: 'slides',
+              toolName: 'update-slide',
+            },
+            transport: {
+              kind: 'http',
+              network: true,
+            },
+            environment: 'production',
+            operations: ['write'],
+          },
+          execute: async () => ({ ok: true }),
+        },
+      }),
+      profile,
+    });
+
+    expect(evaluation.facts.operations).toEqual(['write']);
+    expect(evaluation.envelope).toEqual(expect.objectContaining({
+      operations: ['write'],
+      environment: 'production',
+    }));
+    expect(evaluation.decision).toEqual(expect.objectContaining({
+      type: 'request',
+      reason: expect.stringContaining('remote mutating authority requires explicit approval'),
+    }));
+  });
+
   it('does not auto-allow a mutating shell call whose envelope declares no roots', () => {
     const evaluation = AutonomyPolicyService.evaluate({
       context: context({

--- a/src/__tests__/unit/core/autonomy-policy-service.test.ts
+++ b/src/__tests__/unit/core/autonomy-policy-service.test.ts
@@ -425,6 +425,62 @@ describe('AutonomyPolicyService', () => {
     }));
   });
 
+  it('does not let local root claims authorize a host-classified remote mutation', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-mcp-write-with-roots',
+          tool: 'update_slide',
+          input: {
+            title: 'Updated',
+            policy: {
+              operations: ['write'],
+              intent: 'update a remote slide',
+              targetRoots: ['.'],
+              writeRoots: ['.'],
+              expectedEffects: ['update slide'],
+              environment: 'local',
+              confidence: 'high',
+            },
+          },
+        },
+        tool: {
+          name: 'update_slide',
+          description: 'updates a remote slide',
+          requiresApproval: true,
+          parameters: {},
+          hostPolicy: {
+            authority: {
+              kind: 'mcp',
+              serverId: 'slides',
+              toolName: 'update-slide',
+            },
+            transport: {
+              kind: 'http',
+              network: true,
+            },
+            environment: 'local',
+            operations: ['write'],
+          },
+          execute: async () => ({ ok: true }),
+        },
+      }),
+      profile,
+    });
+
+    expect(evaluation.facts.claimedWriteRoots).toEqual(['/workspace/current']);
+    expect(evaluation.facts.rootDecisions).toEqual([
+      expect.objectContaining({
+        root: '/workspace/current',
+        access: 'autopilot',
+      }),
+    ]);
+    expect(evaluation.decision).toEqual(expect.objectContaining({
+      type: 'request',
+      reason: 'remote mutating authority requires explicit approval',
+    }));
+  });
+
   it('does not auto-allow a mutating shell call whose envelope declares no roots', () => {
     const evaluation = AutonomyPolicyService.evaluate({
       context: context({

--- a/src/__tests__/unit/core/mcp-host-extension.test.ts
+++ b/src/__tests__/unit/core/mcp-host-extension.test.ts
@@ -148,6 +148,39 @@ describe('defineMcpHostExtension', () => {
     }));
   });
 
+  it('attaches host-owned environment, authority, tenant, and effect classification', () => {
+    const context = contextFixture();
+    const extension = defineMcpHostExtension({
+      id: 'slides',
+      serverId: 'deck_service',
+      includeTools: ['create-deck'],
+      environment: 'production',
+      tenantId: 'tenant-42',
+      toolOverrides: {
+        'create-deck': {
+          operations: ['write'],
+        },
+      },
+    });
+
+    const [tool] = extension.toolkits?.flatMap((toolkit) => toolkit.createTools(context)) ?? [];
+
+    expect(tool?.hostPolicy).toEqual({
+      authority: {
+        kind: 'mcp',
+        serverId: 'deck_service',
+        toolName: 'create-deck',
+        tenantId: 'tenant-42',
+      },
+      transport: {
+        kind: 'stdio',
+        network: false,
+      },
+      environment: 'production',
+      operations: ['write'],
+    });
+  });
+
   it('exposes all enabled catalog tools when includeTools is omitted', () => {
     const context = contextFixture();
     const extension = defineMcpHostExtension({

--- a/src/__tests__/unit/core/mcp-policy-context-service.test.ts
+++ b/src/__tests__/unit/core/mcp-policy-context-service.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  McpPolicyContextService,
+  type McpServerConfig,
+} from '@/core/mcp/index.js';
+
+function httpServer(args: {
+  id?: string;
+  url: string;
+  environment?: 'local' | 'dev' | 'staging' | 'production' | 'unknown';
+}): McpServerConfig {
+  return {
+    id: args.id ?? 'remote',
+    transport: 'http',
+    source: 'heddle',
+    url: args.url,
+    headers: {},
+    ...(args.environment ? { environment: args.environment } : {}),
+  };
+}
+
+describe('McpPolicyContextService', () => {
+  it.each([
+    {
+      name: 'a local stdio process',
+      server: {
+        id: 'local_stdio',
+        transport: 'stdio' as const,
+        source: 'heddle' as const,
+        command: 'node',
+        args: ['server.js'],
+        env: {},
+      },
+      environment: 'local',
+      transport: { kind: 'stdio', network: false },
+    },
+    {
+      name: 'a loopback HTTP endpoint',
+      server: httpServer({ id: 'local_http', url: 'http://127.0.0.1:3010/mcp' }),
+      environment: 'local',
+      transport: { kind: 'http', network: true },
+    },
+    {
+      name: 'an explicitly classified development endpoint',
+      server: httpServer({
+        id: 'development',
+        url: 'https://mcp.dev.example.test',
+        environment: 'dev',
+      }),
+      environment: 'dev',
+      transport: { kind: 'http', network: true },
+    },
+    {
+      name: 'an explicitly classified production endpoint',
+      server: httpServer({
+        id: 'production',
+        url: 'https://mcp.example.test',
+        environment: 'production',
+      }),
+      environment: 'production',
+      transport: { kind: 'http', network: true },
+    },
+  ])('derives host-owned provenance for $name', ({ server, environment, transport }) => {
+    expect(McpPolicyContextService.create({
+      server,
+      toolName: 'search',
+    })).toEqual({
+      authority: {
+        kind: 'mcp',
+        serverId: server.id,
+        toolName: 'search',
+      },
+      transport,
+      environment,
+    });
+  });
+
+  it('uses an embedding host override and records tenant and effect ownership', () => {
+    expect(McpPolicyContextService.create({
+      server: httpServer({
+        id: 'shared',
+        url: 'https://mcp.example.test',
+        environment: 'production',
+      }),
+      toolName: 'update-record',
+      environment: 'staging',
+      tenantId: 'tenant-42',
+      operations: ['write'],
+    })).toEqual({
+      authority: {
+        kind: 'mcp',
+        serverId: 'shared',
+        toolName: 'update-record',
+        tenantId: 'tenant-42',
+      },
+      transport: {
+        kind: 'http',
+        network: true,
+      },
+      environment: 'staging',
+      operations: ['write'],
+    });
+  });
+});

--- a/src/__tests__/unit/core/mcp-service.test.ts
+++ b/src/__tests__/unit/core/mcp-service.test.ts
@@ -92,6 +92,27 @@ describe('MCP service', () => {
     });
   });
 
+  it('preserves host-owned environment classification from MCP config', () => {
+    const { workspaceRoot, stateRoot } = workspaceFixture();
+    writeFileSync(FileMcpConfigRepository.resolvePath(stateRoot), JSON.stringify({
+      mcpServers: {
+        production_data: {
+          type: 'streamable-http',
+          url: 'https://mcp.example.test',
+          environment: 'production',
+        },
+      },
+    }), 'utf8');
+
+    const [server] = new FileMcpConfigRepository({ workspaceRoot, stateRoot }).read().servers;
+
+    expect(server).toEqual(expect.objectContaining({
+      id: 'production_data',
+      transport: 'http',
+      environment: 'production',
+    }));
+  });
+
   it('rejects invalid MCP config document saves', () => {
     const { workspaceRoot, stateRoot } = workspaceFixture();
     const service = new McpService({ workspaceRoot, stateRoot });

--- a/src/__tests__/unit/tools/mcp-toolkit.test.ts
+++ b/src/__tests__/unit/tools/mcp-toolkit.test.ts
@@ -132,6 +132,41 @@ describe('MCP toolkit', () => {
     }));
   });
 
+  it('resolves broker and cached-tool policy provenance from host configuration', () => {
+    const tools = mcpToolkit.createTools(contextFixture());
+    const callTool = tools.find((candidate) => candidate.name === 'mcp_call_tool');
+    const cachedTool = tools.find((candidate) => candidate.name === 'mcp__notion__search_pages');
+
+    expect(callTool?.resolveHostPolicy?.({
+      serverId: 'notion',
+      toolName: 'search-pages',
+      arguments: { query: 'roadmap' },
+    })).toEqual({
+      authority: {
+        kind: 'mcp',
+        serverId: 'notion',
+        toolName: 'search-pages',
+      },
+      transport: {
+        kind: 'stdio',
+        network: false,
+      },
+      environment: 'local',
+    });
+    expect(cachedTool?.hostPolicy).toEqual({
+      authority: {
+        kind: 'mcp',
+        serverId: 'notion',
+        toolName: 'search-pages',
+      },
+      transport: {
+        kind: 'stdio',
+        network: false,
+      },
+      environment: 'local',
+    });
+  });
+
   it('hides host-owned MCP servers from the default tool surface', async () => {
     const tools = mcpToolkit.createTools(contextFixture({
       includeGithub: true,

--- a/src/__tests__/unit/tools/tool-policy-envelope.test.ts
+++ b/src/__tests__/unit/tools/tool-policy-envelope.test.ts
@@ -133,7 +133,10 @@ describe('tool policy envelope', () => {
       },
     })).resolves.toEqual({ ok: true, output: 'ok' });
 
-    expect(execute).toHaveBeenCalledWith({ path: 'remote-document' });
+    expect(execute).toHaveBeenCalledWith(
+      { path: 'remote-document' },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it('rejects an envelope with empty roots for mutating operations', async () => {

--- a/src/__tests__/unit/tools/tool-policy-envelope.test.ts
+++ b/src/__tests__/unit/tools/tool-policy-envelope.test.ts
@@ -112,6 +112,30 @@ describe('tool policy envelope', () => {
     );
   });
 
+  it('does not treat network transport as a filesystem mutation requiring roots', async () => {
+    const execute = vi.fn(async () => ({ ok: true, output: 'ok' }));
+    const registry = new ToolRegistry([tool({ execute })]);
+
+    await expect(ToolExecutionService.execute(registry, {
+      id: 'call-1',
+      tool: 'test_tool',
+      input: {
+        path: 'remote-document',
+        policy: {
+          operations: ['read', 'network'],
+          intent: 'read a document through an HTTP MCP transport',
+          targetRoots: [],
+          expectedEffects: ['read remote document'],
+          maxDestructiveScope: 'none',
+          environment: 'production',
+          confidence: 'high',
+        },
+      },
+    })).resolves.toEqual({ ok: true, output: 'ok' });
+
+    expect(execute).toHaveBeenCalledWith({ path: 'remote-document' });
+  });
+
   it('rejects an envelope with empty roots for mutating operations', async () => {
     const execute = vi.fn(async () => ({ ok: true }));
     const registry = new ToolRegistry([tool({ execute })]);
@@ -179,6 +203,35 @@ describe('tool policy envelope', () => {
     })).resolves.toEqual(expect.objectContaining({
       ok: false,
       error: expect.stringContaining('Invalid tool policy envelope'),
+    }));
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects model attempts to add host-owned authority fields before execution', async () => {
+    const execute = vi.fn(async () => ({ ok: true }));
+    const registry = new ToolRegistry([tool({ execute })]);
+
+    await expect(ToolExecutionService.execute(registry, {
+      id: 'call-1',
+      tool: 'test_tool',
+      input: {
+        path: 'README.md',
+        policy: {
+          operations: ['read'],
+          intent: 'inspect README',
+          targetRoots: ['.'],
+          expectedEffects: ['read README'],
+          environment: 'local',
+          confidence: 'high',
+          authority: {
+            serverId: 'spoofed-server',
+          },
+        },
+      },
+    })).resolves.toEqual(expect.objectContaining({
+      ok: false,
+      error: expect.stringContaining('authority, transport, target environment, and tenant provenance are host-owned'),
     }));
 
     expect(execute).not.toHaveBeenCalled();

--- a/src/core/approvals/autonomy/policy-service.ts
+++ b/src/core/approvals/autonomy/policy-service.ts
@@ -1,6 +1,12 @@
 import { resolve } from 'node:path';
 import type { ToolApprovalPolicyContext, ToolApprovalPolicyDecision } from '../types.js';
-import { TOOL_POLICY_MUTATING_OPERATIONS, ToolPolicyEnvelopeInputService, type ToolPolicyEnvelope, type ToolPolicyOperation } from '@/core/tools/index.js';
+import {
+  TOOL_POLICY_MUTATING_OPERATIONS,
+  ToolPolicyResolutionService,
+  type ToolPolicyEnvelope,
+  type ToolPolicyOperation,
+  type ToolPolicyReconciliation,
+} from '@/core/tools/index.js';
 import type {
   AutonomyEvaluation,
   AutonomyPolicyHint,
@@ -28,15 +34,19 @@ export class AutonomyPolicyService {
       profile: args.profile,
       workspaceRoot,
     });
-    const extraction = ToolPolicyEnvelopeInputService.extract(args.context.call.input);
-    const envelope = extraction.envelope;
+    const resolution = ToolPolicyResolutionService.resolve({
+      tool: args.context.tool,
+      input: args.context.call.input,
+    });
+    const envelope = resolution.envelope;
     const facts = AutonomyPolicyService.computeFacts({
       context: args.context,
       envelope,
       profile,
       workspaceRoot,
-      extractionError: extraction.error,
-      toolInput: extraction.toolInput,
+      policy: resolution.reconciliation,
+      extractionError: resolution.error,
+      toolInput: resolution.toolInput,
     });
     const policyHints = AutonomyPolicyService.createPolicyHints(facts);
     const decision = AutonomyPolicyService.decide({
@@ -50,6 +60,7 @@ export class AutonomyPolicyService {
       call: args.context.call,
       profileMode: profile.mode,
       profilePreset: profile.preset,
+      policy: resolution.reconciliation,
       envelope,
       facts,
       decision,
@@ -93,16 +104,17 @@ export class AutonomyPolicyService {
       return { type: 'request', reason: facts.approvalReasons.join('; '), facts };
     }
 
-    if (!envelope) {
-      return { type: 'allow', reason: 'allowed by autopilot profile without a required policy envelope', facts };
-    }
-
-    if (envelope.confidence === 'low' || envelope.operations.includes('unknown')) {
+    if (envelope && (envelope.confidence === 'low' || envelope.operations.includes('unknown'))) {
       return { type: 'request', reason: 'policy envelope is not specific enough for autopilot', facts };
     }
 
-    if (!profile.environments.allow.includes(envelope.environment as 'local' | 'dev')) {
+    const hasEnvironmentClaim = envelope !== undefined || facts.environment !== 'unknown';
+    if (hasEnvironmentClaim && !profile.environments.allow.includes(facts.environment as 'local' | 'dev')) {
       return { type: 'request', reason: 'environment is not allowed for unattended execution', facts };
+    }
+
+    if (!envelope) {
+      return { type: 'allow', reason: 'allowed by autopilot profile without a required policy envelope', facts };
     }
 
     return { type: 'allow', reason: 'allowed by autopilot profile and declared policy envelope', facts };
@@ -113,6 +125,7 @@ export class AutonomyPolicyService {
     envelope?: ToolPolicyEnvelope;
     profile: NormalizedAutopilotProfile;
     workspaceRoot: string;
+    policy: ToolPolicyReconciliation;
     extractionError?: string;
     toolInput: unknown;
   }): ToolPolicyFacts {
@@ -122,7 +135,11 @@ export class AutonomyPolicyService {
       input: args.toolInput,
       workspaceRoot: args.workspaceRoot,
     });
-    const operations = args.envelope?.operations ?? AutonomyPolicyService.inferOperations(args.context);
+    const operations = ToolPolicyResolutionService.operations({
+      reconciliation: args.policy,
+      fallback: AutonomyPolicyService.inferOperations(args.context),
+    });
+    const environment = args.policy.hostOwned?.environment ?? args.envelope?.environment ?? 'unknown';
     const claimedReadRoots = AutonomyPolicyService.resolveEnvelopeRoots({
       roots: args.envelope?.readRoots ?? args.envelope?.targetRoots ?? [],
       workspaceRoot: args.workspaceRoot,
@@ -146,11 +163,14 @@ export class AutonomyPolicyService {
       rootDecisions,
       profile: args.profile,
       context: args.context,
+      policy: args.policy,
+      claimedWriteRoots,
     });
 
     return {
       tool: args.context.call.tool,
       operations,
+      environment,
       command,
       cwd: args.workspaceRoot,
       claimedReadRoots,
@@ -159,7 +179,7 @@ export class AutonomyPolicyService {
       rootDecisions,
       hardDenyReasons,
       approvalReasons,
-      claimMismatches: [],
+      claimMismatches: args.policy.diagnostics.map((diagnostic) => diagnostic.message),
     };
   }
 
@@ -288,7 +308,15 @@ export class AutonomyPolicyService {
     rootDecisions: ToolPolicyRootDecision[];
     profile: NormalizedAutopilotProfile;
     context: ToolApprovalPolicyContext;
+    policy: ToolPolicyReconciliation;
+    claimedWriteRoots: string[];
   }): string[] {
+    const host = args.policy.hostOwned;
+    const remoteEffectsUnclassified = host?.transport.network && !host.operations;
+    const remoteMutationWithoutAuthorityPolicy = host?.transport.network
+      && args.operations.some((operation) => TOOL_POLICY_MUTATING_OPERATIONS.has(operation))
+      && args.claimedWriteRoots.length === 0;
+
     return [
       ...args.rootDecisions.flatMap((decision) => AutonomyPolicyService.rootApprovalReasons({
         decision,
@@ -297,6 +325,12 @@ export class AutonomyPolicyService {
         profile: args.profile,
       })),
       ...(args.operations.includes('network') ? ['network operations require approval in initial autopilot policy'] : []),
+      ...(remoteEffectsUnclassified
+        ? ['remote MCP tool effects are not classified by the host']
+        : []),
+      ...(remoteMutationWithoutAuthorityPolicy
+        ? ['remote mutating authority requires explicit approval']
+        : []),
     ];
   }
 

--- a/src/core/approvals/autonomy/policy-service.ts
+++ b/src/core/approvals/autonomy/policy-service.ts
@@ -164,7 +164,6 @@ export class AutonomyPolicyService {
       profile: args.profile,
       context: args.context,
       policy: args.policy,
-      claimedWriteRoots,
     });
 
     return {
@@ -309,13 +308,11 @@ export class AutonomyPolicyService {
     profile: NormalizedAutopilotProfile;
     context: ToolApprovalPolicyContext;
     policy: ToolPolicyReconciliation;
-    claimedWriteRoots: string[];
   }): string[] {
     const host = args.policy.hostOwned;
     const remoteEffectsUnclassified = host?.transport.network && !host.operations;
     const remoteMutationWithoutAuthorityPolicy = host?.transport.network
-      && args.operations.some((operation) => TOOL_POLICY_MUTATING_OPERATIONS.has(operation))
-      && args.claimedWriteRoots.length === 0;
+      && args.operations.some((operation) => TOOL_POLICY_MUTATING_OPERATIONS.has(operation));
 
     return [
       ...args.rootDecisions.flatMap((decision) => AutonomyPolicyService.rootApprovalReasons({

--- a/src/core/approvals/autonomy/types.ts
+++ b/src/core/approvals/autonomy/types.ts
@@ -1,5 +1,10 @@
 import type { ToolCall } from '@/core/types.js';
-import type { ToolPolicyEnvelope, ToolPolicyOperation } from '@/core/tools/index.js';
+import type {
+  ToolPolicyEnvelope,
+  ToolPolicyEnvironment,
+  ToolPolicyOperation,
+  ToolPolicyReconciliation,
+} from '@/core/tools/index.js';
 
 export type AutopilotRootAccess = 'read' | 'write' | 'autopilot' | 'manual-only' | 'deny';
 
@@ -82,6 +87,7 @@ export type ToolPolicyRootDecision = {
 export type ToolPolicyFacts = {
   tool: string;
   operations: ToolPolicyOperation[];
+  environment: ToolPolicyEnvironment;
   command?: string;
   cwd?: string;
   claimedReadRoots: string[];
@@ -108,6 +114,9 @@ export type AutonomyEvaluation = {
   call: ToolCall;
   profileMode: AutopilotProfile['mode'];
   profilePreset?: AutopilotProfilePreset;
+  /** Proposed, host-owned, and effective fields retained for policy audit. */
+  policy: ToolPolicyReconciliation;
+  /** Effective envelope retained for compatibility with existing consumers. */
   envelope?: ToolPolicyEnvelope;
   facts: ToolPolicyFacts;
   decision: AutopilotDecision;

--- a/src/core/chat/engine/mcp-host-extension/README.md
+++ b/src/core/chat/engine/mcp-host-extension/README.md
@@ -34,6 +34,34 @@ original behavior: the toolkit reads the server + catalog from `stateRoot` at
 runtime (the local CLI-host path). Preparation passes the embedded data as the
 optional second argument to `defineMcpHostExtension(options, resolved)`.
 
+## Host-owned policy provenance
+
+The extension owns execution facts that a model cannot safely supply:
+
+```ts
+defineMcpHostExtension({
+  id: 'slides',
+  serverId: 'motiondoc',
+  environment: 'production',
+  tenantId: currentTenantId,
+  toolOverrides: {
+    validate_deck: { operations: ['read'] },
+    update_deck: { operations: ['write'] },
+  },
+});
+```
+
+Every generated tool records the configured MCP server id, original tool name,
+transport, target environment, optional tenant, and optional verified effect
+classification. The model still describes intent and expected effects in its
+policy envelope, but approval evaluation retains both sources and applies the
+host-owned facts when they disagree.
+
+Only classify `operations` when the embedding host knows the tool contract.
+Remote MCP annotations are untrusted hints, not Heddle authorization. An
+unclassified remote tool remains manual in autopilot rather than inheriting a
+model claim.
+
 ## Service Boundaries
 
 - `McpHostExtensionService` composes the Heddle host extension shell. Keep this
@@ -42,7 +70,7 @@ optional second argument to `defineMcpHostExtension(options, resolved)`.
   activate server, refresh catalog, and return a prepared extension.
 - `McpHostToolDefinitionService` owns converting cached MCP descriptors into
   Heddle `ToolDefinition`s: filtering, host tool names, descriptions, approval
-  defaults, and wrapping tool execution.
+  defaults, host-owned policy provenance, and wrapping tool execution.
 - `McpResultArtifactService` owns the result-artifact policy entrypoint. It
   resolves manual rules and beginner-friendly auto capture.
 - `McpAutoResultArtifactService` owns auto capture heuristics for

--- a/src/core/chat/engine/mcp-host-extension/tool-definition-service.ts
+++ b/src/core/chat/engine/mcp-host-extension/tool-definition-service.ts
@@ -1,5 +1,6 @@
 import {
   McpClientService,
+  McpPolicyContextService,
   McpService,
   isToolAllowed,
   shouldMcpToolRequireApproval,
@@ -96,6 +97,13 @@ export class McpHostToolDefinitionService {
       description: override?.description ?? McpHostToolDefinitionService.describeTool(args.options, args.tool),
       capabilities: override?.capabilities ?? args.options.defaultCapabilities ?? ['mcp.unknown'],
       parameters: args.tool.inputSchema,
+      hostPolicy: McpPolicyContextService.create({
+        server: args.server,
+        toolName: args.tool.name,
+        environment: args.options.environment,
+        tenantId: args.options.tenantId,
+        operations: override?.operations,
+      }),
       async execute(raw: unknown, execution?: ToolExecutionContext) {
         const callArgs = McpHostValueService.isRecord(raw) ? raw : {};
         const result = args.resolved

--- a/src/core/chat/engine/mcp-host-extension/types.ts
+++ b/src/core/chat/engine/mcp-host-extension/types.ts
@@ -1,6 +1,6 @@
 import type { ArtifactKind, RuntimeArtifact } from '@/core/artifacts/index.js';
 import type { McpRefreshResult, McpServerCatalogRecord, McpServerConfig, McpToolDescriptor } from '@/core/mcp/index.js';
-import type { ToolToolkitContext } from '@/core/tools/index.js';
+import type { ToolPolicyEnvironment, ToolPolicyOperation, ToolToolkitContext } from '@/core/tools/index.js';
 import type {
   ConversationEngineHostArtifactOptions,
   ConversationEngineHostExtension,
@@ -11,6 +11,11 @@ export type McpHostToolOverride = {
   description?: string;
   capabilities?: string[];
   requiresApproval?: boolean;
+  /**
+   * Host-owned effect classification. Omit when the host cannot verify the
+   * remote tool's effects; model claims remain proposals.
+   */
+  operations?: readonly ToolPolicyOperation[];
 };
 
 export type McpHostResultArtifactRule = {
@@ -96,6 +101,10 @@ export type DefineMcpHostExtensionOptions = {
   /** Prefix exposed tool names only when multiple MCP servers may collide. */
   toolNamePrefix?: string;
   defaultCapabilities?: string[];
+  /** Host-owned target environment. Overrides config/endpoint derivation. */
+  environment?: ToolPolicyEnvironment;
+  /** Optional opaque tenant boundary recorded in policy evaluation traces. */
+  tenantId?: string;
   toolOverrides?: Record<string, McpHostToolOverride>;
   hideDefaultMcpTools?: boolean;
   resultArtifacts?: McpHostResultArtifactsOptions;

--- a/src/core/mcp/README.md
+++ b/src/core/mcp/README.md
@@ -34,6 +34,8 @@ document into Settings -> MCP. All of those paths target the same config file.
   - user-authored MCP server config;
   - accepts the common `mcpServers` shape and VS Code's `servers` alias;
   - supports `stdio`, `http`, normalized `streamable-http`, and legacy `sse`.
+  - optionally accepts a Heddle-specific `environment` classification:
+    `local`, `dev`, `staging`, `production`, or `unknown`.
 - `.heddle/mcp/activation.json`
   - Heddle-owned workspace state;
   - stores only whether a configured server is enabled or disabled;
@@ -93,6 +95,13 @@ work inside a synchronous toolkit.
   - forwards the owning run's abort signal to connection and request calls;
   - closes client and transport resources after each operation, on both success
     and failure.
+- `McpPolicyContextService`
+  - converts configured server identity, transport, environment, and optional
+    host-verified effects into immutable tool policy context;
+  - derives stdio and loopback endpoints as `local`;
+  - leaves an unclassified remote endpoint as `unknown` unless config or the
+    embedding host supplies its environment;
+  - never treats remote MCP annotations as authorization facts.
 - `McpService`
   - owns Heddle-level semantics on top of repositories and SDK calls;
   - exposes config document read/create/save methods for control-plane hosts;
@@ -128,7 +137,8 @@ The runtime MCP toolkit exposes:
 - cached per-tool adapters such as `mcp__notion__search_pages`
   - created only from cached catalog records;
   - use Heddle-safe namespaced names;
-  - preserve the original server id and MCP tool name when calling `McpService`.
+  - preserve the original server id and MCP tool name when calling `McpService`;
+  - attach host-owned MCP authority, transport, and environment provenance.
 
 The toolkit should stay an adapter. It should not parse config, manage
 enablement, launch servers, or decide policy beyond setting Heddle
@@ -171,6 +181,8 @@ Keep these invariants:
 - Saving config does not enable servers or refresh cached tools.
 - Enabled does not mean trusted for unattended execution.
 - Tool calls still go through Heddle approval and tracing.
+- MCP server id, tool name, transport, configured environment, and tenant
+  provenance are host-owned. A model policy envelope cannot override them.
 - MCP server/tool descriptions and outputs are untrusted external content.
 - Local stdio servers run commands with the user's OS permissions.
 - Secret values should be resolved at connection time and redacted from
@@ -185,6 +197,10 @@ Server-level tool policy is intentionally small:
 
 Do not treat MCP tool annotations such as read-only or destructive hints as
 Heddle permissions until an approval-domain design explicitly supports that.
+Likewise, an HTTP or SSE transport is not a mutating `network` operation.
+Transport provenance is recorded separately, so a host-classified remote read
+does not need fake write roots. If a remote tool's effects are not classified
+by the host, unattended execution remains approval-gated.
 
 ## Extension Rules
 

--- a/src/core/mcp/index.ts
+++ b/src/core/mcp/index.ts
@@ -1,4 +1,5 @@
 export { McpClientService } from './client-service.js';
+export { McpPolicyContextService } from './policy-context-service.js';
 export {
   FileMcpActivationRepository,
   FileMcpCatalogRepository,

--- a/src/core/mcp/policy-context-service.ts
+++ b/src/core/mcp/policy-context-service.ts
@@ -1,0 +1,55 @@
+import type {
+  ToolPolicyEnvironment,
+  ToolPolicyHostContext,
+  ToolPolicyOperation,
+} from '@/core/tools/policy-envelope/types.js';
+import type { McpServerConfig } from './types.js';
+
+/**
+ * Projects configured MCP execution facts into the shared host-owned policy
+ * boundary. It never treats remote tool annotations as authorization facts.
+ */
+export class McpPolicyContextService {
+  static create(args: {
+    server: McpServerConfig;
+    toolName: string;
+    environment?: ToolPolicyEnvironment;
+    tenantId?: string;
+    operations?: readonly ToolPolicyOperation[];
+  }): ToolPolicyHostContext {
+    return {
+      authority: {
+        kind: 'mcp',
+        serverId: args.server.id,
+        toolName: args.toolName,
+        ...(args.tenantId ? { tenantId: args.tenantId } : {}),
+      },
+      transport: {
+        kind: args.server.transport,
+        network: args.server.transport === 'http' || args.server.transport === 'sse',
+      },
+      environment:
+        args.environment
+        ?? args.server.environment
+        ?? McpPolicyContextService.deriveEnvironment(args.server),
+      ...(args.operations ? { operations: args.operations } : {}),
+    };
+  }
+
+  static deriveEnvironment(server: McpServerConfig): ToolPolicyEnvironment {
+    if (server.transport === 'stdio') {
+      return 'local';
+    }
+
+    const hostname = new URL(server.url).hostname.toLowerCase();
+    return isLoopbackHostname(hostname) ? 'local' : 'unknown';
+  }
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost'
+    || hostname.endsWith('.localhost')
+    || hostname === '127.0.0.1'
+    || hostname === '[::1]'
+    || hostname === '::1';
+}

--- a/src/core/mcp/repositories.ts
+++ b/src/core/mcp/repositories.ts
@@ -248,6 +248,7 @@ function normalizeServer(
       cwd: raw.cwd ? resolveTemplatePath(raw.cwd, options.workspaceRoot) : undefined,
       env: raw.env ?? {},
       envFile: raw.envFile,
+      environment: raw.environment,
       tools: raw.tools,
     };
     return { server, issues: [] };
@@ -271,6 +272,7 @@ function normalizeServer(
       source: options.source,
       url: url.toString(),
       headers: raw.headers ?? {},
+      environment: raw.environment,
       tools: raw.tools,
     };
     return { server, issues: [] };

--- a/src/core/mcp/schemas.ts
+++ b/src/core/mcp/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { TOOL_POLICY_ENVIRONMENTS } from '@/core/tools/policy-envelope/types.js';
 
 const McpToolApprovalModeSchema = z.enum(['always', 'never']);
 
@@ -18,6 +19,7 @@ const McpRawServerSchema = z.object({
   envFile: z.string().min(1).optional(),
   url: z.string().min(1).optional(),
   headers: z.record(z.string(), z.string()).optional(),
+  environment: z.enum(TOOL_POLICY_ENVIRONMENTS).optional(),
   tools: McpToolPolicySchema.optional(),
 }).passthrough();
 

--- a/src/core/mcp/types.ts
+++ b/src/core/mcp/types.ts
@@ -1,3 +1,5 @@
+import type { ToolPolicyEnvironment } from '@/core/tools/policy-envelope/types.js';
+
 export type McpTransportKind = 'stdio' | 'http' | 'sse';
 
 export type McpServerConfigSource = 'heddle' | 'standard' | 'vscode';
@@ -19,6 +21,7 @@ export type McpStdioServerConfig = {
   cwd?: string;
   env: Record<string, string>;
   envFile?: string;
+  environment?: ToolPolicyEnvironment;
   tools?: McpToolPolicy;
 };
 
@@ -28,6 +31,7 @@ export type McpHttpServerConfig = {
   source: McpServerConfigSource;
   url: string;
   headers: Record<string, string>;
+  environment?: ToolPolicyEnvironment;
   tools?: McpToolPolicy;
 };
 

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -6,12 +6,16 @@ export type { ToolToolkit, ToolToolkitContext } from './toolkit.js';
 export {
   TOOL_POLICY_MUTATING_OPERATIONS,
   ToolPolicyEnvelopeInputService,
+  ToolPolicyResolutionService,
   ToolPolicyEnvelopeSchemaService,
 } from './policy-envelope/index.js';
 export type {
   ToolPolicyConfidence,
   ToolPolicyEnvelope,
   ToolPolicyEnvelopeExtraction,
+  ToolPolicyHostContext,
   ToolPolicyEnvironment,
   ToolPolicyOperation,
+  ToolPolicyReconciliation,
+  ToolPolicyResolution,
 } from './policy-envelope/index.js';

--- a/src/core/tools/policy-envelope/README.md
+++ b/src/core/tools/policy-envelope/README.md
@@ -12,6 +12,7 @@ low-friction intent contract without duplicating schema fragments.
 - Central schema augmentation for object-shaped tool parameters.
 - Input extraction that separates the envelope from tool business input before
   execution.
+- Reconciliation between model-proposed intent and host-owned execution facts.
 
 ## Does Not Own
 
@@ -23,7 +24,21 @@ low-friction intent contract without duplicating schema fragments.
 ## Boundary Rule
 
 Agents report intent through this envelope. The runtime may use it as a policy
-claim, but it must not treat it as verified fact.
+claim, but it must not treat it as verified fact. A host that owns a tool can
+attach immutable authority, transport, target-environment, and effect
+classification through `ToolDefinition.hostPolicy` or
+`ToolDefinition.resolveHostPolicy(...)`.
+
+Policy evaluation keeps three views rather than collapsing their provenance:
+
+- `modelProposed`: the model-authored intent envelope;
+- `hostOwned`: immutable execution facts supplied by the tool owner;
+- `effective`: the reconciled envelope consumed by approval policy.
+
+The reconciliation record also identifies which source owns each field and
+records normalization diagnostics. This lets approval traces explain why a
+model claim was overridden without copying tool business arguments into the
+trace.
 
 The envelope is deliberately shared across tools. It gives the agent one stable
 vocabulary for "what I am trying to do" while each tool keeps its own business
@@ -56,7 +71,9 @@ Field meanings:
 
 - `operations`: all operation classes the agent expects the call to perform.
   This is an array because real work often combines actions, such as
-  `execute + write` for a migration script.
+  `execute + write` for a migration script. `network` describes a network
+  effect for an ordinary host tool; it is not a synonym for an MCP HTTP
+  transport. MCP transport is host-owned provenance.
 - `intent`: short natural-language explanation of why the tool call exists.
 - `targetRoots`: project/workspace roots involved in the work.
 - `readRoots`: optional narrower project/workspace roots when read and write
@@ -147,18 +164,30 @@ ToolExecutionService.execute(...)
   -> ToolPolicyEnvelopeInputService.extract(...)
   -> validate and remove policy
   -> execute raw tool with stripped business input
+
+AutonomyPolicyService.evaluate(...)
+  -> ToolPolicyResolutionService.resolve(...)
+  -> retain modelProposed + hostOwned
+  -> normalize transport claims and apply host environment/effects
+  -> evaluate the effective envelope
 ```
 
 Approval code also extracts the envelope before building previews and approval
 requests. Tool implementations should not receive or inspect `policy`; it is
 intent metadata for approval, trace, and future postflight auditing.
 
+The model-facing envelope schema is strict. Unsupported top-level policy fields
+such as `authority`, `transport`, or tenant provenance are rejected before tool
+execution with an actionable diagnostic. The model cannot silently redefine
+host-owned facts.
+
 ## Relationship To Autonomy
 
 `src/core/approvals/autonomy/` consumes this shape directly. It compares the
-agent's declared intent with configured roots, known tool targets, command
-hard-deny patterns, and environment policy. Trace records the same domain
-objects that include this envelope.
+agent's declared intent and host facts with configured roots, known tool
+targets, command hard-deny patterns, and environment policy. Trace records the
+same reconciliation object, including the proposed, host-owned, and effective
+views.
 
 Do not create a second "trace envelope" or "approval envelope" with the same
 fields. If a consumer needs less data, project from this type at that consumer's
@@ -170,6 +199,8 @@ presentation boundary.
 - Add fields only when they are useful across tool families, not for one tool's
   private needs.
 - Keep tool-specific validation in the toolkit that owns the tool.
+- Keep server identity, transport, environment, tenant, and verified effect
+  classification host-owned. Never infer authorization from model input.
 - Keep approval decisions in `src/core/approvals`, not here.
 - Keep extraction centralized in `ToolPolicyEnvelopeInputService` so tools,
   approvals, and tests agree on the stripped input shape.

--- a/src/core/tools/policy-envelope/index.ts
+++ b/src/core/tools/policy-envelope/index.ts
@@ -1,4 +1,5 @@
 export { ToolPolicyEnvelopeInputService } from './input-service.js';
+export { ToolPolicyResolutionService } from './resolution-service.js';
 export { ToolPolicyEnvelopeSchemaService } from './schema-service.js';
 export {
   TOOL_POLICY_CONFIDENCE_LEVELS,
@@ -12,6 +13,13 @@ export type {
   ToolPolicyDestructiveScope,
   ToolPolicyEnvelope,
   ToolPolicyEnvelopeExtraction,
+  ToolPolicyFieldOwnership,
+  ToolPolicyHostAuthority,
+  ToolPolicyHostContext,
+  ToolPolicyHostTransport,
   ToolPolicyEnvironment,
   ToolPolicyOperation,
+  ToolPolicyReconciliation,
+  ToolPolicyReconciliationDiagnostic,
+  ToolPolicyResolution,
 } from './types.js';

--- a/src/core/tools/policy-envelope/input-service.ts
+++ b/src/core/tools/policy-envelope/input-service.ts
@@ -17,7 +17,7 @@ const ToolPolicyEnvelopeSchema = z.object({
     'Human-readable purpose for the tool call. Used for approval/debugging context, not for deterministic verification.',
   ),
   targetRoots: z.array(z.string()).describe(
-    'Project/workspace roots involved in the call. These should be project boundaries such as repo roots or config-bearing folders, not individual file paths. May be empty only for read-only or state-only calls that touch no project root, such as planning tools. Calls that write, delete, move, execute, run git, or use the network must declare at least one target or write root.',
+    'Project/workspace roots involved in the call. These should be project boundaries such as repo roots or config-bearing folders, not individual file paths. May be empty only for read-only or state-only calls that touch no project root, such as planning tools. Calls that write, delete, move, execute, or run git must declare at least one target or write root.',
   ),
   readRoots: z.array(z.string()).optional().describe(
     'Optional project/workspace roots the agent claims the call may read when read scope differs from targetRoots.',
@@ -37,7 +37,7 @@ const ToolPolicyEnvelopeSchema = z.object({
   confidence: z.enum(TOOL_POLICY_CONFIDENCE_LEVELS).describe(
     'Agent confidence that the envelope completely describes the purpose and impact surface of the call.',
   ),
-}).strip().superRefine((envelope, ctx) => {
+}).strict().superRefine((envelope, ctx) => {
   // A mutating envelope must declare a write scope. Autonomy policy derives
   // claimed write roots from writeRoots (or targetRoots for mutating ops), so an
   // empty-root mutating envelope would evaluate against zero roots and could be
@@ -48,7 +48,7 @@ const ToolPolicyEnvelopeSchema = z.object({
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['targetRoots'],
-      message: 'mutating operations (write, delete, move, execute, git, network, unknown) must declare at least one target or write root',
+      message: 'mutating operations (write, delete, move, execute, git, unknown) must declare at least one target or write root',
     });
   }
 }).describe(
@@ -86,7 +86,7 @@ export class ToolPolicyEnvelopeInputService {
     if (!parsed.success) {
       return {
         toolInput,
-        error: `Invalid tool policy envelope: ${parsed.error.issues.map((issue) => issue.message).join('; ')}`,
+        error: `Invalid tool policy envelope: ${parsed.error.issues.map(formatIssue).join('; ')}`,
       };
     }
 
@@ -95,6 +95,15 @@ export class ToolPolicyEnvelopeInputService {
       toolInput,
     };
   }
+}
+
+function formatIssue(issue: z.ZodIssue): string {
+  if (issue.code === z.ZodIssueCode.unrecognized_keys) {
+    return `unsupported model-provided fields [${issue.keys.join(', ')}]; `
+      + 'authority, transport, target environment, and tenant provenance are host-owned';
+  }
+
+  return issue.message;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/core/tools/policy-envelope/resolution-service.ts
+++ b/src/core/tools/policy-envelope/resolution-service.ts
@@ -1,0 +1,161 @@
+import type { ToolDefinition } from '@/core/types.js';
+import { ToolPolicyEnvelopeInputService } from './input-service.js';
+import type {
+  ToolPolicyEnvelope,
+  ToolPolicyHostContext,
+  ToolPolicyOperation,
+  ToolPolicyReconciliation,
+  ToolPolicyReconciliationDiagnostic,
+  ToolPolicyResolution,
+} from './types.js';
+
+const MODEL_ENVELOPE_FIELDS: Array<keyof ToolPolicyEnvelope> = [
+  'operations',
+  'intent',
+  'targetRoots',
+  'readRoots',
+  'writeRoots',
+  'expectedEffects',
+  'maxDestructiveScope',
+  'environment',
+  'confidence',
+];
+
+/**
+ * Reconciles a model-authored intent envelope with immutable host execution
+ * facts. Approval policy consumes `effective`; traces retain both sources.
+ */
+export class ToolPolicyResolutionService {
+  static resolve(args: {
+    tool: ToolDefinition;
+    input: unknown;
+  }): ToolPolicyResolution {
+    const extraction = ToolPolicyEnvelopeInputService.extract(args.input);
+    const hostOwned = extraction.error
+      ? args.tool.hostPolicy
+      : ToolPolicyResolutionService.resolveHostContext(args.tool, extraction.toolInput);
+    const diagnostics = ToolPolicyResolutionService.resolveDiagnostics({
+      modelProposed: extraction.envelope,
+      hostOwned,
+    });
+    const effective = ToolPolicyResolutionService.resolveEffectiveEnvelope({
+      modelProposed: extraction.envelope,
+      hostOwned,
+    });
+
+    return {
+      ...extraction,
+      envelope: effective,
+      reconciliation: {
+        modelProposed: extraction.envelope,
+        hostOwned,
+        effective,
+        ownership: {
+          hostOwned: [
+            ...(hostOwned ? ['authority', 'transport', 'environment'] as const : []),
+            ...(hostOwned?.operations ? ['operations'] as const : []),
+          ],
+          modelProposed: extraction.envelope
+            ? MODEL_ENVELOPE_FIELDS.filter((field) => extraction.envelope?.[field] !== undefined)
+            : [],
+        },
+        diagnostics,
+      },
+    };
+  }
+
+  static operations(args: {
+    reconciliation: ToolPolicyReconciliation;
+    fallback: ToolPolicyOperation[];
+  }): ToolPolicyOperation[] {
+    return [
+      ...(args.reconciliation.hostOwned?.operations
+        ?? args.reconciliation.effective?.operations
+        ?? args.fallback),
+    ];
+  }
+
+  private static resolveHostContext(
+    tool: ToolDefinition,
+    toolInput: unknown,
+  ): ToolPolicyHostContext | undefined {
+    return tool.resolveHostPolicy?.(toolInput) ?? tool.hostPolicy;
+  }
+
+  private static resolveEffectiveEnvelope(args: {
+    modelProposed?: ToolPolicyEnvelope;
+    hostOwned?: ToolPolicyHostContext;
+  }): ToolPolicyEnvelope | undefined {
+    if (!args.modelProposed) {
+      return undefined;
+    }
+
+    const proposedOperations = ToolPolicyResolutionService.removeTransportOperation({
+      operations: args.modelProposed.operations,
+      hostOwned: args.hostOwned,
+    });
+    const operations = args.hostOwned?.operations
+      ? [...args.hostOwned.operations]
+      : proposedOperations;
+
+    return {
+      ...args.modelProposed,
+      operations: operations.length > 0 ? operations : ['unknown'],
+      environment: args.hostOwned?.environment ?? args.modelProposed.environment,
+    };
+  }
+
+  private static removeTransportOperation(args: {
+    operations: ToolPolicyOperation[];
+    hostOwned?: ToolPolicyHostContext;
+  }): ToolPolicyOperation[] {
+    return args.hostOwned?.transport.network
+      ? args.operations.filter((operation) => operation !== 'network')
+      : args.operations;
+  }
+
+  private static resolveDiagnostics(args: {
+    modelProposed?: ToolPolicyEnvelope;
+    hostOwned?: ToolPolicyHostContext;
+  }): ToolPolicyReconciliationDiagnostic[] {
+    if (!args.modelProposed || !args.hostOwned) {
+      return [];
+    }
+
+    return [
+      ...(args.modelProposed.environment !== args.hostOwned.environment
+        ? [{
+            code: 'environment_overridden' as const,
+            message:
+              `Model proposed environment "${args.modelProposed.environment}", `
+              + `but the host targets "${args.hostOwned.environment}"; host environment applied.`,
+          }]
+        : []),
+      ...(args.hostOwned.transport.network && args.modelProposed.operations.includes('network')
+        ? [{
+            code: 'network_transport_normalized' as const,
+            message:
+              `Model proposed "network" as an operation, but ${args.hostOwned.transport.kind} `
+              + 'is host-owned transport provenance; transport operation removed.',
+          }]
+        : []),
+      ...(args.hostOwned.operations
+        && !sameOperations(args.modelProposed.operations, args.hostOwned.operations)
+        ? [{
+            code: 'operations_overridden' as const,
+            message:
+              `Model proposed operations [${args.modelProposed.operations.join(', ')}], `
+              + `but the host classifies this tool as [${args.hostOwned.operations.join(', ')}]; `
+              + 'host operations applied.',
+          }]
+        : []),
+    ];
+  }
+}
+
+function sameOperations(
+  left: readonly ToolPolicyOperation[],
+  right: readonly ToolPolicyOperation[],
+): boolean {
+  return left.length === right.length && left.every((operation) => right.includes(operation));
+}

--- a/src/core/tools/policy-envelope/schema-service.ts
+++ b/src/core/tools/policy-envelope/schema-service.ts
@@ -13,7 +13,7 @@ const POLICY_ENVELOPE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   description:
-    'Optional agent-declared intent envelope for approval/autopilot policy. Use this to honestly declare the purpose, operation categories, expected impact surface, target roots, environment, and confidence for this tool call. The harness treats this as a claim, combines it with runtime environment facts and configured policy, then decides whether to allow, request approval, or deny the action.',
+    'Optional agent-declared intent envelope for approval/autopilot policy. Use this to honestly declare the purpose, operation categories, expected impact surface, target roots, proposed environment, and confidence for this tool call. The harness treats this as a claim, reconciles it with immutable host authority, transport, environment, and tenant facts, then decides whether to allow, request approval, or deny the action.',
   properties: {
     operations: {
       type: 'array',
@@ -22,7 +22,7 @@ const POLICY_ENVELOPE_SCHEMA = {
         type: 'string',
         enum: [...TOOL_POLICY_OPERATIONS],
       },
-      description: 'Operation categories the agent expects this tool call to perform. Use multiple values when appropriate.',
+      description: 'Effect categories the agent expects this tool call to perform. Use multiple values when appropriate. Do not add "network" merely because the host uses HTTP or another network transport; transport is host-owned provenance.',
     },
     intent: {
       type: 'string',
@@ -31,7 +31,7 @@ const POLICY_ENVELOPE_SCHEMA = {
     targetRoots: {
       type: 'array',
       items: { type: 'string' },
-      description: `Project/workspace roots the agent expects this call to touch. May be empty only for read-only or state-only calls that touch no project root, such as planning tools. Calls that write, delete, move, execute, run git, or use the network must declare at least one target or write root. ${ROOT_DESCRIPTION}`,
+      description: `Project/workspace roots the agent expects this call to touch. May be empty only for read-only or state-only calls that touch no project root, such as planning tools. Calls that write, delete, move, execute, or run git must declare at least one target or write root. ${ROOT_DESCRIPTION}`,
     },
     readRoots: {
       type: 'array',
@@ -56,7 +56,7 @@ const POLICY_ENVELOPE_SCHEMA = {
     environment: {
       type: 'string',
       enum: [...TOOL_POLICY_ENVIRONMENTS],
-      description: 'Environment the agent believes this call targets.',
+      description: 'Environment the agent believes this call targets. When a tool has host-owned environment provenance, the host value is authoritative and this field remains only an auditable proposal.',
     },
     confidence: {
       type: 'string',

--- a/src/core/tools/policy-envelope/types.ts
+++ b/src/core/tools/policy-envelope/types.ts
@@ -16,7 +16,6 @@ export const TOOL_POLICY_MUTATING_OPERATIONS: ReadonlySet<ToolPolicyOperation> =
   'move',
   'execute',
   'git',
-  'network',
   'unknown',
 ]);
 
@@ -36,8 +35,69 @@ export type ToolPolicyEnvelope = {
   confidence: ToolPolicyConfidence;
 };
 
+export type ToolPolicyHostAuthority =
+  | {
+      kind: 'mcp';
+      serverId: string;
+      toolName: string;
+      tenantId?: string;
+    }
+  | {
+      kind: 'host-tool';
+      id: string;
+      tenantId?: string;
+    };
+
+export type ToolPolicyHostTransport = {
+  kind: 'in-process' | 'stdio' | 'http' | 'sse';
+  network: boolean;
+};
+
+/**
+ * Immutable execution facts supplied by the host that owns a tool.
+ *
+ * Model-authored policy envelopes may describe intent and expected effects,
+ * but they cannot replace these facts during approval evaluation.
+ */
+export type ToolPolicyHostContext = {
+  authority: ToolPolicyHostAuthority;
+  transport: ToolPolicyHostTransport;
+  environment: ToolPolicyEnvironment;
+  operations?: readonly ToolPolicyOperation[];
+};
+
+export type ToolPolicyReconciliationDiagnostic = {
+  code:
+    | 'environment_overridden'
+    | 'network_transport_normalized'
+    | 'operations_overridden';
+  message: string;
+};
+
+export type ToolPolicyFieldOwnership = {
+  hostOwned: Array<'authority' | 'transport' | 'environment' | 'operations'>;
+  modelProposed: Array<keyof ToolPolicyEnvelope>;
+};
+
+/**
+ * Trace-safe policy reconciliation record. It intentionally excludes tool
+ * business input so authorization traces do not duplicate potentially
+ * sensitive arguments.
+ */
+export type ToolPolicyReconciliation = {
+  modelProposed?: ToolPolicyEnvelope;
+  hostOwned?: ToolPolicyHostContext;
+  effective?: ToolPolicyEnvelope;
+  ownership: ToolPolicyFieldOwnership;
+  diagnostics: ToolPolicyReconciliationDiagnostic[];
+};
+
 export type ToolPolicyEnvelopeExtraction = {
   envelope?: ToolPolicyEnvelope;
   toolInput: unknown;
   error?: string;
+};
+
+export type ToolPolicyResolution = ToolPolicyEnvelopeExtraction & {
+  reconciliation: ToolPolicyReconciliation;
 };

--- a/src/core/tools/toolkits/mcp/toolkit.ts
+++ b/src/core/tools/toolkits/mcp/toolkit.ts
@@ -2,6 +2,7 @@ import {
   FileMcpActivationRepository,
   FileMcpCatalogRepository,
   FileMcpConfigRepository,
+  McpPolicyContextService,
   McpService,
   isToolAllowed,
   shouldMcpToolRequireApproval,
@@ -133,6 +134,20 @@ function createMcpCallToolTool(options: {
       },
       required: ['serverId', 'toolName', 'arguments'],
     },
+    resolveHostPolicy(raw: unknown) {
+      if (!isMcpCallInput(raw) || options.hiddenServerIds.has(raw.serverId)) {
+        return undefined;
+      }
+
+      const server = mcpService(options)
+        .listOverview()
+        .servers
+        .find((candidate) => candidate.id === raw.serverId)
+        ?.config;
+      return server
+        ? McpPolicyContextService.create({ server, toolName: raw.toolName })
+        : undefined;
+    },
     async execute(raw: unknown, execution?: ToolExecutionContext): Promise<ToolResult> {
       if (!isMcpCallInput(raw)) {
         return { ok: false, error: 'Invalid input for mcp_call_tool. Required fields: serverId, toolName, arguments.' };
@@ -168,6 +183,10 @@ function createMcpServerTool(options: {
       'Calls external MCP capability through Heddle approval and trace boundaries.',
     ].join(' '),
     parameters: options.tool.inputSchema,
+    hostPolicy: McpPolicyContextService.create({
+      server: options.server,
+      toolName: options.tool.name,
+    }),
     async execute(raw: unknown, execution?: ToolExecutionContext): Promise<ToolResult> {
       const result = await mcpService(options).callTool(
         options.server.id,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,6 +6,7 @@
 import type { ChatMessage, LlmUsage } from './llm/types.js';
 import { HeddleEventType } from './event-types.js';
 import type { AutonomyEvaluation, AutonomyPostflightAudit } from './approvals/autonomy/index.js';
+import type { ToolPolicyHostContext } from './tools/policy-envelope/types.js';
 
 /**
  * Input to the agent loop.
@@ -32,6 +33,10 @@ export type ToolDefinition = {
   requiresApproval?: boolean;
   capabilities?: string[];
   parameters: Record<string, unknown>; // JSON Schema object
+  /** Immutable execution provenance owned by the host, never by the model. */
+  hostPolicy?: ToolPolicyHostContext;
+  /** Resolve host provenance for broker tools whose authority is input-selected. */
+  resolveHostPolicy?: (input: unknown) => ToolPolicyHostContext | undefined;
   execute: (input: unknown, context?: ToolExecutionContext) => Promise<ToolResult>;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,15 @@ export {
   ToolExecutionService,
   ToolRegistry,
 } from './core/tools/index.js';
-export type { ToolToolkit, ToolToolkitContext } from './core/tools/index.js';
+export type {
+  ToolPolicyEnvironment,
+  ToolPolicyEnvelope,
+  ToolPolicyHostContext,
+  ToolPolicyOperation,
+  ToolPolicyReconciliation,
+  ToolToolkit,
+  ToolToolkitContext,
+} from './core/tools/index.js';
 export { artifactsToolkit } from './core/tools/toolkits/artifacts/index.js';
 export { AgentSkillService, AgentSkillsRuntimeContextService, FileAgentSkillActivationRepository } from './core/skills/index.js';
 export type {


### PR DESCRIPTION
## Summary

- separate host-owned MCP authority, transport, environment, tenant, and verified effect classification from model-proposed intent
- reconcile proposed and host-owned policy fields into an auditable effective policy without treating HTTP transport as a filesystem mutation
- reject model attempts to provide host-only policy fields before tool execution
- attach provenance to default MCP tools and host extensions, while keeping unclassified remote effects approval-gated
- document the SDK boundary and add local, development, production, read, mutation, and spoofing coverage

## Safety boundary

MCP descriptions and annotations remain untrusted. A remote tool is not eligible for unattended execution unless its embedding host explicitly classifies the tool effects. A model cannot downgrade a host-classified mutation or change the configured target environment.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` (125 files, 755 tests)
- `yarn test:integration` (34 files, 311 tests)
- `yarn build`

Closes #267
