### PR TITLE
test: certify archive repository adapters

### DIFF
--- a/examples/sdk/06-persistence/postgres-drizzle/README.md
+++ b/examples/sdk/06-persistence/postgres-drizzle/README.md
@@ -3,7 +3,7 @@
 This runnable SDK reference shows how a TypeScript host can persist Heddle's
 complete conversation sessions and compacted archives in PostgreSQL. It uses
 `drizzle-orm` with the mature `pg` driver, Heddle's public repository contracts,
-and the public session conformance suite.
+and the public session and archive conformance suites.
 
 This is host-owned reference code, not an official Heddle database adapter.
 Copy and adapt it inside the service that already owns authentication,
@@ -21,6 +21,8 @@ PostgreSQL, migrations, connection pooling, and operations.
   one transaction; and
 - another trusted scope can reuse the same session/archive IDs without reading
   or mutating the first scope's records.
+- both repositories pass the same public conformance suites used to certify
+  Heddle's file implementations.
 
 The verification makes no model request and requires no API key.
 
@@ -68,7 +70,7 @@ docker compose \
   postgres-chat-archive-repository.ts    locked manifest + atomic archive append
   migration.ts                           host-callable migration boundary
   migrate.ts                             standalone migration command
-  verify.ts                              conformance + fresh-service recovery
+  verify.ts                              both conformance suites + fresh-service recovery
   compose.yaml                           isolated local PostgreSQL 17 service
 ```
 
@@ -159,8 +161,8 @@ Before adapting this example for production, the host still needs to own:
 
 - migration rollout/rollback and compatibility across mixed application
   versions;
-- TLS, secret rotation, pool sizing, statement/lock timeouts, retry policy, and
-  graceful pool shutdown;
+- encryption in transit and at rest, secret rotation, pool sizing,
+  statement/lock timeouts, retry policy, and graceful pool shutdown;
 - authenticated scope derivation and optional PostgreSQL RLS as defense in
   depth;
 - query-plan/load testing, metrics, slow-query and lock observability;
@@ -169,7 +171,7 @@ Before adapting this example for production, the host still needs to own:
 - process routing for active runs and SSE plus durability for artifacts, traces,
   memory, and any product-visible transcript.
 
-Passing Heddle's conformance suite certifies the exercised repository contract;
+Passing Heddle's conformance suites certifies the exercised repository contracts;
 it does not certify those operational concerns. Keep this reference in host
 code until at least two independent hosts validate the same configuration and
 migration surface. Only then consider extracting an optional maintained adapter

--- a/examples/sdk/06-persistence/postgres-drizzle/verify.ts
+++ b/examples/sdk/06-persistence/postgres-drizzle/verify.ts
@@ -7,10 +7,11 @@ import { and, eq, inArray } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import {
-  ChatArchiveStorageCorruptionError,
+  ChatArchiveRepositoryConformance,
   ChatSessionRepositoryConformance,
   createConversationEngine,
   type AppendChatArchiveInput,
+  type ChatArchiveRepositoryConformanceHarness,
   type ChatSessionRepositoryConformanceHarness,
 } from '../../../../src/index.js';
 import type { PostgresStorageDatabase } from './database.js';
@@ -69,57 +70,32 @@ async function verifySessionRepositoryConformance(
 async function verifyArchiveRepository(
   database: PostgresStorageDatabase,
 ): Promise<void> {
-  const scopeId = `archive-${randomUUID()}`;
-  const sessionId = `archive-session-${randomUUID()}`;
-  const firstRepository = new PostgresChatArchiveRepository({ database, scopeId });
-  const secondRepository = new PostgresChatArchiveRepository({ database, scopeId });
-  const firstInput = createArchiveInput(sessionId, 'archive-a', 'First rolling summary.');
-  const secondInput = createArchiveInput(sessionId, 'archive-b', 'Second rolling summary.');
+  const harness: ChatArchiveRepositoryConformanceHarness = {
+    createRepository: (scopeId) => new PostgresChatArchiveRepository({
+      database,
+      scopeId,
+    }),
+    cleanupScope: async (scopeId) => await cleanupScopes(database, [scopeId]),
+    corruptManifest: async ({ scopeId, sessionId }) => {
+      const changed = await database
+        .update(heddleChatSessionArchiveHeads)
+        .set({
+          manifest: {
+            version: 1,
+            sessionId: 'wrong-session',
+            archives: [],
+          },
+        })
+        .where(and(
+          eq(heddleChatSessionArchiveHeads.scopeId, scopeId),
+          eq(heddleChatSessionArchiveHeads.sessionId, sessionId),
+        ))
+        .returning({ sessionId: heddleChatSessionArchiveHeads.sessionId });
+      assert.equal(changed.length, 1, 'the conformance corruption hook must change one row');
+    },
+  };
 
-  try {
-    const appended = await Promise.all([
-      firstRepository.append(firstInput),
-      secondRepository.append(secondInput),
-    ]);
-    const freshRepository = new PostgresChatArchiveRepository({ database, scopeId });
-    const manifest = await freshRepository.loadManifest(sessionId);
-    assert.deepEqual(
-      manifest.archives.map((archive) => archive.id).sort(),
-      ['archive-a', 'archive-b'],
-      'concurrent appends must not lose either immutable archive',
-    );
-    for (const result of appended) {
-      const expectedSummary = result.archive.id === firstInput.archive.id
-        ? firstInput.summary
-        : secondInput.summary;
-      assert.equal(
-        await freshRepository.readSummary(result.archive.summaryPath),
-        expectedSummary,
-        `archive ${result.archive.id} must resolve its committed summary`,
-      );
-    }
-
-    await database
-      .update(heddleChatSessionArchiveHeads)
-      .set({
-        manifest: {
-          version: 1,
-          sessionId: 'wrong-session',
-          archives: [],
-        },
-      })
-      .where(and(
-        eq(heddleChatSessionArchiveHeads.scopeId, scopeId),
-        eq(heddleChatSessionArchiveHeads.sessionId, sessionId),
-      ));
-    await assert.rejects(
-      () => freshRepository.loadManifest(sessionId),
-      (error) => error instanceof ChatArchiveStorageCorruptionError,
-      'a malformed or session-mismatched manifest must fail loudly',
-    );
-  } finally {
-    await cleanupScopes(database, [scopeId]);
-  }
+  await ChatArchiveRepositoryConformance.runAll(harness);
 }
 
 async function verifyFreshServiceRecovery(

--- a/src/__tests__/integration/chat/chat-archive-repository-conformance.test.ts
+++ b/src/__tests__/integration/chat/chat-archive-repository-conformance.test.ts
@@ -1,0 +1,72 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  ChatArchiveRepositoryConformance,
+  ChatArchiveRepositoryConformanceError,
+  FileChatArchiveRepository,
+  type ChatArchiveRepositoryConformanceHarness,
+} from '@/core/chat/engine/sessions/archives/index.js';
+
+describe('ChatArchiveRepositoryConformance', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'heddle-archive-conformance-'));
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const stateRoot = (scopeId: string) => join(root, scopeId);
+
+  const harness: ChatArchiveRepositoryConformanceHarness = {
+    createRepository: (scopeId) => new FileChatArchiveRepository({
+      stateRoot: stateRoot(scopeId),
+    }),
+    cleanupScope: async (scopeId) => {
+      await rm(stateRoot(scopeId), { recursive: true, force: true });
+    },
+    corruptManifest: async ({ scopeId, sessionId }) => {
+      const repository = new FileChatArchiveRepository({
+        stateRoot: stateRoot(scopeId),
+      });
+      const paths = repository.deriveStoragePaths(sessionId);
+      await mkdir(paths.archivesDir, { recursive: true });
+      await writeFile(paths.manifestPath, '{"version":');
+    },
+  };
+
+  const scenarios = ChatArchiveRepositoryConformance.createScenarios(harness);
+
+  it('publishes six uniquely named scenarios', () => {
+    expect(scenarios).toHaveLength(6);
+    expect(new Set(scenarios.map((scenario) => scenario.name)).size).toBe(6);
+  });
+
+  it.each(scenarios)('$name', async ({ run }) => {
+    await run();
+  });
+
+  it('cleans every generated scope when an adapter operation fails', async () => {
+    const cleanedScopes: string[] = [];
+    const failingHarness: ChatArchiveRepositoryConformanceHarness = {
+      createRepository: () => {
+        throw new Error('adapter unavailable');
+      },
+      cleanupScope: (scopeId) => {
+        cleanedScopes.push(scopeId);
+      },
+      corruptManifest: () => undefined,
+    };
+    const [scenario] = ChatArchiveRepositoryConformance.createScenarios(failingHarness);
+
+    await expect(scenario?.run()).rejects.toBeInstanceOf(
+      ChatArchiveRepositoryConformanceError,
+    );
+    expect(cleanedScopes).toHaveLength(1);
+    expect(cleanedScopes[0]).toMatch(/^[0-9a-f-]{36}$/u);
+  });
+});

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -56,6 +56,8 @@ export {
   ChatArchivePersistenceCodec,
   ChatArchiveStorageCorruptionError,
   ChatArchiveSummaryNotFoundError,
+  ChatArchiveRepositoryConformance,
+  ChatArchiveRepositoryConformanceError,
   ChatArchiveRepositoryError,
   FileChatArchiveRepository,
 } from './sessions/archives/index.js';
@@ -63,6 +65,9 @@ export type {
   AppendChatArchiveInput,
   AppendChatArchiveResult,
   ChatArchiveRecordDraft,
+  ChatArchiveRepositoryConformanceHarness,
+  ChatArchiveRepositoryConformanceScenario,
+  CorruptChatArchiveManifestInput,
   ChatArchiveRepository,
   ChatArchiveStoragePaths,
   FileChatArchiveRepositoryOptions,

--- a/src/core/chat/engine/sessions/archives/README.md
+++ b/src/core/chat/engine/sessions/archives/README.md
@@ -34,6 +34,35 @@ present and lists the host checks still required. It cannot prove that two
 arbitrary adapters use the same scope, transaction system, migration, backup,
 or deletion policy.
 
+## Certifying a host adapter
+
+`ChatArchiveRepositoryConformance` is the public, runner-neutral contract suite
+for archive adapters. A host supplies only fresh scope-bound repositories,
+scope cleanup, and a test-only corruption hook:
+
+```ts
+const harness: ChatArchiveRepositoryConformanceHarness = {
+  createRepository: (scopeId) => createArchiveRepository({ scopeId }),
+  cleanupScope: (scopeId) => deleteTestScope(scopeId),
+  corruptManifest: ({ scopeId, sessionId }) =>
+    corruptTestManifest({ scopeId, sessionId }),
+}
+
+await ChatArchiveRepositoryConformance.runAll(harness)
+```
+
+Use `createScenarios(harness)` when registering each named scenario with a test
+runner. The suite verifies append order, concurrent atomic appends, duplicate
+conflicts, trusted-scope isolation, fresh-instance recovery, summary reads, and
+corruption failure. Heddle's file adapter and the PostgreSQL + Drizzle reference
+both run this same suite in CI.
+
+The v1 port returns one complete append-ordered manifest per session. It has no
+pagination or cursor operation; cursor semantics belong to the session catalog
+repository. A host adapter must not silently invent a different archive order
+or partial-manifest contract. If archive catalogs later need paging, that
+requires a versioned Heddle port rather than adapter-specific behavior.
+
 ## File adapter durability
 
 `FileChatArchiveRepository` preserves the v1 layout under

--- a/src/core/chat/engine/sessions/archives/chat-archive-repository-conformance.ts
+++ b/src/core/chat/engine/sessions/archives/chat-archive-repository-conformance.ts
@@ -1,0 +1,536 @@
+/**
+ * Runner-neutral contract tests for `ChatArchiveRepository` adapters.
+ *
+ * Hosts supply fresh, scope-bound repository instances plus lifecycle and
+ * corruption hooks. Heddle owns the assertions so file and remote adapters are
+ * certified against one append, isolation, and recovery contract.
+ */
+import { randomUUID } from 'node:crypto';
+import isEqual from 'lodash/isEqual.js';
+import type { ChatArchiveManifest, ChatArchiveRecord } from '@/core/chat/types.js';
+import { ChatArchiveRepositoryConformanceError } from './errors.js';
+import type {
+  AppendChatArchiveInput,
+  ChatArchiveRepository,
+} from './types.js';
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type CorruptChatArchiveManifestInput = {
+  scopeId: string;
+  sessionId: string;
+};
+
+export type ChatArchiveRepositoryConformanceHarness = {
+  /** Return a new repository instance bound to only this opaque test scope. */
+  createRepository(scopeId: string): MaybePromise<ChatArchiveRepository>;
+  /** Remove all records and resources created for one opaque test scope. */
+  cleanupScope(scopeId: string): MaybePromise<void>;
+  /** Make one existing manifest malformed while leaving it addressable. */
+  corruptManifest(input: CorruptChatArchiveManifestInput): MaybePromise<void>;
+};
+
+export type ChatArchiveRepositoryConformanceScenario = Readonly<{
+  name: string;
+  run: () => Promise<void>;
+}>;
+
+type ScenarioOperation = (
+  scopeIds: readonly string[],
+  harness: ChatArchiveRepositoryConformanceHarness,
+) => Promise<void>;
+
+const timestamp = {
+  first: '2026-01-01T00:00:00.000Z',
+  second: '2026-01-02T00:00:00.000Z',
+} as const;
+
+const scenarioName = {
+  appendOrder: 'append preserves manifest order and readable summaries',
+  atomicAppends: 'concurrent appends commit complete non-conflicting archives',
+  duplicateConflict: 'duplicate archive ids reject without changing committed state',
+  scopeIsolation: 'scope-bound repositories isolate identical archive addresses',
+  reopen: 'fresh repository instances reopen complete archive state',
+  corruption: 'malformed stored manifests propagate as read failures',
+} as const;
+
+/**
+ * Canonical behavioral suite for certifying a custom archive repository.
+ *
+ * `createScenarios` integrates with any test runner that accepts named async
+ * callbacks. `runAll` is useful for scripts and smoke checks.
+ *
+ * The v1 archive port exposes one authoritative append-ordered manifest per
+ * session. It deliberately has no cursor/page operation; hosts should not add
+ * adapter-specific pagination semantics to this conformance boundary.
+ */
+export class ChatArchiveRepositoryConformance {
+  static createScenarios(
+    harness: ChatArchiveRepositoryConformanceHarness,
+  ): ChatArchiveRepositoryConformanceScenario[] {
+    return [
+      ChatArchiveRepositoryConformance.createScenario(
+        scenarioName.appendOrder,
+        harness,
+        1,
+        ChatArchiveRepositoryConformance.verifyAppendOrder,
+      ),
+      ChatArchiveRepositoryConformance.createScenario(
+        scenarioName.atomicAppends,
+        harness,
+        1,
+        ChatArchiveRepositoryConformance.verifyAtomicAppends,
+      ),
+      ChatArchiveRepositoryConformance.createScenario(
+        scenarioName.duplicateConflict,
+        harness,
+        1,
+        ChatArchiveRepositoryConformance.verifyDuplicateConflict,
+      ),
+      ChatArchiveRepositoryConformance.createScenario(
+        scenarioName.scopeIsolation,
+        harness,
+        2,
+        ChatArchiveRepositoryConformance.verifyScopeIsolation,
+      ),
+      ChatArchiveRepositoryConformance.createScenario(
+        scenarioName.reopen,
+        harness,
+        1,
+        ChatArchiveRepositoryConformance.verifyReopen,
+      ),
+      ChatArchiveRepositoryConformance.createScenario(
+        scenarioName.corruption,
+        harness,
+        1,
+        ChatArchiveRepositoryConformance.verifyCorruption,
+      ),
+    ];
+  }
+
+  static async runAll(
+    harness: ChatArchiveRepositoryConformanceHarness,
+  ): Promise<void> {
+    for (const scenario of ChatArchiveRepositoryConformance.createScenarios(harness)) {
+      await scenario.run();
+    }
+  }
+
+  private static createScenario(
+    name: string,
+    harness: ChatArchiveRepositoryConformanceHarness,
+    scopeCount: number,
+    operation: ScenarioOperation,
+  ): ChatArchiveRepositoryConformanceScenario {
+    return {
+      name,
+      run: async () => {
+        const scopeIds = Array.from({ length: scopeCount }, () => randomUUID());
+        await ChatArchiveRepositoryConformance.runWithCleanup(
+          name,
+          harness,
+          scopeIds,
+          operation,
+        );
+      },
+    };
+  }
+
+  private static async runWithCleanup(
+    scenario: string,
+    harness: ChatArchiveRepositoryConformanceHarness,
+    scopeIds: readonly string[],
+    operation: ScenarioOperation,
+  ): Promise<void> {
+    let operationFailed = false;
+    let operationError: unknown;
+    try {
+      await operation(scopeIds, harness);
+    } catch (error) {
+      operationFailed = true;
+      operationError = error;
+    }
+
+    const cleanupResults = await Promise.allSettled(
+      scopeIds.map(async (scopeId) => await harness.cleanupScope(scopeId)),
+    );
+    const cleanupErrors = cleanupResults.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason as unknown] : []
+    );
+
+    if (operationFailed && cleanupErrors.length > 0) {
+      throw new ChatArchiveRepositoryConformanceError(
+        scenario,
+        'the scenario and scope cleanup both failed',
+        { cause: new AggregateError([operationError, ...cleanupErrors]) },
+      );
+    }
+    if (operationError instanceof ChatArchiveRepositoryConformanceError) {
+      throw operationError;
+    }
+    if (operationFailed) {
+      throw new ChatArchiveRepositoryConformanceError(
+        scenario,
+        'the adapter operation failed unexpectedly',
+        { cause: operationError },
+      );
+    }
+    if (cleanupErrors.length > 0) {
+      throw new ChatArchiveRepositoryConformanceError(
+        scenario,
+        'scope cleanup failed',
+        { cause: new AggregateError(cleanupErrors) },
+      );
+    }
+  }
+
+  private static async verifyAppendOrder(
+    [scopeId]: readonly string[],
+    harness: ChatArchiveRepositoryConformanceHarness,
+  ): Promise<void> {
+    const scenario = scenarioName.appendOrder;
+    const repository = await ChatArchiveRepositoryConformance.repository(harness, scopeId);
+    const sessionId = 'ordered-session';
+    ChatArchiveRepositoryConformance.equal(
+      await repository.loadManifest(sessionId),
+      ChatArchiveRepositoryConformance.emptyManifest(sessionId),
+      scenario,
+      'a missing session must load as an empty manifest',
+    );
+
+    const firstInput = ChatArchiveRepositoryConformance.input(
+      sessionId,
+      'archive-first',
+      'First summary.\n',
+      timestamp.second,
+    );
+    const secondInput = ChatArchiveRepositoryConformance.input(
+      sessionId,
+      'archive-second',
+      'Second summary.\n',
+      timestamp.first,
+    );
+    const first = await repository.append(firstInput);
+    const second = await repository.append(secondInput);
+
+    ChatArchiveRepositoryConformance.equal(
+      second.manifest.archives,
+      [first.archive, second.archive],
+      scenario,
+      'manifest archives must remain in append order rather than timestamp order',
+    );
+    ChatArchiveRepositoryConformance.equal(
+      second.manifest.currentSummaryPath,
+      second.archive.summaryPath,
+      scenario,
+      'the latest appended archive must own the current summary locator',
+    );
+    await ChatArchiveRepositoryConformance.expectReadableSummary(
+      repository,
+      first.archive,
+      firstInput.summary,
+      scenario,
+    );
+    await ChatArchiveRepositoryConformance.expectReadableSummary(
+      repository,
+      second.archive,
+      secondInput.summary,
+      scenario,
+    );
+  }
+
+  private static async verifyAtomicAppends(
+    [scopeId]: readonly string[],
+    harness: ChatArchiveRepositoryConformanceHarness,
+  ): Promise<void> {
+    const scenario = scenarioName.atomicAppends;
+    const [firstRepository, secondRepository] = await Promise.all([
+      ChatArchiveRepositoryConformance.repository(harness, scopeId),
+      ChatArchiveRepositoryConformance.repository(harness, scopeId),
+    ]);
+    ChatArchiveRepositoryConformance.expect(
+      firstRepository !== secondRepository,
+      scenario,
+      'createRepository must return a fresh instance for each call',
+    );
+    const sessionId = 'concurrent-session';
+    const inputs = [
+      ChatArchiveRepositoryConformance.input(
+        sessionId,
+        'archive-a',
+        'Concurrent summary A.\n',
+        timestamp.first,
+      ),
+      ChatArchiveRepositoryConformance.input(
+        sessionId,
+        'archive-b',
+        'Concurrent summary B.\n',
+        timestamp.second,
+      ),
+    ] as const;
+    const results = await Promise.all([
+      firstRepository.append(inputs[0]),
+      secondRepository.append(inputs[1]),
+    ]);
+
+    const reopened = await ChatArchiveRepositoryConformance.repository(harness, scopeId);
+    const manifest = await reopened.loadManifest(sessionId);
+    ChatArchiveRepositoryConformance.equal(
+      [...manifest.archives.map(({ id }) => id)].sort(),
+      ['archive-a', 'archive-b'],
+      scenario,
+      'concurrent appends must not lose either archive',
+    );
+    ChatArchiveRepositoryConformance.expect(
+      manifest.currentSummaryPath === manifest.archives.at(-1)?.summaryPath,
+      scenario,
+      'the manifest head must reference its final committed archive',
+    );
+    for (const [index, result] of results.entries()) {
+      ChatArchiveRepositoryConformance.expect(
+        manifest.archives.some((archive) => isEqual(archive, result.archive)),
+        scenario,
+        `archive ${result.archive.id} must be fully visible from the committed manifest`,
+      );
+      await ChatArchiveRepositoryConformance.expectReadableSummary(
+        reopened,
+        result.archive,
+        inputs[index]?.summary ?? '',
+        scenario,
+      );
+    }
+  }
+
+  private static async verifyDuplicateConflict(
+    [scopeId]: readonly string[],
+    harness: ChatArchiveRepositoryConformanceHarness,
+  ): Promise<void> {
+    const scenario = scenarioName.duplicateConflict;
+    const repository = await ChatArchiveRepositoryConformance.repository(harness, scopeId);
+    const sessionId = 'duplicate-session';
+    const originalInput = ChatArchiveRepositoryConformance.input(
+      sessionId,
+      'archive-shared',
+      'Original summary.\n',
+      timestamp.first,
+    );
+    const original = await repository.append(originalInput);
+
+    await ChatArchiveRepositoryConformance.rejects(
+      () => repository.append({
+        ...originalInput,
+        summary: 'Conflicting summary.\n',
+      }),
+      scenario,
+      'a duplicate archive id must reject',
+    );
+    ChatArchiveRepositoryConformance.equal(
+      await repository.loadManifest(sessionId),
+      original.manifest,
+      scenario,
+      'a rejected duplicate must not change the committed manifest',
+    );
+    await ChatArchiveRepositoryConformance.expectReadableSummary(
+      repository,
+      original.archive,
+      originalInput.summary,
+      scenario,
+    );
+  }
+
+  private static async verifyScopeIsolation(
+    scopeIds: readonly string[],
+    harness: ChatArchiveRepositoryConformanceHarness,
+  ): Promise<void> {
+    const scenario = scenarioName.scopeIsolation;
+    const [firstScope, secondScope] = scopeIds;
+    const [first, second] = await Promise.all([
+      ChatArchiveRepositoryConformance.repository(harness, firstScope),
+      ChatArchiveRepositoryConformance.repository(harness, secondScope),
+    ]);
+    const sessionId = 'shared-session';
+    const firstInput = ChatArchiveRepositoryConformance.input(
+      sessionId,
+      'shared-archive',
+      'First scope summary.\n',
+      timestamp.first,
+    );
+    const secondInput = {
+      ...firstInput,
+      summary: 'Second scope summary.\n',
+    };
+    const [firstResult, secondResult] = await Promise.all([
+      first.append(firstInput),
+      second.append(secondInput),
+    ]);
+
+    await ChatArchiveRepositoryConformance.expectReadableSummary(
+      first,
+      firstResult.archive,
+      firstInput.summary,
+      scenario,
+    );
+    await ChatArchiveRepositoryConformance.expectReadableSummary(
+      second,
+      secondResult.archive,
+      secondInput.summary,
+      scenario,
+    );
+    ChatArchiveRepositoryConformance.equal(
+      await first.loadManifest(sessionId),
+      firstResult.manifest,
+      scenario,
+      'the first scope must retain only its own manifest',
+    );
+    ChatArchiveRepositoryConformance.equal(
+      await second.loadManifest(sessionId),
+      secondResult.manifest,
+      scenario,
+      'the second scope must retain only its own manifest',
+    );
+  }
+
+  private static async verifyReopen(
+    [scopeId]: readonly string[],
+    harness: ChatArchiveRepositoryConformanceHarness,
+  ): Promise<void> {
+    const scenario = scenarioName.reopen;
+    const first = await ChatArchiveRepositoryConformance.repository(harness, scopeId);
+    const input = ChatArchiveRepositoryConformance.input(
+      'reopen-session',
+      'reopen-archive',
+      'Reopened summary.\n',
+      timestamp.first,
+    );
+    const appended = await first.append(input);
+    const second = await ChatArchiveRepositoryConformance.repository(harness, scopeId);
+
+    ChatArchiveRepositoryConformance.expect(
+      first !== second,
+      scenario,
+      'reopen must use a fresh repository instance',
+    );
+    ChatArchiveRepositoryConformance.equal(
+      await second.loadManifest(input.sessionId),
+      appended.manifest,
+      scenario,
+      'a fresh repository must recover the complete manifest',
+    );
+    await ChatArchiveRepositoryConformance.expectReadableSummary(
+      second,
+      appended.archive,
+      input.summary,
+      scenario,
+    );
+  }
+
+  private static async verifyCorruption(
+    [scopeId]: readonly string[],
+    harness: ChatArchiveRepositoryConformanceHarness,
+  ): Promise<void> {
+    const scenario = scenarioName.corruption;
+    const repository = await ChatArchiveRepositoryConformance.repository(harness, scopeId);
+    const input = ChatArchiveRepositoryConformance.input(
+      'corrupt-session',
+      'corrupt-archive',
+      'Summary before corruption.\n',
+      timestamp.first,
+    );
+    await repository.append(input);
+    await harness.corruptManifest({ scopeId, sessionId: input.sessionId });
+    const fresh = await ChatArchiveRepositoryConformance.repository(harness, scopeId);
+
+    await ChatArchiveRepositoryConformance.rejects(
+      () => fresh.loadManifest(input.sessionId),
+      scenario,
+      'loading a malformed addressable manifest must reject',
+    );
+  }
+
+  private static async repository(
+    harness: ChatArchiveRepositoryConformanceHarness,
+    scopeId: string | undefined,
+  ): Promise<ChatArchiveRepository> {
+    if (!scopeId) {
+      throw new Error('Conformance scenario did not receive its required scope.');
+    }
+    return await harness.createRepository(scopeId);
+  }
+
+  private static input(
+    sessionId: string,
+    archiveId: string,
+    summary: string,
+    createdAt: string,
+  ): AppendChatArchiveInput {
+    return {
+      sessionId,
+      archive: {
+        id: archiveId,
+        shortDescription: `Conformance archive ${archiveId}`,
+        messageCount: 2,
+        createdAt,
+        summaryModel: 'conformance-no-model-call',
+      },
+      messages: [
+        { role: 'user', content: `Remember ${archiveId}.` },
+        { role: 'assistant', content: `Remembered ${archiveId}.` },
+      ],
+      summary,
+    };
+  }
+
+  private static emptyManifest(sessionId: string): ChatArchiveManifest {
+    return {
+      version: 1,
+      sessionId,
+      archives: [],
+    };
+  }
+
+  private static async expectReadableSummary(
+    repository: ChatArchiveRepository,
+    archive: ChatArchiveRecord,
+    expected: string,
+    scenario: string,
+  ): Promise<void> {
+    ChatArchiveRepositoryConformance.equal(
+      await repository.readSummary(archive.summaryPath),
+      expected,
+      scenario,
+      `archive ${archive.id} must resolve its committed summary`,
+    );
+  }
+
+  private static expect(
+    condition: boolean,
+    scenario: string,
+    detail: string,
+  ): asserts condition {
+    if (!condition) {
+      throw new ChatArchiveRepositoryConformanceError(scenario, detail);
+    }
+  }
+
+  private static equal(
+    actual: unknown,
+    expected: unknown,
+    scenario: string,
+    detail: string,
+  ): void {
+    ChatArchiveRepositoryConformance.expect(isEqual(actual, expected), scenario, detail);
+  }
+
+  private static async rejects(
+    operation: () => Promise<unknown>,
+    scenario: string,
+    detail: string,
+  ): Promise<void> {
+    try {
+      await operation();
+    } catch {
+      return;
+    }
+    throw new ChatArchiveRepositoryConformanceError(scenario, detail);
+  }
+}

--- a/src/core/chat/engine/sessions/archives/errors.ts
+++ b/src/core/chat/engine/sessions/archives/errors.ts
@@ -37,3 +37,17 @@ export class ChatArchiveRepositoryError extends Error {
     this.name = 'ChatArchiveRepositoryError';
   }
 }
+
+/** Raised when an adapter violates the reusable archive repository contract. */
+export class ChatArchiveRepositoryConformanceError extends Error {
+  readonly code = 'CHAT_ARCHIVE_REPOSITORY_CONFORMANCE';
+
+  constructor(
+    readonly scenario: string,
+    detail: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Chat archive repository conformance failed (${scenario}): ${detail}`, options);
+    this.name = 'ChatArchiveRepositoryConformanceError';
+  }
+}

--- a/src/core/chat/engine/sessions/archives/index.ts
+++ b/src/core/chat/engine/sessions/archives/index.ts
@@ -1,12 +1,19 @@
+export { ChatArchiveRepositoryConformance } from './chat-archive-repository-conformance.js';
 export { FileChatArchiveRepository } from './file-chat-archive-repository.js';
 export { ChatArchivePersistenceCodec } from './persistence-codec.js';
 export {
+  ChatArchiveRepositoryConformanceError,
   ChatArchiveStorageCorruptionError,
   ChatArchiveSummaryNotFoundError,
   ChatArchiveRepositoryError,
 } from './errors.js';
 export type { ChatArchiveRepositoryOperation } from './errors.js';
 export { ChatArchiveManifestSchema, ChatArchiveRecordSchema } from './schemas.js';
+export type {
+  ChatArchiveRepositoryConformanceHarness,
+  ChatArchiveRepositoryConformanceScenario,
+  CorruptChatArchiveManifestInput,
+} from './chat-archive-repository-conformance.js';
 export type {
   AppendChatArchiveInput,
   AppendChatArchiveResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,6 +339,8 @@ export type {
   UpdateChatSessionInput,
 } from './core/chat/engine/sessions/repository/index.js';
 export {
+  ChatArchiveRepositoryConformance,
+  ChatArchiveRepositoryConformanceError,
   ChatArchivePersistenceCodec,
   ChatArchiveStorageCorruptionError,
   ChatArchiveSummaryNotFoundError,
@@ -348,11 +350,14 @@ export {
 export type {
   AppendChatArchiveInput,
   AppendChatArchiveResult,
+  ChatArchiveRepositoryConformanceHarness,
+  ChatArchiveRepositoryConformanceScenario,
   ChatArchiveRecordDraft,
   ChatArchiveRepository,
   ChatArchiveStoragePaths,
   FileChatArchiveRepositoryOptions,
   ChatArchiveRepositoryOperation,
+  CorruptChatArchiveManifestInput,
 } from './core/chat/engine/sessions/archives/index.js';
 export type {
   ChatArchiveManifest,


### PR DESCRIPTION
## Summary

- add a public, runner-neutral `ChatArchiveRepositoryConformance` suite
- certify append ordering, concurrent atomic appends, duplicate conflicts, scope isolation, fresh-instance recovery, summary reads, corruption failures, and cleanup
- run the suite against Heddle's file repository and the existing PostgreSQL + Drizzle reference
- document the minimal host harness and the adopter-owned database boundary

## Contract decision

The existing PostgreSQL reference already satisfies the issue's non-file adapter requirement. This PR reuses and certifies it rather than creating a second example.

The v1 archive port exposes one complete append-ordered manifest per session and has no cursor/page operation. This PR documents that boundary explicitly instead of inventing adapter-specific pagination. Session catalog pagination remains covered by `ChatSessionRepositoryConformance`.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` — 130 files, 783 tests
- `yarn test:integration` — 36 files, 329 tests
- `yarn build`
- `yarn test:postgres-storage` — PostgreSQL session/archive conformance and fresh-service recovery passed locally against the isolated PostgreSQL 17 reference service

Closes #278