### PR TITLE
fix: canonicalize workspace tool paths

### DIFF
--- a/src/__tests__/integration/tools/tools.test.ts
+++ b/src/__tests__/integration/tools/tools.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, realpath, symlink, writeFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -89,14 +89,14 @@ describe('tool input validation', () => {
 
   it('tool descriptions distinguish directories from files', () => {
     expect(listFilesTool.description).toContain('Use this to inspect folders, not to read file contents');
-    expect(listFilesTool.description).toContain('explore an obvious nearby folder');
-    expect(listFilesTool.description).toContain('may also point to nearby parent or sibling folders');
+    expect(listFilesTool.description).toContain('explore an obvious folder');
+    expect(listFilesTool.description).toContain('canonical path checks reject parent traversal');
     expect(listFilesTool.description).toContain('newline-separated list of entry names');
     expect(readFileTool.description).toContain('not when you want to inspect a directory');
-    expect(readFileTool.description).toContain('may also point to nearby parent or sibling folders');
+    expect(readFileTool.description).toContain('canonical path checks reject parent traversal');
     expect(readFileTool.description).toContain('Returns the file text directly');
     expect(readFileTool.description).toContain('0-based line offset');
-    expect(editFileTool.description).toContain('Edit a file directly without going through shell redirection or heredocs');
+    expect(editFileTool.description).toContain('Edit a file inside the active workspace directly');
     expect(editFileTool.description).toContain('Prefer this over shell commands');
     expect(editFileTool.description).toContain('exact replacement');
     expect(editFileTool.description).toContain('overwrite an existing file or create a new one explicitly');
@@ -105,17 +105,14 @@ describe('tool input validation', () => {
     expect(moveFileTool.description).toContain('Move or rename a file or directory');
     expect(moveFileTool.description).toContain('createParentDirs');
     expect(listFilesTool.description).toContain('{ "path": "." }');
-    expect(listFilesTool.description).toContain('{ "path": ".." }');
     expect(readFileTool.description).toContain('{ "path": "path/to/file.txt" }');
-    expect(readFileTool.description).toContain('{ "path": "../shared-notes/summary.md" }');
     expect(searchFilesTool.description).toContain('locate a specific symbol or text string');
     expect(searchFilesTool.description).toContain('Prefer searching for concrete terms');
-    expect(searchFilesTool.description).toContain('may also point to nearby parent or sibling folders');
+    expect(searchFilesTool.description).toContain('canonical path checks reject parent traversal or symlinks that escape it');
     expect(searchFilesTool.description).toContain('Prefer rg when available');
     expect(searchFilesTool.description).toContain('grep-style path:line:content format');
     expect(searchFilesTool.description).toContain('includeIgnored');
     expect(searchFilesTool.description).toContain('{ "query": "createUser" }');
-    expect(searchFilesTool.description).toContain('{ "query": "incident", "path": "../shared-notes" }');
     expect(projectDashboardTool.description).toContain('Collect the initial coding project dashboard');
     expect(projectDashboardTool.description).toContain('current working-environment state, a bounded workspace tree');
     expect(projectDashboardTool.description).toContain('cheap project signals');
@@ -359,7 +356,7 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
-    const result = await createSearchFilesTool({ backend: 'grep' }).execute({ query: 'needle', path: root });
+    const result = await createSearchFilesTool({ backend: 'grep', workspaceRoot: root }).execute({ query: 'needle' });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -376,7 +373,7 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
-    const result = await createSearchFilesTool({ backend: 'rg' }).execute({ query: 'needle', path: root });
+    const result = await createSearchFilesTool({ backend: 'rg', workspaceRoot: root }).execute({ query: 'needle' });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -389,9 +386,8 @@ describe('searchFilesTool', () => {
     await mkdir(join(root, 'src'));
     await writeFile(join(root, 'src', 'main.ts'), 'setCurrentEditPreview();\n');
 
-    const result = await createSearchFilesTool({ backend: 'rg' }).execute({
+    const result = await createSearchFilesTool({ backend: 'rg', workspaceRoot: root }).execute({
       query: 'setCurrentEditPreview()',
-      path: root,
     });
 
     expect(result.ok).toBe(true);
@@ -411,9 +407,9 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'packages', 'app', 'dist', 'generated.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'packages', 'app', 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
-    const result = await createSearchFilesTool({ backend: 'rg' }).execute({
+    const result = await createSearchFilesTool({ backend: 'rg', workspaceRoot: root }).execute({
       query: 'needle',
-      path: join(root, 'packages', 'app'),
+      path: 'packages/app',
     });
 
     expect(result.ok).toBe(true);
@@ -436,7 +432,8 @@ describe('searchFilesTool', () => {
     const result = await createSearchFilesTool({
       backend: 'rg',
       excludedDirs: ['.git', 'dist', 'node_modules', '.heddle'],
-    }).execute({ query: 'needle', path: root });
+      workspaceRoot: root,
+    }).execute({ query: 'needle' });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -451,8 +448,8 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'vendor', 'hidden.ts'), 'const needle = true;\n');
 
-    const tool = createSearchFilesTool({ excludedDirs: ['vendor'] });
-    const result = await tool.execute({ query: 'needle', path: root });
+    const tool = createSearchFilesTool({ excludedDirs: ['vendor'], workspaceRoot: root });
+    const result = await tool.execute({ query: 'needle' });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -470,8 +467,8 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'src', 'Cargo.toml'), 'needle = "yes"\n');
     await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
 
-    const tool = createSearchFilesTool({ backend: 'grep' });
-    const result = await tool.execute({ query: 'needle', path: root });
+    const tool = createSearchFilesTool({ backend: 'grep', workspaceRoot: root });
+    const result = await tool.execute({ query: 'needle' });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -486,8 +483,8 @@ describe('searchFilesTool', () => {
     await mkdir(join(root, 'src'));
     await writeFile(join(root, 'src', 'main.ts'), 'appendMessage(sessionId);\n');
 
-    const tool = createSearchFilesTool({ backend: 'grep' });
-    const result = await tool.execute({ query: 'appendMessage(sessionId)', path: root });
+    const tool = createSearchFilesTool({ backend: 'grep', workspaceRoot: root });
+    const result = await tool.execute({ query: 'appendMessage(sessionId)' });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -501,8 +498,8 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'src', 'Makefile'), 'needle: all\n');
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
 
-    const tool = createSearchFilesTool({ backend: 'grep' });
-    const result = await tool.execute({ query: 'needle', path: root });
+    const tool = createSearchFilesTool({ backend: 'grep', workspaceRoot: root });
+    const result = await tool.execute({ query: 'needle' });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -518,9 +515,8 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
-    const result = await createSearchFilesTool({ backend: 'rg' }).execute({
+    const result = await createSearchFilesTool({ backend: 'rg', workspaceRoot: root }).execute({
       query: 'needle',
-      path: root,
       includeIgnored: true,
     });
 
@@ -538,8 +534,8 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
-    const tool = createSearchFilesTool({ backend: 'grep' });
-    const result = await tool.execute({ query: 'needle', path: root, includeIgnored: true });
+    const tool = createSearchFilesTool({ backend: 'grep', workspaceRoot: root });
+    const result = await tool.execute({ query: 'needle', includeIgnored: true });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -555,9 +551,8 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, '.heddle', 'traces', 'trace-1.json'), '{"needle":true}\n');
 
-    const result = await createSearchFilesTool({ backend: 'rg' }).execute({
+    const result = await createSearchFilesTool({ backend: 'rg', workspaceRoot: root }).execute({
       query: 'needle',
-      path: root,
       includeIgnored: true,
     });
 
@@ -576,8 +571,8 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'src', 'main.ts'), 'const needle = true;\n');
     await writeFile(join(root, '.heddle', 'traces', 'trace-1.json'), '{"needle":true}\n');
 
-    const tool = createSearchFilesTool({ backend: 'grep' });
-    const result = await tool.execute({ query: 'needle', path: root });
+    const tool = createSearchFilesTool({ backend: 'grep', workspaceRoot: root });
+    const result = await tool.execute({ query: 'needle' });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -594,8 +589,8 @@ describe('searchFilesTool', () => {
     await writeFile(join(root, 'dist', 'generated.ts'), 'const needle = true;\n');
     await writeFile(join(root, 'node_modules', 'pkg.ts'), 'const needle = true;\n');
 
-    const tool = createSearchFilesTool({ backend: 'grep' });
-    const result = await tool.execute({ query: 'needle', path: root });
+    const tool = createSearchFilesTool({ backend: 'grep', workspaceRoot: root });
+    const result = await tool.execute({ query: 'needle' });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('src/main.ts');
@@ -610,7 +605,10 @@ describe('searchFilesTool', () => {
     await mkdir(join(root, '.heddle', 'traces'));
     await writeFile(join(root, '.heddle', 'traces', 'trace-1.json'), '{"needle":true}\n');
 
-    const result = await createSearchFilesTool({ backend: 'rg' }).execute({ query: 'needle', path: join(root, '.heddle') });
+    const result = await createSearchFilesTool({ backend: 'rg', workspaceRoot: root }).execute({
+      query: 'needle',
+      path: '.heddle',
+    });
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain('traces/trace-1.json');
@@ -1260,6 +1258,7 @@ describe('file mutation tools', () => {
   it('deletes a file through delete_file', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-delete-file-'));
     const filePath = join(root, 'obsolete.txt');
+    const canonicalFilePath = join(await realpath(root), 'obsolete.txt');
     await writeFile(filePath, 'remove me');
     const tool = createDeleteFileTool({ workspaceRoot: root });
 
@@ -1268,7 +1267,7 @@ describe('file mutation tools', () => {
     expect(result).toEqual({
       ok: true,
       output: {
-        path: filePath,
+        path: canonicalFilePath,
         deleted: true,
         kind: 'file',
         recursive: false,
@@ -1292,6 +1291,7 @@ describe('file mutation tools', () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-move-file-'));
     const fromPath = join(root, 'draft.txt');
     const toPath = join(root, 'docs', 'draft.txt');
+    const canonicalRoot = await realpath(root);
     await writeFile(fromPath, 'move me');
     const tool = createMoveFileTool({ workspaceRoot: root });
 
@@ -1300,8 +1300,8 @@ describe('file mutation tools', () => {
     expect(result).toEqual({
       ok: true,
       output: {
-        from: fromPath,
-        to: toPath,
+        from: join(canonicalRoot, 'draft.txt'),
+        to: join(canonicalRoot, 'docs', 'draft.txt'),
         moved: true,
         kind: 'file',
         createdParentDirs: true,
@@ -1309,6 +1309,122 @@ describe('file mutation tools', () => {
     });
     await expect(readFile(toPath, 'utf8')).resolves.toBe('move me');
     await expect(readFile(fromPath, 'utf8')).rejects.toThrow();
+  });
+
+  it('rejects read, list, and search paths that escape through workspace symlinks', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-read-symlink-root-'));
+    const outside = await mkdtemp(join(tmpdir(), 'heddle-read-symlink-outside-'));
+    await writeFile(join(outside, 'secret.txt'), 'outside\n');
+    await symlink(outside, join(root, 'external'));
+
+    const readTool = createReadFileTool({ workspaceRoot: root });
+    const listTool = createListFilesTool({ workspaceRoot: root });
+    const searchTool = createSearchFilesTool({ workspaceRoot: root, backend: 'grep' });
+
+    await expect(readTool.execute({ path: 'external/secret.txt' })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Workspace path resolves outside the canonical workspace root'),
+    });
+    await expect(listTool.execute({ path: 'external' })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Workspace path resolves outside the canonical workspace root'),
+    });
+    await expect(searchTool.execute({ path: 'external', query: 'outside' })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Workspace path resolves outside the canonical workspace root'),
+    });
+  });
+
+  it('allows canonical reads through a symlink that remains inside the workspace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-read-symlink-inside-'));
+    await mkdir(join(root, 'src'));
+    await writeFile(join(root, 'src', 'note.txt'), 'inside\n');
+    await symlink('src', join(root, 'current'));
+    const tool = createReadFileTool({ workspaceRoot: root });
+
+    await expect(tool.execute({ path: 'current/note.txt' })).resolves.toEqual({
+      ok: true,
+      output: 'inside\n',
+    });
+  });
+
+  it('rejects edit, delete, and nested create paths that escape through workspace symlinks', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-mutate-symlink-root-'));
+    const outside = await mkdtemp(join(tmpdir(), 'heddle-mutate-symlink-outside-'));
+    const outsideFile = join(outside, 'outside.txt');
+    await writeFile(outsideFile, 'original\n');
+    await symlink(outside, join(root, 'external'));
+    await symlink('external', join(root, 'nested-external'));
+
+    const editTool = createEditFileTool({ workspaceRoot: root });
+    const deleteTool = createDeleteFileTool({ workspaceRoot: root });
+
+    await expect(editTool.execute({
+      path: 'external/outside.txt',
+      oldText: 'original',
+      newText: 'changed',
+    })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Workspace path resolves outside the canonical workspace root'),
+    });
+    await expect(editTool.execute({
+      path: 'nested-external/new/deep.txt',
+      content: 'created\n',
+      createIfMissing: true,
+    })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Workspace path resolves outside the canonical workspace root'),
+    });
+    await expect(deleteTool.execute({ path: 'external/outside.txt' })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Workspace path resolves outside the canonical workspace root'),
+    });
+    await expect(readFile(outsideFile, 'utf8')).resolves.toBe('original\n');
+    await expect(readFile(join(outside, 'new', 'deep.txt'), 'utf8')).rejects.toThrow();
+  });
+
+  it('does not treat a broken symlink as a creatable directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-broken-symlink-root-'));
+    await symlink(join(root, 'missing-target'), join(root, 'broken'));
+    const tool = createEditFileTool({ workspaceRoot: root });
+
+    const result = await tool.execute({
+      path: 'broken/nested.txt',
+      content: 'must not be created\n',
+      createIfMissing: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('ENOENT'),
+    });
+    await expect(readFile(join(root, 'missing-target', 'nested.txt'), 'utf8')).rejects.toThrow();
+  });
+
+  it('rejects move sources and destinations that escape through workspace symlinks', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-move-symlink-root-'));
+    const outside = await mkdtemp(join(tmpdir(), 'heddle-move-symlink-outside-'));
+    await writeFile(join(root, 'inside.txt'), 'inside\n');
+    await writeFile(join(outside, 'outside.txt'), 'outside\n');
+    await symlink(outside, join(root, 'external'));
+    const tool = createMoveFileTool({ workspaceRoot: root });
+
+    await expect(tool.execute({
+      from: 'external/outside.txt',
+      to: 'moved.txt',
+    })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Workspace path resolves outside the canonical workspace root'),
+    });
+    await expect(tool.execute({
+      from: 'inside.txt',
+      to: 'external/moved.txt',
+    })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Workspace path resolves outside the canonical workspace root'),
+    });
+    await expect(readFile(join(root, 'inside.txt'), 'utf8')).resolves.toBe('inside\n');
+    await expect(readFile(join(outside, 'outside.txt'), 'utf8')).resolves.toBe('outside\n');
   });
 
   it('creates a new file when explicitly allowed', async () => {
@@ -1398,7 +1514,7 @@ describe('file mutation tools', () => {
     }
   });
 
-  it('allows writing outside the current workspace root when the runtime permits it', async () => {
+  it('rejects writing outside the canonical workspace root', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-edit-scope-'));
     const outsidePath = join(root, '..', `outside-${Date.now()}.txt`);
     const previousCwd = process.cwd();
@@ -1411,11 +1527,11 @@ describe('file mutation tools', () => {
         createIfMissing: true,
       });
 
-      expect(result.ok).toBe(true);
-      expect(result.output).toMatchObject({
-        path: outsidePath,
-        action: 'created',
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining('Workspace path resolves outside the canonical workspace root'),
       });
+      await expect(readFile(outsidePath, 'utf8')).rejects.toThrow();
     } finally {
       process.chdir(previousCwd);
     }
@@ -1429,6 +1545,7 @@ describe('file mutation tools', () => {
     process.chdir(root);
 
     try {
+      const canonicalFilePath = await realpath(filePath);
       const preview = await previewEditFileInput({
         path: 'sample.ts',
         oldText: '"old"',
@@ -1436,9 +1553,9 @@ describe('file mutation tools', () => {
       });
 
       expect(preview).toEqual({
-        path: 'sample.ts',
+        path: canonicalFilePath,
         action: 'replaced',
-        diff: ['--- a/sample.ts', '+++ b/sample.ts', '@@ -1 +1 @@', '-const mode = "old";', '+const mode = "new";'].join('\n'),
+        diff: [`--- ${canonicalFilePath}`, `+++ ${canonicalFilePath}`, '@@ -1 +1 @@', '-const mode = "old";', '+const mode = "new";'].join('\n'),
         truncated: false,
       });
     } finally {

--- a/src/__tests__/unit/control-plane/session-cancel.test.ts
+++ b/src/__tests__/unit/control-plane/session-cancel.test.ts
@@ -227,12 +227,13 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
         execute: async () => ({ ok: true }),
       },
     });
-    await Promise.resolve();
 
-    expect(controller.getPendingApproval({ workspaceId, sessionId })).toEqual(expect.objectContaining({
-      callId: 'call-approval-state',
-      tool: 'run_shell_mutate',
-    }));
+    await vi.waitFor(() => {
+      expect(controller.getPendingApproval({ workspaceId, sessionId })).toEqual(expect.objectContaining({
+        callId: 'call-approval-state',
+        tool: 'run_shell_mutate',
+      }));
+    });
     expect(publisher.publishApprovalUpdated).toHaveBeenCalledTimes(1);
 
     expect(controller.resolvePendingApproval({ workspaceId, sessionId }, {

--- a/src/__tests__/unit/core/approval-policy-chain.test.ts
+++ b/src/__tests__/unit/core/approval-policy-chain.test.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -312,6 +319,51 @@ describe('approval policy chain', () => {
     expect(human).not.toHaveBeenCalled();
   });
 
+  it('evaluates Auto access against a symlink target canonicalized outside the workspace', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-auto-symlink-root-'));
+    const outsideRoot = mkdtempSync(join(tmpdir(), 'heddle-auto-symlink-outside-'));
+    writeFileSync(join(outsideRoot, 'secret.txt'), 'outside\n');
+    symlinkSync(outsideRoot, join(workspaceRoot, 'external'));
+    const canonicalOutsideFile = join(realpathSync(outsideRoot), 'secret.txt');
+    const profile: AutopilotProfile = {
+      mode: 'autopilot',
+      roots: [{
+        path: '.',
+        access: 'autopilot',
+        allow: ['read'],
+      }],
+      environments: {
+        allow: ['local', 'dev'],
+        requireApproval: ['staging', 'production', 'unknown'],
+      },
+    };
+
+    const decision = await ToolApprovalPolicies.autopilot({ profile })(context({
+      call: {
+        id: 'call-read-symlink',
+        tool: 'read_file',
+        input: { path: 'external/secret.txt' },
+      },
+      tool: {
+        name: 'read_file',
+        description: 'reads files',
+        parameters: {},
+        execute: async () => ({ ok: true }),
+      },
+      workspaceRoot,
+    }));
+
+    expect(decision).toEqual(expect.objectContaining({
+      type: 'request',
+      reason: `root is not configured for autopilot: ${canonicalOutsideFile}`,
+      autonomyEvaluation: expect.objectContaining({
+        facts: expect.objectContaining({
+          resolvedKnownTargets: [canonicalOutsideFile],
+        }),
+      }),
+    }));
+  });
+
   it('lets autopilot deny unsafe commands without falling through to human approval', async () => {
     const service = new ToolApprovalService();
     const human = vi.fn(async () => ({ approved: true, reason: 'should not request human approval' }));
@@ -453,6 +505,8 @@ describe('approval policy chain', () => {
       workspaceRoot,
       reason: 'edit_file requires approval',
     }));
+    const canonicalWorkspaceRoot = realpathSync(workspaceRoot);
+    const canonicalFilePath = join(canonicalWorkspaceRoot, 'README.md');
 
     expect(request).toEqual(expect.objectContaining({
       tool: 'edit_file',
@@ -462,8 +516,48 @@ describe('approval policy chain', () => {
       summary: 'edit_file (README.md)',
       reason: 'edit_file requires approval',
     }));
-    expect(request.editPreview?.path).toBe('README.md');
+    expect(request.editPreview?.path).toBe(canonicalFilePath);
+    expect(request.canonicalTargets).toEqual([{
+      role: 'target',
+      requestedPath: join(workspaceRoot, 'README.md'),
+      canonicalPath: canonicalFilePath,
+      canonicalRoot: canonicalWorkspaceRoot,
+      exists: true,
+    }]);
     expect(request.rememberProjectApproval?.label).toBe('allow edit_file for this project');
+  });
+
+  it('labels a canonical move destination that escapes through a symlink', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-approval-move-root-'));
+    const outsideRoot = mkdtempSync(join(tmpdir(), 'heddle-approval-move-outside-'));
+    writeFileSync(join(workspaceRoot, 'source.txt'), 'source\n');
+    symlinkSync(outsideRoot, join(workspaceRoot, 'external'));
+    const service = new ToolApprovalService({ workspaceRoot });
+
+    const request = await service.createRequest(context({
+      call: {
+        id: 'call-move',
+        tool: 'move_file',
+        input: { from: 'source.txt', to: 'external/moved.txt' },
+      },
+      tool: {
+        name: 'move_file',
+        description: 'moves files',
+        requiresApproval: true,
+        parameters: {},
+        execute: async () => ({ ok: true }),
+      },
+      workspaceRoot,
+      reason: 'move_file requires approval',
+    }));
+
+    expect(request.canonicalTargets).toEqual([{
+      role: 'destination',
+      requestedPath: join(workspaceRoot, 'external', 'moved.txt'),
+      canonicalPath: join(realpathSync(outsideRoot), 'moved.txt'),
+      canonicalRoot: realpathSync(workspaceRoot),
+      exists: false,
+    }]);
   });
 
   it('adds an Auto repo expansion option when autonomy requests approval for a sibling project root', async () => {

--- a/src/core/approvals/autonomy/policy-service.ts
+++ b/src/core/approvals/autonomy/policy-service.ts
@@ -131,6 +131,7 @@ export class AutonomyPolicyService {
   }): ToolPolicyFacts {
     const command = AutonomyPolicyService.getShellCommand(args.context.call.tool, args.toolInput);
     const resolvedKnownTargets = AutonomyPolicyService.resolveKnownTargets({
+      context: args.context,
       tool: args.context.call.tool,
       input: args.toolInput,
       workspaceRoot: args.workspaceRoot,
@@ -232,10 +233,15 @@ export class AutonomyPolicyService {
   }
 
   private static resolveKnownTargets(args: {
+    context?: ToolApprovalPolicyContext;
     tool: string;
     input: unknown;
     workspaceRoot: string;
   }): string[] {
+    if (args.context?.canonicalTargetPaths) {
+      return args.context.canonicalTargetPaths;
+    }
+
     const input = args.input;
     if (!isRecord(input)) {
       return [];

--- a/src/core/approvals/policies.ts
+++ b/src/core/approvals/policies.ts
@@ -4,6 +4,10 @@ import {
   classifyShellCommandPolicy,
   DEFAULT_MUTATE_RULES,
 } from '@/core/tools/toolkits/shell-process/shell-policy.js';
+import {
+  WorkspacePathOutsideRootError,
+  WorkspacePathPolicy,
+} from '@/core/tools/toolkits/coding-files/workspace-path-policy.js';
 import type { ToolApprovalPolicy, ToolApprovalPolicyContext, ToolApprovalSurface } from './types.js';
 import { AutonomyPolicyService, type AutopilotProfile } from './autonomy/index.js';
 
@@ -24,10 +28,26 @@ export class ToolApprovalPolicies {
   }
 
   static outsideWorkspaceInspection(): ToolApprovalPolicy {
-    return ({ call, workspaceRoot }) =>
-      ToolApprovalPolicies.isOutsideWorkspaceInspectionCall({ call, workspaceRoot }) ?
-        { type: 'request', reason: `${call.tool} targets a path outside the workspace` }
-      : undefined;
+    return async ({ call, workspaceRoot }) => {
+      try {
+        await WorkspacePathPolicy.resolveToolTargets({
+          tool: call.tool,
+          input: call.input,
+          workspaceRoot: workspaceRoot ?? process.cwd(),
+        });
+      } catch (error) {
+        if (error instanceof WorkspacePathOutsideRootError) {
+          return {
+            type: 'request',
+            reason: `${call.tool} targets a canonical path outside the workspace: ${error.canonicalPath}`,
+          };
+        }
+      }
+
+      return ToolApprovalPolicies.isOutsideWorkspaceInspectionCall({ call, workspaceRoot })
+        ? { type: 'request', reason: `${call.tool} targets a path outside the workspace` }
+        : undefined;
+    };
   }
 
   static rememberedProjectRule(args: {
@@ -73,13 +93,28 @@ export class ToolApprovalPolicies {
   }
 
   static autopilot(args: { profile: AutopilotProfile }): ToolApprovalPolicy {
-    return (context) =>
-      AutonomyPolicyService.toApprovalDecision(
+    return async (context) => {
+      let canonicalTargetPaths: string[] | undefined;
+      try {
+        const targets = await WorkspacePathPolicy.resolveToolTargets({
+          tool: context.call.tool,
+          input: context.call.input,
+          workspaceRoot: context.workspaceRoot ?? process.cwd(),
+        });
+        canonicalTargetPaths = targets.map((target) => target.canonicalPath);
+      } catch (error) {
+        if (error instanceof WorkspacePathOutsideRootError) {
+          canonicalTargetPaths = [error.canonicalPath];
+        }
+      }
+
+      return AutonomyPolicyService.toApprovalDecision(
         AutonomyPolicyService.evaluate({
-          context,
+          context: canonicalTargetPaths ? { ...context, canonicalTargetPaths } : context,
           profile: args.profile,
         }),
       );
+    };
   }
 
   static isOutsideWorkspaceInspectionCall(args: {

--- a/src/core/approvals/service.ts
+++ b/src/core/approvals/service.ts
@@ -15,6 +15,11 @@ import {
 import { previewEditFileInput } from '@/core/tools/toolkits/coding-files/edit-file.js';
 import { ToolActivitySummarizer } from '@/core/live/index.js';
 import { ToolPolicyEnvelopeInputService } from '@/core/tools/index.js';
+import {
+  WorkspacePathOutsideRootError,
+  WorkspacePathPolicy,
+  type CanonicalToolTarget,
+} from '@/core/tools/toolkits/coding-files/workspace-path-policy.js';
 import type { ToolApprovalPolicyContext } from './types.js';
 import { AutonomyRootScopeService } from './autonomy/index.js';
 
@@ -108,10 +113,16 @@ export class ToolApprovalService {
       ...args.call,
       input,
     };
+    const workspaceRoot = args.workspaceRoot ?? this.options.workspaceRoot ?? process.cwd();
     const rememberedRule = ProjectApprovalRules.createForCall(call);
+    const canonicalTargets = await this.resolveCanonicalTargets({
+      tool: args.call.tool,
+      input,
+      workspaceRoot,
+    });
     const editPreview =
       args.call.tool === 'edit_file'
-        ? await previewEditFileInput(input, this.options.workspaceRoot)
+        ? await previewEditFileInput(input, workspaceRoot)
         : undefined;
 
     return {
@@ -122,9 +133,10 @@ export class ToolApprovalService {
       summary: ToolActivitySummarizer.summarizeCall(call),
       reason: args.reason,
       editPreview,
+      canonicalTargets: canonicalTargets.length > 0 ? canonicalTargets : undefined,
       autopilotRootApproval: AutonomyRootScopeService.resolveAutoRootApproval({
         evaluation: args.autonomyEvaluation,
-        workspaceRoot: args.workspaceRoot ?? this.options.workspaceRoot ?? process.cwd(),
+        workspaceRoot,
       }),
       rememberProjectApproval: rememberedRule
         ? {
@@ -201,6 +213,28 @@ export class ToolApprovalService {
     return this.options.projectApprovalRulesFile
       ? new FileProjectApprovalRuleRepository(this.options.projectApprovalRulesFile)
       : undefined;
+  }
+
+  private async resolveCanonicalTargets(args: {
+    tool: string;
+    input: unknown;
+    workspaceRoot: string;
+  }): Promise<CanonicalToolTarget[]> {
+    try {
+      return await WorkspacePathPolicy.resolveToolTargets(args);
+    } catch (error) {
+      if (error instanceof WorkspacePathOutsideRootError) {
+        return [{
+          role: error.role,
+          requestedPath: error.requestedPath,
+          canonicalPath: error.canonicalPath,
+          canonicalRoot: error.canonicalRoot,
+          exists: error.exists,
+        }];
+      }
+
+      return [];
+    }
   }
 
   private static withAutonomyEvaluation(

--- a/src/core/approvals/types.ts
+++ b/src/core/approvals/types.ts
@@ -1,5 +1,6 @@
 import type { ToolCall, ToolDefinition } from '@/core/types.js';
 import type { EditFilePreview } from '@/core/tools/toolkits/coding-files/edit-file.js';
+import type { CanonicalToolTarget } from '@/core/tools/toolkits/coding-files/workspace-path-policy.js';
 import type { ProjectApprovalRule } from './remembered-rules/index.js';
 import type { AutonomyEvaluation, AutopilotRootApproval } from './autonomy/index.js';
 
@@ -20,6 +21,7 @@ export type ToolApprovalPolicyContext = {
   call: ToolCall;
   tool: ToolDefinition;
   workspaceRoot?: string;
+  canonicalTargetPaths?: string[];
 };
 
 export type ToolApprovalPolicy = (
@@ -51,6 +53,7 @@ export type ToolApprovalRequest = {
   summary: string;
   reason?: string;
   editPreview?: EditFilePreview;
+  canonicalTargets?: CanonicalToolTarget[];
   autopilotRootApproval?: AutopilotRootApproval;
   rememberProjectApproval?: {
     label: string;

--- a/src/core/memory/note-service.ts
+++ b/src/core/memory/note-service.ts
@@ -57,7 +57,6 @@ export class MemoryNoteService {
       rootLabel: 'memory root',
       subjectLabel: 'memory note',
       creationHint: 'Set createIfMissing to true if you want edit_memory_note to create it.',
-      enforceRoot: true,
     });
   }
 

--- a/src/core/tools/README.md
+++ b/src/core/tools/README.md
@@ -37,8 +37,8 @@ workspace.
 - `policy-envelope/`: shared `ToolPolicyEnvelope` contract, model-visible
   schema injection, and execution-time stripping/validation. Tool-specific
   input remains owned by the individual tool.
-- `toolkits/coding-files/`: file/search/edit tool implementations plus shared
-  edit-core behavior.
+- `toolkits/coding-files/`: file/search/edit tool implementations, shared
+  edit-core behavior, and canonical workspace containment.
 - `toolkits/knowledge/`: memory notes, memory checkpoint, and durable knowledge
   recording tools plus the knowledge toolkit composition and memory-mode policy.
 - `toolkits/external-context/`: provider-backed web search and image inspection
@@ -91,7 +91,8 @@ workspace.
 ## Common Changes
 
 - To add a coding workspace tool, place it under `toolkits/coding-files/` when
-  it belongs to the file/search/edit surface.
+  it belongs to the file/search/edit surface, and reuse its canonical path
+  policy rather than adding a lexical containment check.
 - To add a knowledge or memory-surface tool, place it under
   `toolkits/knowledge/` and keep memory-mode behavior centralized in the
   knowledge toolkit.

--- a/src/core/tools/toolkits/coding-files/README.md
+++ b/src/core/tools/toolkits/coding-files/README.md
@@ -1,0 +1,57 @@
+# Coding Files Toolkit
+
+The coding-files toolkit owns structured file inspection and mutation inside
+one host-provided workspace root.
+
+## Owns
+
+- File reads, directory listing, and literal search.
+- Direct file edits, deletion, and moves.
+- Canonical workspace containment through `WorkspacePathPolicy`.
+- Tool-level input validation and deterministic result shapes.
+
+## Canonical Containment
+
+Every coding-file operation resolves its workspace root and target through the
+filesystem before access:
+
+- Existing targets use their canonical `realpath`.
+- New targets use the canonical nearest existing parent plus the missing path
+  suffix.
+- Move operations validate both the existing source and the destination.
+- Approval and Auto policy receive the same canonical targets used by tool
+  execution.
+
+This prevents an in-workspace symlink from redirecting a coding-file operation
+outside the configured root. The canonical target is the path the operation
+uses and the path approval surfaces should display.
+
+Canonical containment is defense in depth. It reduces accidental or
+model-directed path escape, but it is not an operating-system sandbox and
+cannot eliminate filesystem time-of-check/time-of-use races. Hosts running
+untrusted workloads should still use mature OS isolation and least-privilege
+filesystem permissions.
+
+## Does Not Own
+
+- Shell command filesystem access. Shell tools have separate policy and should
+  run inside host-selected OS isolation when required.
+- Human approval UI or remembered approval rules.
+- Host authentication and workspace-to-tenant authorization.
+- Repository-specific source-control behavior.
+
+## Extension Guidance
+
+New coding-file operations must use `WorkspacePathPolicy` rather than adding
+their own lexical `resolve`/`relative` checks. Use `resolveExisting` for reads
+and existing mutation sources, and `resolveCreatable` when a target may not yet
+exist. If an operation has multiple targets, expose them through
+`resolveToolTargets` so Auto policy and approval surfaces see the same
+canonical scope as execution.
+
+## Tests
+
+The integration suite in
+`src/__tests__/integration/tools/tools.test.ts` covers valid in-root access,
+outside symlink targets, nested symlinks, missing create targets, and move
+source/destination containment.

--- a/src/core/tools/toolkits/coding-files/delete-file.ts
+++ b/src/core/tools/toolkits/coding-files/delete-file.ts
@@ -1,6 +1,7 @@
 import { rm, stat } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
+import { WorkspacePathPolicy } from './workspace-path-policy.js';
 
 type DeleteFileInput = {
   path: string;
@@ -17,7 +18,7 @@ export function createDeleteFileTool(options: DeleteFileToolOptions = {}): ToolD
   return {
     name: 'delete_file',
     description:
-      'Delete a file or remove a directory when you explicitly need to clean up or retire workspace content. Prefer this over shell rm for normal file deletion. Use { "path" } for files, or set recursive to true if you intentionally want to remove a directory tree. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Returns a structured deletion summary.',
+      'Delete a file or remove a directory inside the active workspace when you explicitly need to clean up or retire workspace content. Prefer this over shell rm for normal file deletion. Use { "path" } for files, or set recursive to true if you intentionally want to remove a directory tree. Canonical path checks reject parent traversal or symlinks that escape the workspace. Returns a structured deletion summary.',
     requiresApproval: true,
     parameters: {
       type: 'object',
@@ -43,9 +44,13 @@ export function createDeleteFileTool(options: DeleteFileToolOptions = {}): ToolD
       }
 
       const workspaceRoot = configuredWorkspaceRoot ?? process.cwd();
-      const targetPath = resolve(workspaceRoot, raw.path);
+      const requestedPath = resolve(workspaceRoot, raw.path);
 
       try {
+        const { canonicalPath: targetPath } = await WorkspacePathPolicy.resolveExisting({
+          workspaceRoot,
+          path: raw.path,
+        });
         const info = await stat(targetPath);
         if (info.isDirectory() && !raw.recursive) {
           return {
@@ -71,7 +76,7 @@ export function createDeleteFileTool(options: DeleteFileToolOptions = {}): ToolD
       } catch (error) {
         return {
           ok: false,
-          error: `Failed to delete ${targetPath}: ${error instanceof Error ? error.message : String(error)}`,
+          error: `Failed to delete ${requestedPath}: ${error instanceof Error ? error.message : String(error)}`,
         };
       }
     },

--- a/src/core/tools/toolkits/coding-files/edit-file.ts
+++ b/src/core/tools/toolkits/coding-files/edit-file.ts
@@ -23,7 +23,7 @@ export function createEditFileTool(options: EditFileToolOptions = {}): ToolDefin
   return {
     name: 'edit_file',
     description:
-      'Edit a file directly without going through shell redirection or heredocs. Prefer this over shell commands when you need to create or change file contents. Use { "path", "oldText", "newText" } for an exact replacement, optionally with replaceAll, or use { "path", "content", "createIfMissing" } to overwrite an existing file or create a new one explicitly. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Writes may require approval depending on runtime policy, and the tool returns a structured edit summary.',
+      'Edit a file inside the active workspace directly without going through shell redirection or heredocs. Prefer this over shell commands when you need to create or change file contents. Use { "path", "oldText", "newText" } for an exact replacement, optionally with replaceAll, or use { "path", "content", "createIfMissing" } to overwrite an existing file or create a new one explicitly. Canonical path checks reject parent traversal or symlinks that escape the workspace. Writes may require approval depending on runtime policy, and the tool returns a structured edit summary.',
     requiresApproval: true,
     parameters: {
       type: 'object',

--- a/src/core/tools/toolkits/coding-files/file-edit-core.ts
+++ b/src/core/tools/toolkits/coding-files/file-edit-core.ts
@@ -1,6 +1,10 @@
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, relative } from 'node:path';
 import type { ToolResult } from '../../../types.js';
+import {
+  WorkspacePathOutsideRootError,
+  WorkspacePathPolicy,
+} from './workspace-path-policy.js';
 
 export type ReplaceEditInput = {
   path: string;
@@ -30,7 +34,6 @@ type ScopedEditOptions = {
   rootLabel: string;
   subjectLabel: string;
   creationHint: string;
-  enforceRoot?: boolean;
 };
 
 const DIFF_CONTEXT_LINES = 2;
@@ -75,19 +78,24 @@ export async function executeScopedEdit(raw: unknown, options: ScopedEditOptions
     };
   }
 
-  const targetPath = resolve(options.rootPath, raw.path);
-  if (options.enforceRoot && isOutsideRoot(options.rootPath, targetPath)) {
+  let target: Awaited<ReturnType<typeof resolveEditTarget>>;
+  try {
+    target = await resolveEditTarget(raw, options.rootPath);
+  } catch (error) {
+    const detail = error instanceof WorkspacePathOutsideRootError
+      ? `${options.subjectLabel} paths must stay inside ${options.rootLabel}. ${error.message}`
+      : `Failed to resolve ${options.subjectLabel} path ${raw.path}: ${error instanceof Error ? error.message : String(error)}`;
     return {
       ok: false,
-      error: `${options.subjectLabel} paths must stay inside ${options.rootLabel}: ${options.rootPath}. Refusing to access ${targetPath}.`,
+      error: detail,
     };
   }
 
   if ('content' in raw) {
-    return writeScopedContent(raw, targetPath, options);
+    return writeScopedContent(raw, target.canonicalPath, target.canonicalRoot, options);
   }
 
-  return replaceScopedContent(raw, targetPath, options);
+  return replaceScopedContent(raw, target.canonicalPath, target.canonicalRoot, options);
 }
 
 export async function previewScopedEdit(raw: unknown, options: Omit<ScopedEditOptions, 'creationHint'>): Promise<EditPreview | undefined> {
@@ -95,8 +103,14 @@ export async function previewScopedEdit(raw: unknown, options: Omit<ScopedEditOp
     return undefined;
   }
 
-  const targetPath = resolve(options.rootPath, raw.path);
-  const scopedPath = toScopedPath(options.rootPath, targetPath);
+  let target: Awaited<ReturnType<typeof resolveEditTarget>>;
+  try {
+    target = await resolveEditTarget(raw, options.rootPath);
+  } catch {
+    return undefined;
+  }
+  const targetPath = target.canonicalPath;
+  const scopedPath = targetPath;
 
   if ('content' in raw) {
     const existed = await pathExists(targetPath);
@@ -133,7 +147,12 @@ export async function previewScopedEdit(raw: unknown, options: Omit<ScopedEditOp
   return buildDiffPreview(current, nextContent, scopedPath, 'replaced');
 }
 
-async function writeScopedContent(input: WriteEditInput, targetPath: string, options: ScopedEditOptions): Promise<ToolResult> {
+async function writeScopedContent(
+  input: WriteEditInput,
+  targetPath: string,
+  canonicalRoot: string,
+  options: ScopedEditOptions,
+): Promise<ToolResult> {
   const existed = await pathExists(targetPath);
   let previousContent = '';
   if (existed) {
@@ -160,15 +179,20 @@ async function writeScopedContent(input: WriteEditInput, targetPath: string, opt
   return {
     ok: true,
     output: {
-      path: toScopedPath(options.rootPath, targetPath),
+      path: toScopedPath(canonicalRoot, targetPath),
       action: existed ? 'overwritten' : 'created',
       bytesWritten: Buffer.byteLength(input.content, 'utf8'),
-      diff: buildDiffPreview(previousContent, input.content, toScopedPath(options.rootPath, targetPath), existed ? 'overwritten' : 'created'),
+      diff: buildDiffPreview(previousContent, input.content, toScopedPath(canonicalRoot, targetPath), existed ? 'overwritten' : 'created'),
     },
   };
 }
 
-async function replaceScopedContent(input: ReplaceEditInput, targetPath: string, options: ScopedEditOptions): Promise<ToolResult> {
+async function replaceScopedContent(
+  input: ReplaceEditInput,
+  targetPath: string,
+  canonicalRoot: string,
+  options: ScopedEditOptions,
+): Promise<ToolResult> {
   let current: string;
   try {
     current = await readFile(targetPath, 'utf8');
@@ -202,13 +226,19 @@ async function replaceScopedContent(input: ReplaceEditInput, targetPath: string,
   return {
     ok: true,
     output: {
-      path: toScopedPath(options.rootPath, targetPath),
+      path: toScopedPath(canonicalRoot, targetPath),
       action: 'replaced',
       matchCount,
       bytesWritten: Buffer.byteLength(nextContent, 'utf8'),
-      diff: buildDiffPreview(current, nextContent, toScopedPath(options.rootPath, targetPath), 'replaced'),
+      diff: buildDiffPreview(current, nextContent, toScopedPath(canonicalRoot, targetPath), 'replaced'),
     },
   };
+}
+
+async function resolveEditTarget(input: ScopedEditInput, rootPath: string) {
+  return 'content' in input
+    ? WorkspacePathPolicy.resolveCreatable({ workspaceRoot: rootPath, path: input.path })
+    : WorkspacePathPolicy.resolveExisting({ workspaceRoot: rootPath, path: input.path });
 }
 
 function countOccurrences(content: string, search: string): number {
@@ -250,11 +280,6 @@ function toScopedPath(rootPath: string, targetPath: string): string {
   return rel;
 }
 
-function isOutsideRoot(rootPath: string, targetPath: string): boolean {
-  const rel = relative(rootPath, targetPath);
-  return rel.startsWith('..') || isAbsolute(rel);
-}
-
 async function pathExists(path: string): Promise<boolean> {
   try {
     await access(path);
@@ -281,8 +306,8 @@ function buildDiffPreview(
   const nextContextEnd = Math.min(nextLines.length, nextChangedEnd + DIFF_CONTEXT_LINES);
 
   const lines = [
-    `--- ${action === 'created' ? '/dev/null' : `a/${path}`}`,
-    `+++ b/${path}`,
+    `--- ${action === 'created' ? '/dev/null' : formatDiffPath(path, 'a')}`,
+    `+++ ${formatDiffPath(path, 'b')}`,
     `@@ -${formatHunkRange(contextStart + 1, previousContextEnd - contextStart)} +${formatHunkRange(contextStart + 1, nextContextEnd - contextStart)} @@`,
     ...previousLines.slice(contextStart, prefix).map((line) => ` ${line}`),
     ...previousLines.slice(prefix, previousChangedEnd).map((line) => `-${line}`),
@@ -299,6 +324,10 @@ function buildDiffPreview(
     '... diff preview truncated ...',
   ];
   return { path, action, diff: truncatedLines.join('\n'), truncated: true };
+}
+
+function formatDiffPath(path: string, prefix: 'a' | 'b'): string {
+  return isAbsolute(path) ? path : `${prefix}/${path}`;
 }
 
 function splitLines(content: string): string[] {

--- a/src/core/tools/toolkits/coding-files/index.ts
+++ b/src/core/tools/toolkits/coding-files/index.ts
@@ -17,3 +17,9 @@ export {
   type SearchFilesOptions,
 } from './search-files.js';
 export { codingFilesToolkit } from './toolkit.js';
+export {
+  WorkspacePathOutsideRootError,
+  WorkspacePathPolicy,
+  type CanonicalToolTarget,
+  type CanonicalWorkspacePath,
+} from './workspace-path-policy.js';

--- a/src/core/tools/toolkits/coding-files/list-files.ts
+++ b/src/core/tools/toolkits/coding-files/list-files.ts
@@ -5,6 +5,7 @@
 import { readdir } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
+import { WorkspacePathPolicy } from './workspace-path-policy.js';
 
 type ListFilesInput = {
   path?: string;
@@ -21,7 +22,7 @@ export function createListFilesTool(options: ListFilesToolOptions = {}): ToolDef
     name: 'list_files',
     concurrency: 'parallel-safe',
     description:
-      'List files and directories inside a directory path. Use this to inspect folders, not to read file contents. Prefer this when you need an initial view of the workspace or want to explore an obvious nearby folder before using broader search. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders, such as "..". Defaults to the active workspace root. Returns a flat newline-separated list of entry names; directories end with /. Example inputs: { "path": "." }, { "path": ".." }',
+      'List files and directories inside the active workspace. Use this to inspect folders, not to read file contents. Prefer this when you need an initial view of the workspace or want to explore an obvious folder before using broader search. Relative paths are resolved from the active workspace root, and canonical path checks reject parent traversal or symlinks that escape it. Defaults to the active workspace root. Returns a flat newline-separated list of entry names; directories end with /. Example input: { "path": "." }',
     parameters: {
       type: 'object',
       additionalProperties: false,
@@ -39,17 +40,21 @@ export function createListFilesTool(options: ListFilesToolOptions = {}): ToolDef
 
       const input: ListFilesInput = raw;
       const workspaceRoot = configuredWorkspaceRoot ?? process.cwd();
-      const dir = resolve(workspaceRoot, input.path ?? '.');
+      const requestedPath = resolve(workspaceRoot, input.path ?? '.');
 
       try {
+        const { canonicalPath: dir } = await WorkspacePathPolicy.resolveExisting({
+          workspaceRoot,
+          path: input.path ?? '.',
+        });
         const entries = await readdir(dir, { withFileTypes: true });
         const names = entries.map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
         return { ok: true, output: names.join('\n') };
       } catch (err) {
         if (err instanceof Error && 'code' in err && err.code === 'ENOTDIR') {
-          return { ok: false, error: `Failed to list ${dir}: path is a file, not a directory. Use read_file for file contents.` };
+          return { ok: false, error: `Failed to list ${requestedPath}: path is a file, not a directory. Use read_file for file contents.` };
         }
-        return { ok: false, error: `Failed to list ${dir}: ${err instanceof Error ? err.message : String(err)}` };
+        return { ok: false, error: `Failed to list ${requestedPath}: ${err instanceof Error ? err.message : String(err)}` };
       }
     },
   };

--- a/src/core/tools/toolkits/coding-files/move-file.ts
+++ b/src/core/tools/toolkits/coding-files/move-file.ts
@@ -1,6 +1,7 @@
 import { mkdir, rename, stat } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
+import { WorkspacePathPolicy } from './workspace-path-policy.js';
 
 type MoveFileInput = {
   from: string;
@@ -18,7 +19,7 @@ export function createMoveFileTool(options: MoveFileToolOptions = {}): ToolDefin
   return {
     name: 'move_file',
     description:
-      'Move or rename a file or directory within the workspace when you need a direct file operation without shell mv. Use this for renames, relocations, or cleanup moves. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Optionally create missing destination parent directories with createParentDirs. Returns a structured move summary.',
+      'Move or rename a file or directory within the active workspace when you need a direct file operation without shell mv. Use this for renames, relocations, or cleanup moves. Canonical path checks reject source or destination symlinks that escape the workspace. Optionally create missing destination parent directories with createParentDirs. Returns a structured move summary.',
     requiresApproval: true,
     parameters: {
       type: 'object',
@@ -48,10 +49,18 @@ export function createMoveFileTool(options: MoveFileToolOptions = {}): ToolDefin
       }
 
       const workspaceRoot = configuredWorkspaceRoot ?? process.cwd();
-      const fromPath = resolve(workspaceRoot, raw.from);
-      const toPath = resolve(workspaceRoot, raw.to);
+      const requestedFromPath = resolve(workspaceRoot, raw.from);
+      const requestedToPath = resolve(workspaceRoot, raw.to);
 
       try {
+        const { canonicalPath: fromPath } = await WorkspacePathPolicy.resolveExisting({
+          workspaceRoot,
+          path: raw.from,
+        });
+        const { canonicalPath: toPath } = await WorkspacePathPolicy.resolveCreatable({
+          workspaceRoot,
+          path: raw.to,
+        });
         const info = await stat(fromPath);
         if (raw.createParentDirs) {
           await mkdir(dirname(toPath), { recursive: true });
@@ -72,7 +81,7 @@ export function createMoveFileTool(options: MoveFileToolOptions = {}): ToolDefin
       } catch (error) {
         return {
           ok: false,
-          error: `Failed to move ${fromPath} to ${toPath}: ${error instanceof Error ? error.message : String(error)}`,
+          error: `Failed to move ${requestedFromPath} to ${requestedToPath}: ${error instanceof Error ? error.message : String(error)}`,
         };
       }
     },

--- a/src/core/tools/toolkits/coding-files/read-file.ts
+++ b/src/core/tools/toolkits/coding-files/read-file.ts
@@ -5,6 +5,7 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
+import { WorkspacePathPolicy } from './workspace-path-policy.js';
 
 type ReadFileInput = {
   path: string;
@@ -23,7 +24,7 @@ export function createReadFileTool(options: ReadFileToolOptions = {}): ToolDefin
     name: 'read_file',
     concurrency: 'parallel-safe',
     description:
-      'Read the contents of a file. Use this when you already know the file path and want its contents, not when you want to inspect a directory. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Optionally limit returned lines with maxLines and start from a 0-based line offset with offset, which is useful for paging through long files. Returns the file text directly, or just the selected window when maxLines and/or offset are provided. Example inputs: { "path": "path/to/file.txt" }, { "path": "../shared-notes/summary.md" }, { "path": "src/run-agent.ts", "offset": 200, "maxLines": 120 }',
+      'Read the contents of a file inside the active workspace. Use this when you already know the file path and want its contents, not when you want to inspect a directory. Relative paths are resolved from the active workspace root, and canonical path checks reject parent traversal or symlinks that escape it. Optionally limit returned lines with maxLines and start from a 0-based line offset with offset, which is useful for paging through long files. Returns the file text directly, or just the selected window when maxLines and/or offset are provided. Example inputs: { "path": "path/to/file.txt" }, { "path": "src/run-agent.ts", "offset": 200, "maxLines": 120 }',
     parameters: {
       type: 'object',
       additionalProperties: false,
@@ -50,9 +51,13 @@ export function createReadFileTool(options: ReadFileToolOptions = {}): ToolDefin
 
       const input: ReadFileInput = raw;
       const workspaceRoot = configuredWorkspaceRoot ?? process.cwd();
-      const filePath = resolve(workspaceRoot, input.path);
+      const requestedPath = resolve(workspaceRoot, input.path);
 
       try {
+        const { canonicalPath: filePath } = await WorkspacePathPolicy.resolveExisting({
+          workspaceRoot,
+          path: input.path,
+        });
         const content = await readFile(filePath, 'utf-8');
 
         const lines = content.split('\n');
@@ -71,9 +76,9 @@ export function createReadFileTool(options: ReadFileToolOptions = {}): ToolDefin
         return { ok: true, output: content };
       } catch (err) {
         if (err instanceof Error && 'code' in err && err.code === 'EISDIR') {
-          return { ok: false, error: `Failed to read ${filePath}: path is a directory, not a file. Use list_files to inspect directories.` };
+          return { ok: false, error: `Failed to read ${requestedPath}: path is a directory, not a file. Use list_files to inspect directories.` };
         }
-        return { ok: false, error: `Failed to read ${filePath}: ${err instanceof Error ? err.message : String(err)}` };
+        return { ok: false, error: `Failed to read ${requestedPath}: ${err instanceof Error ? err.message : String(err)}` };
       }
     },
   };

--- a/src/core/tools/toolkits/coding-files/search-files.ts
+++ b/src/core/tools/toolkits/coding-files/search-files.ts
@@ -8,6 +8,7 @@ import { existsSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, relative, resolve } from 'node:path';
 import type { ToolDefinition, ToolResult } from '../../../types.js';
+import { WorkspacePathPolicy } from './workspace-path-policy.js';
 
 type SearchFilesInput = {
   query: string;
@@ -42,7 +43,7 @@ export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDef
   return {
     name: 'search_files',
     description:
-      'Search for literal text in files. Prefer rg when available for fast ignored-aware search, with a grep fallback. Use this when you need to locate a specific symbol or text string, not when a likely folder or file is already obvious from the workspace structure. Prefer searching for concrete terms such as tool names, symbols, or filenames rather than copying broad question text. Relative paths are resolved from the active workspace root and may also point to nearby parent or sibling folders. Returns newline-separated matches in grep-style path:line:content format, or "No matches found.". By default, search honors project ignore files such as .gitignore when rg is available; when no ignore file is present, fallback excludes avoid expensive/generated folders like dist, node_modules, and local. .git and .heddle stay protected from accidental broad searches unless explicitly targeted. Set includeIgnored: true only when intentionally searching ignored/dependency content such as node_modules. Example inputs: { "query": "createUser" }, { "query": "incident", "path": "../shared-notes" }, { "query": "packageName", "path": "node_modules", "includeIgnored": true }',
+      'Search for literal text in files inside the active workspace. Prefer rg when available for fast ignored-aware search, with a grep fallback. Use this when you need to locate a specific symbol or text string, not when a likely folder or file is already obvious from the workspace structure. Prefer searching for concrete terms such as tool names, symbols, or filenames rather than copying broad question text. Relative paths are resolved from the active workspace root, and canonical path checks reject parent traversal or symlinks that escape it. Returns newline-separated matches in grep-style path:line:content format, or "No matches found.". By default, search honors project ignore files such as .gitignore when rg is available; when no ignore file is present, fallback excludes avoid expensive/generated folders like dist, node_modules, and local. .git and .heddle stay protected from accidental broad searches unless explicitly targeted. Set includeIgnored: true only when intentionally searching ignored/dependency content such as node_modules. Example inputs: { "query": "createUser" }, { "query": "packageName", "path": "node_modules", "includeIgnored": true }',
     parameters: {
       type: 'object',
       additionalProperties: false,
@@ -72,22 +73,25 @@ export function createSearchFilesTool(options: SearchFilesOptions = {}): ToolDef
 
       const input: SearchFilesInput = raw;
       const workspaceRoot = configuredWorkspaceRoot ?? process.cwd();
-      const dir = resolve(workspaceRoot, input.path ?? '.');
-      const explicitlyTargetedConfiguredDirs = configuredExcludedDirNames.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
-      const explicitlyTargetedProtectedDirs = PROTECTED_STATE_DIRS.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
-      const includeIgnored = input.includeIgnored === true || explicitlyTargetedConfiguredDirs.length > 0 || explicitlyTargetedProtectedDirs.length > 0;
-      const protectedExcludedDirs = getProtectedExcludedDirs(dir);
-      const customExcludedDirs = customExcludedDirNames.filter((name) => !isExplicitlyTargetingExcludedDir(dir, name));
-      const fallbackExcludedDirs = getFallbackExcludedDirs({
-        dir,
-        fallbackExcludedDirs: customExcludedDirNames.length > 0 ? customExcludedDirNames : DEFAULT_SEARCH_EXCLUDED_DIRS,
-      });
-      const selectedBackend = selectSearchBackend(backend, dir);
-      const gitRepoRoot = findGitRepoRoot(dir);
-      const hasProjectIgnoreFile = findProjectIgnoreFile(dir, gitRepoRoot ?? workspaceRoot) !== undefined;
-      const fallbackExcludesApply = !includeIgnored && !hasProjectIgnoreFile;
 
       try {
+        const { canonicalPath: dir, canonicalRoot } = await WorkspacePathPolicy.resolveExisting({
+          workspaceRoot,
+          path: input.path ?? '.',
+        });
+        const explicitlyTargetedConfiguredDirs = configuredExcludedDirNames.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
+        const explicitlyTargetedProtectedDirs = PROTECTED_STATE_DIRS.filter((name) => isExplicitlyTargetingExcludedDir(dir, name));
+        const includeIgnored = input.includeIgnored === true || explicitlyTargetedConfiguredDirs.length > 0 || explicitlyTargetedProtectedDirs.length > 0;
+        const protectedExcludedDirs = getProtectedExcludedDirs(dir);
+        const customExcludedDirs = customExcludedDirNames.filter((name) => !isExplicitlyTargetingExcludedDir(dir, name));
+        const fallbackExcludedDirs = getFallbackExcludedDirs({
+          dir,
+          fallbackExcludedDirs: customExcludedDirNames.length > 0 ? customExcludedDirNames : DEFAULT_SEARCH_EXCLUDED_DIRS,
+        });
+        const selectedBackend = selectSearchBackend(backend, dir);
+        const gitRepoRoot = findGitRepoRoot(dir);
+        const hasProjectIgnoreFile = findProjectIgnoreFile(dir, gitRepoRoot ?? canonicalRoot) !== undefined;
+        const fallbackExcludesApply = !includeIgnored && !hasProjectIgnoreFile;
         const output = selectedBackend === 'rg'
           ? runRipgrepSearch({
               query: input.query,

--- a/src/core/tools/toolkits/coding-files/workspace-path-policy.ts
+++ b/src/core/tools/toolkits/coding-files/workspace-path-policy.ts
@@ -1,0 +1,242 @@
+import { lstat, realpath } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+
+export type CanonicalWorkspacePath = {
+  requestedPath: string;
+  canonicalPath: string;
+  canonicalRoot: string;
+  exists: boolean;
+};
+
+export type CanonicalToolTarget = CanonicalWorkspacePath & {
+  role: CanonicalToolTargetRole;
+};
+
+export type CanonicalToolTargetRole = 'target' | 'source' | 'destination';
+
+export class WorkspacePathOutsideRootError extends Error {
+  readonly code = 'WORKSPACE_PATH_OUTSIDE_ROOT';
+
+  constructor(
+    readonly requestedPath: string,
+    readonly canonicalPath: string,
+    readonly canonicalRoot: string,
+    readonly exists: boolean,
+    readonly role: CanonicalToolTargetRole = 'target',
+  ) {
+    super(
+      `Workspace path resolves outside the canonical workspace root ${canonicalRoot}: `
+      + `${requestedPath} -> ${canonicalPath}`,
+    );
+    this.name = 'WorkspacePathOutsideRootError';
+  }
+}
+
+/**
+ * Owns canonical workspace containment for coding-file operations.
+ *
+ * Existing paths are resolved through every symlink before containment is
+ * checked. New paths are anchored at their nearest existing canonical parent,
+ * so a symlinked parent cannot redirect creation outside the workspace.
+ */
+export class WorkspacePathPolicy {
+  static async resolveExisting(args: {
+    workspaceRoot: string;
+    path: string;
+  }): Promise<CanonicalWorkspacePath> {
+    const requestedPath = resolve(args.workspaceRoot, args.path);
+    const canonicalRoot = await realpath(resolve(args.workspaceRoot));
+    const canonicalPath = await realpath(requestedPath);
+    WorkspacePathPolicy.assertContained({
+      requestedPath,
+      canonicalPath,
+      canonicalRoot,
+      exists: true,
+    });
+
+    return {
+      requestedPath,
+      canonicalPath,
+      canonicalRoot,
+      exists: true,
+    };
+  }
+
+  static async resolveCreatable(args: {
+    workspaceRoot: string;
+    path: string;
+  }): Promise<CanonicalWorkspacePath> {
+    const requestedPath = resolve(args.workspaceRoot, args.path);
+    const canonicalRoot = await realpath(resolve(args.workspaceRoot));
+    const resolvedTarget = await WorkspacePathPolicy.resolveFromNearestExistingPath(requestedPath);
+    WorkspacePathPolicy.assertContained({
+      requestedPath,
+      canonicalPath: resolvedTarget.canonicalPath,
+      canonicalRoot,
+      exists: resolvedTarget.exists,
+    });
+
+    return {
+      requestedPath,
+      canonicalPath: resolvedTarget.canonicalPath,
+      canonicalRoot,
+      exists: resolvedTarget.exists,
+    };
+  }
+
+  static async resolveToolTargets(args: {
+    tool: string;
+    input: unknown;
+    workspaceRoot: string;
+  }): Promise<CanonicalToolTarget[]> {
+    if (!isRecord(args.input)) {
+      return [];
+    }
+
+    const path = typeof args.input.path === 'string' ? args.input.path : undefined;
+    if (args.tool === 'read_file' || args.tool === 'delete_file') {
+      return path
+        ? [await WorkspacePathPolicy.resolveToolTarget(
+          'target',
+          WorkspacePathPolicy.resolveExisting({ workspaceRoot: args.workspaceRoot, path }),
+        )]
+        : [];
+    }
+
+    if (args.tool === 'list_files' || args.tool === 'search_files') {
+      return [await WorkspacePathPolicy.resolveToolTarget(
+        'target',
+        WorkspacePathPolicy.resolveExisting({
+          workspaceRoot: args.workspaceRoot,
+          path: path ?? '.',
+        }),
+      )];
+    }
+
+    if (args.tool === 'edit_file') {
+      if (!path) {
+        return [];
+      }
+
+      const isFullContentWrite = typeof args.input.content === 'string';
+      const target = isFullContentWrite
+        ? WorkspacePathPolicy.resolveCreatable({ workspaceRoot: args.workspaceRoot, path })
+        : WorkspacePathPolicy.resolveExisting({ workspaceRoot: args.workspaceRoot, path });
+      return [await WorkspacePathPolicy.resolveToolTarget('target', target)];
+    }
+
+    if (args.tool !== 'move_file') {
+      return [];
+    }
+
+    const from = typeof args.input.from === 'string' ? args.input.from : undefined;
+    const to = typeof args.input.to === 'string' ? args.input.to : undefined;
+    if (!from || !to) {
+      return [];
+    }
+
+    return [
+      await WorkspacePathPolicy.resolveToolTarget(
+        'source',
+        WorkspacePathPolicy.resolveExisting({
+          workspaceRoot: args.workspaceRoot,
+          path: from,
+        }),
+      ),
+      await WorkspacePathPolicy.resolveToolTarget(
+        'destination',
+        WorkspacePathPolicy.resolveCreatable({
+          workspaceRoot: args.workspaceRoot,
+          path: to,
+        }),
+      ),
+    ];
+  }
+
+  private static async resolveFromNearestExistingPath(path: string): Promise<{
+    canonicalPath: string;
+    exists: boolean;
+  }> {
+    const missingSegments: string[] = [];
+    let candidate = path;
+
+    while (true) {
+      try {
+        await lstat(candidate);
+      } catch (error) {
+        if (!isMissingPathError(error)) {
+          throw error;
+        }
+
+        const parent = dirname(candidate);
+        if (parent === candidate) {
+          throw error;
+        }
+
+        missingSegments.push(relative(parent, candidate));
+        candidate = parent;
+        continue;
+      }
+
+      // Keep realpath failures separate from "not found". A broken symlink is
+      // an existing filesystem entry and must not be treated as a creatable
+      // directory whose destination can be reconstructed lexically.
+      const canonicalParent = await realpath(candidate);
+      return {
+        canonicalPath: resolve(canonicalParent, ...missingSegments.reverse()),
+        exists: missingSegments.length === 0,
+      };
+    }
+  }
+
+  private static async resolveToolTarget(
+    role: CanonicalToolTargetRole,
+    target: Promise<CanonicalWorkspacePath>,
+  ): Promise<CanonicalToolTarget> {
+    try {
+      return { ...await target, role };
+    } catch (error) {
+      if (error instanceof WorkspacePathOutsideRootError) {
+        throw new WorkspacePathOutsideRootError(
+          error.requestedPath,
+          error.canonicalPath,
+          error.canonicalRoot,
+          error.exists,
+          role,
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  private static assertContained(args: {
+    requestedPath: string;
+    canonicalPath: string;
+    canonicalRoot: string;
+    exists: boolean;
+  }): void {
+    const relativeTarget = relative(args.canonicalRoot, args.canonicalPath);
+    const outsideRoot = relativeTarget === '..'
+      || relativeTarget.startsWith(`..${sep}`)
+      || isAbsolute(relativeTarget);
+    if (outsideRoot) {
+      throw new WorkspacePathOutsideRootError(
+        args.requestedPath,
+        args.canonicalPath,
+        args.canonicalRoot,
+        args.exists,
+      );
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && (error.code === 'ENOENT' || error.code === 'ENOTDIR');
+}


### PR DESCRIPTION
## Summary

- enforce one canonical workspace-containment policy across read, list, search, edit, delete, and move tools
- validate create destinations through their nearest existing canonical parent
- carry canonical targets into Auto policy and host-neutral approval requests, including move source/destination provenance
- document the defense-in-depth boundary and its OS-sandbox/TOCTOU limitations
- cover outside and nested symlinks, broken symlinks, move escapes, valid in-root symlinks, and approval behavior

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test` (785 unit, 326 integration)
- `yarn build`

Closes #280