### PR TITLE
Add durable scheduler-waking heartbeat run requests

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -89,8 +89,10 @@ disabled, and blocked tasks remain blocked until an operator resumes them.
 
 Custom stores implement this protocol through `HeartbeatTaskStore`:
 
+- `requestTaskRun` persists a monotonically distinguishable, level-triggered run request
+- `subscribeToRunRequests` optionally wakes a scheduler in the same process; polling remains the cross-process fallback
 - `claimTaskExecution` atomically establishes the current `executionId` fencing token
-- `completeTaskExecution`, `failTaskExecution`, and `recordTaskExecutionOutcome` reject a stale token with `claim-lost`
+- `completeTaskExecution`, `failTaskExecution`, and `recordTaskExecutionOutcome` project from the latest stored task and reject a stale token with `claim-lost`
 - `recoverInterruptedTasks` records the interrupted execution and makes only eligible tasks retryable
 
 The built-in file adapter serializes those transitions within one Node.js
@@ -100,6 +102,40 @@ transactions, or leases. Recovery cannot undo external effects, so host tools
 must keep domain mutations idempotent.
 
 Cron, launchd, systemd, hosted queues, and Lucid-style services should be treated as hosts around this API, not as Heddle's internal scheduler model.
+
+### Durable event-driven run requests
+
+Product hosts should request prompt work through the task service instead of
+editing `schedule.nextRunAt` or polling a running task:
+
+```ts
+import { FileHeartbeatTaskService } from '@roackb2/heddle/advanced';
+
+const heartbeatTasks = new FileHeartbeatTaskService({ stateRoot });
+const request = await heartbeatTasks.requestTaskRun('mailbox-consumer', {
+  reason: 'new-work-available',
+});
+
+console.log(request.disposition); // requested | coalesced
+```
+
+An idle enabled task becomes due immediately. If the task is already running,
+Heddle persists one pending follow-up. Additional requests advance the durable
+generation but coalesce into that same follow-up. The execution claim records
+which generation it consumed, so a request arriving after the claim remains
+pending for the next run. Success, failure, skip, and cancellation settle from
+the latest stored task state and cannot overwrite a newer request.
+
+`HeartbeatSchedulerService.start()` and `runLoop()` subscribe to file-store run
+requests and rescan promptly. `heartbeat.task.run_requested`,
+`heartbeat.task.run_request_claimed`, and `heartbeat.scheduler.awakened` expose
+the lifecycle without carrying credentials or domain payloads. The configured
+poll interval remains the process-restart and external-writer fallback.
+
+Task views expose `state.runRequest.pending`, the latest generation,
+`claimedGeneration`, timestamp, and bounded operator-facing reason. Disabled,
+completed, and blocked tasks reject requests; they must be enabled or resumed
+explicitly instead of retaining hidden work that might run later.
 
 ### Custom host work with the standard agent runtime
 

--- a/examples/heartbeat-scheduler.ts
+++ b/examples/heartbeat-scheduler.ts
@@ -121,8 +121,14 @@ async function ensureDemoTask(
 
 function formatSchedulerEvent(event: HeartbeatSchedulerEvent): string | undefined {
   switch (event.type) {
+    case 'heartbeat.scheduler.awakened':
+      return `[event] scheduler.awakened tasks=${event.taskIds.join(',')}`;
     case 'heartbeat.task.due':
       return `[event] task.due id=${event.taskId}`;
+    case 'heartbeat.task.run_requested':
+      return `[event] task.run_requested id=${event.taskId} generation=${event.generation} disposition=${event.disposition}`;
+    case 'heartbeat.task.run_request_claimed':
+      return `[event] task.run_request_claimed id=${event.taskId} generation=${event.generation} execution=${event.executionId}`;
     case 'heartbeat.task.started':
       return `[event] task.started id=${event.taskId} execution=${event.executionId} loadedCheckpoint=${event.loadedCheckpoint}`;
     case 'heartbeat.task.recovered':

--- a/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
+++ b/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
@@ -164,8 +164,32 @@ describe('control-plane heartbeat mutations', () => {
 
     await ControlPlaneHeartbeatController.setTaskEnabled(stateRoot, 'repo-check', true);
     const triggered = await ControlPlaneHeartbeatController.triggerTaskRun(stateRoot, 'repo-check');
-    expect(triggered).toMatchObject({ taskId: 'repo-check', enabled: true, state: { status: 'waiting' } });
+    expect(triggered).toMatchObject({
+      taskId: 'repo-check',
+      enabled: true,
+      state: {
+        status: 'waiting',
+        runRequest: {
+          generation: 1,
+          pending: true,
+          reason: 'manual-trigger',
+        },
+      },
+    });
     expect(triggered.schedule.nextRunAt).toBeTruthy();
+
+    const requested = await ControlPlaneHeartbeatController.requestTaskRun(stateRoot, 'repo-check', {
+      reason: 'new-work-available',
+    });
+    expect(requested).toMatchObject({
+      disposition: 'coalesced',
+      generation: 2,
+      reason: 'new-work-available',
+      task: {
+        taskId: 'repo-check',
+        state: { runRequest: { pending: true } },
+      },
+    });
 
     const task = (await store.listTasks())[0];
     expect(task?.schedule.nextRunAt).toBeTruthy();
@@ -236,6 +260,17 @@ describe('control-plane heartbeat mutations', () => {
 
     const triggered = await caller.heartbeatTaskTrigger({ taskId: 'repo-check' });
     expect(triggered.task).toMatchObject({ taskId: 'repo-check', enabled: true, state: { status: 'waiting' } });
+
+    const requested = await caller.heartbeatTaskRequestRun({
+      taskId: 'repo-check',
+      reason: 'router-new-work',
+    });
+    expect(requested).toMatchObject({
+      disposition: 'coalesced',
+      generation: 2,
+      reason: 'router-new-work',
+      task: { taskId: 'repo-check', state: { runRequest: { pending: true } } },
+    });
 
     const created = await caller.heartbeatTaskCreate({
       id: 'router-created',

--- a/src/__tests__/integration/core/heartbeat-run-requests.test.ts
+++ b/src/__tests__/integration/core/heartbeat-run-requests.test.ts
@@ -1,0 +1,341 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  FileHeartbeatTaskService,
+  HeartbeatSchedulerService,
+  type AgentHeartbeatResult,
+  type HeartbeatSchedulerEvent,
+  type HeartbeatTask,
+} from '../../../advanced.js';
+import { AgentLoopCheckpointService } from '@/core/runtime/loop/index.js';
+
+const NOW = new Date('2026-08-04T00:00:00.000Z');
+
+describe('heartbeat run requests', () => {
+  it('coalesces concurrent requests during a run and preserves one follow-up across service reconstruction', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-run-request-coalesce-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    await store.saveTask(createTask());
+    const firstStarted = deferred<void>();
+    const firstResult = deferred<AgentHeartbeatResult>();
+
+    const firstRun = HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      runner: async () => {
+        firstStarted.resolve();
+        return await firstResult.promise;
+      },
+    });
+    await firstStarted.promise;
+
+    const requests = await Promise.all(Array.from({ length: 10 }, async () => (
+      await new FileHeartbeatTaskService({ dir }).requestTaskRun('mailbox-consumer', {
+        reason: 'new-work-available',
+        requestedAt: NOW,
+      })
+    )));
+    expect(requests.filter((request) => request.disposition === 'requested')).toHaveLength(1);
+    expect(requests.filter((request) => request.disposition === 'coalesced')).toHaveLength(9);
+    await store.updateTask('mailbox-consumer', { name: 'Updated while running' });
+
+    firstResult.resolve(createHeartbeatResult('run-initial'));
+    await expect(firstRun).resolves.toMatchObject({ checked: 1, ran: 1, failed: 0 });
+
+    const reconstructed = new FileHeartbeatTaskService({ dir });
+    await expect(reconstructed.listTaskViews()).resolves.toMatchObject([{
+      name: 'Updated while running',
+      state: {
+        status: 'waiting',
+        runRequest: {
+          generation: 10,
+          claimedGeneration: 0,
+          pending: true,
+          requestedAt: NOW.toISOString(),
+          reason: 'new-work-available',
+        },
+      },
+    }]);
+
+    const followUpEvents: HeartbeatSchedulerEvent[] = [];
+    await expect(HeartbeatSchedulerService.runDueTasks({
+      store: reconstructed,
+      now: () => NOW,
+      onEvent: (event) => followUpEvents.push(event),
+      runner: async () => createHeartbeatResult('run-follow-up'),
+    })).resolves.toMatchObject({ checked: 1, ran: 1, failed: 0 });
+    expect(followUpEvents).toContainEqual(expect.objectContaining({
+      type: 'heartbeat.task.run_request_claimed',
+      generation: 10,
+    }));
+    await expect(reconstructed.listTaskViews()).resolves.toMatchObject([{
+      state: {
+        runRequest: {
+          generation: 10,
+          claimedGeneration: 10,
+          pending: false,
+        },
+        lastExecution: {
+          runRequestGeneration: 10,
+        },
+      },
+    }]);
+    await expect(HeartbeatSchedulerService.runDueTasks({
+      store: reconstructed,
+      now: () => NOW,
+      runner: async () => createHeartbeatResult('unexpected-run'),
+    })).resolves.toMatchObject({ checked: 0, ran: 0, failed: 0 });
+  });
+
+  it('retains a request that arrives after the current follow-up generation was claimed', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-run-request-after-claim-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    await store.saveTask(createTask());
+    await store.requestTaskRun('mailbox-consumer', { reason: 'first-event', requestedAt: NOW });
+    const followUpStarted = deferred<void>();
+    const followUpResult = deferred<AgentHeartbeatResult>();
+
+    const followUp = HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      runner: async () => {
+        followUpStarted.resolve();
+        return await followUpResult.promise;
+      },
+    });
+    await followUpStarted.promise;
+    await store.requestTaskRun('mailbox-consumer', { reason: 'second-event', requestedAt: NOW });
+    followUpResult.resolve(createHeartbeatResult('run-claimed-first-generation'));
+    await followUp;
+
+    await expect(store.listTaskViews()).resolves.toMatchObject([{
+      state: {
+        runRequest: {
+          generation: 2,
+          claimedGeneration: 1,
+          pending: true,
+          reason: 'second-event',
+        },
+      },
+    }]);
+    await expect(HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      runner: async () => createHeartbeatResult('run-claimed-second-generation'),
+    })).resolves.toMatchObject({ checked: 1, ran: 1, failed: 0 });
+  });
+
+  it('preserves a newer pending request when the active execution fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-run-request-failure-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    await store.saveTask(createTask());
+    const runStarted = deferred<void>();
+    const rejectRun = deferred<AgentHeartbeatResult>();
+    const events: HeartbeatSchedulerEvent[] = [];
+
+    const run = HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      failureRetryMs: 60_000,
+      onEvent: (event) => events.push(event),
+      runner: async () => {
+        runStarted.resolve();
+        return await rejectRun.promise;
+      },
+    });
+    await runStarted.promise;
+    await store.requestTaskRun('mailbox-consumer', { reason: 'work-arrived-during-failure', requestedAt: NOW });
+    rejectRun.reject(new Error('temporary failure'));
+
+    await expect(run).resolves.toMatchObject({ checked: 1, ran: 0, failed: 1 });
+    await expect(store.listTaskViews()).resolves.toMatchObject([{
+      schedule: { nextRunAt: '2026-08-03T23:59:59.000Z' },
+      state: {
+        status: 'waiting',
+        error: 'temporary failure',
+        runRequest: {
+          pending: true,
+          reason: 'work-arrived-during-failure',
+        },
+      },
+    }]);
+    expect(events.at(-1)).toMatchObject({
+      type: 'heartbeat.task.failed',
+      status: 'waiting',
+      nextRunAt: '2026-08-03T23:59:59.000Z',
+    });
+  });
+
+  it('preserves a disable made during execution and consumes its pending follow-up', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-run-request-disable-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    await store.saveTask(createTask());
+    const runStarted = deferred<void>();
+    const runResult = deferred<AgentHeartbeatResult>();
+
+    const run = HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      runner: async () => {
+        runStarted.resolve();
+        return await runResult.promise;
+      },
+    });
+    await runStarted.promise;
+    await store.requestTaskRun('mailbox-consumer', { reason: 'work-arrived', requestedAt: NOW });
+    await store.setTaskEnabled('mailbox-consumer', false);
+    runResult.resolve(createHeartbeatResult('run-disabled-during-execution'));
+
+    await expect(run).resolves.toMatchObject({ checked: 1, ran: 1, failed: 0 });
+    const [settledTask] = await store.listTaskViews();
+    expect(settledTask).toMatchObject({
+      enabled: false,
+      state: {
+        status: 'idle',
+        runRequest: {
+          generation: 1,
+          claimedGeneration: 1,
+          pending: false,
+        },
+      },
+    });
+    expect(settledTask?.schedule).not.toHaveProperty('nextRunAt');
+  });
+
+  it('rejects hidden requests for disabled, completed, and blocked tasks', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-run-request-guards-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    await Promise.all([
+      store.saveTask(createTask({
+        id: 'disabled',
+        enabled: false,
+        state: { status: 'idle' },
+      })),
+      store.saveTask(createTask({
+        id: 'complete',
+        enabled: false,
+        state: { status: 'complete' },
+      })),
+      store.saveTask(createTask({
+        id: 'blocked',
+        enabled: false,
+        state: { status: 'blocked' },
+      })),
+    ]);
+
+    await expect(store.requestTaskRun('disabled')).rejects.toThrow(/disabled.*enable/i);
+    await expect(store.requestTaskRun('complete')).rejects.toThrow(/complete.*resume/i);
+    await expect(store.requestTaskRun('blocked')).rejects.toThrow(/blocked.*resume/i);
+    await expect(store.requestTaskRun('disabled', { reason: 'x'.repeat(201) })).rejects.toThrow(/at most 200/i);
+    expect((await store.listTasks()).every((task) => task.state?.runRequest === undefined)).toBe(true);
+  });
+
+  it('wakes a sleeping scheduler promptly and removes the wake subscription on stop', async () => {
+    const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-run-request-wake-'));
+    const tasks = new FileHeartbeatTaskService({ stateRoot });
+    await tasks.saveTask(createTask({
+      schedule: {
+        intervalMs: 60_000,
+        nextRunAt: '2099-08-04T00:00:00.000Z',
+      },
+    }));
+    const handlerStarted = deferred<void>();
+    const releaseHandler = deferred<void>();
+    const runSettled = deferred<void>();
+    const events: HeartbeatSchedulerEvent[] = [];
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: stateRoot,
+      stateRoot,
+      pollIntervalMs: 60_000,
+      handler: async (context) => {
+        handlerStarted.resolve();
+        await releaseHandler.promise;
+        return context.skip({ summary: 'No work remained.' });
+      },
+      onEvent: (event) => {
+        events.push(event);
+        if (event.type === 'heartbeat.task.skipped') {
+          runSettled.resolve();
+        }
+      },
+    });
+
+    await tasks.requestTaskRun('mailbox-consumer', {
+      reason: 'new-mail',
+      requestedAt: new Date('2000-01-01T00:00:00.000Z'),
+    });
+    await handlerStarted.promise;
+    releaseHandler.resolve();
+    await runSettled.promise;
+    await handle.stop();
+
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'heartbeat.task.run_requested', reason: 'new-mail' }),
+      expect.objectContaining({ type: 'heartbeat.scheduler.awakened', taskIds: ['mailbox-consumer'] }),
+      expect.objectContaining({ type: 'heartbeat.task.run_request_claimed', generation: 1 }),
+    ]));
+
+    const eventCountAfterStop = events.length;
+    await tasks.requestTaskRun('mailbox-consumer', {
+      reason: 'after-stop',
+      requestedAt: new Date('2000-01-01T00:00:00.000Z'),
+    });
+    expect(events).toHaveLength(eventCountAfterStop);
+  });
+});
+
+function createTask(partial: Partial<HeartbeatTask> = {}): HeartbeatTask {
+  return {
+    id: 'mailbox-consumer',
+    task: 'Process newly available mailbox work.',
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt: '2026-08-03T23:59:00.000Z',
+    },
+    state: {
+      status: 'waiting',
+      resumable: true,
+    },
+    ...partial,
+  };
+}
+
+function createHeartbeatResult(runId: string): AgentHeartbeatResult {
+  const summary = 'Heartbeat result.\n\nHEARTBEAT_DECISION: continue';
+  const state = {
+    status: 'finished' as const,
+    runId,
+    goal: 'Heartbeat runner cycle.',
+    model: 'gpt-test',
+    provider: 'openai' as const,
+    workspaceRoot: '/tmp/project',
+    startedAt: NOW.toISOString(),
+    finishedAt: NOW.toISOString(),
+    outcome: 'done' as const,
+    summary,
+    transcript: [],
+    trace: [],
+  };
+
+  return {
+    decision: 'continue',
+    summary,
+    state,
+    checkpoint: AgentLoopCheckpointService.createCheckpoint(state, {
+      createdAt: NOW.toISOString(),
+    }),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}

--- a/src/__tests__/integration/core/heartbeat-scheduler.test.ts
+++ b/src/__tests__/integration/core/heartbeat-scheduler.test.ts
@@ -598,19 +598,13 @@ describe('heartbeat scheduler', () => {
     expect(replacementClaim.status).toBe('claimed');
 
     const lateResult = createHeartbeatResult('continue');
-    const lateTask = HeartbeatTaskStateProjector.afterResult({
-      task: interruptedTask,
-      execution: originalExecution,
-      result: lateResult,
-      now: NOW,
-      loadedCheckpoint: false,
-    });
     await expect(store.completeTaskExecution({
       execution: originalExecution,
-      task: lateTask,
+      taskId: interruptedTask.id,
       checkpoint: lateResult.checkpoint,
       result: lateResult,
       loadedCheckpoint: false,
+      completedAt: NOW,
     })).resolves.toEqual({ status: 'claim-lost' });
     await expect(store.requireTask(interruptedTask.id)).resolves.toMatchObject({
       state: {
@@ -642,6 +636,30 @@ function createMemoryTaskStore(options: {
     async saveCheckpoint(_task, checkpoint) {
       options.saveCheckpoint?.(checkpoint);
     },
+    async requestTaskRun(taskId, requestOptions = {}) {
+      const task = tasks.find((candidate) => candidate.id === taskId);
+      if (!task) throw new Error(`Heartbeat task not found: ${taskId}`);
+      if (!task.enabled || task.state?.status === 'blocked' || task.state?.status === 'complete') {
+        throw new Error(`Heartbeat task ${taskId} cannot accept a run request.`);
+      }
+      const projected = HeartbeatTaskStateProjector.requestRun({
+        task,
+        now: requestOptions.requestedAt ?? NOW,
+        reason: requestOptions.reason,
+      });
+      const request = projected.task.state?.runRequest;
+      if (!request) throw new Error('expected run request');
+      tasks = [...tasks.filter((candidate) => candidate.id !== task.id), projected.task];
+      options.saveTask?.(projected.task);
+      return {
+        task: projected.task,
+        taskId,
+        generation: request.generation,
+        disposition: projected.disposition,
+        requestedAt: request.requestedAt,
+        reason: request.reason,
+      };
+    },
     async claimTaskExecution(input) {
       const task = tasks.find((candidate) => candidate.id === input.taskId);
       if (!task) return { status: 'not-found' };
@@ -658,15 +676,22 @@ function createMemoryTaskStore(options: {
       return { status: 'claimed', task: runningTask };
     },
     async completeTaskExecution(input) {
-      const task = tasks.find((candidate) => candidate.id === input.task.id);
+      const task = tasks.find((candidate) => candidate.id === input.taskId);
       if (task?.state?.execution?.executionId !== input.execution.executionId) {
         return { status: 'claim-lost' };
       }
       if (input.signal?.aborted) {
         return { status: 'cancelled' };
       }
+      const nextTask = HeartbeatTaskStateProjector.afterResult({
+        task,
+        execution: task.state.execution ?? input.execution,
+        result: input.result,
+        now: input.completedAt,
+        loadedCheckpoint: input.loadedCheckpoint,
+      });
       const record = {
-        task: input.task,
+        task: nextTask,
         result: input.result,
         loadedCheckpoint: input.loadedCheckpoint,
         outcome: {
@@ -674,37 +699,61 @@ function createMemoryTaskStore(options: {
           executionId: input.execution.executionId,
           summary: input.result.summary,
           finishedAt: input.result.state.finishedAt,
+          runRequestGeneration: task.state.execution?.runRequestGeneration,
         },
       };
-      tasks = [...tasks.filter((candidate) => candidate.id !== input.task.id), input.task];
-      options.saveTask?.(input.task);
+      tasks = [...tasks.filter((candidate) => candidate.id !== input.taskId), nextTask];
+      options.saveTask?.(nextTask);
       options.saveCheckpoint?.(input.checkpoint);
-      return { status: 'saved', task: input.task, record };
+      return { status: 'saved', task: nextTask, record };
     },
     async failTaskExecution(input) {
-      const task = tasks.find((candidate) => candidate.id === input.task.id);
+      const task = tasks.find((candidate) => candidate.id === input.taskId);
       if (task?.state?.execution?.executionId !== input.execution.executionId) {
         return { status: 'claim-lost' };
       }
       if (input.signal?.aborted) {
         return { status: 'cancelled' };
       }
-      tasks = [...tasks.filter((candidate) => candidate.id !== input.task.id), input.task];
-      options.saveTask?.(input.task);
-      return { status: 'saved', task: input.task };
+      const nextTask = HeartbeatTaskStateProjector.afterFailure({
+        task,
+        execution: task.state.execution ?? input.execution,
+        error: input.error,
+        now: input.failedAt,
+        retryMs: input.retryMs,
+      });
+      tasks = [...tasks.filter((candidate) => candidate.id !== input.taskId), nextTask];
+      options.saveTask?.(nextTask);
+      return { status: 'saved', task: nextTask };
     },
     async recordTaskExecutionOutcome(input) {
-      const task = tasks.find((candidate) => candidate.id === input.task.id);
+      const task = tasks.find((candidate) => candidate.id === input.taskId);
       if (task?.state?.execution?.executionId !== input.execution.executionId) {
         return { status: 'claim-lost' };
       }
       if (input.signal?.aborted) {
         return { status: 'cancelled' };
       }
-      const record = { task: input.task, outcome: input.outcome };
-      tasks = [...tasks.filter((candidate) => candidate.id !== input.task.id), input.task];
-      options.saveTask?.(input.task);
-      return { status: 'saved', task: input.task, record };
+      const execution = task.state.execution ?? input.execution;
+      const nextTask = input.kind === 'skipped' ?
+        HeartbeatTaskStateProjector.afterSkip({
+          task,
+          execution,
+          summary: input.summary,
+          now: input.finishedAt,
+        })
+      : HeartbeatTaskStateProjector.afterCancellation({
+          task,
+          execution,
+          summary: input.summary,
+          now: input.finishedAt,
+        });
+      const outcome = nextTask.state?.lastExecution;
+      if (!outcome || outcome.kind !== input.kind) throw new Error('expected projected outcome');
+      const record = { task: nextTask, outcome };
+      tasks = [...tasks.filter((candidate) => candidate.id !== input.taskId), nextTask];
+      options.saveTask?.(nextTask);
+      return { status: 'saved', task: nextTask, record };
     },
     async recoverInterruptedTasks() {
       return [];

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -256,6 +256,7 @@ export type {
 } from './core/heartbeat/checkpoint/index.js';
 export {
   FileHeartbeatTaskService,
+  MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH,
 } from './core/heartbeat/tasks/index.js';
 export type {
   FileHeartbeatTaskServiceOptions,
@@ -271,7 +272,11 @@ export type {
   HeartbeatTaskRecoveryResult,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
+  HeartbeatTaskRunRequest,
+  HeartbeatTaskRunRequestResult,
+  HeartbeatTaskRunRequestSignal,
   HeartbeatTaskStore,
+  RequestHeartbeatTaskRunOptions,
 } from './core/heartbeat/tasks/index.js';
 export {
   HeartbeatSchedulerService,
@@ -294,6 +299,7 @@ export type {
 } from './core/heartbeat/scheduler/index.js';
 export type {
   HeartbeatRunView,
+  HeartbeatTaskRunRequestView,
   HeartbeatTaskView,
 } from './core/heartbeat/views/index.js';
 export {

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -20,8 +20,10 @@ operator-facing heartbeat views.
   non-repository service that should instantiate `FileHeartbeatTaskRepository`.
   It also owns process-local execution claims, recovery of interrupted
   single-host executions, and fencing of late completion/failure/outcome
-  writes. `HeartbeatTaskStateProjector` owns task state transitions after
-  agent success, no-work skip, cancellation, failure, or recovery.
+  writes. Durable run-request generations and the file adapter's process-local
+  scheduler wake signal also live here. `HeartbeatTaskStateProjector` owns task
+  state transitions after agent success, no-work skip, cancellation, failure,
+  request, claim, or recovery.
 - `scheduler/`: `HeartbeatSchedulerService` owns due-task selection and the
   periodic scheduler loop. It delegates execution to
   `HeartbeatTaskRunnerService` instead of running tasks itself. Daemon, CLI,
@@ -53,11 +55,21 @@ operator-facing heartbeat views.
 - `executionId` is the fencing token for one task attempt. A store must reject
   completion, failure, skip, or cancellation persistence when that execution
   no longer owns the task.
+- Run requests are durable, level-triggered intent. `generation` advances for
+  accepted requests, `claimedGeneration` identifies work already admitted, and
+  an execution records the request generation it claimed. Multiple requests
+  may coalesce into one pending follow-up, but a request after claim belongs to
+  a later execution.
+- Execution settlement must read and project from the latest stored task inside
+  the same atomic store transition. Saving a projection derived from the
+  pre-run snapshot can erase newer run requests or operator control changes.
 - `executionOwnerId` identifies one scheduler process/worker generation. Do not
   reuse it across process restarts: scheduler startup uses it to distinguish a
   current claim from an execution interrupted by the prior single-host process.
 - The file service serializes claim/recover/complete/fail transitions with a
-  shared in-process mutex and tracks live executions in process memory. This is
+  shared in-process mutex, serializes task control read-transform-write
+  transitions, and tracks live executions in process memory. Its process-local
+  wake signal reduces event latency; polling remains the restart fallback. This is
   reliable for one Node.js process owning a state root; it is not a distributed
   lease. Multiple processes or replicas must provide a remote
   `HeartbeatTaskStore` that implements atomic claim, fencing, and recovery with

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -23,6 +23,7 @@ export type {
   StopHeartbeatSchedulerOptions,
 } from './scheduler/index.js';
 export { FileHeartbeatTaskService, HeartbeatTaskStateProjector } from './tasks/index.js';
+export { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './tasks/index.js';
 export type {
   CreateHeartbeatTaskInput,
   FileHeartbeatTaskServiceOptions,
@@ -39,8 +40,12 @@ export type {
   HeartbeatTaskRecoveryResult,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
+  HeartbeatTaskRunRequest,
+  HeartbeatTaskRunRequestResult,
+  HeartbeatTaskRunRequestSignal,
   HeartbeatTaskStatus,
   HeartbeatTaskStore,
+  RequestHeartbeatTaskRunOptions,
   UpdateHeartbeatTaskInput,
 } from './tasks/index.js';
 export { HeartbeatDecisionPolicy, HeartbeatRunnerAgent, HeartbeatRunnerAgentPrompt } from './agent/index.js';
@@ -55,6 +60,7 @@ export type {
 export { HeartbeatLucidPresenter } from './views/index.js';
 export type {
   HeartbeatRunView,
+  HeartbeatTaskRunRequestView,
   HeartbeatTaskView,
   LucidAdapterOptions,
   LucidAgentMessage,

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -12,12 +12,10 @@ import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
 import type { AgentLoopCheckpoint, AgentLoopState } from '@/core/runtime/loop/index.js';
 import { HeartbeatRunnerAgent } from '../agent/index.js';
 import type { AgentHeartbeatResult, RunAgentHeartbeatOptions } from '../agent/index.js';
-import { HeartbeatTaskStateProjector } from '../tasks/index.js';
 import type {
   HeartbeatTask,
   HeartbeatTaskAgentRunRecord,
   HeartbeatTaskExecution,
-  HeartbeatTaskExecutionOutcome,
   HeartbeatTaskNonAgentRunRecord,
   HeartbeatTaskRunRecord,
 } from '../tasks/index.js';
@@ -67,14 +65,14 @@ export class HeartbeatTaskRunnerService {
     }
 
     const loadedCheckpoint = Boolean(checkpoint);
-    const execution: HeartbeatTaskExecution = {
+    const proposedExecution: HeartbeatTaskExecution = {
       executionId: randomUUID(),
       ownerId: options.executionOwnerId ?? `heartbeat-worker:${randomUUID()}`,
       claimedAt: startedAt,
     };
     const claim = await options.store.claimTaskExecution({
       taskId: task.id,
-      execution,
+      execution: proposedExecution,
       loadedCheckpoint,
       claimedAt: runAt,
     });
@@ -83,8 +81,18 @@ export class HeartbeatTaskRunnerService {
     }
 
     const runningTask = claim.task;
+    const execution = runningTask.state?.execution ?? proposedExecution;
     const scopeController = new AbortController();
     const executionSignal = HeartbeatTaskRunnerService.composeExecutionSignal(options.signal, scopeController.signal);
+    if (execution.runRequestGeneration !== undefined) {
+      options.onEvent?.({
+        type: 'heartbeat.task.run_request_claimed',
+        taskId: task.id,
+        executionId: execution.executionId,
+        generation: execution.runRequestGeneration,
+        timestamp: startedAt,
+      });
+    }
     options.onEvent?.(HeartbeatTaskRunnerService.startedEvent(runningTask, execution, loadedCheckpoint, startedAt));
 
     try {
@@ -110,18 +118,12 @@ export class HeartbeatTaskRunnerService {
 
       const settledAt = options.now?.() ?? dayjs().toDate();
       if (HeartbeatTaskRunnerService.isSkippedOutcome(result)) {
-        const nextTask = HeartbeatTaskStateProjector.afterSkip({
-          task: runningTask,
-          execution,
-          summary: result.summary,
-          now: settledAt,
-        });
-        const outcome = HeartbeatTaskRunnerService.requireProjectedOutcome(nextTask, 'skipped');
-
         const completion = await options.store.recordTaskExecutionOutcome({
           execution,
-          task: nextTask,
-          outcome,
+          taskId: task.id,
+          kind: 'skipped',
+          summary: result.summary,
+          finishedAt: settledAt,
           signal: options.signal,
         });
         if (completion.status === 'cancelled') {
@@ -140,24 +142,18 @@ export class HeartbeatTaskRunnerService {
           taskId: task.id,
           executionId: execution.executionId,
           record: completion.record,
-          timestamp: outcome.finishedAt,
+          timestamp: completion.record.outcome.finishedAt,
         });
         return { record: completion.record, failed: false };
       }
 
-      const nextTask = HeartbeatTaskStateProjector.afterResult({
-        task: runningTask,
-        execution,
-        result,
-        now: settledAt,
-        loadedCheckpoint,
-      });
       const completion = await options.store.completeTaskExecution({
         execution,
-        task: nextTask,
+        taskId: task.id,
         checkpoint: result.checkpoint,
         result,
         loadedCheckpoint,
+        completedAt: settledAt,
         signal: options.signal,
       });
       if (completion.status === 'cancelled') {
@@ -189,16 +185,12 @@ export class HeartbeatTaskRunnerService {
       }
 
       const settledAt = options.now?.() ?? dayjs().toDate();
-      const nextTask = HeartbeatTaskStateProjector.afterFailure({
-        task: runningTask,
-        execution,
-        error,
-        now: settledAt,
-        retryMs: options.failureRetryMs ?? DEFAULT_FAILURE_RETRY_MS,
-      });
       const failure = await options.store.failTaskExecution({
         execution,
-        task: nextTask,
+        taskId: task.id,
+        error,
+        failedAt: settledAt,
+        retryMs: options.failureRetryMs ?? DEFAULT_FAILURE_RETRY_MS,
         signal: options.signal,
       });
       if (failure.status === 'cancelled') {
@@ -208,11 +200,11 @@ export class HeartbeatTaskRunnerService {
           execution,
         });
       }
-      if (failure.status === 'claim-lost') {
+      if (failure.status !== 'saved') {
         return { failed: false };
       }
 
-      options.onEvent?.(HeartbeatTaskRunnerService.failedEvent(nextTask, execution, error, dayjs(settledAt).toISOString()));
+      options.onEvent?.(HeartbeatTaskRunnerService.failedEvent(failure.task, execution, error, dayjs(settledAt).toISOString()));
       return { failed: true };
     } finally {
       scopeController.abort();
@@ -392,18 +384,12 @@ export class HeartbeatTaskRunnerService {
     execution: HeartbeatTaskExecution;
   }): Promise<{ record?: HeartbeatTaskRunRecord; failed: boolean }> {
     const settledAt = args.now?.() ?? dayjs().toDate();
-    const nextTask = HeartbeatTaskStateProjector.afterCancellation({
-      task: args.task,
-      execution: args.execution,
-      summary: CANCELLATION_SUMMARY,
-      now: settledAt,
-    });
-    const outcome = HeartbeatTaskRunnerService.requireProjectedOutcome(nextTask, 'cancelled');
-
     const completion = await args.store.recordTaskExecutionOutcome({
       execution: args.execution,
-      task: nextTask,
-      outcome,
+      taskId: args.task.id,
+      kind: 'cancelled',
+      summary: CANCELLATION_SUMMARY,
+      finishedAt: settledAt,
     });
     if (completion.status !== 'saved' || !HeartbeatTaskRunnerService.isNonAgentRecord(completion.record, 'cancelled')) {
       return { failed: false };
@@ -414,7 +400,7 @@ export class HeartbeatTaskRunnerService {
       taskId: args.task.id,
       executionId: args.execution.executionId,
       record: completion.record,
-      timestamp: outcome.finishedAt,
+      timestamp: completion.record.outcome.finishedAt,
     });
     return { record: completion.record, failed: false };
   }
@@ -459,17 +445,6 @@ export class HeartbeatTaskRunnerService {
     kind: K,
   ): record is HeartbeatTaskNonAgentRunRecord & { outcome: { kind: K } } {
     return Boolean(record && !record.result && record.outcome?.kind === kind);
-  }
-
-  private static requireProjectedOutcome<K extends HeartbeatTaskExecutionOutcome['kind']>(
-    task: HeartbeatTask,
-    kind: K,
-  ): HeartbeatTaskExecutionOutcome & { kind: K } {
-    const outcome = task.state?.lastExecution;
-    if (outcome?.kind !== kind) {
-      throw new Error(`Heartbeat task ${task.id} did not project a ${kind} execution outcome.`);
-    }
-    return outcome as HeartbeatTaskExecutionOutcome & { kind: K };
   }
 
   private static startedEvent(

--- a/src/core/heartbeat/scheduler/service.ts
+++ b/src/core/heartbeat/scheduler/service.ts
@@ -8,7 +8,13 @@
 import { randomUUID } from 'node:crypto';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js';
-import { FileHeartbeatTaskService, type HeartbeatTask, type HeartbeatTaskRunRecord } from '../tasks/index.js';
+import {
+  FileHeartbeatTaskService,
+  type HeartbeatTask,
+  type HeartbeatTaskRunRecord,
+  type HeartbeatTaskRunRequestSignal,
+  type HeartbeatTaskStore,
+} from '../tasks/index.js';
 import { HeartbeatTaskRunnerService } from './runner.js';
 import type {
   HeartbeatSchedulerHandle,
@@ -21,6 +27,45 @@ import type {
 const DEFAULT_SCHEDULER_POLL_INTERVAL_MS = 60_000;
 
 dayjs.extend(isSameOrBefore);
+
+class HeartbeatSchedulerWakeController {
+  private readonly pendingRequests = new Map<string, HeartbeatTaskRunRequestSignal>();
+  private readonly unsubscribe?: () => void;
+  private waitController = new AbortController();
+
+  constructor(store: HeartbeatTaskStore) {
+    this.unsubscribe = store.subscribeToRunRequests?.((request) => {
+      this.pendingRequests.set(request.taskId, request);
+      this.waitController.abort();
+    });
+  }
+
+  drain(): HeartbeatTaskRunRequestSignal[] {
+    const requests = [...this.pendingRequests.values()]
+      .sort((left, right) => left.taskId.localeCompare(right.taskId));
+    this.pendingRequests.clear();
+    return requests;
+  }
+
+  async wait(args: {
+    intervalMs: number;
+    signal?: AbortSignal;
+    sleep: (ms: number, signal?: AbortSignal) => Promise<void>;
+  }): Promise<void> {
+    const cycleController = this.waitController;
+    const signal = args.signal ? AbortSignal.any([args.signal, cycleController.signal]) : cycleController.signal;
+    await args.sleep(args.intervalMs, signal);
+    if (this.waitController === cycleController) {
+      this.waitController = new AbortController();
+    }
+  }
+
+  dispose(): void {
+    this.unsubscribe?.();
+    this.waitController.abort();
+    this.pendingRequests.clear();
+  }
+}
 
 export class HeartbeatSchedulerService {
   // Starts a background scheduler loop for one workspace and returns a handle the host can stop.
@@ -113,6 +158,7 @@ export class HeartbeatSchedulerService {
   static async runLoop(options: RunHeartbeatSchedulerOptions): Promise<void> {
     const executionOwnerId = options.executionOwnerId ?? HeartbeatSchedulerService.createExecutionOwnerId();
     const startedAt = options.now?.() ?? dayjs().toDate();
+    const wakeController = new HeartbeatSchedulerWakeController(options.store);
     options.onEvent?.({ type: 'heartbeat.scheduler.started', timestamp: dayjs(startedAt).toISOString() });
     try {
       const recoveries = await options.store.recoverInterruptedTasks({
@@ -133,6 +179,7 @@ export class HeartbeatSchedulerService {
       }));
 
       while (!options.signal?.aborted) {
+        HeartbeatSchedulerService.emitRunRequestWakeEvents(options, wakeController.drain());
         await HeartbeatSchedulerService.runDueTasks({
           ...options,
           executionOwnerId,
@@ -142,7 +189,11 @@ export class HeartbeatSchedulerService {
         if (options.signal?.aborted) {
           break;
         }
-        await (options.sleep ?? HeartbeatSchedulerService.sleep)(options.pollIntervalMs ?? DEFAULT_SCHEDULER_POLL_INTERVAL_MS, options.signal);
+        await wakeController.wait({
+          intervalMs: options.pollIntervalMs ?? DEFAULT_SCHEDULER_POLL_INTERVAL_MS,
+          signal: options.signal,
+          sleep: options.sleep ?? HeartbeatSchedulerService.sleep,
+        });
       }
       options.onEvent?.({ type: 'heartbeat.scheduler.stopped', reason: 'aborted', timestamp: HeartbeatSchedulerService.resolveNowIso(options) });
     } catch (error) {
@@ -153,7 +204,29 @@ export class HeartbeatSchedulerService {
 
       options.onEvent?.({ type: 'heartbeat.scheduler.stopped', reason: 'error', timestamp: HeartbeatSchedulerService.resolveNowIso(options) });
       throw error;
+    } finally {
+      wakeController.dispose();
     }
+  }
+
+  private static emitRunRequestWakeEvents(
+    options: Pick<RunHeartbeatSchedulerOptions, 'onEvent'>,
+    requests: HeartbeatTaskRunRequestSignal[],
+  ): void {
+    if (requests.length === 0) {
+      return;
+    }
+
+    requests.forEach((request) => options.onEvent?.({
+      type: 'heartbeat.task.run_requested',
+      ...request,
+      timestamp: request.requestedAt,
+    }));
+    options.onEvent?.({
+      type: 'heartbeat.scheduler.awakened',
+      taskIds: requests.map((request) => request.taskId),
+      timestamp: requests.at(-1)?.requestedAt ?? dayjs().toISOString(),
+    });
   }
 
   // Decides whether a task should be selected by the scheduler at the current time.
@@ -188,11 +261,13 @@ export class HeartbeatSchedulerService {
     }
 
     return new Promise((resolve) => {
-      const timeout = setTimeout(resolve, ms);
-      signal?.addEventListener('abort', () => {
+      const finish = () => {
         clearTimeout(timeout);
+        signal?.removeEventListener('abort', finish);
         resolve();
-      }, { once: true });
+      };
+      const timeout = setTimeout(finish, ms);
+      signal?.addEventListener('abort', finish, { once: true });
     });
   }
 }

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -13,7 +13,24 @@ import type {
 export type HeartbeatSchedulerEvent =
   | { type: 'heartbeat.scheduler.started'; timestamp: string }
   | { type: 'heartbeat.scheduler.stopped'; reason: 'aborted' | 'completed' | 'error'; timestamp: string }
+  | { type: 'heartbeat.scheduler.awakened'; taskIds: string[]; timestamp: string }
   | { type: 'heartbeat.task.due'; taskId: string; timestamp: string }
+  | {
+      type: 'heartbeat.task.run_requested';
+      taskId: string;
+      generation: number;
+      disposition: 'requested' | 'coalesced';
+      requestedAt: string;
+      reason?: string;
+      timestamp: string;
+    }
+  | {
+      type: 'heartbeat.task.run_request_claimed';
+      taskId: string;
+      executionId: string;
+      generation: number;
+      timestamp: string;
+    }
   | {
       type: 'heartbeat.task.started';
       taskId: string;

--- a/src/core/heartbeat/tasks/index.ts
+++ b/src/core/heartbeat/tasks/index.ts
@@ -19,9 +19,14 @@ export type {
   HeartbeatTaskRecoveryResult,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
+  HeartbeatTaskRunRequest,
+  HeartbeatTaskRunRequestResult,
+  HeartbeatTaskRunRequestSignal,
   HeartbeatTaskRuntime,
   HeartbeatTaskSchedule,
   HeartbeatTaskState,
   HeartbeatTaskStatus,
   HeartbeatTaskStore,
+  RequestHeartbeatTaskRunOptions,
 } from './types.js';
+export { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './types.js';

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -7,6 +7,7 @@
  */
 import { z } from 'zod';
 import { LlmUsageSchema } from '@/core/llm/usage/index.js';
+import { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './types.js';
 
 export const HeartbeatTaskStatusSchema = z.enum(['idle', 'running', 'waiting', 'blocked', 'complete', 'failed']);
 export const HeartbeatDecisionSchema = z.enum(['continue', 'pause', 'complete', 'escalate']);
@@ -17,6 +18,14 @@ const HeartbeatTaskExecutionSchema = z.object({
   executionId: z.string().describe('Fencing token for the currently owned execution attempt.'),
   ownerId: z.string().describe('Scheduler process or worker generation that owns this execution.'),
   claimedAt: z.string().describe('Timestamp when this execution claimed the task.'),
+  runRequestGeneration: z.number().int().nonnegative().optional().describe('Run-request generation claimed by this execution.'),
+});
+
+const HeartbeatTaskRunRequestSchema = z.object({
+  generation: z.number().int().nonnegative().describe('Latest accepted run-request generation.'),
+  claimedGeneration: z.number().int().nonnegative().describe('Latest generation claimed by an execution.'),
+  requestedAt: z.string().describe('Timestamp of the latest accepted run request.'),
+  reason: z.string().min(1).max(MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH).optional().describe('Bounded operator-facing reason for the latest request.'),
 });
 
 const HeartbeatTaskRecoverySchema = z.object({
@@ -31,6 +40,7 @@ export const HeartbeatTaskExecutionOutcomeSchema = z.object({
   executionId: z.string().describe('Outer heartbeat execution fencing identity.'),
   summary: z.string().describe('Operator-facing execution outcome summary.'),
   finishedAt: z.string().describe('Timestamp when the outer heartbeat execution settled.'),
+  runRequestGeneration: z.number().int().nonnegative().optional().describe('Run-request generation claimed by this execution.'),
 });
 
 export const HeartbeatTaskSchema = z.object({
@@ -64,6 +74,7 @@ export const HeartbeatTaskSchema = z.object({
     result: z.lazy(() => AgentHeartbeatResultSchema).optional().describe('Latest heartbeat runner result.'),
     error: z.string().optional().describe('Latest scheduler or runner error.'),
     execution: HeartbeatTaskExecutionSchema.optional().describe('Currently owned execution attempt and fencing identity.'),
+    runRequest: HeartbeatTaskRunRequestSchema.optional().describe('Durable level-triggered request state for a prompt task run.'),
     lastExecution: HeartbeatTaskExecutionOutcomeSchema.optional().describe('Latest outer heartbeat execution outcome.'),
     recovery: HeartbeatTaskRecoverySchema.optional().describe('Most recent explicit interrupted-execution recovery.'),
     updatedAt: z.string().optional().describe('Timestamp when this task record was last updated.'),

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { resolve } from 'node:path';
 import { Mutex } from 'async-mutex';
 import dayjs from 'dayjs';
@@ -5,6 +6,7 @@ import omit from 'lodash/omit.js';
 import orderBy from 'lodash/orderBy.js';
 import { FileHeartbeatTaskRepository } from './repository.js';
 import { HeartbeatTaskStateProjector } from './task-state.js';
+import { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './types.js';
 import type {
   FileHeartbeatTaskRepositoryOptions,
   HeartbeatTask,
@@ -13,6 +15,8 @@ import type {
   HeartbeatTaskState,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
+  HeartbeatTaskRunRequestResult,
+  HeartbeatTaskRunRequestSignal,
   HeartbeatTaskStore,
 } from './types.js';
 import type { HeartbeatRunView, HeartbeatTaskResultView, HeartbeatTaskView } from '../views/index.js';
@@ -62,14 +66,17 @@ export type UpdateHeartbeatTaskInput = {
 export class FileHeartbeatTaskService implements HeartbeatTaskStore {
   private static readonly mutationMutexes = new Map<string, Mutex>();
   private static readonly activeExecutions = new Set<string>();
+  private static readonly runRequestEventBuses = new Map<string, EventEmitter>();
 
   private readonly heartbeatRoot: string;
   private readonly mutationMutex: Mutex;
   private readonly repository: FileHeartbeatTaskRepository;
+  private readonly runRequestEventBus: EventEmitter;
 
   constructor(options: FileHeartbeatTaskServiceOptions) {
     this.heartbeatRoot = FileHeartbeatTaskService.resolveHeartbeatRoot(options);
     this.mutationMutex = FileHeartbeatTaskService.resolveMutationMutex(this.heartbeatRoot);
+    this.runRequestEventBus = FileHeartbeatTaskService.resolveRunRequestEventBus(this.heartbeatRoot);
     this.repository = new FileHeartbeatTaskRepository({
       dir: this.heartbeatRoot,
     });
@@ -89,6 +96,67 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
 
   async saveCheckpoint(task: HeartbeatTask, checkpoint: Parameters<HeartbeatTaskStore['saveCheckpoint']>[1]) {
     await this.mutationMutex.runExclusive(async () => await this.repository.saveCheckpoint(task, checkpoint));
+  }
+
+  /**
+   * Persists level-triggered intent for one prompt run and notifies schedulers
+   * sharing this file-backed state root. The durable task record remains the
+   * recovery source of truth across process boundaries.
+   */
+  async requestTaskRun(
+    taskId: string,
+    options: Parameters<HeartbeatTaskStore['requestTaskRun']>[1] = {},
+  ): Promise<HeartbeatTaskRunRequestResult> {
+    const reason = FileHeartbeatTaskService.normalizeRunRequestReason(options.reason);
+    const requestedAt = options.requestedAt ?? dayjs().toDate();
+    if (!dayjs(requestedAt).isValid()) {
+      throw new Error('Heartbeat run-request timestamp must be a valid date.');
+    }
+    const result = await this.mutationMutex.runExclusive(async () => {
+      const task = await this.findTask(taskId);
+      if (!task) {
+        throw new Error(`Heartbeat task not found: ${taskId}`);
+      }
+      FileHeartbeatTaskService.assertTaskAcceptsRunRequest(task);
+
+      const projection = HeartbeatTaskStateProjector.requestRun({
+        task,
+        now: requestedAt,
+        reason,
+      });
+      await this.repository.saveTask(projection.task);
+      const request = projection.task.state?.runRequest;
+      if (!request) {
+        throw new Error(`Heartbeat task ${taskId} did not persist its run request.`);
+      }
+
+      return {
+        task: projection.task,
+        taskId,
+        generation: request.generation,
+        disposition: projection.disposition,
+        requestedAt: request.requestedAt,
+        reason: request.reason,
+      } as const;
+    });
+
+    this.publishRunRequest(FileHeartbeatTaskService.toRunRequestSignal(result));
+    return result;
+  }
+
+  subscribeToRunRequests(listener: (request: HeartbeatTaskRunRequestSignal) => void): () => void {
+    this.runRequestEventBus.on('run-requested', listener);
+    return () => this.runRequestEventBus.off('run-requested', listener);
+  }
+
+  private publishRunRequest(request: HeartbeatTaskRunRequestSignal): void {
+    this.runRequestEventBus.listeners('run-requested').forEach((listener) => {
+      try {
+        (listener as (event: HeartbeatTaskRunRequestSignal) => void)(request);
+      } catch {
+        // A wake-up subscriber cannot roll back or invalidate durable intent.
+      }
+    });
   }
 
   async saveRunRecord(record: Parameters<NonNullable<HeartbeatTaskStore['saveRunRecord']>>[0]) {
@@ -134,8 +202,8 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
    */
   async completeTaskExecution(input: Parameters<HeartbeatTaskStore['completeTaskExecution']>[0]) {
     return await this.mutationMutex.runExclusive(async () => {
-      const currentTask = await this.findTask(input.task.id);
-      if (!FileHeartbeatTaskService.executionMatches(currentTask, input.execution)) {
+      const currentTask = await this.findTask(input.taskId);
+      if (!currentTask || !FileHeartbeatTaskService.executionMatches(currentTask, input.execution)) {
         FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
         return { status: 'claim-lost' } as const;
       }
@@ -143,34 +211,44 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
         return { status: 'cancelled' } as const;
       }
 
+      const currentExecution = currentTask.state?.execution ?? input.execution;
+      const nextTask = HeartbeatTaskStateProjector.afterResult({
+        task: currentTask,
+        execution: currentExecution,
+        result: input.result,
+        now: input.completedAt,
+        loadedCheckpoint: input.loadedCheckpoint,
+      });
+
       const record: HeartbeatTaskRunRecord = {
-        task: input.task,
+        task: nextTask,
         result: input.result,
         loadedCheckpoint: input.loadedCheckpoint,
         outcome:
-          input.task.state?.lastExecution?.kind === 'agent'
-          && input.task.state.lastExecution.executionId === input.execution.executionId ?
-            input.task.state.lastExecution
+          nextTask.state?.lastExecution?.kind === 'agent'
+          && nextTask.state.lastExecution.executionId === input.execution.executionId ?
+            nextTask.state.lastExecution
           : {
               kind: 'agent',
               executionId: input.execution.executionId,
               summary: input.result.summary,
               finishedAt: input.result.state.finishedAt,
+              runRequestGeneration: currentExecution.runRequestGeneration,
             },
       };
-      await this.repository.saveCheckpoint(input.task, input.checkpoint);
-      await this.repository.saveTask(input.task);
+      await this.repository.saveCheckpoint(nextTask, input.checkpoint);
+      await this.repository.saveTask(nextTask);
       await this.repository.saveRunRecord(record);
       FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
-      return { status: 'saved', task: input.task, record } as const;
+      return { status: 'saved', task: nextTask, record } as const;
     });
   }
 
   /** Persists a failed attempt only while its execution fencing token is current. */
   async failTaskExecution(input: Parameters<HeartbeatTaskStore['failTaskExecution']>[0]) {
     return await this.mutationMutex.runExclusive(async () => {
-      const currentTask = await this.findTask(input.task.id);
-      if (!FileHeartbeatTaskService.executionMatches(currentTask, input.execution)) {
+      const currentTask = await this.findTask(input.taskId);
+      if (!currentTask || !FileHeartbeatTaskService.executionMatches(currentTask, input.execution)) {
         FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
         return { status: 'claim-lost' } as const;
       }
@@ -178,17 +256,24 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
         return { status: 'cancelled' } as const;
       }
 
-      await this.repository.saveTask(input.task);
+      const nextTask = HeartbeatTaskStateProjector.afterFailure({
+        task: currentTask,
+        execution: currentTask.state?.execution ?? input.execution,
+        error: input.error,
+        now: input.failedAt,
+        retryMs: input.retryMs,
+      });
+      await this.repository.saveTask(nextTask);
       FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
-      return { status: 'saved', task: input.task } as const;
+      return { status: 'saved', task: nextTask } as const;
     });
   }
 
   /** Persists a claim-fenced non-agent outcome without creating or replacing a checkpoint. */
   async recordTaskExecutionOutcome(input: Parameters<HeartbeatTaskStore['recordTaskExecutionOutcome']>[0]) {
     return await this.mutationMutex.runExclusive(async () => {
-      const currentTask = await this.findTask(input.task.id);
-      if (!FileHeartbeatTaskService.executionMatches(currentTask, input.execution)) {
+      const currentTask = await this.findTask(input.taskId);
+      if (!currentTask || !FileHeartbeatTaskService.executionMatches(currentTask, input.execution)) {
         FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
         return { status: 'claim-lost' } as const;
       }
@@ -196,14 +281,35 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
         return { status: 'cancelled' } as const;
       }
 
+      const execution = currentTask.state?.execution ?? input.execution;
+      const projectors = {
+        skipped: () => HeartbeatTaskStateProjector.afterSkip({
+          task: currentTask,
+          execution,
+          summary: input.summary,
+          now: input.finishedAt,
+        }),
+        cancelled: () => HeartbeatTaskStateProjector.afterCancellation({
+          task: currentTask,
+          execution,
+          summary: input.summary,
+          now: input.finishedAt,
+        }),
+      } satisfies Record<typeof input.kind, () => HeartbeatTask>;
+      const nextTask = projectors[input.kind]();
+      const outcome = nextTask.state?.lastExecution;
+      if (!outcome || outcome.kind !== input.kind) {
+        throw new Error(`Heartbeat task ${input.taskId} did not project a ${input.kind} execution outcome.`);
+      }
+
       const record: HeartbeatTaskRunRecord = {
-        task: input.task,
-        outcome: input.outcome,
+        task: nextTask,
+        outcome,
       };
-      await this.repository.saveTask(input.task);
+      await this.repository.saveTask(nextTask);
       await this.repository.saveRunRecord(record);
       FileHeartbeatTaskService.activeExecutions.delete(this.executionKey(input.execution));
-      return { status: 'saved', task: input.task, record } as const;
+      return { status: 'saved', task: nextTask, record } as const;
     });
   }
 
@@ -253,112 +359,124 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
   }
 
   async createTask(input: CreateHeartbeatTaskInput) {
-    const tasks = await this.listTasks();
-    const now = dayjs();
-    const id = input.id ?? FileHeartbeatTaskService.createTaskId(input.name ?? input.task, tasks.map((task) => task.id));
-    if (tasks.some((task) => task.id === id)) {
-      throw new Error(`Heartbeat task already exists: ${id}`);
-    }
+    return await this.mutationMutex.runExclusive(async () => {
+      const tasks = await this.repository.listTasks();
+      const now = dayjs();
+      const id = input.id ?? FileHeartbeatTaskService.createTaskId(input.name ?? input.task, tasks.map((task) => task.id));
+      if (tasks.some((task) => task.id === id)) {
+        throw new Error(`Heartbeat task already exists: ${id}`);
+      }
 
-    const intervalMs = input.intervalMs ?? 60 * 60_000;
-    const task: HeartbeatTask = {
-      id,
-      workspaceId: input.workspaceId,
-      name: input.name,
-      task: input.task.trim(),
-      enabled: input.enabled ?? true,
-      continuationMode: input.continuationMode ?? 'operator',
-      schedule: {
-        intervalMs,
-        nextRunAt: (input.defer === false ? now.subtract(1, 'second') : now.add(intervalMs, 'millisecond')).toISOString(),
-      },
-      runtime: {
-        model: input.model,
-        maxSteps: input.maxSteps,
-        workspaceRoot: input.workspaceRoot,
-        stateDir: input.stateDir,
-        searchIgnoreDirs: input.searchIgnoreDirs,
-        systemContext: input.systemContext,
-      },
-      state: {
-        status: input.enabled === false ? 'idle' : 'waiting',
-        updatedAt: now.toISOString(),
-      },
-    };
+      const intervalMs = input.intervalMs ?? 60 * 60_000;
+      const task: HeartbeatTask = {
+        id,
+        workspaceId: input.workspaceId,
+        name: input.name,
+        task: input.task.trim(),
+        enabled: input.enabled ?? true,
+        continuationMode: input.continuationMode ?? 'operator',
+        schedule: {
+          intervalMs,
+          nextRunAt: (input.defer === false ? now.subtract(1, 'second') : now.add(intervalMs, 'millisecond')).toISOString(),
+        },
+        runtime: {
+          model: input.model,
+          maxSteps: input.maxSteps,
+          workspaceRoot: input.workspaceRoot,
+          stateDir: input.stateDir,
+          searchIgnoreDirs: input.searchIgnoreDirs,
+          systemContext: input.systemContext,
+        },
+        state: {
+          status: input.enabled === false ? 'idle' : 'waiting',
+          updatedAt: now.toISOString(),
+        },
+      };
 
-    await this.saveTask(task);
-    return FileHeartbeatTaskService.projectTaskView(task);
+      await this.repository.saveTask(task);
+      return FileHeartbeatTaskService.projectTaskView(task);
+    });
   }
 
   async updateTask(taskId: string, input: UpdateHeartbeatTaskInput) {
-    const task = await this.requireTask(taskId);
-    const now = dayjs();
-    const intervalMs = input.intervalMs ?? task.schedule.intervalMs;
-    const running = task.state?.status === 'running';
-    const nextTask: HeartbeatTask = {
-      ...task,
-      name: input.name ?? task.name,
-      task: input.task?.trim() ?? task.task,
-      enabled: input.enabled ?? task.enabled,
-      continuationMode: input.continuationMode ?? task.continuationMode ?? 'operator',
-      schedule: {
-        ...task.schedule,
-        intervalMs,
-        nextRunAt: running ? task.schedule.nextRunAt : now.add(intervalMs, 'millisecond').toISOString(),
-      },
-      runtime: {
-        ...task.runtime,
-        model: input.model === undefined ? task.runtime?.model : input.model ?? undefined,
-        maxSteps: input.maxSteps === undefined ? task.runtime?.maxSteps : input.maxSteps ?? undefined,
-        searchIgnoreDirs: input.searchIgnoreDirs ?? task.runtime?.searchIgnoreDirs,
-        systemContext: input.systemContext ?? task.runtime?.systemContext,
-      },
-      state: {
-        ...task.state,
-        updatedAt: now.toISOString(),
-      },
-    };
-
-    await this.saveTask(nextTask);
+    const nextTask = await this.updateStoredTask(taskId, (task) => {
+      const now = dayjs();
+      const intervalMs = input.intervalMs ?? task.schedule.intervalMs;
+      const running = task.state?.status === 'running';
+      const enabled = input.enabled ?? task.enabled;
+      const pendingRunRequest = HeartbeatTaskStateProjector.hasPendingRunRequest(task);
+      return {
+        ...task,
+        name: input.name ?? task.name,
+        task: input.task?.trim() ?? task.task,
+        enabled,
+        continuationMode: input.continuationMode ?? task.continuationMode ?? 'operator',
+        schedule: {
+          ...task.schedule,
+          intervalMs,
+          nextRunAt:
+            !enabled ? undefined
+            : running || pendingRunRequest ? task.schedule.nextRunAt
+            : now.add(intervalMs, 'millisecond').toISOString(),
+        },
+        runtime: {
+          ...task.runtime,
+          model: input.model === undefined ? task.runtime?.model : input.model ?? undefined,
+          maxSteps: input.maxSteps === undefined ? task.runtime?.maxSteps : input.maxSteps ?? undefined,
+          searchIgnoreDirs: input.searchIgnoreDirs ?? task.runtime?.searchIgnoreDirs,
+          systemContext: input.systemContext ?? task.runtime?.systemContext,
+        },
+        state: {
+          ...task.state,
+          runRequest: !enabled ? FileHeartbeatTaskService.consumePendingRunRequest(task.state?.runRequest) : task.state?.runRequest,
+          updatedAt: now.toISOString(),
+        },
+      };
+    });
     return FileHeartbeatTaskService.projectTaskView(nextTask);
   }
 
   async deleteTask(taskId: string) {
-    const task = await this.requireTask(taskId);
-    if (task.state?.status === 'running') {
-      throw new Error(`Heartbeat task ${taskId} is running. Wait for the run to finish before deleting it.`);
-    }
+    const task = await this.mutationMutex.runExclusive(async () => {
+      const currentTask = await this.findTask(taskId);
+      if (!currentTask) {
+        throw new Error(`Heartbeat task not found: ${taskId}`);
+      }
+      if (currentTask.state?.status === 'running') {
+        throw new Error(`Heartbeat task ${taskId} is running. Wait for the run to finish before deleting it.`);
+      }
 
-    await this.repository.deleteTask(task);
+      await this.repository.deleteTask(currentTask);
+      return currentTask;
+    });
     return FileHeartbeatTaskService.projectTaskView(task);
   }
 
   async resumeTask(taskId: string) {
-    const task = await this.requireTask(taskId);
-    if (task.state?.status === 'running') {
-      throw new Error(`Heartbeat task ${taskId} is already running.`);
-    }
-    if (task.state?.resumable === false) {
-      throw new Error(`Heartbeat task ${taskId} cannot be resumed.`);
-    }
+    const nextTask = await this.updateStoredTask(taskId, (task) => {
+      if (task.state?.status === 'running') {
+        throw new Error(`Heartbeat task ${taskId} is already running.`);
+      }
+      if (task.state?.resumable === false) {
+        throw new Error(`Heartbeat task ${taskId} cannot be resumed.`);
+      }
 
-    const now = dayjs();
-    const nextTask: HeartbeatTask = {
-      ...task,
-      enabled: true,
-      schedule: {
-        ...task.schedule,
-        nextRunAt: now.subtract(1, 'second').toISOString(),
-      },
-      state: {
-        ...omit(task.state, ['error']),
-        status: 'waiting',
-        progress: 'Heartbeat task resumed. Waiting for the next scheduler poll.',
-        updatedAt: now.toISOString(),
-      },
-    };
-
-    await this.saveTask(nextTask);
+      const now = dayjs();
+      return {
+        ...task,
+        enabled: true,
+        schedule: {
+          ...task.schedule,
+          nextRunAt: now.subtract(1, 'second').toISOString(),
+        },
+        state: {
+          ...omit(task.state, ['error']),
+          status: 'waiting',
+          progress: 'Heartbeat task resumed. Waiting for the next scheduler poll.',
+          updatedAt: now.toISOString(),
+        },
+      };
+    });
     return FileHeartbeatTaskService.projectTaskView(nextTask);
   }
 
@@ -388,62 +506,40 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
   }
 
   async setTaskEnabled(taskId: string, enabled: boolean) {
-    const task = await this.requireTask(taskId);
-    const now = dayjs();
-    if (enabled && task.state?.status === 'blocked') {
-      throw new Error(`Heartbeat task ${taskId} is blocked. Use resume to unblock it.`);
-    }
+    const nextTask = await this.updateStoredTask(taskId, (task) => {
+      const now = dayjs();
+      if (enabled && task.state?.status === 'blocked') {
+        throw new Error(`Heartbeat task ${taskId} is blocked. Use resume to unblock it.`);
+      }
 
-    const status = FileHeartbeatTaskService.resolveTaskEnabledStatus(task, enabled);
-    const progress = FileHeartbeatTaskService.resolveTaskEnabledProgress(task, enabled);
-    const nextTask: HeartbeatTask = {
-      ...task,
-      enabled,
-      schedule: {
-        ...task.schedule,
-        nextRunAt:
-          enabled ?
-            task.schedule.nextRunAt ?? now.subtract(1, 'second').toISOString()
-          : undefined,
-      },
-      state: {
-        ...task.state,
-        status,
-        progress,
-        resumable: enabled ? true : task.state?.resumable,
-        updatedAt: now.toISOString(),
-      },
-    };
-    await this.saveTask(nextTask);
+      const status = FileHeartbeatTaskService.resolveTaskEnabledStatus(task, enabled);
+      const progress = FileHeartbeatTaskService.resolveTaskEnabledProgress(task, enabled);
+      return {
+        ...task,
+        enabled,
+        schedule: {
+          ...task.schedule,
+          nextRunAt:
+            enabled ?
+              task.schedule.nextRunAt ?? now.subtract(1, 'second').toISOString()
+            : undefined,
+        },
+        state: {
+          ...task.state,
+          status,
+          progress,
+          resumable: enabled ? true : task.state?.resumable,
+          runRequest: enabled ? task.state?.runRequest : FileHeartbeatTaskService.consumePendingRunRequest(task.state?.runRequest),
+          updatedAt: now.toISOString(),
+        },
+      };
+    });
     return FileHeartbeatTaskService.projectTaskView(nextTask);
   }
 
   async triggerTaskRun(taskId: string) {
-    const task = await this.requireTask(taskId);
-    if (!task.enabled) {
-      throw new Error(`Heartbeat task ${taskId} is disabled. Enable it before triggering a run.`);
-    }
-
-    const now = dayjs();
-    const status = task.state?.status === 'running' ? 'running' : 'waiting';
-    const nextTask: HeartbeatTask = {
-      ...task,
-      schedule: {
-        ...task.schedule,
-        nextRunAt: now.subtract(1, 'second').toISOString(),
-      },
-      state: {
-        ...task.state,
-        status,
-        progress:
-          task.state?.status === 'running' ?
-            task.state.progress
-          : 'Task manually triggered from control plane. Waiting for the next heartbeat worker poll.',
-        updatedAt: now.toISOString(),
-      },
-    };
-    await this.saveTask(nextTask);
-    return FileHeartbeatTaskService.projectTaskView(nextTask);
+    const result = await this.requestTaskRun(taskId, { reason: 'manual-trigger' });
+    return FileHeartbeatTaskService.projectTaskView(result.task);
   }
 
   async requireTask(taskId: string): Promise<HeartbeatTask> {
@@ -504,9 +600,13 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
       : state?.lastExecution ? FileHeartbeatTaskService.projectOutcomeView(state.lastExecution)
       : undefined;
     return {
-      ...omit(state ?? {}, ['result']),
+      ...omit(state ?? {}, ['result', 'runRequest']),
       status: state?.status ?? 'idle',
       result,
+      runRequest: state?.runRequest ? {
+        ...state.runRequest,
+        pending: state.runRequest.generation > state.runRequest.claimedGeneration,
+      } : undefined,
     };
   }
 
@@ -580,8 +680,73 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
     return resolve(options.workspaceRoot, options.stateDir ?? '.heddle', 'heartbeat');
   }
 
+  private static assertTaskAcceptsRunRequest(task: HeartbeatTask): void {
+    if (task.state?.status === 'blocked') {
+      throw new Error(`Heartbeat task ${task.id} is blocked. Resume it before requesting a run.`);
+    }
+    if (task.state?.status === 'complete') {
+      throw new Error(`Heartbeat task ${task.id} is complete. Resume it before requesting a run.`);
+    }
+    if (!task.enabled) {
+      throw new Error(`Heartbeat task ${task.id} is disabled. Enable it before requesting a run.`);
+    }
+  }
+
+  private static normalizeRunRequestReason(reason: string | undefined): string | undefined {
+    if (reason === undefined) {
+      return undefined;
+    }
+
+    const normalized = reason.trim();
+    if (!normalized) {
+      throw new Error('Heartbeat run-request reason cannot be empty.');
+    }
+    if (normalized.length > MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH) {
+      throw new Error(`Heartbeat run-request reason must be at most ${MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH} characters.`);
+    }
+    return normalized;
+  }
+
+  private static consumePendingRunRequest(
+    runRequest: HeartbeatTaskState['runRequest'],
+  ): HeartbeatTaskState['runRequest'] {
+    return runRequest ? {
+      ...runRequest,
+      claimedGeneration: runRequest.generation,
+    } : undefined;
+  }
+
+  private static toRunRequestSignal(
+    result: HeartbeatTaskRunRequestResult,
+  ): HeartbeatTaskRunRequestSignal {
+    return {
+      taskId: result.taskId,
+      generation: result.generation,
+      disposition: result.disposition,
+      requestedAt: result.requestedAt,
+      reason: result.reason,
+    };
+  }
+
   private async findTask(taskId: string): Promise<HeartbeatTask | undefined> {
     return (await this.repository.listTasks()).find((candidate) => candidate.id === taskId);
+  }
+
+  /** Serializes one task read-transform-write transition for the file adapter. */
+  private async updateStoredTask(
+    taskId: string,
+    update: (task: HeartbeatTask) => HeartbeatTask,
+  ): Promise<HeartbeatTask> {
+    return await this.mutationMutex.runExclusive(async () => {
+      const task = await this.findTask(taskId);
+      if (!task) {
+        throw new Error(`Heartbeat task not found: ${taskId}`);
+      }
+
+      const nextTask = update(task);
+      await this.repository.saveTask(nextTask);
+      return nextTask;
+    });
   }
 
   private executionKey(execution: HeartbeatTaskExecution): string {
@@ -615,6 +780,17 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
     const mutex = new Mutex();
     FileHeartbeatTaskService.mutationMutexes.set(heartbeatRoot, mutex);
     return mutex;
+  }
+
+  private static resolveRunRequestEventBus(heartbeatRoot: string): EventEmitter {
+    const existing = FileHeartbeatTaskService.runRequestEventBuses.get(heartbeatRoot);
+    if (existing) {
+      return existing;
+    }
+
+    const eventBus = new EventEmitter();
+    FileHeartbeatTaskService.runRequestEventBuses.set(heartbeatRoot, eventBus);
+    return eventBus;
   }
 
   private static withLegacyExecution(task: HeartbeatTask): HeartbeatTask {

--- a/src/core/heartbeat/tasks/task-state.ts
+++ b/src/core/heartbeat/tasks/task-state.ts
@@ -41,6 +41,13 @@ export class HeartbeatTaskStateProjector {
     loadedCheckpoint: boolean;
     execution: HeartbeatTaskExecution;
   }): HeartbeatTask {
+    const runRequest = args.task.state?.runRequest;
+    const claimsPendingRequest = HeartbeatTaskStateProjector.hasPendingRunRequest(args.task);
+    const execution = claimsPendingRequest && runRequest ? {
+      ...args.execution,
+      runRequestGeneration: runRequest.generation,
+    } : args.execution;
+
     return HeartbeatTaskStateProjector.normalize({
       ...args.task,
       state: {
@@ -52,10 +59,61 @@ export class HeartbeatTaskStateProjector {
           : 'Starting a new heartbeat runner cycle.',
         loadedCheckpoint: args.loadedCheckpoint,
         error: undefined,
-        execution: args.execution,
+        execution,
+        runRequest: claimsPendingRequest && runRequest ? {
+          ...runRequest,
+          claimedGeneration: runRequest.generation,
+        } : runRequest,
         updatedAt: dayjs(args.now).toISOString(),
       },
     });
+  }
+
+  static requestRun(args: {
+    task: HeartbeatTask;
+    now: Date;
+    reason?: string;
+  }): {
+    task: HeartbeatTask;
+    disposition: 'requested' | 'coalesced';
+  } {
+    const previousRequest = args.task.state?.runRequest;
+    const generation = (previousRequest?.generation ?? 0) + 1;
+    if (!Number.isSafeInteger(generation)) {
+      throw new Error(`Heartbeat task ${args.task.id} run-request generation is exhausted.`);
+    }
+
+    const requestedAt = dayjs(args.now).toISOString();
+    const disposition = HeartbeatTaskStateProjector.hasPendingRunRequest(args.task) ? 'coalesced' : 'requested';
+    const running = args.task.state?.status === 'running';
+    const task = HeartbeatTaskStateProjector.normalize({
+      ...args.task,
+      schedule: {
+        ...args.task.schedule,
+        nextRunAt: dayjs(args.now).subtract(1, 'second').toISOString(),
+      },
+      state: {
+        ...args.task.state,
+        status: running ? 'running' : 'waiting',
+        progress: running ?
+          args.task.state?.progress
+        : 'Heartbeat run requested. Waiting for the scheduler.',
+        runRequest: {
+          generation,
+          claimedGeneration: previousRequest?.claimedGeneration ?? 0,
+          requestedAt,
+          reason: args.reason,
+        },
+        updatedAt: requestedAt,
+      },
+    });
+
+    return { task, disposition };
+  }
+
+  static hasPendingRunRequest(task: Pick<HeartbeatTask, 'state'>): boolean {
+    const request = task.state?.runRequest;
+    return Boolean(request && request.generation > request.claimedGeneration);
   }
 
   static afterRecovery(args: {
@@ -114,7 +172,7 @@ export class HeartbeatTaskStateProjector {
     });
     const projection = HeartbeatTaskStateProjector.projectResult(args.result, delayMs);
 
-    return HeartbeatTaskStateProjector.normalize({
+    return HeartbeatTaskStateProjector.afterExecutionSettlement(HeartbeatTaskStateProjector.normalize({
       ...args.task,
       enabled: terminal ? false : args.task.enabled,
       schedule: {
@@ -130,6 +188,7 @@ export class HeartbeatTaskStateProjector {
         resumable: args.result.decision !== 'complete' || continuationMode === 'operator',
         result: args.result,
         error: undefined,
+        runRequest: args.task.state?.runRequest,
         lastExecution: HeartbeatTaskStateProjector.executionOutcome({
           kind: 'agent',
           execution: args.execution,
@@ -139,7 +198,7 @@ export class HeartbeatTaskStateProjector {
         recovery: args.task.state?.recovery,
         updatedAt: dayjs(args.now).toISOString(),
       },
-    });
+    }));
   }
 
   static afterFailure(args: {
@@ -150,7 +209,7 @@ export class HeartbeatTaskStateProjector {
     retryMs: number;
   }): HeartbeatTask {
     const summary = args.error instanceof Error ? args.error.message : String(args.error);
-    return HeartbeatTaskStateProjector.normalize({
+    return HeartbeatTaskStateProjector.afterExecutionSettlement(HeartbeatTaskStateProjector.normalize({
       ...args.task,
       schedule: {
         ...args.task.schedule,
@@ -171,7 +230,7 @@ export class HeartbeatTaskStateProjector {
         }),
         updatedAt: dayjs(args.now).toISOString(),
       },
-    });
+    }));
   }
 
   static afterSkip(args: {
@@ -181,7 +240,7 @@ export class HeartbeatTaskStateProjector {
     now: Date;
   }): HeartbeatTask {
     const finishedAt = dayjs(args.now).toISOString();
-    return HeartbeatTaskStateProjector.normalize({
+    return HeartbeatTaskStateProjector.afterExecutionSettlement(HeartbeatTaskStateProjector.normalize({
       ...args.task,
       schedule: {
         ...args.task.schedule,
@@ -196,6 +255,7 @@ export class HeartbeatTaskStateProjector {
         resumable: true,
         error: undefined,
         execution: undefined,
+        runRequest: args.task.state?.runRequest,
         lastExecution: HeartbeatTaskStateProjector.executionOutcome({
           kind: 'skipped',
           execution: args.execution,
@@ -205,7 +265,7 @@ export class HeartbeatTaskStateProjector {
         recovery: args.task.state?.recovery,
         updatedAt: finishedAt,
       },
-    });
+    }));
   }
 
   static afterCancellation(args: {
@@ -215,7 +275,7 @@ export class HeartbeatTaskStateProjector {
     now: Date;
   }): HeartbeatTask {
     const finishedAt = dayjs(args.now).toISOString();
-    return HeartbeatTaskStateProjector.normalize({
+    return HeartbeatTaskStateProjector.afterExecutionSettlement(HeartbeatTaskStateProjector.normalize({
       ...args.task,
       schedule: {
         ...args.task.schedule,
@@ -230,6 +290,7 @@ export class HeartbeatTaskStateProjector {
         resumable: true,
         error: undefined,
         execution: undefined,
+        runRequest: args.task.state?.runRequest,
         lastExecution: HeartbeatTaskStateProjector.executionOutcome({
           kind: 'cancelled',
           execution: args.execution,
@@ -239,7 +300,7 @@ export class HeartbeatTaskStateProjector {
         recovery: args.task.state?.recovery,
         updatedAt: finishedAt,
       },
-    });
+    }));
   }
 
   private static normalizeState(state: HeartbeatTaskState | undefined): HeartbeatTaskState {
@@ -248,6 +309,63 @@ export class HeartbeatTaskStateProjector {
       status: state?.status ?? 'idle',
       resumable: state?.resumable ?? true,
     };
+  }
+
+  private static afterExecutionSettlement(task: HeartbeatTask): HeartbeatTask {
+    const runRequest = task.state?.runRequest;
+    if (!task.enabled) {
+      const terminal = task.state?.status === 'blocked' || task.state?.status === 'complete';
+      return HeartbeatTaskStateProjector.normalize({
+        ...task,
+        schedule: {
+          ...task.schedule,
+          nextRunAt: undefined,
+        },
+        state: {
+          ...task.state,
+          status: terminal ? task.state?.status : 'idle',
+          progress: terminal ? task.state?.progress : 'Heartbeat execution settled. Task remains disabled.',
+          runRequest: runRequest ? {
+            ...runRequest,
+            claimedGeneration: runRequest.generation,
+          } : undefined,
+        },
+      });
+    }
+
+    if (!runRequest || !HeartbeatTaskStateProjector.hasPendingRunRequest(task)) {
+      return task;
+    }
+
+    if (task.state?.status === 'blocked' || task.state?.status === 'complete') {
+      return HeartbeatTaskStateProjector.normalize({
+        ...task,
+        schedule: {
+          ...task.schedule,
+          nextRunAt: undefined,
+        },
+        state: {
+          ...task.state,
+          runRequest: {
+            ...runRequest,
+            claimedGeneration: runRequest.generation,
+          },
+        },
+      });
+    }
+
+    return HeartbeatTaskStateProjector.normalize({
+      ...task,
+      schedule: {
+        ...task.schedule,
+        nextRunAt: dayjs(runRequest.requestedAt).subtract(1, 'second').toISOString(),
+      },
+      state: {
+        ...task.state,
+        status: 'waiting',
+        progress: 'A newer heartbeat run was requested during this execution. Waiting for an immediate follow-up.',
+      },
+    });
   }
 
   private static projectResult(
@@ -345,6 +463,7 @@ export class HeartbeatTaskStateProjector {
       executionId: args.execution.executionId,
       summary: args.summary,
       finishedAt: args.finishedAt,
+      runRequestGeneration: args.execution.runRequestGeneration,
     };
   }
 }

--- a/src/core/heartbeat/tasks/types.ts
+++ b/src/core/heartbeat/tasks/types.ts
@@ -16,6 +16,39 @@ export type HeartbeatTaskSchedule = {
 
 export type HeartbeatTaskContinuationMode = 'operator' | 'agent';
 
+export const MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH = 200;
+
+/**
+ * Durable level-triggered intent to run a task promptly.
+ *
+ * `generation` advances for every accepted request. `claimedGeneration` is the
+ * newest generation already claimed by an execution, so a larger generation
+ * represents one pending follow-up regardless of how many requests coalesced.
+ */
+export type HeartbeatTaskRunRequest = {
+  generation: number;
+  claimedGeneration: number;
+  requestedAt: string;
+  reason?: string;
+};
+
+export type RequestHeartbeatTaskRunOptions = {
+  reason?: string;
+  requestedAt?: Date;
+};
+
+export type HeartbeatTaskRunRequestSignal = {
+  taskId: string;
+  generation: number;
+  disposition: 'requested' | 'coalesced';
+  requestedAt: string;
+  reason?: string;
+};
+
+export type HeartbeatTaskRunRequestResult = HeartbeatTaskRunRequestSignal & {
+  task: HeartbeatTask;
+};
+
 export type HeartbeatTaskRuntime = Pick<
   RunAgentHeartbeatOptions,
   | 'model'
@@ -39,6 +72,7 @@ export type HeartbeatTaskExecution = {
   executionId: string;
   ownerId: string;
   claimedAt: string;
+  runRequestGeneration?: number;
 };
 
 export type HeartbeatTaskRecoveryReason = 'host-restart' | 'operator';
@@ -54,6 +88,7 @@ type HeartbeatTaskExecutionOutcomeBase = {
   executionId: string;
   summary: string;
   finishedAt: string;
+  runRequestGeneration?: number;
 };
 
 export type HeartbeatTaskExecutionOutcome = HeartbeatTaskExecutionOutcomeBase & (
@@ -73,6 +108,7 @@ export type HeartbeatTaskState = {
   result?: AgentHeartbeatResult;
   error?: string;
   execution?: HeartbeatTaskExecution;
+  runRequest?: HeartbeatTaskRunRequest;
   lastExecution?: HeartbeatTaskExecutionOutcome;
   recovery?: HeartbeatTaskRecovery;
   updatedAt?: string;
@@ -137,6 +173,11 @@ export type HeartbeatTaskStore = {
   saveTask: (task: HeartbeatTask) => Promise<void>;
   loadCheckpoint: (task: HeartbeatTask) => Promise<AgentLoopCheckpoint | undefined>;
   saveCheckpoint: (task: HeartbeatTask, checkpoint: AgentLoopCheckpoint) => Promise<void>;
+  requestTaskRun: (
+    taskId: string,
+    options?: RequestHeartbeatTaskRunOptions,
+  ) => Promise<HeartbeatTaskRunRequestResult>;
+  subscribeToRunRequests?: (listener: (request: HeartbeatTaskRunRequestSignal) => void) => () => void;
   claimTaskExecution: (input: {
     taskId: string;
     execution: HeartbeatTaskExecution;
@@ -145,21 +186,27 @@ export type HeartbeatTaskStore = {
   }) => Promise<HeartbeatTaskClaimResult>;
   completeTaskExecution: (input: {
     execution: HeartbeatTaskExecution;
-    task: HeartbeatTask;
+    taskId: string;
     checkpoint: AgentLoopCheckpoint;
     result: AgentHeartbeatResult;
     loadedCheckpoint: boolean;
+    completedAt: Date;
     signal?: AbortSignal;
   }) => Promise<HeartbeatTaskExecutionWriteResult>;
   failTaskExecution: (input: {
     execution: HeartbeatTaskExecution;
-    task: HeartbeatTask;
+    taskId: string;
+    error: unknown;
+    failedAt: Date;
+    retryMs: number;
     signal?: AbortSignal;
   }) => Promise<HeartbeatTaskExecutionWriteResult>;
   recordTaskExecutionOutcome: (input: {
     execution: HeartbeatTaskExecution;
-    task: HeartbeatTask;
-    outcome: HeartbeatTaskExecutionOutcome & { kind: 'skipped' | 'cancelled' };
+    taskId: string;
+    kind: 'skipped' | 'cancelled';
+    summary: string;
+    finishedAt: Date;
     signal?: AbortSignal;
   }) => Promise<HeartbeatTaskExecutionWriteResult>;
   recoverInterruptedTasks: (input: {

--- a/src/core/heartbeat/views/index.ts
+++ b/src/core/heartbeat/views/index.ts
@@ -1,6 +1,7 @@
 export { HeartbeatLucidPresenter } from './lucid-presenter.js';
 export type {
   HeartbeatRunView,
+  HeartbeatTaskRunRequestView,
   HeartbeatTaskResultView,
   HeartbeatTaskView,
   LucidAdapterOptions,

--- a/src/core/heartbeat/views/lucid-presenter.ts
+++ b/src/core/heartbeat/views/lucid-presenter.ts
@@ -75,7 +75,11 @@ export class HeartbeatLucidPresenter {
     event: HeartbeatSchedulerEvent,
     options: LucidAdapterOptions = {},
   ): LucidAgentMessage[] {
-    if (event.type === 'heartbeat.scheduler.started' || event.type === 'heartbeat.scheduler.stopped') {
+    if (
+      event.type === 'heartbeat.scheduler.started'
+      || event.type === 'heartbeat.scheduler.stopped'
+      || event.type === 'heartbeat.scheduler.awakened'
+    ) {
       return [];
     }
 
@@ -83,6 +87,8 @@ export class HeartbeatLucidPresenter {
 
     switch (event.type) {
       case 'heartbeat.task.due':
+      case 'heartbeat.task.run_requested':
+      case 'heartbeat.task.run_request_claimed':
         return [];
       case 'heartbeat.task.started':
         return [

--- a/src/core/heartbeat/views/types.ts
+++ b/src/core/heartbeat/views/types.ts
@@ -1,6 +1,11 @@
 import type { LlmUsage } from '@/core/llm/types.js';
 import type { HeartbeatDecision } from '../agent/index.js';
-import type { HeartbeatTask, HeartbeatTaskState, HeartbeatTaskStatus } from '../tasks/index.js';
+import type {
+  HeartbeatTask,
+  HeartbeatTaskRunRequest,
+  HeartbeatTaskState,
+  HeartbeatTaskStatus,
+} from '../tasks/index.js';
 
 export type HeartbeatTaskResultView = {
   kind: 'agent' | 'skipped' | 'cancelled' | 'failed';
@@ -10,11 +15,16 @@ export type HeartbeatTaskResultView = {
   usage?: LlmUsage;
 };
 
+export type HeartbeatTaskRunRequestView = HeartbeatTaskRunRequest & {
+  pending: boolean;
+};
+
 export type HeartbeatTaskView = Omit<HeartbeatTask, 'state'> & {
   taskId: string;
-  state: Omit<HeartbeatTaskState, 'result'> & {
+  state: Omit<HeartbeatTaskState, 'result' | 'runRequest'> & {
     status: HeartbeatTaskStatus;
     result?: HeartbeatTaskResultView;
+    runRequest?: HeartbeatTaskRunRequestView;
   };
 };
 

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -293,7 +293,24 @@ export type ControlPlaneHeartbeatAgentEvent = {
 export type ControlPlaneHeartbeatEvent =
   | { type: 'heartbeat.scheduler.started'; timestamp: string }
   | { type: 'heartbeat.scheduler.stopped'; reason: 'aborted' | 'completed' | 'error'; timestamp: string }
+  | { type: 'heartbeat.scheduler.awakened'; taskIds: string[]; timestamp: string }
   | { type: 'heartbeat.task.due'; taskId: string; timestamp: string }
+  | {
+    type: 'heartbeat.task.run_requested';
+    taskId: string;
+    generation: number;
+    disposition: 'requested' | 'coalesced';
+    requestedAt: string;
+    reason?: string;
+    timestamp: string;
+  }
+  | {
+    type: 'heartbeat.task.run_request_claimed';
+    taskId: string;
+    executionId: string;
+    generation: number;
+    timestamp: string;
+  }
   | {
     type: 'heartbeat.task.started';
     taskId: string;

--- a/src/server/controllers/trpc/control-plane/heartbeat.ts
+++ b/src/server/controllers/trpc/control-plane/heartbeat.ts
@@ -116,6 +116,19 @@ export class ControlPlaneHeartbeatController {
     return await new FileHeartbeatTaskService({ stateRoot }).triggerTaskRun(taskId);
   }
 
+  static async requestTaskRun(
+    stateRoot: string,
+    taskId: string,
+    options: { reason?: string } = {},
+  ) {
+    const tasks = new FileHeartbeatTaskService({ stateRoot });
+    const result = await tasks.requestTaskRun(taskId, options);
+    return {
+      ...result,
+      task: tasks.projectTaskView(result.task),
+    };
+  }
+
   static async runTaskNow(
     stateRoot: string,
     args: RunHeartbeatTaskNowArgs,

--- a/src/server/lifecycle.ts
+++ b/src/server/lifecycle.ts
@@ -254,7 +254,10 @@ function logHeartbeatSchedulerEvent(
   const messages = {
     'heartbeat.scheduler.started': 'Heddle heartbeat scheduler started',
     'heartbeat.scheduler.stopped': 'Heddle heartbeat scheduler stopped',
+    'heartbeat.scheduler.awakened': 'Heddle heartbeat scheduler awakened for requested work',
     'heartbeat.task.due': 'Heartbeat task due',
+    'heartbeat.task.run_requested': 'Heartbeat task run requested',
+    'heartbeat.task.run_request_claimed': 'Heartbeat task run request claimed',
     'heartbeat.task.started': 'Heartbeat task started',
     'heartbeat.task.recovered': 'Heartbeat task recovered after interrupted execution',
     'heartbeat.task.agent_event': 'Heartbeat task agent event',

--- a/src/server/routes/trpc/control-plane.ts
+++ b/src/server/routes/trpc/control-plane.ts
@@ -56,6 +56,7 @@ import {
   heartbeatTaskCreateInputSchema,
   heartbeatTaskDetailInputSchema,
   heartbeatTaskInputSchema,
+  heartbeatTaskRunRequestInputSchema,
   heartbeatTaskRunNowInputSchema,
   heartbeatTaskUpdateInputSchema,
   layoutSnapshotInputSchema,
@@ -636,14 +637,31 @@ export const controlPlaneRouter = router({
   }),
   heartbeatTaskTrigger: controlPlaneWorkspaceProcedure.input(heartbeatTaskInputSchema).mutation(async ({ ctx, input }) => {
     const { workspace } = ctx.requestWorkspace;
+    const requested = await ControlPlaneHeartbeatController.requestTaskRun(
+      workspace.stateRoot,
+      input.taskId,
+      { reason: 'manual-trigger' },
+    );
     return {
-      task: await ControlPlaneHeartbeatController.triggerTaskRun(workspace.stateRoot, input.taskId),
+      task: requested.task,
     };
+  }),
+  heartbeatTaskRequestRun: controlPlaneWorkspaceProcedure.input(heartbeatTaskRunRequestInputSchema).mutation(async ({ ctx, input }) => {
+    const { workspace } = ctx.requestWorkspace;
+    return await ControlPlaneHeartbeatController.requestTaskRun(
+      workspace.stateRoot,
+      input.taskId,
+      { reason: input.reason },
+    );
   }),
   heartbeatTaskRunNow: controlPlaneWorkspaceProcedure.input(heartbeatTaskRunNowInputSchema).mutation(async ({ ctx, input }) => {
     const { logger, workspace } = ctx.requestWorkspace;
     const { workspaceId: _workspaceId, ...runInput } = input;
-    const task = await ControlPlaneHeartbeatController.triggerTaskRun(workspace.stateRoot, input.taskId);
+    const requested = await ControlPlaneHeartbeatController.requestTaskRun(
+      workspace.stateRoot,
+      input.taskId,
+      { reason: 'manual-run-now' },
+    );
     controlPlaneHeartbeatEventsController.publish({
       workspaceId: workspace.id,
       event: {
@@ -668,7 +686,7 @@ export const controlPlaneRouter = router({
 
     return {
       accepted: true,
-      task,
+      task: requested.task,
       run: null,
     };
   }),

--- a/src/server/routes/trpc/schema.ts
+++ b/src/server/routes/trpc/schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { REASONING_EFFORTS } from '@/core/llm/types.js';
 import { AUTONOMY_PERMISSION_MODES } from '@/core/approvals/index.js';
+import { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from '@/core/heartbeat/tasks/index.js';
 import {
   CustomAgentApprovalPresetSchema,
   CustomAgentModeAliasSchema,
@@ -185,6 +186,10 @@ export const heartbeatRunsInputSchema = z.object({
 export const heartbeatTaskInputSchema = z.object({
   workspaceId: z.string().min(1).optional(),
   taskId: z.string().min(1),
+});
+
+export const heartbeatTaskRunRequestInputSchema = heartbeatTaskInputSchema.extend({
+  reason: z.string().trim().min(1).max(MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH).optional(),
 });
 
 export const heartbeatTaskCreateInputSchema = z.object({

--- a/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
@@ -60,7 +60,12 @@ export function useControlPlaneHeartbeatEvents({
       });
     }
 
-    if (event.type === 'heartbeat.task.failed' || event.type === 'heartbeat.task.recovered') {
+    if (
+      event.type === 'heartbeat.task.failed'
+      || event.type === 'heartbeat.task.recovered'
+      || event.type === 'heartbeat.task.run_requested'
+      || event.type === 'heartbeat.task.run_request_claimed'
+    ) {
       void utils.controlPlane.heartbeatTasks.invalidate(workspaceId ? { workspaceId } : undefined);
       void utils.controlPlane.heartbeatTask.invalidate(workspaceId ? { workspaceId, taskId: event.taskId } : { taskId: event.taskId });
       void utils.controlPlane.state.invalidate();
@@ -123,6 +128,20 @@ function projectHeartbeatTaskEvent(
         status: 'waiting',
         progress: 'Task is due. Waiting for the heartbeat runner...',
       };
+    case 'heartbeat.task.run_requested':
+      return {
+        ...base,
+        progress:
+          event.disposition === 'coalesced' ?
+            'A follow-up run is already pending; the latest request was coalesced.'
+          : 'A prompt heartbeat run was requested.',
+      };
+    case 'heartbeat.task.run_request_claimed':
+      return {
+        ...base,
+        status: 'running',
+        progress: `Heartbeat runner claimed request generation ${event.generation}.`,
+      };
     case 'heartbeat.task.started':
       return {
         ...base,
@@ -160,8 +179,8 @@ function projectHeartbeatTaskEvent(
     case 'heartbeat.task.failed':
       return {
         ...base,
-        status: 'failed',
-        progress: event.error,
+        status: event.status,
+        progress: event.progress || event.error,
       };
   }
 }


### PR DESCRIPTION
## Summary
- add durable, generation-based heartbeat run requests with coalesced follow-ups
- merge execution settlement against the latest task state and wake sleeping in-process schedulers
- expose request state through task views, scheduler events, control-plane APIs, docs, and examples

## Validation
- yarn test (806 unit + 368 integration tests)
- yarn typecheck
- yarn lint
- yarn tsc -p src/web-v2/tsconfig.json --noEmit
- yarn build

Closes #297