### PR TITLE
feat: normalize provider usage telemetry

### DIFF
--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { AgentRunService } from '../../../core/agent/index.js';
 import type { AgentRunEvent } from '../../../core/agent/index.js';
 import { ToolApprovalPolicies, type AutopilotProfile } from '../../../core/approvals/index.js';
+import { LlmUsageService } from '../../../core/llm/usage/index.js';
 import type { ChatMessage, LlmAdapter, LlmResponse } from '../../../core/llm/types.js';
 import type { ToolDefinition } from '../../../core/types.js';
 import { createLogger } from '../../../core/utils/logger.js';
@@ -352,26 +353,27 @@ describe('AgentRunService.run', () => {
         if (messages.some((message) => message.role === 'tool')) {
           return {
             content: 'Done.',
-            usage: {
-              inputTokens: 140,
+            usage: LlmUsageService.fromProviderRequest({
+              provider: 'anthropic',
+              model: 'claude-sonnet-4-6',
+              billedInputTokens: 100,
+              cachedInputTokens: 40,
               outputTokens: 20,
-              totalTokens: 160,
-              requests: 1,
-            },
+            }),
           };
         }
 
         return {
           content: 'Inspecting first.',
           toolCalls: [{ id: 'call-1', tool: 'list_files', input: { path: '.' } }],
-          usage: {
-            inputTokens: 120,
+          usage: LlmUsageService.fromProviderRequest({
+            provider: 'anthropic',
+            model: 'claude-haiku-4-5',
+            billedInputTokens: 90,
+            cachedInputTokens: 20,
+            cacheWriteInputTokens: 10,
             outputTokens: 30,
-            totalTokens: 150,
-            cachedInputTokens: 10,
-            reasoningTokens: 6,
-            requests: 1,
-          },
+          }),
         };
       },
     };
@@ -395,11 +397,71 @@ describe('AgentRunService.run', () => {
 
     expect(result.usage).toEqual({
       inputTokens: 260,
+      billedInputTokens: 190,
       outputTokens: 50,
       totalTokens: 310,
-      cachedInputTokens: 10,
-      reasoningTokens: 6,
+      cachedInputTokens: 60,
+      cacheWriteInputTokens: 10,
       requests: 2,
+      cost: { status: 'unavailable' },
+      byModel: [
+        expect.objectContaining({
+          provider: 'anthropic',
+          model: 'claude-haiku-4-5',
+          requests: 1,
+        }),
+        expect.objectContaining({
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+          requests: 1,
+        }),
+      ],
+    });
+  });
+
+  it('includes usage from retryable model responses', async () => {
+    let calls = 0;
+    const fakeLlm: LlmAdapter = {
+      async chat(): Promise<LlmResponse> {
+        calls += 1;
+        return {
+          content: calls === 3 ? 'Recovered.' : undefined,
+          usage: LlmUsageService.fromProviderRequest({
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-6',
+            billedInputTokens: 10,
+            outputTokens: calls === 3 ? 2 : 0,
+          }),
+        };
+      },
+    };
+
+    const result = await runWithRetryTimers(() => AgentRunService.run({
+      goal: 'Retry empty responses.',
+      llm: fakeLlm,
+      tools: [],
+      maxSteps: 1,
+      logger: silentLogger,
+    }));
+
+    expect(calls).toBe(3);
+    expect(result.usage).toMatchObject({
+      inputTokens: 30,
+      billedInputTokens: 30,
+      outputTokens: 2,
+      totalTokens: 32,
+      requests: 3,
+      cost: { status: 'unavailable' },
+      byModel: [{
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        inputTokens: 30,
+        billedInputTokens: 30,
+        outputTokens: 2,
+        totalTokens: 32,
+        requests: 3,
+        cost: { status: 'unavailable' },
+      }],
     });
   });
 

--- a/src/__tests__/unit/core/llm-factory.test.ts
+++ b/src/__tests__/unit/core/llm-factory.test.ts
@@ -197,9 +197,21 @@ describe('llm adapter factory', () => {
       toolCalls: [{ id: 'call_1', tool: 'add', input: { a: 2, b: 3 } }],
       usage: {
         inputTokens: 10,
+        billedInputTokens: 10,
         outputTokens: 4,
         totalTokens: 14,
         requests: 1,
+        cost: { status: 'unavailable' },
+        byModel: [{
+          provider: 'ollama',
+          model: 'ollama/llama3.2:latest',
+          inputTokens: 10,
+          billedInputTokens: 10,
+          outputTokens: 4,
+          totalTokens: 14,
+          requests: 1,
+          cost: { status: 'unavailable' },
+        }],
       },
     });
   });
@@ -260,9 +272,21 @@ describe('llm adapter factory', () => {
     expect(result.content).toBe('ok');
     expect(result.usage).toEqual({
       inputTokens: 3,
+      billedInputTokens: 3,
       outputTokens: 1,
       totalTokens: 4,
       requests: 1,
+      cost: { status: 'unavailable' },
+      byModel: [{
+        provider: 'openrouter',
+        model: 'openrouter/meta-llama/llama-3.3-70b-instruct',
+        inputTokens: 3,
+        billedInputTokens: 3,
+        outputTokens: 1,
+        totalTokens: 4,
+        requests: 1,
+        cost: { status: 'unavailable' },
+      }],
     });
   });
 

--- a/src/__tests__/unit/core/llm-usage.test.ts
+++ b/src/__tests__/unit/core/llm-usage.test.ts
@@ -2,6 +2,7 @@ import type { Usage } from '@anthropic-ai/sdk/resources/messages';
 import type { Response as OpenAiResponse } from 'openai/resources/responses/responses.js';
 import { describe, expect, it } from 'vitest';
 import { AnthropicCodec } from '../../../core/llm/adapters/anthropic/anthropic-codec.js';
+import { OpenAiCompatibleCodec } from '../../../core/llm/adapters/openai-compatible/openai-compatible-codec.js';
 import { OpenAiCodec } from '../../../core/llm/adapters/openai/openai-codec.js';
 import { LlmUsageService } from '../../../core/llm/usage/index.js';
 
@@ -82,6 +83,45 @@ describe('LlmUsageService', () => {
       byModel: [{
         provider: 'openai',
         model: 'gpt-5.6-sol',
+        inputTokens: 100,
+        billedInputTokens: 75,
+        outputTokens: 20,
+        totalTokens: 120,
+        cachedInputTokens: 25,
+        reasoningTokens: 5,
+        requests: 1,
+        cost: { status: 'unavailable' },
+      }],
+    });
+  });
+
+  it('maps OpenAI-compatible cache reads and reasoning tokens into the normalized contract', () => {
+    const usage = OpenAiCompatibleCodec.extractUsage({
+      model: 'gateway-model',
+      usage: {
+        prompt_tokens: 100,
+        prompt_tokens_details: { cached_tokens: 25 },
+        completion_tokens: 20,
+        completion_tokens_details: { reasoning_tokens: 5 },
+        total_tokens: 120,
+      },
+    }, {
+      provider: 'litellm',
+      model: 'configured-model',
+    });
+
+    expect(usage).toEqual({
+      inputTokens: 100,
+      billedInputTokens: 75,
+      outputTokens: 20,
+      totalTokens: 120,
+      cachedInputTokens: 25,
+      reasoningTokens: 5,
+      requests: 1,
+      cost: { status: 'unavailable' },
+      byModel: [{
+        provider: 'litellm',
+        model: 'gateway-model',
         inputTokens: 100,
         billedInputTokens: 75,
         outputTokens: 20,

--- a/src/__tests__/unit/core/llm-usage.test.ts
+++ b/src/__tests__/unit/core/llm-usage.test.ts
@@ -1,0 +1,190 @@
+import type { Usage } from '@anthropic-ai/sdk/resources/messages';
+import type { Response as OpenAiResponse } from 'openai/resources/responses/responses.js';
+import { describe, expect, it } from 'vitest';
+import { AnthropicCodec } from '../../../core/llm/adapters/anthropic/anthropic-codec.js';
+import { OpenAiCodec } from '../../../core/llm/adapters/openai/openai-codec.js';
+import { LlmUsageService } from '../../../core/llm/usage/index.js';
+
+describe('LlmUsageService', () => {
+  it('preserves Anthropic billed, cache-read, and cache-write counters', () => {
+    const usage = AnthropicCodec.extractUsage({
+      input_tokens: 100,
+      output_tokens: 20,
+      cache_creation_input_tokens: 30,
+      cache_read_input_tokens: 70,
+    } as Usage, 'claude-opus-4-1');
+
+    expect(usage).toEqual({
+      inputTokens: 200,
+      billedInputTokens: 100,
+      outputTokens: 20,
+      totalTokens: 220,
+      cachedInputTokens: 70,
+      cacheWriteInputTokens: 30,
+      requests: 1,
+      cost: { status: 'unavailable' },
+      byModel: [{
+        provider: 'anthropic',
+        model: 'claude-opus-4-1',
+        inputTokens: 200,
+        billedInputTokens: 100,
+        outputTokens: 20,
+        totalTokens: 220,
+        cachedInputTokens: 70,
+        cacheWriteInputTokens: 30,
+        requests: 1,
+        cost: { status: 'unavailable' },
+      }],
+    });
+  });
+
+  it('keeps unavailable Anthropic cache counters absent for uncached responses', () => {
+    const usage = AnthropicCodec.extractUsage({
+      input_tokens: 50,
+      output_tokens: 10,
+      cache_creation_input_tokens: null,
+      cache_read_input_tokens: null,
+    } as Usage, 'claude-sonnet-4-6');
+
+    expect(usage).toMatchObject({
+      inputTokens: 50,
+      billedInputTokens: 50,
+      outputTokens: 10,
+      totalTokens: 60,
+      requests: 1,
+      cost: { status: 'unavailable' },
+    });
+    expect(usage).not.toHaveProperty('cachedInputTokens');
+    expect(usage).not.toHaveProperty('cacheWriteInputTokens');
+  });
+
+  it('maps OpenAI cache reads into the same normalized contract', () => {
+    const usage = OpenAiCodec.extractUsage({
+      model: 'gpt-5.6-sol',
+      usage: {
+        input_tokens: 100,
+        input_tokens_details: { cached_tokens: 25 },
+        output_tokens: 20,
+        output_tokens_details: { reasoning_tokens: 5 },
+        total_tokens: 120,
+      },
+    } as OpenAiResponse);
+
+    expect(usage).toEqual({
+      inputTokens: 100,
+      billedInputTokens: 75,
+      outputTokens: 20,
+      totalTokens: 120,
+      cachedInputTokens: 25,
+      reasoningTokens: 5,
+      requests: 1,
+      cost: { status: 'unavailable' },
+      byModel: [{
+        provider: 'openai',
+        model: 'gpt-5.6-sol',
+        inputTokens: 100,
+        billedInputTokens: 75,
+        outputTokens: 20,
+        totalTokens: 120,
+        cachedInputTokens: 25,
+        reasoningTokens: 5,
+        requests: 1,
+        cost: { status: 'unavailable' },
+      }],
+    });
+  });
+
+  it('aggregates requests by their actual provider and model', () => {
+    const anthropic = LlmUsageService.fromProviderRequest({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      billedInputTokens: 80,
+      cachedInputTokens: 20,
+      outputTokens: 15,
+    });
+    const openAi = LlmUsageService.fromProviderRequest({
+      provider: 'openai',
+      model: 'gpt-5.6-terra',
+      billedInputTokens: 40,
+      cachedInputTokens: 10,
+      outputTokens: 5,
+      providerReportedCostUsd: 0.012,
+    });
+
+    expect(LlmUsageService.aggregate(anthropic, openAi)).toEqual({
+      inputTokens: 150,
+      billedInputTokens: 120,
+      outputTokens: 20,
+      totalTokens: 170,
+      cachedInputTokens: 30,
+      requests: 2,
+      cost: {
+        status: 'partial',
+        reportedAmountUsd: 0.012,
+        unavailableRequests: 1,
+      },
+      byModel: [
+        expect.objectContaining({
+          provider: 'anthropic',
+          model: 'claude-haiku-4-5',
+          requests: 1,
+          cost: { status: 'unavailable' },
+        }),
+        expect.objectContaining({
+          provider: 'openai',
+          model: 'gpt-5.6-terra',
+          requests: 1,
+          cost: { status: 'reported', amountUsd: 0.012 },
+        }),
+      ],
+    });
+  });
+
+  it('merges repeated model requests without losing request count or cost', () => {
+    const first = LlmUsageService.fromProviderRequest({
+      provider: 'openai',
+      model: 'gpt-5.6-sol',
+      billedInputTokens: 30,
+      outputTokens: 10,
+      providerReportedCostUsd: 0.01,
+    });
+    const second = LlmUsageService.fromProviderRequest({
+      provider: 'openai',
+      model: 'gpt-5.6-sol',
+      billedInputTokens: 40,
+      outputTokens: 20,
+      providerReportedCostUsd: 0.02,
+    });
+
+    const usage = LlmUsageService.aggregate(first, second);
+    expect(usage?.requests).toBe(2);
+    expect(usage?.cost).toEqual({ status: 'reported', amountUsd: 0.03 });
+    expect(usage?.byModel).toEqual([
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5.6-sol',
+        inputTokens: 70,
+        outputTokens: 30,
+        requests: 2,
+        cost: { status: 'reported', amountUsd: 0.03 },
+      }),
+    ]);
+  });
+
+  it('marks legacy aggregate-only requests as unattributed', () => {
+    expect(LlmUsageService.aggregate(undefined, {
+      inputTokens: 10,
+      outputTokens: 2,
+      totalTokens: 12,
+      requests: 1,
+    })).toEqual({
+      inputTokens: 10,
+      billedInputTokens: 10,
+      outputTokens: 2,
+      totalTokens: 12,
+      requests: 1,
+      cost: { status: 'unavailable' },
+      unattributedRequests: 1,
+    });
+  });
+});

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -28,7 +28,9 @@ export type {
   ReasoningEffort,
   LlmAdapterCapabilities,
   LlmAdapterInfo,
+  LlmModelUsage,
   LlmUsage,
+  LlmUsageCost,
 } from './core/llm/types.js';
 export {
   AnthropicAdapter,
@@ -46,6 +48,10 @@ export {
   OpenAiCompatibleProviderAdapter,
   OPENAI_COMPATIBLE_PROVIDER_PROFILES,
   OpenAiCompatibleProviderProfileService,
+  LlmModelUsageSchema,
+  LlmUsageCostSchema,
+  LlmUsageSchema,
+  LlmUsageService,
   OpenAiCodexSseService,
   OpenAiOAuthFetchService,
   OpenAiProviderAdapter,
@@ -62,6 +68,7 @@ export type {
   OpenAiCompatibleProviderId,
   OpenAiCompatibleProviderProfile,
   OpenAiOAuthFetchOptions,
+  LlmProviderRequestUsage,
 } from './core/llm/index.js';
 export {
   OPENAI_MODEL_GROUPS,

--- a/src/core/agent/model/index.ts
+++ b/src/core/agent/model/index.ts
@@ -1,7 +1,6 @@
 export { AgentModelTurnService } from './model-turn-service.js';
 export { AgentModelTurnRetryService } from './model-turn-retry-service.js';
 export type {
-  AccumulateAgentUsageArgs,
   AgentModelTurnResult,
   RequestAgentModelTurnArgs,
 } from './types.js';

--- a/src/core/agent/model/model-turn-service.ts
+++ b/src/core/agent/model/model-turn-service.ts
@@ -1,10 +1,11 @@
 import { setTimeout as sleep } from 'node:timers/promises';
-import type { LlmStreamEvent, LlmUsage } from '@/core/llm/types.js';
+import { LlmUsageService } from '@/core/llm/usage/index.js';
+import type { LlmStreamEvent } from '@/core/llm/types.js';
 import { HeddleEventType } from '@/core/event-types.js';
 import { isAbortError } from '@/core/agent/utils/index.js';
 import { STREAM_UPDATE_INTERVAL_MS } from '../constants.js';
 import { AgentRunFinisher } from '../finish/index.js';
-import type { AccumulateAgentUsageArgs, AgentModelTurnResult, RequestAgentModelTurnArgs } from './types.js';
+import type { AgentModelTurnResult, RequestAgentModelTurnArgs } from './types.js';
 import { AgentModelTurnRetryService } from './model-turn-retry-service.js';
 
 /**
@@ -27,10 +28,7 @@ export class AgentModelTurnService {
     while (true) {
       try {
         const response = await AgentModelTurnService.requestOnce(args);
-        context.state.usage = AgentModelTurnService.accumulateUsage({
-          current: context.state.usage,
-          next: response.usage,
-        });
+        context.state.usage = LlmUsageService.aggregate(context.state.usage, response.usage);
 
         const retry = AgentModelTurnRetryService.resolve({ kind: 'response', response });
         if (!retry.retryable || attempt >= retry.maxAttempts) {
@@ -235,28 +233,5 @@ export class AgentModelTurnService {
 
     streamState.lastStreamEmitAt = nowMs;
     return true;
-  }
-
-  private static accumulateUsage(args: AccumulateAgentUsageArgs): LlmUsage | undefined {
-    if (!args.next) {
-      return args.current;
-    }
-
-    if (!args.current) {
-      return { ...args.next };
-    }
-
-    const cachedInputTokens = (args.current.cachedInputTokens ?? 0) + (args.next.cachedInputTokens ?? 0);
-    const reasoningTokens = (args.current.reasoningTokens ?? 0) + (args.next.reasoningTokens ?? 0);
-    const requests = (args.current.requests ?? 0) + (args.next.requests ?? 0);
-
-    return {
-      inputTokens: args.current.inputTokens + args.next.inputTokens,
-      outputTokens: args.current.outputTokens + args.next.outputTokens,
-      totalTokens: args.current.totalTokens + args.next.totalTokens,
-      cachedInputTokens: cachedInputTokens || undefined,
-      reasoningTokens: reasoningTokens || undefined,
-      requests: requests || undefined,
-    };
   }
 }

--- a/src/core/agent/model/types.ts
+++ b/src/core/agent/model/types.ts
@@ -1,4 +1,4 @@
-import type { LlmResponse, LlmUsage } from '@/core/llm/types.js';
+import type { LlmResponse } from '@/core/llm/types.js';
 import type { RunResult } from '@/core/types.js';
 import type { AgentRunContext } from '../types.js';
 
@@ -7,8 +7,3 @@ export type RequestAgentModelTurnArgs = {
 };
 
 export type AgentModelTurnResult = LlmResponse | RunResult;
-
-export type AccumulateAgentUsageArgs = {
-  current?: LlmUsage;
-  next?: LlmUsage;
-};

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -9,6 +9,7 @@ import { ConversationDirectShellLineResultSchema } from '@/core/chat/engine/dire
 import { ChatArchiveRecordSchema } from '@/core/chat/engine/sessions/archives/schemas.js';
 import { ConversationTurnPresentationSchema } from '@/core/chat/engine/turns/presentation/index.js';
 import { CustomAgentExecutionSnapshotSchema } from '@/core/custom-agents/index.js';
+import { LlmUsageSchema } from '@/core/llm/usage/index.js';
 import { REASONING_EFFORTS } from '@/core/llm/types.js';
 
 const ReasoningEffortSchema = z.enum(REASONING_EFFORTS);
@@ -123,21 +124,6 @@ const TurnSummariesSchema = z.array(z.unknown())
     const parsed = TurnSummaryReadSchema.safeParse(turn);
     return parsed.success ? [parsed.data] : [];
   }));
-
-const LlmUsageSchema = z.object({
-  inputTokens: z.number().describe('Prompt tokens charged or reported for the model request.'),
-  outputTokens: z.number().describe('Completion tokens charged or reported for the model request.'),
-  totalTokens: z.number().describe('Total tokens reported for the model request.'),
-  cachedInputTokens: z.number()
-    .describe('Input tokens served from provider-side prompt cache, when reported.')
-    .optional(),
-  reasoningTokens: z.number()
-    .describe('Reasoning tokens reported by reasoning-capable model providers.')
-    .optional(),
-  requests: z.number()
-    .describe('Number of provider requests represented by this usage aggregate.')
-    .optional(),
-});
 
 const ChatContextStatsSchema = z.object({
   estimatedHistoryTokens: z.number().describe('Estimated token count for the session history currently retained in context.'),

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -6,19 +6,11 @@
  * the runtime loop does not yet expose a full checkpoint schema.
  */
 import { z } from 'zod';
+import { LlmUsageSchema } from '@/core/llm/usage/index.js';
 
 export const HeartbeatTaskStatusSchema = z.enum(['idle', 'running', 'waiting', 'blocked', 'complete', 'failed']);
 export const HeartbeatDecisionSchema = z.enum(['continue', 'pause', 'complete', 'escalate']);
 export const HeartbeatTaskContinuationModeSchema = z.enum(['operator', 'agent']);
-
-const LlmUsageSchema = z.object({
-  inputTokens: z.number().describe('Prompt tokens reported for the heartbeat run.'),
-  outputTokens: z.number().describe('Completion tokens reported for the heartbeat run.'),
-  totalTokens: z.number().describe('Total tokens reported for the heartbeat run.'),
-  cachedInputTokens: z.number().optional().describe('Provider-reported cached input tokens.'),
-  reasoningTokens: z.number().optional().describe('Provider-reported reasoning tokens.'),
-  requests: z.number().optional().describe('Number of provider requests represented by this usage aggregate.'),
-}).passthrough();
 
 export const HeartbeatTaskSchema = z.object({
   id: z.string().describe('Stable heartbeat task identifier.'),

--- a/src/core/llm/README.md
+++ b/src/core/llm/README.md
@@ -21,6 +21,8 @@ choosing providers themselves.
   including exact replay of provider-private reasoning continuation.
 - `models/` owns the curated model catalog and model policy decisions used by
   hosts.
+- `usage/` owns provider-normalized token, cache, cost, request, and model
+  attribution telemetry.
 
 The OpenAI adapter accepts two account-sign-in lifecycles. Stored OAuth
 credentials may refresh through Heddle's credential repository. A
@@ -49,3 +51,28 @@ Provider adapters should follow the local pattern:
 Callers may still choose product semantics such as the active model, but model
 ownership, provider inference, adapter construction, and credential
 compatibility live here.
+
+## Normalized usage
+
+Every built-in adapter reports one `LlmUsage` record per successful provider
+response. The agent runtime aggregates those records across retries and model
+turns without changing their billing categories:
+
+| Heddle field | OpenAI Responses API | Anthropic Messages API |
+| --- | --- | --- |
+| `inputTokens` | `input_tokens` | `input_tokens + cache_creation_input_tokens + cache_read_input_tokens` |
+| `billedInputTokens` | `input_tokens - input_tokens_details.cached_tokens` | `input_tokens` |
+| `cachedInputTokens` | `input_tokens_details.cached_tokens` | `cache_read_input_tokens` |
+| `cacheWriteInputTokens` | unavailable | `cache_creation_input_tokens` |
+| `outputTokens` | `output_tokens` | `output_tokens` |
+| `reasoningTokens` | `output_tokens_details.reasoning_tokens` | unavailable |
+
+`billedInputTokens` is the regular, non-cache input category. Cache writes may
+also be billable, but remain separate because providers price them differently.
+`byModel` preserves the provider and actual model for each aggregate, so helper
+model usage is not silently assigned to the conversation's requested model.
+
+Costs are provider-reported only. Heddle does not estimate cost from a mutable
+pricing table. `cost.status` is therefore `unavailable` when the response does
+not include a monetary amount, `reported` when all represented requests include
+one, and `partial` when an aggregate mixes reported and unavailable requests.

--- a/src/core/llm/adapters/anthropic/anthropic-adapter.ts
+++ b/src/core/llm/adapters/anthropic/anthropic-adapter.ts
@@ -72,7 +72,7 @@ export class AnthropicAdapter implements LlmAdapter {
     return {
       content: text || undefined,
       toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-      usage: AnthropicCodec.extractUsage(response.usage),
+      usage: AnthropicCodec.extractUsage(response.usage, response.model),
     };
   }
 

--- a/src/core/llm/adapters/anthropic/anthropic-codec.ts
+++ b/src/core/llm/adapters/anthropic/anthropic-codec.ts
@@ -1,4 +1,10 @@
-import type { MessageParam, Tool, ToolResultBlockParam } from '@anthropic-ai/sdk/resources/messages';
+import type {
+  MessageParam,
+  Tool,
+  ToolResultBlockParam,
+  Usage,
+} from '@anthropic-ai/sdk/resources/messages';
+import { LlmUsageService } from '@/core/llm/usage/index.js';
 import type { ChatMessage, LlmUsage } from '@/core/llm/types.js';
 import type { ToolDefinition } from '@/core/types.js';
 
@@ -57,16 +63,18 @@ export class AnthropicCodec {
     };
   }
 
-  static extractUsage(usage: { input_tokens: number; output_tokens: number } | undefined): LlmUsage | undefined {
+  static extractUsage(usage: Usage | undefined, model: string): LlmUsage | undefined {
     if (!usage) {
       return undefined;
     }
 
-    return {
-      inputTokens: usage.input_tokens,
+    return LlmUsageService.fromProviderRequest({
+      provider: 'anthropic',
+      model,
+      billedInputTokens: usage.input_tokens,
+      cachedInputTokens: usage.cache_read_input_tokens ?? undefined,
+      cacheWriteInputTokens: usage.cache_creation_input_tokens ?? undefined,
       outputTokens: usage.output_tokens,
-      totalTokens: usage.input_tokens + usage.output_tokens,
-      requests: 1,
-    };
+    });
   }
 }

--- a/src/core/llm/adapters/openai-compatible/openai-compatible-adapter.ts
+++ b/src/core/llm/adapters/openai-compatible/openai-compatible-adapter.ts
@@ -81,7 +81,10 @@ export class OpenAiCompatibleAdapter implements LlmAdapter {
     return {
       content,
       toolCalls: OpenAiCompatibleCodec.extractToolCalls(body),
-      usage: OpenAiCompatibleCodec.extractUsage(body),
+      usage: OpenAiCompatibleCodec.extractUsage(body, {
+        provider: this.profile.id,
+        model: this.displayModel,
+      }),
     };
   }
 

--- a/src/core/llm/adapters/openai-compatible/openai-compatible-codec.ts
+++ b/src/core/llm/adapters/openai-compatible/openai-compatible-codec.ts
@@ -117,12 +117,21 @@ export class OpenAiCompatibleCodec {
 
     const inputTokens = OpenAiCompatibleCodec.numberField(usage, 'prompt_tokens') ?? 0;
     const outputTokens = OpenAiCompatibleCodec.numberField(usage, 'completion_tokens') ?? 0;
+    const promptDetails = OpenAiCompatibleCodec.objectField(usage, 'prompt_tokens_details');
+    const completionDetails = OpenAiCompatibleCodec.objectField(usage, 'completion_tokens_details');
+    const cachedInputTokens = promptDetails
+      ? OpenAiCompatibleCodec.numberField(promptDetails, 'cached_tokens')
+      : undefined;
     return LlmUsageService.fromProviderRequest({
       provider: attribution.provider,
       model: OpenAiCompatibleCodec.stringField(response, 'model') ?? attribution.model,
-      billedInputTokens: inputTokens,
+      billedInputTokens: Math.max(inputTokens - (cachedInputTokens ?? 0), 0),
+      cachedInputTokens,
       outputTokens,
       totalTokens: OpenAiCompatibleCodec.numberField(usage, 'total_tokens') ?? inputTokens + outputTokens,
+      reasoningTokens: completionDetails
+        ? OpenAiCompatibleCodec.numberField(completionDetails, 'reasoning_tokens')
+        : undefined,
     });
   }
 
@@ -157,6 +166,11 @@ export class OpenAiCompatibleCodec {
   private static numberField(value: object, key: string): number | undefined {
     const field = (value as Record<string, unknown>)[key];
     return typeof field === 'number' ? field : undefined;
+  }
+
+  private static objectField(value: object, key: string): object | undefined {
+    const field = (value as Record<string, unknown>)[key];
+    return field && typeof field === 'object' ? field : undefined;
   }
 
   private static stringField(value: object, key: string): string | undefined {

--- a/src/core/llm/adapters/openai-compatible/openai-compatible-codec.ts
+++ b/src/core/llm/adapters/openai-compatible/openai-compatible-codec.ts
@@ -1,4 +1,5 @@
-import type { ChatMessage, LlmUsage } from '@/core/llm/types.js';
+import { LlmUsageService } from '@/core/llm/usage/index.js';
+import type { ChatMessage, LlmProvider, LlmUsage } from '@/core/llm/types.js';
 import type { ToolCall, ToolDefinition } from '@/core/types.js';
 
 type OpenAiCompatibleChatCompletionMessage = {
@@ -101,7 +102,10 @@ export class OpenAiCompatibleCodec {
     return parsed.length > 0 ? parsed : undefined;
   }
 
-  static extractUsage(response: unknown): LlmUsage | undefined {
+  static extractUsage(
+    response: unknown,
+    attribution: { provider: LlmProvider; model: string },
+  ): LlmUsage | undefined {
     if (!response || typeof response !== 'object') {
       return undefined;
     }
@@ -113,12 +117,13 @@ export class OpenAiCompatibleCodec {
 
     const inputTokens = OpenAiCompatibleCodec.numberField(usage, 'prompt_tokens') ?? 0;
     const outputTokens = OpenAiCompatibleCodec.numberField(usage, 'completion_tokens') ?? 0;
-    return {
-      inputTokens,
+    return LlmUsageService.fromProviderRequest({
+      provider: attribution.provider,
+      model: OpenAiCompatibleCodec.stringField(response, 'model') ?? attribution.model,
+      billedInputTokens: inputTokens,
       outputTokens,
       totalTokens: OpenAiCompatibleCodec.numberField(usage, 'total_tokens') ?? inputTokens + outputTokens,
-      requests: 1,
-    };
+    });
   }
 
   private static toToolCall(call: ToolCall): OpenAiCompatibleToolCall {
@@ -152,5 +157,10 @@ export class OpenAiCompatibleCodec {
   private static numberField(value: object, key: string): number | undefined {
     const field = (value as Record<string, unknown>)[key];
     return typeof field === 'number' ? field : undefined;
+  }
+
+  private static stringField(value: object, key: string): string | undefined {
+    const field = (value as Record<string, unknown>)[key];
+    return typeof field === 'string' && field.trim() ? field : undefined;
   }
 }

--- a/src/core/llm/adapters/openai/openai-codec.ts
+++ b/src/core/llm/adapters/openai/openai-codec.ts
@@ -7,6 +7,7 @@ import type {
 } from 'openai/resources/responses/responses.js';
 import type { ReasoningEffort as OpenAiReasoningEffort } from 'openai/resources/shared.js';
 import { ModelPolicyService } from '@/core/llm/models/index.js';
+import { LlmUsageService } from '@/core/llm/usage/index.js';
 import type { ChatMessage, LlmUsage, ReasoningEffort } from '@/core/llm/types.js';
 import type { AssistantDiagnostics, ToolCall, ToolDefinition } from '@/core/types.js';
 
@@ -158,14 +159,16 @@ export class OpenAiCodec {
       return undefined;
     }
 
-    return {
-      inputTokens: usage.input_tokens,
+    const cachedInputTokens = usage.input_tokens_details?.cached_tokens;
+    return LlmUsageService.fromProviderRequest({
+      provider: 'openai',
+      model: response.model,
+      billedInputTokens: Math.max(usage.input_tokens - (cachedInputTokens ?? 0), 0),
+      cachedInputTokens,
       outputTokens: usage.output_tokens,
       totalTokens: usage.total_tokens,
-      cachedInputTokens: usage.input_tokens_details?.cached_tokens,
       reasoningTokens: usage.output_tokens_details?.reasoning_tokens,
-      requests: 1,
-    };
+    });
   }
 
   static buildResponsesRequest(

--- a/src/core/llm/index.ts
+++ b/src/core/llm/index.ts
@@ -42,6 +42,13 @@ export {
   LlmProviderInference,
   LlmProviderRegistry,
 } from './registry/index.js';
+export {
+  LlmModelUsageSchema,
+  LlmUsageCostSchema,
+  LlmUsageSchema,
+  LlmUsageService,
+} from './usage/index.js';
+export type { LlmProviderRequestUsage } from './usage/index.js';
 export type {
   LlmProviderAdapter,
   LlmProviderDefaultModelContext,
@@ -50,6 +57,7 @@ export type {
 export type {
   AssistantProviderContinuation,
   ChatMessage,
+  LlmModelUsage,
   LlmAdapter,
   LlmAdapterCapabilities,
   LlmAdapterCreateInput,
@@ -63,5 +71,6 @@ export type {
   LlmRuntimeContext,
   LlmStreamEvent,
   LlmUsage,
+  LlmUsageCost,
   ReasoningEffort,
 } from './types.js';

--- a/src/core/llm/types.ts
+++ b/src/core/llm/types.ts
@@ -19,19 +19,22 @@ export type LlmStreamEvent =
   | { type: 'reasoning_summary.delta'; delta: string }
   | { type: 'reasoning_summary.done'; text: string };
 
-export type LlmProvider =
-  | 'openai'
-  | 'anthropic'
-  | 'google'
-  | 'kimi'
-  | 'ollama'
-  | 'lmstudio'
-  | 'litellm'
-  | 'vllm'
-  | 'huggingface'
-  | 'openrouter'
-  | 'together'
-  | 'groq';
+export const LLM_PROVIDERS = [
+  'openai',
+  'anthropic',
+  'google',
+  'kimi',
+  'ollama',
+  'lmstudio',
+  'litellm',
+  'vllm',
+  'huggingface',
+  'openrouter',
+  'together',
+  'groq',
+] as const;
+
+export type LlmProvider = (typeof LLM_PROVIDERS)[number];
 
 export const REASONING_EFFORTS = [
   'none',
@@ -57,13 +60,44 @@ export type LlmAdapterInfo = {
   capabilities: LlmAdapterCapabilities;
 };
 
-export type LlmUsage = {
+export type LlmUsageCost =
+  | { status: 'reported'; amountUsd: number }
+  | { status: 'partial'; reportedAmountUsd: number; unavailableRequests: number }
+  | { status: 'unavailable' };
+
+export type LlmModelUsage = {
+  provider: LlmProvider;
+  model: string;
   inputTokens: number;
+  billedInputTokens: number;
   outputTokens: number;
   totalTokens: number;
   cachedInputTokens?: number;
+  cacheWriteInputTokens?: number;
+  reasoningTokens?: number;
+  requests: number;
+  cost: LlmUsageCost;
+};
+
+export type LlmUsage = {
+  /**
+   * All model input tokens, including cache reads and cache writes.
+   */
+  inputTokens: number;
+  /**
+   * Regular provider input tokens, excluding separately reported cache reads
+   * and cache writes.
+   */
+  billedInputTokens?: number;
+  outputTokens: number;
+  totalTokens: number;
+  cachedInputTokens?: number;
+  cacheWriteInputTokens?: number;
   reasoningTokens?: number;
   requests?: number;
+  cost?: LlmUsageCost;
+  byModel?: LlmModelUsage[];
+  unattributedRequests?: number;
 };
 
 /**

--- a/src/core/llm/usage/README.md
+++ b/src/core/llm/usage/README.md
@@ -1,0 +1,24 @@
+# LLM Usage
+
+This domain owns Heddle's provider-neutral usage contract and aggregation
+semantics.
+
+## Owns
+
+- translating one provider response into normalized input, cache-read,
+  cache-write, output, reasoning, request, and cost categories;
+- retaining the actual provider/model that produced usage;
+- aggregating successful responses across retries, turns, and helper models;
+- representing missing provider cost as unavailable instead of zero;
+- backward-compatible parsing of older aggregate-only persisted usage.
+
+## Does not own
+
+- model pricing tables or estimated cost;
+- provider request execution;
+- retry policy;
+- tenant budgets or enforcement.
+
+Provider codecs call `LlmUsageService.fromProviderRequest`. Runtime code calls
+`LlmUsageService.aggregate`; it must not hand-sum usage fields because doing so
+can erase cache categories, partial cost, or model attribution.

--- a/src/core/llm/usage/index.ts
+++ b/src/core/llm/usage/index.ts
@@ -1,0 +1,7 @@
+export { LlmUsageService } from './llm-usage-service.js';
+export type { LlmProviderRequestUsage } from './llm-usage-service.js';
+export {
+  LlmModelUsageSchema,
+  LlmUsageCostSchema,
+  LlmUsageSchema,
+} from './schemas.js';

--- a/src/core/llm/usage/llm-usage-service.ts
+++ b/src/core/llm/usage/llm-usage-service.ts
@@ -1,0 +1,253 @@
+import type {
+  LlmModelUsage,
+  LlmProvider,
+  LlmUsage,
+  LlmUsageCost,
+} from '../types.js';
+
+export type LlmProviderRequestUsage = {
+  provider: LlmProvider;
+  model: string;
+  billedInputTokens: number;
+  cachedInputTokens?: number;
+  cacheWriteInputTokens?: number;
+  outputTokens: number;
+  totalTokens?: number;
+  reasoningTokens?: number;
+  providerReportedCostUsd?: number;
+};
+
+/**
+ * Normalizes one provider request and aggregates usage across retries, turns,
+ * and helper models without losing cache or model attribution.
+ */
+export class LlmUsageService {
+  static fromProviderRequest(usage: LlmProviderRequestUsage): LlmUsage {
+    const inputTokens =
+      usage.billedInputTokens
+      + (usage.cachedInputTokens ?? 0)
+      + (usage.cacheWriteInputTokens ?? 0);
+    const totalTokens = usage.totalTokens ?? inputTokens + usage.outputTokens;
+    const cost = LlmUsageService.providerCost(usage.providerReportedCostUsd);
+    const optionalCounters = LlmUsageService.optionalCounters(usage);
+    const byModel: LlmModelUsage = {
+      provider: usage.provider,
+      model: usage.model,
+      inputTokens,
+      billedInputTokens: usage.billedInputTokens,
+      outputTokens: usage.outputTokens,
+      totalTokens,
+      ...optionalCounters,
+      requests: 1,
+      cost,
+    };
+
+    return {
+      inputTokens,
+      billedInputTokens: usage.billedInputTokens,
+      outputTokens: usage.outputTokens,
+      totalTokens,
+      ...optionalCounters,
+      requests: 1,
+      cost,
+      byModel: [byModel],
+    };
+  }
+
+  static aggregate(current: LlmUsage | undefined, next: LlmUsage | undefined): LlmUsage | undefined {
+    if (!next) {
+      return current ? LlmUsageService.normalize(current) : undefined;
+    }
+
+    if (!current) {
+      return LlmUsageService.normalize(next);
+    }
+
+    const normalizedCurrent = LlmUsageService.normalize(current);
+    const normalizedNext = LlmUsageService.normalize(next);
+    const unattributedRequests =
+      (normalizedCurrent.unattributedRequests ?? 0)
+      + (normalizedNext.unattributedRequests ?? 0);
+    const optionalCounters = LlmUsageService.optionalCounters({
+      cachedInputTokens: LlmUsageService.sumOptional(
+        normalizedCurrent.cachedInputTokens,
+        normalizedNext.cachedInputTokens,
+      ),
+      cacheWriteInputTokens: LlmUsageService.sumOptional(
+        normalizedCurrent.cacheWriteInputTokens,
+        normalizedNext.cacheWriteInputTokens,
+      ),
+      reasoningTokens: LlmUsageService.sumOptional(
+        normalizedCurrent.reasoningTokens,
+        normalizedNext.reasoningTokens,
+      ),
+    });
+    const requests = LlmUsageService.sumOptional(
+      normalizedCurrent.requests,
+      normalizedNext.requests,
+    );
+    const byModel = LlmUsageService.aggregateByModel([
+      ...(normalizedCurrent.byModel ?? []),
+      ...(normalizedNext.byModel ?? []),
+    ]);
+
+    return {
+      inputTokens: normalizedCurrent.inputTokens + normalizedNext.inputTokens,
+      billedInputTokens:
+        (normalizedCurrent.billedInputTokens ?? 0)
+        + (normalizedNext.billedInputTokens ?? 0),
+      outputTokens: normalizedCurrent.outputTokens + normalizedNext.outputTokens,
+      totalTokens: normalizedCurrent.totalTokens + normalizedNext.totalTokens,
+      ...optionalCounters,
+      ...(requests === undefined ? {} : { requests }),
+      cost: LlmUsageService.aggregateCost([
+        {
+          cost: normalizedCurrent.cost ?? { status: 'unavailable' },
+          requests: normalizedCurrent.requests,
+        },
+        {
+          cost: normalizedNext.cost ?? { status: 'unavailable' },
+          requests: normalizedNext.requests,
+        },
+      ]),
+      ...(byModel ? { byModel } : {}),
+      ...(unattributedRequests ? { unattributedRequests } : {}),
+    };
+  }
+
+  private static normalize(usage: LlmUsage): LlmUsage {
+    const cachedInputTokens = usage.cachedInputTokens ?? 0;
+    const cacheWriteInputTokens = usage.cacheWriteInputTokens ?? 0;
+    const billedInputTokens = usage.billedInputTokens
+      ?? Math.max(usage.inputTokens - cachedInputTokens - cacheWriteInputTokens, 0);
+    const attributedRequests = (usage.byModel ?? [])
+      .reduce((total, modelUsage) => total + modelUsage.requests, 0);
+    const unattributedRequests = usage.unattributedRequests
+      ?? Math.max((usage.requests ?? 0) - attributedRequests, 0);
+
+    return {
+      ...usage,
+      billedInputTokens,
+      cost: usage.cost ?? { status: 'unavailable' },
+      ...(usage.byModel
+        ? { byModel: usage.byModel.map((modelUsage) => ({ ...modelUsage })) }
+        : {}),
+      ...(unattributedRequests ? { unattributedRequests } : {}),
+    };
+  }
+
+  private static aggregateByModel(modelUsage: LlmModelUsage[]): LlmModelUsage[] | undefined {
+    if (modelUsage.length === 0) {
+      return undefined;
+    }
+
+    const aggregated = new Map<string, LlmModelUsage>();
+    for (const usage of modelUsage) {
+      const key = `${usage.provider}\u0000${usage.model}`;
+      const current = aggregated.get(key);
+      if (!current) {
+        aggregated.set(key, { ...usage });
+        continue;
+      }
+
+      aggregated.set(key, {
+        provider: usage.provider,
+        model: usage.model,
+        inputTokens: current.inputTokens + usage.inputTokens,
+        billedInputTokens: current.billedInputTokens + usage.billedInputTokens,
+        outputTokens: current.outputTokens + usage.outputTokens,
+        totalTokens: current.totalTokens + usage.totalTokens,
+        ...LlmUsageService.optionalCounters({
+          cachedInputTokens: LlmUsageService.sumOptional(
+            current.cachedInputTokens,
+            usage.cachedInputTokens,
+          ),
+          cacheWriteInputTokens: LlmUsageService.sumOptional(
+            current.cacheWriteInputTokens,
+            usage.cacheWriteInputTokens,
+          ),
+          reasoningTokens: LlmUsageService.sumOptional(
+            current.reasoningTokens,
+            usage.reasoningTokens,
+          ),
+        }),
+        requests: current.requests + usage.requests,
+        cost: LlmUsageService.aggregateCost([
+          { cost: current.cost, requests: current.requests },
+          { cost: usage.cost, requests: usage.requests },
+        ]),
+      });
+    }
+
+    return [...aggregated.values()];
+  }
+
+  private static providerCost(amountUsd: number | undefined): LlmUsageCost {
+    return amountUsd === undefined || !Number.isFinite(amountUsd) || amountUsd < 0
+      ? { status: 'unavailable' }
+      : { status: 'reported', amountUsd };
+  }
+
+  private static aggregateCost(
+    entries: Array<{ cost: LlmUsageCost; requests?: number }>,
+  ): LlmUsageCost {
+    let reportedAmountUsd = 0;
+    let reported = false;
+    let unavailableRequests = 0;
+
+    for (const entry of entries) {
+      if (entry.cost.status === 'reported') {
+        reported = true;
+        reportedAmountUsd += entry.cost.amountUsd;
+        continue;
+      }
+
+      if (entry.cost.status === 'partial') {
+        reported = true;
+        reportedAmountUsd += entry.cost.reportedAmountUsd;
+        unavailableRequests += entry.cost.unavailableRequests;
+        continue;
+      }
+
+      unavailableRequests += entry.requests ?? 1;
+    }
+
+    if (!reported) {
+      return { status: 'unavailable' };
+    }
+
+    return unavailableRequests > 0
+      ? { status: 'partial', reportedAmountUsd, unavailableRequests }
+      : { status: 'reported', amountUsd: reportedAmountUsd };
+  }
+
+  private static sumOptional(
+    current: number | undefined,
+    next: number | undefined,
+  ): number | undefined {
+    return current === undefined && next === undefined
+      ? undefined
+      : (current ?? 0) + (next ?? 0);
+  }
+
+  private static optionalCounters(usage: {
+    cachedInputTokens?: number;
+    cacheWriteInputTokens?: number;
+    reasoningTokens?: number;
+  }): Pick<
+    LlmUsage,
+    'cachedInputTokens' | 'cacheWriteInputTokens' | 'reasoningTokens'
+  > {
+    return {
+      ...(usage.cachedInputTokens === undefined
+        ? {}
+        : { cachedInputTokens: usage.cachedInputTokens }),
+      ...(usage.cacheWriteInputTokens === undefined
+        ? {}
+        : { cacheWriteInputTokens: usage.cacheWriteInputTokens }),
+      ...(usage.reasoningTokens === undefined
+        ? {}
+        : { reasoningTokens: usage.reasoningTokens }),
+    };
+  }
+}

--- a/src/core/llm/usage/schemas.ts
+++ b/src/core/llm/usage/schemas.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import { LLM_PROVIDERS } from '../types.js';
+
+export const LlmUsageCostSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal('reported'),
+    amountUsd: z.number().nonnegative()
+      .describe('Provider-reported cost in US dollars.'),
+  }),
+  z.object({
+    status: z.literal('partial'),
+    reportedAmountUsd: z.number().nonnegative()
+      .describe('Sum of provider-reported cost in US dollars.'),
+    unavailableRequests: z.number().int().positive()
+      .describe('Number of aggregated requests whose cost is unavailable.'),
+  }),
+  z.object({
+    status: z.literal('unavailable'),
+  }),
+]);
+
+export const LlmModelUsageSchema = z.object({
+  provider: z.enum(LLM_PROVIDERS)
+    .describe('Provider that produced this usage.'),
+  model: z.string().min(1)
+    .describe('Provider-returned model identifier.'),
+  inputTokens: z.number().int().nonnegative()
+    .describe('All input tokens, including cache reads and writes.'),
+  billedInputTokens: z.number().int().nonnegative()
+    .describe('Regular input tokens outside separately reported cache categories.'),
+  outputTokens: z.number().int().nonnegative()
+    .describe('Output tokens reported by the provider.'),
+  totalTokens: z.number().int().nonnegative()
+    .describe('Total normalized input and output tokens.'),
+  cachedInputTokens: z.number().int().nonnegative().optional()
+    .describe('Input tokens read from a provider cache.'),
+  cacheWriteInputTokens: z.number().int().nonnegative().optional()
+    .describe('Input tokens written to a provider cache.'),
+  reasoningTokens: z.number().int().nonnegative().optional()
+    .describe('Reasoning output tokens when reported separately.'),
+  requests: z.number().int().positive()
+    .describe('Successful provider responses represented by this record.'),
+  cost: LlmUsageCostSchema,
+});
+
+/**
+ * Durable, provider-neutral usage contract.
+ *
+ * New built-in adapters populate the cache, cost, and model-attribution
+ * fields. They remain optional here so existing persisted sessions and custom
+ * adapters written against the earlier aggregate-only contract still load.
+ */
+export const LlmUsageSchema = z.object({
+  inputTokens: z.number().int().nonnegative()
+    .describe('All input tokens, including cache reads and writes.'),
+  billedInputTokens: z.number().int().nonnegative().optional()
+    .describe('Regular input tokens outside separately reported cache categories.'),
+  outputTokens: z.number().int().nonnegative()
+    .describe('Output tokens reported by providers.'),
+  totalTokens: z.number().int().nonnegative()
+    .describe('Total normalized input and output tokens.'),
+  cachedInputTokens: z.number().int().nonnegative().optional()
+    .describe('Input tokens read from provider caches.'),
+  cacheWriteInputTokens: z.number().int().nonnegative().optional()
+    .describe('Input tokens written to provider caches.'),
+  reasoningTokens: z.number().int().nonnegative().optional()
+    .describe('Reasoning output tokens when reported separately.'),
+  requests: z.number().int().positive().optional()
+    .describe('Successful provider responses represented by this record.'),
+  cost: LlmUsageCostSchema.optional(),
+  byModel: z.array(LlmModelUsageSchema).optional(),
+  unattributedRequests: z.number().int().positive().optional()
+    .describe('Legacy or custom-adapter requests without provider/model attribution.'),
+}).passthrough();

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,11 @@ export type {
   TraceEvent,
   StopReason,
 } from './core/types.js';
+export type {
+  LlmModelUsage,
+  LlmUsage,
+  LlmUsageCost,
+} from './core/llm/types.js';
 
 // Provider-specific credential acquisition remains opt-in. The device-code
 // service is useful to hosted adopters that cannot receive a loopback callback.

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -5,7 +5,7 @@ import type { MemoryStatusView } from '@/core/memory/types.js';
 import type { ReviewDiffFile } from '@/core/review/index.js';
 import type { ProviderCredentialSource } from '@/core/runtime/credentials/index.js';
 import type { ReasoningEffortOption } from '@/core/llm/models/index.js';
-import type { ReasoningEffort } from '@/core/llm/types.js';
+import type { LlmUsage, ReasoningEffort } from '@/core/llm/types.js';
 import type {
   AutonomyPermissionMode,
   AutonomyPermissionModeOption,
@@ -43,13 +43,7 @@ export type ChatSessionView = {
       estimatedTokens?: number;
       toolNames?: string[];
       goal?: string;
-      usage?: {
-        inputTokens?: number;
-        outputTokens?: number;
-        totalTokens?: number;
-        cachedInputTokens?: number;
-        reasoningTokens?: number;
-      };
+      usage?: LlmUsage;
     };
     compaction?: {
       compactedMessages?: number;

--- a/src/server/controllers/trpc/control-plane/chat-session-presenter.ts
+++ b/src/server/controllers/trpc/control-plane/chat-session-presenter.ts
@@ -1,4 +1,5 @@
 import type { ChatSession, ConversationDirectShellLineResult } from '@/core/chat/types.js';
+import { LlmUsageSchema } from '@/core/llm/usage/index.js';
 import { REASONING_EFFORTS, type ReasoningEffort } from '@/core/llm/types.js';
 import { ConversationDirectShellLineResultSchema } from '@/core/chat/engine/direct-shell/result-schema.js';
 import { ConversationTurnPresentationService } from '@/core/chat/engine/turns/presentation/index.js';
@@ -59,13 +60,7 @@ export class ControlPlaneChatSessionPresenter {
       estimatedTokens: readNumber(request?.estimatedTokens),
       toolNames: readStringArray(request?.toolNames),
       goal: readString(request?.goal),
-      usage: omitEmpty({
-        inputTokens: readNumber(usage?.inputTokens),
-        outputTokens: readNumber(usage?.outputTokens),
-        totalTokens: readNumber(usage?.totalTokens),
-        cachedInputTokens: readNumber(usage?.cachedInputTokens),
-        reasoningTokens: readNumber(usage?.reasoningTokens),
-      }),
+      usage: ControlPlaneChatSessionPresenter.readUsage(usage),
     });
     const compactionView = omitEmpty({
       compactedMessages: readNumber(compaction?.compactedMessages),
@@ -208,6 +203,11 @@ export class ControlPlaneChatSessionPresenter {
   private static projectDirectShellResult(raw: unknown): ConversationDirectShellLineResult | undefined {
     const directShellResult = ConversationDirectShellLineResultSchema.safeParse(raw);
     return directShellResult.success ? directShellResult.data : undefined;
+  }
+
+  private static readUsage(raw: unknown) {
+    const usage = LlmUsageSchema.safeParse(raw);
+    return usage.success ? usage.data : undefined;
   }
 
   private static projectTurnView(raw: unknown): ChatTurnView[] {


### PR DESCRIPTION
## Summary

- normalize OpenAI, OpenAI-compatible, and Anthropic usage into one public contract
- preserve billed input, cache reads, cache writes, output, reasoning, request count, and provider/model attribution
- aggregate usage across retries, turns, and helper models without losing provider-specific categories
- represent provider cost as reported, partial, or unavailable instead of estimating from mutable price tables
- persist and present the complete normalized usage shape while remaining compatible with older aggregate-only records

## Provider mapping

- Anthropic `input_tokens` remains billed input; `cache_read_input_tokens` and `cache_creation_input_tokens` remain distinct
- OpenAI cached input is split from regular billed input; reasoning output remains distinct
- current native OpenAI and Anthropic response objects do not report dollar cost, so cost is explicitly unavailable
- custom/provider adapters can supply provider-reported cost and receive partial-cost aggregation when only some requests include it

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` (125 files, 748 tests)
- `yarn test:integration` (34 files, 312 tests)
- `yarn build`
- `git diff --check`

Closes #269
