### PR TITLE
feat: add hosted control-plane access boundary

### DIFF
--- a/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
+++ b/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
@@ -5,6 +5,7 @@ import pino from 'pino';
 import { describe, expect, it } from 'vitest';
 import { FileHeartbeatTaskService, type HeartbeatTask } from '@/advanced.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
+import { createLocalHeddleServerRequestAccess } from '@/server/access/index.js';
 import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
 import { ControlPlaneHeartbeatController } from '@/server/controllers/trpc/control-plane/heartbeat.js';
 import type { AgentHeartbeatResult } from '@/core/heartbeat/index.js';
@@ -194,6 +195,7 @@ describe('control-plane heartbeat mutations', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: null,
       logger: pino({ level: 'silent' }),
     });
@@ -221,6 +223,7 @@ describe('control-plane heartbeat mutations', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: null,
       logger: pino({ level: 'silent' }),
     });
@@ -310,6 +313,7 @@ describe('control-plane heartbeat mutations', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: null,
       logger: pino({ level: 'silent' }),
     });
@@ -354,6 +358,7 @@ describe('control-plane heartbeat mutations', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: null,
       logger: pino({ level: 'silent' }),
     });

--- a/src/__tests__/integration/control-plane/hosted-request-access.test.ts
+++ b/src/__tests__/integration/control-plane/hosted-request-access.test.ts
@@ -1,0 +1,319 @@
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createTRPCProxyClient,
+  httpLink,
+  TRPCClientError,
+} from '@trpc/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
+import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
+import { RuntimeWorkspaceService, type WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
+import { createHeddleServerApp } from '@/server/app.js';
+import { controlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
+import type { AppRouter } from '@/server/router.js';
+import type {
+  HeddleControlPlaneAuditEvent,
+  HeddleControlPlaneOperationAuthorization,
+} from '@/server/types.js';
+
+const AUTHORIZATION = 'Bearer hosted-test-token';
+const openServers = new Set<Server>();
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(Array.from(openServers, closeServer));
+  openServers.clear();
+});
+
+describe('hosted control-plane request access', () => {
+  it('authenticates before handlers and prevents client workspace IDs from broadening host scope', async () => {
+    const fixture = await createHostedFixture();
+
+    const unauthenticated = await fetch(`${fixture.baseUrl}/trpc/health`);
+    expect(unauthenticated.status).toBe(401);
+
+    const health = await fixture.client.health.query();
+    expect(health.workspaces.map((workspace) => workspace.id)).toEqual([fixture.primaryWorkspace.id]);
+
+    const state = await fixture.client.controlPlane.state.query({
+      workspaceId: fixture.primaryWorkspace.id,
+    });
+    expect(state.workspaces.map((workspace) => workspace.id)).toEqual([fixture.primaryWorkspace.id]);
+    expect(state.knownWorkspaces).toEqual([]);
+
+    await expectForbidden(fixture.client.controlPlane.sessions.query({
+      workspaceId: fixture.secondaryWorkspace.id,
+    }));
+    await expectForbidden(fixture.client.controlPlane.workspaceBrowse.query({}));
+  });
+
+  it('filters session catalogs and applies the same session scope to tRPC and REST', async () => {
+    const fixture = await createHostedFixture();
+
+    const sessions = await fixture.client.controlPlane.sessions.query({
+      workspaceId: fixture.primaryWorkspace.id,
+    });
+    expect(sessions.sessions.map((session) => session.id)).toEqual([fixture.permittedSessionId]);
+
+    const state = await fixture.client.controlPlane.state.query({
+      workspaceId: fixture.primaryWorkspace.id,
+    });
+    expect(state.sessions.map((session) => session.id)).toEqual([fixture.permittedSessionId]);
+
+    await expectForbidden(fixture.client.controlPlane.session.query({
+      workspaceId: fixture.primaryWorkspace.id,
+      id: fixture.deniedSessionId,
+    }));
+    await expectForbidden(fixture.client.controlPlane.sessionCreate.mutate({
+      workspaceId: fixture.primaryWorkspace.id,
+      name: 'Not in the resolved scope',
+    }));
+
+    const upload = new FormData();
+    upload.append('images', new Blob(['fake-png'], { type: 'image/png' }), 'screen.png');
+    const response = await fetch(
+      `${fixture.baseUrl}/control-plane/sessions/${fixture.deniedSessionId}/uploads?workspaceId=${fixture.primaryWorkspace.id}`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: AUTHORIZATION,
+        },
+        body: upload,
+      },
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it('authorizes privileged operations and records the authenticated approval actor before mutation', async () => {
+    const sequence: string[] = [];
+    const fixture = await createHostedFixture({
+      authorizeOperation: (authorization) => {
+        sequence.push(`authorize:${authorization.operation.name}`);
+      },
+      recordAuditEvent: (event) => {
+        sequence.push(`audit:${event.operation}`);
+      },
+    });
+    vi.spyOn(controlPlaneChatSessionsController, 'resolvePendingApproval').mockImplementation(() => {
+      sequence.push('mutate:approval.resolve');
+      return true;
+    });
+    vi.spyOn(controlPlaneChatSessionsController, 'cancelRun').mockImplementation(() => {
+      sequence.push('mutate:run.cancel');
+      return true;
+    });
+
+    await expect(fixture.client.controlPlane.sessionResolveApproval.mutate({
+      workspaceId: fixture.primaryWorkspace.id,
+      sessionId: fixture.permittedSessionId,
+      runId: 'run-approval',
+      decision: {
+        type: 'approve',
+        reason: 'Reviewed by the product user.',
+      },
+    })).resolves.toEqual({ resolved: true });
+    await expect(fixture.client.controlPlane.sessionCancel.mutate({
+      workspaceId: fixture.primaryWorkspace.id,
+      id: fixture.permittedSessionId,
+      runId: 'run-cancel',
+    })).resolves.toEqual({ cancelled: true });
+
+    expect(sequence).toEqual([
+      'authorize:sessionResolveApproval',
+      'audit:approval.resolve',
+      'mutate:approval.resolve',
+      'authorize:sessionCancel',
+      'audit:run.cancel',
+      'mutate:run.cancel',
+    ]);
+    expect(fixture.authorizations.map(({ access, operation }) => ({
+      actorId: access.principal.id,
+      workspaceId: operation.workspaceId,
+      sessionId: operation.sessionId,
+    }))).toEqual([
+      {
+        actorId: 'product-user-1',
+        workspaceId: fixture.primaryWorkspace.id,
+        sessionId: fixture.permittedSessionId,
+      },
+      {
+        actorId: 'product-user-1',
+        workspaceId: fixture.primaryWorkspace.id,
+        sessionId: fixture.permittedSessionId,
+      },
+    ]);
+    expect(fixture.auditEvents).toEqual([
+      expect.objectContaining({
+        operation: 'approval.resolve',
+        actor: expect.objectContaining({
+          id: 'product-user-1',
+          auditMetadata: { tenantId: 'tenant-1' },
+        }),
+        workspaceId: fixture.primaryWorkspace.id,
+        sessionId: fixture.permittedSessionId,
+        runId: 'run-approval',
+        metadata: {
+          decisionType: 'approve',
+          reason: 'Reviewed by the product user.',
+        },
+      }),
+      expect.objectContaining({
+        operation: 'run.cancel',
+        actor: expect.objectContaining({ id: 'product-user-1' }),
+        workspaceId: fixture.primaryWorkspace.id,
+        sessionId: fixture.permittedSessionId,
+        runId: 'run-cancel',
+      }),
+    ]);
+  });
+});
+
+type HostedFixtureOptions = {
+  authorizeOperation?: (authorization: HeddleControlPlaneOperationAuthorization) => void;
+  recordAuditEvent?: (event: HeddleControlPlaneAuditEvent) => void;
+};
+
+async function createHostedFixture(options: HostedFixtureOptions = {}) {
+  const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-hosted-access-'));
+  const stateRoot = join(workspaceRoot, '.heddle');
+  RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot });
+  const secondaryWorkspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-hosted-access-secondary-'));
+  const resolved = RuntimeWorkspaceService.createDescriptor({
+    workspaceRoot,
+    stateRoot,
+    name: 'Secondary workspace',
+    newWorkspaceRoot: secondaryWorkspaceRoot,
+    workspaceStateRoot: join(secondaryWorkspaceRoot, '.heddle'),
+    nextId: 'workspace-secondary',
+    setActive: false,
+  });
+  const primaryWorkspace = requireWorkspace(resolved.workspaces, resolved.activeWorkspaceId);
+  const secondaryWorkspace = requireWorkspace(resolved.workspaces, 'workspace-secondary');
+  const permittedSessionId = 'session-permitted';
+  const deniedSessionId = 'session-denied';
+  await createSession(primaryWorkspace, permittedSessionId);
+  await createSession(primaryWorkspace, deniedSessionId);
+
+  const authorizations: HeddleControlPlaneOperationAuthorization[] = [];
+  const auditEvents: HeddleControlPlaneAuditEvent[] = [];
+  const app = createHeddleServerApp({
+    workspaceRoot,
+    stateRoot,
+    serveAssets: false,
+    accessControl: {
+      mode: 'hosted',
+      resolveRequestAccess(request) {
+        if (request.header('authorization') !== AUTHORIZATION) {
+          return null;
+        }
+        return {
+          principal: {
+            id: 'product-user-1',
+            auditMetadata: {
+              tenantId: 'tenant-1',
+            },
+          },
+          scope: {
+            workspaces: [{
+              workspaceId: primaryWorkspace.id,
+              sessionIds: [permittedSessionId],
+            }],
+          },
+        };
+      },
+      authorizeOperation(authorization) {
+        authorizations.push(authorization);
+        options.authorizeOperation?.(authorization);
+      },
+      recordAuditEvent(event) {
+        auditEvents.push(event);
+        options.recordAuditEvent?.(event);
+      },
+    },
+  });
+  const server = app.listen(0, '127.0.0.1');
+  openServers.add(server);
+  await onceListening(server);
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const client = createTRPCProxyClient<AppRouter>({
+    links: [
+      httpLink({
+        url: `${baseUrl}/trpc`,
+        headers: {
+          authorization: AUTHORIZATION,
+        },
+      }),
+    ],
+  });
+
+  return {
+    auditEvents,
+    authorizations,
+    baseUrl,
+    client,
+    deniedSessionId,
+    permittedSessionId,
+    primaryWorkspace,
+    secondaryWorkspace,
+  };
+}
+
+async function createSession(workspace: WorkspaceDescriptor, sessionId: string): Promise<void> {
+  await new FileChatSessionRepository({
+    sessionStoragePath: join(workspace.stateRoot, 'chat-sessions.catalog.json'),
+  }).create(ChatSessionRecords.create({
+    id: sessionId,
+    name: sessionId,
+    apiKeyPresent: true,
+    workspaceId: workspace.id,
+  }));
+}
+
+function requireWorkspace(workspaces: WorkspaceDescriptor[], workspaceId: string): WorkspaceDescriptor {
+  const workspace = workspaces.find((candidate) => candidate.id === workspaceId);
+  if (!workspace) {
+    throw new Error(`Expected workspace: ${workspaceId}`);
+  }
+  return workspace;
+}
+
+async function expectForbidden(result: Promise<unknown>): Promise<void> {
+  try {
+    await result;
+  } catch (error) {
+    expect(error).toBeInstanceOf(TRPCClientError);
+    expect((error as TRPCClientError<AppRouter>).data?.httpStatus).toBe(403);
+    return;
+  }
+  throw new Error('Expected request to be forbidden.');
+}
+
+async function onceListening(server: Server): Promise<void> {
+  if (server.listening) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    server.once('listening', resolve);
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  openServers.delete(server);
+  if (!server.listening) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -9,6 +9,7 @@ import { createConversationEngine } from '@/core/chat/engine/conversation-engine
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import { AgentLoopRuntimeService } from '@/core/runtime/loop/index.js';
 import { RuntimeWorkspaceService, type WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
+import { createLocalHeddleServerRequestAccess } from '@/server/access/index.js';
 import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
 import type {
   ControlPlaneSessionEventEnvelope,
@@ -856,6 +857,7 @@ function createControlPlaneCaller() {
     activeWorkspaceId: activeWorkspace.id,
     activeWorkspace,
     workspaces: resolved.workspaces,
+    requestAccess: createLocalHeddleServerRequestAccess(),
     runtimeHost: null,
     logger: pino({ level: 'silent' }),
   };

--- a/src/__tests__/integration/control-plane/workspace-catalog.test.ts
+++ b/src/__tests__/integration/control-plane/workspace-catalog.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@/core/runtime/workspaces/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
 import { createConversationEngine } from '@/core/chat/engine/conversation-engine.js';
+import { createLocalHeddleServerRequestAccess } from '@/server/access/index.js';
 import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
 
 describe('workspace catalog', () => {
@@ -54,6 +55,7 @@ describe('workspace catalog', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: {
         mode: 'daemon',
         serverId: 'embedded-test',
@@ -154,6 +156,7 @@ describe('workspace catalog', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: {
         mode: 'daemon',
         serverId: 'daemon-test',
@@ -228,6 +231,7 @@ describe('workspace catalog', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: resolved.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: {
         mode: 'daemon',
         serverId: 'daemon-test',
@@ -307,6 +311,7 @@ describe('workspace catalog', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: resolved.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: null,
       logger: pino({ level: 'silent' }),
     });
@@ -382,6 +387,7 @@ describe('workspace catalog', () => {
       activeWorkspaceId: resolved.activeWorkspaceId,
       activeWorkspace: resolved.activeWorkspace,
       workspaces: resolved.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: null,
       logger: pino({ level: 'silent' }),
     });
@@ -414,6 +420,7 @@ describe('workspace catalog', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: {
         mode: 'daemon',
         serverId: 'daemon-test',
@@ -450,6 +457,7 @@ describe('workspace catalog', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: null,
       logger: pino({ level: 'silent' }),
     });

--- a/src/__tests__/integration/control-plane/workspace-diff.test.ts
+++ b/src/__tests__/integration/control-plane/workspace-diff.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import pino from 'pino';
 import { describe, expect, it } from 'vitest';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
+import { createLocalHeddleServerRequestAccess } from '@/server/access/index.js';
 import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
 import { ControlPlaneWorkspaceDiffController } from '@/server/controllers/trpc/control-plane/workspace-diff.js';
 
@@ -106,6 +107,7 @@ describe('workspace diff review', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: null,
       logger: pino({ level: 'silent' }),
     });

--- a/src/__tests__/integration/memory/memory-visibility.test.ts
+++ b/src/__tests__/integration/memory/memory-visibility.test.ts
@@ -7,6 +7,7 @@ import { MemoryCatalogService } from '../../../core/memory/catalog.js';
 import { MemoryValidationService } from '../../../core/memory/validation.js';
 import { MemoryVisibilityService } from '../../../core/memory/visibility.js';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
+import { createLocalHeddleServerRequestAccess } from '@/server/access/index.js';
 import { controlPlaneRouter } from '@/server/routes/trpc/control-plane.js';
 
 describe('memory visibility', () => {
@@ -66,6 +67,7 @@ describe('memory visibility', () => {
       activeWorkspaceId: activeWorkspace.id,
       activeWorkspace,
       workspaces: catalog.workspaces,
+      requestAccess: createLocalHeddleServerRequestAccess(),
       runtimeHost: null,
       logger: pino({ level: 'silent' }),
     });

--- a/src/__tests__/unit/control-plane/control-plane-workspace.test.ts
+++ b/src/__tests__/unit/control-plane/control-plane-workspace.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { createLogger } from '@/core/utils/logger.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
+import { createLocalHeddleServerRequestAccess } from '@/server/access/index.js';
 import type { HeddleServerContext } from '@/server/types.js';
 import { resolveControlPlaneRequestWorkspace } from '@/server/routes/trpc/control-plane-workspace.js';
 
@@ -71,6 +72,7 @@ function createContext(workspace: WorkspaceDescriptor): HeddleServerContext {
     activeWorkspaceId: workspace.id,
     activeWorkspace: workspace,
     workspaces: [workspace],
+    requestAccess: createLocalHeddleServerRequestAccess(),
     runtimeHost: null,
     logger: silentLogger,
   };

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -13,6 +13,25 @@
 
 export * from './index.js';
 
+// --- Embedded control-plane server -----------------------------------------
+export {
+  createHeddleServerApp,
+  HeddleServerAccessError,
+  startHeddleControlPlaneServer,
+} from './server/index.js';
+export type {
+  HeddleControlPlaneAuditEvent,
+  HeddleControlPlaneOperation,
+  HeddleControlPlaneOperationAuthorization,
+  HeddleControlPlaneServerHandle,
+  HeddleControlPlaneServerOptions,
+  HeddleServerAccessControl,
+  HeddleServerHostedRequestAccess,
+  HeddleServerPrincipal,
+  HeddleServerRequestAccess,
+  HeddleServerWorkspaceScope,
+} from './server/index.js';
+
 // ===========================================================================
 // Building blocks
 // ===========================================================================

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -24,6 +24,83 @@ live server, print messages, install signal handlers, and call `process.exit()`.
 Embedded hosts such as future `chat-v2` startup should use the same lifecycle
 path instead of inventing a TUI-only server path.
 
+## Request Access Boundary
+
+The reference server has two explicit access modes:
+
+- `local` is the default single-operator daemon mode. It performs no
+  authentication and is not safe to expose as a hosted or multi-tenant service.
+- `hosted` requires the embedding product to authenticate every HTTP request
+  and return the exact Heddle workspace/session scope for that principal.
+
+Heddle enforces the resolved scope before tRPC or REST handlers run. A
+client-supplied `workspaceId` or `sessionId` can select within that scope but
+cannot broaden it. Hosted mode also disables daemon administration operations
+that browse arbitrary directories or mutate the local workspace catalog.
+
+The product remains responsible for its identity provider, cookies or bearer
+tokens, tenant membership, role policy, CSRF/CORS/TLS, and audit retention.
+Heddle consumes the already-resolved product identity:
+
+```ts
+import {
+  HeddleServerAccessError,
+  startHeddleControlPlaneServer,
+} from '@roackb2/heddle/advanced';
+
+const server = await startHeddleControlPlaneServer({
+  mode: 'daemon',
+  host: '127.0.0.1',
+  port: 8765,
+  workspaceRoot,
+  stateRoot,
+  accessControl: {
+    mode: 'hosted',
+    async resolveRequestAccess(request) {
+      // Product-owned pseudocode: verify the request and resolve tenant scope.
+      const productAccess = await productAuth.resolveAgentAccess(request);
+      if (!productAccess) {
+        return null;
+      }
+
+      return {
+        principal: {
+          id: productAccess.userId,
+          auditMetadata: { tenantId: productAccess.tenantId },
+        },
+        scope: {
+          workspaces: productAccess.workspaces.map((workspace) => ({
+            workspaceId: workspace.heddleWorkspaceId,
+            sessionIds: workspace.permittedSessionIds,
+          })),
+        },
+      };
+    },
+    async authorizeOperation({ access, operation }) {
+      if (!await productPolicy.permits(access.principal.id, operation)) {
+        throw new HeddleServerAccessError(403, 'Operation not permitted.');
+      }
+    },
+    async recordAuditEvent(event) {
+      await productAuditLog.append(event);
+    },
+  },
+});
+```
+
+Omit `sessionIds` to allow every session in a workspace. An empty array permits
+workspace-level reads and operations but no session access. Session creation
+requires unrestricted session scope because a newly generated ID cannot be in
+a pre-resolved allowlist.
+
+Approval resolution and run cancellation are checked by the same operation
+authorizer as other control-plane calls. Before either mutation runs, Heddle
+records the authenticated actor and request metadata in the workspace operation
+log and invokes the optional host audit sink.
+
+See [`access/README.md`](access/README.md) for the service boundary and
+maintenance rules.
+
 ## Conversation Run Transport
 
 The control plane exposes core `ConversationRunService` semantics rather than

--- a/src/server/access/README.md
+++ b/src/server/access/README.md
@@ -1,0 +1,21 @@
+# Server request access
+
+This service owns the authentication and authorization boundary for the
+reference control-plane HTTP server.
+
+- Product hosts authenticate requests and return a typed principal plus an
+  allow-listed workspace/session scope.
+- Heddle intersects client-supplied IDs with that resolved scope for both tRPC
+  and REST routes.
+- Hosts may add operation-specific authorization after Heddle's static scope
+  check.
+- Approval and cancellation routes write actor-aware audit events to the
+  workspace operation log and may forward them to a host audit sink.
+
+This service does not own login, cookies, bearer-token verification, tenant
+membership, role assignment, identity-provider configuration, or audit-log
+retention. Those remain product responsibilities.
+
+Local mode intentionally authenticates no one and permits every local
+workspace/session. It is for a single-operator daemon only and is not safe as a
+hosted or multi-tenant deployment mode.

--- a/src/server/access/index.ts
+++ b/src/server/access/index.ts
@@ -1,0 +1,8 @@
+export {
+  HeddleServerAccessError,
+  HeddleServerRequestAccessService,
+  assertHeddleServerSessionAccess,
+  assertHeddleServerWorkspaceAccess,
+  createLocalHeddleServerRequestAccess,
+  resolveHeddleServerPermittedSessionIds,
+} from './request-access-service.js';

--- a/src/server/access/request-access-service.ts
+++ b/src/server/access/request-access-service.ts
@@ -1,0 +1,312 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import type { Logger } from 'pino';
+import {
+  FileDaemonRegistryRepository,
+  RuntimeDaemonRegistryService,
+} from '@/core/runtime/daemon/index.js';
+import {
+  RuntimeWorkspaceService,
+  type ResolvedWorkspaceContext,
+  type WorkspaceDescriptor,
+} from '@/core/runtime/workspaces/index.js';
+import type {
+  HeddleControlPlaneAuditEvent,
+  HeddleControlPlaneOperation,
+  HeddleServerAccessControl,
+  HeddleServerHostedRequestAccess,
+  HeddleServerRequestAccess,
+  HeddleServerWorkspaceScope,
+} from '@/server/types.js';
+
+type HeddleServerRequestAccessServiceOptions = {
+  workspaceRoot: string;
+  stateRoot: string;
+  registryPath?: string;
+  logger: Logger;
+  accessControl?: HeddleServerAccessControl;
+};
+
+export class HeddleServerAccessError extends Error {
+  constructor(
+    readonly statusCode: 401 | 403,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'HeddleServerAccessError';
+  }
+}
+
+/**
+ * Owns the HTTP request access boundary for the reference control plane.
+ *
+ * Hosted products authenticate requests and resolve product identity before
+ * Heddle handlers run. Heddle then enforces the returned workspace/session
+ * scope consistently across tRPC and REST transports.
+ */
+export class HeddleServerRequestAccessService {
+  private readonly requestAccess = new WeakMap<Request, HeddleServerRequestAccess>();
+  private readonly accessControl: HeddleServerAccessControl;
+
+  constructor(private readonly options: HeddleServerRequestAccessServiceOptions) {
+    this.accessControl = options.accessControl ?? { mode: 'local' };
+  }
+
+  get mode(): HeddleServerAccessControl['mode'] {
+    return this.accessControl.mode;
+  }
+
+  createMiddleware(): RequestHandler {
+    return (request: Request, response: Response, next: NextFunction): void => {
+      void this.bind(request)
+        .then(() => next())
+        .catch((error: unknown) => this.rejectRequest(response, error));
+    };
+  }
+
+  requireAccess(request: Request): HeddleServerRequestAccess {
+    const access = this.requestAccess.get(request);
+    if (!access) {
+      throw new Error('Control-plane request access was not resolved before the handler ran.');
+    }
+    return access;
+  }
+
+  resolveWorkspaceContext(request: Request): ResolvedWorkspaceContext {
+    const access = this.requireAccess(request);
+    const context = RuntimeWorkspaceService.resolveContext({
+      workspaceRoot: this.options.workspaceRoot,
+      stateRoot: this.options.stateRoot,
+    });
+    if (access.mode === 'local') {
+      return context;
+    }
+
+    const workspaces = access.scope.workspaces.map((scope) => (
+      this.requireWorkspaceDescriptor(context, scope.workspaceId)
+    ));
+    const activeWorkspace =
+      workspaces.find((workspace) => workspace.id === context.activeWorkspaceId)
+      ?? workspaces[0];
+    if (!activeWorkspace) {
+      throw new HeddleServerAccessError(403, 'The authenticated principal has no permitted workspace.');
+    }
+
+    return {
+      catalogPath: context.catalogPath,
+      catalog: {
+        ...context.catalog,
+        activeWorkspaceId: activeWorkspace.id,
+        workspaces,
+      },
+      activeWorkspaceId: activeWorkspace.id,
+      activeWorkspace,
+      workspaces,
+    };
+  }
+
+  resolveWorkspace(request: Request, requestedWorkspaceId?: string): WorkspaceDescriptor {
+    const access = this.requireAccess(request);
+    const context = RuntimeWorkspaceService.resolveContext({
+      workspaceRoot: this.options.workspaceRoot,
+      stateRoot: this.options.stateRoot,
+    });
+    const workspaceId = requestedWorkspaceId ?? this.resolveDefaultWorkspaceId(access, context);
+    assertHeddleServerWorkspaceAccess(access, workspaceId);
+    return this.requireWorkspaceDescriptor(context, workspaceId);
+  }
+
+  async authorizeOperation(request: Request, operation: HeddleControlPlaneOperation): Promise<void> {
+    const access = this.requireAccess(request);
+    if (operation.workspaceId) {
+      assertHeddleServerWorkspaceAccess(access, operation.workspaceId);
+    }
+    if (operation.workspaceId && operation.sessionId) {
+      assertHeddleServerSessionAccess(access, operation.workspaceId, operation.sessionId);
+    }
+    if (this.accessControl.mode === 'hosted') {
+      await this.accessControl.authorizeOperation?.({ access, operation });
+    }
+  }
+
+  async recordAuditEvent(event: HeddleControlPlaneAuditEvent): Promise<void> {
+    if (this.accessControl.mode === 'hosted') {
+      await this.accessControl.recordAuditEvent?.(event);
+    }
+  }
+
+  private async bind(request: Request): Promise<void> {
+    const access = await this.resolveRequestAccess(request);
+    this.requestAccess.set(request, access);
+  }
+
+  private async resolveRequestAccess(request: Request): Promise<HeddleServerRequestAccess> {
+    if (this.accessControl.mode === 'local') {
+      return createLocalHeddleServerRequestAccess();
+    }
+
+    const resolved = await this.accessControl.resolveRequestAccess(request);
+    if (!resolved) {
+      throw new HeddleServerAccessError(401, 'Authentication required.');
+    }
+    return normalizeHostedRequestAccess(resolved);
+  }
+
+  private resolveDefaultWorkspaceId(
+    access: HeddleServerRequestAccess,
+    context: ResolvedWorkspaceContext,
+  ): string {
+    if (access.mode === 'local') {
+      return context.activeWorkspaceId;
+    }
+
+    return access.scope.workspaces.find((scope) => scope.workspaceId === context.activeWorkspaceId)?.workspaceId
+      ?? access.scope.workspaces[0]?.workspaceId
+      ?? '';
+  }
+
+  private requireWorkspaceDescriptor(
+    context: ResolvedWorkspaceContext,
+    workspaceId: string,
+  ): WorkspaceDescriptor {
+    const workspace =
+      context.workspaces.find((candidate) => candidate.id === workspaceId)
+      ?? RuntimeDaemonRegistryService.readWorkspaceRegistration(
+        this.options.registryPath ?? FileDaemonRegistryRepository.resolvePath(),
+        workspaceId,
+      )?.workspace;
+    if (!workspace) {
+      throw new HeddleServerAccessError(403, 'The requested workspace is not available to this server.');
+    }
+    return workspace;
+  }
+
+  private rejectRequest(response: Response, error: unknown): void {
+    if (error instanceof HeddleServerAccessError) {
+      this.options.logger.warn({
+        statusCode: error.statusCode,
+        error: error.message,
+      }, 'Control-plane request rejected by access boundary');
+      response.status(error.statusCode).json({ error: error.message });
+      return;
+    }
+
+    this.options.logger.error({ error }, 'Control-plane request authentication failed');
+    response.status(500).json({ error: 'Control-plane request authentication failed.' });
+  }
+}
+
+export function createLocalHeddleServerRequestAccess(): HeddleServerRequestAccess {
+  return {
+    mode: 'local',
+    principal: {
+      id: 'local-operator',
+      displayName: 'Local operator',
+      auditMetadata: {
+        authentication: 'none',
+      },
+    },
+    scope: {
+      workspaces: 'all',
+    },
+  };
+}
+
+export function assertHeddleServerWorkspaceAccess(
+  access: HeddleServerRequestAccess,
+  workspaceId: string,
+): void {
+  if (access.mode === 'local') {
+    return;
+  }
+  if (!findWorkspaceScope(access, workspaceId)) {
+    throw new HeddleServerAccessError(403, 'The authenticated principal cannot access the requested workspace.');
+  }
+}
+
+export function assertHeddleServerSessionAccess(
+  access: HeddleServerRequestAccess,
+  workspaceId: string,
+  sessionId: string,
+): void {
+  if (access.mode === 'local') {
+    return;
+  }
+
+  const workspaceScope = findWorkspaceScope(access, workspaceId);
+  if (!workspaceScope) {
+    throw new HeddleServerAccessError(403, 'The authenticated principal cannot access the requested workspace.');
+  }
+  if (workspaceScope.sessionIds && !workspaceScope.sessionIds.includes(sessionId)) {
+    throw new HeddleServerAccessError(403, 'The authenticated principal cannot access the requested session.');
+  }
+}
+
+export function resolveHeddleServerPermittedSessionIds(
+  access: HeddleServerRequestAccess,
+  workspaceId: string,
+): readonly string[] | undefined {
+  if (access.mode === 'local') {
+    return undefined;
+  }
+
+  const workspaceScope = findWorkspaceScope(access, workspaceId);
+  if (!workspaceScope) {
+    throw new HeddleServerAccessError(403, 'The authenticated principal cannot access the requested workspace.');
+  }
+  return workspaceScope.sessionIds;
+}
+
+function normalizeHostedRequestAccess(
+  access: HeddleServerHostedRequestAccess,
+): HeddleServerRequestAccess {
+  const principalId = access.principal.id.trim();
+  if (!principalId) {
+    throw new Error('Hosted request access requires a non-empty principal ID.');
+  }
+
+  const workspaces = access.scope.workspaces.map(normalizeWorkspaceScope);
+  if (!workspaces.length) {
+    throw new HeddleServerAccessError(403, 'The authenticated principal has no permitted workspace.');
+  }
+  if (new Set(workspaces.map((scope) => scope.workspaceId)).size !== workspaces.length) {
+    throw new Error('Hosted request access contains duplicate workspace scopes.');
+  }
+
+  return {
+    mode: 'hosted',
+    principal: {
+      ...access.principal,
+      id: principalId,
+    },
+    scope: {
+      workspaces,
+    },
+  };
+}
+
+function normalizeWorkspaceScope(scope: HeddleServerWorkspaceScope): HeddleServerWorkspaceScope {
+  const workspaceId = scope.workspaceId.trim();
+  if (!workspaceId) {
+    throw new Error('Hosted request access contains an empty workspace ID.');
+  }
+
+  const sessionIds = scope.sessionIds?.map((sessionId) => sessionId.trim());
+  if (sessionIds?.some((sessionId) => !sessionId)) {
+    throw new Error(`Hosted request access contains an empty session ID for workspace ${workspaceId}.`);
+  }
+  if (sessionIds && new Set(sessionIds).size !== sessionIds.length) {
+    throw new Error(`Hosted request access contains duplicate session IDs for workspace ${workspaceId}.`);
+  }
+
+  return {
+    workspaceId,
+    sessionIds,
+  };
+}
+
+function findWorkspaceScope(
+  access: Extract<HeddleServerRequestAccess, { mode: 'hosted' }>,
+  workspaceId: string,
+): HeddleServerWorkspaceScope | undefined {
+  return access.scope.workspaces.find((scope) => scope.workspaceId === workspaceId);
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,9 +1,14 @@
 import express from 'express';
+import { HeddleServerRequestAccessService } from './access/index.js';
 import { createServerLogger } from './logging/server-logger.js';
 import { createWorkspaceRequestLoggingMiddleware } from './middleware/workspace-request-logging.js';
 import { createTrpcExpressRouter } from './routes/trpc/trpc.js';
 import { installWebStaticRoutes } from './static.js';
-import type { HeddleRuntimeHostDescriptor, HeddleServerContext } from './types.js';
+import type {
+  HeddleRuntimeHostDescriptor,
+  HeddleServerAccessControl,
+  HeddleServerContext,
+} from './types.js';
 import { createControlPlaneApiRouter } from './routes/control-plane-apis.js';
 
 export function createHeddleServerApp(
@@ -11,13 +16,22 @@ export function createHeddleServerApp(
     & { preferApiKey?: boolean }
     & Partial<Pick<HeddleServerContext, 'logger'>>
     & { runtimeHost?: HeddleRuntimeHostDescriptor | null }
+    & { accessControl?: HeddleServerAccessControl }
     & { assetsDir?: string; serveAssets?: boolean },
 ): express.Express {
   const logger = options.logger ?? createServerLogger({ stateRoot: options.stateRoot });
   const app = express();
+  const requestAccess = new HeddleServerRequestAccessService({
+    workspaceRoot: options.workspaceRoot,
+    stateRoot: options.stateRoot,
+    registryPath: options.runtimeHost?.registryPath,
+    logger,
+    accessControl: options.accessControl,
+  });
   const controlPlaneApis = createControlPlaneApiRouter({
     workspaceRoot: options.workspaceRoot,
     stateRoot: options.stateRoot,
+    requestAccess,
   });
   const trpcHandler = createTrpcExpressRouter({
     logger,
@@ -25,13 +39,17 @@ export function createHeddleServerApp(
     runtimeHost: options.runtimeHost,
     workspaceRoot: options.workspaceRoot,
     stateRoot: options.stateRoot,
+    requestAccess,
   });
 
   app.disable('x-powered-by');
+  app.use('/control-plane', requestAccess.createMiddleware());
+  app.use('/trpc', requestAccess.createMiddleware());
   app.use(createWorkspaceRequestLoggingMiddleware({
     logger,
     workspaceRoot: options.workspaceRoot,
     stateRoot: options.stateRoot,
+    requestAccess,
   }));
   app.use(controlPlaneApis);
   app.use(trpcHandler);

--- a/src/server/controllers/restful/control-plane/chat-session-events.ts
+++ b/src/server/controllers/restful/control-plane/chat-session-events.ts
@@ -1,34 +1,42 @@
 import { watch } from 'node:fs';
 import type { Request, Response } from 'express';
-import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
+import {
+  HeddleServerAccessError,
+  type HeddleServerRequestAccessService,
+} from '@/server/access/index.js';
+import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { controlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
 
 type ChatSessionEventsRestControllerOptions = {
-  workspaceRoot: string;
-  stateRoot: string;
+  requestAccess: HeddleServerRequestAccessService;
 };
 
 export class ChatSessionEventsRestController {
   constructor(private readonly options: ChatSessionEventsRestControllerOptions) {}
 
-  streamEvents = (request: Request, response: Response): void => {
+  streamEvents = async (request: Request, response: Response): Promise<void> => {
     const sessionId = typeof request.params.sessionId === 'string' ? request.params.sessionId.trim() : '';
     if (!sessionId) {
       response.status(400).json({ error: 'Missing sessionId' });
       return;
     }
 
-    const workspaceContext = RuntimeWorkspaceService.resolveContext({
-      workspaceRoot: this.options.workspaceRoot,
-      stateRoot: this.options.stateRoot,
-    });
     const workspaceId = this.readWorkspaceId(request);
-    const workspace = workspaceId
-      ? workspaceContext.workspaces.find((candidate) => candidate.id === workspaceId)
-      : workspaceContext.activeWorkspace;
-    if (!workspace) {
-      response.status(404).json({ error: `Workspace not found: ${workspaceId}` });
-      return;
+    let workspace: WorkspaceDescriptor;
+    try {
+      workspace = this.options.requestAccess.resolveWorkspace(request, workspaceId);
+      await this.options.requestAccess.authorizeOperation(request, {
+        name: 'sessionEvents',
+        type: 'subscription',
+        workspaceId: workspace.id,
+        sessionId,
+      });
+    } catch (error) {
+      if (error instanceof HeddleServerAccessError) {
+        response.status(error.statusCode).json({ error: error.message });
+        return;
+      }
+      throw error;
     }
 
     const sessionFilePath = controlPlaneChatSessionsController.resolveFilePath(

--- a/src/server/controllers/restful/control-plane/chat-session-uploads.ts
+++ b/src/server/controllers/restful/control-plane/chat-session-uploads.ts
@@ -1,5 +1,6 @@
 import type { ErrorRequestHandler, Request, RequestHandler, Response } from 'express';
 import multer from 'multer';
+import { HeddleServerAccessError } from '@/server/access/index.js';
 import {
   CHAT_SESSION_IMAGE_UPLOAD_LIMITS,
   ChatSessionImageUploadService,
@@ -8,9 +9,11 @@ import {
 } from '@/server/services/control-plane/chat-session-image-uploads.js';
 
 export class ChatSessionUploadsRestController {
+  readonly authorizeUpload: RequestHandler;
   readonly uploadImagesMiddleware: RequestHandler;
 
   constructor(private readonly imageUploads: ChatSessionImageUploadService) {
+    this.authorizeUpload = this.createAuthorizeUploadMiddleware();
     this.uploadImagesMiddleware = this.createUploadImagesMiddleware();
   }
 
@@ -21,6 +24,14 @@ export class ChatSessionUploadsRestController {
   handleUploadError: ErrorRequestHandler = (error, _request, response, _next): void => {
     this.sendUploadError(response, error);
   };
+
+  private createAuthorizeUploadMiddleware(): RequestHandler {
+    return (request, _response, next): void => {
+      void this.imageUploads.authorizeUpload(request)
+        .then(() => next())
+        .catch((error: unknown) => next(error));
+    };
+  }
 
   private createUploadImagesMiddleware(): RequestHandler {
     const upload = multer({
@@ -57,6 +68,11 @@ export class ChatSessionUploadsRestController {
 
   private sendUploadError(response: Response, error: unknown): void {
     if (isChatSessionUploadError(error)) {
+      response.status(error.statusCode).json({ error: error.message });
+      return;
+    }
+
+    if (error instanceof HeddleServerAccessError) {
       response.status(error.statusCode).json({ error: error.message });
       return;
     }

--- a/src/server/controllers/trpc/control-plane/control-plane-state.ts
+++ b/src/server/controllers/trpc/control-plane/control-plane-state.ts
@@ -58,6 +58,10 @@ export class ControlPlaneStateController {
   }
 
   private static readKnownWorkspaces(context: HeddleServerContext): ControlPlaneState['knownWorkspaces'] {
+    if (context.requestAccess.mode === 'hosted') {
+      return [];
+    }
+
     const registryPath = context.runtimeHost?.registryPath ?? FileDaemonRegistryRepository.resolvePath();
     RuntimeDaemonRegistryService.registerKnownWorkspaces({
       registryPath,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,11 +1,20 @@
 export type {
+  HeddleControlPlaneAuditEvent,
+  HeddleControlPlaneOperation,
+  HeddleControlPlaneOperationAuthorization,
   HeddleControlPlaneServerHandle,
   HeddleHeartbeatSchedulerSettings,
   HeddleControlPlaneServerOptions,
+  HeddleServerAccessControl,
+  HeddleServerHostedRequestAccess,
   HeddleServerOptions,
+  HeddleServerPrincipal,
+  HeddleServerRequestAccess,
+  HeddleServerWorkspaceScope,
 } from './types.js';
 export { appRouter, type AppRouter } from './router.js';
 export { createHeddleServerApp } from './app.js';
 export { startHeddleControlPlaneServer } from './lifecycle.js';
+export { HeddleServerAccessError } from './access/index.js';
 export { createServerLogger } from './logging/server-logger.js';
 export { ControlPlaneChatSessionPresenter } from './controllers/trpc/control-plane/chat-session-presenter.js';

--- a/src/server/lifecycle.ts
+++ b/src/server/lifecycle.ts
@@ -35,6 +35,12 @@ export async function startHeddleControlPlaneServer(
   }
 
   const logger = options.logger ?? createServerLogger({ stateRoot: options.stateRoot });
+  const accessMode = options.accessControl?.mode ?? 'local';
+  if (accessMode === 'local') {
+    logger.warn(
+      'Heddle server uses unauthenticated local-daemon access; do not expose it as a hosted or multi-tenant service',
+    );
+  }
   const registryPath = options.daemonRegistryPath ?? FileDaemonRegistryRepository.resolvePath();
   const serverId = options.serverId ?? `${options.mode}-${process.pid}-${Date.now()}`;
   const startedAt = dayjs().toISOString();
@@ -146,6 +152,7 @@ export async function startHeddleControlPlaneServer(
     registryPath,
     serverId,
     mode: options.mode,
+    accessMode,
     heartbeatSchedulerEnabled,
     heartbeatSchedulerPollIntervalMs: heartbeatSchedulerSettings.pollIntervalMs,
   }, 'Heddle server started');

--- a/src/server/middleware/workspace-request-logging.ts
+++ b/src/server/middleware/workspace-request-logging.ts
@@ -1,6 +1,7 @@
 import type { Request } from 'express';
 import type { Logger } from 'pino';
 import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
+import type { HeddleServerRequestAccessService } from '@/server/access/index.js';
 import { getWorkspaceOperationLogger } from '@/server/logging/workspace-operation-logger.js';
 import { createRequestLoggingMiddleware } from './request-logging.js';
 
@@ -8,6 +9,7 @@ type WorkspaceRequestLoggingOptions = {
   workspaceRoot: string;
   stateRoot: string;
   logger: Logger;
+  requestAccess?: HeddleServerRequestAccessService;
 };
 
 export function createWorkspaceRequestLoggingMiddleware(options: WorkspaceRequestLoggingOptions) {
@@ -19,11 +21,17 @@ export function createWorkspaceRequestLoggingMiddleware(options: WorkspaceReques
 
 function resolveWorkspaceRequestLogger(options: WorkspaceRequestLoggingOptions & { request: Request }): Logger {
   try {
+    const workspaceId = readWorkspaceIdFromRequest(options.request);
+    if (options.requestAccess) {
+      return getWorkspaceOperationLogger(
+        options.requestAccess.resolveWorkspace(options.request, workspaceId).stateRoot,
+      );
+    }
+
     const workspaceContext = RuntimeWorkspaceService.resolveContext({
       workspaceRoot: options.workspaceRoot,
       stateRoot: options.stateRoot,
     });
-    const workspaceId = readWorkspaceIdFromRequest(options.request);
     const workspace =
       workspaceId ?
         workspaceContext.workspaces.find((candidate) => candidate.id === workspaceId)

--- a/src/server/routes/control-plane-apis.ts
+++ b/src/server/routes/control-plane-apis.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
+import type { HeddleServerRequestAccessService } from '@/server/access/index.js';
 import { createChatSessionEventRouter } from './control-plane-chat-session-events.js';
 import { createChatSessionUploadRouter } from './control-plane-chat-session-uploads.js';
 
 type CreateControlPlaneApiRouterOptions = {
   workspaceRoot: string;
   stateRoot: string;
+  requestAccess: HeddleServerRequestAccessService;
 };
 
 export function createControlPlaneApiRouter(options: CreateControlPlaneApiRouterOptions): Router {

--- a/src/server/routes/control-plane-chat-session-events.ts
+++ b/src/server/routes/control-plane-chat-session-events.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
+import type { HeddleServerRequestAccessService } from '@/server/access/index.js';
 import { ChatSessionEventsRestController } from '@/server/controllers/restful/control-plane/chat-session-events.js';
 
 type CreateChatSessionEventRouterOptions = {
-  workspaceRoot: string;
-  stateRoot: string;
+  requestAccess: HeddleServerRequestAccessService;
 };
 
 export function createChatSessionEventRouter(options: CreateChatSessionEventRouterOptions): Router {

--- a/src/server/routes/control-plane-chat-session-uploads.ts
+++ b/src/server/routes/control-plane-chat-session-uploads.ts
@@ -1,10 +1,10 @@
 import { Router } from 'express';
+import type { HeddleServerRequestAccessService } from '@/server/access/index.js';
 import { ChatSessionImageUploadService } from '@/server/services/control-plane/chat-session-image-uploads.js';
 import { ChatSessionUploadsRestController } from '@/server/controllers/restful/control-plane/chat-session-uploads.js';
 
 type CreateChatSessionUploadRouterOptions = {
-  workspaceRoot: string;
-  stateRoot: string;
+  requestAccess: HeddleServerRequestAccessService;
 };
 
 export function createChatSessionUploadRouter(options: CreateChatSessionUploadRouterOptions): Router {
@@ -12,7 +12,12 @@ export function createChatSessionUploadRouter(options: CreateChatSessionUploadRo
   const imageUploads = new ChatSessionImageUploadService(options);
   const controller = new ChatSessionUploadsRestController(imageUploads);
 
-  router.post('/sessions/:sessionId/uploads', controller.uploadImagesMiddleware, controller.uploadImages);
+  router.post(
+    '/sessions/:sessionId/uploads',
+    controller.authorizeUpload,
+    controller.uploadImagesMiddleware,
+    controller.uploadImages,
+  );
   router.use(controller.handleUploadError);
 
   return router;

--- a/src/server/routes/trpc/control-plane-workspace.ts
+++ b/src/server/routes/trpc/control-plane-workspace.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import { TRPCError } from '@trpc/server';
 import type { Logger } from 'pino';
 import { AutonomyPermissionModeService, type AutopilotProfile } from '@/core/approvals/index.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
@@ -7,6 +8,11 @@ import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/co
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { getWorkspaceOperationLogger } from '@/server/logging/workspace-operation-logger.js';
 import type { HeddleServerContext } from '@/server/types.js';
+import {
+  HeddleServerAccessError,
+  assertHeddleServerSessionAccess,
+  assertHeddleServerWorkspaceAccess,
+} from '@/server/access/index.js';
 import { procedure } from '@/server/trpc.js';
 import { workspaceScopedInputSchema } from './schema.js';
 
@@ -34,8 +40,31 @@ export type ControlPlaneWorkspaceContext = HeddleServerContext & {
 
 export const controlPlaneWorkspaceProcedure = procedure
   .input(workspaceScopedInputSchema)
-  .use(async ({ ctx, input, next, path, type }) => {
-    const requestWorkspace = resolveControlPlaneRequestWorkspace(ctx, input);
+  .use(async ({ ctx, input, next, path, type, getRawInput }) => {
+    let requestWorkspace: ControlPlaneRequestWorkspace;
+    try {
+      requestWorkspace = resolveControlPlaneRequestWorkspace(ctx, input);
+      const rawInput = await getRawInput();
+      const operation = {
+        name: resolveOperationName(path),
+        type,
+        workspaceId: requestWorkspace.workspace.id,
+        sessionId: resolveSessionId(path, rawInput),
+      };
+      if (operation.sessionId) {
+        assertHeddleServerSessionAccess(
+          ctx.requestAccess,
+          requestWorkspace.workspace.id,
+          operation.sessionId,
+        );
+      }
+      await ctx.authorizeControlPlaneOperation?.({
+        access: ctx.requestAccess,
+        operation,
+      });
+    } catch (error) {
+      throw projectAccessError(error);
+    }
     const startedAt = Date.now();
     const result = await next({
       ctx: {
@@ -59,6 +88,16 @@ export const controlPlaneWorkspaceProcedure = procedure
 
     return result;
   });
+
+export const controlPlaneLocalProcedure = procedure.use(({ ctx, next }) => {
+  if (ctx.requestAccess.mode !== 'local') {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'This control-plane operation is available only in local-daemon mode.',
+    });
+  }
+  return next();
+});
 
 /**
  * Resolves the workspace for one control-plane request.
@@ -98,6 +137,7 @@ function resolveWorkspaceDescriptor(ctx: HeddleServerContext, workspaceId: strin
     return ctx.activeWorkspace;
   }
 
+  assertHeddleServerWorkspaceAccess(ctx.requestAccess, workspaceId);
   const workspace =
     ctx.workspaces.find((candidate) => candidate.id === workspaceId)
     ?? RuntimeDaemonRegistryService.readWorkspaceRegistration(
@@ -108,4 +148,35 @@ function resolveWorkspaceDescriptor(ctx: HeddleServerContext, workspaceId: strin
     throw new Error(`Workspace not found: ${workspaceId}`);
   }
   return workspace;
+}
+
+function resolveOperationName(path: string): string {
+  return path.split('.').at(-1) ?? path;
+}
+
+function resolveSessionId(path: string, input: unknown): string | undefined {
+  const operationName = resolveOperationName(path);
+  const sessionScoped =
+    (
+      operationName.startsWith('session')
+      && !['sessionCreate', 'sessions', 'sessionsEvents'].includes(operationName)
+    )
+    || operationName === 'slashCommandExecute';
+  if (!sessionScoped || !input || typeof input !== 'object' || Array.isArray(input)) {
+    return undefined;
+  }
+
+  const inputRecord = input as Record<string, unknown>;
+  const sessionId = inputRecord.sessionId ?? inputRecord.id;
+  return typeof sessionId === 'string' ? sessionId : undefined;
+}
+
+function projectAccessError(error: unknown): Error {
+  if (!(error instanceof HeddleServerAccessError)) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  return new TRPCError({
+    code: error.statusCode === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
+    message: error.message,
+  });
 }

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import { TRPCError } from '@trpc/server';
 import type { z } from 'zod';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import { ModelOptionsService, ModelPolicyService } from '@/core/llm/models/index.js';
@@ -25,7 +26,16 @@ import { CustomAgentService } from '@/core/custom-agents/index.js';
 import { BrowserAutomationIntentContextService } from '@/core/browser/index.js';
 import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
-import { controlPlaneWorkspaceProcedure, type ControlPlaneWorkspaceContext } from './control-plane-workspace.js';
+import {
+  resolveHeddleServerPermittedSessionIds,
+} from '@/server/access/index.js';
+import type { ChatSessionView } from '@/server/control-plane-types.js';
+import type { HeddleControlPlaneAuditEvent } from '@/server/types.js';
+import {
+  controlPlaneLocalProcedure,
+  controlPlaneWorkspaceProcedure,
+  type ControlPlaneWorkspaceContext,
+} from './control-plane-workspace.js';
 import {
   agentAskInputSchema,
   browserAutomationInputSchema,
@@ -84,13 +94,18 @@ import {
 
 export const controlPlaneRouter = router({
   state: controlPlaneWorkspaceProcedure.query(async ({ ctx }) => {
-    return await ControlPlaneStateController.load(ctx, ctx.requestWorkspace.workspace);
+    const state = await ControlPlaneStateController.load(ctx, ctx.requestWorkspace.workspace);
+    return {
+      ...state,
+      sessions: filterPermittedSessions(ctx, state.activeWorkspaceId, state.sessions),
+    };
   }),
   sessions: controlPlaneWorkspaceProcedure.input(sessionsInputSchema).query(async ({ ctx }) => {
     const requestWorkspace = ctx.requestWorkspace;
+    const sessions = await controlPlaneChatSessionsController.readViews(requestWorkspace.sessionEngineArgs);
     return {
       workspaceId: requestWorkspace.workspace.id,
-      sessions: await controlPlaneChatSessionsController.readViews(requestWorkspace.sessionEngineArgs),
+      sessions: filterPermittedSessions(ctx, requestWorkspace.workspace.id, sessions),
     };
   }),
   sessionsEvents: controlPlaneWorkspaceProcedure.input(sessionsEventsInputSchema).subscription(({ ctx, signal }) => {
@@ -103,6 +118,7 @@ export const controlPlaneRouter = router({
   }),
   sessionCreate: controlPlaneWorkspaceProcedure.input(createSessionInputSchema).mutation(({ ctx, input }) => {
     const { workspace, sessionEngineArgs } = ctx.requestWorkspace;
+    assertSessionCreationAllowed(ctx, workspace.id);
     return controlPlaneChatSessionsController.createSession({
       ...sessionEngineArgs,
       suggestedName: input?.name,
@@ -301,22 +317,48 @@ export const controlPlaneRouter = router({
       }),
     };
   }),
-  sessionResolveApproval: controlPlaneWorkspaceProcedure.input(sessionApprovalDecisionSchema).mutation(({ ctx, input }) => {
+  sessionResolveApproval: controlPlaneWorkspaceProcedure.input(sessionApprovalDecisionSchema).mutation(async ({ ctx, input }) => {
     const { workspace } = ctx.requestWorkspace;
+    const auditEvent: HeddleControlPlaneAuditEvent = {
+      operation: 'approval.resolve',
+      occurredAt: dayjs().toISOString(),
+      actor: ctx.requestAccess.principal,
+      workspaceId: workspace.id,
+      sessionId: input.sessionId,
+      runId: input.runId,
+      metadata: {
+        decisionType: input.decision.type,
+        ...(input.decision.reason ? { reason: input.decision.reason } : {}),
+      },
+    };
+    await recordPrivilegedControlPlaneOperation(ctx, auditEvent);
+    const resolved = controlPlaneChatSessionsController.resolvePendingApproval({
+      workspaceId: workspace.id,
+      sessionId: input.sessionId,
+    }, input.decision, input.runId);
+    ctx.requestWorkspace.logger.info({ auditEvent, resolved }, 'Control-plane approval resolution completed');
     return {
-      resolved: controlPlaneChatSessionsController.resolvePendingApproval({
-        workspaceId: workspace.id,
-        sessionId: input.sessionId,
-      }, input.decision, input.runId),
+      resolved,
     };
   }),
-  sessionCancel: controlPlaneWorkspaceProcedure.input(sessionCancelInputSchema).mutation(({ ctx, input }) => {
+  sessionCancel: controlPlaneWorkspaceProcedure.input(sessionCancelInputSchema).mutation(async ({ ctx, input }) => {
     const { workspace } = ctx.requestWorkspace;
+    const auditEvent: HeddleControlPlaneAuditEvent = {
+      operation: 'run.cancel',
+      occurredAt: dayjs().toISOString(),
+      actor: ctx.requestAccess.principal,
+      workspaceId: workspace.id,
+      sessionId: input.id,
+      runId: input.runId,
+    };
+    await recordPrivilegedControlPlaneOperation(ctx, auditEvent);
+    const cancelled = controlPlaneChatSessionsController.cancelRun({
+      workspaceId: workspace.id,
+      sessionId: input.id,
+    }, input.runId);
+    ctx.requestWorkspace.logger.info({ auditEvent, cancelled }, 'Control-plane run cancellation completed');
     return {
-      cancelled: controlPlaneChatSessionsController.cancelRun({
-        workspaceId: workspace.id,
-        sessionId: input.id,
-      }, input.runId),
+      cancelled,
     };
   }),
   sessionSendPrompt: controlPlaneWorkspaceProcedure.input(sessionMessageInputSchema).mutation(async ({ ctx, input }) => {
@@ -654,7 +696,7 @@ export const controlPlaneRouter = router({
       }),
     };
   }),
-  workspaceBrowse: procedure.input(workspaceBrowseInputSchema).query(async ({ input }) => {
+  workspaceBrowse: controlPlaneLocalProcedure.input(workspaceBrowseInputSchema).query(async ({ input }) => {
     return await ControlPlaneWorkspaceFilesController.browseDirectories({
       path: input?.path,
       limit: input?.limit ?? 100,
@@ -675,7 +717,7 @@ export const controlPlaneRouter = router({
       ...await ControlPlaneWorkspaceDiffController.readFileDiff(workspace.workspaceRoot, input.path),
     };
   }),
-  workspaceSetActive: procedure.input(workspaceSetActiveInputSchema).mutation(({ ctx, input }) => {
+  workspaceSetActive: controlPlaneLocalProcedure.input(workspaceSetActiveInputSchema).mutation(({ ctx, input }) => {
     const resolved = RuntimeWorkspaceService.setActive({
       workspaceRoot: ctx.workspaceRoot,
       stateRoot: ctx.stateRoot,
@@ -688,7 +730,7 @@ export const controlPlaneRouter = router({
       workspaces: resolved.workspaces,
     };
   }),
-  workspaceCreate: procedure.input(workspaceCreateInputSchema).mutation(({ ctx, input }) => {
+  workspaceCreate: controlPlaneLocalProcedure.input(workspaceCreateInputSchema).mutation(({ ctx, input }) => {
     const resolved = RuntimeWorkspaceService.createDescriptor({
       workspaceRoot: ctx.workspaceRoot,
       stateRoot: ctx.stateRoot,
@@ -704,7 +746,7 @@ export const controlPlaneRouter = router({
       workspaces: resolved.workspaces,
     };
   }),
-  workspaceRename: procedure.input(workspaceRenameInputSchema).mutation(({ ctx, input }) => {
+  workspaceRename: controlPlaneLocalProcedure.input(workspaceRenameInputSchema).mutation(({ ctx, input }) => {
     const resolved = RuntimeWorkspaceService.rename({
       workspaceRoot: ctx.workspaceRoot,
       stateRoot: ctx.stateRoot,
@@ -725,6 +767,37 @@ export const controlPlaneRouter = router({
 });
 
 type SessionMessageInput = z.infer<typeof sessionMessageInputSchema>;
+
+function filterPermittedSessions(
+  ctx: HeddleServerContext,
+  workspaceId: string,
+  sessions: ChatSessionView[],
+): ChatSessionView[] {
+  const permittedSessionIds = resolveHeddleServerPermittedSessionIds(ctx.requestAccess, workspaceId);
+  if (!permittedSessionIds) {
+    return sessions;
+  }
+
+  const permitted = new Set(permittedSessionIds);
+  return sessions.filter((session) => permitted.has(session.id));
+}
+
+function assertSessionCreationAllowed(ctx: HeddleServerContext, workspaceId: string): void {
+  if (resolveHeddleServerPermittedSessionIds(ctx.requestAccess, workspaceId)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Session creation requires unrestricted access to the workspace session catalog.',
+    });
+  }
+}
+
+async function recordPrivilegedControlPlaneOperation(
+  ctx: ControlPlaneWorkspaceContext,
+  auditEvent: HeddleControlPlaneAuditEvent,
+): Promise<void> {
+  ctx.requestWorkspace.logger.info({ auditEvent }, 'Control-plane privileged operation authorized');
+  await ctx.recordControlPlaneAuditEvent?.(auditEvent);
+}
 
 function buildSubmitPromptArgs(ctx: ControlPlaneWorkspaceContext, input: SessionMessageInput) {
   const { logger, sessionEngineArgs } = ctx.requestWorkspace;

--- a/src/server/routes/trpc/trpc.ts
+++ b/src/server/routes/trpc/trpc.ts
@@ -1,23 +1,22 @@
 import { Router } from 'express';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
-import { RuntimeWorkspaceService } from '@/core/runtime/workspaces/index.js';
+import type { HeddleServerRequestAccessService } from '@/server/access/index.js';
 import { appRouter } from '../../router.js';
 import type { HeddleRuntimeHostDescriptor, HeddleServerContext } from '../../types.js';
 
 type CreateTrpcExpressRouterOptions = Pick<HeddleServerContext, 'workspaceRoot' | 'stateRoot' | 'logger'>
   & { preferApiKey?: boolean }
-  & { runtimeHost?: HeddleRuntimeHostDescriptor | null };
+  & { runtimeHost?: HeddleRuntimeHostDescriptor | null }
+  & { requestAccess: HeddleServerRequestAccessService };
 
 export function createTrpcExpressRouter(options: CreateTrpcExpressRouterOptions): Router {
   const trpcRouter = Router();
 
   trpcRouter.use('/trpc', createExpressMiddleware({
     router: appRouter,
-    createContext: () => {
-      const workspaceContext = RuntimeWorkspaceService.resolveContext({
-        workspaceRoot: options.workspaceRoot,
-        stateRoot: options.stateRoot,
-      });
+    createContext: ({ req }) => {
+      const workspaceContext = options.requestAccess.resolveWorkspaceContext(req);
+      const requestAccess = options.requestAccess.requireAccess(req);
       return {
         workspaceRoot: options.workspaceRoot,
         stateRoot: options.stateRoot,
@@ -27,6 +26,11 @@ export function createTrpcExpressRouter(options: CreateTrpcExpressRouterOptions)
         workspaces: workspaceContext.workspaces,
         runtimeHost: options.runtimeHost ?? null,
         logger: options.logger,
+        requestAccess,
+        authorizeControlPlaneOperation: ({ operation }) => (
+          options.requestAccess.authorizeOperation(req, operation)
+        ),
+        recordControlPlaneAuditEvent: (event) => options.requestAccess.recordAuditEvent(event),
       };
     },
     onError: ({ error, path, type }) => {

--- a/src/server/services/control-plane/chat-session-image-uploads.ts
+++ b/src/server/services/control-plane/chat-session-image-uploads.ts
@@ -3,7 +3,8 @@ import { mkdir } from 'node:fs/promises';
 import { basename, extname, join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { Request } from 'express';
-import { RuntimeWorkspaceService, type WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
+import type { HeddleServerRequestAccessService } from '@/server/access/index.js';
+import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
 import { controlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
 import { getWorkspaceOperationLogger } from '@/server/logging/workspace-operation-logger.js';
 
@@ -25,8 +26,7 @@ export type ChatSessionImageUploadResult = {
 };
 
 type ChatSessionImageUploadServiceOptions = {
-  workspaceRoot: string;
-  stateRoot: string;
+  requestAccess: HeddleServerRequestAccessService;
 };
 
 const SUPPORTED_IMAGE_TYPES = {
@@ -46,21 +46,20 @@ const SUPPORTED_IMAGE_TYPES = {
 export class ChatSessionImageUploadService {
   constructor(private readonly options: ChatSessionImageUploadServiceOptions) {}
 
-  resolveWorkspace(request: Request): WorkspaceDescriptor {
-    const workspaceContext = RuntimeWorkspaceService.resolveContext({
-      workspaceRoot: this.options.workspaceRoot,
-      stateRoot: this.options.stateRoot,
+  async authorizeUpload(request: Request): Promise<void> {
+    const sessionId = this.readSessionId(request);
+    const workspace = this.resolveWorkspace(request);
+    await this.options.requestAccess.authorizeOperation(request, {
+      name: 'sessionImageUpload',
+      type: 'mutation',
+      workspaceId: workspace.id,
+      sessionId,
     });
-    const workspaceId = this.readWorkspaceId(request);
-    if (!workspaceId) {
-      return workspaceContext.activeWorkspace;
-    }
+  }
 
-    const workspace = workspaceContext.workspaces.find((candidate) => candidate.id === workspaceId);
-    if (!workspace) {
-      throw new ChatSessionUploadError(404, `Workspace not found: ${workspaceId}`);
-    }
-    return workspace;
+  resolveWorkspace(request: Request): WorkspaceDescriptor {
+    const workspaceId = this.readWorkspaceId(request);
+    return this.options.requestAccess.resolveWorkspace(request, workspaceId);
   }
 
   async resolveUploadDirectory(request: Request): Promise<string> {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,6 +1,92 @@
+import type { Request } from 'express';
 import type { Logger } from 'pino';
 import type { ControlPlaneServerRecord } from '@/core/runtime/daemon/index.js';
 import type { WorkspaceDescriptor } from '@/core/runtime/workspaces/index.js';
+
+export type HeddleServerPrincipal = {
+  id: string;
+  displayName?: string;
+  auditMetadata?: Readonly<Record<string, string | number | boolean | null>>;
+};
+
+export type HeddleServerWorkspaceScope = {
+  workspaceId: string;
+  /**
+   * Omit to permit every session in the workspace. An empty array permits
+   * workspace-level operations but no session-level operation.
+   */
+  sessionIds?: readonly string[];
+};
+
+export type HeddleServerHostedRequestAccess = {
+  principal: HeddleServerPrincipal;
+  scope: {
+    workspaces: readonly HeddleServerWorkspaceScope[];
+  };
+};
+
+export type HeddleServerRequestAccess =
+  | (HeddleServerHostedRequestAccess & { mode: 'hosted' })
+  | {
+    mode: 'local';
+    principal: HeddleServerPrincipal;
+    scope: {
+      workspaces: 'all';
+    };
+  };
+
+export type HeddleControlPlaneOperation = {
+  name: string;
+  type: 'query' | 'mutation' | 'subscription';
+  workspaceId?: string;
+  sessionId?: string;
+};
+
+export type HeddleControlPlaneOperationAuthorization = {
+  access: HeddleServerRequestAccess;
+  operation: HeddleControlPlaneOperation;
+};
+
+export type HeddleControlPlaneAuditEvent = {
+  operation: 'approval.resolve' | 'run.cancel';
+  occurredAt: string;
+  actor: HeddleServerPrincipal;
+  workspaceId: string;
+  sessionId: string;
+  runId?: string;
+  metadata?: Readonly<Record<string, string | number | boolean | null>>;
+};
+
+export type HeddleServerAccessControl =
+  | {
+    /**
+     * Unauthenticated single-operator mode for a local daemon. This mode is
+     * intentionally not safe for hosted or multi-tenant deployment.
+     */
+    mode: 'local';
+  }
+  | {
+    mode: 'hosted';
+    /**
+     * Authenticate the HTTP request and return only the workspace/session
+     * scope that the principal may address. Return null when unauthenticated.
+     */
+    resolveRequestAccess: (
+      request: Request,
+    ) => HeddleServerHostedRequestAccess | null | Promise<HeddleServerHostedRequestAccess | null>;
+    /**
+     * Optional product authorization hook. Heddle enforces the resolved static
+     * workspace/session scope before invoking this hook.
+     */
+    authorizeOperation?: (
+      authorization: HeddleControlPlaneOperationAuthorization,
+    ) => void | Promise<void>;
+    /**
+     * Optional host audit sink. Heddle also records the same event in the
+     * workspace operation log before the privileged mutation runs.
+     */
+    recordAuditEvent?: (event: HeddleControlPlaneAuditEvent) => void | Promise<void>;
+  };
 
 export type HeddleServerOptions = {
   workspaceRoot: string;
@@ -10,6 +96,7 @@ export type HeddleServerOptions = {
   serveAssets?: boolean;
   logger?: Logger;
   runtimeHost?: HeddleRuntimeHostDescriptor;
+  accessControl?: HeddleServerAccessControl;
 };
 
 export type HeddleControlPlaneServerOptions = Omit<HeddleServerOptions, 'runtimeHost'> & {
@@ -64,4 +151,9 @@ export type HeddleServerContext = {
   workspaces: WorkspaceDescriptor[];
   runtimeHost: HeddleRuntimeHostInfo | null;
   logger: Logger;
+  requestAccess: HeddleServerRequestAccess;
+  authorizeControlPlaneOperation?: (
+    authorization: HeddleControlPlaneOperationAuthorization,
+  ) => void | Promise<void>;
+  recordControlPlaneAuditEvent?: (event: HeddleControlPlaneAuditEvent) => void | Promise<void>;
 };


### PR DESCRIPTION
## Summary

- add explicit `local` and `hosted` request-access modes for the embedded control-plane server
- let product hosts resolve an authenticated principal and exact workspace/session scope without coupling Heddle to an identity provider
- enforce host scope consistently across tRPC, session event streaming, and image uploads before handlers or file persistence
- route every workspace operation through an optional host authorizer, while disabling local-daemon administration endpoints in hosted mode
- record authenticated actor metadata for approval resolution and run cancellation before mutation, with an optional host audit sink
- document the service boundary, local-mode warning, and a minimal hosted integration example

## Security boundary

Client-supplied workspace and session IDs can only narrow the host-resolved scope. They cannot broaden it. Session creation requires unrestricted session scope, and hosted mode does not expose daemon registry discovery or local workspace administration.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` — 130 files, 783 tests
- `yarn test:integration` — 36 files, 324 tests
- `yarn build`

The new HTTP integration coverage verifies authentication, workspace/session narrowing, REST parity, privileged-operation authorization, and actor audit ordering.

Closes #279