### PR TITLE
fix: canonicalize memory note paths

### DIFF
--- a/docs/architecture/execution-boundaries.md
+++ b/docs/architecture/execution-boundaries.md
@@ -36,7 +36,7 @@ whole Heddle process inside mature OS isolation.
 | `run_shell_inspect` | **None.** Workspace is the initial `cwd` only | none — policy allowlist only | Read-oriented rules; redirects, chaining, subshells blocked |
 | `run_shell_mutate` | **None.** Workspace is the initial `cwd` only | `requiresApproval: true` | Arbitrary commands permitted once approved |
 | `edit_memory_note` | **Canonical** — reuses `executeScopedEdit` with the memory root | mutation approval-gated | Same core as coding-files |
-| `read`/`search`/`list` memory notes | **Lexical only** — see gap below | none | `MemoryPathUtils.resolveMemoryPath` |
+| `read`/`search`/`list` memory notes | **Canonical** — `MemoryPathUtils.resolveMemoryPath` delegates to `WorkspacePathPolicy` | none | Same policy as coding-files; memory owns only the error vocabulary |
 | MCP tools | delegated to the server | host-owned policy, remote mutations approval-gated | Out of scope for this document |
 
 The `scope: 'workspace'` value in a shell policy decision classifies what a
@@ -81,20 +81,24 @@ request.
 
 These are real findings from this audit. None are fixed by this document.
 
-### 1. Memory note reads use lexical containment while memory edits use canonical
+### 1. Memory note reads used lexical containment — **fixed**
 
-`MemoryPathUtils.resolveMemoryPath` (`core/memory/path-utils.ts:5`) checks
-containment with `resolve` + `relative` + a `..` prefix test. That is a purely
-lexical check: a symlink inside the memory root that points outside it resolves
-to an in-root relative path and passes.
+`MemoryPathUtils.resolveMemoryPath` previously checked containment with
+`resolve` + `relative` + a `..` prefix test. That is a purely lexical check: a
+symlink inside the memory root pointing outside it resolved to an in-root
+relative path and passed, so `read_memory_note` would follow it and return the
+outside file's contents.
 
-`edit_memory_note` is unaffected because it routes through `executeScopedEdit`,
-which canonicalizes. But `read`, `search`, and `list` go through
-`MemoryNoteService.resolvePath` and do not. The same tool family therefore has
-two different containment strengths.
+It now delegates to `WorkspacePathPolicy`, the same canonical policy the
+coding-files toolkit and `edit_memory_note` already use. The memory module
+keeps only its own error vocabulary. Escapes through an in-root symlink are
+covered by tests for read, list, and search.
 
-The fix is to route memory path resolution through the same canonical policy
-the coding-files toolkit already owns — not to add a second path checker.
+One narrow case remains lexical by necessity: when the memory root does not
+exist yet there is no tree to traverse and no symlink that could redirect the
+path, so `resolveAgainstMissingRoot` performs the `..` check directly. That is
+exact rather than approximate, and it is the only path in the module that does
+its own containment arithmetic.
 
 ### 2. Shell cancellation does not supervise the process tree
 
@@ -118,9 +122,9 @@ model cannot tell truncated output from complete output.
 
 30 seconds, not host-configurable, with no per-profile override.
 
-Gaps 2–5 belong to complete local process-tree supervision. Gap 1 belongs to
-canonical path enforcement. Neither should be addressed by introducing a
-parallel execution backend or a second path-policy implementation.
+Gap 1 is closed. Gaps 2–5 remain and belong together to complete local
+process-tree supervision; they should not be addressed by introducing a
+parallel execution backend beside the current one.
 
 ## What Would Change These Guarantees
 

--- a/src/__tests__/integration/tools/tools.test.ts
+++ b/src/__tests__/integration/tools/tools.test.ts
@@ -1131,6 +1131,106 @@ describe('memory note tools', () => {
     expect(editResult.error).toContain('memory note paths must stay inside');
   });
 
+  it('refuses to read through a symlink that escapes the memory root', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'heddle-memory-symlink-'));
+    const root = join(base, 'memory');
+    const outside = join(base, 'outside');
+    await mkdir(root, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await writeFile(join(outside, 'secret.md'), '# Secret\nsensitive value\n');
+    await symlink(outside, join(root, 'escape'));
+
+    const readTool = createReadMemoryNoteTool({ memoryRoot: root });
+    const result = await readTool.execute({ path: 'escape/secret.md' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Memory note paths must stay inside');
+    expect(result.error).not.toContain('sensitive value');
+  });
+
+  it('refuses to list or search through a symlink that escapes the memory root', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'heddle-memory-symlink-scope-'));
+    const root = join(base, 'memory');
+    const outside = join(base, 'outside');
+    await mkdir(root, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await writeFile(join(outside, 'secret.md'), '# Secret\nsensitive value\n');
+    await symlink(outside, join(root, 'escape'));
+
+    const listTool = createListMemoryNotesTool({ memoryRoot: root });
+    const searchTool = createSearchMemoryNotesTool({ memoryRoot: root });
+
+    const listResult = await listTool.execute({ path: 'escape' });
+    const searchResult = await searchTool.execute({ path: 'escape', query: 'sensitive' });
+
+    expect(listResult.ok).toBe(false);
+    expect(listResult.error).toContain('Memory note paths must stay inside');
+    expect(searchResult.ok).toBe(false);
+    expect(searchResult.error).toContain('Memory note paths must stay inside');
+  });
+
+  it('does not follow an escaping symlink when listing the whole memory root', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'heddle-memory-symlink-walk-'));
+    const root = join(base, 'memory');
+    const outside = join(base, 'outside');
+    await mkdir(root, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await writeFile(join(root, 'own-note.md'), '# Own\n');
+    await writeFile(join(outside, 'secret.md'), '# Secret\n');
+    await symlink(outside, join(root, 'escape'));
+
+    const listTool = createListMemoryNotesTool({ memoryRoot: root });
+    const result = await listTool.execute({});
+
+    expect(result).toEqual({ ok: true, output: 'own-note.md' });
+  });
+
+  it('resolves notes correctly when the memory root itself is reached through a symlink', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'heddle-memory-symlinked-root-'));
+    const realRoot = join(base, 'real-memory');
+    const linkedRoot = join(base, 'linked-memory');
+    await mkdir(realRoot, { recursive: true });
+    await mkdir(join(realRoot, 'architecture'), { recursive: true });
+    await writeFile(join(realRoot, 'architecture', 'auth.md'), '# Auth\nsentinel value\n');
+    await symlink(realRoot, linkedRoot);
+
+    const listTool = createListMemoryNotesTool({ memoryRoot: linkedRoot });
+    const readTool = createReadMemoryNoteTool({ memoryRoot: linkedRoot });
+    const searchTool = createSearchMemoryNotesTool({ memoryRoot: linkedRoot });
+
+    // A symlinked root is legitimate: canonicalizing the target must not make
+    // the root's own notes look like escapes.
+    expect(await listTool.execute({})).toEqual({ ok: true, output: 'architecture/auth.md' });
+    expect(await readTool.execute({ path: 'architecture/auth.md' })).toEqual({
+      ok: true,
+      output: '# Auth\nsentinel value\n',
+    });
+    expect(await searchTool.execute({ query: 'sentinel' })).toEqual({
+      ok: true,
+      output: 'architecture/auth.md:2:sentinel value',
+    });
+  });
+
+  it('reports no notes when the memory root does not exist yet', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'heddle-memory-missing-root-'));
+    const root = join(base, 'not-created-yet');
+
+    const listTool = createListMemoryNotesTool({ memoryRoot: root });
+    const searchTool = createSearchMemoryNotesTool({ memoryRoot: root });
+    const readTool = createReadMemoryNoteTool({ memoryRoot: root });
+
+    expect(await listTool.execute({})).toEqual({ ok: true, output: '' });
+    expect(await searchTool.execute({ query: 'anything' })).toEqual({
+      ok: true,
+      output: 'No matches found.',
+    });
+
+    // Containment still applies before the root exists.
+    const escaped = await readTool.execute({ path: '../outside.md' });
+    expect(escaped.ok).toBe(false);
+    expect(escaped.error).toContain('Memory note paths must stay inside');
+  });
+
   it('records knowledge candidates under memory maintenance', async () => {
     const root = await mkdtemp(join(tmpdir(), 'heddle-record-knowledge-'));
     const tool = createRecordKnowledgeTool({

--- a/src/core/memory/README.md
+++ b/src/core/memory/README.md
@@ -41,6 +41,13 @@ guidance.
   trace-triggered maintenance scheduling, locking, and lifecycle events.
 - `note-service.ts`: `MemoryNoteService` owns note list/read/search/edit
   behavior. Tool adapters should call this service, not duplicate file logic.
+- `path-utils.ts`: `MemoryPathUtils` owns memory-root path resolution. It
+  delegates containment to `WorkspacePathPolicy` — the same canonical policy
+  the coding-files toolkit uses — so an in-root symlink cannot redirect a read,
+  listing, or search outside the memory root. This module owns the memory-
+  specific error vocabulary, not a second containment implementation. Resolved
+  paths are canonical, so anything relativizing against the root must use
+  `MemoryPathUtils.canonicalRoot(...)` rather than the configured root.
 - `maintainer-tools.ts`: tools used by maintainer mode.
 - `visibility.ts`: `MemoryVisibilityService` owns host-facing status and note
   visibility views.

--- a/src/core/memory/note-service.ts
+++ b/src/core/memory/note-service.ts
@@ -15,22 +15,25 @@ export class MemoryNoteService {
   constructor(private readonly memoryRoot: string) {}
 
   async list(input: ListMemoryNotesInput = {}): Promise<string[]> {
-    const targetPath = this.resolvePath(input.path ?? '.');
+    const targetPath = await this.resolvePath(input.path ?? '.');
     if (!await MemoryPathUtils.pathExists(targetPath)) {
       return [];
     }
 
+    // Resolved paths are canonical, so listings must be relativized against the
+    // canonical root rather than the configured one.
+    const canonicalRoot = await MemoryPathUtils.canonicalRoot(this.resolveRoot());
     const info = await stat(targetPath);
     if (info.isFile()) {
-      return [MemoryPathUtils.toMemoryRelativePath(this.resolveRoot(), targetPath)];
+      return [MemoryPathUtils.toMemoryRelativePath(canonicalRoot, targetPath)];
     }
 
     const notes = await this.listMarkdownNotes(targetPath);
-    return notes.map((path) => MemoryPathUtils.toMemoryRelativePath(this.resolveRoot(), path)).sort();
+    return notes.map((path) => MemoryPathUtils.toMemoryRelativePath(canonicalRoot, path)).sort();
   }
 
   async read(input: ReadMemoryNoteInput): Promise<string> {
-    const targetPath = this.resolvePath(input.path);
+    const targetPath = await this.resolvePath(input.path);
     try {
       return MemoryNoteService.pageText(await readFile(targetPath, 'utf8'), input.offset, input.maxLines);
     } catch (error) {
@@ -42,7 +45,7 @@ export class MemoryNoteService {
   }
 
   async search(input: SearchMemoryNotesInput): Promise<string> {
-    const targetPath = this.resolvePath(input.path ?? '.');
+    const targetPath = await this.resolvePath(input.path ?? '.');
     if (!await MemoryPathUtils.pathExists(targetPath)) {
       return 'No matches found.';
     }
@@ -60,8 +63,8 @@ export class MemoryNoteService {
     });
   }
 
-  private resolvePath(path: string): string {
-    const result = MemoryPathUtils.resolveMemoryPath(this.resolveRoot(), path);
+  private async resolvePath(path: string): Promise<string> {
+    const result = await MemoryPathUtils.resolveMemoryPath(this.resolveRoot(), path);
     if (!result.ok) {
       throw new Error(result.error);
     }
@@ -91,7 +94,9 @@ export class MemoryNoteService {
   }
 
   private async searchWithCli(targetPath: string, query: string, maxResults: number): Promise<string> {
-    const memoryRoot = this.resolveRoot();
+    // The search runs from the canonical root so its cwd and the relative
+    // target it is given agree with the canonical resolved path.
+    const memoryRoot = await MemoryPathUtils.canonicalRoot(this.resolveRoot());
     const relativeTarget = MemoryPathUtils.toMemoryRelativePath(memoryRoot, targetPath);
     const normalizedTarget = relativeTarget === '.' ? '.' : relativeTarget;
 

--- a/src/core/memory/path-utils.ts
+++ b/src/core/memory/path-utils.ts
@@ -1,19 +1,69 @@
-import { access } from 'node:fs/promises';
+import { access, realpath } from 'node:fs/promises';
 import { isAbsolute, relative, resolve } from 'node:path';
+import {
+  WorkspacePathOutsideRootError,
+  WorkspacePathPolicy,
+} from '@/core/tools/toolkits/coding-files/workspace-path-policy.js';
 
 export class MemoryPathUtils {
-  static resolveMemoryPath(memoryRoot: string, requestedPath: string): { ok: true; path: string } | { ok: false; error: string } {
+  /**
+   * Resolves a requested memory-note path to a canonical path inside the memory
+   * root.
+   *
+   * Containment is delegated to `WorkspacePathPolicy`, the same canonical
+   * policy the coding-files toolkit and `edit_memory_note` already use, so a
+   * symlink inside the memory root cannot redirect a read, search, or listing
+   * outside it. This module owns only the memory-specific error vocabulary.
+   */
+  static async resolveMemoryPath(
+    memoryRoot: string,
+    requestedPath: string,
+  ): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
     if (!requestedPath.trim()) {
       return { ok: false, error: `Memory note paths must be non-empty and stay inside ${memoryRoot}.` };
     }
 
-    const targetPath = resolve(memoryRoot, requestedPath);
-    const rel = relative(memoryRoot, targetPath);
-    if (rel.startsWith('..') || isAbsolute(rel)) {
-      return { ok: false, error: `Memory note paths must stay inside ${memoryRoot}. Refusing to access ${targetPath}.` };
+    const canonicalRoot = await MemoryPathUtils.canonicalRootOrUndefined(resolve(memoryRoot));
+    if (!canonicalRoot) {
+      // The memory root does not exist yet, so there is no tree to traverse and
+      // no symlink that could redirect the path. A lexical check is exact here,
+      // and it still rejects paths that climb out of the root.
+      return MemoryPathUtils.resolveAgainstMissingRoot(memoryRoot, requestedPath);
     }
 
-    return { ok: true, path: targetPath };
+    try {
+      // resolveCreatable tolerates a missing target and anchors it at its
+      // nearest existing canonical parent. Callers decide what a missing note
+      // means: list and search report nothing, read surfaces the read failure.
+      const resolved = await WorkspacePathPolicy.resolveCreatable({
+        workspaceRoot: memoryRoot,
+        path: requestedPath,
+      });
+      return { ok: true, path: resolved.canonicalPath };
+    } catch (error) {
+      if (error instanceof WorkspacePathOutsideRootError) {
+        return {
+          ok: false,
+          error: `Memory note paths must stay inside ${memoryRoot}. Refusing to access ${error.canonicalPath}.`,
+        };
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Canonical form of the memory root, or its lexical form when the root does
+   * not exist yet.
+   *
+   * Resolved paths are canonical, so anything that relativizes against the root
+   * — note listings, search targets — must use this rather than the configured
+   * root. They differ whenever the root sits under a symlink, which is the
+   * normal case for temporary directories on macOS.
+   */
+  static async canonicalRoot(memoryRoot: string): Promise<string> {
+    const resolvedRoot = resolve(memoryRoot);
+    return await MemoryPathUtils.canonicalRootOrUndefined(resolvedRoot) ?? resolvedRoot;
   }
 
   static toMemoryRelativePath(memoryRoot: string, filePath: string): string {
@@ -31,5 +81,33 @@ export class MemoryPathUtils {
 
   static isErrorWithCode(error: unknown, code: string): error is Error & { code: string } {
     return error instanceof Error && 'code' in error && error.code === code;
+  }
+
+  private static async canonicalRootOrUndefined(memoryRoot: string): Promise<string | undefined> {
+    try {
+      return await realpath(resolve(memoryRoot));
+    } catch (error) {
+      if (MemoryPathUtils.isErrorWithCode(error, 'ENOENT') || MemoryPathUtils.isErrorWithCode(error, 'ENOTDIR')) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+
+  private static resolveAgainstMissingRoot(
+    memoryRoot: string,
+    requestedPath: string,
+  ): { ok: true; path: string } | { ok: false; error: string } {
+    const targetPath = resolve(memoryRoot, requestedPath);
+    const rel = relative(resolve(memoryRoot), targetPath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      return {
+        ok: false,
+        error: `Memory note paths must stay inside ${memoryRoot}. Refusing to access ${targetPath}.`,
+      };
+    }
+
+    return { ok: true, path: targetPath };
   }
 }


### PR DESCRIPTION
Milestone 1 of the isolation direction — closes **gap 1** from `docs/architecture/execution-boundaries.md`, the one the Milestone 0 audit recorded but deliberately did not fix.

## The bug

`read_memory_note`, `list_memory_notes`, and `search_memory_notes` resolved paths with a lexical `resolve` + `relative` + `..` check. A symlink *inside* the memory root pointing outside it resolves to an in-root relative path, so it passed — and `readFile` then followed the link and returned the outside file's contents.

`edit_memory_note` was never affected: it routes through `executeScopedEdit`, which canonicalizes. So the same tool family had two different containment strengths, which is what made this worth fixing rather than documenting.

## The fix

`MemoryPathUtils.resolveMemoryPath` now delegates to `WorkspacePathPolicy` — the same canonical policy the coding-files toolkit and `edit_memory_note` already use. The memory module keeps only its memory-specific error vocabulary, not a second containment implementation.

One branch stays lexical: when the memory root does not exist yet, there is no tree to traverse and no symlink that could redirect anything, so the `..` check is exact rather than approximate. It's isolated in `resolveAgainstMissingRoot` and called out in both the module README and the boundary doc.

## The subtle part

Canonicalizing the *target* broke the relativization that turns paths back into note names, because listing and search still relativized against the *configured* root. Those differ whenever the root sits under a symlink — which is the normal case for `tmpdir()` on macOS, where `/var` → `/private/var`.

Both now use `MemoryPathUtils.canonicalRoot(...)`. There's a test covering a legitimately symlinked memory root, so a future change that reintroduces the mismatch fails rather than silently returning `../../../private/var/...` note names.

## Verification

The two escape tests were confirmed to **fail against the previous implementation** and pass with the fix — I stashed the source and re-ran to check, rather than assuming.

New coverage: symlink escape via read; via list and search; the whole-root walk not following an escaping symlink; a legitimately symlinked root resolving correctly; and a missing root reporting empty while still enforcing containment.

`yarn build`, `yarn typecheck`, `yarn test` (131 unit files / 799 tests, 37 integration files / 342 tests — up 5), eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)