### PR TITLE
docs: clarify parallel-safe tool opt-in

### DIFF
--- a/docs/guides/programmatic/quickstart.md
+++ b/docs/guides/programmatic/quickstart.md
@@ -184,7 +184,10 @@ await runQuickstartConversationCli({
 Pass `maxSteps` only when the host intentionally wants a hard turn budget.
 Use `maxToolConcurrency` to bound explicitly parallel-safe tool calls. It
 defaults to `4`; set it to `1` to disable overlapping tool execution. Tools
-remain serial unless both the adapter and the tool opt in.
+remain serial unless both the adapter and the tool opt in by declaring
+`concurrency: 'parallel-safe'` on the `ToolDefinition`. The adapter capability
+only means that a model response may contain multiple calls; it cannot establish
+that arbitrary host-owned tool implementations are safe to overlap.
 
 Use `createConversationEngine` when you are ready to own the host lifecycle,
 commands, approvals, or custom rendering:

--- a/examples/sdk/02-add-a-tool.ts
+++ b/examples/sdk/02-add-a-tool.ts
@@ -11,6 +11,9 @@ import { runQuickstartConversationCli, type ToolDefinition } from '../../src/ind
 const currentTimeTool: ToolDefinition = {
   name: 'current_time',
   description: 'Return the current time as an ISO-8601 timestamp.',
+  // Separate reads do not share mutable state, so the host can safely opt this
+  // tool into bounded overlap. Tools without this declaration remain serial.
+  concurrency: 'parallel-safe',
   parameters: {
     type: 'object',
     properties: {},

--- a/examples/sdk/README.md
+++ b/examples/sdk/README.md
@@ -78,6 +78,13 @@ yarn example:sdk:add-tool
 owns the tool's domain behavior; Heddle owns tool registration, invocation,
 approval integration, and trace visibility.
 
+Tools are serial by default. The example marks `current_time` as
+`concurrency: 'parallel-safe'` because separate invocations do not share mutable
+state or require ordering. Only make that declaration when the same is true for
+your tool. An adapter's `parallelToolCalls` capability means the model can
+request multiple calls in one response; it does not prove that host-owned tool
+implementations are safe to execute concurrently.
+
 ### 03 Add an MCP Server — external capabilities
 
 ```bash


### PR DESCRIPTION
## Summary

- mark the Stage 02 `current_time` custom tool as explicitly `parallel-safe`
- explain the dual opt-in required for bounded same-response tool concurrency
- distinguish adapter response capability from the host's execution-safety guarantee

## Root cause

Issue #289 enables `parallelToolCalls` on the scripted adapter, but its custom
tools omit `ToolDefinition.concurrency`. Heddle therefore keeps them serial by
design.

The adapter capability means a model response may contain multiple tool calls.
It cannot prove that arbitrary host-owned functions are read-only, independent,
or free of shared mutable state. Heddle requires the tool owner to declare
`concurrency: 'parallel-safe'` before the bounded scheduler may overlap calls.

This PR makes that second opt-in visible in the primary copyable custom-tool
example without weakening the existing production safety boundary.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn vitest run src/__tests__/integration/core/run-agent.test.ts -t "bounds parallel-safe tool calls|resolves all approvals before starting allowed parallel calls|keeps calls serial"`
  - 3 passed

Closes #289.
