### PR TITLE
Run heartbeat tasks with bounded concurrency

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -37,8 +37,8 @@ heddle heartbeat task add --id repo-gardener --task "Check for safe maintenance 
 heddle heartbeat task list
 heddle heartbeat task show repo-gardener
 heddle heartbeat task enable repo-gardener
-heddle heartbeat run
-heddle heartbeat start --poll 60s
+heddle heartbeat run --concurrency 2
+heddle heartbeat start --poll 60s --concurrency 2
 heddle heartbeat start --once --id repo-gardener
 heddle heartbeat runs list --task repo-gardener
 heddle heartbeat runs show latest --task repo-gardener
@@ -78,6 +78,13 @@ For repeated runner cycles, Heddle also exposes a local-first scheduler core:
 compact display shape for a UI or service integration, use
 `FileHeartbeatTaskService` task/run view methods instead of flattening task
 state yourself.
+
+Due tasks are selected in stable oldest-`nextRunAt` order with task ID as the
+tie-breaker. Set `maxConcurrentTasks` to let independent tasks share a bounded
+worker pool; the default is `1` for serial compatibility. Completion events are
+emitted when each execution actually settles, while the returned `records`
+array stays in selected-task order. The `heartbeat.task.due` event includes its
+one-based queue position and current pool counts.
 
 `HeartbeatSchedulerService.runLoop` assigns one owner identity to the current
 worker generation. On startup it performs one explicit recovery pass before
@@ -168,6 +175,7 @@ const handler: HeartbeatTaskHandler = async (context) => {
 
 await HeartbeatSchedulerService.runDueTasks({
   store,
+  maxConcurrentTasks: 4,
   runtime: {
     workspaceRoot: process.cwd(),
     stateDir: '.heddle',
@@ -202,6 +210,7 @@ const scheduler = HeartbeatSchedulerService.start({
   workspaceRoot,
   stateRoot,
   handler,
+  maxConcurrentTasks: 4,
 });
 
 // Stop polling, abort the active execution, and wait for handler settlement

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,13 +24,13 @@ OpenAI account sign-in is experimental and user-selected. It is not official Ope
 
 ### Heartbeat and scheduling
 
-- `heddle heartbeat start [--every 30m] [--task "<durable task>"] [--poll 60s] [--once]`: create or update a task and keep the server-backed scheduler running, or run once with `--once`
+- `heddle heartbeat start [--every 30m] [--task "<durable task>"] [--poll 60s] [--concurrency 2] [--once]`: create or update a task and keep the server-backed scheduler running, or run once with `--once`
 - `heddle heartbeat task add --id <id> --task "<durable task>" [--every 15m]`: create or update a scheduled heartbeat task
 - `heddle heartbeat task list`: list local heartbeat tasks
 - `heddle heartbeat task show <id>`: show a task's schedule, last decision, and last run summary
 - `heddle heartbeat task enable <id>`: enable a heartbeat task
 - `heddle heartbeat task disable <id>`: disable a heartbeat task
-- `heddle heartbeat run [--task <id>]`: ask the control-plane server to run due heartbeat tasks, or one task when `--task` is provided
+- `heddle heartbeat run [--task <id>] [--concurrency 2]`: ask the control-plane server to run due heartbeat tasks with bounded concurrency, or one task when `--task` is provided
 - `heddle heartbeat runs list [--task <id>] [--limit 10]`: list saved heartbeat run records
 - `heddle heartbeat runs show <run-id|latest> [--task <id>]`: show the final agent output for a saved heartbeat run
 
@@ -104,13 +104,13 @@ After the daemon starts, open the browser control plane to inspect sessions, rev
 Start the server-backed heartbeat scheduler:
 
 ```bash
-heddle heartbeat start --every 30m
+heddle heartbeat start --every 30m --concurrency 2
 ```
 
 Run due heartbeat tasks once:
 
 ```bash
-heddle heartbeat run
+heddle heartbeat run --concurrency 2
 ```
 
 ## Interactive Chat Commands

--- a/examples/heartbeat-scheduler.ts
+++ b/examples/heartbeat-scheduler.ts
@@ -43,6 +43,7 @@ async function main() {
 
   const result = await HeartbeatSchedulerService.runDueTasks({
     store,
+    maxConcurrentTasks: 2,
     now: () => new Date(),
     runtime: {
       model,
@@ -124,7 +125,12 @@ function formatSchedulerEvent(event: HeartbeatSchedulerEvent): string | undefine
     case 'heartbeat.scheduler.awakened':
       return `[event] scheduler.awakened tasks=${event.taskIds.join(',')}`;
     case 'heartbeat.task.due':
-      return `[event] task.due id=${event.taskId}`;
+      return [
+        `[event] task.due id=${event.taskId}`,
+        event.queuePosition ? `position=${event.queuePosition}` : undefined,
+        event.maxConcurrentTasks ? `concurrency=${event.activeTasks ?? 0}/${event.maxConcurrentTasks}` : undefined,
+        event.queuedTasks !== undefined ? `queued=${event.queuedTasks}` : undefined,
+      ].filter(Boolean).join(' ');
     case 'heartbeat.task.run_requested':
       return `[event] task.run_requested id=${event.taskId} generation=${event.generation} disposition=${event.disposition}`;
     case 'heartbeat.task.run_request_claimed':

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
     "monaco-editor": "^0.55.1",
     "multer": "^2.1.1",
     "openai": "^6.48.0",
+    "p-limit": "^7.3.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "proper-lockfile": "^4.1.2",

--- a/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
+++ b/src/__tests__/integration/control-plane/control-plane-heartbeat-mutations.test.ts
@@ -401,6 +401,7 @@ describe('control-plane heartbeat mutations', () => {
     const result = await caller.heartbeatRunDueTasks({
       workspaceId: activeWorkspace.id,
       model: 'gpt-5.4',
+      maxConcurrentTasks: 2,
     });
 
     expect(result).toMatchObject({

--- a/src/__tests__/integration/core/heartbeat-concurrency.test.ts
+++ b/src/__tests__/integration/core/heartbeat-concurrency.test.ts
@@ -1,0 +1,320 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  FileHeartbeatTaskService,
+  HeartbeatSchedulerService,
+  type AgentHeartbeatResult,
+  type HeartbeatSchedulerEvent,
+  type HeartbeatTask,
+} from '../../../advanced.js';
+import { HeartbeatTaskRunnerService } from '@/core/heartbeat/index.js';
+import { AgentLoopCheckpointService } from '@/core/runtime/loop/index.js';
+
+const NOW = new Date('2026-08-04T00:00:00.000Z');
+
+describe('heartbeat scheduler bounded concurrency', () => {
+  it('runs at most two tasks concurrently in stable due order and returns records in that order', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-concurrency-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    await saveTasks(store, [
+      createTask('zeta', '2026-08-03T23:59:40.000Z'),
+      createTask('bravo', '2026-08-03T23:59:00.000Z'),
+      createTask('echo', '2026-08-03T23:59:30.000Z'),
+      createTask('delta', '2026-08-03T23:59:00.000Z'),
+      createTask('alpha', '2026-08-03T23:58:00.000Z'),
+    ]);
+    const selectedOrder = ['alpha', 'bravo', 'delta', 'echo', 'zeta'];
+    const releases = new Map(selectedOrder.map((taskId) => [taskId, deferred<void>()]));
+    const startGates = selectedOrder.map(() => deferred<void>());
+    const startedTaskIds: string[] = [];
+    const completionOrder: string[] = [];
+    const events: HeartbeatSchedulerEvent[] = [];
+    let active = 0;
+    let maxActive = 0;
+
+    const run = HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      maxConcurrentTasks: 2,
+      onEvent: (event) => events.push(event),
+      runner: async (task) => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        startedTaskIds.push(task.id);
+        startGates[startedTaskIds.length - 1]?.resolve();
+        await releases.get(task.id)?.promise;
+        completionOrder.push(task.id);
+        active--;
+        return createHeartbeatResult(task.id);
+      },
+    });
+
+    await startGates[1]?.promise;
+    expect(startedTaskIds).toEqual(['alpha', 'bravo']);
+    expect(maxActive).toBe(2);
+
+    releases.get('bravo')?.resolve();
+    await startGates[2]?.promise;
+    expect(startedTaskIds).toEqual(['alpha', 'bravo', 'delta']);
+
+    releases.get('delta')?.resolve();
+    await startGates[3]?.promise;
+    expect(startedTaskIds).toEqual(['alpha', 'bravo', 'delta', 'echo']);
+
+    releases.get('echo')?.resolve();
+    await startGates[4]?.promise;
+    expect(startedTaskIds).toEqual(selectedOrder);
+
+    releases.get('zeta')?.resolve();
+    releases.get('alpha')?.resolve();
+    const result = await run;
+
+    expect(maxActive).toBe(2);
+    expect(completionOrder).toEqual(['bravo', 'delta', 'echo', 'zeta', 'alpha']);
+    expect(result).toMatchObject({ checked: 5, ran: 5, failed: 0 });
+    expect(result.records.map((record) => record.task.id)).toEqual(selectedOrder);
+    expect(events.filter((event) => event.type === 'heartbeat.task.due')).toMatchObject(
+      selectedOrder.map((taskId, index) => ({
+        type: 'heartbeat.task.due',
+        taskId,
+        queuePosition: index + 1,
+        maxConcurrentTasks: 2,
+      })),
+    );
+  });
+
+  it.each([
+    { label: 'by default', maxConcurrentTasks: undefined },
+    { label: 'when explicitly set to one', maxConcurrentTasks: 1 },
+  ])('preserves serial admission $label', async ({ maxConcurrentTasks }) => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-serial-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    const taskIds = ['alpha', 'bravo', 'charlie'];
+    await saveTasks(store, taskIds.map((taskId) => createTask(taskId, '2000-01-01T00:00:00.000Z')));
+    const releases = new Map(taskIds.map((taskId) => [taskId, deferred<void>()]));
+    const startGates = taskIds.map(() => deferred<void>());
+    const startedTaskIds: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+
+    const run = HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      maxConcurrentTasks,
+      runner: async (task) => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        startedTaskIds.push(task.id);
+        startGates[startedTaskIds.length - 1]?.resolve();
+        await releases.get(task.id)?.promise;
+        active--;
+        return createHeartbeatResult(task.id);
+      },
+    });
+
+    await startGates[0]?.promise;
+    expect(startedTaskIds).toEqual(['alpha']);
+    releases.get('alpha')?.resolve();
+    await startGates[1]?.promise;
+    expect(startedTaskIds).toEqual(['alpha', 'bravo']);
+    releases.get('bravo')?.resolve();
+    await startGates[2]?.promise;
+    releases.get('charlie')?.resolve();
+
+    await expect(run).resolves.toMatchObject({ checked: 3, ran: 3, failed: 0 });
+    expect(maxActive).toBe(1);
+  });
+
+  it('prevents overlapping scheduler and run-now attempts from executing one task twice', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-single-flight-'));
+    const firstStore = new FileHeartbeatTaskService({ dir });
+    const secondStore = new FileHeartbeatTaskService({ dir });
+    await firstStore.saveTask(createTask('shared-task'));
+    const firstStarted = deferred<void>();
+    const releaseFirst = deferred<void>();
+    let firstRunnerCalls = 0;
+    let competingRunnerCalls = 0;
+
+    const firstRun = HeartbeatSchedulerService.runDueTasks({
+      store: firstStore,
+      now: () => NOW,
+      runner: async (task) => {
+        firstRunnerCalls++;
+        firstStarted.resolve();
+        await releaseFirst.promise;
+        return createHeartbeatResult(task.id);
+      },
+    });
+    await firstStarted.promise;
+
+    const competingRun = await HeartbeatTaskRunnerService.runTaskById({
+      store: secondStore,
+      taskId: 'shared-task',
+      now: () => NOW,
+      runner: async (task) => {
+        competingRunnerCalls++;
+        return createHeartbeatResult(task.id);
+      },
+    });
+    expect(competingRun).toMatchObject({ checked: 1, ran: 0, failed: 0 });
+    expect(competingRunnerCalls).toBe(0);
+
+    releaseFirst.resolve();
+    await expect(firstRun).resolves.toMatchObject({ checked: 1, ran: 1, failed: 0 });
+    expect(firstRunnerCalls).toBe(1);
+  });
+
+  it('isolates one task failure and keeps deterministic aggregate counts and records', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-concurrency-failure-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    await saveTasks(store, ['charlie', 'bravo', 'alpha'].map((taskId) => createTask(taskId)));
+
+    const result = await HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      maxConcurrentTasks: 2,
+      runner: async (task) => {
+        if (task.id === 'bravo') {
+          throw new Error('bravo failed');
+        }
+        return createHeartbeatResult(task.id);
+      },
+    });
+
+    expect(result).toMatchObject({ checked: 3, ran: 2, failed: 1 });
+    expect(result.records.map((record) => record.task.id)).toEqual(['alpha', 'charlie']);
+  });
+
+  it('stops queued admissions, aborts active tasks, and waits for their final persistence', async () => {
+    const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-concurrency-stop-'));
+    const store = new FileHeartbeatTaskService({ stateRoot });
+    const taskIds = ['alpha', 'bravo', 'charlie', 'delta', 'echo'];
+    await saveTasks(store, taskIds.map((taskId) => createTask(taskId, '2000-01-01T00:00:00.000Z')));
+    const startGates = [deferred<void>(), deferred<void>()];
+    const startedTaskIds: string[] = [];
+    const observedAbortTaskIds: string[] = [];
+    const events: HeartbeatSchedulerEvent[] = [];
+
+    const scheduler = HeartbeatSchedulerService.start({
+      workspaceRoot: stateRoot,
+      stateRoot,
+      pollIntervalMs: 60_000,
+      maxConcurrentTasks: 2,
+      handler: async (context) => {
+        startedTaskIds.push(context.task.id);
+        startGates[startedTaskIds.length - 1]?.resolve();
+        await waitForAbort(context.signal);
+        observedAbortTaskIds.push(context.task.id);
+        return context.skip({ summary: 'Stopped by scheduler host.' });
+      },
+      onEvent: (event) => events.push(event),
+    });
+
+    await startGates[1]?.promise;
+    await scheduler.stop({ cancelRunning: true });
+
+    expect(startedTaskIds).toEqual(['alpha', 'bravo']);
+    expect(observedAbortTaskIds).toEqual(['alpha', 'bravo']);
+    expect(events.filter((event) => event.type === 'heartbeat.task.cancelled')).toHaveLength(2);
+    expect(events.at(-1)).toMatchObject({
+      type: 'heartbeat.scheduler.stopped',
+      reason: 'aborted',
+    });
+    await expect(store.listRunRecords()).resolves.toHaveLength(2);
+    await expect(store.listTasks()).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'charlie', state: expect.objectContaining({ status: 'waiting' }) }),
+      expect.objectContaining({ id: 'delta', state: expect.objectContaining({ status: 'waiting' }) }),
+      expect.objectContaining({ id: 'echo', state: expect.objectContaining({ status: 'waiting' }) }),
+    ]));
+  });
+
+  it.each([0, -1, 1.5])('rejects invalid maxConcurrentTasks value %s before touching the store', async (maxConcurrentTasks) => {
+    let listCalls = 0;
+    const store = new FileHeartbeatTaskService({
+      dir: mkdtempSync(join(tmpdir(), 'heddle-heartbeat-invalid-concurrency-')),
+    });
+    const originalListTasks = store.listTasks.bind(store);
+    store.listTasks = async () => {
+      listCalls++;
+      return await originalListTasks();
+    };
+
+    await expect(HeartbeatSchedulerService.runDueTasks({
+      store,
+      maxConcurrentTasks,
+    })).rejects.toThrow(/maxConcurrentTasks.*positive integer/i);
+    expect(listCalls).toBe(0);
+    expect(() => HeartbeatSchedulerService.start({
+      workspaceRoot: '/tmp/heddle-invalid-concurrency',
+      stateRoot: '/tmp/heddle-invalid-concurrency/.heddle',
+      maxConcurrentTasks,
+    })).toThrow(/maxConcurrentTasks.*positive integer/i);
+  });
+});
+
+async function saveTasks(store: FileHeartbeatTaskService, tasks: HeartbeatTask[]): Promise<void> {
+  await Promise.all(tasks.map(async (task) => await store.saveTask(task)));
+}
+
+function createTask(id: string, nextRunAt = '2026-08-03T23:59:00.000Z'): HeartbeatTask {
+  return {
+    id,
+    task: `Run ${id}.`,
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt,
+    },
+    state: {
+      status: 'waiting',
+      resumable: true,
+    },
+  };
+}
+
+function createHeartbeatResult(taskId: string): AgentHeartbeatResult {
+  const summary = `Finished ${taskId}.\n\nHEARTBEAT_DECISION: continue`;
+  const state = {
+    status: 'finished' as const,
+    runId: `run-${taskId}`,
+    goal: `Run ${taskId}.`,
+    model: 'gpt-test',
+    provider: 'openai' as const,
+    workspaceRoot: '/tmp/project',
+    startedAt: NOW.toISOString(),
+    finishedAt: NOW.toISOString(),
+    outcome: 'done' as const,
+    summary,
+    transcript: [],
+    trace: [],
+  };
+
+  return {
+    decision: 'continue',
+    summary,
+    state,
+    checkpoint: AgentLoopCheckpointService.createCheckpoint(state, {
+      createdAt: NOW.toISOString(),
+    }),
+  };
+}
+
+function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => signal.addEventListener('abort', () => resolve(), { once: true }));
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}

--- a/src/__tests__/integration/core/heartbeat-run-requests.test.ts
+++ b/src/__tests__/integration/core/heartbeat-run-requests.test.ts
@@ -232,7 +232,7 @@ describe('heartbeat run requests', () => {
     expect((await store.listTasks()).every((task) => task.state?.runRequest === undefined)).toBe(true);
   });
 
-  it('wakes a sleeping scheduler promptly and removes the wake subscription on stop', async () => {
+  it('wakes a sleeping bounded scheduler promptly and removes the wake subscription on stop', async () => {
     const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-run-request-wake-'));
     const tasks = new FileHeartbeatTaskService({ stateRoot });
     await tasks.saveTask(createTask({
@@ -249,6 +249,7 @@ describe('heartbeat run requests', () => {
       workspaceRoot: stateRoot,
       stateRoot,
       pollIntervalMs: 60_000,
+      maxConcurrentTasks: 2,
       handler: async (context) => {
         handlerStarted.resolve();
         await releaseHandler.promise;
@@ -274,6 +275,7 @@ describe('heartbeat run requests', () => {
     expect(events).toEqual(expect.arrayContaining([
       expect.objectContaining({ type: 'heartbeat.task.run_requested', reason: 'new-mail' }),
       expect.objectContaining({ type: 'heartbeat.scheduler.awakened', taskIds: ['mailbox-consumer'] }),
+      expect.objectContaining({ type: 'heartbeat.task.due', taskId: 'mailbox-consumer', maxConcurrentTasks: 2 }),
       expect.objectContaining({ type: 'heartbeat.task.run_request_claimed', generation: 1 }),
     ]));
 

--- a/src/__tests__/unit/cli-v2/heartbeat-command.test.ts
+++ b/src/__tests__/unit/cli-v2/heartbeat-command.test.ts
@@ -186,7 +186,7 @@ describe('heartbeat CLI helpers', () => {
     const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
     try {
-      await HeartbeatCliCommandEdgeService.run(['start', '--id', 'repo-gardener', '--task', 'Maintain the repo', '--poll', '5s'], {
+      await HeartbeatCliCommandEdgeService.run(['start', '--id', 'repo-gardener', '--task', 'Maintain the repo', '--poll', '5s', '--concurrency', '3'], {
         workspaceRoot: '/repo',
         activeWorkspaceId: 'workspace-1',
         stateDir: '.heddle',
@@ -200,6 +200,7 @@ describe('heartbeat CLI helpers', () => {
         heartbeatScheduler: {
           enabled: true,
           pollIntervalMs: 5_000,
+          maxConcurrentTasks: 3,
         },
       }));
     } finally {
@@ -231,13 +232,25 @@ describe('heartbeat CLI helpers', () => {
         stateDir: '.heddle',
         preferApiKey: true,
         runtimeHost: freshRuntimeHost(),
-      })).rejects.toThrow('--poll only applies when heartbeat start launches an embedded control-plane server.');
+      })).rejects.toThrow('--poll and --concurrency only apply when heartbeat start launches an embedded control-plane server.');
       expect(createClient).not.toHaveBeenCalled();
       expect(runtime.close).toHaveBeenCalledTimes(1);
     } finally {
       resolve.mockRestore();
       createClient.mockRestore();
       stdout.mockRestore();
+    }
+  });
+
+  it('rejects invalid heartbeat concurrency before resolving a runtime', async () => {
+    const resolve = vi.spyOn(ControlPlaneCommandRuntimeService, 'resolve');
+
+    try {
+      await expect(HeartbeatCliCommandEdgeService.run(['start', '--concurrency', '1.5']))
+        .rejects.toThrow('--concurrency must be a positive integer.');
+      expect(resolve).not.toHaveBeenCalled();
+    } finally {
+      resolve.mockRestore();
     }
   });
 });

--- a/src/cli-v2/commands/heartbeat-command.ts
+++ b/src/cli-v2/commands/heartbeat-command.ts
@@ -1,5 +1,5 @@
 import type { ParsedHeartbeatArgs } from './heartbeat/args.js';
-import { parseHeartbeatArgs, renderHeartbeatHelp, stringFlag } from './heartbeat/args.js';
+import { parseHeartbeatArgs, parsePositiveIntegerFlag, renderHeartbeatHelp, stringFlag } from './heartbeat/args.js';
 import { parseDurationMs } from './heartbeat/duration.js';
 import { runHeartbeatRunsCli } from './heartbeat/run-commands.js';
 import { runHeartbeatTaskCli } from './heartbeat/task-commands.js';
@@ -45,8 +45,12 @@ export class HeartbeatCliCommandEdgeService {
 
     try {
       process.stdout.write(`${ControlPlaneCommandRuntimeService.formatNotice(runtime, 'heartbeat')}\n`);
-      if (runtime.kind === 'attached' && heartbeatScheduler.enabled && stringFlag(parsed.flags, 'poll')) {
-        throw new Error('--poll only applies when heartbeat start launches an embedded control-plane server.');
+      if (
+        runtime.kind === 'attached'
+        && heartbeatScheduler.enabled
+        && (stringFlag(parsed.flags, 'poll') || stringFlag(parsed.flags, 'concurrency'))
+      ) {
+        throw new Error('--poll and --concurrency only apply when heartbeat start launches an embedded control-plane server.');
       }
 
       const context = {
@@ -89,6 +93,7 @@ export class HeartbeatCliCommandEdgeService {
   private static resolveHeartbeatScheduler(parsed: ParsedHeartbeatArgs): {
     enabled?: boolean;
     pollIntervalMs?: number;
+    maxConcurrentTasks?: number;
   } {
     if (parsed.command !== 'start' || parsed.flags.once) {
       return { enabled: false };
@@ -98,6 +103,7 @@ export class HeartbeatCliCommandEdgeService {
     return {
       enabled: true,
       pollIntervalMs: poll ? parseDurationMs(poll) : undefined,
+      maxConcurrentTasks: parsePositiveIntegerFlag(stringFlag(parsed.flags, 'concurrency'), '--concurrency'),
     };
   }
 }

--- a/src/cli-v2/commands/heartbeat/args.ts
+++ b/src/cli-v2/commands/heartbeat/args.ts
@@ -118,6 +118,7 @@ export function buildHeartbeatCommand(onParsed: HeartbeatCommandBuilder = () => 
     .command('run [rest...]')
     .description('ask the server to run due tasks or one task now')
     .option('--task <id>', 'run one heartbeat task immediately')
+    .option('--concurrency <n>', 'maximum due tasks to run concurrently')
     .option('--model <name>', 'override model')
     .option('--max-steps <n>', 'override step limit')
     .addHelpText('after', [
@@ -132,7 +133,7 @@ export function buildHeartbeatCommand(onParsed: HeartbeatCommandBuilder = () => 
       command: 'run',
       subcommand: undefined,
       rest,
-      flags: stringFlags(flags, ['task', 'model', 'maxSteps']),
+      flags: stringFlags(flags, ['task', 'concurrency', 'model', 'maxSteps']),
     }));
 
   const runs = root
@@ -186,6 +187,7 @@ export function buildHeartbeatCommand(onParsed: HeartbeatCommandBuilder = () => 
     .option('--every <duration>', 'schedule interval')
     .option('--interval <duration>', 'alias for --every')
     .option('--poll <duration>', 'embedded scheduler poll interval')
+    .option('--concurrency <n>', 'embedded scheduler task concurrency')
     .option('--model <name>', 'override model')
     .option('--max-steps <n>', 'override step limit')
     .option('--defer', 'skip the immediate first run')
@@ -202,7 +204,7 @@ export function buildHeartbeatCommand(onParsed: HeartbeatCommandBuilder = () => 
       subcommand: rest[0],
       rest: rest.slice(1),
       flags: {
-        ...stringFlags(flags, ['id', 'task', 'goal', 'name', 'every', 'interval', 'poll', 'model', 'maxSteps']),
+        ...stringFlags(flags, ['id', 'task', 'goal', 'name', 'every', 'interval', 'poll', 'concurrency', 'model', 'maxSteps']),
         ...booleanFlags(flags, ['defer', 'once']),
       },
     }));
@@ -253,6 +255,18 @@ export function parsePositiveInt(raw: string | undefined): number | undefined {
 
   const value = Number.parseInt(raw, 10);
   return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export function parsePositiveIntegerFlag(raw: string | undefined, flag: string): number | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${flag} must be a positive integer.`);
+  }
+  return value;
 }
 
 function normalizeHelpArgs(args: string[]): string[] {
@@ -318,6 +332,7 @@ type HeartbeatTaskIdFlags = {
 
 type HeartbeatRunFlags = {
   task?: string;
+  concurrency?: string;
   model?: string;
   maxSteps?: string;
 };
@@ -340,6 +355,7 @@ type HeartbeatStartFlags = {
   every?: string;
   interval?: string;
   poll?: string;
+  concurrency?: string;
   model?: string;
   maxSteps?: string;
   defer?: boolean;

--- a/src/cli-v2/commands/heartbeat/worker.ts
+++ b/src/cli-v2/commands/heartbeat/worker.ts
@@ -1,5 +1,5 @@
 import type { ParsedHeartbeatArgs } from './args.js';
-import { booleanFlag, parsePositiveInt, stringFlag } from './args.js';
+import { booleanFlag, parsePositiveInt, parsePositiveIntegerFlag, stringFlag } from './args.js';
 import { formatDurationMs, parseDurationMs } from './duration.js';
 import type { HeartbeatCliContext } from './types.js';
 
@@ -30,6 +30,7 @@ export async function runHeartbeatWorkerCli(
 
   const result = await context.client.controlPlane.heartbeatRunDueTasks.mutate({
     workspaceId: context.workspaceId,
+    maxConcurrentTasks: parsePositiveIntegerFlag(stringFlag(parsed.flags, 'concurrency'), '--concurrency'),
     model: stringFlag(parsed.flags, 'model') ?? context.options.model,
     maxSteps: parsePositiveInt(stringFlag(parsed.flags, 'max-steps')) ?? context.options.maxSteps,
     preferApiKey: context.options.preferApiKey,
@@ -89,9 +90,10 @@ export async function startHeartbeatCli(
   }
 
   const poll = stringFlag(parsed.flags, 'poll');
+  const concurrency = stringFlag(parsed.flags, 'concurrency');
   process.stdout.write([
     `Heartbeat scheduler is server-backed for workspace ${context.workspaceId}.`,
-    `task=${task.taskId} status=${task.state.status} every=${formatDurationMs(intervalMs)}${poll ? ` poll=${poll}` : ''}`,
+    `task=${task.taskId} status=${task.state.status} every=${formatDurationMs(intervalMs)}${poll ? ` poll=${poll}` : ''}${concurrency ? ` concurrency=${concurrency}` : ''}`,
     'Use `heddle daemon` for a standalone long-running server, or keep this embedded command running.',
   ].join('\n') + '\n');
 }

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -25,7 +25,8 @@ operator-facing heartbeat views.
   state transitions after agent success, no-work skip, cancellation, failure,
   request, claim, or recovery.
 - `scheduler/`: `HeartbeatSchedulerService` owns due-task selection and the
-  periodic scheduler loop. It delegates execution to
+  periodic scheduler loop. It selects due work in stable oldest-due-first order
+  and uses `p-limit` to enforce the configured task concurrency ceiling. It delegates execution to
   `HeartbeatTaskRunnerService` instead of running tasks itself. Daemon, CLI,
   and future hosts should start or run the scheduler through this service
   instead of constructing task repositories or duplicating loop logic.
@@ -66,6 +67,10 @@ operator-facing heartbeat views.
 - `executionOwnerId` identifies one scheduler process/worker generation. Do not
   reuse it across process restarts: scheduler startup uses it to distinguish a
   current claim from an execution interrupted by the prior single-host process.
+- `maxConcurrentTasks` defaults to `1`. The scheduler may run different task IDs
+  concurrently, but every execution still passes through the store's atomic
+  claim and fencing contract. Aggregate records retain selected-task order even
+  when completion events arrive in another order.
 - The file service serializes claim/recover/complete/fail transitions with a
   shared in-process mutex, serializes task control read-transform-write
   transitions, and tracks live executions in process memory. Its process-local
@@ -94,8 +99,9 @@ operator-facing heartbeat views.
   same pipeline.
 - `HeartbeatSchedulerService.start()` returns an awaitable, idempotent stop
   handle. Hosts must await `stop({ cancelRunning: true })` before resetting
-  domain state. A handler that ignores its abort signal delays stop until it
-  settles; final writes remain fenced by the execution claim.
+  domain state. Stop prevents bounded-pool jobs that are still queued from being
+  admitted. A handler that ignores its abort signal delays stop until active
+  work settles; final writes remain fenced by the execution claim.
 - `heddle heartbeat run` and `heddle heartbeat start` are server-backed command
   paths. The control-plane server owns recurring scheduler lifetime; CLI
   commands may request due-task execution or keep an embedded server alive, but

--- a/src/core/heartbeat/scheduler/service.ts
+++ b/src/core/heartbeat/scheduler/service.ts
@@ -8,6 +8,8 @@
 import { randomUUID } from 'node:crypto';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js';
+import orderBy from 'lodash/orderBy.js';
+import pLimit from 'p-limit';
 import {
   FileHeartbeatTaskService,
   type HeartbeatTask,
@@ -25,6 +27,7 @@ import type {
 } from './types.js';
 
 const DEFAULT_SCHEDULER_POLL_INTERVAL_MS = 60_000;
+const DEFAULT_MAX_CONCURRENT_TASKS = 1;
 
 dayjs.extend(isSameOrBefore);
 
@@ -67,10 +70,13 @@ class HeartbeatSchedulerWakeController {
   }
 }
 
+type HeartbeatScheduledTaskResult = Awaited<ReturnType<typeof HeartbeatTaskRunnerService.runTask>>;
+
 export class HeartbeatSchedulerService {
   // Starts a background scheduler loop for one workspace and returns a handle the host can stop.
   static start(options: StartHeartbeatSchedulerOptions): HeartbeatSchedulerHandle {
     HeartbeatTaskRunnerService.assertHandlerConfiguration(options);
+    const maxConcurrentTasks = HeartbeatSchedulerService.resolveMaxConcurrentTasks(options.maxConcurrentTasks);
     const loopController = new AbortController();
     const executionController = new AbortController();
     const store = new FileHeartbeatTaskService({ stateRoot: options.stateRoot });
@@ -90,6 +96,7 @@ export class HeartbeatSchedulerService {
         onAgentEvent: options.onAgentEvent,
       },
       pollIntervalMs: options.pollIntervalMs ?? DEFAULT_SCHEDULER_POLL_INTERVAL_MS,
+      maxConcurrentTasks,
       signal: loopController.signal,
       executionSignal: executionController.signal,
       onEvent: options.onEvent,
@@ -122,40 +129,61 @@ export class HeartbeatSchedulerService {
   // Scans stored tasks once, picks enabled tasks whose nextRunAt is due, and delegates each selected task to the runner service.
   static async runDueTasks(options: RunDueHeartbeatTasksOptions): Promise<RunDueHeartbeatTasksResult> {
     HeartbeatTaskRunnerService.assertHandlerConfiguration(options);
+    const maxConcurrentTasks = HeartbeatSchedulerService.resolveMaxConcurrentTasks(options.maxConcurrentTasks);
     const now = options.now?.() ?? dayjs().toDate();
     const timestamp = dayjs(now).toISOString();
     const tasks = await options.store.listTasks();
-    const dueTasks = tasks.filter((task) => HeartbeatSchedulerService.isTaskDue(task, now));
-    const records: HeartbeatTaskRunRecord[] = [];
-    let checked = 0;
-    let failed = 0;
+    const dueTasks = HeartbeatSchedulerService.selectDueTasks(tasks, now);
     const executionOwnerId = options.executionOwnerId ?? HeartbeatSchedulerService.createExecutionOwnerId();
-
-    for (const task of dueTasks) {
+    const limit = pLimit(maxConcurrentTasks);
+    const executions = dueTasks.map((task, index) => limit(async () => {
       if ((options.admissionSignal ?? options.signal)?.aborted) {
-        break;
+        return undefined;
       }
-      checked++;
-      options.onEvent?.({ type: 'heartbeat.task.due', taskId: task.id, timestamp });
-      const result = await HeartbeatTaskRunnerService.runTask({ ...options, executionOwnerId, task, runAt: now });
-      if (result.record) {
-        records.push(result.record);
-      }
-      if (result.failed) {
-        failed++;
-      }
+
+      options.onEvent?.({
+        type: 'heartbeat.task.due',
+        taskId: task.id,
+        timestamp,
+        queuePosition: index + 1,
+        maxConcurrentTasks,
+        activeTasks: limit.activeCount,
+        queuedTasks: limit.pendingCount,
+      });
+      return await HeartbeatTaskRunnerService.runTask({
+        ...options,
+        executionOwnerId,
+        task,
+        runAt: now,
+      });
+    }));
+    const settledExecutions = await Promise.allSettled(executions);
+    const infrastructureFailures = settledExecutions
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map((result) => result.reason);
+    if (infrastructureFailures.length > 0) {
+      throw new AggregateError(infrastructureFailures, 'One or more heartbeat tasks failed before durable settlement.');
     }
 
+    const results = settledExecutions
+      .filter((result): result is PromiseFulfilledResult<HeartbeatScheduledTaskResult | undefined> => result.status === 'fulfilled')
+      .map((result) => result.value)
+      .filter((result): result is HeartbeatScheduledTaskResult => result !== undefined);
+    const records = results
+      .map((result) => result.record)
+      .filter((record): record is HeartbeatTaskRunRecord => record !== undefined);
+
     return {
-      checked,
+      checked: results.length,
       ran: records.length,
-      failed,
+      failed: results.filter((result) => result.failed).length,
       records,
     };
   }
 
   // Repeats due-task checks until the host aborts the loop.
   static async runLoop(options: RunHeartbeatSchedulerOptions): Promise<void> {
+    const maxConcurrentTasks = HeartbeatSchedulerService.resolveMaxConcurrentTasks(options.maxConcurrentTasks);
     const executionOwnerId = options.executionOwnerId ?? HeartbeatSchedulerService.createExecutionOwnerId();
     const startedAt = options.now?.() ?? dayjs().toDate();
     const wakeController = new HeartbeatSchedulerWakeController(options.store);
@@ -183,6 +211,7 @@ export class HeartbeatSchedulerService {
         await HeartbeatSchedulerService.runDueTasks({
           ...options,
           executionOwnerId,
+          maxConcurrentTasks,
           admissionSignal: options.signal,
           signal: options.executionSignal ?? options.signal,
         });
@@ -244,6 +273,34 @@ export class HeartbeatSchedulerService {
 
     const nextRunAt = dayjs(task.schedule.nextRunAt);
     return nextRunAt.isValid() && nextRunAt.isSameOrBefore(dayjs(now));
+  }
+
+  /** Selects due work in oldest-due-first order, using task id as the stable tie-breaker. */
+  private static selectDueTasks(tasks: HeartbeatTask[], now: Date): HeartbeatTask[] {
+    return orderBy(
+      tasks.filter((task) => HeartbeatSchedulerService.isTaskDue(task, now)),
+      [
+        (task) => HeartbeatSchedulerService.taskDueTime(task),
+        (task) => task.id,
+      ],
+      ['asc', 'asc'],
+    );
+  }
+
+  private static taskDueTime(task: HeartbeatTask): number {
+    if (!task.schedule.nextRunAt) {
+      return Number.NEGATIVE_INFINITY;
+    }
+
+    return dayjs(task.schedule.nextRunAt).valueOf();
+  }
+
+  private static resolveMaxConcurrentTasks(value: number | undefined): number {
+    const maxConcurrentTasks = value ?? DEFAULT_MAX_CONCURRENT_TASKS;
+    if (!Number.isInteger(maxConcurrentTasks) || maxConcurrentTasks < 1) {
+      throw new Error('Heartbeat maxConcurrentTasks must be a positive integer.');
+    }
+    return maxConcurrentTasks;
   }
 
   private static resolveNowIso(options: Pick<RunDueHeartbeatTasksOptions, 'now'>): string {

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -14,7 +14,19 @@ export type HeartbeatSchedulerEvent =
   | { type: 'heartbeat.scheduler.started'; timestamp: string }
   | { type: 'heartbeat.scheduler.stopped'; reason: 'aborted' | 'completed' | 'error'; timestamp: string }
   | { type: 'heartbeat.scheduler.awakened'; taskIds: string[]; timestamp: string }
-  | { type: 'heartbeat.task.due'; taskId: string; timestamp: string }
+  | {
+      type: 'heartbeat.task.due';
+      taskId: string;
+      timestamp: string;
+      /** One-based position in the stable due-task selection order. */
+      queuePosition?: number;
+      /** Configured scheduler-wide task concurrency ceiling. */
+      maxConcurrentTasks?: number;
+      /** Active bounded-pool jobs, including this admitted task. */
+      activeTasks?: number;
+      /** Selected jobs still waiting for a bounded-pool slot. */
+      queuedTasks?: number;
+    }
   | {
       type: 'heartbeat.task.run_requested';
       taskId: string;
@@ -182,6 +194,8 @@ export type RunDueHeartbeatTasksOptions = {
   now?: () => Date;
   onEvent?: (event: HeartbeatSchedulerEvent) => void;
   failureRetryMs?: number;
+  /** Maximum independent heartbeat tasks admitted concurrently. Defaults to 1. */
+  maxConcurrentTasks?: number;
   /** Stable only for this scheduler process/worker generation. */
   executionOwnerId?: string;
   /** Cancels task executions selected by this call. */
@@ -227,6 +241,8 @@ export type StartHeartbeatSchedulerOptions = {
   /** @deprecated Use `handler`. */
   runner?: HeartbeatTaskRunner;
   pollIntervalMs?: number;
+  /** Maximum independent heartbeat tasks admitted concurrently. Defaults to 1. */
+  maxConcurrentTasks?: number;
   onEvent?: (event: HeartbeatSchedulerEvent) => void;
   onError?: (error: unknown) => void;
 };

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -294,7 +294,15 @@ export type ControlPlaneHeartbeatEvent =
   | { type: 'heartbeat.scheduler.started'; timestamp: string }
   | { type: 'heartbeat.scheduler.stopped'; reason: 'aborted' | 'completed' | 'error'; timestamp: string }
   | { type: 'heartbeat.scheduler.awakened'; taskIds: string[]; timestamp: string }
-  | { type: 'heartbeat.task.due'; taskId: string; timestamp: string }
+  | {
+      type: 'heartbeat.task.due';
+      taskId: string;
+      timestamp: string;
+      queuePosition?: number;
+      maxConcurrentTasks?: number;
+      activeTasks?: number;
+      queuedTasks?: number;
+    }
   | {
     type: 'heartbeat.task.run_requested';
     taskId: string;

--- a/src/server/controllers/trpc/control-plane/heartbeat.ts
+++ b/src/server/controllers/trpc/control-plane/heartbeat.ts
@@ -51,7 +51,9 @@ type RunHeartbeatTaskNowArgs = {
   onEvent?: (event: HeartbeatSchedulerEvent) => void;
 };
 
-type RunDueHeartbeatTasksArgs = Omit<RunHeartbeatTaskNowArgs, 'taskId' | 'handler' | 'runner'>;
+type RunDueHeartbeatTasksArgs = Omit<RunHeartbeatTaskNowArgs, 'taskId' | 'handler' | 'runner'> & {
+  maxConcurrentTasks?: number;
+};
 
 export class ControlPlaneHeartbeatController {
   static async listTasks(stateRoot: string) {
@@ -169,6 +171,7 @@ export class ControlPlaneHeartbeatController {
   ) {
     return await HeartbeatSchedulerService.runDueTasks({
       store: new FileHeartbeatTaskService({ stateRoot }),
+      maxConcurrentTasks: args.maxConcurrentTasks,
       runtime: {
         apiKey: args.apiKey,
         apiKeyProvider: args.apiKey ? 'explicit' : undefined,

--- a/src/server/heartbeat-scheduler-host.ts
+++ b/src/server/heartbeat-scheduler-host.ts
@@ -15,6 +15,7 @@ export type HeddleHeartbeatSchedulerHostOptions = {
   stateRoot: string;
   preferApiKey?: boolean;
   pollIntervalMs?: number;
+  maxConcurrentTasks?: number;
   onEvent?: (workspace: WorkspaceDescriptor, event: HeartbeatSchedulerEvent) => void;
   onError?: (workspace: WorkspaceDescriptor, error: unknown) => void;
 };
@@ -76,6 +77,7 @@ export class HeddleHeartbeatSchedulerHost {
       stateRoot: workspace.stateRoot,
       preferApiKey: this.options.preferApiKey,
       pollIntervalMs: this.options.pollIntervalMs,
+      maxConcurrentTasks: this.options.maxConcurrentTasks,
       onEvent: (event) => this.options.onEvent?.(workspace, event),
       onError: (error) => this.options.onError?.(workspace, error),
     });

--- a/src/server/lifecycle.ts
+++ b/src/server/lifecycle.ts
@@ -171,6 +171,7 @@ export async function startHeddleControlPlaneServer(
     accessMode,
     heartbeatSchedulerEnabled,
     heartbeatSchedulerPollIntervalMs: heartbeatSchedulerSettings.pollIntervalMs,
+    heartbeatSchedulerMaxConcurrentTasks: heartbeatSchedulerSettings.maxConcurrentTasks,
   }, 'Heddle server started');
 
   return {
@@ -193,6 +194,7 @@ function createHeartbeatSchedulerHost(options: HeddleControlPlaneServerOptions):
     stateRoot: options.stateRoot,
     preferApiKey: options.preferApiKey,
     pollIntervalMs: options.heartbeatScheduler?.pollIntervalMs,
+    maxConcurrentTasks: options.heartbeatScheduler?.maxConcurrentTasks,
     onEvent: (workspace, event) => {
       logHeartbeatSchedulerEvent(getWorkspaceOperationLogger(workspace.stateRoot), workspace, event);
       controlPlaneHeartbeatEventsController.publish({

--- a/src/server/routes/trpc/schema.ts
+++ b/src/server/routes/trpc/schema.ts
@@ -236,6 +236,7 @@ export const heartbeatTaskRunNowInputSchema = z.object({
 
 export const heartbeatRunDueTasksInputSchema = z.object({
   workspaceId: z.string().min(1).optional(),
+  maxConcurrentTasks: z.number().int().min(1).optional(),
   model: z.string().min(1).optional(),
   maxSteps: z.number().int().min(1).max(500).optional(),
   apiKey: z.string().min(1).optional(),

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -111,6 +111,7 @@ export type HeddleControlPlaneServerOptions = Omit<HeddleServerOptions, 'runtime
 export type HeddleHeartbeatSchedulerSettings = {
   enabled?: boolean;
   pollIntervalMs?: number;
+  maxConcurrentTasks?: number;
 };
 
 export type HeddleRuntimeHostDescriptor = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5835,6 +5835,13 @@ p-limit@^3.0.2:
   dependencies:
     yocto-queue "^0.1.0"
 
+p-limit@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-7.3.1.tgz#ded48cbfa10b161a9928120261fa82c9a282eb3f"
+  integrity sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==
+  dependencies:
+    yocto-queue "^1.2.1"
+
 p-locate@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
@@ -7411,6 +7418,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
+  integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==
 
 yoga-layout@~3.2.1:
   version "3.2.1"


### PR DESCRIPTION
## Summary
- run independent due heartbeat tasks through a configurable p-limit worker pool while keeping the default serial limit of 1
- select work by nextRunAt and task ID, preserve record ordering, and retain atomic per-task claim/fencing
- stop queued admissions on shutdown, expose pool context in due events, and add SDK, server, control-plane, and CLI configuration

## Validation
- yarn test (807 unit + 371 integration tests)
- yarn typecheck
- yarn lint
- yarn build
- live CLI help and invalid-limit checks

Closes #299