### PR TITLE
feat: execute independent safe tool calls concurrently

### DIFF
--- a/docs/guides/programmatic/quickstart.md
+++ b/docs/guides/programmatic/quickstart.md
@@ -182,6 +182,9 @@ await runQuickstartConversationCli({
 ```
 
 Pass `maxSteps` only when the host intentionally wants a hard turn budget.
+Use `maxToolConcurrency` to bound explicitly parallel-safe tool calls. It
+defaults to `4`; set it to `1` to disable overlapping tool execution. Tools
+remain serial unless both the adapter and the tool opt in.
 
 Use `createConversationEngine` when you are ready to own the host lifecycle,
 commands, approvals, or custom rendering:

--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -12,6 +12,14 @@ import { createLogger } from '../../../core/utils/logger.js';
 
 const silentLogger = createLogger({ level: 'silent', console: false });
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 async function runWithRetryTimers(run: () => Promise<Awaited<ReturnType<typeof AgentRunService.run>>>) {
   vi.useFakeTimers();
   try {
@@ -2098,4 +2106,337 @@ describe('AgentRunService.run', () => {
       ],
     });
   });
+
+  it('bounds parallel-safe tool calls and projects mixed results in call order', async () => {
+    const started: string[] = [];
+    const completed: string[] = [];
+    let active = 0;
+    let peakActive = 0;
+    let modelCalls = 0;
+    const gates = new Map([
+      ['first', deferred<{ ok: true; output: string }>()],
+      ['second', deferred<{ ok: false; error: string }>()],
+      ['third', deferred<{ ok: true; output: string }>()],
+    ]);
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          parallelToolCalls: true,
+          reasoningSummaries: false,
+          systemMessages: true,
+          toolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        modelCalls++;
+        if (modelCalls === 1) {
+          return {
+            toolCalls: [
+              { id: 'call-first', tool: 'parallel_read', input: { id: 'first' } },
+              { id: 'call-second', tool: 'parallel_read', input: { id: 'second' } },
+              { id: 'call-third', tool: 'parallel_read', input: { id: 'third' } },
+            ],
+          };
+        }
+        return { content: 'Finished the reads.' };
+      },
+    };
+    const parallelRead: ToolDefinition = {
+      name: 'parallel_read',
+      description: 'Reads one independent value.',
+      concurrency: 'parallel-safe',
+      parameters: { type: 'object', properties: { id: { type: 'string' } } },
+      async execute(input) {
+        const id = (input as { id: string }).id;
+        const gate = gates.get(id);
+        if (!gate) {
+          throw new Error(`Missing gate for ${id}`);
+        }
+        started.push(id);
+        active++;
+        peakActive = Math.max(peakActive, active);
+        try {
+          return await gate.promise;
+        } finally {
+          active--;
+          completed.push(id);
+        }
+      },
+    };
+
+    const run = AgentRunService.run({
+      goal: 'Read three independent values.',
+      llm: fakeLlm,
+      tools: [parallelRead],
+      maxSteps: 2,
+      maxToolConcurrency: 2,
+      logger: silentLogger,
+    });
+
+    await vi.waitFor(() => expect(started).toEqual(['first', 'second']));
+    gates.get('second')?.resolve({ ok: false, error: 'second failed' });
+    await vi.waitFor(() => expect(started).toEqual(['first', 'second', 'third']));
+    gates.get('third')?.resolve({ ok: true, output: 'third result' });
+    gates.get('first')?.resolve({ ok: true, output: 'first result' });
+
+    const result = await run;
+    expect(result.outcome).toBe('done');
+    expect(peakActive).toBe(2);
+    expect(completed).toEqual(['second', 'third', 'first']);
+    expect(
+      result.transcript
+        .filter((message) => message.role === 'tool')
+        .map((message) => message.toolCallId),
+    ).toEqual(['call-first', 'call-second', 'call-third']);
+    expect(
+      result.transcript
+        .filter((message) => message.role === 'tool')
+        .map((message) => JSON.parse(message.content)),
+    ).toEqual([
+      { ok: true, output: 'first result' },
+      { ok: false, error: 'second failed' },
+      { ok: true, output: 'third result' },
+    ]);
+  });
+
+  it('resolves every same-response approval before starting allowed calls', async () => {
+    const approvalRequests: string[] = [];
+    const executions: string[] = [];
+    const approvals = new Map([
+      ['call-allowed', deferred<{ approved: true }>()],
+      ['call-denied', deferred<{ approved: false; reason: string }>()],
+    ]);
+    let modelCalls = 0;
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          parallelToolCalls: true,
+          reasoningSummaries: false,
+          systemMessages: true,
+          toolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        modelCalls++;
+        return modelCalls === 1
+          ? {
+              toolCalls: [
+                { id: 'call-allowed', tool: 'approved_read', input: { id: 'allowed' } },
+                { id: 'call-denied', tool: 'approved_read', input: { id: 'denied' } },
+              ],
+            }
+          : { content: 'Approval handling finished.' };
+      },
+    };
+    const approvedRead: ToolDefinition = {
+      name: 'approved_read',
+      description: 'Reads only after explicit approval.',
+      concurrency: 'parallel-safe',
+      requiresApproval: true,
+      parameters: { type: 'object', properties: { id: { type: 'string' } } },
+      async execute(input) {
+        const id = (input as { id: string }).id;
+        executions.push(id);
+        return { ok: true, output: id };
+      },
+    };
+
+    const run = AgentRunService.run({
+      goal: 'Run the approved reads.',
+      llm: fakeLlm,
+      tools: [approvedRead],
+      maxSteps: 2,
+      logger: silentLogger,
+      approveToolCall: async (call) => {
+        approvalRequests.push(call.id);
+        const approval = approvals.get(call.id);
+        if (!approval) {
+          throw new Error(`Missing approval for ${call.id}`);
+        }
+        return await approval.promise;
+      },
+    });
+
+    await vi.waitFor(() => expect(approvalRequests).toEqual(['call-allowed']));
+    expect(executions).toEqual([]);
+    approvals.get('call-allowed')?.resolve({ approved: true });
+    await vi.waitFor(() =>
+      expect(approvalRequests).toEqual(['call-allowed', 'call-denied']),
+    );
+    expect(executions).toEqual([]);
+    approvals.get('call-denied')?.resolve({
+      approved: false,
+      reason: 'not needed',
+    });
+
+    const result = await run;
+    expect(executions).toEqual(['allowed']);
+    expect(
+      result.transcript
+        .filter((message) => message.role === 'tool')
+        .map((message) => ({
+          id: message.toolCallId,
+          result: JSON.parse(message.content),
+        })),
+    ).toEqual([
+      {
+        id: 'call-allowed',
+        result: { ok: true, output: 'allowed' },
+      },
+      {
+        id: 'call-denied',
+        result: { ok: false, error: 'Approval denied for approved_read: not needed' },
+      },
+    ]);
+  });
+
+  it('aborts all in-flight parallel tool calls and emits one terminal event', async () => {
+    const controller = new AbortController();
+    const started: string[] = [];
+    const seenSignals: AbortSignal[] = [];
+    const events: AgentRunEvent[] = [];
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          parallelToolCalls: true,
+          reasoningSummaries: false,
+          systemMessages: true,
+          toolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        return {
+          toolCalls: [
+            { id: 'call-one', tool: 'cancellable_read', input: { id: 'one' } },
+            { id: 'call-two', tool: 'cancellable_read', input: { id: 'two' } },
+          ],
+        };
+      },
+    };
+    const cancellableRead: ToolDefinition = {
+      name: 'cancellable_read',
+      description: 'Waits until its host cancels the read.',
+      concurrency: 'parallel-safe',
+      parameters: { type: 'object', properties: { id: { type: 'string' } } },
+      async execute(input, context) {
+        const id = (input as { id: string }).id;
+        const signal = context?.signal;
+        if (!signal) {
+          throw new Error('Expected a cancellation signal');
+        }
+        started.push(id);
+        seenSignals.push(signal);
+        return await new Promise((resolve) => {
+          signal.addEventListener(
+            'abort',
+            () => resolve({ ok: false, error: `${id} cancelled` }),
+            { once: true },
+          );
+        });
+      },
+    };
+
+    const run = AgentRunService.run({
+      goal: 'Start cancellable reads.',
+      llm: fakeLlm,
+      tools: [cancellableRead],
+      maxSteps: 2,
+      maxToolConcurrency: 2,
+      abortSignal: controller.signal,
+      logger: silentLogger,
+      onEvent: (event) => events.push(event),
+    });
+
+    await vi.waitFor(() => expect(started).toEqual(['one', 'two']));
+    controller.abort();
+
+    const result = await run;
+    expect(result.outcome).toBe('interrupted');
+    expect(seenSignals).toHaveLength(2);
+    expect(seenSignals.every((signal) => signal.aborted)).toBe(true);
+    expect(
+      events.filter(
+        (event) =>
+          event.type === 'trace' && event.event.type === 'run.finished',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: 'the tool has not opted in',
+      adapterSupportsParallel: true,
+      concurrency: undefined,
+    },
+    {
+      name: 'the adapter does not support parallel calls',
+      adapterSupportsParallel: false,
+      concurrency: 'parallel-safe' as const,
+    },
+  ])(
+    'keeps calls serial when $name',
+    async ({ adapterSupportsParallel, concurrency }) => {
+      const started: string[] = [];
+      const first = deferred<{ ok: true; output: string }>();
+      let modelCalls = 0;
+      const fakeLlm: LlmAdapter = {
+        info: {
+          provider: 'openai',
+          model: 'gpt-test',
+          capabilities: {
+            parallelToolCalls: adapterSupportsParallel,
+            reasoningSummaries: false,
+            systemMessages: true,
+            toolCalls: true,
+          },
+        },
+        async chat(): Promise<LlmResponse> {
+          modelCalls++;
+          return modelCalls === 1
+            ? {
+                toolCalls: [
+                  { id: 'call-first', tool: 'serial_tool', input: { id: 'first' } },
+                  { id: 'call-second', tool: 'serial_tool', input: { id: 'second' } },
+                ],
+              }
+            : { content: 'Serial execution finished.' };
+        },
+      };
+      const serialTool: ToolDefinition = {
+        name: 'serial_tool',
+        description: 'Uses the default serial policy.',
+        parameters: { type: 'object', properties: { id: { type: 'string' } } },
+        concurrency,
+        async execute(input) {
+          const id = (input as { id: string }).id;
+          started.push(id);
+          return id === 'first'
+            ? await first.promise
+            : { ok: true, output: id };
+        },
+      };
+
+      const run = AgentRunService.run({
+        goal: 'Run the serial calls.',
+        llm: fakeLlm,
+        tools: [serialTool],
+        maxSteps: 2,
+        maxToolConcurrency: 2,
+        logger: silentLogger,
+      });
+
+      await vi.waitFor(() => expect(started).toEqual(['first']));
+      first.resolve({ ok: true, output: 'first' });
+      const result = await run;
+
+      expect(result.outcome).toBe('done');
+      expect(started).toEqual(['first', 'second']);
+    },
+  );
 });

--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -2294,6 +2294,68 @@ describe('AgentRunService.run', () => {
     ]);
   });
 
+  it('authorizes serial calls after preceding serial effects', async () => {
+    const approvalSnapshots: string[] = [];
+    const executions: string[] = [];
+    let value = 'initial';
+    let modelCalls = 0;
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          parallelToolCalls: true,
+          reasoningSummaries: false,
+          systemMessages: true,
+          toolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        modelCalls++;
+        return modelCalls === 1
+          ? {
+              toolCalls: [
+                { id: 'call-first', tool: 'serial_edit', input: { value: 'first' } },
+                { id: 'call-second', tool: 'serial_edit', input: { value: 'second' } },
+              ],
+            }
+          : { content: 'Serial edits finished.' };
+      },
+    };
+    const serialEdit: ToolDefinition = {
+      name: 'serial_edit',
+      description: 'Mutates shared state after explicit approval.',
+      requiresApproval: true,
+      parameters: { type: 'object', properties: { value: { type: 'string' } } },
+      async execute(input) {
+        const nextValue = (input as { value: string }).value;
+        executions.push(nextValue);
+        value = nextValue;
+        return { ok: true, output: nextValue };
+      },
+    };
+
+    const result = await AgentRunService.run({
+      goal: 'Apply two serial edits.',
+      llm: fakeLlm,
+      tools: [serialEdit],
+      maxSteps: 2,
+      maxToolConcurrency: 2,
+      logger: silentLogger,
+      approveToolCall: async (call) => {
+        approvalSnapshots.push(`${call.id}:${value}`);
+        return { approved: true };
+      },
+    });
+
+    expect(result.outcome).toBe('done');
+    expect(approvalSnapshots).toEqual([
+      'call-first:initial',
+      'call-second:first',
+    ]);
+    expect(executions).toEqual(['first', 'second']);
+  });
+
   it('aborts all in-flight parallel tool calls and emits one terminal event', async () => {
     const controller = new AbortController();
     const started: string[] = [];

--- a/src/__tests__/integration/tools/tools.test.ts
+++ b/src/__tests__/integration/tools/tools.test.ts
@@ -346,6 +346,10 @@ describe('readFileTool', () => {
 });
 
 describe('searchFilesTool', () => {
+  it('stays serial while its subprocess implementation is synchronous', () => {
+    expect(searchFilesTool.concurrency).toBeUndefined();
+  });
+
   it('uses fallback excludes when no project ignore file is present', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-search-'));
     await mkdir(join(root, 'src'));

--- a/src/__tests__/unit/core/agent-run-context.test.ts
+++ b/src/__tests__/unit/core/agent-run-context.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_MAX_STEPS } from '@/core/agent/constants.js';
+import {
+  DEFAULT_MAX_STEPS,
+  DEFAULT_MAX_TOOL_CONCURRENCY,
+} from '@/core/agent/constants.js';
 import { AgentRunContextBuilder } from '@/core/agent/context/index.js';
 import type { LlmAdapter } from '@/core/llm/types.js';
 
@@ -19,6 +22,7 @@ describe('AgentRunContextBuilder', () => {
 
     expect(context.maxSteps).toBe(DEFAULT_MAX_STEPS);
     expect(context.maxSteps).toBe(Number.MAX_SAFE_INTEGER);
+    expect(context.maxToolConcurrency).toBe(DEFAULT_MAX_TOOL_CONCURRENCY);
   });
 
   it('still honors explicit host step budgets', () => {
@@ -31,4 +35,29 @@ describe('AgentRunContextBuilder', () => {
 
     expect(context.maxSteps).toBe(3);
   });
+
+  it('honors an explicit tool concurrency limit', () => {
+    const context = AgentRunContextBuilder.create({
+      goal: 'Do bounded parallel reads.',
+      llm: fakeLlm,
+      maxToolConcurrency: 1,
+      tools: [],
+    });
+
+    expect(context.maxToolConcurrency).toBe(1);
+  });
+
+  it.each([0, 1.5, 33])(
+    'rejects invalid tool concurrency limit %s',
+    (maxToolConcurrency) => {
+      expect(() =>
+        AgentRunContextBuilder.create({
+          goal: 'Reject an invalid scheduler configuration.',
+          llm: fakeLlm,
+          maxToolConcurrency,
+          tools: [],
+        }),
+      ).toThrow('maxToolConcurrency must be an integer between 1 and 32');
+    },
+  );
 });

--- a/src/__tests__/unit/sdk/conversation-agent.test.ts
+++ b/src/__tests__/unit/sdk/conversation-agent.test.ts
@@ -42,6 +42,7 @@ describe('ConversationAgentService', () => {
       env: {},
       host: { events: { onActivity } },
       maxSteps: 7,
+      maxToolConcurrency: 3,
       model: 'gpt-test',
       session: {
         id: 'project-assistant',
@@ -55,6 +56,7 @@ describe('ConversationAgentService', () => {
 
     expect(agent.runtime).toEqual(expect.objectContaining({
       maxSteps: 7,
+      maxToolConcurrency: 3,
       memoryMaintenanceMode: 'none',
       model: 'gpt-test',
       stateRoot: join(workspaceRoot, '.heddle'),
@@ -79,6 +81,7 @@ describe('ConversationAgentService', () => {
       1,
       expect.objectContaining({
         maxSteps: 7,
+        maxToolConcurrency: 3,
         memoryMaintenanceMode: 'none',
         prompt: 'Summarize this project.',
         sessionId: 'project-assistant',

--- a/src/__tests__/unit/tools/tool-policy-envelope.test.ts
+++ b/src/__tests__/unit/tools/tool-policy-envelope.test.ts
@@ -239,4 +239,57 @@ describe('tool policy envelope', () => {
 
     expect(execute).not.toHaveBeenCalled();
   });
+
+  it('passes cooperative cancellation context to tool execution', async () => {
+    const controller = new AbortController();
+    const execute = vi.fn(async () => ({ ok: true, output: 'ok' }));
+    const registry = new ToolRegistry([tool({ execute })]);
+
+    await expect(ToolExecutionService.execute(
+      registry,
+      {
+        id: 'call-1',
+        tool: 'test_tool',
+        input: { path: 'README.md' },
+      },
+      30_000,
+      controller.signal,
+    )).resolves.toEqual({ ok: true, output: 'ok' });
+
+    expect(execute).toHaveBeenCalledWith(
+      { path: 'README.md' },
+      { signal: controller.signal },
+    );
+  });
+
+  it('returns promptly when an in-flight tool execution is aborted', async () => {
+    const controller = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+    const registry = new ToolRegistry([
+      tool({
+        async execute(_input, context) {
+          receivedSignal = context?.signal;
+          return await new Promise(() => undefined);
+        },
+      }),
+    ]);
+
+    const execution = ToolExecutionService.execute(
+      registry,
+      {
+        id: 'call-1',
+        tool: 'test_tool',
+        input: { path: 'README.md' },
+      },
+      30_000,
+      controller.signal,
+    );
+    controller.abort();
+
+    await expect(execution).resolves.toEqual({
+      ok: false,
+      error: 'Tool "test_tool" execution aborted',
+    });
+    expect(receivedSignal).toBe(controller.signal);
+  });
 });

--- a/src/__tests__/unit/tools/tool-policy-envelope.test.ts
+++ b/src/__tests__/unit/tools/tool-policy-envelope.test.ts
@@ -252,13 +252,15 @@ describe('tool policy envelope', () => {
         tool: 'test_tool',
         input: { path: 'README.md' },
       },
-      30_000,
-      controller.signal,
+      {
+        signal: controller.signal,
+        timeoutMs: 30_000,
+      },
     )).resolves.toEqual({ ok: true, output: 'ok' });
 
     expect(execute).toHaveBeenCalledWith(
       { path: 'README.md' },
-      { signal: controller.signal },
+      { signal: expect.any(AbortSignal) },
     );
   });
 
@@ -281,15 +283,17 @@ describe('tool policy envelope', () => {
         tool: 'test_tool',
         input: { path: 'README.md' },
       },
-      30_000,
-      controller.signal,
+      {
+        signal: controller.signal,
+        timeoutMs: 30_000,
+      },
     );
-    controller.abort();
+    controller.abort(new Error('Host cancelled tool execution'));
 
     await expect(execution).resolves.toEqual({
       ok: false,
-      error: 'Tool "test_tool" execution aborted',
+      error: 'Host cancelled tool execution',
     });
-    expect(receivedSignal).toBe(controller.signal);
+    expect(receivedSignal?.aborted).toBe(true);
   });
 });

--- a/src/core/agent/README.md
+++ b/src/core/agent/README.md
@@ -68,9 +68,11 @@ execution engine used by runtime, chat turns, memory maintenance, and examples.
   integration tests in `run-agent.test.ts`.
 - To change approval behavior, prefer the approval domain. The agent loop should
   ask for decisions, not own policy storage or UI.
-- To change tool scheduling, preserve the dual opt-in contract, finish all
-  same-response authorization decisions before execution, keep serial calls as
-  barriers, and project results in the model's original tool-call order.
+- To change tool scheduling, preserve the dual opt-in contract, authorize every
+  call in a parallel batch before that batch starts, authorize serial calls
+  immediately before execution so previews observe earlier mutations, keep
+  serial calls as barriers, and project results in the model's original
+  tool-call order.
 
 ## Tests
 

--- a/src/core/agent/README.md
+++ b/src/core/agent/README.md
@@ -9,6 +9,8 @@ execution engine used by runtime, chat turns, memory maintenance, and examples.
 - Calling the LLM adapter step by step.
 - Streaming assistant content to host callbacks.
 - Executing model-requested tools through a registry.
+- Scheduling explicitly parallel-safe tool calls within a bounded concurrency
+  limit while preserving deterministic transcript order.
 - Recording low-level `TraceEvent` evidence.
 - Emitting user-facing `ConversationActivity` for inner-loop moments that
   interfaces should render live.
@@ -34,8 +36,8 @@ execution engine used by runtime, chat turns, memory maintenance, and examples.
 - `context/`: builds the mutable run context and initial model transcript.
 - `budget/`: tracks max-step consumption for one run.
 - `model/`: owns one LLM request, stream presentation, and usage accumulation.
-- `tools/`: owns assistant tool-call turns, dispatch, approval, fallback, and
-  repeat tracking.
+- `tools/`: owns assistant tool-call turns, authorization, bounded scheduling,
+  dispatch, fallback, and repeat tracking.
 - `finish/`: owns final response, interruption, error, and max-step completion.
 - `history/`: sanitizes reused transcripts before model calls.
 - `mutation/`: classifies workspace-changing tool results.
@@ -48,6 +50,9 @@ execution engine used by runtime, chat turns, memory maintenance, and examples.
 - Add per-step behavior by explicit callbacks or future turn/runtime middleware,
   not by importing host state.
 - Add tool execution behavior through `ToolDefinition` and the tool registry.
+- Mark a tool `concurrency: 'parallel-safe'` only when independent invocations
+  can overlap without shared-state, capability, or ordering conflicts. Adapter
+  support and the host concurrency limit must also opt in before calls overlap.
 - Add trace detail by emitting typed `TraceEvent` values and updating the
   observability summarizer/projection path. If the same moment is also
   user-facing, use the live recorder helper to emit trace and activity together
@@ -63,6 +68,9 @@ execution engine used by runtime, chat turns, memory maintenance, and examples.
   integration tests in `run-agent.test.ts`.
 - To change approval behavior, prefer the approval domain. The agent loop should
   ask for decisions, not own policy storage or UI.
+- To change tool scheduling, preserve the dual opt-in contract, finish all
+  same-response authorization decisions before execution, keep serial calls as
+  barriers, and project results in the model's original tool-call order.
 
 ## Tests
 

--- a/src/core/agent/constants.ts
+++ b/src/core/agent/constants.ts
@@ -1,5 +1,7 @@
 // Omitted maxSteps should not be a practical default ceiling. Hosts that need a
 // hard budget should pass maxSteps explicitly at their boundary.
 export const DEFAULT_MAX_STEPS = Number.MAX_SAFE_INTEGER;
+export const DEFAULT_MAX_TOOL_CONCURRENCY = 4;
+export const MAX_TOOL_CONCURRENCY = 32;
 export const STREAM_UPDATE_INTERVAL_MS = 75;
 export const INTERRUPTED_SUMMARY = 'Run interrupted by host request';

--- a/src/core/agent/context/run-context-builder.ts
+++ b/src/core/agent/context/run-context-builder.ts
@@ -9,6 +9,7 @@ import { AgentStepBudget } from '../budget/index.js';
 import { AgentHistorySanitizer } from '../history/index.js';
 import { AgentMemoryCheckpointTracker } from '../memory/index.js';
 import { AgentMutationTracker } from '../mutation/index.js';
+import { AgentToolConcurrencyService } from '../tools/tool-concurrency-service.js';
 import type { BuildAgentRunContextArgs, BuildInitialAgentMessagesArgs } from './types.js';
 import type { AgentRunContext } from '../types.js';
 import type { ChatMessage } from '@/core/llm/types.js';
@@ -22,11 +23,15 @@ export class AgentRunContextBuilder {
     const trace = new TraceRecorder();
     const now = () => new Date().toISOString();
     const maxSteps = options.maxSteps ?? DEFAULT_MAX_STEPS;
+    const maxToolConcurrency = AgentToolConcurrencyService.resolveLimit(
+      options.maxToolConcurrency,
+    );
     const toolNames = registry.names();
 
     return {
       goal: options.goal,
       maxSteps,
+      maxToolConcurrency,
       llm: options.llm,
       registry,
       workspaceRoot: resolve(options.workspaceRoot ?? process.cwd()),

--- a/src/core/agent/finish/run-finisher.ts
+++ b/src/core/agent/finish/run-finisher.ts
@@ -9,8 +9,12 @@ import type { FinishAgentRunOptions } from './types.js';
  * Owns terminal run outcomes and final RunResult shaping.
  */
 export class AgentRunFinisher {
+  static isInterrupted(context: AgentRunContext): boolean {
+    return context.abortSignal?.aborted === true || context.shouldStop?.() === true;
+  }
+
   static maybeInterrupted(context: AgentRunContext, logMessage: string): RunResult | undefined {
-    if (!context.shouldStop?.()) {
+    if (!AgentRunFinisher.isInterrupted(context)) {
       return undefined;
     }
 

--- a/src/core/agent/service.ts
+++ b/src/core/agent/service.ts
@@ -13,7 +13,12 @@ export class AgentRunService {
   static async run(options: RunAgentOptions): Promise<RunResult> {
     const context = AgentRunContextBuilder.create(options);
 
-    context.log.info({ goal: options.goal, maxSteps: context.maxSteps, tools: context.registry.names() }, 'Agent run started');
+    context.log.info({
+      goal: options.goal,
+      maxSteps: context.maxSteps,
+      maxToolConcurrency: context.maxToolConcurrency,
+      tools: context.registry.names(),
+    }, 'Agent run started');
     context.live.trace({ type: HeddleEventType.runStarted, goal: options.goal, timestamp: context.now() });
 
     while (!context.budget.exhausted()) {

--- a/src/core/agent/tools/index.ts
+++ b/src/core/agent/tools/index.ts
@@ -1,8 +1,9 @@
 export { AgentToolTurnService } from './tool-turn-service.js';
 export { AgentToolDispatcher } from './tool-dispatcher.js';
+export { AgentToolConcurrencyService } from './tool-concurrency-service.js';
+export type { ScheduledAgentToolCall } from './tool-concurrency-service.js';
 export type {
   AgentToolTurnResult,
-  ExecuteAgentToolTurnArgs,
   HandleAgentToolResultArgs,
   HandleAgentToolTurnArgs,
 } from './types.js';

--- a/src/core/agent/tools/tool-concurrency-service.ts
+++ b/src/core/agent/tools/tool-concurrency-service.ts
@@ -1,0 +1,110 @@
+import { Semaphore } from 'async-mutex';
+import {
+  DEFAULT_MAX_TOOL_CONCURRENCY,
+  MAX_TOOL_CONCURRENCY,
+} from '../constants.js';
+import type { ToolCall, ToolDefinition } from '@/core/types.js';
+
+export type ScheduledAgentToolCall = {
+  index: number;
+  call: ToolCall;
+  tool?: ToolDefinition;
+};
+
+/**
+ * Owns bounded scheduling for one assistant response's authorized tool calls.
+ *
+ * Parallel execution is deliberately opt-in at both boundaries: the adapter
+ * must support parallel calls and the tool owner must declare the tool
+ * `parallel-safe`. Serial calls act as barriers, so mutations and tools with
+ * unknown safety retain deterministic execution semantics.
+ */
+export class AgentToolConcurrencyService {
+  static resolveLimit(value: number | undefined): number {
+    if (value === undefined) {
+      return DEFAULT_MAX_TOOL_CONCURRENCY;
+    }
+
+    if (!Number.isInteger(value) || value < 1 || value > MAX_TOOL_CONCURRENCY) {
+      throw new RangeError(
+        `maxToolConcurrency must be an integer between 1 and ${MAX_TOOL_CONCURRENCY}`,
+      );
+    }
+
+    return value;
+  }
+
+  static async execute<TCall extends ScheduledAgentToolCall, TResult>(args: {
+    calls: TCall[];
+    adapterSupportsParallel: boolean;
+    maxConcurrency: number;
+    isInterrupted: () => boolean;
+    execute: (call: TCall) => Promise<TResult>;
+  }): Promise<Map<number, TResult>> {
+    const results = new Map<number, TResult>();
+    const semaphore = new Semaphore(args.maxConcurrency);
+    let batch: TCall[] = [];
+
+    const flushParallelBatch = async (): Promise<void> => {
+      if (batch.length === 0) {
+        return;
+      }
+
+      const activeBatch = batch;
+      batch = [];
+      const completed = await Promise.all(
+        activeBatch.map((call) =>
+          semaphore.runExclusive(async () => {
+            if (args.isInterrupted()) {
+              return undefined;
+            }
+
+            return {
+              index: call.index,
+              result: await args.execute(call),
+            };
+          }),
+        ),
+      );
+
+      completed.forEach((entry) => {
+        if (entry) {
+          results.set(entry.index, entry.result);
+        }
+      });
+    };
+
+    for (const call of args.calls) {
+      if (args.isInterrupted()) {
+        break;
+      }
+
+      if (AgentToolConcurrencyService.canRunInParallel(call, args)) {
+        batch.push(call);
+        continue;
+      }
+
+      await flushParallelBatch();
+      if (args.isInterrupted()) {
+        break;
+      }
+
+      results.set(call.index, await args.execute(call));
+    }
+
+    await flushParallelBatch();
+    return results;
+  }
+
+  private static canRunInParallel(
+    call: ScheduledAgentToolCall,
+    args: {
+      adapterSupportsParallel: boolean;
+      maxConcurrency: number;
+    },
+  ): boolean {
+    return args.adapterSupportsParallel
+      && args.maxConcurrency > 1
+      && call.tool?.concurrency === 'parallel-safe';
+  }
+}

--- a/src/core/agent/tools/tool-concurrency-service.ts
+++ b/src/core/agent/tools/tool-concurrency-service.ts
@@ -39,6 +39,11 @@ export class AgentToolConcurrencyService {
     adapterSupportsParallel: boolean;
     maxConcurrency: number;
     isInterrupted: () => boolean;
+    /**
+     * Prepares one parallel batch or one serial barrier immediately before it
+     * executes. Returning a subset lets authorization exclude denied calls.
+     */
+    prepareStage?: (calls: TCall[]) => Promise<TCall[]>;
     execute: (call: TCall) => Promise<TResult>;
   }): Promise<Map<number, TResult>> {
     const results = new Map<number, TResult>();
@@ -46,14 +51,22 @@ export class AgentToolConcurrencyService {
     let batch: TCall[] = [];
 
     const flushParallelBatch = async (): Promise<void> => {
-      if (batch.length === 0) {
+      if (batch.length === 0 || args.isInterrupted()) {
+        batch = [];
         return;
       }
 
       const activeBatch = batch;
       batch = [];
+      const preparedBatch = args.prepareStage
+        ? await args.prepareStage(activeBatch)
+        : activeBatch;
+      if (args.isInterrupted()) {
+        return;
+      }
+
       const completed = await Promise.all(
-        activeBatch.map((call) =>
+        preparedBatch.map((call) =>
           semaphore.runExclusive(async () => {
             if (args.isInterrupted()) {
               return undefined;
@@ -89,7 +102,16 @@ export class AgentToolConcurrencyService {
         break;
       }
 
-      results.set(call.index, await args.execute(call));
+      const preparedCalls = args.prepareStage
+        ? await args.prepareStage([call])
+        : [call];
+      if (args.isInterrupted()) {
+        break;
+      }
+
+      for (const preparedCall of preparedCalls) {
+        results.set(preparedCall.index, await args.execute(preparedCall));
+      }
     }
 
     await flushParallelBatch();

--- a/src/core/agent/tools/tool-dispatcher.ts
+++ b/src/core/agent/tools/tool-dispatcher.ts
@@ -244,6 +244,7 @@ export class AgentToolDispatcher {
         'Executing repeated identical tool call; warning only',
       );
     }
+    seenToolCalls.set(signature, seenCount + 1);
 
     const startedAt = Date.now();
     const rawResult = await ToolExecutionService.execute(registry, call, {
@@ -267,7 +268,6 @@ export class AgentToolDispatcher {
       }
       : rawResult;
     const durationMs = Date.now() - startedAt;
-    seenToolCalls.set(signature, seenCount + 1);
     log.debug({ step, tool: call.tool, ok: result.ok }, 'Tool result');
     if (audit) {
       live.trace(AutonomyTraceService.postflight({

--- a/src/core/agent/tools/tool-turn-service.ts
+++ b/src/core/agent/tools/tool-turn-service.ts
@@ -12,7 +12,7 @@ import type {
 } from './types.js';
 import type { RunResult, ToolCall, ToolDefinition, ToolResult } from '@/core/types.js';
 
-type AuthorizedToolCall = {
+type ToolCallScheduleEntry = {
   index: number;
   call: ToolCall;
   tool?: ToolDefinition;
@@ -50,59 +50,60 @@ export class AgentToolTurnService {
     });
 
     const projectedByIndex = new Map<number, ProjectedToolCall>();
-    const authorizedCalls: AuthorizedToolCall[] = [];
-    for (const [index, call] of toolCalls.entries()) {
-      const interrupted = AgentRunFinisher.maybeInterrupted(
-        context,
-        'Agent run interrupted before tool authorization',
-      );
-      if (interrupted) {
-        return interrupted;
-      }
-
-      const tool = context.registry.get(call.tool);
-      const authorization = await AgentToolDispatcher.authorizeToolCall({
-        call,
-        tool,
-        step: context.state.step,
-        now: context.now,
-        approveToolCall: context.approveToolCall,
-        approvalPolicies: context.approvalPolicies,
-        workspaceRoot: context.workspaceRoot,
-        live: context.live,
-        log: context.log,
-      });
-      if (authorization.type === 'denied') {
-        projectedByIndex.set(index, {
-          effectiveCall: call,
-          result: authorization.result,
-          executed: false,
-        });
-        continue;
-      }
-
-      authorizedCalls.push({
-        index,
-        call,
-        tool,
-        autonomyEvaluation: authorization.autonomyEvaluation,
-      });
-    }
-
-    const interrupted = AgentRunFinisher.maybeInterrupted(
+    const scheduledCalls: ToolCallScheduleEntry[] = toolCalls.map((call, index) => ({
+      index,
+      call,
+      tool: context.registry.get(call.tool),
+    }));
+    const interruptedBeforeScheduling = AgentRunFinisher.maybeInterrupted(
       context,
-      'Agent run interrupted before tool execution',
+      'Agent run interrupted before tool scheduling',
     );
-    if (interrupted) {
-      return interrupted;
+    if (interruptedBeforeScheduling) {
+      return interruptedBeforeScheduling;
     }
 
     const executions = await AgentToolConcurrencyService.execute({
-      calls: authorizedCalls,
+      calls: scheduledCalls,
       adapterSupportsParallel:
         context.llm.info?.capabilities.parallelToolCalls === true,
       maxConcurrency: context.maxToolConcurrency,
       isInterrupted: () => AgentRunFinisher.isInterrupted(context),
+      prepareStage: async (calls) => {
+        const authorizedCalls: ToolCallScheduleEntry[] = [];
+        for (const scheduled of calls) {
+          if (AgentRunFinisher.isInterrupted(context)) {
+            break;
+          }
+
+          const authorization = await AgentToolDispatcher.authorizeToolCall({
+            call: scheduled.call,
+            tool: scheduled.tool,
+            step: context.state.step,
+            now: context.now,
+            approveToolCall: context.approveToolCall,
+            approvalPolicies: context.approvalPolicies,
+            workspaceRoot: context.workspaceRoot,
+            live: context.live,
+            log: context.log,
+          });
+          if (authorization.type === 'denied') {
+            projectedByIndex.set(scheduled.index, {
+              effectiveCall: scheduled.call,
+              result: authorization.result,
+              executed: false,
+            });
+            continue;
+          }
+
+          authorizedCalls.push({
+            ...scheduled,
+            autonomyEvaluation: authorization.autonomyEvaluation,
+          });
+        }
+
+        return authorizedCalls;
+      },
       execute: async (authorized) => await AgentToolDispatcher.executeToolCallWithFallback({
         call: authorized.call,
         autonomyEvaluation: authorized.autonomyEvaluation,

--- a/src/core/agent/tools/tool-turn-service.ts
+++ b/src/core/agent/tools/tool-turn-service.ts
@@ -2,15 +2,28 @@ import { AgentMemoryCheckpointTracker } from '../memory/index.js';
 import { AgentMutationTracker } from '../mutation/index.js';
 import { AgentPlanStateParser } from '../planning/index.js';
 import { AgentRunFinisher } from '../finish/index.js';
+import { AgentToolConcurrencyService } from './tool-concurrency-service.js';
 import { AgentToolDispatcher } from './tool-dispatcher.js';
 import { HeddleEventType } from '@/core/event-types.js';
 import type {
   AgentToolTurnResult,
-  ExecuteAgentToolTurnArgs,
   HandleAgentToolResultArgs,
   HandleAgentToolTurnArgs,
 } from './types.js';
-import type { RunResult, ToolResult } from '@/core/types.js';
+import type { RunResult, ToolCall, ToolDefinition, ToolResult } from '@/core/types.js';
+
+type AuthorizedToolCall = {
+  index: number;
+  call: ToolCall;
+  tool?: ToolDefinition;
+  autonomyEvaluation?: Parameters<typeof AgentToolDispatcher.executeToolCallWithFallback>[0]['autonomyEvaluation'];
+};
+
+type ProjectedToolCall = {
+  effectiveCall: ToolCall;
+  result: ToolResult;
+  executed: boolean;
+};
 
 /**
  * Owns assistant tool-call turns inside the agent loop.
@@ -36,8 +49,113 @@ export class AgentToolTurnService {
       providerContinuation: response.providerContinuation,
     });
 
-    for (const call of toolCalls) {
-      const toolCallResult = await AgentToolTurnService.execute({ context, call });
+    const projectedByIndex = new Map<number, ProjectedToolCall>();
+    const authorizedCalls: AuthorizedToolCall[] = [];
+    for (const [index, call] of toolCalls.entries()) {
+      const interrupted = AgentRunFinisher.maybeInterrupted(
+        context,
+        'Agent run interrupted before tool authorization',
+      );
+      if (interrupted) {
+        return interrupted;
+      }
+
+      const tool = context.registry.get(call.tool);
+      const authorization = await AgentToolDispatcher.authorizeToolCall({
+        call,
+        tool,
+        step: context.state.step,
+        now: context.now,
+        approveToolCall: context.approveToolCall,
+        approvalPolicies: context.approvalPolicies,
+        workspaceRoot: context.workspaceRoot,
+        live: context.live,
+        log: context.log,
+      });
+      if (authorization.type === 'denied') {
+        projectedByIndex.set(index, {
+          effectiveCall: call,
+          result: authorization.result,
+          executed: false,
+        });
+        continue;
+      }
+
+      authorizedCalls.push({
+        index,
+        call,
+        tool,
+        autonomyEvaluation: authorization.autonomyEvaluation,
+      });
+    }
+
+    const interrupted = AgentRunFinisher.maybeInterrupted(
+      context,
+      'Agent run interrupted before tool execution',
+    );
+    if (interrupted) {
+      return interrupted;
+    }
+
+    const executions = await AgentToolConcurrencyService.execute({
+      calls: authorizedCalls,
+      adapterSupportsParallel:
+        context.llm.info?.capabilities.parallelToolCalls === true,
+      maxConcurrency: context.maxToolConcurrency,
+      isInterrupted: () => AgentRunFinisher.isInterrupted(context),
+      execute: async (authorized) => await AgentToolDispatcher.executeToolCallWithFallback({
+        call: authorized.call,
+        autonomyEvaluation: authorized.autonomyEvaluation,
+        step: context.state.step,
+        now: context.now,
+        registry: context.registry,
+        seenToolCalls: context.seenToolCalls,
+        approveToolCall: context.approveToolCall,
+        approvalPolicies: context.approvalPolicies,
+        workspaceRoot: context.workspaceRoot,
+        abortSignal: context.abortSignal,
+        live: context.live,
+        log: context.log,
+      }),
+    });
+
+    executions.forEach((execution, index) => {
+      projectedByIndex.set(index, {
+        ...execution,
+        executed: true,
+      });
+    });
+
+    const interruptedDuringExecution = AgentRunFinisher.maybeInterrupted(
+      context,
+      'Agent run interrupted during tool execution',
+    );
+    if (interruptedDuringExecution) {
+      return interruptedDuringExecution;
+    }
+
+    for (const [index, call] of toolCalls.entries()) {
+      const projected = projectedByIndex.get(index);
+      if (!projected) {
+        continue;
+      }
+
+      if (!projected.executed) {
+        AgentToolTurnService.handleDeniedResult(
+          context,
+          call.id,
+          projected.result,
+        );
+        continue;
+      }
+
+      context.state.executedToolCalls++;
+      const toolCallResult = AgentToolTurnService.handleExecutedResult({
+        context,
+        effectiveCall: projected.effectiveCall,
+        toolCallId: call.id,
+        result: projected.result,
+      });
       if (toolCallResult) {
         return toolCallResult;
       }
@@ -46,56 +164,8 @@ export class AgentToolTurnService {
     return 'continue';
   }
 
-  private static async execute(args: ExecuteAgentToolTurnArgs): Promise<RunResult | undefined> {
-    const { context, call } = args;
-    const interrupted = AgentRunFinisher.maybeInterrupted(context, 'Agent run interrupted before tool execution');
-    if (interrupted) {
-      return interrupted;
-    }
-
-    const tool = context.registry.get(call.tool);
-    const authorization = await AgentToolDispatcher.authorizeToolCall({
-      call,
-      tool,
-      step: context.state.step,
-      now: context.now,
-      approveToolCall: context.approveToolCall,
-      approvalPolicies: context.approvalPolicies,
-      workspaceRoot: context.workspaceRoot,
-      live: context.live,
-      log: context.log,
-    });
-    if (authorization.type === 'denied') {
-      return AgentToolTurnService.handleDeniedResult(context, call.id, authorization.result);
-    }
-
-    const execution = await AgentToolDispatcher.executeToolCallWithFallback({
-      call,
-      autonomyEvaluation: authorization.autonomyEvaluation,
-      step: context.state.step,
-      now: context.now,
-      registry: context.registry,
-      seenToolCalls: context.seenToolCalls,
-      abortSignal: context.abortSignal,
-      approveToolCall: context.approveToolCall,
-      approvalPolicies: context.approvalPolicies,
-      workspaceRoot: context.workspaceRoot,
-      live: context.live,
-      log: context.log,
-    });
-
-    context.state.executedToolCalls++;
-
-    return AgentToolTurnService.handleExecutedResult({
-      context,
-      effectiveCall: execution.effectiveCall,
-      toolCallId: call.id,
-      result: execution.result,
-    });
-  }
-
   private static handleDeniedResult(
-    context: ExecuteAgentToolTurnArgs['context'],
+    context: HandleAgentToolTurnArgs['context'],
     toolCallId: string,
     result: ToolResult,
   ): RunResult | undefined {
@@ -141,12 +211,12 @@ export class AgentToolTurnService {
     return undefined;
   }
 
-  private static handleFailedExecution(context: ExecuteAgentToolTurnArgs['context'], _result: ToolResult): RunResult | undefined {
+  private static handleFailedExecution(context: HandleAgentToolTurnArgs['context'], _result: ToolResult): RunResult | undefined {
     context.state.consecutiveErrors++;
     return undefined;
   }
 
-  private static pushHostRequirementReminders(context: ExecuteAgentToolTurnArgs['context']): void {
+  private static pushHostRequirementReminders(context: HandleAgentToolTurnArgs['context']): void {
     const memoryReminder = AgentMemoryCheckpointTracker.buildReminder(context);
     if (memoryReminder && !context.state.reminders.memoryCheckpointSent) {
       context.state.reminders.memoryCheckpointSent = true;

--- a/src/core/agent/tools/types.ts
+++ b/src/core/agent/tools/types.ts
@@ -7,11 +7,6 @@ export type HandleAgentToolTurnArgs = {
   response: LlmResponse;
 };
 
-export type ExecuteAgentToolTurnArgs = {
-  context: AgentRunContext;
-  call: ToolCall;
-};
-
 export type AgentToolTurnResult = RunResult | 'continue';
 
 export type HandleAgentToolResultArgs = {

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -41,6 +41,7 @@ export type RunAgentOptions = {
   llm: LlmAdapter;
   tools: ToolDefinition[];
   maxSteps?: number;
+  maxToolConcurrency?: number;
   workspaceRoot?: string;
   logger?: Logger;
   history?: ChatMessage[];
@@ -83,6 +84,7 @@ export type AgentRunState = {
 export type AgentRunContext = {
   goal: string;
   maxSteps: number;
+  maxToolConcurrency: number;
   llm: LlmAdapter;
   registry: ToolRegistry;
   workspaceRoot: string;

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -132,6 +132,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
         tools,
         includeDefaultTools: false,
         maxSteps: args.maxSteps ?? agentSnapshot?.runtime.maxSteps,
+        maxToolConcurrency: args.maxToolConcurrency,
         history: preflight.compacted.history,
         systemContext: runtime.systemContext,
         onEvent: host.onEvent,

--- a/src/core/chat/engine/turns/types.ts
+++ b/src/core/chat/engine/turns/types.ts
@@ -30,6 +30,7 @@ export type RunConversationTurnArgs = {
   systemContext?: string;
   traceDir: string;
   maxSteps?: number;
+  maxToolConcurrency?: number;
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;
   memoryMaintenanceMode?: 'none' | 'background' | 'inline';
@@ -82,6 +83,7 @@ export type TurnSubmitInput = Pick<
   | 'sessionId'
   | 'prompt'
   | 'maxSteps'
+  | 'maxToolConcurrency'
   | 'searchIgnoreDirs'
   | 'includePlanTool'
   | 'abortSignal'
@@ -102,7 +104,7 @@ export type TurnPreflightInput = Pick<
 
 export type AgentLoopTurnInput = Pick<
   RunConversationTurnArgs,
-  'prompt' | 'maxSteps' | 'workspaceRoot' | 'stateRoot' | 'onTraceEvent' | 'approvalPolicies' | 'shouldStop' | 'abortSignal'
+  'prompt' | 'maxSteps' | 'maxToolConcurrency' | 'workspaceRoot' | 'stateRoot' | 'onTraceEvent' | 'approvalPolicies' | 'shouldStop' | 'abortSignal'
 >;
 
 export type TurnPersistenceInput = Pick<

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -279,6 +279,7 @@ export type SubmitConversationTurnInput = {
   agentProfileId?: string;
   agentSnapshot?: CustomAgentExecutionSnapshot;
   maxSteps?: number;
+  maxToolConcurrency?: number;
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;
   host?: ConversationEngineHost;
@@ -294,6 +295,7 @@ export type ContinueConversationTurnInput = {
   sessionId: string;
   prompt?: string;
   maxSteps?: number;
+  maxToolConcurrency?: number;
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;
   host?: ConversationEngineHost;

--- a/src/core/runtime/loop/README.md
+++ b/src/core/runtime/loop/README.md
@@ -11,3 +11,15 @@ checkpointable loop state.
 Use `AgentLoopCheckpointService` for state/checkpoint conversion and resume
 history extraction. Do not put chat sessions, heartbeat scheduling, or host UI
 logic in this folder.
+
+## Tool Concurrency
+
+`maxToolConcurrency` bounds parallel-safe tool execution for one run. The
+default is `4`, valid values are integers from `1` through `32`, and `1`
+disables overlap.
+
+Calls overlap only when both the active LLM adapter advertises
+`parallelToolCalls` and the tool declares `concurrency: 'parallel-safe'`.
+Authorization for every tool call in one model response finishes before any
+allowed call starts. Undeclared tools remain serial barriers, and results are
+projected back into the transcript in the model's original tool-call order.

--- a/src/core/runtime/loop/service.ts
+++ b/src/core/runtime/loop/service.ts
@@ -100,6 +100,7 @@ export class AgentLoopRuntimeService {
       tools,
       workspaceRoot,
       maxSteps: options.maxSteps,
+      maxToolConcurrency: options.maxToolConcurrency,
       logger,
       history: AgentLoopCheckpointService.resolveHistory(options),
       systemContext,

--- a/src/core/runtime/loop/types.ts
+++ b/src/core/runtime/loop/types.ts
@@ -87,6 +87,7 @@ export type RunAgentLoopOptions = {
   apiKey?: string;
   credential?: RuntimeProviderCredential;
   maxSteps?: number;
+  maxToolConcurrency?: number;
   workspaceRoot?: string;
   stateDir?: string;
   memoryDir?: string;

--- a/src/core/tools/README.md
+++ b/src/core/tools/README.md
@@ -10,7 +10,7 @@ workspace.
 - Toolkit composition and guardrails for duplicate toolkit ids and duplicate
   tool names.
 - Tool registry creation and duplicate-name protection at execution time.
-- Tool execution wrapper and timeout behavior.
+- Tool execution wrapper, timeout behavior, and cooperative cancellation.
 - Shared tool policy-envelope schema injection and input stripping.
 - Coding file tools under `toolkits/coding-files/`.
 - Knowledge and memory-surface tools under `toolkits/knowledge/`.
@@ -55,7 +55,8 @@ workspace.
 - `ToolRegistry`: duplicate-checked registry for the tools in one run.
 - `ToolExecutionService`: executes one tool call against a registry with
   timeout/error normalization. It removes the shared policy envelope before
-  calling the tool implementation.
+  calling the tool implementation and forwards an optional `AbortSignal`
+  through `ToolExecutionContext`.
 - `ToolBundleComposer`: toolkit composition API used by runtime default-tool
   assembly.
 - `policy-envelope/*`: the cross-tool declaration shape used by approval
@@ -79,6 +80,11 @@ workspace.
   family, policy, or composition responsibility.
 - Attach approval policy through approval/toolkit registration rather than
   embedding host approval UI in tool implementations.
+- Tools are serial by default. Declare `concurrency: 'parallel-safe'` only when
+  separate calls can safely overlap. Approval eligibility does not imply
+  concurrency safety.
+- Long-running tools should observe `ToolExecutionContext.signal` so host
+  cancellation can stop in-flight work promptly.
 - Extend the shared `ToolPolicyEnvelope` only when all tool families can use
   the field consistently. Tool-specific arguments stay in each tool schema.
 

--- a/src/core/tools/execute-tool.ts
+++ b/src/core/tools/execute-tool.ts
@@ -73,4 +73,5 @@ export class ToolExecutionService {
       };
     }
   }
+
 }

--- a/src/core/tools/toolkits/coding-files/list-files.ts
+++ b/src/core/tools/toolkits/coding-files/list-files.ts
@@ -19,6 +19,7 @@ export function createListFilesTool(options: ListFilesToolOptions = {}): ToolDef
 
   return {
     name: 'list_files',
+    concurrency: 'parallel-safe',
     description:
       'List files and directories inside a directory path. Use this to inspect folders, not to read file contents. Prefer this when you need an initial view of the workspace or want to explore an obvious nearby folder before using broader search. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders, such as "..". Defaults to the active workspace root. Returns a flat newline-separated list of entry names; directories end with /. Example inputs: { "path": "." }, { "path": ".." }',
     parameters: {

--- a/src/core/tools/toolkits/coding-files/read-file.ts
+++ b/src/core/tools/toolkits/coding-files/read-file.ts
@@ -21,6 +21,7 @@ export function createReadFileTool(options: ReadFileToolOptions = {}): ToolDefin
 
   return {
     name: 'read_file',
+    concurrency: 'parallel-safe',
     description:
       'Read the contents of a file. Use this when you already know the file path and want its contents, not when you want to inspect a directory. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Optionally limit returned lines with maxLines and start from a 0-based line offset with offset, which is useful for paging through long files. Returns the file text directly, or just the selected window when maxLines and/or offset are provided. Example inputs: { "path": "path/to/file.txt" }, { "path": "../shared-notes/summary.md" }, { "path": "src/run-agent.ts", "offset": 200, "maxLines": 120 }',
     parameters: {

--- a/src/core/tools/toolkits/coding-files/search-files.ts
+++ b/src/core/tools/toolkits/coding-files/search-files.ts
@@ -41,7 +41,6 @@ export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDef
 
   return {
     name: 'search_files',
-    concurrency: 'parallel-safe',
     description:
       'Search for literal text in files. Prefer rg when available for fast ignored-aware search, with a grep fallback. Use this when you need to locate a specific symbol or text string, not when a likely folder or file is already obvious from the workspace structure. Prefer searching for concrete terms such as tool names, symbols, or filenames rather than copying broad question text. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Returns newline-separated matches in grep-style path:line:content format, or "No matches found.". By default, search honors project ignore files such as .gitignore when rg is available; when no ignore file is present, fallback excludes avoid expensive/generated folders like dist, node_modules, and local. .git and .heddle stay protected from accidental broad searches unless explicitly targeted. Set includeIgnored: true only when intentionally searching ignored/dependency content such as node_modules. Example inputs: { "query": "createUser" }, { "query": "incident", "path": "../shared-notes" }, { "query": "packageName", "path": "node_modules", "includeIgnored": true }',
     parameters: {

--- a/src/core/tools/toolkits/coding-files/search-files.ts
+++ b/src/core/tools/toolkits/coding-files/search-files.ts
@@ -41,6 +41,7 @@ export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDef
 
   return {
     name: 'search_files',
+    concurrency: 'parallel-safe',
     description:
       'Search for literal text in files. Prefer rg when available for fast ignored-aware search, with a grep fallback. Use this when you need to locate a specific symbol or text string, not when a likely folder or file is already obvious from the workspace structure. Prefer searching for concrete terms such as tool names, symbols, or filenames rather than copying broad question text. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Returns newline-separated matches in grep-style path:line:content format, or "No matches found.". By default, search honors project ignore files such as .gitignore when rg is available; when no ignore file is present, fallback excludes avoid expensive/generated folders like dist, node_modules, and local. .git and .heddle stay protected from accidental broad searches unless explicitly targeted. Set includeIgnored: true only when intentionally searching ignored/dependency content such as node_modules. Example inputs: { "query": "createUser" }, { "query": "incident", "path": "../shared-notes" }, { "query": "packageName", "path": "node_modules", "includeIgnored": true }',
     parameters: {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -14,6 +14,18 @@ import type { ToolPolicyHostContext } from './tools/policy-envelope/types.js';
 export type RunInput = {
   goal: string;
   maxSteps?: number;
+  maxToolConcurrency?: number;
+};
+
+export type ToolConcurrencyMode = 'serial' | 'parallel-safe';
+
+export type ToolExecutionContext = {
+  /**
+   * Cooperative cancellation for an in-flight tool call. Tool implementations
+   * should pass this signal to cancellable I/O instead of creating a detached
+   * request that outlives the agent run.
+   */
+  signal?: AbortSignal;
 };
 
 /**
@@ -32,6 +44,12 @@ export type ToolDefinition = {
   description: string;
   requiresApproval?: boolean;
   capabilities?: string[];
+  /**
+   * Defaults to `serial`. `parallel-safe` is an explicit guarantee from the
+   * tool owner that separate calls may overlap without conflicting effects or
+   * shared mutable state.
+   */
+  concurrency?: ToolConcurrencyMode;
   parameters: Record<string, unknown>; // JSON Schema object
   /** Immutable execution provenance owned by the host, never by the model. */
   hostPolicy?: ToolPolicyHostContext;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -19,15 +19,6 @@ export type RunInput = {
 
 export type ToolConcurrencyMode = 'serial' | 'parallel-safe';
 
-export type ToolExecutionContext = {
-  /**
-   * Cooperative cancellation for an in-flight tool call. Tool implementations
-   * should pass this signal to cancellable I/O instead of creating a detached
-   * request that outlives the agent run.
-   */
-  signal?: AbortSignal;
-};
-
 /**
  * A tool the agent can invoke.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export type {
   RunResult,
   ModelRunFailureCode,
   ToolDefinition,
+  ToolConcurrencyMode,
   ToolExecutionContext,
   ToolCall,
   ToolResult,

--- a/src/sdk/conversation/console/README.md
+++ b/src/sdk/conversation/console/README.md
@@ -115,9 +115,11 @@ The default model order is:
 5. `ANTHROPIC_MODEL`
 6. Heddle's built-in OpenAI default
 
-The runner defaults memory maintenance to `none` and leaves `maxSteps`
-unset. Hosts that need background maintenance or a hard turn budget should
-override those values once at this boundary.
+The runner defaults memory maintenance to `none`, leaves `maxSteps` unset, and
+uses the core default `maxToolConcurrency` of `4`. Hosts that need background
+maintenance, a hard turn budget, or a different bound for explicitly
+parallel-safe tools should override those values once at this boundary. Set
+`maxToolConcurrency` to `1` to disable overlapping tool execution.
 
 When a host needs custom UI, routing, approvals, or domain commands, use
 `createConversationEngine` directly and treat this runner as the migration

--- a/src/sdk/conversation/console/service.ts
+++ b/src/sdk/conversation/console/service.ts
@@ -334,6 +334,7 @@ export class QuickstartConversationCliRunnerService {
       sessionId: input.session.id,
       prompt: submittedPrompt,
       maxSteps: input.defaults.maxSteps,
+      maxToolConcurrency: input.defaults.maxToolConcurrency,
       host: input.host,
       memoryMaintenanceMode: input.defaults.memoryMaintenanceMode,
     });

--- a/src/sdk/conversation/console/types.ts
+++ b/src/sdk/conversation/console/types.ts
@@ -64,6 +64,7 @@ export type QuickstartConversationCliRunnerOptions = {
   oncePrompt?: string;
   prompts?: string[];
   maxSteps?: number;
+  maxToolConcurrency?: number;
   reasoningEffort?: ConversationSdkRuntimeDefaultsInput['reasoningEffort'];
   apiKey?: string;
   credential?: RuntimeProviderCredential;

--- a/src/sdk/conversation/headless/service.ts
+++ b/src/sdk/conversation/headless/service.ts
@@ -51,6 +51,7 @@ export class ConversationAgentService {
         'env',
         'host',
         'maxSteps',
+        'maxToolConcurrency',
         'memoryMaintenanceMode',
         'model',
         'reasoningEffort',
@@ -58,7 +59,7 @@ export class ConversationAgentService {
         'stateRoot',
         'workspaceRoot',
       ]),
-      ...omit(defaults, ['maxSteps']),
+      ...omit(defaults, ['maxSteps', 'maxToolConcurrency']),
     } satisfies ConversationEngineConfig;
 
     this.engine = createConversationEngine(engineConfig);
@@ -121,6 +122,8 @@ export class ConversationAgentService {
       sessionId: session.session.id,
       prompt,
       maxSteps: input.maxSteps ?? this.runtime.maxSteps,
+      maxToolConcurrency:
+        input.maxToolConcurrency ?? this.runtime.maxToolConcurrency,
       memoryMaintenanceMode: input.memoryMaintenanceMode ?? this.runtime.memoryMaintenanceMode,
       abortSignal: input.abortSignal
         ? AbortSignal.any([this.lifecycleController.signal, input.abortSignal])

--- a/src/sdk/conversation/runtime/service.ts
+++ b/src/sdk/conversation/runtime/service.ts
@@ -23,6 +23,9 @@ export class ConversationSdkRuntimeService {
 
     return {
       ...(options.maxSteps === undefined ? {} : { maxSteps: options.maxSteps }),
+      ...(options.maxToolConcurrency === undefined
+        ? {}
+        : { maxToolConcurrency: options.maxToolConcurrency }),
       memoryMaintenanceMode: options.memoryMaintenanceMode ?? DEFAULT_MEMORY_MAINTENANCE_MODE,
       model: ConversationSdkRuntimeService.resolveModel(options),
       reasoningEffort: ConversationSdkRuntimeService.resolveReasoningEffort(

--- a/src/sdk/conversation/runtime/types.ts
+++ b/src/sdk/conversation/runtime/types.ts
@@ -22,6 +22,7 @@ export type ConversationSdkRuntimeDefaultsInput = {
   workspaceRoot?: string;
   stateRoot?: string;
   maxSteps?: number;
+  maxToolConcurrency?: number;
   reasoningEffort?: ReasoningEffort | string;
   memoryMaintenanceMode?: ConversationSdkMemoryMaintenanceMode;
   env?: Pick<
@@ -35,6 +36,7 @@ export type ConversationSdkRuntimeDefaults = {
   workspaceRoot: string;
   stateRoot: string;
   maxSteps?: number;
+  maxToolConcurrency?: number;
   reasoningEffort?: ReasoningEffort;
   memoryMaintenanceMode: ConversationSdkMemoryMaintenanceMode;
 };


### PR DESCRIPTION
## Summary

- add a bounded `maxToolConcurrency` run option with a safe default of 4
- run same-response tool calls concurrently only when both the adapter supports it and the tool explicitly declares `concurrency: 'parallel-safe'`
- keep undeclared tools serial, treat serial calls as barriers, and project all results back into transcript order
- finish all same-response authorization decisions before starting execution and never start denied calls
- propagate cooperative cancellation into every in-flight tool call
- opt the built-in read, list, and search file tools into parallel-safe execution

## Safety guarantees

- valid concurrency is bounded to integers from 1 through 32; `1` disables overlap
- mutating and capability-conflicting tools remain serial by default
- mixed success and failure does not change tool-result ordering
- cancellation produces one interrupted terminal result while signaling all active tools

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` — 124 files, 748 tests
- `yarn test:integration` — 34 files, 316 tests
- `yarn vitest run src/__tests__/integration/core/run-agent.test.ts` — 42 tests
- `yarn build`

Closes #270