### PR TITLE
release: prepare v5.5.0

### DIFF
--- a/docs/releases/v5.5.0.md
+++ b/docs/releases/v5.5.0.md
@@ -1,0 +1,83 @@
+# Heddle v5.5.0
+
+Heddle v5.5 expands the models product teams can build with while making
+long-running agent execution safer, more observable, and more predictable.
+This release adds GPT-5.6 and Kimi Platform support, provider-neutral usage
+telemetry, host-owned MCP policy provenance, deterministic resource cleanup,
+and bounded parallel execution for explicitly safe tools.
+
+## Model and provider support
+
+- **GPT-5.6 is available across Heddle model selectors.** Hosts can choose
+  `gpt-5.6-sol`, `gpt-5.6-terra`, or `gpt-5.6-luna`; the `gpt-5.6` alias routes
+  to Sol. Existing defaults remain unchanged, so adoption is opt-in.
+- **Kimi Platform K3 has a dedicated adapter.** `kimi/kimi-k3` supports
+  streaming, tool-call continuation, reasoning-effort policy, and the Kimi
+  continuation state required across tool turns without exposing private
+  reasoning content.
+- **Provider usage has one normalized contract.** Successful responses retain
+  provider and model attribution together with input, cache-read, cache-write,
+  output, reasoning, request, and reported-cost categories. Aggregation
+  preserves those categories across retries, turns, and helper-model calls.
+- **Compatible providers retain detailed usage.** OpenAI-compatible and
+  Anthropic responses preserve cache and reasoning-token details when the
+  provider reports them. Heddle does not invent pricing or treat unavailable
+  cost as zero.
+
+## Safer and faster tool execution
+
+- **Explicitly parallel-safe calls can overlap.** A provider capability, the
+  tool owner's `concurrency: "parallel-safe"` declaration, and the host
+  concurrency limit must all opt in before Heddle executes calls concurrently.
+- **Ordering stays deterministic.** Parallel results are returned to the model
+  in its original call order. Serial and mutating tools remain barriers and are
+  authorized immediately before execution so approval previews include earlier
+  effects.
+- **Approval remains conservative.** Every call in a parallel batch is
+  authorized before the batch starts. Denied calls produce normal denied tool
+  results without preventing approved peers from running.
+- **MCP authority is host-owned.** Server identity, transport, target
+  environment, tenant provenance, and host-verified operation classes cannot be
+  supplied or overridden by the model. Remote mutations remain approval-gated
+  independently of model-claimed local roots.
+
+## Runtime reliability
+
+- **Conversation-agent cleanup is deterministic.** Closing a conversation
+  agent aborts in-flight work, waits for owned runs to settle, and releases MCP
+  resources without leaving background work behind.
+- **MCP connections are operation-scoped.** Discovery and tool calls close
+  their client and transport resources on success, failure, and cancellation.
+- **Run-completion notifications stay concise.** Desktop and web notifications
+  summarize terminal status instead of reproducing an entire long answer.
+
+## Upgrade notes
+
+- Install `@roackb2/heddle@5.5.0` for the new model, telemetry, policy, lifecycle,
+  and scheduling behavior.
+- `@roackb2/heddle-remote@5.5.0` is released in lockstep. Its ordered run
+  protocol remains compatible.
+- To use Kimi Platform, set `MOONSHOT_API_KEY` or
+  `KIMI_PLATFORM_API_KEY`, then select `kimi/kimi-k3`. Kimi Code membership keys
+  use a different service and are intentionally unsupported by this adapter.
+- Tools remain serial by default. Only mark a tool `parallel-safe` when
+  independent invocations have no shared-state, ordering, capability, or
+  mutation conflicts.
+- Existing persisted aggregate-only usage records remain readable. New runs can
+  expose the richer provider-neutral usage categories when providers supply
+  them.
+
+## Verification
+
+- `yarn build`
+- `yarn test`
+- `npm pack --dry-run --cache /tmp/heddle-npm-cache`
+- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`
+- Pull-request lint, typecheck, unit, integration, browser-integration, and
+  PostgreSQL-reference checks
+
+## Release state
+
+- Package versions are `5.5.0` in both manifests.
+- The latest published npm and GitHub release before this release is `5.4.0`.
+- This note is curated from the real git range `v5.4.0..HEAD`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "An open-source AI coding agent runtime and terminal CLI for real repositories, with persistent memory, sessions, approvals, heartbeat, and a browser control plane",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/packages/heddle-remote/package.json
+++ b/packages/heddle-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle-remote",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Browser-safe protocol and run-consumer services for remotely hosted Heddle conversations",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `@roackb2/heddle` and `@roackb2/heddle-remote` from `5.4.0` to `5.5.0` in lockstep
- add curated release notes for the real `v5.4.0..HEAD` range
- document GPT-5.6 and Kimi support, provider-neutral usage telemetry, bounded parallel-safe tool execution, host-owned MCP policy, deterministic cleanup, and concise completion notifications

## Why a minor release

This range adds opt-in public capabilities and provider/runtime behavior while preserving existing defaults and compatibility, so `5.5.0` is the appropriate SemVer increment.

## Verification

- `yarn build`
- `yarn test` — 130 unit files / 783 tests and 35 integration files / 321 tests (1,104 total)
- `npm pack --dry-run --cache /tmp/heddle-npm-cache`
- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`
- both generated package manifests report version `5.5.0`

## Release boundary

After this PR is merged, tag the merged `main` commit as `v5.5.0`, create the GitHub release from `docs/releases/v5.5.0.md`, then publish `@roackb2/heddle-remote` before `@roackb2/heddle`.