### PR TITLE
fix: support host-owned domain write scope

### DIFF
--- a/src/__tests__/unit/core/autonomy-policy-service.test.ts
+++ b/src/__tests__/unit/core/autonomy-policy-service.test.ts
@@ -481,6 +481,139 @@ describe('AutonomyPolicyService', () => {
     }));
   });
 
+  it('reconciles model roots with an in-process host-owned domain write scope', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-domain-write',
+          tool: 'post_shared_message',
+          input: {
+            content: 'hello',
+            policy: {
+              operations: ['write'],
+              intent: 'post a shared message',
+              targetRoots: ['../denied'],
+              expectedEffects: ['append one message row'],
+              environment: 'local',
+              confidence: 'high',
+            },
+          },
+        },
+        tool: {
+          name: 'post_shared_message',
+          description: 'writes product-owned domain state',
+          requiresApproval: true,
+          parameters: {},
+          hostPolicy: {
+            authority: {
+              kind: 'host-tool',
+              id: 'test:messages',
+            },
+            transport: {
+              kind: 'in-process',
+              network: false,
+            },
+            environment: 'local',
+            operations: ['write'],
+            writeScope: {
+              kind: 'domain',
+              resources: ['sqlite:messages'],
+            },
+          },
+          execute: async () => ({ ok: true }),
+        },
+      }),
+      profile,
+    });
+
+    expect(evaluation.decision).toEqual(expect.objectContaining({
+      type: 'allow',
+      reason: 'allowed by autopilot profile and declared policy envelope',
+    }));
+    expect(evaluation.envelope).toEqual(expect.objectContaining({
+      targetRoots: [],
+      writeRoots: [],
+    }));
+    expect(evaluation.facts).toEqual(expect.objectContaining({
+      claimedReadRoots: [],
+      claimedWriteRoots: [],
+      rootDecisions: [],
+      hostWriteScope: {
+        kind: 'domain',
+        resources: ['sqlite:messages'],
+      },
+    }));
+    expect(evaluation.policy).toEqual(expect.objectContaining({
+      modelProposed: expect.objectContaining({
+        targetRoots: ['../denied'],
+      }),
+      ownership: {
+        hostOwned: ['authority', 'transport', 'environment', 'operations', 'writeScope'],
+        modelProposed: expect.arrayContaining(['operations', 'targetRoots']),
+      },
+    }));
+    expect(evaluation.facts.claimMismatches).toEqual([
+      expect.stringContaining('domain resources [sqlite:messages]'),
+    ]);
+  });
+
+  it('applies filesystem protections to a host-owned filesystem write scope', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-host-filesystem-write',
+          tool: 'write_generated_file',
+          input: {
+            policy: {
+              operations: ['write'],
+              intent: 'write a generated file',
+              targetRoots: ['.'],
+              expectedEffects: ['write one file'],
+              environment: 'local',
+              confidence: 'high',
+            },
+          },
+        },
+        tool: {
+          name: 'write_generated_file',
+          description: 'writes a host-selected file',
+          requiresApproval: true,
+          parameters: {},
+          hostPolicy: {
+            authority: {
+              kind: 'host-tool',
+              id: 'test:generated-file',
+            },
+            transport: {
+              kind: 'in-process',
+              network: false,
+            },
+            environment: 'local',
+            operations: ['write'],
+            writeScope: {
+              kind: 'filesystem',
+              roots: ['../denied'],
+            },
+          },
+          execute: async () => ({ ok: true }),
+        },
+      }),
+      profile,
+    });
+
+    expect(evaluation.facts.claimedWriteRoots).toEqual(['/workspace/denied']);
+    expect(evaluation.facts.rootDecisions).toEqual([
+      expect.objectContaining({
+        root: '/workspace/denied',
+        access: 'deny',
+      }),
+    ]);
+    expect(evaluation.decision).toEqual(expect.objectContaining({
+      type: 'deny',
+      reason: 'root is hard-denied by autopilot policy: /workspace/denied',
+    }));
+  });
+
   it('does not auto-allow a mutating shell call whose envelope declares no roots', () => {
     const evaluation = AutonomyPolicyService.evaluate({
       context: context({

--- a/src/__tests__/unit/tools/tool-policy-envelope.test.ts
+++ b/src/__tests__/unit/tools/tool-policy-envelope.test.ts
@@ -165,6 +165,55 @@ describe('tool policy envelope', () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
+  it('executes a rootless domain-state mutation with host-owned write scope', async () => {
+    const messages: string[] = [];
+    const execute = vi.fn(async (input: unknown) => {
+      messages.push((input as { content: string }).content);
+      return { ok: true, output: 'saved' };
+    });
+    const registry = new ToolRegistry([tool({
+      execute,
+      hostPolicy: {
+        authority: {
+          kind: 'host-tool',
+          id: 'test:messages',
+        },
+        transport: {
+          kind: 'in-process',
+          network: false,
+        },
+        environment: 'local',
+        operations: ['write'],
+        writeScope: {
+          kind: 'domain',
+          resources: ['sqlite:messages'],
+        },
+      },
+    })]);
+
+    await expect(ToolExecutionService.execute(registry, {
+      id: 'call-domain-write',
+      tool: 'test_tool',
+      input: {
+        content: 'hello',
+        policy: {
+          operations: ['write'],
+          intent: 'post a shared message',
+          targetRoots: [],
+          expectedEffects: ['append one message row'],
+          environment: 'local',
+          confidence: 'high',
+        },
+      },
+    })).resolves.toEqual({ ok: true, output: 'saved' });
+
+    expect(messages).toEqual(['hello']);
+    expect(execute).toHaveBeenCalledWith(
+      { content: 'hello' },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
   it('accepts a mutating envelope when writeRoots are declared without targetRoots', async () => {
     const execute = vi.fn(async () => ({ ok: true, output: 'ok' }));
     const registry = new ToolRegistry([tool({ execute })]);

--- a/src/core/approvals/autonomy/README.md
+++ b/src/core/approvals/autonomy/README.md
@@ -36,6 +36,11 @@ The agent's envelope is a claim. The autonomy policy uses it as the declared
 scope contract for ambiguous tools, but deterministic hard-deny rules and
 configured root policy remain runtime-owned.
 
+An in-process host tool may declare authoritative `writeScope`. Filesystem
+scopes replace model-proposed write roots and still pass through normal root
+policy. Domain scopes are retained as non-filesystem facts in the autonomy
+evaluation and trace rather than being coerced into a repository path.
+
 The harness must not fully trust the claim, but it also must not block every
 free-form shell command only because static parsing is incomplete. For shell
 commands and scripts, the envelope is the agent's explicit contract about the
@@ -360,6 +365,7 @@ Tool call with optional policy envelope
 The service currently computes:
 
 - declared operations, read roots, and write roots;
+- host-owned filesystem or domain write scope when the tool owner supplies it;
 - known tool targets such as `path`, `from`, and `to`;
 - root decisions for each claimed or known target;
 - hard-deny reasons from root policy and dangerous command patterns;

--- a/src/core/approvals/autonomy/policy-service.ts
+++ b/src/core/approvals/autonomy/policy-service.ts
@@ -4,6 +4,7 @@ import {
   TOOL_POLICY_MUTATING_OPERATIONS,
   ToolPolicyResolutionService,
   type ToolPolicyEnvelope,
+  type ToolPolicyHostWriteScope,
   type ToolPolicyOperation,
   type ToolPolicyReconciliation,
 } from '@/core/tools/index.js';
@@ -141,12 +142,18 @@ export class AutonomyPolicyService {
       fallback: AutonomyPolicyService.inferOperations(args.context),
     });
     const environment = args.policy.hostOwned?.environment ?? args.envelope?.environment ?? 'unknown';
+    const hostWriteScope = args.policy.hostOwned?.writeScope;
     const claimedReadRoots = AutonomyPolicyService.resolveEnvelopeRoots({
-      roots: args.envelope?.readRoots ?? args.envelope?.targetRoots ?? [],
+      roots: operations.includes('read')
+        ? args.envelope?.readRoots ?? args.envelope?.targetRoots ?? []
+        : [],
       workspaceRoot: args.workspaceRoot,
     });
     const claimedWriteRoots = AutonomyPolicyService.resolveEnvelopeRoots({
-      roots: AutonomyPolicyService.resolveDeclaredWriteRoots(args.envelope),
+      roots: AutonomyPolicyService.resolveDeclaredWriteRoots({
+        envelope: args.envelope,
+        hostWriteScope,
+      }),
       workspaceRoot: args.workspaceRoot,
     });
     const rootsToEvaluate = [...claimedReadRoots, ...claimedWriteRoots, ...resolvedKnownTargets];
@@ -175,6 +182,7 @@ export class AutonomyPolicyService {
       cwd: args.workspaceRoot,
       claimedReadRoots,
       claimedWriteRoots,
+      ...(hostWriteScope ? { hostWriteScope } : {}),
       resolvedKnownTargets,
       rootDecisions,
       hardDenyReasons,
@@ -211,17 +219,24 @@ export class AutonomyPolicyService {
     return context.tool.requiresApproval ? ['unknown'] : ['read'];
   }
 
-  private static resolveDeclaredWriteRoots(envelope: ToolPolicyEnvelope | undefined): string[] {
-    if (!envelope) {
+  private static resolveDeclaredWriteRoots(args: {
+    envelope: ToolPolicyEnvelope | undefined;
+    hostWriteScope: ToolPolicyHostWriteScope | undefined;
+  }): string[] {
+    if (args.hostWriteScope?.kind === 'filesystem') {
+      return [...args.hostWriteScope.roots];
+    }
+
+    if (args.hostWriteScope?.kind === 'domain' || !args.envelope) {
       return [];
     }
 
-    if (envelope.writeRoots) {
-      return envelope.writeRoots;
+    if (args.envelope.writeRoots) {
+      return args.envelope.writeRoots;
     }
 
-    return envelope.operations.some((operation) => TOOL_POLICY_MUTATING_OPERATIONS.has(operation))
-      ? envelope.targetRoots
+    return args.envelope.operations.some((operation) => TOOL_POLICY_MUTATING_OPERATIONS.has(operation))
+      ? args.envelope.targetRoots
       : [];
   }
 

--- a/src/core/approvals/autonomy/types.ts
+++ b/src/core/approvals/autonomy/types.ts
@@ -2,6 +2,7 @@ import type { ToolCall } from '@/core/types.js';
 import type {
   ToolPolicyEnvelope,
   ToolPolicyEnvironment,
+  ToolPolicyHostWriteScope,
   ToolPolicyOperation,
   ToolPolicyReconciliation,
 } from '@/core/tools/index.js';
@@ -92,6 +93,8 @@ export type ToolPolicyFacts = {
   cwd?: string;
   claimedReadRoots: string[];
   claimedWriteRoots: string[];
+  /** Authoritative non-model write scope declared by the tool owner. */
+  hostWriteScope?: ToolPolicyHostWriteScope;
   resolvedKnownTargets: string[];
   rootDecisions: ToolPolicyRootDecision[];
   hardDenyReasons: string[];

--- a/src/core/tools/execute-tool.ts
+++ b/src/core/tools/execute-tool.ts
@@ -1,6 +1,6 @@
 import type { ToolCall, ToolResult } from '@/core/types.js';
 import type { ToolRegistry } from './registry.js';
-import { ToolPolicyEnvelopeInputService } from './policy-envelope/index.js';
+import { ToolPolicyResolutionService } from './policy-envelope/index.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -35,11 +35,14 @@ export class ToolExecutionService {
         : timeoutController.signal;
       signal.throwIfAborted();
 
-      const extraction = ToolPolicyEnvelopeInputService.extract(call.input);
-      if (extraction.error) {
+      const resolution = ToolPolicyResolutionService.resolve({
+        tool,
+        input: call.input,
+      });
+      if (resolution.error) {
         return {
           ok: false,
-          error: extraction.error,
+          error: resolution.error,
         };
       }
 
@@ -57,7 +60,7 @@ export class ToolExecutionService {
 
       try {
         return await Promise.race([
-          tool.execute(extraction.toolInput, { signal }),
+          tool.execute(resolution.toolInput, { signal }),
           cancellation,
         ]);
       } finally {

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -14,6 +14,7 @@ export type {
   ToolPolicyEnvelope,
   ToolPolicyEnvelopeExtraction,
   ToolPolicyHostContext,
+  ToolPolicyHostWriteScope,
   ToolPolicyEnvironment,
   ToolPolicyOperation,
   ToolPolicyReconciliation,

--- a/src/core/tools/policy-envelope/README.md
+++ b/src/core/tools/policy-envelope/README.md
@@ -12,7 +12,8 @@ low-friction intent contract without duplicating schema fragments.
 - Central schema augmentation for object-shaped tool parameters.
 - Input extraction that separates the envelope from tool business input before
   execution.
-- Reconciliation between model-proposed intent and host-owned execution facts.
+- Reconciliation between model-proposed intent and host-owned execution facts,
+  including authoritative filesystem or domain-state write scope.
 
 ## Does Not Own
 
@@ -25,9 +26,11 @@ low-friction intent contract without duplicating schema fragments.
 
 Agents report intent through this envelope. The runtime may use it as a policy
 claim, but it must not treat it as verified fact. A host that owns a tool can
-attach immutable authority, transport, target-environment, and effect
+attach immutable authority, transport, target-environment, effect
 classification through `ToolDefinition.hostPolicy` or
-`ToolDefinition.resolveHostPolicy(...)`.
+`ToolDefinition.resolveHostPolicy(...)`. It can also attach a `writeScope`
+when the tool owner knows where a mutation occurs more reliably than the
+model.
 
 Policy evaluation keeps three views rather than collapsing their provenance:
 
@@ -50,6 +53,21 @@ impact surface of the operation: operation categories, target roots, read/write
 roots, expected effects, environment, destructive scope, and confidence. The
 harness combines that declaration with runtime environment facts and configured
 policy before deciding whether to allow, request approval, or deny the action.
+
+Host write scope uses one of two explicit authority shapes:
+
+```ts
+type ToolPolicyHostWriteScope =
+  | { kind: 'filesystem'; roots: readonly string[] }
+  | { kind: 'domain'; resources: readonly string[] };
+```
+
+Filesystem roots still pass through configured root and capability policy.
+Domain resource identifiers are trace-safe host vocabulary such as
+`sqlite:messages`, `queue:outbound-mail`, or `session:active-draft`; they are
+not converted into fake local paths. Declaring a scope identifies the actual
+impact surface. It does not bypass environment, remote-authority, hard-deny,
+or human-approval policy.
 
 ## Envelope Shape
 
@@ -91,6 +109,43 @@ folder with project config such as `package.json`, `requirements.txt`,
 narrowest project root involved, not an individual file path. For example,
 reading `src/core/tools/registry.ts` should normally claim `targetRoots: ["."]`,
 not `targetRoots: ["src/core/tools/registry.ts"]`.
+
+Do not invent a filesystem root for an in-process tool that only mutates
+host-owned domain state. Such a tool should declare host-owned `writeScope`,
+and the model should leave `targetRoots` empty. Structural envelope validation
+runs first, then effective mutation scope is validated after host
+reconciliation.
+
+## Host-Owned Domain Mutation
+
+```ts
+const postSharedMessage: ToolDefinition = {
+  name: 'post_shared_message',
+  description: 'Append one shared message to product-owned state.',
+  parameters: {
+    type: 'object',
+    properties: { content: { type: 'string' } },
+    required: ['content'],
+    additionalProperties: false,
+  },
+  hostPolicy: {
+    authority: { kind: 'host-tool', id: 'product:shared-messages' },
+    transport: { kind: 'in-process', network: false },
+    environment: 'local',
+    operations: ['write'],
+    writeScope: {
+      kind: 'domain',
+      resources: ['sqlite:shared-messages'],
+    },
+  },
+  execute: async (input) => saveSharedMessage(input),
+};
+```
+
+The trace retains the model-proposed roots, the host-owned domain scope, the
+effective root projection, field ownership, and a reconciliation diagnostic.
+This makes an omitted or mistaken model root inspectable without making a
+known host fact model-dependent.
 
 ## Example Tool Inputs
 
@@ -161,8 +216,10 @@ ToolRegistry.list()
   -> model sees optional policy field
 
 ToolExecutionService.execute(...)
-  -> ToolPolicyEnvelopeInputService.extract(...)
-  -> validate and remove policy
+  -> ToolPolicyResolutionService.resolve(...)
+  -> structurally validate the model envelope
+  -> reconcile host authority, transport, environment, operations, and scope
+  -> validate effective mutation scope and remove policy
   -> execute raw tool with stripped business input
 
 AutonomyPolicyService.evaluate(...)
@@ -199,8 +256,9 @@ presentation boundary.
 - Add fields only when they are useful across tool families, not for one tool's
   private needs.
 - Keep tool-specific validation in the toolkit that owns the tool.
-- Keep server identity, transport, environment, tenant, and verified effect
-  classification host-owned. Never infer authorization from model input.
+- Keep server identity, transport, environment, tenant, verified effect
+  classification, and authoritative write scope host-owned. Never infer
+  authorization from model input.
 - Keep approval decisions in `src/core/approvals`, not here.
 - Keep extraction centralized in `ToolPolicyEnvelopeInputService` so tools,
   approvals, and tests agree on the stripped input shape.

--- a/src/core/tools/policy-envelope/index.ts
+++ b/src/core/tools/policy-envelope/index.ts
@@ -17,6 +17,7 @@ export type {
   ToolPolicyHostAuthority,
   ToolPolicyHostContext,
   ToolPolicyHostTransport,
+  ToolPolicyHostWriteScope,
   ToolPolicyEnvironment,
   ToolPolicyOperation,
   ToolPolicyReconciliation,

--- a/src/core/tools/policy-envelope/input-service.ts
+++ b/src/core/tools/policy-envelope/input-service.ts
@@ -3,7 +3,6 @@ import {
   TOOL_POLICY_CONFIDENCE_LEVELS,
   TOOL_POLICY_DESTRUCTIVE_SCOPES,
   TOOL_POLICY_ENVIRONMENTS,
-  TOOL_POLICY_MUTATING_OPERATIONS,
   TOOL_POLICY_OPERATIONS,
   type ToolPolicyEnvelope,
   type ToolPolicyEnvelopeExtraction,
@@ -17,7 +16,7 @@ const ToolPolicyEnvelopeSchema = z.object({
     'Human-readable purpose for the tool call. Used for approval/debugging context, not for deterministic verification.',
   ),
   targetRoots: z.array(z.string()).describe(
-    'Project/workspace roots involved in the call. These should be project boundaries such as repo roots or config-bearing folders, not individual file paths. May be empty only for read-only or state-only calls that touch no project root, such as planning tools. Calls that write, delete, move, execute, or run git must declare at least one target or write root.',
+    'Project/workspace roots involved in the call. These should be project boundaries such as repo roots or config-bearing folders, not individual file paths. Leave this empty for state-only calls that touch no project root. Mutating filesystem calls must declare at least one target or write root; a host-owned domain-state tool may instead supply its authoritative non-filesystem scope.',
   ),
   readRoots: z.array(z.string()).optional().describe(
     'Optional project/workspace roots the agent claims the call may read when read scope differs from targetRoots.',
@@ -37,22 +36,8 @@ const ToolPolicyEnvelopeSchema = z.object({
   confidence: z.enum(TOOL_POLICY_CONFIDENCE_LEVELS).describe(
     'Agent confidence that the envelope completely describes the purpose and impact surface of the call.',
   ),
-}).strict().superRefine((envelope, ctx) => {
-  // A mutating envelope must declare a write scope. Autonomy policy derives
-  // claimed write roots from writeRoots (or targetRoots for mutating ops), so an
-  // empty-root mutating envelope would evaluate against zero roots and could be
-  // allowed unattended without any configured root/capability check.
-  const mutates = envelope.operations.some((operation) => TOOL_POLICY_MUTATING_OPERATIONS.has(operation));
-  const declaresRoot = envelope.targetRoots.length > 0 || (envelope.writeRoots?.length ?? 0) > 0;
-  if (mutates && !declaresRoot) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['targetRoots'],
-      message: 'mutating operations (write, delete, move, execute, git, unknown) must declare at least one target or write root',
-    });
-  }
-}).describe(
-  'Developer-facing validator for the shared ToolPolicyEnvelope shape. It validates the agent declaration before approval/autonomy policy consumes it, then strips the envelope from tool business input.',
+}).strict().describe(
+  'Developer-facing structural validator for the shared ToolPolicyEnvelope shape. Effective mutation scope is validated after immutable host facts are reconciled, then the envelope is stripped from tool business input.',
 );
 
 type AssertExactSchemaShape<Actual, Expected> = Actual extends Expected

--- a/src/core/tools/policy-envelope/resolution-service.ts
+++ b/src/core/tools/policy-envelope/resolution-service.ts
@@ -3,11 +3,17 @@ import { ToolPolicyEnvelopeInputService } from './input-service.js';
 import type {
   ToolPolicyEnvelope,
   ToolPolicyHostContext,
+  ToolPolicyHostWriteScope,
   ToolPolicyOperation,
   ToolPolicyReconciliation,
   ToolPolicyReconciliationDiagnostic,
   ToolPolicyResolution,
 } from './types.js';
+import { TOOL_POLICY_MUTATING_OPERATIONS } from './types.js';
+
+const MISSING_MUTATION_SCOPE_ERROR =
+  'Invalid tool policy envelope: mutating operations (write, delete, move, execute, git, unknown) '
+  + 'must declare at least one target or write root unless the tool owner supplies an authoritative write scope';
 
 const MODEL_ENVELOPE_FIELDS: Array<keyof ToolPolicyEnvelope> = [
   'operations',
@@ -42,9 +48,14 @@ export class ToolPolicyResolutionService {
       modelProposed: extraction.envelope,
       hostOwned,
     });
+    const error = extraction.error ?? ToolPolicyResolutionService.validateEffectiveScope({
+      effective,
+      hostOwned,
+    });
 
     return {
       ...extraction,
+      ...(error ? { error } : {}),
       envelope: effective,
       reconciliation: {
         modelProposed: extraction.envelope,
@@ -54,6 +65,7 @@ export class ToolPolicyResolutionService {
           hostOwned: [
             ...(hostOwned ? ['authority', 'transport', 'environment'] as const : []),
             ...(hostOwned?.operations ? ['operations'] as const : []),
+            ...(hostOwned?.writeScope ? ['writeScope'] as const : []),
           ],
           modelProposed: extraction.envelope
             ? MODEL_ENVELOPE_FIELDS.filter((field) => extraction.envelope?.[field] !== undefined)
@@ -97,12 +109,78 @@ export class ToolPolicyResolutionService {
     const operations = args.hostOwned?.operations
       ? [...args.hostOwned.operations]
       : proposedOperations;
+    const effectiveOperations: ToolPolicyOperation[] = operations.length > 0
+      ? operations
+      : ['unknown'];
+    const writeScope = args.hostOwned?.writeScope;
+    const appliesWriteScope = writeScope
+      && effectiveOperations.some((operation) => TOOL_POLICY_MUTATING_OPERATIONS.has(operation));
 
     return {
       ...args.modelProposed,
-      operations: operations.length > 0 ? operations : ['unknown'],
+      operations: effectiveOperations,
       environment: args.hostOwned?.environment ?? args.modelProposed.environment,
+      ...(appliesWriteScope
+        ? ToolPolicyResolutionService.resolveEffectiveRoots({
+            modelProposed: args.modelProposed,
+            operations: effectiveOperations,
+            writeScope,
+          })
+        : {}),
     };
+  }
+
+  private static resolveEffectiveRoots(args: {
+    modelProposed: ToolPolicyEnvelope;
+    operations: ToolPolicyOperation[];
+    writeScope: ToolPolicyHostWriteScope;
+  }): Pick<ToolPolicyEnvelope, 'targetRoots' | 'writeRoots'> {
+    const writeRoots = args.writeScope.kind === 'filesystem'
+      ? [...args.writeScope.roots]
+      : [];
+
+    return {
+      targetRoots: args.operations.includes('read')
+        ? args.modelProposed.targetRoots
+        : writeRoots,
+      writeRoots,
+    };
+  }
+
+  private static validateEffectiveScope(args: {
+    effective?: ToolPolicyEnvelope;
+    hostOwned?: ToolPolicyHostContext;
+  }): string | undefined {
+    if (!args.effective) {
+      return undefined;
+    }
+
+    const mutates = args.effective.operations.some((operation) =>
+      TOOL_POLICY_MUTATING_OPERATIONS.has(operation));
+    if (!mutates) {
+      return undefined;
+    }
+
+    const declaresFilesystemRoot = args.effective.targetRoots.length > 0
+      || (args.effective.writeRoots?.length ?? 0) > 0;
+    // Remote tool authority is already host-owned and remains approval-gated by
+    // autonomy policy. It must not be forced into a local filesystem-root shape.
+    const declaresHostScope = ToolPolicyResolutionService.hasWriteScope(args.hostOwned?.writeScope)
+      || args.hostOwned?.transport.network === true;
+
+    return declaresFilesystemRoot || declaresHostScope
+      ? undefined
+      : MISSING_MUTATION_SCOPE_ERROR;
+  }
+
+  private static hasWriteScope(scope: ToolPolicyHostWriteScope | undefined): boolean {
+    if (!scope) {
+      return false;
+    }
+
+    return scope.kind === 'filesystem'
+      ? scope.roots.length > 0
+      : scope.resources.length > 0;
   }
 
   private static removeTransportOperation(args: {
@@ -149,8 +227,30 @@ export class ToolPolicyResolutionService {
               + 'host operations applied.',
           }]
         : []),
+      ...(args.hostOwned.writeScope
+        ? [{
+            code: 'write_scope_reconciled' as const,
+            message: describeWriteScopeReconciliation({
+              modelProposed: args.modelProposed,
+              hostOwned: args.hostOwned.writeScope,
+            }),
+          }]
+        : []),
     ];
   }
+}
+
+function describeWriteScopeReconciliation(args: {
+  modelProposed: ToolPolicyEnvelope;
+  hostOwned: ToolPolicyHostWriteScope;
+}): string {
+  const modelRoots = args.modelProposed.writeRoots ?? args.modelProposed.targetRoots;
+  const hostScope = args.hostOwned.kind === 'filesystem'
+    ? `filesystem roots [${args.hostOwned.roots.join(', ')}]`
+    : `domain resources [${args.hostOwned.resources.join(', ')}]`;
+
+  return `Model proposed filesystem write roots [${modelRoots.join(', ')}], `
+    + `but the tool owner declares authoritative ${hostScope}; host write scope applied.`;
 }
 
 function sameOperations(

--- a/src/core/tools/policy-envelope/schema-service.ts
+++ b/src/core/tools/policy-envelope/schema-service.ts
@@ -13,7 +13,7 @@ const POLICY_ENVELOPE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   description:
-    'Optional agent-declared intent envelope for approval/autopilot policy. Use this to honestly declare the purpose, operation categories, expected impact surface, target roots, proposed environment, and confidence for this tool call. The harness treats this as a claim, reconciles it with immutable host authority, transport, environment, and tenant facts, then decides whether to allow, request approval, or deny the action.',
+    'Optional agent-declared intent envelope for approval/autopilot policy. Use this to honestly declare the purpose, operation categories, expected impact surface, target roots, proposed environment, and confidence for this tool call. The harness treats this as a claim, reconciles it with immutable host authority, transport, environment, tenant, and write-scope facts, then decides whether to allow, request approval, or deny the action.',
   properties: {
     operations: {
       type: 'array',
@@ -31,7 +31,7 @@ const POLICY_ENVELOPE_SCHEMA = {
     targetRoots: {
       type: 'array',
       items: { type: 'string' },
-      description: `Project/workspace roots the agent expects this call to touch. May be empty only for read-only or state-only calls that touch no project root, such as planning tools. Calls that write, delete, move, execute, or run git must declare at least one target or write root. ${ROOT_DESCRIPTION}`,
+      description: `Project/workspace roots the agent expects this call to touch. Leave empty for state-only calls that touch no project root. Mutating filesystem calls must declare at least one target or write root. When an in-process host tool mutates domain state such as a database or queue, leave filesystem roots empty rather than inventing a path; the tool owner supplies its authoritative scope. ${ROOT_DESCRIPTION}`,
     },
     readRoots: {
       type: 'array',

--- a/src/core/tools/policy-envelope/types.ts
+++ b/src/core/tools/policy-envelope/types.ts
@@ -54,6 +54,23 @@ export type ToolPolicyHostTransport = {
 };
 
 /**
+ * Authoritative write scope supplied by the tool owner.
+ *
+ * Filesystem scopes continue through the configured root policy. Domain
+ * scopes identify non-filesystem state such as database tables, queues, or
+ * product records and must never be projected into fake filesystem paths.
+ */
+export type ToolPolicyHostWriteScope =
+  | {
+      kind: 'filesystem';
+      roots: readonly string[];
+    }
+  | {
+      kind: 'domain';
+      resources: readonly string[];
+    };
+
+/**
  * Immutable execution facts supplied by the host that owns a tool.
  *
  * Model-authored policy envelopes may describe intent and expected effects,
@@ -64,18 +81,20 @@ export type ToolPolicyHostContext = {
   transport: ToolPolicyHostTransport;
   environment: ToolPolicyEnvironment;
   operations?: readonly ToolPolicyOperation[];
+  writeScope?: ToolPolicyHostWriteScope;
 };
 
 export type ToolPolicyReconciliationDiagnostic = {
   code:
     | 'environment_overridden'
     | 'network_transport_normalized'
-    | 'operations_overridden';
+    | 'operations_overridden'
+    | 'write_scope_reconciled';
   message: string;
 };
 
 export type ToolPolicyFieldOwnership = {
-  hostOwned: Array<'authority' | 'transport' | 'environment' | 'operations'>;
+  hostOwned: Array<'authority' | 'transport' | 'environment' | 'operations' | 'writeScope'>;
   modelProposed: Array<keyof ToolPolicyEnvelope>;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ export type {
   ToolPolicyEnvironment,
   ToolPolicyEnvelope,
   ToolPolicyHostContext,
+  ToolPolicyHostWriteScope,
   ToolPolicyOperation,
   ToolPolicyReconciliation,
   ToolToolkit,


### PR DESCRIPTION
## Summary

- add a typed host-owned write scope for filesystem roots or non-filesystem domain resources
- reconcile model-proposed roots only after immutable host facts are available
- retain model, host, effective, ownership, and diagnostic views in approval and trace data
- preserve root policy for host-owned filesystem scope and remote MCP mutation approval behavior

## Root cause

Mutating model envelopes were rejected during structural parsing when they had no filesystem roots. That happened before `ToolDefinition.hostPolicy` could supply the known impact surface, forcing in-process database tools to invent repository paths in product prompts.

## Impact

Custom tools that mutate databases, queues, sessions, or other product-owned state can declare `writeScope: { kind: "domain", resources: [...] }`. Ordinary filesystem mutations still require effective roots, and host-owned filesystem roots still pass through configured root and capability policy.

Closes #294.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit src/__tests__/unit/tools/tool-policy-envelope.test.ts src/__tests__/unit/core/autonomy-policy-service.test.ts` (132 files, 805 tests)
- `yarn build`
