### PR TITLE
test: certify catalog projection in session conformance

### DIFF
--- a/src/__tests__/integration/chat/chat-session-repository-conformance.test.ts
+++ b/src/__tests__/integration/chat/chat-session-repository-conformance.test.ts
@@ -48,13 +48,49 @@ describe('ChatSessionRepositoryConformance', () => {
 
   const scenarios = ChatSessionRepositoryConformance.createScenarios(harness);
 
-  it('publishes eight uniquely named scenarios', () => {
-    expect(scenarios).toHaveLength(8);
-    expect(new Set(scenarios.map((scenario) => scenario.name)).size).toBe(8);
+  it('publishes nine uniquely named scenarios', () => {
+    expect(scenarios).toHaveLength(9);
+    expect(new Set(scenarios.map((scenario) => scenario.name)).size).toBe(9);
   });
 
   it.each(scenarios)('$name', async ({ run }) => {
     await run();
+  });
+
+  it('rejects an adapter whose catalog carries transcript state', async () => {
+    // The contract violation this scenario exists to catch: an adapter that
+    // returns the stored record as its catalog entry, so transcript arrays
+    // reach every session list.
+    const leakingHarness: ChatSessionRepositoryConformanceHarness = {
+      ...harness,
+      createRepository: (scopeId) => {
+        const inner = new FileChatSessionRepository({
+          sessionStoragePath: storagePath(scopeId),
+        });
+        return {
+          create: (session) => inner.create(session),
+          read: (sessionId) => inner.read(sessionId),
+          update: (input) => inner.update(input),
+          delete: (input) => inner.delete(input),
+          list: async (input) => {
+            const page = await inner.list(input);
+            const items = await Promise.all(page.items.map(async (item) => {
+              const stored = await inner.read(item.id);
+              return stored
+                ? { ...stored.session, revision: stored.revision }
+                : item;
+            }));
+            return { ...page, items };
+          },
+        };
+      },
+    };
+    const catalogScenario = ChatSessionRepositoryConformance
+      .createScenarios(leakingHarness)
+      .find(({ name }) => name === 'catalog entries expose only catalog fields');
+
+    await expect(catalogScenario?.run()).rejects.toThrow(/history/u);
+    await expect(catalogScenario?.run()).rejects.toThrow(/projectCatalogEntry/u);
   });
 
   it('cleans every generated scope when an adapter operation fails', async () => {

--- a/src/core/chat/engine/sessions/repository/README.md
+++ b/src/core/chat/engine/sessions/repository/README.md
@@ -91,8 +91,16 @@ scripts and smoke checks. The harness owns only three integration points:
 The suite checks exact CRUD revisions, concurrent unique-create and CAS races,
 stable cursor pages including binary UTF-8 ties, filters before page boundaries,
 identical-ID isolation across two scopes, complete reopen through fresh adapter
-instances, corruption propagation, and invalid page limits. It invokes cleanup
-for every generated scope even when the adapter or an assertion fails.
+instances, corruption propagation, invalid page limits, and that catalog entries
+carry only the fields the catalog schema defines. It invokes cleanup for every
+generated scope even when the adapter or an assertion fails.
+
+The catalog-projection check exists because an adapter can pass every other
+scenario while building its catalog entry by *removing* known-large record
+fields instead of *selecting* known-catalog fields. Both approaches agree today;
+only the second stays correct when `ChatSession` gains a field. Project with
+`ChatSessionPersistenceCodec.projectCatalogEntry` rather than reproducing the
+field list.
 
 Passing this suite certifies the Heddle repository behavior exercised by the
 scenarios. It does not certify product authentication, RLS policy, migrations,

--- a/src/core/chat/engine/sessions/repository/chat-session-repository-conformance.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-repository-conformance.ts
@@ -8,6 +8,7 @@
 import { randomUUID } from 'node:crypto';
 import isEqual from 'lodash/isEqual.js';
 import type { ChatSession } from '@/core/chat/types.js';
+import { CatalogEntryWriteSchema } from './chat-session-schemas.js';
 import {
   ChatSessionAlreadyExistsError,
   ChatSessionRepositoryConformanceError,
@@ -63,7 +64,16 @@ const scenarioName = {
   reopen: 'fresh repository instances reopen complete session state',
   corruption: 'malformed stored records propagate as read failures',
   pageLimits: 'invalid page limits are rejected',
+  catalogProjection: 'catalog entries expose only catalog fields',
 } as const;
+
+/**
+ * The complete set of keys a catalog entry may carry, derived from the schema
+ * that owns the projection so the two cannot drift apart.
+ */
+const CATALOG_ENTRY_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(CatalogEntryWriteSchema.shape),
+);
 
 /**
  * Canonical behavioral suite for certifying a custom session repository.
@@ -123,6 +133,12 @@ export class ChatSessionRepositoryConformance {
         harness,
         1,
         ChatSessionRepositoryConformance.verifyPageLimits,
+      ),
+      ChatSessionRepositoryConformance.createScenario(
+        scenarioName.catalogProjection,
+        harness,
+        1,
+        ChatSessionRepositoryConformance.verifyCatalogProjection,
       ),
     ];
   }
@@ -596,6 +612,51 @@ export class ChatSessionRepositoryConformance {
         `list must reject invalid page limit ${limit}`,
       );
     }
+  }
+
+  /**
+   * A catalog entry carries only the fields the catalog schema defines.
+   *
+   * An adapter that projects by removing known-large fields rather than
+   * selecting known-catalog fields passes today and drifts tomorrow: the next
+   * field added to `ChatSession` reaches every session list without anyone
+   * deciding it should. Selecting is the property under test, not the size of
+   * the result.
+   */
+  private static async verifyCatalogProjection(
+    [scopeId]: readonly string[],
+    harness: ChatSessionRepositoryConformanceHarness,
+  ): Promise<void> {
+    const scenario = scenarioName.catalogProjection;
+    const repository = await ChatSessionRepositoryConformance.repository(harness, scopeId);
+    const session = ChatSessionRepositoryConformance.session('catalog-projection-session', {
+      history: [{ role: 'user', content: 'Transcript content must not reach the catalog.' }],
+    });
+    await repository.create(session);
+
+    const page = await repository.list({ limit: 10 });
+    const entry = ChatSessionRepositoryConformance.value(
+      page.items.find((item) => item.id === session.id),
+      scenario,
+      'list must return the created session',
+    );
+
+    const unexpectedKeys = Object.keys(entry)
+      .filter((key) => !CATALOG_ENTRY_KEYS.has(key))
+      .sort();
+    ChatSessionRepositoryConformance.expect(
+      unexpectedKeys.length === 0,
+      scenario,
+      'catalog entries must expose only catalog fields, but this adapter also published '
+      + `${unexpectedKeys.join(', ')}. Project with ChatSessionPersistenceCodec.projectCatalogEntry `
+      + 'rather than removing individual record fields.',
+    );
+    ChatSessionRepositoryConformance.equal(
+      entry.revision,
+      1,
+      scenario,
+      'a catalog entry must carry the stored revision',
+    );
   }
 
   private static async repository(


### PR DESCRIPTION
Adds a ninth scenario to `ChatSessionRepositoryConformance`. Tracked as SDK-22, from a review of how SlideX consumes Heddle.

## Why

The eight existing scenarios cover CRUD, atomic writes, pagination, filters, scope isolation, reopen, corruption, and page limits. **None asserts what a catalog entry may contain**, so an adapter can pass the whole suite while returning the entire stored record as its catalog entry — putting transcript arrays into every session list.

The subtler case is the one that motivated this. An adapter can build its catalog by *removing* the known-large record fields:

```ts
const { history, messages, turns, queuedPrompts, ...catalog } = session;
```

That agrees with `ChatSessionPersistenceCodec.projectCatalogEntry` today — I verified the key sets are identical — and diverges the first time `ChatSession` gains a field the catalog schema does not, with nobody deciding it should be published.

## What

The allowed key set is derived from `CatalogEntryWriteSchema.shape` rather than written out, so the check cannot drift from the schema that owns the projection. The failure message names the offending keys and points at the codec.

Verified in both directions: the scenario passes the file adapter, and a new test drives it with a deliberately leaking adapter and asserts it rejects.

## Scope note

This is a contract lock, not a bug fix. I originally filed it expecting it to catch a live leak in the SlideX adapter; it does not, and the correction is recorded in the workspace notes. Heddle's catalog schema is deliberately `ChatSession` minus the four transcript arrays, so both projections currently emit the same keys.

That said, the schema is documented as "the columns needed for catalog queries without exposing transcript or tool payloads to the host's browser-facing catalog", and it carries `lastContinuePrompt`, `lease`, `leaseEpoch`, `context`, and `archives`. Whether that set is right for a browser-facing session list is a separate question I have not touched here — narrowing it would break every session-list surface.

## Verification

`yarn build`, `yarn typecheck`, `yarn test` (131 unit files / 799 tests, 37 integration files / 344 tests — up 2), eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)