### PR TITLE
Fix CLI workspace session selection

### DIFF
--- a/src/__tests__/integration/control-plane/workspace-catalog.test.ts
+++ b/src/__tests__/integration/control-plane/workspace-catalog.test.ts
@@ -120,6 +120,35 @@ describe('workspace catalog', () => {
     });
   });
 
+  it('resolves the command workspace by root without changing the persisted web selection', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-workspace-command-root-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const primary = RuntimeWorkspaceService.ensureCatalog({ workspaceRoot, stateRoot }).workspaces[0];
+    if (!primary) {
+      throw new Error('expected primary workspace');
+    }
+
+    RuntimeWorkspaceService.createDescriptor({
+      workspaceRoot,
+      stateRoot,
+      name: 'Web-selected workspace',
+      newWorkspaceRoot: join(workspaceRoot, 'web-selected'),
+      setActive: true,
+      nextId: 'workspace-web-selected',
+    });
+
+    const commandContext = RuntimeWorkspaceService.resolveContextForRoot({ workspaceRoot, stateRoot });
+    expect(commandContext.activeWorkspace).toMatchObject({
+      id: primary.id,
+      workspaceRoot,
+      stateRoot,
+    });
+
+    const webContext = RuntimeWorkspaceService.resolveContext({ workspaceRoot, stateRoot });
+    expect(webContext.activeWorkspaceId).toBe('workspace-web-selected');
+    expect(webContext.catalog.activeWorkspaceId).toBe('workspace-web-selected');
+  });
+
   it('can rename a workspace', () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-workspace-rename-'));
     const stateRoot = join(workspaceRoot, '.heddle');

--- a/src/cli-v2/main.ts
+++ b/src/cli-v2/main.ts
@@ -348,7 +348,7 @@ function resolveCliOptions(flags: RootCliOptions): ResolvedCliOptions {
   const workspaceRoot = resolve(flags.cwd ?? process.cwd());
   const projectConfig = ProjectConfigService.read(workspaceRoot);
   const stateRoot = resolve(workspaceRoot, projectConfig.stateDir ?? '.heddle');
-  const workspaceContext = RuntimeWorkspaceService.resolveContext({
+  const workspaceContext = RuntimeWorkspaceService.resolveContextForRoot({
     workspaceRoot,
     stateRoot,
   });

--- a/src/core/runtime/workspaces/README.md
+++ b/src/core/runtime/workspaces/README.md
@@ -5,3 +5,10 @@ creating, and renaming runtime workspaces.
 
 Host surfaces should call `RuntimeWorkspaceService`. File I/O stays behind
 `FileWorkspaceRepository`, and the JSON contract lives in `schemas.ts`.
+
+`resolveContext()` follows the catalog's persisted active workspace for hosts
+that own workspace selection, such as the browser control plane.
+`resolveContextForRoot()` is the non-mutating command-host path: it selects the
+descriptor whose workspace and state roots match the command invocation. This
+keeps a terminal launched inside one repository from inheriting an unrelated
+workspace that was last selected in another host.

--- a/src/core/runtime/workspaces/service.ts
+++ b/src/core/runtime/workspaces/service.ts
@@ -58,6 +58,35 @@ export class RuntimeWorkspaceService {
     };
   }
 
+  /**
+   * Resolves the descriptor owned by the supplied workspace and state roots
+   * without changing the catalog's persisted active workspace.
+   *
+   * Workspace-scoped command hosts use this path so launching Heddle from one
+   * repository cannot silently attach to a different workspace selected by a
+   * long-running web or daemon host.
+   */
+  static resolveContextForRoot(config: WorkspaceRootConfig): ResolvedWorkspaceContext {
+    const resolved = RuntimeWorkspaceService.resolveContext(config);
+    const workspaceRoot = resolve(config.workspaceRoot);
+    const stateRoot = resolve(config.stateRoot);
+    const workspace = resolved.workspaces.find((candidate) => (
+      resolve(candidate.workspaceRoot) === workspaceRoot
+      && resolve(candidate.stateRoot) === stateRoot
+    ));
+    if (!workspace) {
+      throw new Error(
+        `Workspace catalog ${resolved.catalogPath} does not contain the command workspace ${workspaceRoot} with state root ${stateRoot}.`,
+      );
+    }
+
+    return {
+      ...resolved,
+      activeWorkspaceId: workspace.id,
+      activeWorkspace: workspace,
+    };
+  }
+
   static setActive(input: SetActiveWorkspaceInput): ResolvedWorkspaceContext {
     const resolved = RuntimeWorkspaceService.resolveContext(input);
     if (!resolved.workspaces.some((workspace) => workspace.id === input.workspaceId)) {


### PR DESCRIPTION
## Summary

- resolve CLI commands against the descriptor matching the invoked workspace and state roots
- keep the browser control plane's persisted active workspace selection independent
- document the host boundary and add regression coverage

## Root cause

The CLI reused the workspace catalog's globally persisted active workspace. Selecting or creating another workspace in the browser could therefore make a later `heddle chat` launched from this repository query the unrelated workspace's session catalog and show a new empty session. The existing Heddle sessions were never deleted.

## Impact

A terminal launched inside a repository now attaches to that repository's sessions, while browser workspace switching remains persisted for the browser/control-plane host.

## Validation

- live terminal attached to the already-running control plane while another workspace was persisted active, resolved the Heddle workspace, and displayed existing conversation history
- Chrome control plane displayed the existing Heddle session catalog
- `yarn lint`
- `yarn typecheck`
- `yarn test` (132 unit files / 806 tests; 39 integration files / 363 tests)
- `yarn build`
- `git diff --check`
