### PR TITLE
release: prepare v5.6.1

### DIFF
--- a/docs/releases/v5.6.1.md
+++ b/docs/releases/v5.6.1.md
@@ -1,0 +1,76 @@
+# Heddle v5.6.1
+
+Heddle v5.6.1 is a reliability and boundary-clarity patch. Long conversation
+turns now retain their fenced session lease for the full turn, memory-note reads
+use canonical path containment, and the published session-repository
+conformance suite rejects catalog projections that leak full session fields.
+
+It also makes two adopter-facing contracts explicit: tools remain serial unless
+the host marks them parallel-safe, and shell commands run with the authority of
+the host process rather than inside an operating-system sandbox.
+
+## Long-turn lease renewal
+
+- **Conversation turns renew their lease on a wall-clock interval.** Renewal
+  begins immediately after preflight acquires the fenced claim and continues
+  through model calls, tools, compaction, and terminal persistence. A quiet
+  model request can therefore run longer than the lease TTL without losing
+  ownership.
+- **Lease loss stops the turn.** A failed renewal aborts the runtime signal and
+  prevents the turn from reporting terminal success with stale ownership.
+- **The engine owns this lifecycle.** Hosts should not wrap
+  `engine.turns.submit()` or `engine.turns.continue()` in a second heartbeat.
+  Host-owned heartbeats remain appropriate for operations that acquire leases
+  outside the turn engine, such as direct shell execution and explicit
+  compaction.
+
+## Canonical memory-note containment
+
+- `read_memory_note`, `list_memory_notes`, and `search_memory_notes` now reuse
+  the same canonical `WorkspacePathPolicy` as direct coding-file tools.
+- A symlink inside the memory root can no longer redirect those operations to a
+  path outside the configured root.
+- Canonical roots are used consistently when returning relative note paths,
+  including when the configured root itself sits below a symlink.
+
+## Stricter repository conformance
+
+- `ChatSessionRepositoryConformance` now verifies that catalog entries contain
+  only fields defined by the catalog schema.
+- Custom adapters should project entries with
+  `ChatSessionPersistenceCodec.projectCatalogEntry` rather than removing a
+  hand-maintained list of large session fields.
+
+## Clearer execution contracts
+
+- Host tools remain serial by default. Bounded overlap requires both adapter
+  support for multiple same-response calls and an explicit
+  `concurrency: 'parallel-safe'` declaration on the tool definition.
+- The execution-boundary reference now states that shell tools start in the
+  workspace but run with the full authority of the host user. Approval and
+  command policy are not operating-system containment; untrusted workloads
+  still require mature process isolation.
+
+## Upgrade notes
+
+- Install `@roackb2/heddle@5.6.1`.
+  `@roackb2/heddle-remote@5.6.1` releases in lockstep.
+- No persisted data migration is required.
+- No host change is required for normal conversation turns. Remove any
+  duplicate host heartbeat wrapped around `engine.turns.submit()` or
+  `engine.turns.continue()`; the engine now owns renewal.
+- Custom session repositories should run the updated published conformance
+  suite and correct any catalog projection that returns non-schema fields.
+
+## Verification
+
+- `yarn build`
+- `yarn test` (132 unit files / 802 tests, 37 integration files / 345 tests)
+- `npm pack --dry-run --cache /tmp/heddle-npm-cache`
+- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`
+
+## Release state
+
+- Package versions are `5.6.1` in both manifests.
+- The latest published npm and GitHub release before this release is `5.6.0`.
+- This note is curated from the real git range `v5.6.0..HEAD`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "An open-source AI coding agent runtime and terminal CLI for real repositories, with persistent memory, sessions, approvals, heartbeat, and a browser control plane",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/packages/heddle-remote/package.json
+++ b/packages/heddle-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle-remote",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Browser-safe protocol and run-consumer services for remotely hosted Heddle conversations",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `@roackb2/heddle` and `@roackb2/heddle-remote` to `5.6.1`
- add curated release notes from the real `v5.6.0..HEAD` range
- ship long-turn lease renewal, canonical memory-note containment, stricter session catalog conformance, and clarified execution/concurrency contracts

## Release boundary

This PR prepares the reviewed release commit only. After it merges into `main`, create and push the annotated `v5.6.1` tag, create the GitHub release from `docs/releases/v5.6.1.md`, then publish `@roackb2/heddle-remote` before `@roackb2/heddle`.

## Verification

- `yarn release:context v5.6.0 HEAD`
- `yarn build`
- `yarn test` (132 unit files / 802 tests; 37 integration files / 345 tests)
- `npm pack --dry-run --cache /tmp/heddle-npm-cache`
- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`