### PR TITLE
fix: bound live subscription buffers

### DIFF
--- a/src/__tests__/unit/core/runtime-subscription-stream.test.ts
+++ b/src/__tests__/unit/core/runtime-subscription-stream.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { RuntimeSubscriptionStream } from '@/core/runtime/subscriptions/index.js';
+import {
+  RuntimeSubscriptionOverflowError,
+  RuntimeSubscriptionStream,
+} from '@/core/runtime/subscriptions/index.js';
+import type { RuntimeSubscriptionSink } from '@/core/runtime/subscriptions/index.js';
 
 describe('RuntimeSubscriptionStream', () => {
   it('buffers source events until a subscription reader asks for them', async () => {
@@ -56,4 +60,110 @@ describe('RuntimeSubscriptionStream', () => {
 
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
+
+  it('preserves event order at the configured buffer bound', async () => {
+    const stream = RuntimeSubscriptionStream.fromSources<number>({
+      maxBufferedEvents: 3,
+      sources: [
+        (sink) => {
+          [1, 2, 3].forEach((event) => sink.push(event));
+          sink.close();
+        },
+      ],
+    });
+
+    await expect(collect(stream)).resolves.toEqual([1, 2, 3]);
+  });
+
+  it('fails a stalled consumer explicitly when its buffer overflows', async () => {
+    const cleanup = vi.fn();
+    const onOverflow = vi.fn();
+    const stream = RuntimeSubscriptionStream.fromSources<string>({
+      maxBufferedEvents: 1,
+      onOverflow,
+      sources: [
+        (sink) => {
+          sink.push('retained');
+          sink.push('overflow');
+          return cleanup;
+        },
+      ],
+    });
+
+    await expect(collect(stream)).rejects.toMatchObject({
+      name: 'RuntimeSubscriptionOverflowError',
+      code: 'RUNTIME_SUBSCRIPTION_OVERFLOW',
+      maxBufferedEvents: 1,
+      bufferedEvents: 1,
+    });
+    expect(onOverflow).toHaveBeenCalledWith({
+      maxBufferedEvents: 1,
+      bufferedEvents: 1,
+    });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('discards buffered events and releases waiters when cancelled', async () => {
+    const abort = new AbortController();
+    const cleanup = vi.fn();
+    const stream = RuntimeSubscriptionStream.fromSources<string>({
+      signal: abort.signal,
+      sources: [
+        (sink) => {
+          sink.push('stale');
+          return cleanup;
+        },
+      ],
+    });
+    const iterator = stream[Symbol.asyncIterator]();
+
+    abort.abort();
+
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates fast and slow consumers of the same event source', async () => {
+    let fastSink: RuntimeSubscriptionSink<string> | undefined;
+    let slowSink: RuntimeSubscriptionSink<string> | undefined;
+    const fast = RuntimeSubscriptionStream.fromSources<string>({
+      maxBufferedEvents: 1,
+      sources: [(sink) => {
+        fastSink = sink;
+      }],
+    });
+    const slow = RuntimeSubscriptionStream.fromSources<string>({
+      maxBufferedEvents: 1,
+      sources: [(sink) => {
+        slowSink = sink;
+      }],
+    });
+    const fastIterator = fast[Symbol.asyncIterator]();
+    const slowIterator = slow[Symbol.asyncIterator]();
+
+    fastSink?.push('one');
+    slowSink?.push('one');
+    await expect(fastIterator.next()).resolves.toEqual({ done: false, value: 'one' });
+
+    fastSink?.push('two');
+    slowSink?.push('two');
+    await expect(fastIterator.next()).resolves.toEqual({ done: false, value: 'two' });
+    await expect(slowIterator.next()).rejects.toBeInstanceOf(RuntimeSubscriptionOverflowError);
+
+    fast.close();
+    await expect(fastIterator.next()).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it('rejects invalid buffer bounds', () => {
+    expect(() => RuntimeSubscriptionStream.fromSources({ maxBufferedEvents: 0 })).toThrow(RangeError);
+    expect(() => RuntimeSubscriptionStream.fromSources({ maxBufferedEvents: 1.5 })).toThrow(RangeError);
+  });
 });
+
+async function collect<Event>(stream: AsyncIterable<Event>): Promise<Event[]> {
+  const events: Event[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}

--- a/src/core/runtime/subscriptions/README.md
+++ b/src/core/runtime/subscriptions/README.md
@@ -6,7 +6,7 @@ transport primitive used by control-plane subscriptions.
 The service intentionally does not know about tRPC, SSE, conversation activity,
 heartbeat task records, or session metadata. Callers provide event sources such
 as an `EventEmitter` listener, a file watcher, or an interval; the stream owns
-buffering, waiter wakeups, abort handling, and cleanup.
+bounded buffering, waiter wakeups, abort handling, and cleanup.
 
 Use this when a host needs to bridge callback-style runtime/server events into
 a subscription transport. Keep domain vocabulary and event projection in the
@@ -30,9 +30,22 @@ event source callback -> sink.push(event) -> stream buffer/waiter -> for await
 
 If the client is already waiting for the next event, `push` wakes that reader.
 If the client is busy, `push` buffers the event until the reader asks again.
+Each stream retains at most `maxBufferedEvents` payloads (256 by default).
+Exceeding that bound fails the iterator with
+`RuntimeSubscriptionOverflowError`, releases the queued payloads and source
+resources, and invokes the optional `onOverflow` observation hook. Hosts should
+record that hook in their metrics or tracing system.
+
+Overflow never drops events while pretending the subscription is complete.
+When a source has durable replay, the client reconnects from its last consumed
+cursor. Conversation-run streams provide this through `afterSequence`; their
+bounded replay window can reject an older cursor explicitly. Sources without
+durable replay should treat overflow as an invalidation signal and refetch
+their canonical query before opening a new live subscription.
+
 When the browser aborts the request or the consumer stops iterating, the stream
-runs registered cleanups and wakes any pending reader so the subscription can
-finish without leaking listeners.
+discards queued events, runs registered cleanups, and wakes any pending reader
+so the subscription can finish without retaining payloads or listeners.
 
 ## Fanout
 
@@ -49,7 +62,8 @@ publisher.emit(sessionId, event)
   -> TUI stream listener -> TUI tRPC subscription
 ```
 
-No change is needed in this primitive for that fanout model. Change it only if
-we later need shared delivery guarantees across subscribers, durable replay, or
-cross-process distribution; those would be event-source responsibilities rather
-than per-subscription buffer mechanics.
+Each subscriber has an independent bound, so one stalled client can overflow
+and disconnect without slowing or corrupting another subscriber. No change is
+needed in this primitive for that fanout model. Shared delivery guarantees,
+durable replay, and cross-process distribution remain event-source
+responsibilities rather than per-subscription buffer mechanics.

--- a/src/core/runtime/subscriptions/errors.ts
+++ b/src/core/runtime/subscriptions/errors.ts
@@ -1,0 +1,14 @@
+/** A subscription consumer fell behind the stream's bounded in-memory buffer. */
+export class RuntimeSubscriptionOverflowError extends Error {
+  readonly code = 'RUNTIME_SUBSCRIPTION_OVERFLOW';
+
+  constructor(
+    readonly maxBufferedEvents: number,
+    readonly bufferedEvents: number,
+  ) {
+    super(
+      `Runtime subscription consumer exceeded the ${maxBufferedEvents}-event buffer. Reconnect and replay from the last acknowledged cursor when the source supports replay.`,
+    );
+    this.name = 'RuntimeSubscriptionOverflowError';
+  }
+}

--- a/src/core/runtime/subscriptions/index.ts
+++ b/src/core/runtime/subscriptions/index.ts
@@ -1,8 +1,13 @@
 export {
+  DEFAULT_RUNTIME_SUBSCRIPTION_BUFFER_SIZE,
   RuntimeSubscriptionStream,
 } from './stream.js';
+export {
+  RuntimeSubscriptionOverflowError,
+} from './errors.js';
 export type {
   RuntimeSubscriptionCleanup,
+  RuntimeSubscriptionOverflow,
   RuntimeSubscriptionSink,
   RuntimeSubscriptionSource,
   RuntimeSubscriptionStreamArgs,

--- a/src/core/runtime/subscriptions/stream.ts
+++ b/src/core/runtime/subscriptions/stream.ts
@@ -1,11 +1,14 @@
 import type {
   RuntimeSubscriptionCleanup,
+  RuntimeSubscriptionOverflow,
   RuntimeSubscriptionSink,
   RuntimeSubscriptionSource,
   RuntimeSubscriptionStreamArgs,
 } from './types.js';
+import { RuntimeSubscriptionOverflowError } from './errors.js';
 
 const CLOSED = Symbol('runtime-subscription-closed');
+export const DEFAULT_RUNTIME_SUBSCRIPTION_BUFFER_SIZE = 256;
 
 /**
  * Push-to-AsyncIterable bridge for host subscription transports.
@@ -19,7 +22,10 @@ export class RuntimeSubscriptionStream<Event> implements AsyncIterable<Event> {
   private readonly waiters: Array<(event: Event | typeof CLOSED) => void> = [];
   private readonly cleanups: RuntimeSubscriptionCleanup[] = [];
   private readonly abortSignal?: AbortSignal;
-  private readonly abort = () => this.close();
+  private readonly maxBufferedEvents: number;
+  private readonly onOverflow?: (overflow: RuntimeSubscriptionOverflow) => void;
+  private readonly abort = () => this.cancel();
+  private failure?: Error;
   private closed = false;
 
   // Convenience constructor for controllers that create a stream from several
@@ -31,10 +37,12 @@ export class RuntimeSubscriptionStream<Event> implements AsyncIterable<Event> {
   // Starts the stream and attaches abort handling. Sources are registered
   // immediately so callers can return the stream directly to tRPC.
   constructor(args: RuntimeSubscriptionStreamArgs<Event> = {}) {
+    this.maxBufferedEvents = RuntimeSubscriptionStream.resolveMaxBufferedEvents(args.maxBufferedEvents);
+    this.onOverflow = args.onOverflow;
     this.abortSignal = args.signal;
     this.abortSignal?.addEventListener('abort', this.abort, { once: true });
     if (this.abortSignal?.aborted) {
-      this.close();
+      this.cancel();
       return;
     }
 
@@ -88,12 +96,77 @@ export class RuntimeSubscriptionStream<Event> implements AsyncIterable<Event> {
       return;
     }
 
+    if (this.events.length >= this.maxBufferedEvents) {
+      const overflow = {
+        maxBufferedEvents: this.maxBufferedEvents,
+        bufferedEvents: this.events.length,
+      };
+      this.reportOverflow(overflow);
+      this.fail(new RuntimeSubscriptionOverflowError(
+        overflow.maxBufferedEvents,
+        overflow.bufferedEvents,
+      ));
+      return;
+    }
+
     this.events.push(event);
   }
 
   // Stops accepting new events, removes abort handling, runs source cleanups,
   // and wakes pending readers so the AsyncIterator can finish.
   close(): void {
+    this.finish();
+  }
+
+  // Lets tRPC consume the stream with `for await`. The iterator drains buffered
+  // events first, then waits for future pushes until the stream closes.
+  async *[Symbol.asyncIterator](): AsyncIterator<Event> {
+    try {
+      while (true) {
+        if (this.failure) {
+          throw this.failure;
+        }
+
+        if (this.events.length > 0) {
+          yield this.events.shift() as Event;
+          continue;
+        }
+
+        if (this.closed) {
+          return;
+        }
+
+        const event = await new Promise<Event | typeof CLOSED>((resolve) => {
+          this.waiters.push(resolve);
+        });
+        if (event === CLOSED) {
+          if (this.failure) {
+            throw this.failure;
+          }
+          return;
+        }
+
+        yield event;
+      }
+    } finally {
+      this.cancel();
+    }
+  }
+
+  // Cancels a consumer subscription and releases queued payload references.
+  // Graceful source close uses close() so already-buffered events can drain.
+  private cancel(): void {
+    this.events.splice(0);
+    this.finish();
+  }
+
+  private fail(error: Error): void {
+    this.failure = error;
+    this.events.splice(0);
+    this.finish();
+  }
+
+  private finish(): void {
     if (this.closed) {
       return;
     }
@@ -104,25 +177,21 @@ export class RuntimeSubscriptionStream<Event> implements AsyncIterable<Event> {
     this.waiters.splice(0).forEach((waiter) => waiter(CLOSED));
   }
 
-  // Lets tRPC consume the stream with `for await`. The iterator drains buffered
-  // events first, then waits for future pushes until the stream closes.
-  async *[Symbol.asyncIterator](): AsyncIterator<Event> {
+  private reportOverflow(overflow: RuntimeSubscriptionOverflow): void {
     try {
-      while (!this.closed || this.events.length > 0) {
-        const event = this.events.length > 0
-          ? this.events.shift() as Event
-          : await new Promise<Event | typeof CLOSED>((resolve) => {
-            this.waiters.push(resolve);
-          });
-        if (event === CLOSED) {
-          break;
-        }
-
-        yield event;
-      }
-    } finally {
-      this.close();
+      this.onOverflow?.(overflow);
+    } catch {
+      // Diagnostics must never prevent the subscription from failing closed.
     }
+  }
+
+  private static resolveMaxBufferedEvents(value?: number): number {
+    const maxBufferedEvents = value ?? DEFAULT_RUNTIME_SUBSCRIPTION_BUFFER_SIZE;
+    if (!Number.isSafeInteger(maxBufferedEvents) || maxBufferedEvents < 1) {
+      throw new RangeError('Runtime subscription maxBufferedEvents must be a positive safe integer.');
+    }
+
+    return maxBufferedEvents;
   }
 
   // Runs one cleanup defensively so a failed listener/timer cleanup does not

--- a/src/core/runtime/subscriptions/types.ts
+++ b/src/core/runtime/subscriptions/types.ts
@@ -12,8 +12,17 @@ export type RuntimeSubscriptionSource<Event> = (
   sink: RuntimeSubscriptionSink<Event>
 ) => RuntimeSubscriptionCleanup | void;
 
+export type RuntimeSubscriptionOverflow = {
+  maxBufferedEvents: number;
+  bufferedEvents: number;
+};
+
 // Construction options for one per-client subscription stream.
 export type RuntimeSubscriptionStreamArgs<Event> = {
   signal?: AbortSignal;
   sources?: Array<RuntimeSubscriptionSource<Event>>;
+  /** Maximum number of events retained for a consumer that is not reading. */
+  maxBufferedEvents?: number;
+  /** Host observation hook for metrics, tracing, or structured logs. */
+  onOverflow?: (overflow: RuntimeSubscriptionOverflow) => void;
 };


### PR DESCRIPTION
## Summary

- cap every runtime subscription's per-consumer queue with a configurable bound and a production default
- fail stalled consumers with a typed `RuntimeSubscriptionOverflowError` instead of dropping events or pretending the stream completed
- release queued payloads, waiters, listeners, and timers on overflow or cancellation
- expose an `onOverflow` observation hook for host metrics and tracing
- document replay/refetch behavior for durable and non-durable sources

## Root cause

`RuntimeSubscriptionStream` retained an unbounded `events` array for every subscriber. A disconnected or slow client could therefore retain an unlimited number of payloads and had no explicit recovery signal.

## Behavior

Fast subscribers remain independent from stalled subscribers. When a subscriber exceeds its bound, only that stream fails. Conversation-run clients can reconnect with their last `afterSequence` cursor; non-replayable subscriptions must refetch canonical state before reconnecting.

## Verification

- `yarn vitest run src/__tests__/unit/core/runtime-subscription-stream.test.ts src/__tests__/unit/core/conversation-run-service.test.ts`
- `yarn test:unit` (130 files, 788 tests)
- `yarn typecheck`
- `yarn lint`
- `yarn build`

Closes #276