### PR TITLE
fix: fence session leases across replicas

### DIFF
--- a/docs/architecture/durable-state.md
+++ b/docs/architecture/durable-state.md
@@ -45,7 +45,7 @@ the same storage, not as remote portability.
 
 | State surface | Current class | Browser refresh | Same-filesystem process restart | Host replacement | Delete and retention behavior |
 | --- | --- | --- | --- | --- | --- |
-| Conversation sessions | **Remote-ready** | Reloaded from the repository | Survives; stale local leases can be recovered | Survives when the host supplies the same remote repository and authenticated scope | Session delete is revision-checked; default files retain superseded and interrupted revision bodies |
+| Conversation sessions | **Remote-ready** | Reloaded from the repository | Survives; expired fenced leases can be reclaimed | Survives when the host supplies the same remote repository and authenticated scope with atomic revision compare-and-set | Session delete is revision-checked; default files retain superseded and interrupted revision bodies |
 | Conversation archives | **Remote-ready** | Reloaded through the session manifest | Survives | Survives when the host supplies the same remote archive repository and scope | Append-only today; default files can retain orphan content and have no archive GC policy |
 | Result artifacts | **Host-replaceable** | Reloaded from catalog and content keys | Survives with the same artifact root | Only if a custom synchronous repository reaches shared storage; not a remote-ready promise | No public delete, retention, or orphan cleanup contract |
 | Raw turn traces | **Workspace-local diagnostic** | Existing trace files remain | Survives | Does not follow the session unless state storage is shared or copied | No retention or GC policy; session summaries can retain a local-only `traceFile` locator |
@@ -113,6 +113,15 @@ Current limits:
   authentication, row-level policy, migrations, query plans, backups, or
   disaster recovery;
 - a host must keep session and archive repositories in the same identity scope.
+
+Persisted leases use a composite host/runtime owner and a monotonic fencing
+token. Turn-owned writes revalidate the exact claim against the latest record
+before each atomic revision update. Expiry therefore revokes write authority:
+after another replica takes over, the stale owner cannot commit its completed
+turn over the new owner. This guarantee depends on the adapter applying
+`expectedRevision` atomically with the write. The default file adapter provides
+that property across processes sharing its supported local filesystem; it does
+not claim generic multi-host or network-filesystem safety.
 
 See the repository's
 [`README`](../../src/core/chat/engine/sessions/repository/README.md) for the full
@@ -337,10 +346,11 @@ approval resolvers in memory. Control-plane event buses, browser windows,
 profile leases, cached loggers, and heartbeat scheduler handles are also
 process-local.
 
-Persisted session leases protect accepted conversation state across competing
-clients, but they do not make an in-flight model/tool execution resumable. A
-process restart must be represented as interruption; replaying a pending tool
-call or approval from partial durable evidence would be unsafe.
+Persisted fenced session leases protect accepted conversation state across
+competing clients and shared-storage replicas. They do not make an in-flight
+model/tool execution resumable. A process restart must be represented as
+interruption; replaying a pending tool call or approval from partial durable
+evidence would be unsafe.
 
 ## Explicitly Excluded Writers
 

--- a/docs/guides/runtime-host-model.md
+++ b/docs/guides/runtime-host-model.md
@@ -123,13 +123,22 @@ That means:
   control-plane/session path;
 - the risky case is multiple live writers touching the same session.
 
-Heddle records a lightweight session lease while a session is being mutated. If
-another client tries to continue that same session while the lease is fresh, the
-run is blocked with a warning about concurrent mutation risk.
+Heddle records a fenced session lease while a session is being mutated. The
+owner identity combines a stable host/replica ID with a globally unique runtime
+ID; a PID is never treated as persisted ownership or liveness evidence. If
+another client tries to continue that same session while the lease is fresh,
+the run is blocked with a warning about concurrent mutation risk.
 
 Active control-plane runs refresh that lease on a short heartbeat. If the owner
 process dies and the heartbeat stops, the lease becomes stale quickly and a new
-run can reclaim the session without manual state-file edits.
+run receives a higher fencing token. The old run loses write authority at
+expiry, so even if it later finishes local work it cannot commit over the new
+owner.
+
+The default file repository provides this guarantee to processes sharing its
+supported local filesystem. A replicated hosted deployment must use one shared
+repository whose revision check and write are one atomic database operation;
+read-then-unconditional-write adapters are unsafe and unsupported.
 
 ## What `heddle ask` Does
 

--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -19,6 +19,7 @@ import type { HeddleServerContext } from '@/server/types.js';
 
 const EXTERNAL_TUI_LEASE_OWNER: ChatSessionLeaseOwner = {
   ownerKind: 'tui',
+  hostId: 'external-host',
   ownerId: 'external-tui-client',
   clientLabel: 'terminal chat',
 };

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -180,6 +180,7 @@ describe('control-plane session runtime integration', () => {
       prompt: 'inspect file with expanded mention contents',
       leaseOwner: {
         ownerKind: 'daemon',
+        hostId: 'test-host',
         ownerId: 'daemon-test',
         clientLabel: 'control plane',
       },
@@ -192,6 +193,7 @@ describe('control-plane session runtime integration', () => {
       sessionId: session.id,
       leaseOwner: {
         ownerKind: 'daemon',
+        hostId: 'test-host',
         ownerId: 'daemon-test',
         clientLabel: 'control plane',
       },
@@ -245,6 +247,7 @@ describe('control-plane session runtime integration', () => {
       apiKey: 'test-openai-key',
       leaseOwner: {
         ownerKind: 'daemon',
+        hostId: 'test-host',
         ownerId: 'daemon-test',
         clientLabel: 'control plane',
       },
@@ -476,6 +479,7 @@ describe('conversation turn lifecycle', () => {
       artifactsEnabled: true,
       leaseOwner: {
         ownerKind: 'daemon',
+        hostId: 'test-host',
         ownerId: 'daemon-test',
         clientLabel: 'control plane',
       },

--- a/src/__tests__/unit/chat/chat-session-lease-service.test.ts
+++ b/src/__tests__/unit/chat/chat-session-lease-service.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  ChatSessionLeaseLostError,
+  ChatSessionLeases,
+  type ChatSessionLeaseOwner,
+} from '../../../core/chat/engine/sessions/leases/index.js';
+import { FileChatSessionRepository } from '../../../core/chat/engine/sessions/repository/index.js';
+import { FileConversationSessionService } from '../../../core/chat/engine/sessions/service.js';
+
+const ownerA: ChatSessionLeaseOwner = {
+  ownerKind: 'daemon',
+  hostId: 'host-a',
+  ownerId: 'daemon-runtime-a',
+  clientLabel: 'control plane A',
+};
+const ownerB: ChatSessionLeaseOwner = {
+  ownerKind: 'daemon',
+  hostId: 'host-b',
+  ownerId: 'daemon-runtime-b',
+  clientLabel: 'control plane B',
+};
+
+describe('chat session lease service', () => {
+  it('allows only one winner when an expired owner renewal races a takeover', async () => {
+    const fixture = createFixture();
+    const session = await fixture.serviceA.create({ id: 'session-1', name: 'Session 1' });
+    await fixture.serviceA.acquireLease(session.id, ownerA);
+    await expireLease(fixture.repository, session.id);
+
+    const results = await Promise.allSettled([
+      fixture.serviceA.refreshLease(session.id, ownerA),
+      fixture.serviceB.acquireLease(session.id, ownerB),
+    ]);
+
+    expect(results[0]?.status).toBe('rejected');
+    expect(results[1]?.status).toBe('fulfilled');
+
+    const persisted = await fixture.serviceA.require(session.id);
+    expect(persisted.lease).toMatchObject({
+      hostId: ownerB.hostId,
+      ownerId: ownerB.ownerId,
+      fencingToken: 2,
+    });
+  });
+
+  it('rejects an expired owner write before another host takes over', async () => {
+    const fixture = createFixture();
+    const session = await fixture.serviceA.create({ id: 'session-1', name: 'Session 1' });
+    const leased = await fixture.serviceA.acquireLease(session.id, ownerA);
+    const claim = ChatSessionLeases.claim(leased);
+    await expireLease(fixture.repository, session.id);
+
+    await expect(fixture.serviceA.updateWithLease(session.id, claim, (current) => ({
+      ...current,
+      name: 'stale mutation',
+    }))).rejects.toBeInstanceOf(ChatSessionLeaseLostError);
+
+    expect((await fixture.serviceA.require(session.id)).name).toBe('Session 1');
+  });
+
+  it('rejects a stale owner commit after reassignment to another host', async () => {
+    const fixture = createFixture();
+    const session = await fixture.serviceA.create({ id: 'session-1', name: 'Session 1' });
+    const firstLease = await fixture.serviceA.acquireLease(session.id, ownerA);
+    const staleClaim = ChatSessionLeases.claim(firstLease);
+    await expireLease(fixture.repository, session.id);
+
+    const reassigned = await fixture.serviceB.acquireLease(session.id, ownerB);
+    expect(reassigned.lease?.fencingToken).toBe(staleClaim.fencingToken + 1);
+
+    await expect(fixture.serviceA.updateWithLease(session.id, staleClaim, (current) => ({
+      ...current,
+      name: 'stale mutation',
+    }))).rejects.toBeInstanceOf(ChatSessionLeaseLostError);
+
+    const persisted = await fixture.serviceB.require(session.id);
+    expect(persisted.name).toBe('Session 1');
+    expect(persisted.lease).toMatchObject({
+      hostId: ownerB.hostId,
+      ownerId: ownerB.ownerId,
+      fencingToken: staleClaim.fencingToken + 1,
+    });
+  });
+});
+
+function createFixture(): {
+  repository: FileChatSessionRepository;
+  serviceA: FileConversationSessionService;
+  serviceB: FileConversationSessionService;
+} {
+  const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-session-lease-'));
+  const stateRoot = join(workspaceRoot, '.heddle');
+  const sessionStoragePath = join(stateRoot, 'chat-sessions.catalog.json');
+  const createService = () => new FileConversationSessionService({
+    workspaceRoot,
+    stateRoot,
+    sessionStoragePath,
+    model: 'gpt-5.4',
+  });
+
+  return {
+    repository: new FileChatSessionRepository({ sessionStoragePath }),
+    serviceA: createService(),
+    serviceB: createService(),
+  };
+}
+
+async function expireLease(
+  repository: FileChatSessionRepository,
+  sessionId: string,
+): Promise<void> {
+  const stored = await repository.read(sessionId);
+  if (!stored?.session.lease) {
+    throw new Error(`Expected session ${sessionId} to have a lease.`);
+  }
+
+  await repository.update({
+    session: {
+      ...stored.session,
+      lease: {
+        ...stored.session.lease,
+        lastSeenAt: '1970-01-01T00:00:00.000Z',
+      },
+    },
+    expectedRevision: stored.revision,
+  });
+}

--- a/src/__tests__/unit/chat/chat-session-lease.test.ts
+++ b/src/__tests__/unit/chat/chat-session-lease.test.ts
@@ -5,6 +5,14 @@ import {
 } from '../../../core/chat/engine/sessions/leases/index.js';
 import type { ChatSession } from '../../../core/chat/types.js';
 
+const acquiredAt = Date.parse('2026-04-21T01:00:00.000Z');
+const owner = {
+  ownerKind: 'tui' as const,
+  hostId: 'host-a',
+  ownerId: 'tui-runtime-1',
+  clientLabel: 'terminal chat',
+};
+
 function createSession(): ChatSession {
   return {
     id: 'session-1',
@@ -19,166 +27,143 @@ function createSession(): ChatSession {
 }
 
 describe('chat session leases', () => {
-  it('acquires and releases a lease for the same owner', () => {
-    const leased = ChatSessionLeases.acquire(createSession(), {
-      ownerKind: 'tui',
-      ownerId: 'tui-123',
-      clientLabel: 'terminal chat',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z'),
-    });
+  it('acquires a fenced lease and preserves its epoch after release', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), owner, { now: acquiredAt });
+    const claim = ChatSessionLeases.claim(leased);
 
-    expect(leased.lease).toMatchObject({
-      ownerKind: 'tui',
-      ownerId: 'tui-123',
-      clientLabel: 'terminal chat',
+    expect(leased).toMatchObject({
+      leaseEpoch: 1,
+      lease: {
+        ownerKind: 'tui',
+        hostId: 'host-a',
+        ownerId: 'tui-runtime-1',
+        fencingToken: 1,
+        clientLabel: 'terminal chat',
+      },
     });
-    expect(ChatSessionLeases.isFresh(leased.lease, { now: Date.parse('2026-04-21T01:00:19.000Z') })).toBe(true);
-    expect(ChatSessionLeases.isFresh(leased.lease, { now: Date.parse('2026-04-21T01:00:21.000Z') })).toBe(false);
+    expect(ChatSessionLeases.isHeld(leased, claim, { now: acquiredAt + 1 })).toBe(true);
 
-    const released = ChatSessionLeases.release(leased, { ownerId: 'tui-123' });
+    const released = ChatSessionLeases.release(leased, owner);
     expect(released.lease).toBeUndefined();
+    expect(released.leaseEpoch).toBe(1);
+
+    const reacquired = ChatSessionLeases.acquire(released, {
+      ...owner,
+      ownerId: 'tui-runtime-2',
+    }, { now: acquiredAt + 1 });
+    expect(reacquired.lease?.fencingToken).toBe(2);
+    expect(reacquired.leaseEpoch).toBe(2);
   });
 
-  it('uses a short stale window for crashed control-plane recovery', () => {
-    const leased = ChatSessionLeases.acquire(createSession(), {
-      ownerKind: 'daemon',
-      ownerId: 'embedded-chat-12345-1779894401584',
-      clientLabel: 'control plane',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z'),
+  it('refreshes the matching owner without changing its fence or acquisition time', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), owner, { now: acquiredAt });
+    const refreshed = ChatSessionLeases.refresh(leased, owner, { now: acquiredAt + 5_000 });
+
+    expect(refreshed.lease).toMatchObject({
+      acquiredAt: '2026-04-21T01:00:00.000Z',
+      lastSeenAt: '2026-04-21T01:00:05.000Z',
+      fencingToken: 1,
     });
-
-    expect(ChatSessionLeases.conflict(leased, {
-      ownerKind: 'daemon',
-      ownerId: 'embedded-chat-99999-1779894500000',
-      clientLabel: 'control plane',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z') + SESSION_LEASE_STALE_AFTER_MS - 1,
-    })).toContain('already active in control plane');
-
-    expect(ChatSessionLeases.conflict(leased, {
-      ownerKind: 'daemon',
-      ownerId: 'embedded-chat-99999-1779894500000',
-      clientLabel: 'control plane',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z') + SESSION_LEASE_STALE_AFTER_MS + 1,
-    })).toBeUndefined();
+    expect(ChatSessionLeases.claim(refreshed)).toEqual(ChatSessionLeases.claim(leased));
   });
 
-  it('refreshes lastSeenAt only for the matching owner', () => {
+  it('does not equate identical process-local owner IDs on different hosts', () => {
     const leased = ChatSessionLeases.acquire(createSession(), {
-      ownerKind: 'daemon',
-      ownerId: 'daemon-123',
+      ...owner,
+      ownerId: 'daemon-4686',
+    }, { now: acquiredAt });
+    const collidingOwner = {
+      ...owner,
+      hostId: 'host-b',
+      ownerId: 'daemon-4686',
+    };
+
+    expect(ChatSessionLeases.isSameOwner(leased.lease, collidingOwner)).toBe(false);
+    expect(ChatSessionLeases.conflict(leased, collidingOwner, { now: acquiredAt + 1_000 }))
+      .toContain('already active in terminal chat');
+  });
+
+  it('does not infer lease liveness from a reused PID on the same host', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), {
+      ...owner,
+      ownerId: 'daemon-4686-runtime-a',
+    }, { now: acquiredAt });
+    const restartedOwner = {
+      ...owner,
+      ownerId: 'daemon-4686-runtime-b',
+    };
+
+    expect(ChatSessionLeases.conflict(leased, restartedOwner, { now: acquiredAt + 1_000 }))
+      .toContain('already active in terminal chat');
+  });
+
+  it('allows stale takeover and invalidates the previous owner claim', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), owner, { now: acquiredAt });
+    const previousClaim = ChatSessionLeases.claim(leased);
+    const takeoverAt = acquiredAt + SESSION_LEASE_STALE_AFTER_MS + 1;
+    const replacement = {
+      ownerKind: 'daemon' as const,
+      hostId: 'host-b',
+      ownerId: 'daemon-runtime-1',
       clientLabel: 'control plane',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z'),
-    });
+    };
 
-    const ignored = ChatSessionLeases.refresh(leased, { ownerId: 'daemon-other' }, {
-      now: Date.parse('2026-04-21T01:00:05.000Z'),
-    });
-    expect(ignored.lease?.lastSeenAt).toBe('2026-04-21T01:00:00.000Z');
+    expect(ChatSessionLeases.conflict(leased, replacement, { now: takeoverAt })).toBeUndefined();
+    const reassigned = ChatSessionLeases.acquire(leased, replacement, { now: takeoverAt });
 
-    const refreshed = ChatSessionLeases.refresh(leased, { ownerId: 'daemon-123' }, {
-      now: Date.parse('2026-04-21T01:00:05.000Z'),
-    });
-    expect(refreshed.lease?.lastSeenAt).toBe('2026-04-21T01:00:05.000Z');
-    expect(refreshed.lease?.acquiredAt).toBe('2026-04-21T01:00:00.000Z');
+    expect(reassigned.lease?.fencingToken).toBe(2);
+    expect(ChatSessionLeases.isHeld(reassigned, previousClaim, { now: takeoverAt })).toBe(false);
+    expect(ChatSessionLeases.isHeld(
+      reassigned,
+      ChatSessionLeases.claim(reassigned),
+      { now: takeoverAt },
+    )).toBe(true);
   });
 
-  it('reports a conflict for a different fresh owner', () => {
-    const leased = ChatSessionLeases.acquire(createSession(), {
-      ownerKind: 'daemon',
-      ownerId: 'daemon-1',
-      clientLabel: 'control plane',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z'),
+  it('reacquires an expired lease for the same owner with a new fence', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), owner, { now: acquiredAt });
+    const reacquired = ChatSessionLeases.acquire(leased, owner, {
+      now: acquiredAt + SESSION_LEASE_STALE_AFTER_MS + 1,
     });
 
-    expect(ChatSessionLeases.conflict(leased, {
-      ownerKind: 'tui',
-      ownerId: 'tui-123',
-      clientLabel: 'terminal chat',
-    }, {
-      now: Date.parse('2026-04-21T01:00:10.000Z'),
-    })).toContain('Continuing from multiple clients in the same session may corrupt the conversation.');
+    expect(reacquired.lease?.fencingToken).toBe(2);
+    expect(reacquired.lease?.acquiredAt).not.toBe(leased.lease?.acquiredAt);
+    expect(ChatSessionLeases.isHeld(
+      reacquired,
+      ChatSessionLeases.claim(leased),
+      { now: acquiredAt + SESSION_LEASE_STALE_AFTER_MS + 1 },
+    )).toBe(false);
   });
 
-  it('ignores stale leases', () => {
-    const leased = ChatSessionLeases.acquire(createSession(), {
-      ownerKind: 'ask',
-      ownerId: 'ask-123',
-      clientLabel: 'heddle ask',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z'),
-    });
+  it('treats an expired lease as lost even before another owner takes it over', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), owner, { now: acquiredAt });
 
-    expect(ChatSessionLeases.conflict(leased, {
-      ownerKind: 'tui',
-      ownerId: 'tui-123',
-      clientLabel: 'terminal chat',
-    }, {
-      now: Date.parse('2026-04-21T01:20:00.000Z'),
-    })).toBeUndefined();
+    expect(ChatSessionLeases.isHeld(
+      leased,
+      ChatSessionLeases.claim(leased),
+      { now: acquiredAt + SESSION_LEASE_STALE_AFTER_MS + 1 },
+    )).toBe(false);
   });
 
-  it('ignores fresh leases owned by dead local Heddle processes', () => {
-    const leased = ChatSessionLeases.acquire(createSession(), {
-      ownerKind: 'tui',
-      ownerId: 'tui-4686',
-      clientLabel: 'terminal chat',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z'),
+  it('does not refresh an expired lease', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), owner, { now: acquiredAt });
+    const refreshed = ChatSessionLeases.refresh(leased, owner, {
+      now: acquiredAt + SESSION_LEASE_STALE_AFTER_MS + 1,
     });
 
-    expect(ChatSessionLeases.isOwnedByDeadLocalProcess(leased.lease, { isProcessAlive: () => false })).toBe(true);
-    expect(ChatSessionLeases.conflict(leased, {
-      ownerKind: 'tui',
-      ownerId: 'tui-123',
-      clientLabel: 'terminal chat',
-    }, {
-      now: Date.parse('2026-04-21T01:01:00.000Z'),
-      isProcessAlive: () => false,
-    })).toBeUndefined();
+    expect(refreshed).toEqual(leased);
   });
 
-  it('recognizes restarted daemon leases as dead local process leases', () => {
-    const leased = ChatSessionLeases.acquire(createSession(), {
-      ownerKind: 'daemon',
-      ownerId: 'daemon-4686-1779894401584',
-      clientLabel: 'control plane',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z'),
-    });
+  it('ignores release requests from a different host or runtime', () => {
+    const leased = ChatSessionLeases.acquire(createSession(), owner, { now: acquiredAt });
 
-    expect(ChatSessionLeases.isOwnedByDeadLocalProcess(leased.lease, { isProcessAlive: () => false })).toBe(true);
-    expect(ChatSessionLeases.conflict(leased, {
-      ownerKind: 'daemon',
-      ownerId: 'daemon-9999-1779894500000',
-      clientLabel: 'control plane',
-    }, {
-      now: Date.parse('2026-04-21T01:01:00.000Z'),
-      isProcessAlive: () => false,
-    })).toBeUndefined();
-  });
-
-  it('still reports fresh local process leases when the owner is alive', () => {
-    const leased = ChatSessionLeases.acquire(createSession(), {
-      ownerKind: 'tui',
-      ownerId: 'tui-4686',
-      clientLabel: 'terminal chat',
-    }, {
-      now: Date.parse('2026-04-21T01:00:00.000Z'),
-    });
-
-    expect(ChatSessionLeases.conflict(leased, {
-      ownerKind: 'tui',
-      ownerId: 'tui-123',
-      clientLabel: 'terminal chat',
-    }, {
-      now: Date.parse('2026-04-21T01:00:10.000Z'),
-      isProcessAlive: () => true,
-    })).toContain('already active in terminal chat');
+    expect(ChatSessionLeases.release(leased, {
+      hostId: 'host-b',
+      ownerId: owner.ownerId,
+    })).toEqual(leased);
+    expect(ChatSessionLeases.release(leased, {
+      hostId: owner.hostId,
+      ownerId: 'tui-runtime-2',
+    })).toEqual(leased);
   });
 });

--- a/src/__tests__/unit/control-plane/session-cancel.test.ts
+++ b/src/__tests__/unit/control-plane/session-cancel.test.ts
@@ -176,6 +176,7 @@ describe('ControlPlaneChatSessionsController run cancellation', () => {
           prompt: 'Stop this run.',
           leaseOwner: {
             ownerKind: 'daemon',
+            hostId: 'test-host',
             ownerId: 'test-daemon',
             clientLabel: 'test',
           },

--- a/src/__tests__/unit/core/chat-turn-runtime.test.ts
+++ b/src/__tests__/unit/core/chat-turn-runtime.test.ts
@@ -536,6 +536,7 @@ describe('chat turn preparation modules', () => {
       apiKeyPresent: true,
       model: 'gpt-5.4',
     });
+    const leaseTimestamp = new Date().toISOString();
     const leasedSession = {
       ...session,
       history: [
@@ -543,12 +544,15 @@ describe('chat turn preparation modules', () => {
         { role: 'assistant' as const, content: 'Earlier answer' },
       ],
       lease: {
+        hostId: 'test-host',
         ownerId: 'owner-1',
         ownerKind: 'ask' as const,
+        fencingToken: 1,
         clientLabel: 'test client',
-        acquiredAt: '2026-05-03T00:00:00.000Z',
-        lastSeenAt: '2026-05-03T00:00:00.000Z',
+        acquiredAt: leaseTimestamp,
+        lastSeenAt: leaseTimestamp,
       },
+      leaseEpoch: 1,
     };
     const repository = new FileChatSessionRepository({ sessionStoragePath });
     await seedChatSessionRepository(repository, [leasedSession]);
@@ -558,6 +562,11 @@ describe('chat turn preparation modules', () => {
       sessionService,
       sessionId: 'session-1',
       leasedSession,
+      leaseClaim: {
+        hostId: 'test-host',
+        ownerId: 'owner-1',
+        fencingToken: 1,
+      },
       archivePath: '.heddle/chat-sessions/session-1/archives/archive-1.jsonl',
     });
 

--- a/src/__tests__/unit/core/conversation-compaction-state-restoration.test.ts
+++ b/src/__tests__/unit/core/conversation-compaction-state-restoration.test.ts
@@ -29,7 +29,7 @@ describe('compaction infrastructure failure restoration', () => {
       stateRoot: fixture.stateRoot,
       toolNames: [],
       summarizer: {},
-      leaseOwner: { ownerKind: 'daemon', ownerId: 'daemon-test' },
+      leaseOwner: { ownerKind: 'daemon', hostId: 'test-host', ownerId: 'daemon-test' },
       host: {},
     })).rejects.toThrow('archive backend unavailable');
 

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -795,11 +795,13 @@ describe('createConversationEngine', () => {
     const session = await engine.sessions.create({ id: 'session-1', name: 'Alpha' });
     const owner = {
       ownerKind: 'tui' as const,
+      hostId: 'host-a',
       ownerId: 'tui-test-client',
       clientLabel: 'terminal chat',
     };
     const otherOwner = {
       ownerKind: 'daemon' as const,
+      hostId: 'host-b',
       ownerId: 'daemon-1',
       clientLabel: 'control plane',
     };
@@ -821,7 +823,10 @@ describe('createConversationEngine', () => {
     const refreshed = await engine.sessions.refreshLease(session.id, owner);
     expect(refreshed.lease?.ownerId).toBe('tui-test-client');
 
-    const stillLeased = await engine.sessions.releaseLease(session.id, { ownerId: 'daemon-1' });
+    const stillLeased = await engine.sessions.releaseLease(session.id, {
+      hostId: 'host-b',
+      ownerId: 'daemon-1',
+    });
     expect(stillLeased.lease?.ownerId).toBe('tui-test-client');
 
     const released = await engine.sessions.releaseLease(session.id, owner);
@@ -998,19 +1003,30 @@ describe('createConversationEngine', () => {
 
     await expect(engine.turns.clearLease({
       sessionId: 'missing',
-      owner: { ownerKind: 'daemon', ownerId: 'daemon-1', clientLabel: 'control plane' },
+      owner: {
+        ownerKind: 'daemon',
+        hostId: 'test-host',
+        ownerId: 'daemon-1',
+        clientLabel: 'control plane',
+      },
     })).resolves.toBeUndefined();
 
     const session = await engine.sessions.create({ id: 'session-leased', name: 'Leased' });
     await engine.sessions.acquireLease(session.id, {
       ownerKind: 'daemon',
+      hostId: 'test-host',
       ownerId: 'daemon-1',
       clientLabel: 'control plane',
     });
 
     await engine.turns.clearLease({
       sessionId: session.id,
-      owner: { ownerKind: 'daemon', ownerId: 'daemon-1', clientLabel: 'control plane' },
+      owner: {
+        ownerKind: 'daemon',
+        hostId: 'test-host',
+        ownerId: 'daemon-1',
+        clientLabel: 'control plane',
+      },
     });
 
     const sessionRepository = new FileChatSessionRepository({

--- a/src/core/chat/engine/direct-shell/service.ts
+++ b/src/core/chat/engine/direct-shell/service.ts
@@ -89,12 +89,18 @@ export class ConversationDirectShellService {
 
     const session = await input.sessions.require(input.sessionId);
     const shellDisplay = `!${command}`;
-    await input.sessions.appendMessage(input.sessionId, {
-      id: `direct-shell-user-${input.runId}`,
-      role: 'user',
-      text: shellDisplay,
-    });
-    await input.sessions.setLastContinuePrompt(input.sessionId, undefined);
+    await input.sessions.updateWithLease(input.sessionId, input.leaseClaim, (current) => ({
+      ...current,
+      messages: [
+        ...current.messages,
+        {
+          id: `direct-shell-user-${input.runId}`,
+          role: 'user',
+          text: shellDisplay,
+        },
+      ],
+      lastContinuePrompt: undefined,
+    }));
 
     const chosenCall = ConversationDirectShellService.createCall(input.runId, preflight.tool ?? 'run_shell_inspect', command);
     const options = chosenCall.tool === 'run_shell_inspect' ? {
@@ -144,7 +150,10 @@ export class ConversationDirectShellService {
       onStatusChange: input.onCompactionStatus,
     });
 
-    await input.sessions.applyCompactionResult(input.sessionId, compacted);
+    await input.sessions.applyCompactionResult(input.sessionId, {
+      ...compacted,
+      leaseClaim: input.leaseClaim,
+    });
     input.onActivity?.(ConversationDirectShellService.createCompletedActivity(input, chosenCall, chosenResult, chosenDurationMs));
 
     return {

--- a/src/core/chat/engine/direct-shell/types.ts
+++ b/src/core/chat/engine/direct-shell/types.ts
@@ -2,6 +2,7 @@ import type { ConversationActivity, ConversationCompactionStatus } from '@/core/
 import type { ConversationDirectShellLineResult } from '@/core/chat/types.js';
 import type { ConversationSessionService } from '../types.js';
 import type { ChatArchiveRepository } from '../sessions/archives/index.js';
+import type { ChatSessionLeaseClaim } from '../sessions/leases/index.js';
 import type { ConversationCompactionOptions } from '../compaction/index.js';
 
 export type DirectShellToolName = 'run_shell_inspect' | 'run_shell_mutate';
@@ -27,6 +28,7 @@ export type ConversationDirectShellInput = {
   systemContext?: string;
   summarizer: ConversationCompactionOptions['summarizer'];
   sessions: ConversationSessionService;
+  leaseClaim: ChatSessionLeaseClaim;
   abortSignal?: AbortSignal;
   onActivity?: (activity: ConversationActivity) => void;
   onCompactionStatus?: (activity: ConversationCompactionStatus) => void;

--- a/src/core/chat/engine/sessions/README.md
+++ b/src/core/chat/engine/sessions/README.md
@@ -42,7 +42,9 @@ The intended structure is class-based by responsibility:
   line projection. These are static domain methods because they need no
   service instance.
 - `leases/` owns pure lease policy. Lease acquisition, release, freshness, and
-  conflict semantics live together as static domain methods.
+  conflict semantics live together as static domain methods. A lease owner is
+  identified by both `hostId` and a globally unique runtime `ownerId`; process
+  IDs are not ownership or liveness evidence.
 - `repository/types.ts` defines the async port used by local and hosted
   adapters; `repository/file-chat-session-repository.ts` owns the default JSON
   persistence implementation.
@@ -83,6 +85,41 @@ storage.
 
 Do not introduce a ceremonial repository layer for everything. Extract it when
 it materially simplifies a real flow being changed.
+
+## Lease Safety Invariants
+
+Session leases coordinate accepted conversation writes; they do not resume an
+in-flight model or tool execution.
+
+- Acquisition, renewal, release, and every lease-protected session mutation
+  run through the repository's atomic revision compare-and-set.
+- Every new owner receives a monotonically increasing `fencingToken`. The
+  session retains `leaseEpoch` after release so a later owner cannot reuse an
+  old token.
+- A writer carries the exact `hostId`, `ownerId`, and `fencingToken` claim
+  acquired at preflight. The session service revalidates that claim before
+  every compare-and-set retry.
+- An expired lease has already lost write authority, even before another owner
+  takes it over. A stalled process may finish local work, but its final session
+  commit is rejected.
+- A different host with the same PID-like owner string is still a different
+  owner. Heddle never probes a PID to decide whether persisted remote ownership
+  is alive.
+- Heartbeat failure and process crash recovery happen through expiry and a
+  fenced takeover. There is no accepted dual-writer commit window.
+
+The generic `update` method is intentionally not lease-protected and remains
+appropriate for administration outside an active turn. Turn, compaction, and
+direct-shell state that belongs to an acquired run must use `updateWithLease`
+or a named session operation that accepts its lease claim.
+
+Deployment safety depends on the repository:
+
+| Repository deployment | Lease guarantee |
+| --- | --- |
+| Default file repository on one local filesystem | Safe across local Heddle processes because writes use a cross-process lock plus revision compare-and-set. This is not a generic NFS or multi-host guarantee. |
+| Hosted relational or transactional adapter | Safe across replicas only when create/update/delete implement the repository contract atomically in shared storage and all replicas bind the same authenticated scope. |
+| Adapter that performs read-then-write without atomic revision matching | Unsupported. Fencing in the record cannot prevent stale commits if the adapter ignores compare-and-set. |
 
 ## Session Rule
 

--- a/src/core/chat/engine/sessions/leases/errors.ts
+++ b/src/core/chat/engine/sessions/leases/errors.ts
@@ -1,0 +1,25 @@
+import type { ChatSessionLease, ChatSession } from '@/core/chat/types.js';
+import type { ChatSessionLeaseClaim, ChatSessionLeaseIdentity } from './types.js';
+
+export class ChatSessionLeaseLostError extends Error {
+  readonly sessionId: string;
+  readonly expected: ChatSessionLeaseClaim | ChatSessionLeaseIdentity;
+  readonly actual?: ChatSessionLease;
+
+  constructor(args: {
+    session: Pick<ChatSession, 'id' | 'lease'>;
+    expected: ChatSessionLeaseClaim | ChatSessionLeaseIdentity;
+  }) {
+    const fence = 'fencingToken' in args.expected
+      ? ` at fence ${args.expected.fencingToken}`
+      : '';
+    super(
+      `Session ${args.session.id} lease is no longer held by `
+      + `${args.expected.hostId}/${args.expected.ownerId}${fence}.`,
+    );
+    this.name = 'ChatSessionLeaseLostError';
+    this.sessionId = args.session.id;
+    this.expected = args.expected;
+    this.actual = args.session.lease;
+  }
+}

--- a/src/core/chat/engine/sessions/leases/index.ts
+++ b/src/core/chat/engine/sessions/leases/index.ts
@@ -3,4 +3,10 @@ export {
   SESSION_LEASE_REFRESH_INTERVAL_MS,
   SESSION_LEASE_STALE_AFTER_MS,
 } from './leases.js';
-export type { ChatSessionLeaseConflictOptions, ChatSessionLeaseOwner } from './types.js';
+export { ChatSessionLeaseLostError } from './errors.js';
+export type {
+  ChatSessionLeaseClaim,
+  ChatSessionLeaseConflictOptions,
+  ChatSessionLeaseIdentity,
+  ChatSessionLeaseOwner,
+} from './types.js';

--- a/src/core/chat/engine/sessions/leases/leases.ts
+++ b/src/core/chat/engine/sessions/leases/leases.ts
@@ -6,12 +6,16 @@
  * session through the owning service or repository.
  */
 import type { ChatSession, ChatSessionLease } from '@/core/chat/types.js';
-import type { ChatSessionLeaseConflictOptions, ChatSessionLeaseOwner } from './types.js';
+import type {
+  ChatSessionLeaseClaim,
+  ChatSessionLeaseConflictOptions,
+  ChatSessionLeaseIdentity,
+  ChatSessionLeaseOwner,
+} from './types.js';
 import dayjs from 'dayjs';
 
 export const SESSION_LEASE_REFRESH_INTERVAL_MS = 5 * 1000;
 export const SESSION_LEASE_STALE_AFTER_MS = 20 * 1000;
-const LOCAL_PROCESS_LEASE_OWNER_PATTERN = /^(?:tui|ask|submit|daemon)-(\d+)(?:-\d+)?$/;
 
 export class ChatSessionLeases {
   static isFresh(
@@ -30,22 +34,34 @@ export class ChatSessionLeases {
     return dayjs(options?.now ?? Date.now()).diff(lastSeenAt) <= (options?.staleAfterMs ?? SESSION_LEASE_STALE_AFTER_MS);
   }
 
-  static isOwnedByDeadLocalProcess(
+  static isSameOwner(
     lease: ChatSessionLease | undefined,
-    options?: { isProcessAlive?: (pid: number) => boolean },
+    owner: ChatSessionLeaseIdentity,
   ): boolean {
-    if (!lease) {
-      return false;
+    return lease?.hostId === owner.hostId && lease.ownerId === owner.ownerId;
+  }
+
+  static claim(session: Pick<ChatSession, 'id' | 'lease'>): ChatSessionLeaseClaim {
+    const lease = session.lease;
+    if (!lease?.hostId) {
+      throw new Error(`Session ${session.id} does not have a fenced lease.`);
     }
 
-    const match = LOCAL_PROCESS_LEASE_OWNER_PATTERN.exec(lease.ownerId);
-    const pid = match ? Number.parseInt(match[1] ?? '', 10) : NaN;
-    if (!Number.isInteger(pid) || pid <= 0) {
-      return false;
-    }
+    return {
+      hostId: lease.hostId,
+      ownerId: lease.ownerId,
+      fencingToken: lease.fencingToken,
+    };
+  }
 
-    const isProcessAlive = options?.isProcessAlive ?? ChatSessionLeases.defaultIsProcessAlive;
-    return !isProcessAlive(pid);
+  static isHeld(
+    session: Pick<ChatSession, 'lease'>,
+    claim: ChatSessionLeaseClaim,
+    options?: { now?: number; staleAfterMs?: number },
+  ): boolean {
+    return ChatSessionLeases.isFresh(session.lease, options)
+      && ChatSessionLeases.isSameOwner(session.lease, claim)
+      && session.lease?.fencingToken === claim.fencingToken;
   }
 
   static acquire(
@@ -54,12 +70,19 @@ export class ChatSessionLeases {
     options?: { now?: number },
   ): ChatSession {
     const timestamp = dayjs(options?.now ?? Date.now()).toISOString();
+    const continuingOwner = ChatSessionLeases.isSameOwner(session.lease, owner)
+      && ChatSessionLeases.isFresh(session.lease, options);
+    const currentToken = Math.max(session.leaseEpoch ?? 0, session.lease?.fencingToken ?? 0);
+    const fencingToken = continuingOwner ? session.lease?.fencingToken ?? currentToken + 1 : currentToken + 1;
     return {
       ...session,
+      leaseEpoch: Math.max(currentToken, fencingToken),
       lease: {
         ownerKind: owner.ownerKind,
+        hostId: owner.hostId,
         ownerId: owner.ownerId,
-        acquiredAt: session.lease?.ownerId === owner.ownerId ? session.lease.acquiredAt : timestamp,
+        fencingToken,
+        acquiredAt: continuingOwner ? session.lease?.acquiredAt ?? timestamp : timestamp,
         lastSeenAt: timestamp,
         clientLabel: owner.clientLabel,
       },
@@ -68,24 +91,29 @@ export class ChatSessionLeases {
 
   static refresh(
     session: ChatSession,
-    owner: Pick<ChatSessionLeaseOwner, 'ownerId'>,
+    owner: ChatSessionLeaseIdentity,
     options?: { now?: number },
   ): ChatSession {
-    if (!session.lease || session.lease.ownerId !== owner.ownerId) {
+    const lease = session.lease;
+    if (
+      !lease
+      || !ChatSessionLeases.isSameOwner(lease, owner)
+      || !ChatSessionLeases.isFresh(lease, options)
+    ) {
       return session;
     }
 
     return {
       ...session,
       lease: {
-        ...session.lease,
+        ...lease,
         lastSeenAt: dayjs(options?.now ?? Date.now()).toISOString(),
       },
     };
   }
 
-  static release(session: ChatSession, owner?: Pick<ChatSessionLeaseOwner, 'ownerId'>): ChatSession {
-    if (!session.lease || (owner && session.lease.ownerId !== owner.ownerId)) {
+  static release(session: ChatSession, owner?: ChatSessionLeaseIdentity): ChatSession {
+    if (!session.lease || (owner && !ChatSessionLeases.isSameOwner(session.lease, owner))) {
       return session;
     }
 
@@ -102,8 +130,7 @@ export class ChatSessionLeases {
   ): string | undefined {
     if (
       !session.lease ||
-      session.lease.ownerId === owner.ownerId ||
-      ChatSessionLeases.isOwnedByDeadLocalProcess(session.lease, options) ||
+      ChatSessionLeases.isSameOwner(session.lease, owner) ||
       !ChatSessionLeases.isFresh(session.lease, options)
     ) {
       return undefined;
@@ -114,18 +141,5 @@ export class ChatSessionLeases {
       'Continuing from multiple clients in the same session may corrupt the conversation.',
       'Wait for the other client to finish or use a different session.',
     ].join(' ');
-  }
-
-  private static defaultIsProcessAlive(pid: number): boolean {
-    try {
-      process.kill(pid, 0);
-      return true;
-    } catch (error) {
-      if (typeof error === 'object' && error && 'code' in error && error.code === 'ESRCH') {
-        return false;
-      }
-
-      return true;
-    }
   }
 }

--- a/src/core/chat/engine/sessions/leases/types.ts
+++ b/src/core/chat/engine/sessions/leases/types.ts
@@ -2,12 +2,23 @@ import type { ChatSessionLease } from '@/core/chat/types.js';
 
 export type ChatSessionLeaseOwner = {
   ownerKind: ChatSessionLease['ownerKind'];
+  /**
+   * Stable host or replica identity. It prevents equal process-local owner IDs
+   * on different machines from being treated as the same lease holder.
+   */
+  hostId: string;
+  /** Globally unique identity for one runtime instance on this host. */
   ownerId: string;
   clientLabel?: string;
+};
+
+export type ChatSessionLeaseIdentity = Pick<ChatSessionLeaseOwner, 'hostId' | 'ownerId'>;
+
+export type ChatSessionLeaseClaim = ChatSessionLeaseIdentity & {
+  fencingToken: number;
 };
 
 export type ChatSessionLeaseConflictOptions = {
   now?: number;
   staleAfterMs?: number;
-  isProcessAlive?: (pid: number) => boolean;
 };

--- a/src/core/chat/engine/sessions/records/records.ts
+++ b/src/core/chat/engine/sessions/records/records.ts
@@ -40,6 +40,7 @@ export class ChatSessionRecords {
       lastContinuePrompt: undefined,
       context: undefined,
       archives: [],
+      leaseEpoch: 0,
       lease: undefined,
       queuedPrompts: [],
     };

--- a/src/core/chat/engine/sessions/repository/README.md
+++ b/src/core/chat/engine/sessions/repository/README.md
@@ -59,6 +59,12 @@ Every adapter must:
 - scope all operations to the authenticated product boundary chosen by the
   host. Heddle's record does not invent product-specific account or RLS fields.
 
+The atomic `expectedRevision` condition is also the enforcement point for
+session lease fencing. It must be evaluated in the same storage operation that
+commits the next session record. An adapter that reads a matching revision and
+then performs an unconditional write can let an expired owner overwrite a
+takeover, so it is not conformant or safe for replicated hosts.
+
 The authoring primitives deliberately do not own SQL, transactions, connection
 pooling, migrations, identity, tenant filters, RLS, or database error codes.
 Those stay in the host adapter. `ChatSessionPersistenceCodec.parseRecord(...)`
@@ -94,6 +100,11 @@ query plans, connection pooling, load behavior, process-kill recovery, backups,
 or disaster recovery. Scope isolation proves only that the host-provided
 scope-bound factories do not cross records. The corruption hook is intentionally
 test-only and must not be exposed by production adapter APIs.
+
+The suite's compare-and-set race is a prerequisite for replica-safe leases.
+Hosts should additionally exercise acquisition/renewal races and stale-owner
+commit rejection against their real shared database and transaction settings;
+the default file adapter cannot certify another adapter's deployment topology.
 
 ## Default JSON Layout
 

--- a/src/core/chat/engine/sessions/repository/chat-session-codec.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-codec.ts
@@ -73,6 +73,7 @@ export class ChatSessionCodec {
       lastContinuePrompt: undefined,
       context: undefined,
       archives: undefined,
+      leaseEpoch: 0,
       lease: undefined,
       ...value,
       revision: value.revision ?? 1,

--- a/src/core/chat/engine/sessions/repository/chat-session-repository-conformance.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-repository-conformance.ts
@@ -659,9 +659,12 @@ export class ChatSessionRepositoryConformance {
       lastContinuePrompt: 'Continue.',
       context: { estimatedHistoryTokens: 0 },
       archives: [],
+      leaseEpoch: 1,
       lease: {
         ownerKind: 'daemon',
+        hostId: 'host-a',
         ownerId: 'conformance-owner',
+        fencingToken: 1,
         acquiredAt: timestamp.first,
         lastSeenAt: timestamp.first,
       },
@@ -737,7 +740,9 @@ export class ChatSessionRepositoryConformance {
       }],
       lease: {
         ownerKind: 'daemon',
+        hostId: 'host-a',
         ownerId: 'daemon-1',
+        fencingToken: 1,
         acquiredAt: timestamp.second,
         lastSeenAt: timestamp.third,
         clientLabel: 'Hosted agent',

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -176,7 +176,15 @@ const ChatArchiveRecordsSchema = z.array(z.unknown())
 
 const ChatSessionLeaseSchema = z.object({
   ownerKind: ChatSessionLeaseOwnerSchema.describe('Kind of host currently holding the session lease.'),
+  hostId: z.string()
+    .describe('Host or replica identity for the current lease holder.')
+    .optional(),
   ownerId: z.string().describe('Unique owner identifier for the current lease holder.'),
+  fencingToken: z.number()
+    .int()
+    .nonnegative()
+    .describe('Monotonic token that fences stale lease holders.')
+    .default(0),
   acquiredAt: z.string().describe('Timestamp when the current lease was acquired.'),
   lastSeenAt: z.string().describe('Timestamp when the lease holder last refreshed ownership.'),
   clientLabel: z.string()
@@ -261,6 +269,12 @@ export const CatalogEntryReadSchema = z.object({
     .describe('Conversation archives associated with this session.')
     .optional()
     .catch(undefined),
+  leaseEpoch: z.number()
+    .int()
+    .nonnegative()
+    .describe('Last fencing token issued for this session.')
+    .optional()
+    .catch(0),
   lease: ChatSessionLeaseSchema
     .describe('Current session lease held by a TUI, daemon, or ask host.')
     .optional()
@@ -322,6 +336,12 @@ export const SessionBodyReadSchema = z.object({
     .describe('Conversation archives duplicated in the body for session reconstruction.')
     .optional()
     .catch(undefined),
+  leaseEpoch: z.number()
+    .int()
+    .nonnegative()
+    .describe('Last fencing token issued for this session.')
+    .optional()
+    .catch(0),
   lease: ChatSessionLeaseSchema
     .describe('Current session lease duplicated in the body for session reconstruction.')
     .optional()
@@ -352,6 +372,11 @@ export const SessionBodyWriteSchema = z.object({
   archives: z.array(ChatArchiveRecordSchema)
     .describe('Conversation archives duplicated in the body for session reconstruction.')
     .optional(),
+  leaseEpoch: z.number()
+    .int()
+    .nonnegative()
+    .describe('Last fencing token issued for this session.')
+    .optional(),
   lease: ChatSessionLeaseSchema
     .describe('Current session lease duplicated in the body for session reconstruction.')
     .optional(),
@@ -376,6 +401,7 @@ export const ChatSessionRecordSchema = CatalogEntryWriteSchema
     driftEnabled: z.boolean().optional(),
     context: ChatContextStatsSchema.optional(),
     archives: z.array(ChatArchiveRecordSchema).optional(),
+    leaseEpoch: z.number().int().nonnegative().optional(),
     lease: ChatSessionLeaseSchema.optional(),
     history: z.array(ChatMessageSchema),
     messages: z.array(ConversationLineSchema),

--- a/src/core/chat/engine/sessions/repository/types.ts
+++ b/src/core/chat/engine/sessions/repository/types.ts
@@ -18,6 +18,7 @@ export type ChatSessionCatalogEntry = {
   lastContinuePrompt?: string;
   context?: ChatContextStats;
   archives?: ChatArchiveRecord[];
+  leaseEpoch?: number;
   lease?: ChatSessionLease;
 };
 

--- a/src/core/chat/engine/sessions/service.ts
+++ b/src/core/chat/engine/sessions/service.ts
@@ -25,7 +25,13 @@ import type {
   ChatSessionRepository,
   ListChatSessionsInput,
 } from '@/core/chat/engine/sessions/repository/types.js';
-import { ChatSessionLeases, type ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
+import {
+  ChatSessionLeaseLostError,
+  ChatSessionLeases,
+  type ChatSessionLeaseClaim,
+  type ChatSessionLeaseIdentity,
+  type ChatSessionLeaseOwner,
+} from '@/core/chat/engine/sessions/leases/index.js';
 import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
 import { ChatSessionRecords, ChatSessionTitles, ConversationLines } from '@/core/chat/engine/sessions/records/index.js';
 import type { ChatSession } from '@/core/chat/types.js';
@@ -180,12 +186,34 @@ export class FileConversationSessionService implements ConversationSessionServic
     id: string,
     updater: (session: ChatSession) => ChatSession,
   ): Promise<ChatSession | undefined> {
+    return await this.updatePersisted(id, updater);
+  }
+
+  async updateWithLease(
+    id: string,
+    claim: ChatSessionLeaseClaim,
+    updater: (session: ChatSession) => ChatSession,
+  ): Promise<ChatSession | undefined> {
+    return await this.updatePersisted(id, updater, claim);
+  }
+
+  private async updatePersisted(
+    id: string,
+    updater: (session: ChatSession) => ChatSession,
+    leaseClaim?: ChatSessionLeaseClaim,
+  ): Promise<ChatSession | undefined> {
     let conflictCount = 0;
 
     while (true) {
       const record = await this.repository.read(id);
       if (!record) {
         return undefined;
+      }
+      if (leaseClaim && !ChatSessionLeases.isHeld(record.session, leaseClaim)) {
+        throw new ChatSessionLeaseLostError({
+          session: record.session,
+          expected: leaseClaim,
+        });
       }
 
       const nextSession = updater(record.session);
@@ -368,7 +396,7 @@ export class FileConversationSessionService implements ConversationSessionServic
         history: input.sourceHistory,
         lastArchivePath: input.archivePath,
       }),
-    }));
+    }), input.leaseClaim);
   }
 
   async applyCompactionResult(id: string, input: ApplyConversationCompactionResultInput): Promise<ChatSession> {
@@ -378,14 +406,15 @@ export class FileConversationSessionService implements ConversationSessionServic
       context: input.context,
       archives: input.archive.archives,
       messages: ConversationLines.fromHistory(input.history),
-    }));
+    }), input.leaseClaim);
   }
 
   async restoreCompactionState(id: string, input: RestoreConversationCompactionStateInput): Promise<ChatSession> {
     return await this.updateRequiredSession(id, (session) => ({
       ...session,
-      ...input,
-    }));
+      context: input.context,
+      archives: input.archives,
+    }), input.leaseClaim);
   }
 
   async setDriftEnabled(id: string, enabled: boolean): Promise<ChatSession> {
@@ -407,11 +436,19 @@ export class FileConversationSessionService implements ConversationSessionServic
     });
   }
 
-  async refreshLease(id: string, owner: Pick<ChatSessionLeaseOwner, 'ownerId'>): Promise<ChatSession> {
-    return await this.updateRequiredSession(id, (session) => ChatSessionLeases.refresh(session, owner));
+  async refreshLease(id: string, owner: ChatSessionLeaseIdentity): Promise<ChatSession> {
+    return await this.updateRequiredSession(id, (session) => {
+      if (
+        !ChatSessionLeases.isSameOwner(session.lease, owner)
+        || !ChatSessionLeases.isFresh(session.lease)
+      ) {
+        throw new ChatSessionLeaseLostError({ session, expected: owner });
+      }
+      return ChatSessionLeases.refresh(session, owner);
+    });
   }
 
-  async releaseLease(id: string, owner: Pick<ChatSessionLeaseOwner, 'ownerId'>): Promise<ChatSession> {
+  async releaseLease(id: string, owner: ChatSessionLeaseIdentity): Promise<ChatSession> {
     return await this.updateRequiredSession(id, (session) => ChatSessionLeases.release(session, owner));
   }
 
@@ -491,8 +528,11 @@ export class FileConversationSessionService implements ConversationSessionServic
   private async updateRequiredSession(
     id: string,
     updater: (session: ChatSession) => ChatSession,
+    leaseClaim?: ChatSessionLeaseClaim,
   ): Promise<ChatSession> {
-    const updated = await this.update(id, updater);
+    const updated = leaseClaim
+      ? await this.updateWithLease(id, leaseClaim, updater)
+      : await this.update(id, updater);
     if (!updated) {
       throw new Error(`Chat session not found: ${id}`);
     }

--- a/src/core/chat/engine/turns/context/turn-context-builder.ts
+++ b/src/core/chat/engine/turns/context/turn-context-builder.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+import { hostname } from 'node:os';
 import { RuntimeToolService } from '@/core/runtime/tools/index.js';
 import { CustomAgentRuntimeContextService } from '@/core/custom-agents/index.js';
 import { ConversationTurnRuntimeResolver } from '../runtime/index.js';
@@ -8,6 +10,9 @@ import type {
   PrepareConversationTurnContextArgs,
 } from './types.js';
 import type { ConversationTurnRuntimeConfig } from '../runtime/index.js';
+
+const DEFAULT_LEASE_HOST_ID = hostname();
+const DEFAULT_LEASE_OWNER_ID = `submit-${randomUUID()}`;
 
 /**
  * Builds the concrete runtime context needed before a persisted turn can run.
@@ -45,7 +50,8 @@ export class ConversationTurnContextBuilder {
       toolNames: tools.map((tool) => tool.name),
       leaseOwner: args.leaseOwner ?? {
         ownerKind: 'ask',
-        ownerId: `submit-${process.pid}`,
+        hostId: DEFAULT_LEASE_HOST_ID,
+        ownerId: DEFAULT_LEASE_OWNER_ID,
         clientLabel: 'another Heddle client',
       },
     };

--- a/src/core/chat/engine/turns/persistence/turn-persistence-service.ts
+++ b/src/core/chat/engine/turns/persistence/turn-persistence-service.ts
@@ -36,12 +36,13 @@ export class ConversationTurnPersistenceService {
         await args.sessionService.restoreCompactionState(args.session.id, {
           context: args.session.context,
           archives: args.session.archives,
+          leaseClaim: args.leaseClaim,
         });
       }
       throw error;
     }
 
-    const session = await args.sessionService.update(args.session.id, (latestSession) => ({
+    const session = await args.sessionService.updateWithLease(args.session.id, args.leaseClaim, (latestSession) => ({
         ...persisted.session,
         queuedPrompts: latestSession.queuedPrompts,
       }));
@@ -61,6 +62,7 @@ export class ConversationTurnPersistenceService {
     await args.sessionService.markCompactionRunning(args.session.id, {
       sourceHistory,
       archivePath: args.archivePath,
+      leaseClaim: args.leaseClaim,
     });
   }
 }

--- a/src/core/chat/engine/turns/persistence/types.ts
+++ b/src/core/chat/engine/turns/persistence/types.ts
@@ -7,6 +7,7 @@ import type { ChatSession, TurnSummary } from '@/core/chat/types.js';
 import type { ConversationSessionService } from '@/core/chat/engine/types.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
+import type { ChatSessionLeaseClaim } from '@/core/chat/engine/sessions/leases/index.js';
 import type { ChatTurnHostPort } from '../host/index.js';
 import type {
   ConversationCompactionResult,
@@ -75,6 +76,7 @@ export type PersistCompletedChatTurnBase = {
 
 export type PersistCompletedChatTurnArgs = PersistCompletedChatTurnBase & {
   sessionService: ConversationSessionService;
+  leaseClaim: ChatSessionLeaseClaim;
   summarizer: ConversationCompactionOptions['summarizer'];
   host: Pick<ChatTurnHostPort, 'onCompactionStatus'>;
 };

--- a/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
+++ b/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
@@ -1,4 +1,5 @@
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
+import { ChatSessionLeases } from '@/core/chat/engine/sessions/leases/index.js';
 import { ConversationCompactionService } from '@/core/chat/engine/compaction/index.js';
 import type { ConversationCompactionResult } from '@/core/chat/engine/compaction/index.js';
 import { ChatArchiveRepositoryError } from '@/core/chat/engine/sessions/archives/index.js';
@@ -31,6 +32,10 @@ export class ConversationTurnPreflightService {
     const leasedSession = persistedSession
       ? await args.sessionService.acquireLease(args.sessionId, args.leaseOwner)
       : undefined;
+    if (!leasedSession) {
+      throw new Error(`Chat session not found: ${args.sessionId}`);
+    }
+    const leaseClaim = ChatSessionLeases.claim(leasedSession);
     const initialHistory = leasedSession?.history ?? args.fallbackHistory;
     const compactionRuntime: PreflightTurnCompactionRuntime = args;
     const compactionRequest: PreflightTurnCompactionRequest = {
@@ -53,6 +58,7 @@ export class ConversationTurnPreflightService {
             await ConversationTurnPreflightService.persistRunningSeed({
               ...args,
               leasedSession,
+              leaseClaim,
               archivePath: event.archivePath,
             });
             runningSeedPersisted = true;
@@ -64,6 +70,7 @@ export class ConversationTurnPreflightService {
         await args.sessionService.restoreCompactionState(args.sessionId, {
           context: leasedSession.context,
           archives: leasedSession.archives,
+          leaseClaim,
         });
       }
       throw error;
@@ -73,6 +80,7 @@ export class ConversationTurnPreflightService {
       ...args,
       session: persistedSession ?? await args.sessionService.require(args.sessionId),
       compacted: preflightCompacted,
+      leaseClaim,
     });
   }
 
@@ -80,13 +88,14 @@ export class ConversationTurnPreflightService {
     await args.sessionService.markCompactionRunning(args.sessionId, {
       sourceHistory: args.leasedSession.history,
       archivePath: args.archivePath,
+      leaseClaim: args.leaseClaim,
     });
   }
 
   static async persistPrepared(
     args: PersistPreparedChatSessionTurnArgs,
   ): Promise<Extract<PrepareChatSessionTurnResult, { ok: true }>> {
-    const preparedSession = await args.sessionService.update(args.session.id, (session) => (
+    const preparedSession = await args.sessionService.updateWithLease(args.session.id, args.leaseClaim, (session) => (
       ChatSessionRecords.applyCompactedHistory({
         session,
         compacted: args.compacted,
@@ -101,6 +110,7 @@ export class ConversationTurnPreflightService {
       ok: true,
       session: preparedSession,
       compacted: args.compacted,
+      leaseClaim: args.leaseClaim,
     };
   }
 

--- a/src/core/chat/engine/turns/preflight/types.ts
+++ b/src/core/chat/engine/turns/preflight/types.ts
@@ -2,7 +2,10 @@ import type { ChatMessage } from '@/core/llm/types.js';
 import type { ChatSession } from '@/core/chat/types.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import type { ConversationCompactionStatus } from '@/core/live/index.js';
-import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
+import type {
+  ChatSessionLeaseClaim,
+  ChatSessionLeaseOwner,
+} from '@/core/chat/engine/sessions/leases/index.js';
 import type { ChatArchiveRepository } from '@/core/chat/engine/sessions/archives/index.js';
 import type { ConversationSessionService } from '@/core/chat/engine/types.js';
 import type { ChatTurnHostPort } from '../host/index.js';
@@ -44,6 +47,7 @@ export type PersistPreflightRunningSeedArgs = Pick<
   'sessionService' | 'sessionId'
 > & {
   leasedSession: ChatSession;
+  leaseClaim: ChatSessionLeaseClaim;
   archivePath?: string;
 };
 
@@ -53,6 +57,7 @@ export type PersistPreparedChatSessionTurnArgs = Pick<
 > & {
   session: ChatSession;
   compacted: ConversationCompactionResult;
+  leaseClaim: ChatSessionLeaseClaim;
 };
 
 export type PrepareChatSessionTurnResult =
@@ -60,6 +65,7 @@ export type PrepareChatSessionTurnResult =
       ok: true;
       session: ChatSession;
       compacted: ConversationCompactionResult;
+      leaseClaim: ChatSessionLeaseClaim;
     }
   | {
       ok: false;

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -168,6 +168,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
         summarizer: runtime.summarizer,
         host,
         agentSnapshot,
+        leaseClaim: preflight.leaseClaim,
       });
 
       if (maintenanceMode === 'background') {

--- a/src/core/chat/engine/types.ts
+++ b/src/core/chat/engine/types.ts
@@ -10,7 +10,11 @@ import type {
 import type { AgentLoopEvent, RunAgentLoopOptions } from '../../runtime/loop/index.js';
 import type { ChatMessage, LlmAdapter, ReasoningEffort } from '../../llm/types.js';
 import type { ToolDefinition, TraceEvent } from '../../types.js';
-import type { ChatSessionLeaseOwner } from './sessions/leases/index.js';
+import type {
+  ChatSessionLeaseClaim,
+  ChatSessionLeaseIdentity,
+  ChatSessionLeaseOwner,
+} from './sessions/leases/index.js';
 import type { ChatArchiveRepository } from './sessions/archives/index.js';
 import type {
   ChatSessionCatalogPage,
@@ -138,6 +142,15 @@ export type ConversationSessionService = {
   // Generic mutation escape hatch. The updater may be reapplied after an
   // optimistic-concurrency conflict, so it must not perform external side effects.
   update(id: string, updater: (session: ChatSession) => ChatSession): Promise<ChatSession | undefined>;
+  /**
+   * Lease-protected mutation. The claim is revalidated against the latest
+   * revision before every compare-and-set attempt.
+   */
+  updateWithLease(
+    id: string,
+    claim: ChatSessionLeaseClaim,
+    updater: (session: ChatSession) => ChatSession,
+  ): Promise<ChatSession | undefined>;
 
   // Settings
   updateSettings(id: string, input: UpdateConversationSessionSettingsInput): Promise<ChatSession>;
@@ -166,8 +179,8 @@ export type ConversationSessionService = {
   // Leases
   getLeaseConflict(id: string, owner: ChatSessionLeaseOwner): Promise<string | undefined>;
   acquireLease(id: string, owner: ChatSessionLeaseOwner): Promise<ChatSession>;
-  refreshLease(id: string, owner: Pick<ChatSessionLeaseOwner, 'ownerId'>): Promise<ChatSession>;
-  releaseLease(id: string, owner: Pick<ChatSessionLeaseOwner, 'ownerId'>): Promise<ChatSession>;
+  refreshLease(id: string, owner: ChatSessionLeaseIdentity): Promise<ChatSession>;
+  releaseLease(id: string, owner: ChatSessionLeaseIdentity): Promise<ChatSession>;
 };
 
 export type CreateConversationSessionInput = {
@@ -261,11 +274,16 @@ export type DequeuedConversationPromptResult = {
 export type MarkConversationCompactionRunningInput = {
   sourceHistory: ChatMessage[];
   archivePath?: string;
+  leaseClaim?: ChatSessionLeaseClaim;
 };
 
-export type ApplyConversationCompactionResultInput = ConversationCompactionResult;
+export type ApplyConversationCompactionResultInput = ConversationCompactionResult & {
+  leaseClaim?: ChatSessionLeaseClaim;
+};
 
-export type RestoreConversationCompactionStateInput = Pick<ChatSession, 'context' | 'archives'>;
+export type RestoreConversationCompactionStateInput = Pick<ChatSession, 'context' | 'archives'> & {
+  leaseClaim?: ChatSessionLeaseClaim;
+};
 
 export type ConversationTurnService = {
   submit(input: SubmitConversationTurnInput): Promise<SubmitConversationTurnResult>;

--- a/src/core/chat/types.ts
+++ b/src/core/chat/types.ts
@@ -131,7 +131,12 @@ export type ChatArchiveManifest = {
 
 export type ChatSessionLease = {
   ownerKind: 'tui' | 'daemon' | 'ask';
+  /** Host or replica identity. Legacy persisted leases may not have one. */
+  hostId?: string;
+  /** Unique identity for one runtime instance on the host. */
   ownerId: string;
+  /** Monotonic session-owned token used to fence stale writers. */
+  fencingToken: number;
   acquiredAt: string;
   lastSeenAt: string;
   clientLabel?: string;
@@ -167,6 +172,8 @@ export type ChatSession = {
   lastContinuePrompt?: string;
   context?: ChatContextStats;
   archives?: ChatArchiveRecord[];
+  /** Last fencing token issued for this session, retained after release. */
+  leaseEpoch?: number;
   lease?: ChatSessionLease;
   queuedPrompts: QueuedConversationPrompt[];
 };

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -34,6 +34,7 @@ import type {
   ConversationEngineHost,
   UpdateConversationSessionSettingsInput,
 } from '@/core/chat/engine/types.js';
+import { ChatSessionLeases } from '@/core/chat/engine/sessions/leases/index.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import type { ChatSession } from '@/core/chat/types.js';
 import {
@@ -668,7 +669,8 @@ export class ControlPlaneChatSessionsController {
         const sessions = this.createEngine(args).sessions;
         const session = await sessions.require(args.sessionId);
         await this.assertNoLeaseConflict(sessions, args.sessionId, args.leaseOwner);
-        await sessions.acquireLease(args.sessionId, args.leaseOwner);
+        const leasedSession = await sessions.acquireLease(args.sessionId, args.leaseOwner);
+        const leaseClaim = ChatSessionLeases.claim(leasedSession);
 
         try {
           const model = session.model ?? args.model ?? DEFAULT_OPENAI_MODEL;
@@ -694,6 +696,7 @@ export class ControlPlaneChatSessionsController {
               credentialSource: providerRuntime.credentialSource,
             },
             sessions,
+            leaseClaim,
             abortSignal: run.controller.signal,
             onActivity: publisher.publishActivity,
             onCompactionStatus: publisher.publishActivity,

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+import { hostname } from 'node:os';
 import dayjs from 'dayjs';
 import type { z } from 'zod';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
@@ -81,6 +83,9 @@ import {
   workspaceRenameInputSchema,
   workspaceSetActiveInputSchema,
 } from './schema.js';
+
+const CONTROL_PLANE_LEASE_HOST_ID = hostname();
+const FALLBACK_CONTROL_PLANE_LEASE_OWNER_ID = `daemon-${randomUUID()}`;
 
 export const controlPlaneRouter = router({
   state: controlPlaneWorkspaceProcedure.query(async ({ ctx }) => {
@@ -745,7 +750,8 @@ function buildSubmitPromptArgs(ctx: ControlPlaneWorkspaceContext, input: Session
 function resolveControlPlaneLeaseOwner(ctx: Pick<HeddleServerContext, 'runtimeHost'>): ChatSessionLeaseOwner {
   return {
     ownerKind: 'daemon',
-    ownerId: ctx.runtimeHost?.serverId ?? `daemon-${process.pid}`,
+    hostId: CONTROL_PLANE_LEASE_HOST_ID,
+    ownerId: ctx.runtimeHost?.serverId ?? FALLBACK_CONTROL_PLANE_LEASE_OWNER_ID,
     clientLabel: 'control plane',
   };
 }


### PR DESCRIPTION
## Summary

- replace PID-derived lease liveness with composite host/runtime ownership
- persist a monotonically increasing fencing token and revalidate it before every turn-owned session commit
- make expiry revoke renewal and write authority, while allowing a higher-fenced takeover
- carry the lease claim through preflight, compaction, direct-shell, and terminal persistence paths
- document the local-filesystem and hosted-repository deployment guarantees

## Safety boundary

Replica safety depends on `ChatSessionRepository.update` applying `expectedRevision` atomically with the write. The default file repository provides this across processes sharing its supported local filesystem; it does not claim generic NFS or multi-host filesystem safety. Hosted adapters need a shared transactional/CAS implementation.

## Verification

- `yarn test:unit` — 131 files, 787 tests
- `yarn test:integration` — 35 files, 321 tests
- `yarn typecheck`
- `yarn lint`
- `yarn build`

Closes #277