### PR TITLE
feat: add heartbeat runtime credential handoff

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -99,6 +99,38 @@ must keep domain mutations idempotent.
 
 Cron, launchd, systemd, hosted queues, and Lucid-style services should be treated as hosts around this API, not as Heddle's internal scheduler model.
 
+### Custom host work with the standard agent runtime
+
+A host can claim domain work or assemble domain tools in a custom runner, then
+delegate model execution back to Heddle:
+
+```ts
+await HeartbeatSchedulerService.runDueTasks({
+  store,
+  runtime: {
+    workspaceRoot: process.cwd(),
+    stateDir: '.heddle',
+    model: 'gpt-5.4',
+  },
+  runner: async (task, _checkpoint, context) => context.runAgent({
+    task: `${task.task}\n\nReview the host-owned work claim before acting.`,
+    tools: domainTools,
+    includeDefaultTools: false,
+  }),
+});
+```
+
+`context.runAgent()` is the supported credential handoff. It uses the same
+runtime builder as an ordinary heartbeat task and resolves API keys, stored
+OpenAI OAuth login state, and local/OpenAI-compatible endpoints inside Heddle.
+The host does not receive credential records or token fields and must not retain
+the execution context. Set `preferApiKey: true` in `runtime` only when an
+environment API key should take precedence over stored OpenAI OAuth state.
+
+Custom runners still return an agent result today. Domain-level no-work skips,
+execution cancellation, and awaitable custom-runner shutdown are separate
+lifecycle concerns; do not fabricate an agent result to emulate those features.
+
 ## Examples
 
 Try a small local heartbeat example:
@@ -114,6 +146,10 @@ Try the local scheduler API with a real LLM:
 export OPENAI_API_KEY=your_key_here
 yarn example:heartbeat-scheduler
 ```
+
+The scheduler example uses a custom runner and `context.runAgent()` while
+leaving credentials entirely inside Heddle. It works with stored OpenAI login
+state or provider API-key environment variables.
 
 ## Host Notes
 

--- a/examples/heartbeat-scheduler.ts
+++ b/examples/heartbeat-scheduler.ts
@@ -2,10 +2,13 @@
 // Example: Heartbeat Scheduler
 //
 // Usage:
-//   OPENAI_API_KEY=sk-... yarn example:heartbeat-scheduler
+//   heddle auth login openai
+//   yarn example:heartbeat-scheduler
 //
 // Optional:
+//   OPENAI_API_KEY=sk-... yarn example:heartbeat-scheduler
 //   HEDDLE_EXAMPLE_MODEL=claude-3-5-haiku-latest ANTHROPIC_API_KEY=sk-ant-... yarn example:heartbeat-scheduler
+//   HEDDLE_EXAMPLE_PREFER_API_KEY=true OPENAI_API_KEY=sk-... yarn example:heartbeat-scheduler
 //
 // This demonstrates Heddle's local-first scheduler API. It creates or updates
 // one durable heartbeat task under .heddle/examples/heartbeat-scheduler/, runs
@@ -13,8 +16,6 @@
 // ---------------------------------------------------------------------------
 
 import { join } from 'node:path';
-import { LlmAdapterService } from '../src/core/llm/index.js';
-import { RuntimeCredentialService } from '../src/core/runtime/credentials/index.js';
 import {
   FileHeartbeatTaskService,
   HeartbeatSchedulerService,
@@ -29,15 +30,6 @@ const TASK_ID = 'demo-maintenance';
 
 async function main() {
   const model = process.env.HEDDLE_EXAMPLE_MODEL ?? process.env.OPENAI_MODEL ?? DEFAULT_EXAMPLE_MODEL;
-  const provider = LlmAdapterService.inferProvider(model);
-  const apiKey = RuntimeCredentialService.resolveProviderApiKey(provider);
-  if (!apiKey) {
-    throw new Error(
-      `Missing API key for ${provider}. ` +
-      'Set OPENAI_API_KEY for OpenAI models or ANTHROPIC_API_KEY for Claude models before running this example.',
-    );
-  }
-
   const store = new FileHeartbeatTaskService({ dir: STORE_DIR });
   await ensureDemoTask(store, model);
 
@@ -45,12 +37,16 @@ async function main() {
     store,
     now: () => new Date(),
     runtime: {
-      apiKey,
-      apiKeyProvider: 'explicit',
+      model,
+      stateDir: '.heddle',
+      preferApiKey: process.env.HEDDLE_EXAMPLE_PREFER_API_KEY === 'true',
       tools: [],
       includeDefaultTools: false,
       workspaceRoot: process.cwd(),
     },
+    runner: async (task, _checkpoint, context) => context.runAgent({
+      task: `${task.task}\n\nThis instruction was added by a custom host runner without handling credentials.`,
+    }),
     onEvent: (event) => {
       const line = formatSchedulerEvent(event);
       if (line) {

--- a/src/__tests__/integration/core/heartbeat-runner-credentials.test.ts
+++ b/src/__tests__/integration/core/heartbeat-runner-credentials.test.ts
@@ -1,0 +1,324 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Writable } from 'node:stream';
+import pino from 'pino';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProviderCredentialRepository } from '@/core/auth/index.js';
+import { LlmAdapterService } from '@/core/llm/index.js';
+import type { LlmAdapter, LlmAdapterCreateInput, LlmResponse } from '@/core/llm/types.js';
+import {
+  FileHeartbeatTaskService,
+  HeartbeatSchedulerService,
+  type HeartbeatSchedulerEvent,
+  type HeartbeatTask,
+  type HeartbeatTaskRunnerAgentOptions,
+  type HeartbeatTaskRunnerRuntimeOptions,
+} from '../../../advanced.js';
+
+const NOW = new Date('2026-08-01T04:00:00.000Z');
+
+describe('custom heartbeat runner credentials', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('runs custom host work through stored OpenAI OAuth without exposing credential fields', async () => {
+    clearProviderEnvironment();
+    const workspaceRoot = createWorkspace('oauth');
+    const credentialStorePath = storeOAuthCredential({ workspaceRoot, provider: 'openai' });
+    const createAdapter = mockModelAdapter();
+    const capture = createLogCapture();
+
+    const execution = await runCustomHeartbeat({
+      workspaceRoot,
+      model: 'gpt-5.4',
+      agentOptions: { logger: capture.logger },
+    });
+
+    expect(execution.contextKeys).toEqual(['runAgent']);
+    expect(execution.result).toMatchObject({ checked: 1, ran: 1, failed: 0 });
+    expect(createAdapter).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'gpt-5.4',
+      credentials: {
+        apiKey: undefined,
+        credential: expect.objectContaining({
+          type: 'oauth',
+          provider: 'openai',
+          accessToken: 'stored-access-token',
+        }),
+        credentialStorePath,
+      },
+    }));
+
+    const externallyVisibleState = JSON.stringify({
+      tasks: execution.savedTasks,
+      checkpoints: execution.savedCheckpoints,
+      records: execution.savedRecords,
+      events: execution.events,
+      logs: capture.read(),
+    });
+    expect(externallyVisibleState).not.toContain('stored-access-token');
+    expect(externallyVisibleState).not.toContain('stored-refresh-token');
+    expect(externallyVisibleState).not.toContain('stored-account-id');
+  });
+
+  it('preserves explicit and provider API-key resolution for custom runners', async () => {
+    clearProviderEnvironment();
+    const explicitCreate = mockModelAdapter();
+    const explicit = await runCustomHeartbeat({
+      workspaceRoot: createWorkspace('explicit-key'),
+      model: 'gpt-5.4',
+      runtime: {
+        apiKey: 'explicit-openai-key',
+        apiKeyProvider: 'explicit',
+      },
+    });
+
+    expect(explicit.result).toMatchObject({ ran: 1, failed: 0 });
+    expect(explicitCreate).toHaveBeenCalledWith(expect.objectContaining({
+      credentials: expect.objectContaining({ apiKey: 'explicit-openai-key', credential: undefined }),
+    }));
+    expect(JSON.stringify(explicit.savedRecords)).not.toContain('explicit-openai-key');
+
+    vi.restoreAllMocks();
+    vi.stubEnv('ANTHROPIC_API_KEY', 'provider-anthropic-key');
+    const providerCreate = mockModelAdapter();
+    const provider = await runCustomHeartbeat({
+      workspaceRoot: createWorkspace('provider-key'),
+      model: 'claude-sonnet-4-6',
+    });
+
+    expect(provider.result).toMatchObject({ ran: 1, failed: 0 });
+    expect(providerCreate).toHaveBeenCalledWith(expect.objectContaining({
+      credentials: expect.objectContaining({ apiKey: 'provider-anthropic-key', credential: undefined }),
+    }));
+    expect(JSON.stringify(provider.savedRecords)).not.toContain('provider-anthropic-key');
+  });
+
+  it('honors preferApiKey without exposing the stored OAuth principal', async () => {
+    clearProviderEnvironment();
+    vi.stubEnv('OPENAI_API_KEY', 'preferred-openai-key');
+    const workspaceRoot = createWorkspace('preferred-key');
+    storeOAuthCredential({ workspaceRoot, provider: 'openai' });
+    const createAdapter = mockModelAdapter();
+
+    const execution = await runCustomHeartbeat({
+      workspaceRoot,
+      model: 'gpt-5.4',
+      runtime: { preferApiKey: true },
+    });
+
+    expect(execution.result).toMatchObject({ ran: 1, failed: 0 });
+    expect(createAdapter).toHaveBeenCalledWith(expect.objectContaining({
+      credentials: expect.objectContaining({ apiKey: 'preferred-openai-key', credential: undefined }),
+    }));
+    const persisted = JSON.stringify({
+      tasks: execution.savedTasks,
+      checkpoints: execution.savedCheckpoints,
+      records: execution.savedRecords,
+      events: execution.events,
+    });
+    expect(persisted).not.toContain('preferred-openai-key');
+    expect(persisted).not.toContain('stored-account-id');
+  });
+
+  it('keeps no-key local endpoints on the standard custom-runner path', async () => {
+    clearProviderEnvironment();
+    vi.stubEnv('OLLAMA_OPENAI_BASE_URL', 'http://127.0.0.1:11434/v1/');
+    const createAdapter = mockModelAdapter();
+
+    const execution = await runCustomHeartbeat({
+      workspaceRoot: createWorkspace('local-endpoint'),
+      model: 'ollama/qwen3:8b',
+    });
+
+    expect(execution.result).toMatchObject({ ran: 1, failed: 0 });
+    expect(createAdapter).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'ollama/qwen3:8b',
+      credentials: expect.objectContaining({ apiKey: undefined, credential: undefined }),
+      runtime: expect.objectContaining({
+        endpoint: {
+          baseUrl: 'http://127.0.0.1:11434/v1',
+          auth: { type: 'none' },
+        },
+      }),
+    }));
+  });
+
+  it('fails missing and unsupported credentials before model execution with safe errors', async () => {
+    clearProviderEnvironment();
+    const missingCreate = mockModelAdapter();
+    const missing = await runCustomHeartbeat({
+      workspaceRoot: createWorkspace('missing'),
+      model: 'claude-sonnet-4-6',
+    });
+
+    expect(missing.result).toMatchObject({ ran: 0, failed: 1 });
+    expect(missingCreate).not.toHaveBeenCalled();
+    expect(missing.events.at(-1)).toMatchObject({
+      type: 'heartbeat.task.failed',
+      error: expect.stringContaining('Missing Anthropic credential'),
+    });
+
+    vi.restoreAllMocks();
+    clearProviderEnvironment();
+    const workspaceRoot = createWorkspace('unsupported');
+    storeOAuthCredential({ workspaceRoot, provider: 'anthropic' });
+    const unsupportedCreate = mockModelAdapter();
+    const unsupported = await runCustomHeartbeat({
+      workspaceRoot,
+      model: 'claude-sonnet-4-6',
+    });
+
+    expect(unsupported.result).toMatchObject({ ran: 0, failed: 1 });
+    expect(unsupportedCreate).not.toHaveBeenCalled();
+    expect(unsupported.events.at(-1)).toMatchObject({
+      type: 'heartbeat.task.failed',
+      error: expect.stringMatching(/Stored OAuth credentials are not supported for anthropic.*ANTHROPIC_API_KEY/),
+    });
+    const persisted = JSON.stringify({
+      tasks: unsupported.savedTasks,
+      checkpoints: unsupported.savedCheckpoints,
+      records: unsupported.savedRecords,
+      events: unsupported.events,
+    });
+    expect(persisted).not.toContain('stored-access-token');
+    expect(persisted).not.toContain('stored-refresh-token');
+    expect(persisted).not.toContain('stored-account-id');
+  });
+});
+
+async function runCustomHeartbeat(input: {
+  workspaceRoot: string;
+  model: string;
+  runtime?: Partial<HeartbeatTaskRunnerRuntimeOptions>;
+  agentOptions?: HeartbeatTaskRunnerAgentOptions;
+}) {
+  const events: HeartbeatSchedulerEvent[] = [];
+  const task: HeartbeatTask = {
+    id: `custom-${input.model.replaceAll(/[^a-zA-Z0-9._-]/g, '-')}`,
+    task: 'Process one host-owned work claim.',
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt: '2026-08-01T03:59:00.000Z',
+    },
+  };
+  const store = new FileHeartbeatTaskService({
+    dir: join(input.workspaceRoot, '.heddle', 'heartbeat-credential-test'),
+  });
+  await store.saveTask(task);
+  let contextKeys: string[] = [];
+
+  const result = await HeartbeatSchedulerService.runDueTasks({
+    store,
+    now: () => NOW,
+    runtime: {
+      workspaceRoot: input.workspaceRoot,
+      stateDir: '.heddle',
+      model: input.model,
+      tools: [],
+      includeDefaultTools: false,
+      ...input.runtime,
+    },
+    runner: async (scheduledTask, _checkpoint, context) => {
+      contextKeys = Object.keys(context);
+      return await context.runAgent({
+        task: `${scheduledTask.task}\n\nUse the custom host context.`,
+        maxSteps: 1,
+        ...input.agentOptions,
+      });
+    },
+    onEvent: (event) => events.push(structuredClone(event)),
+  });
+  const savedTasks = await store.listTasks();
+  const savedCheckpoints = (await Promise.all(
+    savedTasks.map(async (savedTask) => await store.loadCheckpoint(savedTask)),
+  )).filter((checkpoint) => checkpoint !== undefined);
+  const savedRecords = (await store.listRunRecords({ taskId: task.id })).map((entry) => entry.record);
+
+  return {
+    result,
+    contextKeys,
+    savedTasks,
+    savedCheckpoints,
+    savedRecords,
+    events,
+  };
+}
+
+function mockModelAdapter() {
+  return vi.spyOn(LlmAdapterService, 'create').mockImplementation((input) => createModelAdapter(input));
+}
+
+function createModelAdapter(input: LlmAdapterCreateInput): LlmAdapter {
+  const model = input.model ?? 'gpt-test';
+  const provider = LlmAdapterService.inferProvider(model);
+  return {
+    info: {
+      provider,
+      model,
+      capabilities: {
+        toolCalls: true,
+        systemMessages: true,
+        reasoningSummaries: false,
+        parallelToolCalls: provider === 'openai',
+      },
+    },
+    async chat(): Promise<LlmResponse> {
+      return {
+        content: 'Processed the custom host work claim.\n\nHEARTBEAT_DECISION: complete',
+      };
+    },
+  };
+}
+
+function createWorkspace(label: string): string {
+  return mkdtempSync(join(tmpdir(), `heddle-heartbeat-credential-${label}-`));
+}
+
+function storeOAuthCredential(input: {
+  workspaceRoot: string;
+  provider: 'openai' | 'anthropic';
+}): string {
+  const storePath = ProviderCredentialRepository.resolveStorePath(join(input.workspaceRoot, '.heddle'));
+  new ProviderCredentialRepository({ storePath }).set({
+    type: 'oauth',
+    provider: input.provider,
+    accessToken: 'stored-access-token',
+    refreshToken: 'stored-refresh-token',
+    expiresAt: Date.now() + 60 * 60_000,
+    accountId: 'stored-account-id',
+    createdAt: '2026-08-01T03:00:00.000Z',
+    updatedAt: '2026-08-01T03:00:00.000Z',
+  });
+  return storePath;
+}
+
+function clearProviderEnvironment(): void {
+  for (const name of [
+    'OPENAI_API_KEY',
+    'PERSONAL_OPENAI_API_KEY',
+    'ANTHROPIC_API_KEY',
+    'PERSONAL_ANTHROPIC_API_KEY',
+  ]) {
+    vi.stubEnv(name, '');
+  }
+}
+
+function createLogCapture() {
+  let output = '';
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      output += String(chunk);
+      callback();
+    },
+  });
+
+  return {
+    logger: pino({ level: 'info' }, stream),
+    read: () => output,
+  };
+}

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -277,6 +277,8 @@ export type {
   HeartbeatSchedulerHandle,
   HeartbeatSchedulerEvent,
   HeartbeatTaskRunner,
+  HeartbeatTaskRunnerAgentOptions,
+  HeartbeatTaskRunnerContext,
   HeartbeatTaskRunnerRuntimeOptions,
   RunDueHeartbeatTasksOptions,
   RunDueHeartbeatTasksResult,

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -29,7 +29,9 @@ operator-facing heartbeat views.
   instead of constructing task repositories or duplicating loop logic.
 - `scheduler/runner.ts`: `HeartbeatTaskRunnerService` owns one task execution:
   checkpoint loading, runner-agent invocation, checkpoint persistence, task
-  state transitions, and run history persistence.
+  state transitions, and run history persistence. Default and custom runners
+  share its framework-owned `context.runAgent()` path, so hosts can add domain
+  prompts and tools without receiving or translating provider credentials.
 - `views/`: `HeartbeatLucidPresenter` owns Lucid-specific adapter messages.
   Generic task/run view projection belongs to `FileHeartbeatTaskService`,
   because that service owns the task persistence boundary.
@@ -67,6 +69,12 @@ operator-facing heartbeat views.
   control-plane heartbeat API as the public task/run contract. Terminal command
   code should not construct `HeartbeatTask` objects, write heartbeat JSON, or run
   its own scheduler loop.
+- A custom scheduler runner may perform domain work before model execution, but
+  it should delegate model work to the execution-scoped `context.runAgent()`.
+  That callback owns model credential resolution, OAuth refresh, unattended
+  approval defaults, checkpoint continuation, and heartbeat event forwarding.
+  The callback is valid only during the current execution and must never be
+  serialized or retained by the host.
 - `heddle heartbeat run` and `heddle heartbeat start` are server-backed command
   paths. The control-plane server owns recurring scheduler lifetime; CLI
   commands may request due-task execution or keep an embedded server alive, but

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -10,6 +10,8 @@ export type {
   HeartbeatSchedulerEvent,
   HeartbeatSchedulerHandle,
   HeartbeatTaskRunner,
+  HeartbeatTaskRunnerAgentOptions,
+  HeartbeatTaskRunnerContext,
   HeartbeatTaskRunnerRuntimeOptions,
   RunDueHeartbeatTasksOptions,
   RunDueHeartbeatTasksResult,

--- a/src/core/heartbeat/scheduler/index.ts
+++ b/src/core/heartbeat/scheduler/index.ts
@@ -4,6 +4,8 @@ export type {
   HeartbeatSchedulerEvent,
   HeartbeatSchedulerHandle,
   HeartbeatTaskRunner,
+  HeartbeatTaskRunnerAgentOptions,
+  HeartbeatTaskRunnerContext,
   HeartbeatTaskRunnerRuntimeOptions,
   RunDueHeartbeatTasksOptions,
   RunDueHeartbeatTasksResult,

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -10,7 +10,6 @@ import { randomUUID } from 'node:crypto';
 import dayjs from 'dayjs';
 import { ToolApprovalPolicies } from '@/core/approvals/index.js';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
-import { RuntimeCredentialService } from '@/core/runtime/credentials/index.js';
 import type { AgentLoopCheckpoint, AgentLoopState } from '@/core/runtime/loop/index.js';
 import { HeartbeatRunnerAgent } from '../agent/index.js';
 import type { AgentHeartbeatResult, RunAgentHeartbeatOptions } from '../agent/index.js';
@@ -19,6 +18,7 @@ import type { HeartbeatTask, HeartbeatTaskExecution, HeartbeatTaskRunRecord } fr
 import type {
   HeartbeatSchedulerEvent,
   HeartbeatTaskRunner,
+  HeartbeatTaskRunnerAgentOptions,
   HeartbeatTaskRunnerRuntimeOptions,
   RunDueHeartbeatTasksOptions,
   RunDueHeartbeatTasksResult,
@@ -137,9 +137,13 @@ export class HeartbeatTaskRunnerService {
     runtime?: HeartbeatTaskRunnerRuntimeOptions;
     onEvent?: (event: HeartbeatSchedulerEvent) => void;
   }): Promise<AgentHeartbeatResult> {
-    return args.runner ?
-      await args.runner(args.task, args.checkpoint)
-    : await HeartbeatRunnerAgent.run(HeartbeatTaskRunnerService.resolveRunnerAgentOptions(args));
+    const runAgent = async (options?: HeartbeatTaskRunnerAgentOptions) => await HeartbeatRunnerAgent.run(
+      HeartbeatTaskRunnerService.resolveRunnerAgentOptions({ ...args, options }),
+    );
+
+    return args.runner
+      ? await args.runner(args.task, args.checkpoint, { runAgent })
+      : await runAgent();
   }
 
   private static resolveRunnerAgentOptions(args: {
@@ -148,21 +152,15 @@ export class HeartbeatTaskRunnerService {
     runAt: Date;
     runtime?: HeartbeatTaskRunnerRuntimeOptions;
     onEvent?: (event: HeartbeatSchedulerEvent) => void;
+    options?: HeartbeatTaskRunnerAgentOptions;
   }): RunAgentHeartbeatOptions {
-    const model = args.task.runtime?.model ?? args.runtime?.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
-    const credentialOptions = {
-      apiKey: args.runtime?.apiKey,
-      apiKeyProvider: args.runtime?.apiKeyProvider,
-      preferApiKey: args.runtime?.preferApiKey,
-    };
-    if (!RuntimeCredentialService.hasCredentialForModel(model, credentialOptions)) {
-      throw new Error(RuntimeCredentialService.formatMissingCredentialMessage(model));
-    }
+    const model = args.options?.model ?? args.task.runtime?.model ?? args.runtime?.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
 
     return {
       ...args.runtime,
       ...args.task.runtime,
-      task: args.task.task,
+      ...args.options,
+      task: args.options?.task ?? args.task.task,
       checkpoint: args.checkpoint,
       runContext: {
         currentDateTime: dayjs(args.runAt).toISOString(),
@@ -173,7 +171,6 @@ export class HeartbeatTaskRunnerService {
         previousRunId: args.task.state?.runId,
       },
       model,
-      apiKey: RuntimeCredentialService.resolveApiKeyForModel(model, credentialOptions),
       workspaceRoot: args.runtime?.workspaceRoot ?? args.task.runtime?.workspaceRoot,
       stateDir: args.runtime?.stateDir ?? args.task.runtime?.stateDir,
       memoryDir: args.runtime?.memoryDir ?? args.task.runtime?.memoryDir,

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -55,7 +55,45 @@ export type HeartbeatSchedulerEvent =
 export type HeartbeatTaskRunner = (
   task: HeartbeatTask,
   checkpoint: AgentLoopState | AgentLoopCheckpoint | undefined,
+  context: HeartbeatTaskRunnerContext,
 ) => Promise<AgentHeartbeatResult>;
+
+/**
+ * Per-run customization accepted by the framework-owned heartbeat agent path.
+ * Credential fields are intentionally absent: Heddle resolves and refreshes
+ * them inside the standard runtime boundary for every invocation.
+ */
+export type HeartbeatTaskRunnerAgentOptions = Partial<Pick<
+  RunAgentHeartbeatOptions,
+  | 'task'
+  | 'model'
+  | 'reasoningEffort'
+  | 'maxSteps'
+  | 'maxToolConcurrency'
+  | 'tools'
+  | 'extraTools'
+  | 'includeDefaultTools'
+  | 'includePlanTool'
+  | 'searchIgnoreDirs'
+  | 'systemContext'
+  | 'history'
+  | 'logger'
+  | 'onTraceEvent'
+  | 'shouldStop'
+  | 'abortSignal'
+>>;
+
+/**
+ * Framework-owned execution handoff for custom heartbeat runners.
+ *
+ * Hosts can add domain prompts and tools through `runAgent` without receiving
+ * API keys, OAuth tokens, account identifiers, or stored credential records.
+ * The context is valid only for the current task execution and must not be
+ * persisted.
+ */
+export type HeartbeatTaskRunnerContext = {
+  runAgent: (options?: HeartbeatTaskRunnerAgentOptions) => Promise<AgentHeartbeatResult>;
+};
 
 export type HeartbeatTaskRunnerRuntimeOptions = {
   workspaceRoot?: string;

--- a/src/core/runtime/credentials/service.ts
+++ b/src/core/runtime/credentials/service.ts
@@ -133,6 +133,12 @@ export class RuntimeCredentialService {
 
     const oauthCredential = this.resolveOAuthCredentialForModel(model, { storePath: runtime?.credentialStorePath });
     if (oauthCredential) {
+      if (oauthCredential.provider !== 'openai') {
+        throw new Error(
+          `Stored OAuth credentials are not supported for ${oauthCredential.provider} model ${model}. `
+          + RuntimeCredentialService.formatMissingCredentialMessage(model),
+        );
+      }
       return {
         provider,
         credential: oauthCredential,

--- a/src/core/runtime/loop/service.ts
+++ b/src/core/runtime/loop/service.ts
@@ -30,14 +30,16 @@ export class AgentLoopRuntimeService {
     const providerRuntime = LlmProviderRuntimeService.resolve({
       model,
       apiKey: options.apiKey,
+      apiKeyProvider: options.apiKeyProvider,
       credential: options.credential,
       credentialStorePath,
+      preferApiKey: options.preferApiKey,
       reasoningEffort: options.reasoningEffort,
     });
     if (!options.llm) {
       LlmProviderRuntimeService.assertRunnable(providerRuntime);
     }
-    const apiKey = options.apiKey ?? providerRuntime.apiKey;
+    const apiKey = providerRuntime.apiKey;
     const llm = options.llm ?? await this.createLoopLlmAdapter({
       model,
       apiKey,

--- a/src/core/runtime/loop/types.ts
+++ b/src/core/runtime/loop/types.ts
@@ -85,7 +85,9 @@ export type RunAgentLoopOptions = {
   model?: string;
   reasoningEffort?: ReasoningEffort;
   apiKey?: string;
+  apiKeyProvider?: LlmProvider | 'explicit';
   credential?: RuntimeProviderCredential;
+  preferApiKey?: boolean;
   maxSteps?: number;
   maxToolConcurrency?: number;
   workspaceRoot?: string;

--- a/src/core/runtime/provider-runtime/service.ts
+++ b/src/core/runtime/provider-runtime/service.ts
@@ -39,7 +39,7 @@ export class LlmProviderRuntimeService {
   private static credentialRuntime(input: LlmProviderRuntimeInput): ApiKeyRuntime {
     return {
       apiKey: input.apiKey,
-      apiKeyProvider: input.apiKey ? 'explicit' : undefined,
+      apiKeyProvider: input.apiKeyProvider ?? (input.apiKey ? 'explicit' : undefined),
       credential: input.credential,
       credentialStorePath: input.credentialStorePath,
       preferApiKey: input.preferApiKey,


### PR DESCRIPTION
## Summary

- add a per-execution `HeartbeatTaskRunnerContext.runAgent()` handoff so custom heartbeat runners can delegate model work without receiving credentials
- route default and custom heartbeat execution through the same runtime credential resolver for stored OpenAI OAuth, explicit and environment API keys, `preferApiKey`, and keyless local endpoints
- export and document the public API, update the domain-neutral scheduler example, and verify that credentials never enter task state, checkpoints, run records, events, or logs

## Boundary

This PR implements the credential-handoff slice only. Domain-level skips, cancellation, and awaitable custom-runner shutdown remain separate lifecycle work tracked by #298.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:unit` (132 files, 805 tests)
- `yarn test:integration` (38 files, 355 tests)
- focused heartbeat credential integration test (5 tests)
- `yarn build`

Closes #296