### PR TITLE
feat(heartbeat): add host-safe execution context

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -16,10 +16,11 @@ A heartbeat runner cycle:
 - checkpoints the new state
 - returns a decision: `continue`, `pause`, `complete`, or `escalate`
 
-Scheduler state keeps the latest runner result as one nested result object instead
-of copying decision, outcome, summary, and usage into separate task fields. Run
-history stores the same result in a durable run record, so CLI, control-plane,
-and host integrations read the same source of truth.
+Scheduler state records the latest outer execution outcome. Agent executions
+also retain their real agent result and checkpoint. A no-work skip or
+cancellation instead stores a lightweight outcome with the outer `executionId`,
+summary, kind, and timestamp; it does not fabricate an agent run ID, model,
+provider, transcript, or checkpoint.
 
 Task continuation is explicit. A task can be configured for operator-controlled
 continuation or agent-selected continuation, and a blocked or paused task must be
@@ -71,8 +72,9 @@ For repeated runner cycles, Heddle also exposes a local-first scheduler core:
 - `HeartbeatSchedulerService.runLoop`
 - `FileHeartbeatTaskService`
 
-`HeartbeatSchedulerService.runDueTasks` returns durable run records, and
-`heartbeat.task.finished` events include the same run record. If you need a
+`HeartbeatSchedulerService.runDueTasks` returns durable execution records.
+`heartbeat.task.finished`, `heartbeat.task.skipped`, and
+`heartbeat.task.cancelled` events include the corresponding record. If you need a
 compact display shape for a UI or service integration, use
 `FileHeartbeatTaskService` task/run view methods instead of flattening task
 state yourself.
@@ -88,7 +90,7 @@ disabled, and blocked tasks remain blocked until an operator resumes them.
 Custom stores implement this protocol through `HeartbeatTaskStore`:
 
 - `claimTaskExecution` atomically establishes the current `executionId` fencing token
-- `completeTaskExecution` and `failTaskExecution` reject a stale token with `claim-lost`
+- `completeTaskExecution`, `failTaskExecution`, and `recordTaskExecutionOutcome` reject a stale token with `claim-lost`
 - `recoverInterruptedTasks` records the interrupted execution and makes only eligible tasks retryable
 
 The built-in file adapter serializes those transitions within one Node.js
@@ -101,10 +103,33 @@ Cron, launchd, systemd, hosted queues, and Lucid-style services should be treate
 
 ### Custom host work with the standard agent runtime
 
-A host can claim domain work or assemble domain tools in a custom runner, then
-delegate model execution back to Heddle:
+A custom handler owns domain discovery and acknowledgement. Heddle owns the
+execution identity, credential resolution, agent defaults, abort signal,
+checkpoint, execution record, and framework events:
 
 ```ts
+import {
+  HeartbeatSchedulerService,
+  type HeartbeatTaskHandler,
+} from '@roackb2/heddle/advanced';
+
+const handler: HeartbeatTaskHandler = async (context) => {
+  const claim = await domainQueue.claimNext({ signal: context.signal });
+  if (!claim) {
+    return context.skip({ summary: 'No eligible domain work was available.' });
+  }
+
+  const result = await context.runAgent({
+    task: `${context.task.task}\n\nClaimed work: ${claim.instruction}`,
+    systemContext: `Operate only on claim ${claim.id}.`,
+    tools: domainTools,
+    includeDefaultTools: false,
+  });
+
+  await domainQueue.acknowledge(claim.id, { summary: result.summary });
+  return result;
+};
+
 await HeartbeatSchedulerService.runDueTasks({
   store,
   runtime: {
@@ -112,14 +137,12 @@ await HeartbeatSchedulerService.runDueTasks({
     stateDir: '.heddle',
     model: 'gpt-5.4',
   },
-  runner: async (task, _checkpoint, context) => context.runAgent({
-    task: `${task.task}\n\nReview the host-owned work claim before acting.`,
-    tools: domainTools,
-    includeDefaultTools: false,
-  }),
+  handler,
 });
 ```
 
+The context also includes a cloned task and checkpoint, the outer
+`executionId`, scheduled `runAt`, and a framework-owned `AbortSignal`.
 `context.runAgent()` is the supported credential handoff. It uses the same
 runtime builder as an ordinary heartbeat task and resolves API keys, stored
 OpenAI OAuth login state, and local/OpenAI-compatible endpoints inside Heddle.
@@ -127,9 +150,40 @@ The host does not receive credential records or token fields and must not retain
 the execution context. Set `preferApiKey: true` in `runtime` only when an
 environment API key should take precedence over stored OpenAI OAuth state.
 
-Custom runners still return an agent result today. Domain-level no-work skips,
-execution cancellation, and awaitable custom-runner shutdown are separate
-lifecycle concerns; do not fabricate an agent result to emulate those features.
+Call `context.runAgent()` at most once, or return the exact outcome from
+`context.skip()`. Context methods are invalid after the handler settles. The
+older positional `runner(task, checkpoint, context)` callback remains as a
+deprecated compatibility adapter, but it uses this same internal execution and
+persistence pipeline.
+
+### Awaitable shutdown and cancellation
+
+The background scheduler separates admission shutdown from active-work
+cancellation:
+
+```ts
+const scheduler = HeartbeatSchedulerService.start({
+  workspaceRoot,
+  stateRoot,
+  handler,
+});
+
+// Stop polling, abort the active execution, and wait for handler settlement
+// plus Heddle's final claim-fenced persistence.
+await scheduler.stop({ cancelRunning: true });
+```
+
+Calling `stop()` without `cancelRunning` drains the active execution while
+stopping new admissions. Repeated calls return the same stop promise; a later
+call may still upgrade a drain to cancellation. A cancelled execution is
+recorded separately from failure and becomes retryable without using the
+failure-delay path.
+
+Heddle cannot force arbitrary host code to observe `AbortSignal`. If a handler
+ignores cancellation, `stop()` deliberately remains pending until that handler
+settles. The execution fencing token prevents its late result from overwriting
+a replacement claim, and a result that settles after the framework signal was
+aborted is persisted as cancellation rather than agent completion.
 
 ## Examples
 
@@ -147,9 +201,11 @@ export OPENAI_API_KEY=your_key_here
 yarn example:heartbeat-scheduler
 ```
 
-The scheduler example uses a custom runner and `context.runAgent()` while
-leaving credentials entirely inside Heddle. It works with stored OpenAI login
-state or provider API-key environment variables.
+The scheduler example demonstrates claim, no-work skip, dynamic prompt/tools,
+agent execution, and host acknowledgement while leaving credentials entirely
+inside Heddle. It works with stored OpenAI login state or provider API-key
+environment variables. Set `HEDDLE_EXAMPLE_NO_WORK=true` to exercise the
+zero-model skip path.
 
 ## Host Notes
 

--- a/examples/heartbeat-scheduler.ts
+++ b/examples/heartbeat-scheduler.ts
@@ -9,6 +9,7 @@
 //   OPENAI_API_KEY=sk-... yarn example:heartbeat-scheduler
 //   HEDDLE_EXAMPLE_MODEL=claude-3-5-haiku-latest ANTHROPIC_API_KEY=sk-ant-... yarn example:heartbeat-scheduler
 //   HEDDLE_EXAMPLE_PREFER_API_KEY=true OPENAI_API_KEY=sk-... yarn example:heartbeat-scheduler
+//   HEDDLE_EXAMPLE_NO_WORK=true yarn example:heartbeat-scheduler
 //
 // This demonstrates Heddle's local-first scheduler API. It creates or updates
 // one durable heartbeat task under .heddle/examples/heartbeat-scheduler/, runs
@@ -21,12 +22,19 @@ import {
   HeartbeatSchedulerService,
   type HeartbeatSchedulerEvent,
   type HeartbeatTask,
+  type HeartbeatTaskRunnerAgentOptions,
   type HeartbeatTaskStore,
 } from '../src/core/heartbeat/index.js';
 
 const DEFAULT_EXAMPLE_MODEL = 'gpt-5.1-codex-mini';
 const STORE_DIR = join(process.cwd(), '.heddle', 'examples', 'heartbeat-scheduler');
 const TASK_ID = 'demo-maintenance';
+const domainTools: NonNullable<HeartbeatTaskRunnerAgentOptions['tools']> = [{
+  name: 'read_claimed_work',
+  description: 'Read the work item already claimed by this example host.',
+  parameters: { type: 'object', properties: {}, additionalProperties: false },
+  execute: async () => ({ ok: true, output: 'Review the example scheduler integration and report one improvement.' }),
+}];
 
 async function main() {
   const model = process.env.HEDDLE_EXAMPLE_MODEL ?? process.env.OPENAI_MODEL ?? DEFAULT_EXAMPLE_MODEL;
@@ -44,9 +52,20 @@ async function main() {
       includeDefaultTools: false,
       workspaceRoot: process.cwd(),
     },
-    runner: async (task, _checkpoint, context) => context.runAgent({
-      task: `${task.task}\n\nThis instruction was added by a custom host runner without handling credentials.`,
-    }),
+    handler: async (context) => {
+      const claim = claimDomainWork();
+      if (!claim) {
+        return context.skip({ summary: 'The host found no domain work to claim.' });
+      }
+
+      const agentResult = await context.runAgent({
+        task: `${context.task.task}\n\nClaimed work: ${claim.instruction}`,
+        systemContext: `Operate only on host claim ${claim.id}.`,
+        tools: domainTools,
+      });
+      acknowledgeDomainWork(claim.id, agentResult.summary);
+      return agentResult;
+    },
     onEvent: (event) => {
       const line = formatSchedulerEvent(event);
       if (line) {
@@ -63,6 +82,17 @@ async function main() {
   process.exit(0);
 }
 
+function claimDomainWork(): { id: string; instruction: string } | undefined {
+  return process.env.HEDDLE_EXAMPLE_NO_WORK === 'true' ? undefined : {
+    id: 'example-claim-1',
+    instruction: 'Use the host-provided tool, then summarize the claimed work.',
+  };
+}
+
+function acknowledgeDomainWork(claimId: string, summary: string): void {
+  console.log(`[host] acknowledged claim=${claimId} summary=${summary.split('\n')[0] ?? ''}`);
+}
+
 async function ensureDemoTask(
   store: HeartbeatTaskStore,
   model: string,
@@ -73,7 +103,7 @@ async function ensureDemoTask(
     id: TASK_ID,
     name: 'Demo maintenance heartbeat',
     task:
-      'Check whether there is useful autonomous maintenance work to do for this demo. No tools are available in this scheduler example. If no useful work is available, explain that the task should pause.',
+      'Check whether there is useful autonomous maintenance work to do for this demo. Use only the host-provided claimed-work tool.',
     enabled: true,
     schedule: {
       intervalMs: 60_000,
@@ -94,11 +124,15 @@ function formatSchedulerEvent(event: HeartbeatSchedulerEvent): string | undefine
     case 'heartbeat.task.due':
       return `[event] task.due id=${event.taskId}`;
     case 'heartbeat.task.started':
-      return `[event] task.started id=${event.taskId} loadedCheckpoint=${event.loadedCheckpoint}`;
+      return `[event] task.started id=${event.taskId} execution=${event.executionId} loadedCheckpoint=${event.loadedCheckpoint}`;
     case 'heartbeat.task.recovered':
       return `[event] task.recovered id=${event.taskId} interruptedExecutionId=${event.interruptedExecutionId} reason=${event.reason}`;
     case 'heartbeat.task.finished':
       return `[event] task.finished id=${event.taskId} decision=${event.record.result.decision} enabled=${event.record.task.enabled} nextRunAt=${event.record.task.schedule.nextRunAt ?? 'none'}`;
+    case 'heartbeat.task.skipped':
+      return `[event] task.skipped id=${event.taskId} execution=${event.executionId} summary=${event.record.outcome.summary}`;
+    case 'heartbeat.task.cancelled':
+      return `[event] task.cancelled id=${event.taskId} execution=${event.executionId}`;
     case 'heartbeat.task.failed':
       return `[event] task.failed id=${event.taskId} error=${event.error}`;
     default:

--- a/src/__tests__/integration/core/heartbeat-execution-context.test.ts
+++ b/src/__tests__/integration/core/heartbeat-execution-context.test.ts
@@ -1,0 +1,402 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LlmAdapterService } from '@/core/llm/index.js';
+import {
+  FileHeartbeatTaskService,
+  HeartbeatRunnerAgent,
+  HeartbeatSchedulerService,
+  type AgentHeartbeatResult,
+  type HeartbeatExecutionContext,
+  type HeartbeatSchedulerEvent,
+  type HeartbeatTask,
+  type RunAgentHeartbeatOptions,
+} from '../../../advanced.js';
+import { AgentLoopCheckpointService } from '@/core/runtime/loop/index.js';
+
+const NOW = new Date('2026-08-01T05:00:00.000Z');
+
+describe('heartbeat execution context', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists no-work without provider calls, fabricated agent state, or checkpoint changes', async () => {
+    const dir = createStateRoot('skip');
+    const store = new FileHeartbeatTaskService({ dir });
+    const task: HeartbeatTask = {
+      ...createTask('no-work'),
+      runtime: { model: 'gpt-5.4' },
+    };
+    const priorCheckpoint = createHeartbeatResult('pause', 'prior-run').checkpoint;
+    await store.saveTask(task);
+    await store.saveCheckpoint(task, priorCheckpoint);
+    const runAgent = vi.spyOn(HeartbeatRunnerAgent, 'run');
+    const createAdapter = vi.spyOn(LlmAdapterService, 'create');
+    const events: HeartbeatSchedulerEvent[] = [];
+    let retainedContext: HeartbeatExecutionContext | undefined;
+
+    const result = await HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      handler: async (context) => {
+        retainedContext = context;
+        context.task.task = 'A host-local mutation must not reach persistence.';
+        expect(context.checkpoint).toMatchObject({ runId: priorCheckpoint.runId });
+        return context.skip({ summary: 'No domain work is currently available.' });
+      },
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    expect(result).toMatchObject({ checked: 1, ran: 1, failed: 0 });
+    expect(runAgent).not.toHaveBeenCalled();
+    expect(createAdapter).not.toHaveBeenCalled();
+    await expect(store.loadCheckpoint(task)).resolves.toEqual(priorCheckpoint);
+    await expect(store.requireTask(task.id)).resolves.toMatchObject({
+      task: task.task,
+      schedule: { nextRunAt: '2026-08-01T05:01:00.000Z' },
+      state: {
+        status: 'waiting',
+        lastExecution: {
+          kind: 'skipped',
+          summary: 'No domain work is currently available.',
+        },
+      },
+    });
+    const savedTask = await store.requireTask(task.id);
+    expect(savedTask.state?.runId).toBeUndefined();
+    expect(savedTask.state?.result).toBeUndefined();
+
+    const [entry] = await store.listRunRecords({ taskId: task.id });
+    expect(entry).toMatchObject({
+      executionId: expect.any(String),
+      runId: undefined,
+      record: {
+        outcome: {
+          kind: 'skipped',
+          summary: 'No domain work is currently available.',
+        },
+      },
+    });
+    expect(entry?.record.result).toBeUndefined();
+    expect(entry?.record.loadedCheckpoint).toBeUndefined();
+    expect(entry?.record.task.runtime?.model).toBe('gpt-5.4');
+    expect(JSON.stringify(entry?.record)).not.toMatch(/checkpoint|transcript|provider|runId/);
+    expect(events.map((event) => event.type)).toEqual([
+      'heartbeat.task.due',
+      'heartbeat.task.started',
+      'heartbeat.task.skipped',
+    ]);
+    expect(events[1]).toMatchObject({ executionId: entry?.executionId });
+    expect(events[2]).toMatchObject({ executionId: entry?.executionId });
+    expect(() => retainedContext?.skip({ summary: 'too late' })).toThrow(/no longer active/);
+  });
+
+  it('routes dynamic prompts, tools, policy, abort, and events through the standard agent builder', async () => {
+    const dir = createStateRoot('dynamic');
+    const store = new FileHeartbeatTaskService({ dir });
+    const task = createTask('dynamic-work');
+    await store.saveTask(task);
+    const agentResult = createHeartbeatResult('continue', 'dynamic-run');
+    let receivedOptions: RunAgentHeartbeatOptions | undefined;
+    const runAgent = vi.spyOn(HeartbeatRunnerAgent, 'run').mockImplementation(async (options) => {
+      receivedOptions = options;
+      options.onEvent?.({
+        type: 'checkpoint.saved',
+        runId: agentResult.state.runId,
+        checkpoint: agentResult.checkpoint,
+        step: 1,
+        timestamp: NOW.toISOString(),
+      });
+      return agentResult;
+    });
+    const events: HeartbeatSchedulerEvent[] = [];
+    const domainTool = {
+      name: 'claim_domain_work',
+      description: 'Claim one domain-owned work item.',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => ({ ok: true, output: 'claimed' }),
+    };
+    let executionContext: HeartbeatExecutionContext | undefined;
+
+    const result = await HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      runtime: {
+        workspaceRoot: dir,
+        stateDir: dir,
+        model: 'gpt-test',
+        includeDefaultTools: false,
+      },
+      handler: async (context) => {
+        executionContext = context;
+        return await context.runAgent({
+          task: 'Process claimed work item domain-42.',
+          systemContext: 'Only operate on domain-42.',
+          tools: [domainTool],
+          maxSteps: 3,
+        });
+      },
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(result).toMatchObject({ checked: 1, ran: 1, failed: 0 });
+    expect(runAgent).toHaveBeenCalledOnce();
+    expect(receivedOptions).toMatchObject({
+      task: 'Process claimed work item domain-42.',
+      systemContext: 'Only operate on domain-42.',
+      tools: [domainTool],
+      maxSteps: 3,
+      checkpoint: undefined,
+      abortSignal: executionContext?.signal,
+      approvalPolicies: expect.arrayContaining([expect.any(Function)]),
+    });
+    expect(receivedOptions?.approveToolCall).toEqual(expect.any(Function));
+    expect(events.find((event) => event.type === 'heartbeat.task.agent_event')).toMatchObject({
+      executionId: executionContext?.executionId,
+      event: { type: 'checkpoint.saved' },
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: 'heartbeat.task.finished',
+      executionId: executionContext?.executionId,
+    });
+    await expect(store.loadCheckpoint(task)).resolves.toEqual(agentResult.checkpoint);
+    await expect(store.listRunRecords({ taskId: task.id })).resolves.toMatchObject([{
+      executionId: executionContext?.executionId,
+      runId: agentResult.state.runId,
+      record: {
+        outcome: { kind: 'agent', executionId: executionContext?.executionId },
+        result: agentResult,
+      },
+    }]);
+  });
+
+  it('cancels active work, awaits handler settlement, and persists cancellation after a late result', async () => {
+    const dir = createStateRoot('cancel');
+    const store = new FileHeartbeatTaskService({ stateRoot: dir });
+    const task = createTask('cancel-work');
+    const priorCheckpoint = createHeartbeatResult('pause', 'prior-cancel-run').checkpoint;
+    await store.saveTask(task);
+    await store.saveCheckpoint(task, priorCheckpoint);
+    const controlledRun = deferred<AgentHeartbeatResult>();
+    vi.spyOn(HeartbeatRunnerAgent, 'run').mockImplementation(async () => await controlledRun.promise);
+    const contextReady = deferred<HeartbeatExecutionContext>();
+    const events: HeartbeatSchedulerEvent[] = [];
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: dir,
+      stateRoot: dir,
+      pollIntervalMs: 60_000,
+      handler: async (context) => {
+        contextReady.resolve(context);
+        return await context.runAgent();
+      },
+      onEvent: (event) => events.push(event),
+    });
+
+    const context = await contextReady.promise;
+    const firstStop = handle.stop({ cancelRunning: true });
+    const repeatedStop = handle.stop({ cancelRunning: true });
+    expect(repeatedStop).toBe(firstStop);
+    expect(context.signal.aborted).toBe(true);
+    let stopped = false;
+    void firstStop.then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+
+    controlledRun.resolve(createHeartbeatResult('continue', 'late-run'));
+    await firstStop;
+    expect(stopped).toBe(true);
+    await expect(handle.stop({ cancelRunning: true })).resolves.toBeUndefined();
+    await expect(store.loadCheckpoint(task)).resolves.toEqual(priorCheckpoint);
+    await expect(store.requireTask(task.id)).resolves.toMatchObject({
+      schedule: { nextRunAt: expect.any(String) },
+      state: {
+        status: 'waiting',
+        lastExecution: { kind: 'cancelled', executionId: context.executionId },
+      },
+    });
+    expect((await store.requireTask(task.id)).state?.result).toBeUndefined();
+    await expect(store.listRunRecords({ taskId: task.id })).resolves.toMatchObject([{
+      executionId: context.executionId,
+      runId: undefined,
+      record: { outcome: { kind: 'cancelled' } },
+    }]);
+    expect((await store.listRunRecords({ taskId: task.id }))[0]?.record.result).toBeUndefined();
+    expect(events.map((event) => event.type)).toEqual([
+      'heartbeat.scheduler.started',
+      'heartbeat.task.due',
+      'heartbeat.task.started',
+      'heartbeat.task.cancelled',
+      'heartbeat.scheduler.stopped',
+    ]);
+  });
+
+  it('stops admissions without cancelling active work when cancelRunning is omitted', async () => {
+    const dir = createStateRoot('drain');
+    const store = new FileHeartbeatTaskService({ stateRoot: dir });
+    const task = createTask('drain-work');
+    await store.saveTask(task);
+    const controlledRun = deferred<AgentHeartbeatResult>();
+    vi.spyOn(HeartbeatRunnerAgent, 'run').mockImplementation(async () => await controlledRun.promise);
+    const contextReady = deferred<HeartbeatExecutionContext>();
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: dir,
+      stateRoot: dir,
+      pollIntervalMs: 60_000,
+      handler: async (context) => {
+        contextReady.resolve(context);
+        return await context.runAgent();
+      },
+    });
+
+    const context = await contextReady.promise;
+    const stopping = handle.stop();
+    expect(context.signal.aborted).toBe(false);
+    controlledRun.resolve(createHeartbeatResult('continue', 'drained-run'));
+    await stopping;
+
+    await expect(store.listRunRecords({ taskId: task.id })).resolves.toMatchObject([{
+      runId: 'drained-run',
+      record: { outcome: { kind: 'agent' } },
+    }]);
+  });
+
+  it('applies failure policy before and after agent start while preserving old runner compatibility', async () => {
+    const beforeDir = createStateRoot('handler-failure');
+    const beforeStore = new FileHeartbeatTaskService({ dir: beforeDir });
+    await beforeStore.saveTask(createTask('handler-failure'));
+    const before = await HeartbeatSchedulerService.runDueTasks({
+      store: beforeStore,
+      now: () => NOW,
+      failureRetryMs: 5_000,
+      handler: async () => {
+        throw new Error('domain claim failed');
+      },
+    });
+    expect(before).toMatchObject({ ran: 0, failed: 1 });
+    await expect(beforeStore.requireTask('handler-failure')).resolves.toMatchObject({
+      schedule: { nextRunAt: '2026-08-01T05:00:05.000Z' },
+      state: { status: 'failed', error: 'domain claim failed', lastExecution: { kind: 'failed' } },
+    });
+
+    const afterDir = createStateRoot('agent-failure');
+    const afterStore = new FileHeartbeatTaskService({ dir: afterDir });
+    await afterStore.saveTask(createTask('agent-failure'));
+    vi.spyOn(HeartbeatRunnerAgent, 'run').mockRejectedValueOnce(new Error('agent runtime failed'));
+    const after = await HeartbeatSchedulerService.runDueTasks({
+      store: afterStore,
+      now: () => NOW,
+      handler: async (context) => await context.runAgent(),
+    });
+    expect(after).toMatchObject({ ran: 0, failed: 1 });
+    await expect(afterStore.requireTask('agent-failure')).resolves.toMatchObject({
+      state: { status: 'failed', error: 'agent runtime failed', lastExecution: { kind: 'failed' } },
+    });
+
+    vi.restoreAllMocks();
+    const legacyDir = createStateRoot('legacy');
+    const legacyStore = new FileHeartbeatTaskService({ dir: legacyDir });
+    await legacyStore.saveTask(createTask('legacy-runner'));
+    const legacy = await HeartbeatSchedulerService.runDueTasks({
+      store: legacyStore,
+      now: () => NOW,
+      runner: async (scheduledTask, checkpoint, context) => {
+        expect(scheduledTask.id).toBe('legacy-runner');
+        expect(checkpoint).toBeUndefined();
+        expect(context.runAgent).toEqual(expect.any(Function));
+        return createHeartbeatResult('continue', 'legacy-run');
+      },
+    });
+    expect(legacy).toMatchObject({ ran: 1, failed: 0 });
+  });
+
+  it('stops idempotently while idle', async () => {
+    const dir = createStateRoot('idle');
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: dir,
+      stateRoot: dir,
+      pollIntervalMs: 60_000,
+    });
+
+    const first = handle.stop({ cancelRunning: true });
+    expect(handle.stop()).toBe(first);
+    await expect(first).resolves.toBeUndefined();
+  });
+
+  it('rejects handler and deprecated runner configuration before scheduler work starts', async () => {
+    const dir = createStateRoot('invalid-handler-configuration');
+    const handler = async (context: HeartbeatExecutionContext) => context.skip({ summary: 'No work.' });
+    const runner = async () => createHeartbeatResult('continue', 'unused-run');
+
+    expect(() => HeartbeatSchedulerService.start({
+      workspaceRoot: dir,
+      stateRoot: dir,
+      handler,
+      runner,
+    })).toThrow(/either heartbeat handler or deprecated runner/);
+    await expect(HeartbeatSchedulerService.runDueTasks({
+      store: new FileHeartbeatTaskService({ dir }),
+      handler,
+      runner,
+    })).rejects.toThrow(/either heartbeat handler or deprecated runner/);
+  });
+});
+
+function createStateRoot(label: string): string {
+  return mkdtempSync(join(tmpdir(), `heddle-heartbeat-context-${label}-`));
+}
+
+function createTask(id: string): HeartbeatTask {
+  return {
+    id,
+    task: `Process ${id}.`,
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt: '2000-01-01T00:00:00.000Z',
+    },
+  };
+}
+
+function createHeartbeatResult(
+  decision: AgentHeartbeatResult['decision'],
+  runId: string,
+): AgentHeartbeatResult {
+  const summary = `Heartbeat result.\n\nHEARTBEAT_DECISION: ${decision}`;
+  const state = {
+    status: 'finished' as const,
+    runId,
+    goal: 'Heartbeat runner cycle.',
+    model: 'gpt-test',
+    provider: 'openai' as const,
+    workspaceRoot: '/tmp/project',
+    startedAt: NOW.toISOString(),
+    finishedAt: '2026-08-01T05:00:01.000Z',
+    outcome: 'done' as const,
+    summary,
+    transcript: [],
+    trace: [],
+  };
+
+  return {
+    decision,
+    summary,
+    state,
+    checkpoint: AgentLoopCheckpointService.createCheckpoint(state, {
+      createdAt: state.finishedAt,
+    }),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/src/__tests__/integration/core/heartbeat-runner-credentials.test.ts
+++ b/src/__tests__/integration/core/heartbeat-runner-credentials.test.ts
@@ -37,7 +37,15 @@ describe('custom heartbeat runner credentials', () => {
       agentOptions: { logger: capture.logger },
     });
 
-    expect(execution.contextKeys).toEqual(['runAgent']);
+    expect(execution.contextKeys).toEqual([
+      'task',
+      'checkpoint',
+      'executionId',
+      'runAt',
+      'signal',
+      'runAgent',
+      'skip',
+    ]);
     expect(execution.result).toMatchObject({ checked: 1, ran: 1, failed: 0 });
     expect(createAdapter).toHaveBeenCalledWith(expect.objectContaining({
       model: 'gpt-5.4',
@@ -223,10 +231,10 @@ async function runCustomHeartbeat(input: {
       includeDefaultTools: false,
       ...input.runtime,
     },
-    runner: async (scheduledTask, _checkpoint, context) => {
+    handler: async (context) => {
       contextKeys = Object.keys(context);
       return await context.runAgent({
-        task: `${scheduledTask.task}\n\nUse the custom host context.`,
+        task: `${context.task.task}\n\nUse the custom host context.`,
         maxSteps: 1,
         ...input.agentOptions,
       });

--- a/src/__tests__/integration/core/heartbeat-scheduler.test.ts
+++ b/src/__tests__/integration/core/heartbeat-scheduler.test.ts
@@ -302,6 +302,7 @@ describe('heartbeat scheduler', () => {
     expect(runs).toHaveLength(1);
     expect(runs?.[0]).toMatchObject({
       taskId: 'local-task',
+      executionId: 'run-pause',
       runId: 'run-pause',
       record: {
         task: {
@@ -599,6 +600,7 @@ describe('heartbeat scheduler', () => {
     const lateResult = createHeartbeatResult('continue');
     const lateTask = HeartbeatTaskStateProjector.afterResult({
       task: interruptedTask,
+      execution: originalExecution,
       result: lateResult,
       now: NOW,
       loadedCheckpoint: false,
@@ -660,7 +662,20 @@ function createMemoryTaskStore(options: {
       if (task?.state?.execution?.executionId !== input.execution.executionId) {
         return { status: 'claim-lost' };
       }
-      const record = { task: input.task, result: input.result, loadedCheckpoint: input.loadedCheckpoint };
+      if (input.signal?.aborted) {
+        return { status: 'cancelled' };
+      }
+      const record = {
+        task: input.task,
+        result: input.result,
+        loadedCheckpoint: input.loadedCheckpoint,
+        outcome: {
+          kind: 'agent' as const,
+          executionId: input.execution.executionId,
+          summary: input.result.summary,
+          finishedAt: input.result.state.finishedAt,
+        },
+      };
       tasks = [...tasks.filter((candidate) => candidate.id !== input.task.id), input.task];
       options.saveTask?.(input.task);
       options.saveCheckpoint?.(input.checkpoint);
@@ -671,9 +686,25 @@ function createMemoryTaskStore(options: {
       if (task?.state?.execution?.executionId !== input.execution.executionId) {
         return { status: 'claim-lost' };
       }
+      if (input.signal?.aborted) {
+        return { status: 'cancelled' };
+      }
       tasks = [...tasks.filter((candidate) => candidate.id !== input.task.id), input.task];
       options.saveTask?.(input.task);
       return { status: 'saved', task: input.task };
+    },
+    async recordTaskExecutionOutcome(input) {
+      const task = tasks.find((candidate) => candidate.id === input.task.id);
+      if (task?.state?.execution?.executionId !== input.execution.executionId) {
+        return { status: 'claim-lost' };
+      }
+      if (input.signal?.aborted) {
+        return { status: 'cancelled' };
+      }
+      const record = { task: input.task, outcome: input.outcome };
+      tasks = [...tasks.filter((candidate) => candidate.id !== input.task.id), input.task];
+      options.saveTask?.(input.task);
+      return { status: 'saved', task: input.task, record };
     },
     async recoverInterruptedTasks() {
       return [];

--- a/src/__tests__/unit/client-shared/notification-intent-service.test.ts
+++ b/src/__tests__/unit/client-shared/notification-intent-service.test.ts
@@ -75,10 +75,12 @@ describe('ClientSharedNotificationIntentService', () => {
             id: 'record-1',
             taskId: 'task-1',
             workspaceId: 'workspace-1',
+            executionId: 'execution-1',
             runId: 'run-2',
             createdAt: '2026-06-12T00:02:00.000Z',
             loadedCheckpoint: false,
             result: {
+              kind: 'agent',
               decision: 'complete',
               summary: 'Done.',
               outcome: 'complete',

--- a/src/__tests__/unit/core/heartbeat-lucid.test.ts
+++ b/src/__tests__/unit/core/heartbeat-lucid.test.ts
@@ -211,7 +211,12 @@ function createTaskView(): HeartbeatTaskView {
       runId: 'run_1',
       loadedCheckpoint: true,
       resumable: true,
-      result: createHeartbeatResult(),
+      result: {
+        kind: 'agent',
+        decision: 'continue',
+        summary: 'Repository check complete.',
+        outcome: 'done',
+      },
     },
   };
 }
@@ -220,10 +225,12 @@ function createRunView(): HeartbeatRunView {
   return {
     id: '2026-04-14T00-00-00.000Z-repo-check',
     taskId: 'repo-check',
+    executionId: 'execution_1',
     runId: 'run_1',
     createdAt: '2026-04-14T00:00:00.000Z',
     task: createTaskView(),
     result: {
+      kind: 'agent',
       decision: 'continue',
       summary: 'Repository check complete.',
       outcome: 'done',
@@ -260,6 +267,12 @@ function createFinishedRecord(): Extract<HeartbeatSchedulerEvent, { type: 'heart
     },
     result: createHeartbeatResult(),
     loadedCheckpoint: true,
+    outcome: {
+      kind: 'agent',
+      executionId: 'execution_1',
+      summary: 'Repository check complete.',
+      finishedAt: '2026-04-14T00:00:00.000Z',
+    },
   };
 }
 

--- a/src/__tests__/unit/core/heartbeat-views.test.ts
+++ b/src/__tests__/unit/core/heartbeat-views.test.ts
@@ -56,6 +56,7 @@ describe('heartbeat task service views', () => {
         loadedCheckpoint: true,
         resumable: true,
         result: {
+          kind: 'agent',
           decision: 'continue',
           outcome: 'done',
           summary: 'Repository check complete.',
@@ -78,6 +79,7 @@ describe('heartbeat task service views', () => {
       id: 'run_1',
       taskId: 'repo-check',
       workspaceId: 'workspace-1',
+      executionId: 'execution_1',
       runId: 'run_1',
       createdAt: '2026-04-14T00:00:00.000Z',
       loadedCheckpoint: true,
@@ -92,6 +94,7 @@ describe('heartbeat task service views', () => {
         },
       },
       result: {
+        kind: 'agent',
         decision: 'continue',
         outcome: 'done',
         summary: 'Repository check complete.',
@@ -103,6 +106,47 @@ describe('heartbeat task service views', () => {
         },
       },
     });
+  });
+
+  it('projects skipped execution records without fabricating an agent run', () => {
+    const service = new FileHeartbeatTaskService({ dir: '/tmp/heddle-heartbeat-view-test' });
+    const outcome = {
+      kind: 'skipped' as const,
+      executionId: 'execution_skip',
+      summary: 'No eligible work was available.',
+      finishedAt: '2026-04-14T00:00:00.000Z',
+    };
+    const task: HeartbeatTask = {
+      ...createTask(),
+      state: {
+        status: 'waiting',
+        progress: 'No work was available.',
+        resumable: true,
+        lastExecution: outcome,
+      },
+    };
+    const view = service.projectRunView({
+      id: '2026-04-14T00-00-00.000Z-repo-check',
+      path: '/tmp/2026-04-14T00-00-00.000Z-repo-check.json',
+      taskId: task.id,
+      workspaceId: task.workspaceId,
+      executionId: outcome.executionId,
+      createdAt: outcome.finishedAt,
+      record: { task, outcome },
+    });
+
+    expect(view).toMatchObject({
+      id: 'execution_skip',
+      executionId: 'execution_skip',
+      runId: undefined,
+      loadedCheckpoint: undefined,
+      result: {
+        kind: 'skipped',
+        outcome: 'skipped',
+        summary: 'No eligible work was available.',
+      },
+    });
+    expect(view.result.decision).toBeUndefined();
   });
 
   it('lists and loads projected views from a store', async () => {
@@ -177,12 +221,19 @@ function createRunEntry(): HeartbeatTaskRunRecordEntry {
     path: '/tmp/2026-04-14T00-00-00.000Z-repo-check.json',
     taskId: 'repo-check',
     workspaceId: 'workspace-1',
+    executionId: 'execution_1',
     runId: 'run_1',
     createdAt: '2026-04-14T00:00:00.000Z',
     record: {
       task: createTask(),
       loadedCheckpoint: true,
       result: createHeartbeatResult(),
+      outcome: {
+        kind: 'agent',
+        executionId: 'execution_1',
+        summary: 'Repository check complete.',
+        finishedAt: '2026-04-14T00:00:00.000Z',
+      },
     },
   };
 }

--- a/src/__tests__/unit/core/slash-command-modules.test.ts
+++ b/src/__tests__/unit/core/slash-command-modules.test.ts
@@ -41,11 +41,18 @@ function testHeartbeatRun(overrides: Partial<HeartbeatTaskRunRecordEntry> = {}):
     id: '2026-04-14T00-00-00.000Z-repo-check',
     path: '/tmp/run.json',
     taskId: 'repo-check',
+    executionId: 'execution_heartbeat_1',
     runId: 'run_heartbeat_1',
     createdAt: '2026-04-14T00:00:00.000Z',
     record: {
       task,
       loadedCheckpoint: true,
+      outcome: {
+        kind: 'agent',
+        executionId: 'execution_heartbeat_1',
+        summary: 'Checked the repository and found one safe next step.',
+        finishedAt: '2026-04-14T00:00:00.000Z',
+      },
       result: {
         decision: 'continue',
         summary: 'Checked the repository and found one safe next step.\n\nHEARTBEAT_DECISION: continue',

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -260,9 +260,12 @@ export {
 export type {
   FileHeartbeatTaskServiceOptions,
   HeartbeatTask,
+  HeartbeatTaskAgentRunRecord,
   HeartbeatTaskClaimResult,
   HeartbeatTaskExecution,
+  HeartbeatTaskExecutionOutcome,
   HeartbeatTaskExecutionWriteResult,
+  HeartbeatTaskNonAgentRunRecord,
   HeartbeatTaskRecovery,
   HeartbeatTaskRecoveryReason,
   HeartbeatTaskRecoveryResult,
@@ -276,6 +279,9 @@ export {
 export type {
   HeartbeatSchedulerHandle,
   HeartbeatSchedulerEvent,
+  HeartbeatExecutionContext,
+  HeartbeatHandlerOutcome,
+  HeartbeatTaskHandler,
   HeartbeatTaskRunner,
   HeartbeatTaskRunnerAgentOptions,
   HeartbeatTaskRunnerContext,
@@ -284,6 +290,7 @@ export type {
   RunDueHeartbeatTasksResult,
   RunHeartbeatSchedulerOptions,
   StartHeartbeatSchedulerOptions,
+  StopHeartbeatSchedulerOptions,
 } from './core/heartbeat/scheduler/index.js';
 export type {
   HeartbeatRunView,

--- a/src/cli-v2/commands/heartbeat/run-commands.ts
+++ b/src/cli-v2/commands/heartbeat/run-commands.ts
@@ -66,9 +66,9 @@ async function showHeartbeatRun(
 
 export function formatRunListItem(run: ControlPlaneHeartbeatRunView): string {
   return [
-    `Run ${run.runId}`,
+    `Run ${run.runId ?? run.executionId}`,
     `  task: ${run.taskId}`,
-    `  result: ${run.result.decision}, ${run.result.outcome}`,
+    `  result: ${run.result.decision ?? run.result.kind}, ${run.result.outcome}`,
     `  finished: ${formatTimestamp(run.createdAt)}`,
     run.result.usage ? `  usage: ${formatUsage(run.result.usage)}` : undefined,
     `  summary: ${truncate(firstLine(stripHeartbeatDecisionLine(run.result.summary)), 140)}`,
@@ -77,13 +77,13 @@ export function formatRunListItem(run: ControlPlaneHeartbeatRunView): string {
 
 export function formatRunDetail(run: ControlPlaneHeartbeatRunView): string {
   return [
-    `Heartbeat run ${run.runId}`,
+    `Heartbeat run ${run.runId ?? run.executionId}`,
     '',
     formatSection('Overview', [
       `task: ${run.taskId}`,
-      `result: ${run.result.decision}, ${run.result.outcome}`,
+      `result: ${run.result.decision ?? run.result.kind}, ${run.result.outcome}`,
       `finished: ${formatTimestamp(run.createdAt)}`,
-      `checkpoint: ${run.loadedCheckpoint ? 'loaded' : 'not loaded'}`,
+      `checkpoint: ${run.loadedCheckpoint === undefined ? 'not applicable' : run.loadedCheckpoint ? 'loaded' : 'not loaded'}`,
       run.result.usage ? `usage: ${formatUsage(run.result.usage)}` : undefined,
     ]),
     formatSection('Task', [run.task.task]),
@@ -137,5 +137,5 @@ async function findHeartbeatRunById(
     return runs[0] ?? null;
   }
 
-  return runs.find((run) => run.id === id || run.runId === id) ?? null;
+  return runs.find((run) => run.id === id || run.executionId === id || run.runId === id) ?? null;
 }

--- a/src/cli-v2/commands/heartbeat/task-commands.ts
+++ b/src/cli-v2/commands/heartbeat/task-commands.ts
@@ -118,7 +118,7 @@ export function formatTaskListItem(task: ControlPlaneHeartbeatTaskView): string 
     `  prompt: ${truncate(firstTextLine(task.task), 140)}`,
     state.progress ? `  progress: ${truncate(state.progress, 140)}` : undefined,
     state.runId ? `  run: ${state.runId} (${state.resumable === false ? 'not resumable' : 'resumable'}, checkpoint ${state.loadedCheckpoint ? 'loaded' : 'not loaded'})` : undefined,
-    state.result ? `  last: ${state.result.decision}, ${state.result.outcome} at ${formatTimestamp(state.runAt)}` : undefined,
+    state.result ? `  last: ${state.result.decision ?? state.result.kind}, ${state.result.outcome} at ${formatTimestamp(state.runAt)}` : undefined,
     state.result?.usage ? `  usage: ${formatUsage(state.result.usage)}` : undefined,
     state.error ? `  error: ${truncate(state.error, 140)}` : undefined,
   ].filter((line): line is string => Boolean(line)).join('\n');
@@ -139,7 +139,7 @@ export function formatTaskDetail(task: ControlPlaneHeartbeatTaskView): string {
       `next: ${formatTimestamp(task.schedule.nextRunAt)}`,
     ]),
     formatSection('Last Run', [
-      state.result ? `decision: ${state.result.decision}` : 'decision: none',
+      state.result ? `decision: ${state.result.decision ?? state.result.kind}` : 'decision: none',
       state.result ? `outcome: ${state.result.outcome}` : undefined,
       state.runAt ? `time: ${formatTimestamp(state.runAt)}` : undefined,
       state.runId ? `run id: ${state.runId}` : undefined,

--- a/src/client-shared/services/notifications/notification-intent-service.ts
+++ b/src/client-shared/services/notifications/notification-intent-service.ts
@@ -101,7 +101,7 @@ export class ClientSharedNotificationIntentService {
           'heartbeat-task-finished',
           input.workspaceId ?? input.envelope.workspaceId,
           event.taskId,
-          event.record.runId,
+          event.record.runId ?? event.executionId,
         ].join(':'),
         title: 'Task run finished',
         body: `${taskName}: ${event.record.task.state.progress ?? event.record.task.state.status}`,

--- a/src/core/commands/slash/modules/heartbeat/heartbeat-commands.ts
+++ b/src/core/commands/slash/modules/heartbeat/heartbeat-commands.ts
@@ -95,8 +95,11 @@ export function formatHeartbeatTask(task: HeartbeatTask): string {
     task.task,
     '',
     state?.progress ? `Progress: ${state.progress}` : undefined,
-    `Last decision: ${state?.result?.decision ?? 'none'}`,
-    state?.result ? `Last outcome: ${state.result.state.outcome}` : undefined,
+    `Last decision: ${state?.lastExecution && state.lastExecution.kind !== 'agent' ? state.lastExecution.kind : state?.result?.decision ?? 'none'}`,
+    state?.lastExecution ? `Last execution: ${state.lastExecution.kind}` : undefined,
+    state?.lastExecution && state.lastExecution.kind !== 'agent' ?
+      `Last outcome: ${state.lastExecution.kind}`
+    : state?.result ? `Last outcome: ${state.result.state.outcome}` : undefined,
     state?.runAt ? `Last run: ${state.runAt}` : undefined,
     state?.runId ? `Last run id: ${state.runId}` : undefined,
     state?.runId ? `Resumable: ${state.resumable === false ? 'no' : 'yes'}` : undefined,
@@ -109,6 +112,20 @@ export function formatHeartbeatTask(task: HeartbeatTask): string {
 
 export function formatHeartbeatRun(run: HeartbeatTaskRunRecordEntry): string {
   const result = run.record.result;
+  if (!result) {
+    return [
+      `Heartbeat execution ${run.id}`,
+      `task=${run.taskId} execution=${run.executionId}`,
+      `outcome=${run.record.outcome.kind} finished=${run.createdAt}`,
+      '',
+      'Task:',
+      run.record.task.task,
+      '',
+      'Summary:',
+      run.record.outcome.summary,
+    ].join('\n');
+  }
+
   return [
     `Heartbeat run ${run.id}`,
     `task=${run.taskId} run=${run.runId} loadedCheckpoint=${run.record.loadedCheckpoint}`,
@@ -125,6 +142,9 @@ export function formatHeartbeatRun(run: HeartbeatTaskRunRecordEntry): string {
 
 export function buildHeartbeatContinuationPrompt(run: HeartbeatTaskRunRecordEntry): string {
   const result = run.record.result;
+  if (!result) {
+    throw new Error(`Heartbeat execution ${run.id} has no agent run context to continue.`);
+  }
   return [
     'Continue from this heartbeat run context.',
     '',
@@ -184,6 +204,9 @@ async function continueHeartbeatRun(
   if (!run) {
     return slashMessageResult(`Heartbeat run not found for task ${request.taskId}: ${request.runRef}`);
   }
+  if (!run.record.result) {
+    return slashMessageResult(`Heartbeat execution ${run.id} was ${run.record.outcome.kind} and has no agent context to continue.`);
+  }
 
   return {
     handled: true,
@@ -223,8 +246,13 @@ function formatHeartbeatTaskListItem(task: HeartbeatTask): string {
 }
 
 function formatHeartbeatRunListItem(run: HeartbeatTaskRunRecordEntry): string {
-  const summary = firstLine(stripHeartbeatDecisionLine(run.record.result.summary));
-  return `${run.id}\n  task=${run.taskId} decision=${run.record.result.decision} outcome=${run.record.result.state.outcome} finished=${run.createdAt}\n  summary=${summary}`;
+  const result = run.record.result;
+  if (!result) {
+    return `${run.id}\n  task=${run.taskId} outcome=${run.record.outcome.kind} finished=${run.createdAt}\n  summary=${firstLine(run.record.outcome.summary)}`;
+  }
+
+  const summary = firstLine(stripHeartbeatDecisionLine(result.summary));
+  return `${run.id}\n  task=${run.taskId} decision=${result.decision} outcome=${result.state.outcome} finished=${run.createdAt}\n  summary=${summary}`;
 }
 
 function firstLine(value: string): string {

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -19,19 +19,21 @@ operator-facing heartbeat views.
   task/checkpoint/run storage and task/run projections. It is the only
   non-repository service that should instantiate `FileHeartbeatTaskRepository`.
   It also owns process-local execution claims, recovery of interrupted
-  single-host executions, and fencing of late completion/failure writes.
-  `HeartbeatTaskStateProjector` owns task state transitions after success,
-  failure, or recovery.
+  single-host executions, and fencing of late completion/failure/outcome
+  writes. `HeartbeatTaskStateProjector` owns task state transitions after
+  agent success, no-work skip, cancellation, failure, or recovery.
 - `scheduler/`: `HeartbeatSchedulerService` owns due-task selection and the
   periodic scheduler loop. It delegates execution to
   `HeartbeatTaskRunnerService` instead of running tasks itself. Daemon, CLI,
   and future hosts should start or run the scheduler through this service
   instead of constructing task repositories or duplicating loop logic.
 - `scheduler/runner.ts`: `HeartbeatTaskRunnerService` owns one task execution:
-  checkpoint loading, runner-agent invocation, checkpoint persistence, task
-  state transitions, and run history persistence. Default and custom runners
-  share its framework-owned `context.runAgent()` path, so hosts can add domain
-  prompts and tools without receiving or translating provider credentials.
+  checkpoint loading, handler invocation, runner-agent invocation, abort
+  propagation, checkpoint persistence, task state transitions, and execution
+  history persistence. Default and custom handlers share its framework-owned
+  `context.runAgent()` path, so hosts can add domain prompts and tools without
+  receiving or translating provider credentials. `context.skip()` records
+  explicit no-work without fabricating agent state.
 - `views/`: `HeartbeatLucidPresenter` owns Lucid-specific adapter messages.
   Generic task/run view projection belongs to `FileHeartbeatTaskService`,
   because that service owns the task persistence boundary.
@@ -49,7 +51,8 @@ operator-facing heartbeat views.
 
 - Keep scheduler/task persistence concerns here, not in runtime.
 - `executionId` is the fencing token for one task attempt. A store must reject
-  completion or failure when that execution no longer owns the task.
+  completion, failure, skip, or cancellation persistence when that execution
+  no longer owns the task.
 - `executionOwnerId` identifies one scheduler process/worker generation. Do not
   reuse it across process restarts: scheduler startup uses it to distinguish a
   current claim from an execution interrupted by the prior single-host process.
@@ -69,16 +72,23 @@ operator-facing heartbeat views.
   control-plane heartbeat API as the public task/run contract. Terminal command
   code should not construct `HeartbeatTask` objects, write heartbeat JSON, or run
   its own scheduler loop.
-- A custom scheduler runner may perform domain work before model execution, but
-  it should delegate model work to the execution-scoped `context.runAgent()`.
-  That callback owns model credential resolution, OAuth refresh, unattended
-  approval defaults, checkpoint continuation, and heartbeat event forwarding.
-  The callback is valid only during the current execution and must never be
-  serialized or retained by the host.
+- A custom scheduler handler may claim domain work before model execution. It
+  must either delegate model work to execution-scoped `context.runAgent()` or
+  return `context.skip()` when no work exists. The context owns model credential
+  resolution, OAuth refresh, unattended approval defaults, checkpoint
+  continuation, abort propagation, and heartbeat event forwarding. It is valid
+  only during the current execution and must never be serialized or retained by
+  the host. The positional runner API is deprecated and adapted through this
+  same pipeline.
+- `HeartbeatSchedulerService.start()` returns an awaitable, idempotent stop
+  handle. Hosts must await `stop({ cancelRunning: true })` before resetting
+  domain state. A handler that ignores its abort signal delays stop until it
+  settles; final writes remain fenced by the execution claim.
 - `heddle heartbeat run` and `heddle heartbeat start` are server-backed command
   paths. The control-plane server owns recurring scheduler lifetime; CLI
   commands may request due-task execution or keep an embedded server alive, but
   should not own recurring heartbeat execution policy.
 - When this domain is refactored further, follow the `src/core/chat/engine`
   pattern: class-backed owning services/repositories, local `types.ts` contracts,
-  schema-owned persistence validation, and no compatibility wrappers.
+  schema-owned persistence validation, and compatibility adapters only at
+  public boundaries rather than parallel internal pipelines.

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -9,6 +9,9 @@ export { HeartbeatSchedulerService, HeartbeatTaskRunnerService } from './schedul
 export type {
   HeartbeatSchedulerEvent,
   HeartbeatSchedulerHandle,
+  HeartbeatExecutionContext,
+  HeartbeatHandlerOutcome,
+  HeartbeatTaskHandler,
   HeartbeatTaskRunner,
   HeartbeatTaskRunnerAgentOptions,
   HeartbeatTaskRunnerContext,
@@ -17,16 +20,20 @@ export type {
   RunDueHeartbeatTasksResult,
   RunHeartbeatSchedulerOptions,
   StartHeartbeatSchedulerOptions,
+  StopHeartbeatSchedulerOptions,
 } from './scheduler/index.js';
 export { FileHeartbeatTaskService, HeartbeatTaskStateProjector } from './tasks/index.js';
 export type {
   CreateHeartbeatTaskInput,
   FileHeartbeatTaskServiceOptions,
   HeartbeatTask,
+  HeartbeatTaskAgentRunRecord,
   HeartbeatTaskClaimResult,
   HeartbeatTaskContinuationMode,
   HeartbeatTaskExecution,
+  HeartbeatTaskExecutionOutcome,
   HeartbeatTaskExecutionWriteResult,
+  HeartbeatTaskNonAgentRunRecord,
   HeartbeatTaskRecovery,
   HeartbeatTaskRecoveryReason,
   HeartbeatTaskRecoveryResult,

--- a/src/core/heartbeat/scheduler/index.ts
+++ b/src/core/heartbeat/scheduler/index.ts
@@ -3,6 +3,9 @@ export { HeartbeatSchedulerService } from './service.js';
 export type {
   HeartbeatSchedulerEvent,
   HeartbeatSchedulerHandle,
+  HeartbeatExecutionContext,
+  HeartbeatHandlerOutcome,
+  HeartbeatTaskHandler,
   HeartbeatTaskRunner,
   HeartbeatTaskRunnerAgentOptions,
   HeartbeatTaskRunnerContext,
@@ -11,4 +14,5 @@ export type {
   RunDueHeartbeatTasksResult,
   RunHeartbeatSchedulerOptions,
   StartHeartbeatSchedulerOptions,
+  StopHeartbeatSchedulerOptions,
 } from './types.js';

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -1,10 +1,9 @@
 /**
  * Heartbeat task runner service.
  *
- * Owns the execution of one durable heartbeat task: checkpoint loading, task
- * state transitions, runner-agent invocation, checkpoint persistence, and run
- * history persistence. The scheduler decides when a task is due; this service
- * decides how that task is executed and recorded.
+ * Owns one durable execution from claim through final claim-fenced persistence.
+ * Custom handlers may discover domain work, but credentials, agent defaults,
+ * cancellation, checkpoints, run records, and framework events stay here.
  */
 import { randomUUID } from 'node:crypto';
 import dayjs from 'dayjs';
@@ -14,9 +13,19 @@ import type { AgentLoopCheckpoint, AgentLoopState } from '@/core/runtime/loop/in
 import { HeartbeatRunnerAgent } from '../agent/index.js';
 import type { AgentHeartbeatResult, RunAgentHeartbeatOptions } from '../agent/index.js';
 import { HeartbeatTaskStateProjector } from '../tasks/index.js';
-import type { HeartbeatTask, HeartbeatTaskExecution, HeartbeatTaskRunRecord } from '../tasks/index.js';
 import type {
+  HeartbeatTask,
+  HeartbeatTaskAgentRunRecord,
+  HeartbeatTaskExecution,
+  HeartbeatTaskExecutionOutcome,
+  HeartbeatTaskNonAgentRunRecord,
+  HeartbeatTaskRunRecord,
+} from '../tasks/index.js';
+import type {
+  HeartbeatExecutionContext,
+  HeartbeatHandlerOutcome,
   HeartbeatSchedulerEvent,
+  HeartbeatTaskHandler,
   HeartbeatTaskRunner,
   HeartbeatTaskRunnerAgentOptions,
   HeartbeatTaskRunnerRuntimeOptions,
@@ -25,23 +34,43 @@ import type {
 } from './types.js';
 
 const DEFAULT_FAILURE_RETRY_MS = 5 * 60_000;
+const CANCELLATION_SUMMARY = 'Heartbeat execution cancelled by its scheduler host.';
 
 export class HeartbeatTaskRunnerService {
-  // Runs one already-selected task and persists the resulting task state, checkpoint, and run record.
+  // Runs one already-selected task and persists its final claim-fenced outcome.
   static async runTask(
-    options: Pick<RunDueHeartbeatTasksOptions, 'store' | 'runner' | 'runtime' | 'onEvent' | 'failureRetryMs' | 'executionOwnerId'> & {
+    options: Pick<RunDueHeartbeatTasksOptions,
+      | 'store'
+      | 'handler'
+      | 'runner'
+      | 'runtime'
+      | 'now'
+      | 'onEvent'
+      | 'failureRetryMs'
+      | 'executionOwnerId'
+      | 'signal'
+    > & {
       task: HeartbeatTask;
       runAt: Date;
     },
   ): Promise<{ record?: HeartbeatTaskRunRecord; failed: boolean }> {
+    HeartbeatTaskRunnerService.assertHandlerConfiguration(options);
+    if (options.signal?.aborted) {
+      return { failed: false };
+    }
+
     const { task, runAt } = options;
-    const timestamp = dayjs(runAt).toISOString();
+    const startedAt = dayjs(runAt).toISOString();
     const checkpoint = await options.store.loadCheckpoint(task);
+    if (options.signal?.aborted) {
+      return { failed: false };
+    }
+
     const loadedCheckpoint = Boolean(checkpoint);
     const execution: HeartbeatTaskExecution = {
       executionId: randomUUID(),
       ownerId: options.executionOwnerId ?? `heartbeat-worker:${randomUUID()}`,
-      claimedAt: timestamp,
+      claimedAt: startedAt,
     };
     const claim = await options.store.claimTaskExecution({
       taskId: task.id,
@@ -54,21 +83,73 @@ export class HeartbeatTaskRunnerService {
     }
 
     const runningTask = claim.task;
-    options.onEvent?.(HeartbeatTaskRunnerService.startedEvent(runningTask, execution, loadedCheckpoint, timestamp));
+    const scopeController = new AbortController();
+    const executionSignal = HeartbeatTaskRunnerService.composeExecutionSignal(options.signal, scopeController.signal);
+    options.onEvent?.(HeartbeatTaskRunnerService.startedEvent(runningTask, execution, loadedCheckpoint, startedAt));
 
     try {
-      const result = await HeartbeatTaskRunnerService.runAgent({
+      const result = await HeartbeatTaskRunnerService.invokeHandler({
         task: runningTask,
         checkpoint,
+        execution,
         runAt,
+        signal: executionSignal,
+        scopeController,
+        handler: options.handler,
         runner: options.runner,
         runtime: options.runtime,
         onEvent: options.onEvent,
       });
+      if (options.signal?.aborted) {
+        return await HeartbeatTaskRunnerService.persistCancellation({
+          ...options,
+          task: runningTask,
+          execution,
+        });
+      }
+
+      const settledAt = options.now?.() ?? dayjs().toDate();
+      if (HeartbeatTaskRunnerService.isSkippedOutcome(result)) {
+        const nextTask = HeartbeatTaskStateProjector.afterSkip({
+          task: runningTask,
+          execution,
+          summary: result.summary,
+          now: settledAt,
+        });
+        const outcome = HeartbeatTaskRunnerService.requireProjectedOutcome(nextTask, 'skipped');
+
+        const completion = await options.store.recordTaskExecutionOutcome({
+          execution,
+          task: nextTask,
+          outcome,
+          signal: options.signal,
+        });
+        if (completion.status === 'cancelled') {
+          return await HeartbeatTaskRunnerService.persistCancellation({
+            ...options,
+            task: runningTask,
+            execution,
+          });
+        }
+        if (completion.status !== 'saved' || !HeartbeatTaskRunnerService.isNonAgentRecord(completion.record, 'skipped')) {
+          return { failed: false };
+        }
+
+        options.onEvent?.({
+          type: 'heartbeat.task.skipped',
+          taskId: task.id,
+          executionId: execution.executionId,
+          record: completion.record,
+          timestamp: outcome.finishedAt,
+        });
+        return { record: completion.record, failed: false };
+      }
+
       const nextTask = HeartbeatTaskStateProjector.afterResult({
         task: runningTask,
+        execution,
         result,
-        now: runAt,
+        now: settledAt,
         loadedCheckpoint,
       });
       const completion = await options.store.completeTaskExecution({
@@ -77,34 +158,64 @@ export class HeartbeatTaskRunnerService {
         checkpoint: result.checkpoint,
         result,
         loadedCheckpoint,
+        signal: options.signal,
       });
-      if (completion.status === 'claim-lost' || !completion.record) {
+      if (completion.status === 'cancelled') {
+        return await HeartbeatTaskRunnerService.persistCancellation({
+          ...options,
+          task: runningTask,
+          execution,
+        });
+      }
+      if (completion.status !== 'saved' || !HeartbeatTaskRunnerService.isAgentRecord(completion.record)) {
         return { failed: false };
       }
 
-      const record = completion.record;
       options.onEvent?.({
         type: 'heartbeat.task.finished',
         taskId: task.id,
         executionId: execution.executionId,
-        record,
-        timestamp,
+        record: completion.record,
+        timestamp: completion.record.outcome?.finishedAt ?? result.state.finishedAt,
       });
-      return { record, failed: false };
+      return { record: completion.record, failed: false };
     } catch (error) {
+      if (options.signal?.aborted) {
+        return await HeartbeatTaskRunnerService.persistCancellation({
+          ...options,
+          task: runningTask,
+          execution,
+        });
+      }
+
+      const settledAt = options.now?.() ?? dayjs().toDate();
       const nextTask = HeartbeatTaskStateProjector.afterFailure({
         task: runningTask,
+        execution,
         error,
-        now: runAt,
+        now: settledAt,
         retryMs: options.failureRetryMs ?? DEFAULT_FAILURE_RETRY_MS,
       });
-      const failure = await options.store.failTaskExecution({ execution, task: nextTask });
+      const failure = await options.store.failTaskExecution({
+        execution,
+        task: nextTask,
+        signal: options.signal,
+      });
+      if (failure.status === 'cancelled') {
+        return await HeartbeatTaskRunnerService.persistCancellation({
+          ...options,
+          task: runningTask,
+          execution,
+        });
+      }
       if (failure.status === 'claim-lost') {
         return { failed: false };
       }
 
-      options.onEvent?.(HeartbeatTaskRunnerService.failedEvent(nextTask, execution, error, timestamp));
+      options.onEvent?.(HeartbeatTaskRunnerService.failedEvent(nextTask, execution, error, dayjs(settledAt).toISOString()));
       return { failed: true };
+    } finally {
+      scopeController.abort();
     }
   }
 
@@ -129,27 +240,108 @@ export class HeartbeatTaskRunnerService {
     };
   }
 
-  private static async runAgent(args: {
+  private static async invokeHandler(args: {
     task: HeartbeatTask;
-    checkpoint: AgentLoopState | AgentLoopCheckpoint | undefined;
+    checkpoint: AgentLoopCheckpoint | undefined;
+    execution: HeartbeatTaskExecution;
     runAt: Date;
+    signal: AbortSignal;
+    scopeController: AbortController;
+    handler?: HeartbeatTaskHandler;
     runner?: HeartbeatTaskRunner;
     runtime?: HeartbeatTaskRunnerRuntimeOptions;
     onEvent?: (event: HeartbeatSchedulerEvent) => void;
-  }): Promise<AgentHeartbeatResult> {
-    const runAgent = async (options?: HeartbeatTaskRunnerAgentOptions) => await HeartbeatRunnerAgent.run(
-      HeartbeatTaskRunnerService.resolveRunnerAgentOptions({ ...args, options }),
+  }): Promise<AgentHeartbeatResult | HeartbeatHandlerOutcome> {
+    let active = true;
+    let agentInvocation: Promise<AgentHeartbeatResult> | undefined;
+    let agentResult: AgentHeartbeatResult | undefined;
+    let skipSelected = false;
+
+    const context: HeartbeatExecutionContext = Object.freeze({
+      task: structuredClone(args.task),
+      checkpoint: args.checkpoint ? structuredClone(args.checkpoint) : undefined,
+      executionId: args.execution.executionId,
+      runAt: new Date(args.runAt),
+      signal: args.signal,
+      runAgent: async (options?: HeartbeatTaskRunnerAgentOptions) => {
+        HeartbeatTaskRunnerService.assertContextActive(active, args.execution.executionId);
+        if (skipSelected) {
+          throw new Error('Cannot run an agent after selecting a skipped heartbeat outcome.');
+        }
+        if (agentInvocation) {
+          throw new Error('Heartbeat execution context runAgent() may be called only once.');
+        }
+
+        agentInvocation = HeartbeatRunnerAgent.run(
+          HeartbeatTaskRunnerService.resolveRunnerAgentOptions({ ...args, options }),
+        );
+        agentResult = await agentInvocation;
+        return agentResult;
+      },
+      skip: (input: { summary: string }) => {
+        HeartbeatTaskRunnerService.assertContextActive(active, args.execution.executionId);
+        if (agentInvocation) {
+          throw new Error('Cannot skip a heartbeat execution after runAgent() has started.');
+        }
+        if (skipSelected) {
+          throw new Error('Heartbeat execution context skip() may be called only once.');
+        }
+
+        const summary = input.summary.trim();
+        if (!summary) {
+          throw new Error('A skipped heartbeat execution requires a non-empty summary.');
+        }
+        skipSelected = true;
+        return Object.freeze({ kind: 'skipped' as const, summary });
+      },
+    });
+
+    const legacyRunner = args.runner;
+    const handler: HeartbeatTaskHandler = args.handler ?? (
+      legacyRunner ?
+        async (handlerContext: HeartbeatExecutionContext) => await legacyRunner(
+          handlerContext.task,
+          handlerContext.checkpoint,
+          handlerContext,
+        )
+      : async (handlerContext: HeartbeatExecutionContext) => await handlerContext.runAgent()
     );
 
-    return args.runner
-      ? await args.runner(args.task, args.checkpoint, { runAgent })
-      : await runAgent();
+    try {
+      const result = await handler(context);
+      if (HeartbeatTaskRunnerService.isSkippedOutcome(result)) {
+        if (!skipSelected || agentInvocation) {
+          throw new Error('Custom heartbeat handlers must return the outcome created by context.skip().');
+        }
+        return result;
+      }
+      if (!HeartbeatTaskRunnerService.isAgentResult(result)) {
+        throw new Error('Custom heartbeat handler returned an unsupported execution outcome.');
+      }
+      if (args.handler && (!agentInvocation || result !== agentResult)) {
+        throw new Error('Custom heartbeat handlers must return the AgentHeartbeatResult produced by context.runAgent().');
+      }
+      if (agentInvocation && result !== agentResult) {
+        throw new Error('Heartbeat handler returned an agent result other than the result produced by context.runAgent().');
+      }
+      return result;
+    } catch (error) {
+      if (agentInvocation && !agentResult) {
+        args.scopeController.abort(error);
+        await agentInvocation.catch(() => undefined);
+      }
+      throw error;
+    } finally {
+      active = false;
+    }
   }
 
   private static resolveRunnerAgentOptions(args: {
     task: HeartbeatTask;
     checkpoint: AgentLoopState | AgentLoopCheckpoint | undefined;
+    execution: HeartbeatTaskExecution;
     runAt: Date;
+    signal: AbortSignal;
     runtime?: HeartbeatTaskRunnerRuntimeOptions;
     onEvent?: (event: HeartbeatSchedulerEvent) => void;
     options?: HeartbeatTaskRunnerAgentOptions;
@@ -177,18 +369,107 @@ export class HeartbeatTaskRunnerService {
       approvalPolicies: [
         ToolApprovalPolicies.unattendedLocalAutomation(),
         ...(args.runtime?.approvalPolicies ?? []),
+        ...(args.options?.approvalPolicies ?? []),
       ],
       approveToolCall: HeartbeatTaskRunnerService.denyInteractiveToolCall,
+      abortSignal: args.signal,
       onEvent: (event) => {
+        args.options?.onEvent?.(event);
         args.runtime?.onAgentEvent?.(event);
         args.onEvent?.({
           type: 'heartbeat.task.agent_event',
           taskId: args.task.id,
+          executionId: args.execution.executionId,
           event,
           timestamp: 'timestamp' in event && typeof event.timestamp === 'string' ? event.timestamp : dayjs().toISOString(),
         });
       },
     };
+  }
+
+  private static async persistCancellation(args: Pick<RunDueHeartbeatTasksOptions, 'store' | 'now' | 'onEvent'> & {
+    task: HeartbeatTask;
+    execution: HeartbeatTaskExecution;
+  }): Promise<{ record?: HeartbeatTaskRunRecord; failed: boolean }> {
+    const settledAt = args.now?.() ?? dayjs().toDate();
+    const nextTask = HeartbeatTaskStateProjector.afterCancellation({
+      task: args.task,
+      execution: args.execution,
+      summary: CANCELLATION_SUMMARY,
+      now: settledAt,
+    });
+    const outcome = HeartbeatTaskRunnerService.requireProjectedOutcome(nextTask, 'cancelled');
+
+    const completion = await args.store.recordTaskExecutionOutcome({
+      execution: args.execution,
+      task: nextTask,
+      outcome,
+    });
+    if (completion.status !== 'saved' || !HeartbeatTaskRunnerService.isNonAgentRecord(completion.record, 'cancelled')) {
+      return { failed: false };
+    }
+
+    args.onEvent?.({
+      type: 'heartbeat.task.cancelled',
+      taskId: args.task.id,
+      executionId: args.execution.executionId,
+      record: completion.record,
+      timestamp: outcome.finishedAt,
+    });
+    return { record: completion.record, failed: false };
+  }
+
+  private static composeExecutionSignal(cancellationSignal: AbortSignal | undefined, scopeSignal: AbortSignal): AbortSignal {
+    return cancellationSignal ? AbortSignal.any([cancellationSignal, scopeSignal]) : scopeSignal;
+  }
+
+  static assertHandlerConfiguration(options: Pick<RunDueHeartbeatTasksOptions, 'handler' | 'runner'>): void {
+    if (options.handler && options.runner) {
+      throw new Error('Configure either heartbeat handler or deprecated runner, not both.');
+    }
+  }
+
+  private static assertContextActive(active: boolean, executionId: string): void {
+    if (!active) {
+      throw new Error(`Heartbeat execution context ${executionId} is no longer active.`);
+    }
+  }
+
+  private static isSkippedOutcome(value: unknown): value is HeartbeatHandlerOutcome {
+    return Boolean(value && typeof value === 'object' && 'kind' in value && value.kind === 'skipped');
+  }
+
+  private static isAgentResult(value: unknown): value is AgentHeartbeatResult {
+    return Boolean(
+      value
+      && typeof value === 'object'
+      && 'decision' in value
+      && 'summary' in value
+      && 'state' in value
+      && 'checkpoint' in value,
+    );
+  }
+
+  private static isAgentRecord(record: HeartbeatTaskRunRecord | undefined): record is HeartbeatTaskAgentRunRecord {
+    return Boolean(record?.result);
+  }
+
+  private static isNonAgentRecord<K extends 'skipped' | 'cancelled'>(
+    record: HeartbeatTaskRunRecord | undefined,
+    kind: K,
+  ): record is HeartbeatTaskNonAgentRunRecord & { outcome: { kind: K } } {
+    return Boolean(record && !record.result && record.outcome?.kind === kind);
+  }
+
+  private static requireProjectedOutcome<K extends HeartbeatTaskExecutionOutcome['kind']>(
+    task: HeartbeatTask,
+    kind: K,
+  ): HeartbeatTaskExecutionOutcome & { kind: K } {
+    const outcome = task.state?.lastExecution;
+    if (outcome?.kind !== kind) {
+      throw new Error(`Heartbeat task ${task.id} did not project a ${kind} execution outcome.`);
+    }
+    return outcome as HeartbeatTaskExecutionOutcome & { kind: K };
   }
 
   private static startedEvent(

--- a/src/core/heartbeat/scheduler/service.ts
+++ b/src/core/heartbeat/scheduler/service.ts
@@ -25,10 +25,15 @@ dayjs.extend(isSameOrBefore);
 export class HeartbeatSchedulerService {
   // Starts a background scheduler loop for one workspace and returns a handle the host can stop.
   static start(options: StartHeartbeatSchedulerOptions): HeartbeatSchedulerHandle {
-    const controller = new AbortController();
+    HeartbeatTaskRunnerService.assertHandlerConfiguration(options);
+    const loopController = new AbortController();
+    const executionController = new AbortController();
     const store = new FileHeartbeatTaskService({ stateRoot: options.stateRoot });
-    void HeartbeatSchedulerService.runLoop({
+    let loopError: unknown;
+    const settledLoop = HeartbeatSchedulerService.runLoop({
       store,
+      handler: options.handler,
+      runner: options.runner,
       runtime: {
         workspaceRoot: options.workspaceRoot,
         stateDir: options.stateRoot,
@@ -40,28 +45,52 @@ export class HeartbeatSchedulerService {
         onAgentEvent: options.onAgentEvent,
       },
       pollIntervalMs: options.pollIntervalMs ?? DEFAULT_SCHEDULER_POLL_INTERVAL_MS,
-      signal: controller.signal,
+      signal: loopController.signal,
+      executionSignal: executionController.signal,
       onEvent: options.onEvent,
     }).catch((error: unknown) => {
-      options.onError?.(error);
+      loopError = error;
+      try {
+        options.onError?.(error);
+      } catch {
+        // A host error callback must not create an unhandled scheduler promise.
+      }
     });
+    let stopPromise: Promise<void> | undefined;
 
     return {
-      stop: () => controller.abort(),
+      stop: (stopOptions = {}) => {
+        loopController.abort();
+        if (stopOptions.cancelRunning) {
+          executionController.abort();
+        }
+        stopPromise ??= settledLoop.then(() => {
+          if (loopError) {
+            throw loopError;
+          }
+        });
+        return stopPromise;
+      },
     };
   }
 
   // Scans stored tasks once, picks enabled tasks whose nextRunAt is due, and delegates each selected task to the runner service.
   static async runDueTasks(options: RunDueHeartbeatTasksOptions): Promise<RunDueHeartbeatTasksResult> {
+    HeartbeatTaskRunnerService.assertHandlerConfiguration(options);
     const now = options.now?.() ?? dayjs().toDate();
     const timestamp = dayjs(now).toISOString();
     const tasks = await options.store.listTasks();
     const dueTasks = tasks.filter((task) => HeartbeatSchedulerService.isTaskDue(task, now));
     const records: HeartbeatTaskRunRecord[] = [];
+    let checked = 0;
     let failed = 0;
     const executionOwnerId = options.executionOwnerId ?? HeartbeatSchedulerService.createExecutionOwnerId();
 
     for (const task of dueTasks) {
+      if ((options.admissionSignal ?? options.signal)?.aborted) {
+        break;
+      }
+      checked++;
       options.onEvent?.({ type: 'heartbeat.task.due', taskId: task.id, timestamp });
       const result = await HeartbeatTaskRunnerService.runTask({ ...options, executionOwnerId, task, runAt: now });
       if (result.record) {
@@ -73,7 +102,7 @@ export class HeartbeatSchedulerService {
     }
 
     return {
-      checked: dueTasks.length,
+      checked,
       ran: records.length,
       failed,
       records,
@@ -104,7 +133,15 @@ export class HeartbeatSchedulerService {
       }));
 
       while (!options.signal?.aborted) {
-        await HeartbeatSchedulerService.runDueTasks({ ...options, executionOwnerId });
+        await HeartbeatSchedulerService.runDueTasks({
+          ...options,
+          executionOwnerId,
+          admissionSignal: options.signal,
+          signal: options.executionSignal ?? options.signal,
+        });
+        if (options.signal?.aborted) {
+          break;
+        }
         await (options.sleep ?? HeartbeatSchedulerService.sleep)(options.pollIntervalMs ?? DEFAULT_SCHEDULER_POLL_INTERVAL_MS, options.signal);
       }
       options.onEvent?.({ type: 'heartbeat.scheduler.stopped', reason: 'aborted', timestamp: HeartbeatSchedulerService.resolveNowIso(options) });

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -1,7 +1,14 @@
 import type { AgentLoopCheckpoint, AgentLoopState } from '@/core/runtime/loop/index.js';
 import type { LlmProvider } from '@/core/llm/types.js';
 import type { AgentHeartbeatEvent, AgentHeartbeatResult, RunAgentHeartbeatOptions } from '../agent/index.js';
-import type { HeartbeatTask, HeartbeatTaskRunRecord, HeartbeatTaskStatus, HeartbeatTaskStore } from '../tasks/index.js';
+import type {
+  HeartbeatTask,
+  HeartbeatTaskAgentRunRecord,
+  HeartbeatTaskNonAgentRunRecord,
+  HeartbeatTaskRunRecord,
+  HeartbeatTaskStatus,
+  HeartbeatTaskStore,
+} from '../tasks/index.js';
 
 export type HeartbeatSchedulerEvent =
   | { type: 'heartbeat.scheduler.started'; timestamp: string }
@@ -31,6 +38,7 @@ export type HeartbeatSchedulerEvent =
   | {
       type: 'heartbeat.task.agent_event';
       taskId: string;
+      executionId: string;
       event: AgentHeartbeatEvent;
       timestamp: string;
     }
@@ -38,7 +46,21 @@ export type HeartbeatSchedulerEvent =
       type: 'heartbeat.task.finished';
       taskId: string;
       executionId: string;
-      record: HeartbeatTaskRunRecord;
+      record: HeartbeatTaskAgentRunRecord;
+      timestamp: string;
+    }
+  | {
+      type: 'heartbeat.task.skipped';
+      taskId: string;
+      executionId: string;
+      record: HeartbeatTaskNonAgentRunRecord & { outcome: { kind: 'skipped' } };
+      timestamp: string;
+    }
+  | {
+      type: 'heartbeat.task.cancelled';
+      taskId: string;
+      executionId: string;
+      record: HeartbeatTaskNonAgentRunRecord & { outcome: { kind: 'cancelled' } };
       timestamp: string;
     }
   | {
@@ -51,12 +73,6 @@ export type HeartbeatSchedulerEvent =
       nextRunAt?: string;
       timestamp: string;
     };
-
-export type HeartbeatTaskRunner = (
-  task: HeartbeatTask,
-  checkpoint: AgentLoopState | AgentLoopCheckpoint | undefined,
-  context: HeartbeatTaskRunnerContext,
-) => Promise<AgentHeartbeatResult>;
 
 /**
  * Per-run customization accepted by the framework-owned heartbeat agent path.
@@ -79,21 +95,49 @@ export type HeartbeatTaskRunnerAgentOptions = Partial<Pick<
   | 'history'
   | 'logger'
   | 'onTraceEvent'
-  | 'shouldStop'
-  | 'abortSignal'
+  | 'onEvent'
+  | 'approvalPolicies'
 >>;
 
 /**
- * Framework-owned execution handoff for custom heartbeat runners.
+ * Framework-owned execution handoff for custom heartbeat handlers.
  *
  * Hosts can add domain prompts and tools through `runAgent` without receiving
  * API keys, OAuth tokens, account identifiers, or stored credential records.
  * The context is valid only for the current task execution and must not be
  * persisted.
  */
-export type HeartbeatTaskRunnerContext = {
+export type HeartbeatExecutionContext = {
+  task: HeartbeatTask;
+  checkpoint?: AgentLoopCheckpoint;
+  executionId: string;
+  runAt: Date;
+  signal: AbortSignal;
   runAgent: (options?: HeartbeatTaskRunnerAgentOptions) => Promise<AgentHeartbeatResult>;
+  skip: (input: { summary: string }) => HeartbeatHandlerOutcome;
 };
+
+export type HeartbeatHandlerOutcome = {
+  kind: 'skipped';
+  summary: string;
+};
+
+export type HeartbeatTaskHandler = (
+  context: HeartbeatExecutionContext,
+) => Promise<AgentHeartbeatResult | HeartbeatHandlerOutcome>;
+
+/** @deprecated Use `HeartbeatExecutionContext`. */
+export type HeartbeatTaskRunnerContext = Pick<HeartbeatExecutionContext, 'runAgent'>;
+
+/**
+ * @deprecated Use `HeartbeatTaskHandler`. This positional runner is adapted
+ * through the same execution context and persistence pipeline.
+ */
+export type HeartbeatTaskRunner = (
+  task: HeartbeatTask,
+  checkpoint: AgentLoopState | AgentLoopCheckpoint | undefined,
+  context: HeartbeatTaskRunnerContext,
+) => Promise<AgentHeartbeatResult>;
 
 export type HeartbeatTaskRunnerRuntimeOptions = {
   workspaceRoot?: string;
@@ -114,6 +158,8 @@ export type HeartbeatTaskRunnerRuntimeOptions = {
 
 export type RunDueHeartbeatTasksOptions = {
   store: HeartbeatTaskStore;
+  handler?: HeartbeatTaskHandler;
+  /** @deprecated Use `handler`. */
   runner?: HeartbeatTaskRunner;
   runtime?: HeartbeatTaskRunnerRuntimeOptions;
   now?: () => Date;
@@ -121,6 +167,10 @@ export type RunDueHeartbeatTasksOptions = {
   failureRetryMs?: number;
   /** Stable only for this scheduler process/worker generation. */
   executionOwnerId?: string;
+  /** Cancels task executions selected by this call. */
+  signal?: AbortSignal;
+  /** Stops selection of additional due tasks without cancelling the active one. */
+  admissionSignal?: AbortSignal;
 };
 
 export type RunDueHeartbeatTasksResult = {
@@ -132,12 +182,19 @@ export type RunDueHeartbeatTasksResult = {
 
 export type RunHeartbeatSchedulerOptions = RunDueHeartbeatTasksOptions & {
   pollIntervalMs?: number;
+  /** Stops future polling and admissions. Also cancels active work unless `executionSignal` is supplied. */
   signal?: AbortSignal;
+  /** Optional distinct signal used for active work when admissions and cancellation have separate lifecycles. */
+  executionSignal?: AbortSignal;
   sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
 };
 
+export type StopHeartbeatSchedulerOptions = {
+  cancelRunning?: boolean;
+};
+
 export type HeartbeatSchedulerHandle = {
-  stop: () => void;
+  stop: (options?: StopHeartbeatSchedulerOptions) => Promise<void>;
 };
 
 export type StartHeartbeatSchedulerOptions = {
@@ -149,6 +206,9 @@ export type StartHeartbeatSchedulerOptions = {
   searchIgnoreDirs?: string[];
   systemContext?: string;
   onAgentEvent?: RunAgentHeartbeatOptions['onEvent'];
+  handler?: HeartbeatTaskHandler;
+  /** @deprecated Use `handler`. */
+  runner?: HeartbeatTaskRunner;
   pollIntervalMs?: number;
   onEvent?: (event: HeartbeatSchedulerEvent) => void;
   onError?: (error: unknown) => void;

--- a/src/core/heartbeat/tasks/index.ts
+++ b/src/core/heartbeat/tasks/index.ts
@@ -7,10 +7,13 @@ export type {
 } from './service.js';
 export type {
   HeartbeatTask,
+  HeartbeatTaskAgentRunRecord,
   HeartbeatTaskClaimResult,
   HeartbeatTaskContinuationMode,
   HeartbeatTaskExecution,
+  HeartbeatTaskExecutionOutcome,
   HeartbeatTaskExecutionWriteResult,
+  HeartbeatTaskNonAgentRunRecord,
   HeartbeatTaskRecovery,
   HeartbeatTaskRecoveryReason,
   HeartbeatTaskRecoveryResult,

--- a/src/core/heartbeat/tasks/repository.ts
+++ b/src/core/heartbeat/tasks/repository.ts
@@ -95,7 +95,7 @@ export class FileHeartbeatTaskRepository {
 
   async loadRunRecord(id: string): Promise<HeartbeatTaskRunRecordEntry | undefined> {
     const entries = await this.listRunRecords();
-    return entries.find((entry) => entry.id === id || entry.runId === id);
+    return entries.find((entry) => entry.id === id || entry.executionId === id || entry.runId === id);
   }
 
   private async deleteRunRecordsForTask(taskId: string): Promise<void> {
@@ -144,14 +144,33 @@ export class FileHeartbeatTaskRepository {
 
   private static runRecordEntryFromPath(path: string, record: HeartbeatTaskRunRecord): HeartbeatTaskRunRecordEntry {
     const id = basename(path, '.json');
+    const outcome = FileHeartbeatTaskRepository.resolveRecordOutcome(record);
     return {
       id,
       path,
       taskId: record.task.id,
       workspaceId: record.task.workspaceId,
-      runId: record.result.state.runId,
-      createdAt: record.result.state.finishedAt,
+      executionId: outcome.executionId,
+      runId: record.result?.state.runId,
+      createdAt: outcome.finishedAt,
       record,
+    };
+  }
+
+  private static resolveRecordOutcome(record: HeartbeatTaskRunRecord) {
+    if (record.outcome) {
+      return record.outcome;
+    }
+
+    if (!record.result) {
+      throw new Error(`Heartbeat record for task ${record.task.id} has no execution outcome.`);
+    }
+
+    return {
+      kind: 'agent' as const,
+      executionId: record.result.state.runId,
+      summary: record.result.summary,
+      finishedAt: record.result.state.finishedAt,
     };
   }
 }

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -26,6 +26,13 @@ const HeartbeatTaskRecoverySchema = z.object({
   reason: HeartbeatTaskRecoveryReasonSchema.describe('Host-owned reason for recovering the execution.'),
 });
 
+export const HeartbeatTaskExecutionOutcomeSchema = z.object({
+  kind: z.enum(['agent', 'skipped', 'cancelled', 'failed']).describe('How this outer heartbeat execution settled.'),
+  executionId: z.string().describe('Outer heartbeat execution fencing identity.'),
+  summary: z.string().describe('Operator-facing execution outcome summary.'),
+  finishedAt: z.string().describe('Timestamp when the outer heartbeat execution settled.'),
+});
+
 export const HeartbeatTaskSchema = z.object({
   id: z.string().describe('Stable heartbeat task identifier.'),
   workspaceId: z.string().optional().describe('Workspace identifier this task belongs to.'),
@@ -57,6 +64,7 @@ export const HeartbeatTaskSchema = z.object({
     result: z.lazy(() => AgentHeartbeatResultSchema).optional().describe('Latest heartbeat runner result.'),
     error: z.string().optional().describe('Latest scheduler or runner error.'),
     execution: HeartbeatTaskExecutionSchema.optional().describe('Currently owned execution attempt and fencing identity.'),
+    lastExecution: HeartbeatTaskExecutionOutcomeSchema.optional().describe('Latest outer heartbeat execution outcome.'),
     recovery: HeartbeatTaskRecoverySchema.optional().describe('Most recent explicit interrupted-execution recovery.'),
     updatedAt: z.string().optional().describe('Timestamp when this task record was last updated.'),
   }).optional().describe('Latest scheduler/result state for this heartbeat task.'),
@@ -86,8 +94,23 @@ const AgentHeartbeatResultSchema = z.object({
   }).passthrough(),
 }).passthrough();
 
-export const HeartbeatTaskRunRecordSchema = z.object({
+const HeartbeatTaskAgentRunRecordSchema = z.object({
   task: HeartbeatTaskSchema.describe('Task state captured after this run.'),
   result: AgentHeartbeatResultSchema.describe('Heartbeat runner result.'),
   loadedCheckpoint: z.boolean().describe('Whether this run resumed from a stored checkpoint.'),
+  outcome: HeartbeatTaskExecutionOutcomeSchema.extend({
+    kind: z.literal('agent'),
+  }).optional().describe('Outer execution correlation for agent records created by current Heddle versions.'),
 });
+
+const HeartbeatTaskNonAgentRunRecordSchema = z.object({
+  task: HeartbeatTaskSchema.describe('Task state captured after this execution.'),
+  outcome: HeartbeatTaskExecutionOutcomeSchema.extend({
+    kind: z.enum(['skipped', 'cancelled']),
+  }).describe('Lightweight execution outcome with no fabricated agent state.'),
+}).strict();
+
+export const HeartbeatTaskRunRecordSchema = z.union([
+  HeartbeatTaskAgentRunRecordSchema,
+  HeartbeatTaskNonAgentRunRecordSchema,
+]);

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -9,6 +9,7 @@ import type {
   FileHeartbeatTaskRepositoryOptions,
   HeartbeatTask,
   HeartbeatTaskExecution,
+  HeartbeatTaskExecutionOutcome,
   HeartbeatTaskState,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
@@ -138,11 +139,24 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
         FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
         return { status: 'claim-lost' } as const;
       }
+      if (input.signal?.aborted) {
+        return { status: 'cancelled' } as const;
+      }
 
       const record: HeartbeatTaskRunRecord = {
         task: input.task,
         result: input.result,
         loadedCheckpoint: input.loadedCheckpoint,
+        outcome:
+          input.task.state?.lastExecution?.kind === 'agent'
+          && input.task.state.lastExecution.executionId === input.execution.executionId ?
+            input.task.state.lastExecution
+          : {
+              kind: 'agent',
+              executionId: input.execution.executionId,
+              summary: input.result.summary,
+              finishedAt: input.result.state.finishedAt,
+            },
       };
       await this.repository.saveCheckpoint(input.task, input.checkpoint);
       await this.repository.saveTask(input.task);
@@ -160,10 +174,36 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
         FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
         return { status: 'claim-lost' } as const;
       }
+      if (input.signal?.aborted) {
+        return { status: 'cancelled' } as const;
+      }
 
       await this.repository.saveTask(input.task);
       FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
       return { status: 'saved', task: input.task } as const;
+    });
+  }
+
+  /** Persists a claim-fenced non-agent outcome without creating or replacing a checkpoint. */
+  async recordTaskExecutionOutcome(input: Parameters<HeartbeatTaskStore['recordTaskExecutionOutcome']>[0]) {
+    return await this.mutationMutex.runExclusive(async () => {
+      const currentTask = await this.findTask(input.task.id);
+      if (!FileHeartbeatTaskService.executionMatches(currentTask, input.execution)) {
+        FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
+        return { status: 'claim-lost' } as const;
+      }
+      if (input.signal?.aborted) {
+        return { status: 'cancelled' } as const;
+      }
+
+      const record: HeartbeatTaskRunRecord = {
+        task: input.task,
+        outcome: input.outcome,
+      };
+      await this.repository.saveTask(input.task);
+      await this.repository.saveRunRecord(record);
+      FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
+      return { status: 'saved', task: input.task, record } as const;
     });
   }
 
@@ -439,34 +479,68 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
   }
 
   static projectRunRecordView(record: HeartbeatTaskRunRecord): HeartbeatRunView {
-    const runId = record.result.state.runId;
+    const outcome = FileHeartbeatTaskService.resolveRecordOutcome(record);
+    const runId = record.result?.state.runId;
     return {
-      id: runId,
+      id: runId ?? outcome.executionId,
       taskId: record.task.id,
+      executionId: outcome.executionId,
       runId,
       workspaceId: record.task.workspaceId,
-      createdAt: record.result.state.finishedAt,
+      createdAt: outcome.finishedAt,
       task: FileHeartbeatTaskService.projectTaskView(record.task),
-      result: FileHeartbeatTaskService.projectResultView(record.result),
+      result: record.result ?
+        FileHeartbeatTaskService.projectResultView(record.result)
+      : FileHeartbeatTaskService.projectOutcomeView(outcome),
       loadedCheckpoint: record.loadedCheckpoint,
     };
   }
 
   private static projectTaskStateView(state: HeartbeatTaskState | undefined): HeartbeatTaskView['state'] {
-    const result = state?.result;
+    const result =
+      state?.lastExecution && state.lastExecution.kind !== 'agent' ?
+        FileHeartbeatTaskService.projectOutcomeView(state.lastExecution)
+      : state?.result ? FileHeartbeatTaskService.projectResultView(state.result)
+      : state?.lastExecution ? FileHeartbeatTaskService.projectOutcomeView(state.lastExecution)
+      : undefined;
     return {
       ...omit(state ?? {}, ['result']),
       status: state?.status ?? 'idle',
-      result: result ? FileHeartbeatTaskService.projectResultView(result) : undefined,
+      result,
     };
   }
 
   private static projectResultView(result: AgentHeartbeatResult): HeartbeatTaskResultView {
     return {
+      kind: 'agent',
       decision: result.decision,
       summary: result.summary,
       outcome: result.state.outcome,
       usage: result.state.usage,
+    };
+  }
+
+  private static projectOutcomeView(outcome: HeartbeatTaskExecutionOutcome): HeartbeatTaskResultView {
+    return {
+      kind: outcome.kind,
+      summary: outcome.summary,
+      outcome: outcome.kind,
+    };
+  }
+
+  private static resolveRecordOutcome(record: HeartbeatTaskRunRecord): HeartbeatTaskExecutionOutcome {
+    if (record.outcome) {
+      return record.outcome;
+    }
+    if (!record.result) {
+      throw new Error(`Heartbeat record for task ${record.task.id} has no execution outcome.`);
+    }
+
+    return {
+      kind: 'agent',
+      executionId: record.result.state.runId,
+      summary: record.result.summary,
+      finishedAt: record.result.state.finishedAt,
     };
   }
 

--- a/src/core/heartbeat/tasks/task-state.ts
+++ b/src/core/heartbeat/tasks/task-state.ts
@@ -13,6 +13,7 @@ import type {
   HeartbeatTask,
   HeartbeatTaskContinuationMode,
   HeartbeatTaskExecution,
+  HeartbeatTaskExecutionOutcome,
   HeartbeatTaskRecovery,
   HeartbeatTaskRecoveryReason,
   HeartbeatTaskState,
@@ -98,6 +99,7 @@ export class HeartbeatTaskStateProjector {
 
   static afterResult(args: {
     task: HeartbeatTask;
+    execution: HeartbeatTaskExecution;
     result: AgentHeartbeatResult;
     now: Date;
     loadedCheckpoint: boolean;
@@ -128,6 +130,12 @@ export class HeartbeatTaskStateProjector {
         resumable: args.result.decision !== 'complete' || continuationMode === 'operator',
         result: args.result,
         error: undefined,
+        lastExecution: HeartbeatTaskStateProjector.executionOutcome({
+          kind: 'agent',
+          execution: args.execution,
+          summary: args.result.summary,
+          finishedAt: dayjs(args.now).toISOString(),
+        }),
         recovery: args.task.state?.recovery,
         updatedAt: dayjs(args.now).toISOString(),
       },
@@ -136,10 +144,12 @@ export class HeartbeatTaskStateProjector {
 
   static afterFailure(args: {
     task: HeartbeatTask;
+    execution: HeartbeatTaskExecution;
     error: unknown;
     now: Date;
     retryMs: number;
   }): HeartbeatTask {
+    const summary = args.error instanceof Error ? args.error.message : String(args.error);
     return HeartbeatTaskStateProjector.normalize({
       ...args.task,
       schedule: {
@@ -151,9 +161,83 @@ export class HeartbeatTaskStateProjector {
         status: 'failed',
         progress: 'Heartbeat runner failed and will retry later.',
         runAt: dayjs(args.now).toISOString(),
-        error: args.error instanceof Error ? args.error.message : String(args.error),
+        error: summary,
         execution: undefined,
+        lastExecution: HeartbeatTaskStateProjector.executionOutcome({
+          kind: 'failed',
+          execution: args.execution,
+          summary,
+          finishedAt: dayjs(args.now).toISOString(),
+        }),
         updatedAt: dayjs(args.now).toISOString(),
+      },
+    });
+  }
+
+  static afterSkip(args: {
+    task: HeartbeatTask;
+    execution: HeartbeatTaskExecution;
+    summary: string;
+    now: Date;
+  }): HeartbeatTask {
+    const finishedAt = dayjs(args.now).toISOString();
+    return HeartbeatTaskStateProjector.normalize({
+      ...args.task,
+      schedule: {
+        ...args.task.schedule,
+        nextRunAt: args.task.enabled ? dayjs(args.now).add(args.task.schedule.intervalMs, 'millisecond').toISOString() : undefined,
+      },
+      state: {
+        status: args.task.enabled ? 'waiting' : 'idle',
+        progress: args.task.enabled ?
+          `No work was available. Waiting until the next scheduled run in ${HeartbeatTaskStateProjector.formatDelay(args.task.schedule.intervalMs)}.`
+        : 'No work was available. Task remains disabled.',
+        runAt: finishedAt,
+        resumable: true,
+        error: undefined,
+        execution: undefined,
+        lastExecution: HeartbeatTaskStateProjector.executionOutcome({
+          kind: 'skipped',
+          execution: args.execution,
+          summary: args.summary,
+          finishedAt,
+        }),
+        recovery: args.task.state?.recovery,
+        updatedAt: finishedAt,
+      },
+    });
+  }
+
+  static afterCancellation(args: {
+    task: HeartbeatTask;
+    execution: HeartbeatTaskExecution;
+    summary: string;
+    now: Date;
+  }): HeartbeatTask {
+    const finishedAt = dayjs(args.now).toISOString();
+    return HeartbeatTaskStateProjector.normalize({
+      ...args.task,
+      schedule: {
+        ...args.task.schedule,
+        nextRunAt: args.task.enabled ? dayjs(args.now).subtract(1, 'second').toISOString() : undefined,
+      },
+      state: {
+        status: args.task.enabled ? 'waiting' : 'idle',
+        progress: args.task.enabled ?
+          'Heartbeat execution was cancelled. Waiting for retry.'
+        : 'Heartbeat execution was cancelled. Task remains disabled.',
+        runAt: finishedAt,
+        resumable: true,
+        error: undefined,
+        execution: undefined,
+        lastExecution: HeartbeatTaskStateProjector.executionOutcome({
+          kind: 'cancelled',
+          execution: args.execution,
+          summary: args.summary,
+          finishedAt,
+        }),
+        recovery: args.task.state?.recovery,
+        updatedAt: finishedAt,
       },
     });
   }
@@ -248,5 +332,19 @@ export class HeartbeatTaskStateProjector {
       return `${delay.asSeconds()}s`;
     }
     return `${ms}ms`;
+  }
+
+  private static executionOutcome(args: {
+    kind: HeartbeatTaskExecutionOutcome['kind'];
+    execution: HeartbeatTaskExecution;
+    summary: string;
+    finishedAt: string;
+  }): HeartbeatTaskExecutionOutcome {
+    return {
+      kind: args.kind,
+      executionId: args.execution.executionId,
+      summary: args.summary,
+      finishedAt: args.finishedAt,
+    };
   }
 }

--- a/src/core/heartbeat/tasks/types.ts
+++ b/src/core/heartbeat/tasks/types.ts
@@ -30,10 +30,10 @@ export type HeartbeatTaskRuntime = Pick<
 /**
  * Identifies one owned attempt to execute a heartbeat task.
  *
- * Hosted stores must treat `executionId` as a fencing token: completion and
- * failure writes are valid only while this exact execution still owns the
- * task. `ownerId` identifies the scheduler process/worker generation for
- * operator diagnostics and explicit recovery.
+ * Hosted stores must treat `executionId` as a fencing token: completion,
+ * failure, skip, and cancellation writes are valid only while this exact
+ * execution still owns the task. `ownerId` identifies the scheduler process/
+ * worker generation for operator diagnostics and explicit recovery.
  */
 export type HeartbeatTaskExecution = {
   executionId: string;
@@ -50,6 +50,19 @@ export type HeartbeatTaskRecovery = {
   reason: HeartbeatTaskRecoveryReason;
 };
 
+type HeartbeatTaskExecutionOutcomeBase = {
+  executionId: string;
+  summary: string;
+  finishedAt: string;
+};
+
+export type HeartbeatTaskExecutionOutcome = HeartbeatTaskExecutionOutcomeBase & (
+  | { kind: 'agent' }
+  | { kind: 'skipped' }
+  | { kind: 'cancelled' }
+  | { kind: 'failed' }
+);
+
 export type HeartbeatTaskState = {
   status?: HeartbeatTaskStatus;
   progress?: string;
@@ -60,6 +73,7 @@ export type HeartbeatTaskState = {
   result?: AgentHeartbeatResult;
   error?: string;
   execution?: HeartbeatTaskExecution;
+  lastExecution?: HeartbeatTaskExecutionOutcome;
   recovery?: HeartbeatTaskRecovery;
   updatedAt?: string;
 };
@@ -77,18 +91,30 @@ export type HeartbeatTask = {
   state?: HeartbeatTaskState;
 };
 
-export type HeartbeatTaskRunRecord = {
+export type HeartbeatTaskAgentRunRecord = {
   task: HeartbeatTask;
   result: AgentHeartbeatResult;
   loadedCheckpoint: boolean;
+  /** Present on records created after execution correlation was introduced. */
+  outcome?: HeartbeatTaskExecutionOutcome & { kind: 'agent' };
 };
+
+export type HeartbeatTaskNonAgentRunRecord = {
+  task: HeartbeatTask;
+  outcome: HeartbeatTaskExecutionOutcome & { kind: 'skipped' | 'cancelled' };
+  result?: never;
+  loadedCheckpoint?: never;
+};
+
+export type HeartbeatTaskRunRecord = HeartbeatTaskAgentRunRecord | HeartbeatTaskNonAgentRunRecord;
 
 export type HeartbeatTaskRunRecordEntry = {
   id: string;
   path: string;
   taskId: string;
   workspaceId?: string;
-  runId: string;
+  executionId: string;
+  runId?: string;
   createdAt: string;
   record: HeartbeatTaskRunRecord;
 };
@@ -99,7 +125,7 @@ export type HeartbeatTaskClaimResult =
 
 export type HeartbeatTaskExecutionWriteResult =
   | { status: 'saved'; task: HeartbeatTask; record?: HeartbeatTaskRunRecord }
-  | { status: 'claim-lost' };
+  | { status: 'claim-lost' | 'cancelled' };
 
 export type HeartbeatTaskRecoveryResult = {
   task: HeartbeatTask;
@@ -123,10 +149,18 @@ export type HeartbeatTaskStore = {
     checkpoint: AgentLoopCheckpoint;
     result: AgentHeartbeatResult;
     loadedCheckpoint: boolean;
+    signal?: AbortSignal;
   }) => Promise<HeartbeatTaskExecutionWriteResult>;
   failTaskExecution: (input: {
     execution: HeartbeatTaskExecution;
     task: HeartbeatTask;
+    signal?: AbortSignal;
+  }) => Promise<HeartbeatTaskExecutionWriteResult>;
+  recordTaskExecutionOutcome: (input: {
+    execution: HeartbeatTaskExecution;
+    task: HeartbeatTask;
+    outcome: HeartbeatTaskExecutionOutcome & { kind: 'skipped' | 'cancelled' };
+    signal?: AbortSignal;
   }) => Promise<HeartbeatTaskExecutionWriteResult>;
   recoverInterruptedTasks: (input: {
     ownerId: string;

--- a/src/core/heartbeat/views/lucid-presenter.ts
+++ b/src/core/heartbeat/views/lucid-presenter.ts
@@ -104,6 +104,15 @@ export class HeartbeatLucidPresenter {
           HeartbeatLucidPresenter.responseMessage(agentId, result.summary, event.timestamp),
         ];
       }
+      case 'heartbeat.task.skipped':
+      case 'heartbeat.task.cancelled': {
+        const { task, outcome } = event.record;
+        return [
+          HeartbeatLucidPresenter.statusMessage(agentId, HeartbeatLucidPresenter.taskStatusToLucidStatus(task.state?.status ?? 'waiting'), event.timestamp),
+          HeartbeatLucidPresenter.progressMessage(agentId, task.state?.progress ?? '', event.timestamp),
+          HeartbeatLucidPresenter.responseMessage(agentId, outcome.summary, event.timestamp),
+        ];
+      }
       case 'heartbeat.task.failed':
         return [
           HeartbeatLucidPresenter.statusMessage(agentId, HeartbeatLucidPresenter.taskStatusToLucidStatus(event.status), event.timestamp),

--- a/src/core/heartbeat/views/types.ts
+++ b/src/core/heartbeat/views/types.ts
@@ -3,7 +3,8 @@ import type { HeartbeatDecision } from '../agent/index.js';
 import type { HeartbeatTask, HeartbeatTaskState, HeartbeatTaskStatus } from '../tasks/index.js';
 
 export type HeartbeatTaskResultView = {
-  decision: HeartbeatDecision;
+  kind: 'agent' | 'skipped' | 'cancelled' | 'failed';
+  decision?: HeartbeatDecision;
   summary: string;
   outcome: string;
   usage?: LlmUsage;
@@ -21,11 +22,12 @@ export type HeartbeatRunView = {
   id: string;
   taskId: string;
   workspaceId?: string;
-  runId: string;
+  executionId: string;
+  runId?: string;
   createdAt: string;
   task: HeartbeatTaskView;
   result: HeartbeatTaskResultView;
-  loadedCheckpoint: boolean;
+  loadedCheckpoint?: boolean;
 };
 
 export type LucidAgentStatus = 'running' | 'paused' | 'asleep' | 'terminated' | 'blocked' | 'failed';

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -318,11 +318,19 @@ export type ControlPlaneHeartbeatEvent =
   | {
     type: 'heartbeat.task.agent_event';
     taskId: string;
+    executionId: string;
     event: ControlPlaneHeartbeatAgentEvent;
     timestamp: string;
   }
   | {
     type: 'heartbeat.task.finished';
+    taskId: string;
+    executionId: string;
+    record: HeartbeatRunView;
+    timestamp: string;
+  }
+  | {
+    type: 'heartbeat.task.skipped' | 'heartbeat.task.cancelled';
     taskId: string;
     executionId: string;
     record: HeartbeatRunView;

--- a/src/server/controllers/trpc/control-plane/heartbeat-events.ts
+++ b/src/server/controllers/trpc/control-plane/heartbeat-events.ts
@@ -64,7 +64,11 @@ export class ControlPlaneHeartbeatEventsController {
   }
 
   private static projectEvent(event: HeartbeatSchedulerEvent): ControlPlaneHeartbeatEvent {
-    if (event.type === 'heartbeat.task.finished') {
+    if (
+      event.type === 'heartbeat.task.finished'
+      || event.type === 'heartbeat.task.skipped'
+      || event.type === 'heartbeat.task.cancelled'
+    ) {
       return {
         ...event,
         record: FileHeartbeatTaskService.projectRunRecordView(event.record),

--- a/src/server/controllers/trpc/control-plane/heartbeat.ts
+++ b/src/server/controllers/trpc/control-plane/heartbeat.ts
@@ -3,6 +3,7 @@ import {
   HeartbeatSchedulerService,
   HeartbeatTaskRunnerService,
   type HeartbeatSchedulerEvent,
+  type HeartbeatTaskHandler,
   type HeartbeatTaskRunner,
 } from '@/core/heartbeat/index.js';
 
@@ -45,11 +46,12 @@ type RunHeartbeatTaskNowArgs = {
   maxSteps?: number;
   searchIgnoreDirs?: string[];
   systemContext?: string;
+  handler?: HeartbeatTaskHandler;
   runner?: HeartbeatTaskRunner;
   onEvent?: (event: HeartbeatSchedulerEvent) => void;
 };
 
-type RunDueHeartbeatTasksArgs = Omit<RunHeartbeatTaskNowArgs, 'taskId' | 'runner'>;
+type RunDueHeartbeatTasksArgs = Omit<RunHeartbeatTaskNowArgs, 'taskId' | 'handler' | 'runner'>;
 
 export class ControlPlaneHeartbeatController {
   static async listTasks(stateRoot: string) {
@@ -122,9 +124,10 @@ export class ControlPlaneHeartbeatController {
     const result = await HeartbeatTaskRunnerService.runTaskById({
       store: tasks,
       taskId: args.taskId,
+      handler: args.handler,
       runner: args.runner,
       onEvent: args.onEvent,
-      runtime: args.runner ? undefined : {
+      runtime: {
         apiKey: args.apiKey,
         apiKeyProvider: args.apiKey ? 'explicit' : undefined,
         model: args.model,

--- a/src/server/heartbeat-scheduler-host.ts
+++ b/src/server/heartbeat-scheduler-host.ts
@@ -26,6 +26,8 @@ type WorkspaceSchedulerHandle = {
 
 export class HeddleHeartbeatSchedulerHost {
   private readonly schedulers = new Map<string, WorkspaceSchedulerHandle>();
+  private readonly stoppingSchedulers = new Map<string, Promise<void>>();
+  private stopPromise?: Promise<void>;
 
   constructor(private readonly options: HeddleHeartbeatSchedulerHostOptions) {}
 
@@ -34,6 +36,10 @@ export class HeddleHeartbeatSchedulerHost {
   }
 
   sync(): void {
+    if (this.stopPromise) {
+      return;
+    }
+
     const context = RuntimeWorkspaceService.resolveContext({
       workspaceRoot: this.options.workspaceRoot,
       stateRoot: this.options.stateRoot,
@@ -44,7 +50,7 @@ export class HeddleHeartbeatSchedulerHost {
     ]));
 
     workspacesByKey.forEach((workspace, key) => {
-      if (!this.schedulers.has(key)) {
+      if (!this.schedulers.has(key) && !this.stoppingSchedulers.has(key)) {
         this.schedulers.set(key, {
           workspace,
           scheduler: this.startWorkspaceScheduler(workspace),
@@ -55,14 +61,13 @@ export class HeddleHeartbeatSchedulerHost {
     [...this.schedulers.entries()]
       .filter(([key]) => !workspacesByKey.has(key))
       .forEach(([key, handle]) => {
-        handle.scheduler.stop();
-        this.schedulers.delete(key);
+        this.stopRemovedWorkspaceScheduler(key, handle);
       });
   }
 
-  stop(): void {
-    this.schedulers.forEach((handle) => handle.scheduler.stop());
-    this.schedulers.clear();
+  stop(): Promise<void> {
+    this.stopPromise ??= this.stopAllSchedulers();
+    return this.stopPromise;
   }
 
   private startWorkspaceScheduler(workspace: WorkspaceDescriptor): HeartbeatSchedulerHandle {
@@ -74,6 +79,27 @@ export class HeddleHeartbeatSchedulerHost {
       onEvent: (event) => this.options.onEvent?.(workspace, event),
       onError: (error) => this.options.onError?.(workspace, error),
     });
+  }
+
+  private stopRemovedWorkspaceScheduler(key: string, handle: WorkspaceSchedulerHandle): void {
+    this.schedulers.delete(key);
+    const stopping = handle.scheduler.stop({ cancelRunning: true })
+      .catch((error: unknown) => {
+        this.options.onError?.(handle.workspace, error);
+      })
+      .finally(() => {
+        this.stoppingSchedulers.delete(key);
+      });
+    this.stoppingSchedulers.set(key, stopping);
+  }
+
+  private async stopAllSchedulers(): Promise<void> {
+    const active = [...this.schedulers.values()];
+    this.schedulers.clear();
+    await Promise.all([
+      ...this.stoppingSchedulers.values(),
+      ...active.map(async (handle) => await handle.scheduler.stop({ cancelRunning: true })),
+    ]);
   }
 
   private static workspaceKey(workspace: WorkspaceDescriptor): string {

--- a/src/server/lifecycle.ts
+++ b/src/server/lifecycle.ts
@@ -67,7 +67,7 @@ export async function startHeddleControlPlaneServer(
     },
   });
 
-  let cleanedUp = false;
+  let cleanupPromise: Promise<void> | undefined;
   const lifecycleTimers: { heartbeat?: NodeJS.Timeout } = {};
   const registerServer = (lastSeenAt?: string) => {
     const workspaceContext = RuntimeWorkspaceService.resolveContext({
@@ -91,25 +91,30 @@ export async function startHeddleControlPlaneServer(
       },
     });
   };
-  const cleanup = () => {
-    if (cleanedUp) {
-      return;
-    }
-
-    cleanedUp = true;
-    if (lifecycleTimers.heartbeat) {
-      clearInterval(lifecycleTimers.heartbeat);
-    }
-    heartbeatSchedulerHost?.stop();
-    RuntimeDaemonRegistryService.clearLiveServer({
-      registryPath,
-      serverId,
-    });
+  const cleanup = (): Promise<void> => {
+    cleanupPromise ??= (async () => {
+      if (lifecycleTimers.heartbeat) {
+        clearInterval(lifecycleTimers.heartbeat);
+      }
+      try {
+        await heartbeatSchedulerHost?.stop();
+      } finally {
+        RuntimeDaemonRegistryService.clearLiveServer({
+          registryPath,
+          serverId,
+        });
+      }
+    })();
+    return cleanupPromise;
   };
 
   const server = await listen(app, options.host, options.port);
   endpoint.port = resolveListeningPort(server, options.port);
-  server.once('close', cleanup);
+  server.once('close', () => {
+    void cleanup().catch((error: unknown) => {
+      logger.error({ error, serverId }, 'Failed to clean up Heddle server lifecycle');
+    });
+  });
   server.on('error', (error) => {
     logger.error({ error, serverId }, 'Heddle server emitted an error');
   });
@@ -120,6 +125,9 @@ export async function startHeddleControlPlaneServer(
   } catch (error) {
     await closeServer(server).catch((closeError) => {
       logger.error({ error: closeError, serverId }, 'Failed to close Heddle server after startup error');
+    });
+    await cleanup().catch((cleanupError) => {
+      logger.error({ error: cleanupError, serverId }, 'Failed to clean up Heddle server after startup error');
     });
     throw error;
   }
@@ -136,9 +144,17 @@ export async function startHeddleControlPlaneServer(
 
   let closePromise: Promise<void> | undefined;
   const close = () => {
-    closePromise ??= closeServer(server).then(() => {
-      cleanup();
-    });
+    closePromise ??= (async () => {
+      const closeResults = await Promise.allSettled([
+        heartbeatSchedulerHost?.stop() ?? Promise.resolve(),
+        closeServer(server),
+      ]);
+      const [cleanupResult] = await Promise.allSettled([cleanup()]);
+      const failure = [...closeResults, cleanupResult].find((result) => result.status === 'rejected');
+      if (failure?.status === 'rejected') {
+        throw failure.reason;
+      }
+    })();
     return closePromise;
   };
 
@@ -243,6 +259,8 @@ function logHeartbeatSchedulerEvent(
     'heartbeat.task.recovered': 'Heartbeat task recovered after interrupted execution',
     'heartbeat.task.agent_event': 'Heartbeat task agent event',
     'heartbeat.task.finished': 'Heartbeat task finished',
+    'heartbeat.task.skipped': 'Heartbeat task skipped because no work was available',
+    'heartbeat.task.cancelled': 'Heartbeat task execution cancelled',
     'heartbeat.task.failed': 'Heartbeat task failed',
   } satisfies Record<HeartbeatSchedulerEvent['type'], string>;
 

--- a/src/web-v2/components/tasks/TaskRunDetailsPanel.tsx
+++ b/src/web-v2/components/tasks/TaskRunDetailsPanel.tsx
@@ -56,10 +56,10 @@ export function TaskRunDetailsPanel({
             </section>
             <TaskDetailRows
               rows={[
-                ['decision', run.result.decision],
+                ['decision', run.result.decision ?? run.result.kind],
                 ['outcome', run.result.outcome],
                 ['usage', formatUsage(run.result.usage)],
-                ['checkpoint', run.loadedCheckpoint ? 'loaded' : 'not loaded'],
+                ['checkpoint', run.loadedCheckpoint === undefined ? 'not applicable' : run.loadedCheckpoint ? 'loaded' : 'not loaded'],
               ]}
             />
             <TaskMarkdownBlock title="Task result" body={run.result.summary} />

--- a/src/web-v2/components/tasks/TaskRunList.tsx
+++ b/src/web-v2/components/tasks/TaskRunList.tsx
@@ -41,7 +41,7 @@ export function TaskRunList({
         <TaskRunListItem
           key={run.id}
           run={run}
-          selected={run.runId === selectedRunId || run.id === selectedRunId}
+          selected={run.id === selectedRunId || run.executionId === selectedRunId || run.runId === selectedRunId}
           onSelectRun={onSelectRun}
         />
       ))}
@@ -103,14 +103,14 @@ function TaskRunListItem({
         'v2-task-run-row group min-w-0 text-left outline-none transition-colors hover:bg-accent/45 focus-visible:ring-1 focus-visible:ring-ring',
         selected && 'bg-accent/55',
       )}
-      onClick={() => onSelectRun(run.runId)}
+      onClick={() => onSelectRun(run.id)}
     >
       <span className="flex min-w-0 items-center gap-2">
         <span className="v2-type-nav-primary truncate text-foreground">{formatTaskTimestamp(run.createdAt)}</span>
       </span>
       <span className="mt-1 flex min-w-0 items-center gap-2">
         <span className="v2-type-caption shrink-0 rounded-sm border border-border bg-muted/20 px-1.5 py-0.5 text-muted-foreground">
-          {run.result.decision}
+          {run.result.decision ?? run.result.kind}
         </span>
         <span className="v2-type-nav-secondary truncate text-muted-foreground">{runDisplaySummary(run)}</span>
       </span>

--- a/src/web-v2/components/tasks/task-format.ts
+++ b/src/web-v2/components/tasks/task-format.ts
@@ -37,7 +37,7 @@ export function formatTaskTimestamp(value: string | undefined): string {
 }
 
 export function runDisplaySummary(run: ControlPlaneHeartbeatRunView): string {
-  return run.result.summary || run.result.outcome || run.task.state.progress || run.result.decision;
+  return run.result.summary || run.result.outcome || run.task.state.progress || run.result.decision || run.result.kind;
 }
 
 export function formatUsage(usage: ControlPlaneHeartbeatRunView['result']['usage']): string {

--- a/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
@@ -45,14 +45,18 @@ export function useControlPlaneHeartbeatEvents({
     onNotificationIntent?.(ClientSharedNotificationIntentService.projectHeartbeatEnvelope({ workspaceId, envelope }));
     setLiveTasks((current) => applyHeartbeatEvent(current, event));
 
-    if (event.type === 'heartbeat.task.finished') {
+    if (
+      event.type === 'heartbeat.task.finished'
+      || event.type === 'heartbeat.task.skipped'
+      || event.type === 'heartbeat.task.cancelled'
+    ) {
       void utils.controlPlane.heartbeatTasks.invalidate(workspaceId ? { workspaceId } : undefined);
       void utils.controlPlane.heartbeatTask.invalidate(workspaceId ? { workspaceId, taskId: event.taskId } : { taskId: event.taskId });
       void utils.controlPlane.state.invalidate();
       void utils.controlPlane.heartbeatRun.invalidate({
         workspaceId,
         taskId: event.taskId,
-        runId: event.record.runId,
+        runId: event.record.runId ?? event.record.id,
       });
     }
 
@@ -144,6 +148,14 @@ function projectHeartbeatTaskEvent(
         status: event.record.task.state.status,
         progress: event.record.task.state.progress ?? 'Heartbeat runner finished.',
         runId: event.record.runId,
+      };
+    case 'heartbeat.task.skipped':
+    case 'heartbeat.task.cancelled':
+      return {
+        ...base,
+        status: event.record.task.state.status,
+        progress: event.record.task.state.progress ?? event.record.result.summary,
+        runId: undefined,
       };
     case 'heartbeat.task.failed':
       return {

--- a/src/web-v2/hooks/tasks/useControlPlaneTaskDetail.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneTaskDetail.ts
@@ -42,5 +42,5 @@ function resolveSelectedRun(
     return runs[0];
   }
 
-  return runs.find((run) => run.runId === selectedRunId || run.id === selectedRunId) ?? runs[0];
+  return runs.find((run) => run.id === selectedRunId || run.executionId === selectedRunId || run.runId === selectedRunId) ?? runs[0];
 }

--- a/src/web-v2/hooks/tasks/useControlPlaneTaskSelection.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneTaskSelection.ts
@@ -19,7 +19,7 @@ export function useControlPlaneTaskSelection({
 }) {
   const detail = useControlPlaneTaskDetail(workspaceId, navigation.selectedTaskId, navigation.selectedTaskRunId);
   const task = detail.task ? applyLiveTaskState(detail.task, taskEvents.liveTasks[detail.task.taskId]) : undefined;
-  const selectedRunId = navigation.selectedTaskRunId ?? detail.selectedRun?.runId;
+  const selectedRunId = navigation.selectedTaskRunId ?? detail.selectedRun?.id;
   const runDetail = useControlPlaneTaskRunDetail(
     workspaceId,
     navigation.selectedTaskId,


### PR DESCRIPTION
## Summary

- add a one-object heartbeat handler context with task/checkpoint identity, executionId, runAt, framework cancellation, runAgent, and zero-model skip
- keep credentials, runtime defaults, approval policy, checkpoint/run persistence, and correlated agent events inside Heddle
- persist skipped and cancelled executions as lightweight outer outcomes without fabricated agent state or run IDs
- make scheduler and server-host stop awaitable, idempotent, and optionally cancelling while preserving claim fencing
- retain the positional runner as a deprecated adapter through the same internal execution pipeline
- update control-plane/CLI/web projections, service documentation, and the domain-neutral scheduler example

## Verification

- yarn typecheck
- yarn client:build
- yarn lint
- yarn test (806 unit tests, 362 integration tests)
- HEDDLE_EXAMPLE_NO_WORK=true yarn example:heartbeat-scheduler

Closes #298