### PR TITLE
fix: renew leases during long conversation turns

### DIFF
--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -5,6 +5,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import { ArtifactService } from '@/core/artifacts/index.js';
 import { EngineConversationTurnService } from '@/core/chat/engine/turns/service.js';
+import { FileConversationSessionService } from '@/core/chat/engine/sessions/service.js';
+import {
+  ChatSessionLeases,
+  SESSION_LEASE_REFRESH_INTERVAL_MS,
+  SESSION_LEASE_STALE_AFTER_MS,
+} from '@/core/chat/engine/sessions/leases/index.js';
 import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js';
 import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
 import { readStoredChatSession } from '@/__tests__/helpers/chat-session-repository.js';
@@ -491,6 +497,95 @@ describe('conversation turn lifecycle', () => {
     );
     expect(persisted?.lease).toBeUndefined();
     expect(persisted?.turns).toEqual([]);
+  });
+
+  it('renews the fenced lease while a direct engine turn exceeds the stale window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-03T00:00:00.000Z'));
+    const storage = await createConversationTurnStorage();
+    let finishLoop: (() => void) | undefined;
+    let markLoopStarted: (() => void) | undefined;
+    const loopStarted = new Promise<void>((resolve) => {
+      markLoopStarted = resolve;
+    });
+    const originalRefreshLease = FileConversationSessionService.prototype.refreshLease;
+    const refreshCompletions: Array<ReturnType<typeof originalRefreshLease>> = [];
+    const refreshSpy = vi
+      .spyOn(FileConversationSessionService.prototype, 'refreshLease')
+      .mockImplementation(function (
+        this: FileConversationSessionService,
+        ...args: Parameters<typeof originalRefreshLease>
+      ) {
+        const completion = originalRefreshLease.apply(this, args);
+        refreshCompletions.push(completion);
+        return completion;
+      });
+    vi.spyOn(agentLoopModule.AgentLoopRuntimeService, 'run').mockImplementation(async () => {
+      markLoopStarted?.();
+      return await new Promise((resolve) => {
+        finishLoop = () => resolve(createLoopResult({
+          workspaceRoot: storage.workspaceRoot,
+          prompt: 'Complete a long turn.',
+          summary: 'Long turn completed.',
+        }) as never);
+      });
+    });
+
+    const turn = EngineConversationTurnService.run({
+      workspaceRoot: storage.workspaceRoot,
+      stateRoot: storage.stateRoot,
+      traceDir: join(storage.stateRoot, 'traces'),
+      sessionStoragePath: storage.sessionStoragePath,
+      sessionId: storage.sessionId,
+      prompt: 'Complete a long turn.',
+      apiKey: 'explicit-key',
+      memoryMaintenanceMode: 'none',
+      artifactRoot: storage.artifactRoot,
+      artifactsEnabled: true,
+    });
+
+    try {
+      await loopStarted;
+      const initiallyLeased = await readStoredChatSession(
+        new FileChatSessionRepository({ sessionStoragePath: storage.sessionStoragePath }),
+        storage.sessionId,
+      );
+      expect(initiallyLeased?.lease).toBeDefined();
+
+      const refreshCount = (
+        SESSION_LEASE_STALE_AFTER_MS + SESSION_LEASE_REFRESH_INTERVAL_MS
+      ) / SESSION_LEASE_REFRESH_INTERVAL_MS;
+      for (let refreshIndex = 0; refreshIndex < refreshCount; refreshIndex += 1) {
+        await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS);
+        expect(refreshSpy).toHaveBeenCalledTimes(refreshIndex + 1);
+        await refreshCompletions[refreshIndex];
+        await Promise.resolve();
+      }
+
+      const renewed = await readStoredChatSession(
+        new FileChatSessionRepository({ sessionStoragePath: storage.sessionStoragePath }),
+        storage.sessionId,
+      );
+      expect(renewed && ChatSessionLeases.isFresh(renewed)).toBe(true);
+      expect(renewed?.lease?.lastSeenAt).not.toBe(initiallyLeased?.lease?.lastSeenAt);
+
+      finishLoop?.();
+      await expect(turn).resolves.toEqual(expect.objectContaining({
+        outcome: 'done',
+        summary: 'Long turn completed.',
+      }));
+
+      const persisted = await readStoredChatSession(
+        new FileChatSessionRepository({ sessionStoragePath: storage.sessionStoragePath }),
+        storage.sessionId,
+      );
+      expect(persisted?.lease).toBeUndefined();
+      expect(persisted?.turns).toHaveLength(1);
+    } finally {
+      finishLoop?.();
+      await turn.catch(() => undefined);
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/__tests__/unit/core/conversation-turn-lease-heartbeat.test.ts
+++ b/src/__tests__/unit/core/conversation-turn-lease-heartbeat.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  SESSION_LEASE_REFRESH_INTERVAL_MS,
+  type ChatSessionLeaseClaim,
+} from '@/core/chat/engine/sessions/leases/index.js';
+import { ConversationTurnLeaseHeartbeatService } from '@/core/chat/engine/turns/lease/index.js';
+
+const leaseClaim: ChatSessionLeaseClaim = {
+  hostId: 'test-host',
+  ownerId: 'test-owner',
+  fencingToken: 1,
+};
+
+describe('ConversationTurnLeaseHeartbeatService', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renews an acquired claim until stopped', async () => {
+    vi.useFakeTimers();
+    const refreshLease = vi.fn().mockResolvedValue(undefined);
+    const heartbeat = new ConversationTurnLeaseHeartbeatService({
+      sessionService: { refreshLease },
+      sessionId: 'session-1',
+    });
+
+    heartbeat.start(leaseClaim);
+    await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS * 3);
+
+    expect(refreshLease).toHaveBeenCalledTimes(3);
+    expect(refreshLease).toHaveBeenNthCalledWith(1, 'session-1', leaseClaim);
+
+    await heartbeat.stop();
+    await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS);
+    expect(refreshLease).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not overlap refreshes when persistence is slow', async () => {
+    vi.useFakeTimers();
+    let finishRefresh: (() => void) | undefined;
+    const refreshLease = vi.fn(async () => await new Promise<void>((resolve) => {
+      finishRefresh = resolve;
+    }));
+    const heartbeat = new ConversationTurnLeaseHeartbeatService({
+      sessionService: { refreshLease },
+      sessionId: 'session-1',
+    });
+
+    heartbeat.start(leaseClaim);
+    await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS * 3);
+    expect(refreshLease).toHaveBeenCalledTimes(1);
+
+    finishRefresh?.();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS);
+    expect(refreshLease).toHaveBeenCalledTimes(2);
+
+    finishRefresh?.();
+    await heartbeat.stop();
+  });
+
+  it('aborts the turn signal and preserves the lease error when renewal fails', async () => {
+    vi.useFakeTimers();
+    const failure = new Error('lease refresh failed');
+    const heartbeat = new ConversationTurnLeaseHeartbeatService({
+      sessionService: {
+        refreshLease: vi.fn().mockRejectedValue(failure),
+      },
+      sessionId: 'session-1',
+    });
+
+    heartbeat.start(leaseClaim);
+    await vi.advanceTimersByTimeAsync(SESSION_LEASE_REFRESH_INTERVAL_MS);
+
+    expect(heartbeat.signal.aborted).toBe(true);
+    expect(heartbeat.signal.reason).toBe(failure);
+    expect(() => heartbeat.throwIfFailed()).toThrow(failure);
+    await heartbeat.stop();
+  });
+});

--- a/src/core/chat/engine/turns/README.md
+++ b/src/core/chat/engine/turns/README.md
@@ -10,11 +10,13 @@ the class that owns that phase.
 
 ## Folder Roles
 
-- `service.ts`: main submit, continue, and lease cleanup service.
+- `service.ts`: main submit, continue, and lease lifecycle service.
 - `runtime/`: resolves model, provider, credentials, memory path, system
   context, and LLM adapter.
 - `context/`: loads the session and builds the concrete turn context.
 - `preflight/`: owns lease acquisition and pre-run compaction persistence.
+- `lease/`: owns wall-clock renewal for the fenced lease held by an in-flight
+  turn. Engine turns renew themselves; hosts must not duplicate that heartbeat.
 - `persistence/`: builds turn artifacts and writes completed turns back to
   session storage.
 - `memory/`: runs inline/background memory maintenance and records its trace

--- a/src/core/chat/engine/turns/lease/README.md
+++ b/src/core/chat/engine/turns/lease/README.md
@@ -1,0 +1,28 @@
+# Conversation Turn Lease Renewal
+
+This folder owns lease liveness while one persisted conversation turn is in
+flight.
+
+## Owns
+
+- Starting renewal immediately after preflight acquires a fenced session lease.
+- Refreshing that lease on a wall-clock interval, independent of model,
+  activity, or tool events.
+- Aborting the turn's runtime signal when the lease can no longer be refreshed,
+  including when another owner has taken it.
+- Deterministic shutdown that waits for an in-flight refresh before the turn
+  releases its lease.
+
+## Does Not Own
+
+- Lease acquisition, conflict policy, fencing tokens, or release. Those remain
+  in `sessions/leases/` and the session service.
+- Host run coordination, replay, approvals, or cancellation. Those remain in
+  `core/chat/runs/`.
+- Retry or recovery of completed model/tool work after ownership is lost.
+
+Engine turns always own this renewal lifecycle. Hosts must not add a second
+session-lease heartbeat around `engine.turns.submit()` or
+`engine.turns.continue()`. Host-owned heartbeats remain valid for operations
+that acquire a lease outside the turn engine, such as direct shell and explicit
+compaction.

--- a/src/core/chat/engine/turns/lease/index.ts
+++ b/src/core/chat/engine/turns/lease/index.ts
@@ -1,0 +1,2 @@
+export { ConversationTurnLeaseHeartbeatService } from './service.js';
+export type { ConversationTurnLeaseHeartbeatOptions } from './types.js';

--- a/src/core/chat/engine/turns/lease/service.ts
+++ b/src/core/chat/engine/turns/lease/service.ts
@@ -1,0 +1,103 @@
+import {
+  SESSION_LEASE_REFRESH_INTERVAL_MS,
+  type ChatSessionLeaseClaim,
+} from '@/core/chat/engine/sessions/leases/index.js';
+import type { ConversationTurnLeaseHeartbeatOptions } from './types.js';
+
+/**
+ * Keeps one acquired turn lease alive until the turn settles.
+ *
+ * Renewal is intentionally time-based. Model requests can be silent for longer
+ * than the lease TTL, so activity-driven refresh would still fence healthy
+ * long-running turns.
+ */
+export class ConversationTurnLeaseHeartbeatService {
+  readonly signal: AbortSignal;
+
+  private readonly controller = new AbortController();
+  private readonly refreshIntervalMs: number;
+  private claim?: ChatSessionLeaseClaim;
+  private timer?: ReturnType<typeof setTimeout>;
+  private refreshInFlight?: Promise<void>;
+  private failure: unknown;
+  private failed = false;
+  private started = false;
+  private stopped = false;
+
+  constructor(private readonly options: ConversationTurnLeaseHeartbeatOptions) {
+    this.refreshIntervalMs = options.refreshIntervalMs ?? SESSION_LEASE_REFRESH_INTERVAL_MS;
+    if (!Number.isSafeInteger(this.refreshIntervalMs) || this.refreshIntervalMs < 1) {
+      throw new Error('Conversation turn lease refresh interval must be a positive integer.');
+    }
+    this.signal = this.controller.signal;
+  }
+
+  /**
+   * Starts renewal for the exact fenced claim acquired by preflight.
+   */
+  start(claim: ChatSessionLeaseClaim): void {
+    if (this.started) {
+      throw new Error('Conversation turn lease heartbeat has already started.');
+    }
+    if (this.stopped) {
+      throw new Error('Conversation turn lease heartbeat has already stopped.');
+    }
+
+    this.started = true;
+    this.claim = claim;
+    this.scheduleNextRefresh();
+  }
+
+  /**
+   * Stops scheduling and waits for a refresh already in progress.
+   */
+  async stop(): Promise<void> {
+    if (this.stopped) {
+      await this.refreshInFlight;
+      return;
+    }
+
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    await this.refreshInFlight;
+  }
+
+  /**
+   * Re-throws the renewal failure before the turn attempts another phase.
+   */
+  throwIfFailed(): void {
+    if (this.failed) {
+      throw this.failure;
+    }
+  }
+
+  private scheduleNextRefresh(): void {
+    const claim = this.claim;
+    if (this.stopped || this.failed || !claim) {
+      return;
+    }
+
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.refreshInFlight = this.refreshLease(claim);
+      void this.refreshInFlight.finally(() => {
+        this.refreshInFlight = undefined;
+        this.scheduleNextRefresh();
+      });
+    }, this.refreshIntervalMs);
+    this.timer.unref?.();
+  }
+
+  private async refreshLease(claim: ChatSessionLeaseClaim): Promise<void> {
+    try {
+      await this.options.sessionService.refreshLease(this.options.sessionId, claim);
+    } catch (error) {
+      this.failed = true;
+      this.failure = error;
+      this.controller.abort(error);
+    }
+  }
+}

--- a/src/core/chat/engine/turns/lease/types.ts
+++ b/src/core/chat/engine/turns/lease/types.ts
@@ -1,0 +1,7 @@
+import type { ConversationSessionService } from '@/core/chat/engine/types.js';
+
+export type ConversationTurnLeaseHeartbeatOptions = {
+  sessionService: Pick<ConversationSessionService, 'refreshLease'>;
+  sessionId: string;
+  refreshIntervalMs?: number;
+};

--- a/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
+++ b/src/core/chat/engine/turns/preflight/turn-preflight-service.ts
@@ -36,6 +36,7 @@ export class ConversationTurnPreflightService {
       throw new Error(`Chat session not found: ${args.sessionId}`);
     }
     const leaseClaim = ChatSessionLeases.claim(leasedSession);
+    args.onLeaseAcquired?.(leaseClaim);
     const initialHistory = leasedSession?.history ?? args.fallbackHistory;
     const compactionRuntime: PreflightTurnCompactionRuntime = args;
     const compactionRequest: PreflightTurnCompactionRequest = {

--- a/src/core/chat/engine/turns/preflight/types.ts
+++ b/src/core/chat/engine/turns/preflight/types.ts
@@ -28,6 +28,11 @@ export type PrepareChatSessionTurnArgs = {
   toolNames: string[];
   summarizer: ConversationCompactionOptions['summarizer'];
   leaseOwner: ChatSessionLeaseOwner;
+  /**
+   * Turn-internal lifecycle hook. The engine starts wall-clock renewal as soon
+   * as preflight has acquired the fenced claim, before compaction can block.
+   */
+  onLeaseAcquired?: (claim: ChatSessionLeaseClaim) => void;
   host: Pick<ChatTurnHostPort, 'onCompactionStatus'>;
   agentSnapshot?: CustomAgentExecutionSnapshot;
 };

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -19,6 +19,7 @@ import { ConversationTurnContextBuilder } from './context/index.js';
 import { ConversationTurnPreflightService } from './preflight/index.js';
 import { ConversationTurnMemoryMaintenance } from './memory/index.js';
 import type { TurnMemoryMaintenanceRuntimeInput } from './memory/index.js';
+import { ConversationTurnLeaseHeartbeatService } from './lease/index.js';
 import { ConversationTurnPersistenceService } from './persistence/index.js';
 import type { ChatSessionLeaseOwner } from '@/core/chat/engine/sessions/leases/index.js';
 import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
@@ -102,6 +103,13 @@ export class EngineConversationTurnService implements ConversationTurnService {
       source,
       onEvent: host.onEvent,
     };
+    const leaseHeartbeat = new ConversationTurnLeaseHeartbeatService({
+      sessionService,
+      sessionId: session.id,
+    });
+    const abortSignal = args.abortSignal
+      ? AbortSignal.any([args.abortSignal, leaseHeartbeat.signal])
+      : leaseHeartbeat.signal;
 
     try {
       const preflight = await ConversationTurnPreflightService.prepare({
@@ -114,11 +122,13 @@ export class EngineConversationTurnService implements ConversationTurnService {
         toolNames,
         summarizer: runtime.summarizer,
         leaseOwner,
+        onLeaseAcquired: (claim) => leaseHeartbeat.start(claim),
         host,
       });
       if (!preflight.ok) {
         throw new Error(preflight.message);
       }
+      leaseHeartbeat.throwIfFailed();
 
       const result = await AgentLoopRuntimeService.run({
         ...agentLoopInput,
@@ -135,6 +145,8 @@ export class EngineConversationTurnService implements ConversationTurnService {
         maxToolConcurrency: args.maxToolConcurrency,
         history: preflight.compacted.history,
         systemContext: runtime.systemContext,
+        abortSignal,
+        shouldStop: () => leaseHeartbeat.signal.aborted || args.shouldStop?.() === true,
         onEvent: host.onEvent,
         approveToolCall: host.approveToolCall,
         approvalPolicies: ToolApprovalProfileService.compile({
@@ -146,7 +158,11 @@ export class EngineConversationTurnService implements ConversationTurnService {
             : undefined,
           basePolicies: args.approvalPolicies,
         }),
+      }).catch((error: unknown) => {
+        leaseHeartbeat.throwIfFailed();
+        throw error;
       });
+      leaseHeartbeat.throwIfFailed();
       const maintenanceMode = args.memoryMaintenanceMode ?? 'background';
       const resultForPersistence =
         maintenanceMode === 'inline'
@@ -155,6 +171,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
               result,
             })
           : result;
+      leaseHeartbeat.throwIfFailed();
 
       const persisted = await ConversationTurnPersistenceService.persistCompleted({
         ...persistenceInput,
@@ -170,6 +187,8 @@ export class EngineConversationTurnService implements ConversationTurnService {
         agentSnapshot,
         leaseClaim: preflight.leaseClaim,
       });
+      await leaseHeartbeat.stop();
+      leaseHeartbeat.throwIfFailed();
 
       if (maintenanceMode === 'background') {
         ConversationTurnMemoryMaintenance.scheduleBackground({
@@ -197,6 +216,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
         toolResults: EngineConversationTurnService.summarizeToolResults(resultForPersistence.trace),
       };
     } finally {
+      await leaseHeartbeat.stop();
       await EngineConversationTurnService.clearLeaseFromStorage(sessionService, session.id, leaseOwner);
     }
   }

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -582,9 +582,6 @@ export class ControlPlaneChatSessionsController {
         },
         onSettled: () => this.startNextQueuedPrompt(args),
       }),
-      onHeartbeat: async () => {
-        await this.createEngine(args).sessions.refreshLease(args.sessionId, args.leaseOwner);
-      },
       execute: async (run: ConversationRunContext) => {
         const result = process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1'
           ? await ControlPlaneChatSessionBrowserIntegrationFake.run({
@@ -621,9 +618,6 @@ export class ControlPlaneChatSessionsController {
       ...this.runStreams.createLifecycle(args, {
         onSettled: () => this.startNextQueuedPrompt(args),
       }),
-      onHeartbeat: async () => {
-        await this.createEngine(args).sessions.refreshLease(args.sessionId, args.leaseOwner);
-      },
       execute: async (run: ConversationRunContext) => {
         if (process.env.HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT === '1') {
           const session = await this.createEngine(args).sessions.require(args.sessionId);


### PR DESCRIPTION
## Summary

- move conversation-turn lease renewal into the engine, starting immediately after preflight acquires the fenced claim
- renew on a non-overlapping wall-clock schedule so silent model and MCP waits do not expire healthy turns
- abort the active turn with the original renewal error, await in-flight renewal before terminal success, and release the lease deterministically
- remove the duplicate control-plane heartbeat for submit/continue while retaining host renewal for operations outside the turn engine
- add service-level timing/failure coverage and a direct-engine turn regression that runs beyond the stale window

## Root cause

`ConversationAgentService` submits directly through `engine.turns`, but lease renewal previously lived only in the control-plane run wrapper. A long SDK turn therefore kept the initial 20-second lease unchanged while the model or MCP transport was quiet. Final fenced persistence then rejected the completed work because the lease was stale.

The conversation engine now owns the full lease lifecycle for every submitted or continued turn, independent of which host invokes it.

## Impact

Long SDK and hosted conversation turns can complete beyond the lease stale window without requiring host-specific heartbeat boilerplate. If renewal fails or ownership changes, the runtime is stopped instead of continuing work under a lost lease.

## Verification

- `yarn test` — 132 unit files / 802 tests and 37 integration files / 345 tests
- `yarn typecheck`
- `yarn lint`
- `yarn build`

Closes #291