### PR TITLE
Support custom heartbeat stores in scheduler start

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -108,6 +108,45 @@ processes or replicas require a remote store backed by compare-and-swap,
 transactions, or leases. Recovery cannot undo external effects, so host tools
 must keep domain mutations idempotent.
 
+Pass a custom store directly to the supported background lifecycle instead of
+rebuilding the scheduler controllers around `runLoop()`:
+
+```ts
+import {
+  HeartbeatSchedulerService,
+  type HeartbeatTaskStore,
+} from '@roackb2/heddle/advanced';
+
+declare const postgresHeartbeatTasks: HeartbeatTaskStore;
+
+const scheduler = HeartbeatSchedulerService.start({
+  workspaceRoot,
+  stateRoot,
+  store: postgresHeartbeatTasks,
+  handler,
+  maxConcurrentTasks: 4,
+  onError: (error) => logger.error(error),
+});
+
+await scheduler.stop({ cancelRunning: true });
+```
+
+The scheduler uses that exact instance for startup recovery, request
+subscriptions, due-task reads, claims, claim-fenced settlement, and run
+history. `stateRoot` remains required for framework-owned agent runtime state;
+when `store` is omitted it additionally selects the built-in file-backed
+heartbeat store. Passing a remote task store moves only Heddle heartbeat task,
+checkpoint, and run persistence. It does not move or replace the host's product
+or domain database.
+
+A production remote adapter must make claims and fenced writes atomic, recover
+only executions whose lease or owner is no longer live, and route run-request
+notifications to the scheduler process that can act on them.
+`subscribeToRunRequests` is an optional low-latency hint: if an adapter cannot
+deliver notifications in the current process, the configured poll interval
+remains the correctness fallback. Providing an arbitrary store does not by
+itself make a scheduler safe for multiple workers.
+
 Cron, launchd, systemd, hosted queues, and Lucid-style services should be treated as hosts around this API, not as Heddle's internal scheduler model.
 
 ### Durable event-driven run requests

--- a/src/__tests__/integration/core/heartbeat-custom-store-start.test.ts
+++ b/src/__tests__/integration/core/heartbeat-custom-store-start.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  HeartbeatSchedulerService,
+  type HeartbeatTask,
+  type HeartbeatTaskExecution,
+  type HeartbeatTaskRunRecord,
+  type HeartbeatTaskRunRequestSignal,
+  type HeartbeatTaskStore,
+} from '../../../advanced.js';
+import { HeartbeatTaskStateProjector } from '@/core/heartbeat/index.js';
+
+const NOW = new Date('2026-08-04T06:00:00.000Z');
+
+describe('heartbeat scheduler custom store lifecycle', () => {
+  it('uses the supplied store for recovery, wake-up, claim, settlement, and run history', async () => {
+    const store = new InstrumentedHeartbeatTaskStore(createTask());
+    const handlerStarted = deferred<void>();
+    const runSettled = deferred<void>();
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: '/tmp/heddle-custom-store-workspace',
+      stateRoot: '/tmp/heddle-custom-store-runtime',
+      store,
+      pollIntervalMs: 60_000,
+      handler: async (context) => {
+        handlerStarted.resolve();
+        return context.skip({ summary: 'The custom store had no domain work.' });
+      },
+      onEvent: (event) => {
+        if (event.type === 'heartbeat.task.skipped') {
+          runSettled.resolve();
+        }
+      },
+    });
+
+    await store.firstScan;
+    await store.requestTaskRun('custom-store-task', {
+      reason: 'remote-notification',
+      requestedAt: NOW,
+    });
+    await handlerStarted.promise;
+    await runSettled.promise;
+    await handle.stop();
+
+    expect(store.calls).toEqual([
+      'subscribeToRunRequests',
+      'recoverInterruptedTasks',
+      'listTasks',
+      'requestTaskRun',
+      'listTasks',
+      'loadCheckpoint',
+      'claimTaskExecution',
+      'recordTaskExecutionOutcome',
+      'unsubscribeFromRunRequests',
+    ]);
+    expect(store.recoveryCalls).toBe(1);
+    expect(store.runRecords).toMatchObject([{
+      task: { id: 'custom-store-task' },
+      outcome: {
+        kind: 'skipped',
+        runRequestGeneration: 1,
+        summary: 'The custom store had no domain work.',
+      },
+    }]);
+  });
+
+  it('keeps stop idempotent and surfaces a custom-store loop failure consistently', async () => {
+    const failure = new Error('remote heartbeat store unavailable');
+    const errorReported = deferred<unknown>();
+    const store = new InstrumentedHeartbeatTaskStore(createTask());
+    store.recoveryError = failure;
+    const onError = vi.fn((error: unknown) => errorReported.resolve(error));
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: '/tmp/heddle-custom-store-error-workspace',
+      stateRoot: '/tmp/heddle-custom-store-error-runtime',
+      store,
+      onError,
+    });
+
+    await expect(errorReported.promise).resolves.toBe(failure);
+    const firstStop = handle.stop();
+    expect(handle.stop({ cancelRunning: true })).toBe(firstStop);
+    await expect(firstStop).rejects.toBe(failure);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(store.calls).toEqual([
+      'subscribeToRunRequests',
+      'recoverInterruptedTasks',
+      'unsubscribeFromRunRequests',
+    ]);
+  });
+});
+
+class InstrumentedHeartbeatTaskStore implements HeartbeatTaskStore {
+  readonly calls: string[] = [];
+  readonly firstScan: Promise<void>;
+  readonly runRecords: HeartbeatTaskRunRecord[] = [];
+  recoveryCalls = 0;
+  recoveryError?: Error;
+
+  private readonly firstScanReady = deferred<void>();
+  private readonly listeners = new Set<(request: HeartbeatTaskRunRequestSignal) => void>();
+  private task: HeartbeatTask;
+
+  constructor(task: HeartbeatTask) {
+    this.task = task;
+    this.firstScan = this.firstScanReady.promise;
+  }
+
+  async listTasks(): Promise<HeartbeatTask[]> {
+    this.calls.push('listTasks');
+    this.firstScanReady.resolve();
+    return [structuredClone(this.task)];
+  }
+
+  async saveTask(task: HeartbeatTask): Promise<void> {
+    this.calls.push('saveTask');
+    this.task = structuredClone(task);
+  }
+
+  async loadCheckpoint(): Promise<undefined> {
+    this.calls.push('loadCheckpoint');
+    return undefined;
+  }
+
+  async saveCheckpoint(): Promise<void> {
+    this.calls.push('saveCheckpoint');
+  }
+
+  async requestTaskRun(
+    taskId: string,
+    options: Parameters<HeartbeatTaskStore['requestTaskRun']>[1] = {},
+  ) {
+    this.calls.push('requestTaskRun');
+    if (taskId !== this.task.id) {
+      throw new Error(`Heartbeat task not found: ${taskId}`);
+    }
+
+    const projection = HeartbeatTaskStateProjector.requestRun({
+      task: this.task,
+      now: options.requestedAt ?? NOW,
+      reason: options.reason,
+    });
+    this.task = projection.task;
+    const request = projection.task.state?.runRequest;
+    if (!request) {
+      throw new Error('Expected the custom store to project a run request.');
+    }
+
+    const result = {
+      task: structuredClone(projection.task),
+      taskId,
+      generation: request.generation,
+      disposition: projection.disposition,
+      requestedAt: request.requestedAt,
+      reason: request.reason,
+    };
+    const signal = {
+      taskId,
+      generation: result.generation,
+      disposition: result.disposition,
+      requestedAt: result.requestedAt,
+      reason: result.reason,
+    };
+    this.listeners.forEach((listener) => listener(signal));
+    return result;
+  }
+
+  subscribeToRunRequests(listener: (request: HeartbeatTaskRunRequestSignal) => void): () => void {
+    this.calls.push('subscribeToRunRequests');
+    this.listeners.add(listener);
+    return () => {
+      this.calls.push('unsubscribeFromRunRequests');
+      this.listeners.delete(listener);
+    };
+  }
+
+  async claimTaskExecution(input: Parameters<HeartbeatTaskStore['claimTaskExecution']>[0]) {
+    this.calls.push('claimTaskExecution');
+    if (input.taskId !== this.task.id) {
+      return { status: 'not-found' } as const;
+    }
+    if (!this.task.enabled) {
+      return { status: 'disabled' } as const;
+    }
+    if (this.task.state?.status === 'running') {
+      return { status: 'busy' } as const;
+    }
+
+    this.task = HeartbeatTaskStateProjector.markRunning({
+      task: this.task,
+      now: input.claimedAt,
+      loadedCheckpoint: input.loadedCheckpoint,
+      execution: input.execution,
+    });
+    return { status: 'claimed', task: structuredClone(this.task) } as const;
+  }
+
+  async completeTaskExecution(): Promise<never> {
+    throw new Error('This test store did not expect an agent completion.');
+  }
+
+  async failTaskExecution(): Promise<never> {
+    throw new Error('This test store did not expect an execution failure.');
+  }
+
+  async recordTaskExecutionOutcome(input: Parameters<HeartbeatTaskStore['recordTaskExecutionOutcome']>[0]) {
+    this.calls.push('recordTaskExecutionOutcome');
+    if (!this.executionMatches(input.execution)) {
+      return { status: 'claim-lost' } as const;
+    }
+    if (input.signal?.aborted) {
+      return { status: 'cancelled' } as const;
+    }
+
+    this.task = input.kind === 'skipped' ?
+      HeartbeatTaskStateProjector.afterSkip({
+        task: this.task,
+        execution: input.execution,
+        summary: input.summary,
+        now: input.finishedAt,
+      })
+    : HeartbeatTaskStateProjector.afterCancellation({
+        task: this.task,
+        execution: input.execution,
+        summary: input.summary,
+        now: input.finishedAt,
+      });
+    const outcome = this.task.state?.lastExecution;
+    if (!outcome || outcome.kind !== input.kind) {
+      throw new Error(`Expected a ${input.kind} outcome.`);
+    }
+    const record: HeartbeatTaskRunRecord = {
+      task: structuredClone(this.task),
+      outcome,
+    };
+    this.runRecords.push(record);
+    return { status: 'saved', task: structuredClone(this.task), record } as const;
+  }
+
+  async recoverInterruptedTasks() {
+    this.calls.push('recoverInterruptedTasks');
+    this.recoveryCalls++;
+    if (this.recoveryError) {
+      throw this.recoveryError;
+    }
+    return [];
+  }
+
+  private executionMatches(execution: HeartbeatTaskExecution): boolean {
+    return this.task.state?.execution?.executionId === execution.executionId
+      && this.task.state.execution.ownerId === execution.ownerId;
+  }
+}
+
+function createTask(): HeartbeatTask {
+  return {
+    id: 'custom-store-task',
+    task: 'Process custom-store work.',
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt: '2099-01-01T00:00:00.000Z',
+    },
+    state: {
+      status: 'waiting',
+      resumable: true,
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -102,6 +102,12 @@ operator-facing heartbeat views.
   domain state. Stop prevents bounded-pool jobs that are still queued from being
   admitted. A handler that ignores its abort signal delays stop until active
   work settles; final writes remain fenced by the execution claim.
+- `HeartbeatSchedulerService.start({ store })` uses the caller-provided
+  `HeartbeatTaskStore` instance for startup recovery, run-request wakeups, due
+  selection, claims, settlement, and run history. `stateRoot` still locates
+  framework-owned agent runtime state; it only locates heartbeat task files
+  when `store` is omitted. A remote adapter must provide its own atomic claim,
+  fencing, recovery, and cross-process notification guarantees.
 - `heddle heartbeat run` and `heddle heartbeat start` are server-backed command
   paths. The control-plane server owns recurring scheduler lifetime; CLI
   commands may request due-task execution or keep an embedded server alive, but

--- a/src/core/heartbeat/scheduler/service.ts
+++ b/src/core/heartbeat/scheduler/service.ts
@@ -79,7 +79,7 @@ export class HeartbeatSchedulerService {
     const maxConcurrentTasks = HeartbeatSchedulerService.resolveMaxConcurrentTasks(options.maxConcurrentTasks);
     const loopController = new AbortController();
     const executionController = new AbortController();
-    const store = new FileHeartbeatTaskService({ stateRoot: options.stateRoot });
+    const store = options.store ?? new FileHeartbeatTaskService({ stateRoot: options.stateRoot });
     let loopError: unknown;
     const settledLoop = HeartbeatSchedulerService.runLoop({
       store,

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -230,7 +230,16 @@ export type HeartbeatSchedulerHandle = {
 
 export type StartHeartbeatSchedulerOptions = {
   workspaceRoot: string;
+  /**
+   * Runtime state used by framework-owned agent execution. When `store` is
+   * omitted, this also locates the built-in file-backed heartbeat store.
+   */
   stateRoot: string;
+  /**
+   * Optional host-owned heartbeat persistence adapter. The scheduler uses this
+   * exact instance for recovery, wake subscriptions, claims, and settlement.
+   */
+  store?: HeartbeatTaskStore;
   preferApiKey?: boolean;
   model?: string;
   maxSteps?: number;


### PR DESCRIPTION
## Summary

- let `HeartbeatSchedulerService.start()` use a caller-provided `HeartbeatTaskStore`
- keep the built-in file store as the source-compatible default
- preserve one framework-owned lifecycle for recovery, request wake-ups, bounded execution, stop, and error handling
- document adapter obligations and the boundary between Heddle heartbeat persistence and host-owned product data

## Why

Production hosts with PostgreSQL, Redis, or another lease-capable adapter should not have to rebuild Heddle's loop controllers and awaitable stop semantics around `runLoop()`. Passing `store` now makes the high-level lifecycle use that exact instance for recovery, subscriptions, due reads, claims, settlement, and run history. `stateRoot` remains the framework-owned agent runtime state location and only selects file-backed heartbeat persistence when `store` is omitted.

## Validation

- `yarn build`
- `yarn test` (132 unit files / 807 tests; 42 integration files / 380 tests)
- `yarn vitest run src/__tests__/integration/core/heartbeat-custom-store-start.test.ts src/__tests__/integration/core/heartbeat-execution-context.test.ts src/__tests__/integration/core/heartbeat-run-requests.test.ts`

Closes #308