### PR TITLE
Merge targeted heartbeat cancellation into main

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -172,8 +172,8 @@ which generation it consumed, so a request arriving after the claim remains
 pending for the next run. Success, failure, skip, and cancellation settle from
 the latest stored task state and cannot overwrite a newer request.
 
-`HeartbeatSchedulerService.start()` and `runLoop()` subscribe to file-store run
-requests and rescan promptly. `heartbeat.task.run_requested`,
+`HeartbeatSchedulerService.start()` and `runLoop()` subscribe to configured-store
+run requests and rescan promptly. `heartbeat.task.run_requested`,
 `heartbeat.task.run_request_claimed`, and `heartbeat.scheduler.awakened` expose
 the lifecycle without carrying credentials or domain payloads. The configured
 poll interval remains the process-restart and external-writer fallback.
@@ -268,6 +268,57 @@ ignores cancellation, `stop()` deliberately remains pending until that handler
 settles. The execution fencing token prevents its late result from overwriting
 a replacement claim, and a result that settles after the framework signal was
 aborted is persisted as cancellation rather than agent completion.
+
+Long-lived hosts can cancel one task without stopping its peers:
+
+```ts
+const cancellation = await scheduler.cancelTask('participant-agent-42', {
+  reason: 'operator-disabled-participant',
+});
+
+if (cancellation.disposition === 'cancelled') {
+  await heartbeatTasks.setTaskEnabled('participant-agent-42', false);
+}
+```
+
+`cancelTask()` immediately invalidates this handle's already-queued admissions
+for that task. If the handle owns an active execution, it aborts only that
+execution's `HeartbeatExecutionContext.signal` and waits for the runner's
+existing claim-fenced outer settlement. Unrelated active and queued tasks keep
+running. Concurrent calls for the same task share the first caller's
+cancellation attempt and bounded reason; a later call after settlement is a
+new read of current task state and does not create another cancellation record.
+
+The result disposition is explicit:
+
+| Disposition | Meaning |
+| --- | --- |
+| `cancelled` | This handle delivered cancellation and the durable cancelled outcome won. |
+| `completion-won` | Completion or failure persisted before cancellation could win. |
+| `not-running` | The task exists but this handle has no active execution; any queued admission selected before the call was invalidated. |
+| `not-owned` | Stored state says running, but this handle does not own the execution. A remote adapter must route a durable request to its owner. |
+| `disabled` | The task exists, is disabled, and is not running. |
+| `blocked` | The task is waiting for operator input and is not running. |
+| `completed` | The task is terminal and is not running. |
+| `not-found` | No task with that ID exists in the configured store. |
+
+The required operator reason is trimmed, collapsed to one line, limited to 200
+characters, and copied into the cancellation event and run outcome. Do not put
+private task input in it. Cancellation preserves the existing checkpoint and
+run history. It also preserves any run-request generation created after the
+active execution's claim; that request is eligible on a later scheduler cycle.
+The low-level operation deliberately does not invent disable/delete semantics
+or consume that newer intent. Disabling the task after awaited cancellation
+uses the task service's existing behavior to consume pending intent, and a host
+may delete immediately after the await without polling for `running` state.
+
+Task-scoped cancellation is a process-local delivery boundary for executions
+started by this scheduler handle. A custom multi-worker store still needs its
+own persisted cancellation-request and owner-notification protocol; a local
+`not-owned` result is not an acknowledgement from the remote owner. Likewise,
+Heddle cannot roll back host database writes or terminate external work that
+ignores `AbortSignal`. Handlers and tools remain responsible for cooperative
+cancellation and idempotent host-owned side effects.
 
 ## Examples
 

--- a/examples/heartbeat-scheduler.ts
+++ b/examples/heartbeat-scheduler.ts
@@ -144,7 +144,11 @@ function formatSchedulerEvent(event: HeartbeatSchedulerEvent): string | undefine
     case 'heartbeat.task.skipped':
       return `[event] task.skipped id=${event.taskId} execution=${event.executionId} summary=${event.record.outcome.summary}`;
     case 'heartbeat.task.cancelled':
-      return `[event] task.cancelled id=${event.taskId} execution=${event.executionId}`;
+      return [
+        `[event] task.cancelled id=${event.taskId}`,
+        `execution=${event.executionId}`,
+        `reason=${event.reason ?? 'scheduler-stop'}`,
+      ].join(' ');
     case 'heartbeat.task.failed':
       return `[event] task.failed id=${event.taskId} error=${event.error}`;
     default:

--- a/src/__tests__/integration/core/heartbeat-targeted-cancellation.test.ts
+++ b/src/__tests__/integration/core/heartbeat-targeted-cancellation.test.ts
@@ -1,0 +1,431 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  FileHeartbeatTaskService,
+  HeartbeatSchedulerService,
+  MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH,
+  type AgentHeartbeatResult,
+  type HeartbeatExecutionContext,
+  type HeartbeatSchedulerEvent,
+  type HeartbeatTask,
+} from '../../../advanced.js';
+import { AgentLoopCheckpointService } from '@/core/runtime/loop/index.js';
+
+const NOW = new Date('2026-08-04T07:00:00.000Z');
+
+describe('heartbeat targeted cancellation', () => {
+  it('cancels and settles one active task without aborting its peer', async () => {
+    const stateRoot = createStateRoot('active');
+    const store = new FileHeartbeatTaskService({ stateRoot });
+    const targetTask = createTask('target-task');
+    const peerTask = createTask('peer-task');
+    const priorCheckpoint = createHeartbeatResult('prior-target-run').checkpoint;
+    await Promise.all([
+      store.saveTask(targetTask),
+      store.saveTask(peerTask),
+      store.saveCheckpoint(targetTask, priorCheckpoint),
+    ]);
+    const contexts = new Map<string, HeartbeatExecutionContext>();
+    const started = new Map([
+      [targetTask.id, deferred<void>()],
+      [peerTask.id, deferred<void>()],
+    ]);
+    const releases = new Map([
+      [targetTask.id, deferred<void>()],
+      [peerTask.id, deferred<void>()],
+    ]);
+    const peerSettled = deferred<void>();
+    let peerHandlerSettled = false;
+    let peerAbortBeforeSettlement = false;
+    const events: HeartbeatSchedulerEvent[] = [];
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: stateRoot,
+      stateRoot,
+      store,
+      maxConcurrentTasks: 2,
+      pollIntervalMs: 60_000,
+      handler: async (context) => {
+        contexts.set(context.task.id, context);
+        if (context.task.id === peerTask.id) {
+          context.signal.addEventListener('abort', () => {
+            peerAbortBeforeSettlement ||= !peerHandlerSettled;
+          });
+        }
+        started.get(context.task.id)?.resolve();
+        await releases.get(context.task.id)?.promise;
+        if (context.task.id === peerTask.id) {
+          peerHandlerSettled = true;
+        }
+        return context.skip({ summary: `Settled ${context.task.id}.` });
+      },
+      onEvent: (event) => {
+        events.push(event);
+        if (event.type === 'heartbeat.task.skipped' && event.taskId === peerTask.id) {
+          peerSettled.resolve();
+        }
+      },
+    });
+
+    await Promise.all([...started.values()].map(async (gate) => await gate.promise));
+    await store.requestTaskRun(targetTask.id, {
+      reason: 'work-arrived-during-active-run',
+      requestedAt: NOW,
+    });
+    const firstCancellation = handle.cancelTask(targetTask.id, {
+      reason: '  operator-disabled\nparticipant  ',
+    });
+    const repeatedCancellation = handle.cancelTask(targetTask.id, {
+      reason: 'the first concurrent caller owns the reason',
+    });
+
+    expect(repeatedCancellation).toBe(firstCancellation);
+    expect(contexts.get(targetTask.id)?.signal.aborted).toBe(true);
+    expect(contexts.get(peerTask.id)?.signal.aborted).toBe(false);
+    let cancellationSettled = false;
+    void firstCancellation.then(() => {
+      cancellationSettled = true;
+    });
+    await Promise.resolve();
+    expect(cancellationSettled).toBe(false);
+
+    releases.get(targetTask.id)?.resolve();
+    const cancellation = await firstCancellation;
+    expect(cancellation).toMatchObject({
+      taskId: targetTask.id,
+      disposition: 'cancelled',
+      reason: 'operator-disabled participant',
+      executionId: contexts.get(targetTask.id)?.executionId,
+      record: {
+        outcome: {
+          kind: 'cancelled',
+          reason: 'operator-disabled participant',
+          summary: expect.stringContaining('operator-disabled participant'),
+        },
+      },
+    });
+    await expect(repeatedCancellation).resolves.toEqual(cancellation);
+    await expect(store.loadCheckpoint(targetTask)).resolves.toEqual(priorCheckpoint);
+    await expect(store.requireTask(targetTask.id)).resolves.toMatchObject({
+      enabled: true,
+      state: {
+        status: 'waiting',
+        lastExecution: {
+          kind: 'cancelled',
+          reason: 'operator-disabled participant',
+        },
+        runRequest: {
+          generation: 1,
+          claimedGeneration: 0,
+        },
+      },
+    });
+    expect((await store.requireTask(targetTask.id)).schedule.nextRunAt).toBeDefined();
+
+    const targetRuns = await store.listRunRecords({ taskId: targetTask.id });
+    expect(targetRuns).toHaveLength(1);
+    expect(targetRuns[0]).toMatchObject({
+      executionId: contexts.get(targetTask.id)?.executionId,
+      record: { outcome: { kind: 'cancelled', reason: 'operator-disabled participant' } },
+    });
+    expect(events.find((event) => event.type === 'heartbeat.task.cancelled')).toMatchObject({
+      taskId: targetTask.id,
+      reason: 'operator-disabled participant',
+    });
+
+    const startedEvent = events.find((event) =>
+      event.type === 'heartbeat.task.started' && event.taskId === targetTask.id,
+    );
+    if (!startedEvent || startedEvent.type !== 'heartbeat.task.started') {
+      throw new Error('Expected the target heartbeat execution to start.');
+    }
+    const execution = {
+      executionId: startedEvent.executionId,
+      ownerId: startedEvent.ownerId,
+      claimedAt: startedEvent.timestamp,
+    };
+    const lateResult = createHeartbeatResult('late-target-result');
+    await expect(store.completeTaskExecution({
+      taskId: targetTask.id,
+      execution,
+      result: lateResult,
+      checkpoint: lateResult.checkpoint,
+      loadedCheckpoint: true,
+      completedAt: NOW,
+    })).resolves.toEqual({ status: 'claim-lost' });
+    await expect(store.failTaskExecution({
+      taskId: targetTask.id,
+      execution,
+      error: new Error('late target failure'),
+      failedAt: NOW,
+      retryMs: 1_000,
+    })).resolves.toEqual({ status: 'claim-lost' });
+    await expect(store.listRunRecords({ taskId: targetTask.id })).resolves.toHaveLength(1);
+
+    await expect(handle.cancelTask(targetTask.id, {
+      reason: 'already settled',
+    })).resolves.toMatchObject({ disposition: 'not-running' });
+    await expect(store.setTaskEnabled(targetTask.id, false)).resolves.toMatchObject({
+      enabled: false,
+      state: {
+        status: 'idle',
+        runRequest: {
+          generation: 1,
+          claimedGeneration: 1,
+          pending: false,
+        },
+      },
+    });
+
+    releases.get(peerTask.id)?.resolve();
+    await peerSettled.promise;
+    expect(peerAbortBeforeSettlement).toBe(false);
+    await handle.stop();
+    await expect(store.listRunRecords({ taskId: peerTask.id })).resolves.toMatchObject([{
+      record: { outcome: { kind: 'skipped', summary: `Settled ${peerTask.id}.` } },
+    }]);
+  });
+
+  it('invalidates a queued admission without touching the active task', async () => {
+    const stateRoot = createStateRoot('queued');
+    const store = new FileHeartbeatTaskService({ stateRoot });
+    await Promise.all([
+      store.saveTask(createTask('active-first')),
+      store.saveTask(createTask('queued-a-target')),
+      store.saveTask(createTask('queued-b-peer')),
+    ]);
+    const activeStarted = deferred<void>();
+    const releaseActive = deferred<void>();
+    const peerStarted = deferred<void>();
+    const handlerCalls: string[] = [];
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: stateRoot,
+      stateRoot,
+      store,
+      maxConcurrentTasks: 1,
+      pollIntervalMs: 60_000,
+      handler: async (context) => {
+        handlerCalls.push(context.task.id);
+        if (context.task.id === 'active-first') {
+          activeStarted.resolve();
+          await releaseActive.promise;
+        }
+        if (context.task.id === 'queued-b-peer') {
+          peerStarted.resolve();
+        }
+        return context.skip({ summary: `Settled ${context.task.id}.` });
+      },
+    });
+
+    await activeStarted.promise;
+    await expect(handle.cancelTask('queued-a-target', {
+      reason: 'operator-cancelled-before-admission',
+    })).resolves.toMatchObject({ disposition: 'not-running' });
+    releaseActive.resolve();
+    await peerStarted.promise;
+
+    expect(handlerCalls).toEqual(['active-first', 'queued-b-peer']);
+    await handle.stop();
+    await expect(store.listRunRecords({ taskId: 'queued-a-target' })).resolves.toEqual([]);
+    await expect(store.listRunRecords({ taskId: 'queued-b-peer' })).resolves.toHaveLength(1);
+  });
+
+  it('retains a concurrent disable and permits deletion immediately after settlement', async () => {
+    const stateRoot = createStateRoot('disable-delete');
+    const store = new FileHeartbeatTaskService({ stateRoot });
+    await store.saveTask(createTask('disable-me'));
+    const handlerStarted = deferred<void>();
+    const releaseHandler = deferred<void>();
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: stateRoot,
+      stateRoot,
+      store,
+      handler: async (context) => {
+        handlerStarted.resolve();
+        await releaseHandler.promise;
+        return context.skip({ summary: 'Late handler settlement.' });
+      },
+    });
+
+    await handlerStarted.promise;
+    const cancellation = handle.cancelTask('disable-me', {
+      reason: 'operator-disabled-task',
+    });
+    await expect(store.setTaskEnabled('disable-me', false)).resolves.toMatchObject({
+      enabled: false,
+      state: { status: 'running' },
+    });
+    releaseHandler.resolve();
+
+    await expect(cancellation).resolves.toMatchObject({ disposition: 'cancelled' });
+    const disabledTask = await store.requireTask('disable-me');
+    expect(disabledTask).toMatchObject({
+      enabled: false,
+      state: { status: 'idle', lastExecution: { kind: 'cancelled' } },
+    });
+    expect(disabledTask.schedule).not.toHaveProperty('nextRunAt');
+    await expect(store.deleteTask('disable-me')).resolves.toMatchObject({ id: 'disable-me' });
+    await handle.stop();
+  });
+
+  it('reports when completion wins the cancellation race', async () => {
+    const stateRoot = createStateRoot('completion-race');
+    const store = new FileHeartbeatTaskService({ stateRoot });
+    await store.saveTask(createTask('completion-wins'));
+    const completionSaved = deferred<void>();
+    const releaseCompletionReturn = deferred<void>();
+    const completeTaskExecution = store.completeTaskExecution.bind(store);
+    store.completeTaskExecution = async (input) => {
+      const result = await completeTaskExecution(input);
+      completionSaved.resolve();
+      await releaseCompletionReturn.promise;
+      return result;
+    };
+    const events: HeartbeatSchedulerEvent[] = [];
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: stateRoot,
+      stateRoot,
+      store,
+      runner: async () => createHeartbeatResult('completion-wins-run'),
+      onEvent: (event) => events.push(event),
+    });
+
+    await completionSaved.promise;
+    const cancellation = handle.cancelTask('completion-wins', {
+      reason: 'operator-raced-with-completion',
+    });
+    releaseCompletionReturn.resolve();
+
+    await expect(cancellation).resolves.toMatchObject({
+      disposition: 'completion-won',
+      record: { outcome: { kind: 'agent' } },
+    });
+    await handle.stop();
+    expect(events.some((event) => event.type === 'heartbeat.task.cancelled')).toBe(false);
+    await expect(store.listRunRecords({ taskId: 'completion-wins' })).resolves.toHaveLength(1);
+  });
+
+  it('returns explicit dispositions for tasks this handle cannot cancel', async () => {
+    const stateRoot = createStateRoot('dispositions');
+    const store = new FileHeartbeatTaskService({ stateRoot });
+    store.recoverInterruptedTasks = async () => [];
+    await Promise.all([
+      store.saveTask(createTask('waiting', { nextRunAt: '2099-01-01T00:00:00.000Z' })),
+      store.saveTask({
+        ...createTask('disabled'),
+        enabled: false,
+        state: { status: 'idle' },
+      }),
+      store.saveTask({
+        ...createTask('blocked'),
+        enabled: false,
+        state: { status: 'blocked' },
+      }),
+      store.saveTask({
+        ...createTask('completed'),
+        enabled: false,
+        state: { status: 'complete' },
+      }),
+      store.saveTask({
+        ...createTask('foreign-running'),
+        state: {
+          status: 'running',
+          execution: {
+            executionId: 'foreign-execution',
+            ownerId: 'foreign-worker',
+            claimedAt: NOW.toISOString(),
+          },
+        },
+      }),
+    ]);
+    const handle = HeartbeatSchedulerService.start({
+      workspaceRoot: stateRoot,
+      stateRoot,
+      store,
+      pollIntervalMs: 60_000,
+    });
+
+    await expect(handle.cancelTask('waiting', { reason: 'classification' })).resolves.toMatchObject({
+      disposition: 'not-running',
+    });
+    await expect(handle.cancelTask('disabled', { reason: 'classification' })).resolves.toMatchObject({
+      disposition: 'disabled',
+    });
+    await expect(handle.cancelTask('blocked', { reason: 'classification' })).resolves.toMatchObject({
+      disposition: 'blocked',
+    });
+    await expect(handle.cancelTask('completed', { reason: 'classification' })).resolves.toMatchObject({
+      disposition: 'completed',
+    });
+    await expect(handle.cancelTask('foreign-running', { reason: 'classification' })).resolves.toMatchObject({
+      disposition: 'not-owned',
+    });
+    await expect(handle.cancelTask('unknown', { reason: 'classification' })).resolves.toMatchObject({
+      disposition: 'not-found',
+    });
+    await expect(handle.cancelTask('waiting', { reason: '   ' })).rejects.toThrow(/cannot be empty/i);
+    await expect(handle.cancelTask('waiting', {
+      reason: 'x'.repeat(MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH + 1),
+    })).rejects.toThrow(/at most 200/i);
+    await handle.stop();
+  });
+});
+
+function createStateRoot(label: string): string {
+  return mkdtempSync(join(tmpdir(), `heddle-heartbeat-targeted-cancel-${label}-`));
+}
+
+function createTask(id: string, schedule: Partial<HeartbeatTask['schedule']> = {}): HeartbeatTask {
+  return {
+    id,
+    task: `Process ${id}.`,
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt: '2000-01-01T00:00:00.000Z',
+      ...schedule,
+    },
+    state: {
+      status: 'waiting',
+      resumable: true,
+    },
+  };
+}
+
+function createHeartbeatResult(runId: string): AgentHeartbeatResult {
+  const summary = 'Heartbeat result.\n\nHEARTBEAT_DECISION: continue';
+  const state = {
+    status: 'finished' as const,
+    runId,
+    goal: 'Heartbeat runner cycle.',
+    model: 'gpt-test',
+    provider: 'openai' as const,
+    workspaceRoot: '/tmp/project',
+    startedAt: NOW.toISOString(),
+    finishedAt: NOW.toISOString(),
+    outcome: 'done' as const,
+    summary,
+    transcript: [],
+    trace: [],
+  };
+
+  return {
+    decision: 'continue',
+    summary,
+    state,
+    checkpoint: AgentLoopCheckpointService.createCheckpoint(state, {
+      createdAt: NOW.toISOString(),
+    }),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -280,10 +280,14 @@ export type {
 } from './core/heartbeat/tasks/index.js';
 export {
   HeartbeatSchedulerService,
+  MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH,
 } from './core/heartbeat/scheduler/index.js';
 export type {
+  CancelHeartbeatTaskOptions,
   HeartbeatSchedulerHandle,
   HeartbeatSchedulerEvent,
+  HeartbeatTaskCancellationDisposition,
+  HeartbeatTaskCancellationResult,
   HeartbeatExecutionContext,
   HeartbeatHandlerOutcome,
   HeartbeatTaskHandler,

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -30,6 +30,11 @@ operator-facing heartbeat views.
   `HeartbeatTaskRunnerService` instead of running tasks itself. Daemon, CLI,
   and future hosts should start or run the scheduler through this service
   instead of constructing task repositories or duplicating loop logic.
+- `scheduler/task-lifecycle.ts`: `HeartbeatSchedulerTaskLifecycle` owns the
+  process-local task admission generation, task-scoped abort delivery, and
+  awaitable settlement registry for one `start()` handle. Durable claims and
+  final fencing remain store responsibilities. It intentionally does not route
+  cancellation to executions owned by another process or scheduler handle.
 - `scheduler/runner.ts`: `HeartbeatTaskRunnerService` owns one task execution:
   checkpoint loading, handler invocation, runner-agent invocation, abort
   propagation, checkpoint persistence, task state transitions, and execution
@@ -102,6 +107,14 @@ operator-facing heartbeat views.
   domain state. Stop prevents bounded-pool jobs that are still queued from being
   admitted. A handler that ignores its abort signal delays stop until active
   work settles; final writes remain fenced by the execution claim.
+- The same handle exposes `cancelTask(taskId, { reason })` for task-scoped
+  quiescence. It invalidates already-queued admissions for that task, aborts an
+  execution only when this handle owns it, and resolves after claim-fenced
+  settlement. Concurrent callers share one cancellation attempt. The method
+  does not disable/delete a task, consume a newer run-request generation, roll
+  back host side effects, or claim remote cancellation delivery; `not-owned`
+  tells an adapter host that another worker must be contacted through its own
+  durable routing mechanism.
 - `HeartbeatSchedulerService.start({ store })` uses the caller-provided
   `HeartbeatTaskStore` instance for startup recovery, run-request wakeups, due
   selection, claims, settlement, and run history. `stateRoot` still locates

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -5,10 +5,17 @@ export type {
   RunStoredHeartbeatOptions,
   StoredHeartbeatResult,
 } from './checkpoint/index.js';
-export { HeartbeatSchedulerService, HeartbeatTaskRunnerService } from './scheduler/index.js';
+export {
+  HeartbeatSchedulerService,
+  HeartbeatTaskRunnerService,
+  MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH,
+} from './scheduler/index.js';
 export type {
+  CancelHeartbeatTaskOptions,
   HeartbeatSchedulerEvent,
   HeartbeatSchedulerHandle,
+  HeartbeatTaskCancellationDisposition,
+  HeartbeatTaskCancellationResult,
   HeartbeatExecutionContext,
   HeartbeatHandlerOutcome,
   HeartbeatTaskHandler,

--- a/src/core/heartbeat/scheduler/index.ts
+++ b/src/core/heartbeat/scheduler/index.ts
@@ -1,8 +1,12 @@
 export { HeartbeatTaskRunnerService } from './runner.js';
 export { HeartbeatSchedulerService } from './service.js';
+export { MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH } from '../tasks/index.js';
 export type {
+  CancelHeartbeatTaskOptions,
   HeartbeatSchedulerEvent,
   HeartbeatSchedulerHandle,
+  HeartbeatTaskCancellationDisposition,
+  HeartbeatTaskCancellationResult,
   HeartbeatExecutionContext,
   HeartbeatHandlerOutcome,
   HeartbeatTaskHandler,

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -30,6 +30,7 @@ import type {
   RunDueHeartbeatTasksOptions,
   RunDueHeartbeatTasksResult,
 } from './types.js';
+import { heartbeatTaskCancellationReason } from './task-lifecycle.js';
 
 const DEFAULT_FAILURE_RETRY_MS = 5 * 60_000;
 const CANCELLATION_SUMMARY = 'Heartbeat execution cancelled by its scheduler host.';
@@ -379,16 +380,18 @@ export class HeartbeatTaskRunnerService {
     };
   }
 
-  private static async persistCancellation(args: Pick<RunDueHeartbeatTasksOptions, 'store' | 'now' | 'onEvent'> & {
+  private static async persistCancellation(args: Pick<RunDueHeartbeatTasksOptions, 'store' | 'now' | 'onEvent' | 'signal'> & {
     task: HeartbeatTask;
     execution: HeartbeatTaskExecution;
   }): Promise<{ record?: HeartbeatTaskRunRecord; failed: boolean }> {
     const settledAt = args.now?.() ?? dayjs().toDate();
+    const reason = heartbeatTaskCancellationReason(args.signal);
     const completion = await args.store.recordTaskExecutionOutcome({
       execution: args.execution,
       taskId: args.task.id,
       kind: 'cancelled',
-      summary: CANCELLATION_SUMMARY,
+      summary: reason ? `${CANCELLATION_SUMMARY} Reason: ${reason}` : CANCELLATION_SUMMARY,
+      reason,
       finishedAt: settledAt,
     });
     if (completion.status !== 'saved' || !HeartbeatTaskRunnerService.isNonAgentRecord(completion.record, 'cancelled')) {
@@ -399,6 +402,7 @@ export class HeartbeatTaskRunnerService {
       type: 'heartbeat.task.cancelled',
       taskId: args.task.id,
       executionId: args.execution.executionId,
+      reason,
       record: completion.record,
       timestamp: completion.record.outcome.finishedAt,
     });

--- a/src/core/heartbeat/scheduler/service.ts
+++ b/src/core/heartbeat/scheduler/service.ts
@@ -18,6 +18,7 @@ import {
   type HeartbeatTaskStore,
 } from '../tasks/index.js';
 import { HeartbeatTaskRunnerService } from './runner.js';
+import { HeartbeatSchedulerTaskLifecycle } from './task-lifecycle.js';
 import type {
   HeartbeatSchedulerHandle,
   RunDueHeartbeatTasksOptions,
@@ -80,8 +81,9 @@ export class HeartbeatSchedulerService {
     const loopController = new AbortController();
     const executionController = new AbortController();
     const store = options.store ?? new FileHeartbeatTaskService({ stateRoot: options.stateRoot });
+    const taskLifecycle = new HeartbeatSchedulerTaskLifecycle(store);
     let loopError: unknown;
-    const settledLoop = HeartbeatSchedulerService.runLoop({
+    const settledLoop = HeartbeatSchedulerService.runLoopWithTaskLifecycle({
       store,
       handler: options.handler,
       runner: options.runner,
@@ -100,7 +102,7 @@ export class HeartbeatSchedulerService {
       signal: loopController.signal,
       executionSignal: executionController.signal,
       onEvent: options.onEvent,
-    }).catch((error: unknown) => {
+    }, taskLifecycle).catch((error: unknown) => {
       loopError = error;
       try {
         options.onError?.(error);
@@ -111,6 +113,7 @@ export class HeartbeatSchedulerService {
     let stopPromise: Promise<void> | undefined;
 
     return {
+      cancelTask: (taskId, cancelOptions) => taskLifecycle.cancelTask(taskId, cancelOptions),
       stop: (stopOptions = {}) => {
         loopController.abort();
         if (stopOptions.cancelRunning) {
@@ -128,6 +131,13 @@ export class HeartbeatSchedulerService {
 
   // Scans stored tasks once, picks enabled tasks whose nextRunAt is due, and delegates each selected task to the runner service.
   static async runDueTasks(options: RunDueHeartbeatTasksOptions): Promise<RunDueHeartbeatTasksResult> {
+    return await HeartbeatSchedulerService.runDueTasksWithLifecycle(options);
+  }
+
+  private static async runDueTasksWithLifecycle(
+    options: RunDueHeartbeatTasksOptions,
+    taskLifecycle?: HeartbeatSchedulerTaskLifecycle,
+  ): Promise<RunDueHeartbeatTasksResult> {
     HeartbeatTaskRunnerService.assertHandlerConfiguration(options);
     const maxConcurrentTasks = HeartbeatSchedulerService.resolveMaxConcurrentTasks(options.maxConcurrentTasks);
     const now = options.now?.() ?? dayjs().toDate();
@@ -136,27 +146,37 @@ export class HeartbeatSchedulerService {
     const dueTasks = HeartbeatSchedulerService.selectDueTasks(tasks, now);
     const executionOwnerId = options.executionOwnerId ?? HeartbeatSchedulerService.createExecutionOwnerId();
     const limit = pLimit(maxConcurrentTasks);
-    const executions = dueTasks.map((task, index) => limit(async () => {
-      if ((options.admissionSignal ?? options.signal)?.aborted) {
-        return undefined;
-      }
+    const executions = dueTasks.map((task, index) => {
+      const admissionGeneration = taskLifecycle?.createAdmission(task.id);
+      return limit(async () => {
+        const runTask = async (taskSignal?: AbortSignal) => {
+          if ((options.admissionSignal ?? options.signal)?.aborted) {
+            return undefined;
+          }
 
-      options.onEvent?.({
-        type: 'heartbeat.task.due',
-        taskId: task.id,
-        timestamp,
-        queuePosition: index + 1,
-        maxConcurrentTasks,
-        activeTasks: limit.activeCount,
-        queuedTasks: limit.pendingCount,
+          options.onEvent?.({
+            type: 'heartbeat.task.due',
+            taskId: task.id,
+            timestamp,
+            queuePosition: index + 1,
+            maxConcurrentTasks,
+            activeTasks: limit.activeCount,
+            queuedTasks: limit.pendingCount,
+          });
+          return await HeartbeatTaskRunnerService.runTask({
+            ...options,
+            executionOwnerId,
+            task,
+            runAt: now,
+            signal: HeartbeatSchedulerService.composeExecutionSignal(options.signal, taskSignal),
+          });
+        };
+
+        return taskLifecycle && admissionGeneration !== undefined ?
+          await taskLifecycle.runTask(task.id, admissionGeneration, async (signal) => await runTask(signal))
+        : await runTask();
       });
-      return await HeartbeatTaskRunnerService.runTask({
-        ...options,
-        executionOwnerId,
-        task,
-        runAt: now,
-      });
-    }));
+    });
     const settledExecutions = await Promise.allSettled(executions);
     const infrastructureFailures = settledExecutions
       .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
@@ -183,6 +203,13 @@ export class HeartbeatSchedulerService {
 
   // Repeats due-task checks until the host aborts the loop.
   static async runLoop(options: RunHeartbeatSchedulerOptions): Promise<void> {
+    await HeartbeatSchedulerService.runLoopWithTaskLifecycle(options);
+  }
+
+  private static async runLoopWithTaskLifecycle(
+    options: RunHeartbeatSchedulerOptions,
+    taskLifecycle?: HeartbeatSchedulerTaskLifecycle,
+  ): Promise<void> {
     const maxConcurrentTasks = HeartbeatSchedulerService.resolveMaxConcurrentTasks(options.maxConcurrentTasks);
     const executionOwnerId = options.executionOwnerId ?? HeartbeatSchedulerService.createExecutionOwnerId();
     const startedAt = options.now?.() ?? dayjs().toDate();
@@ -208,13 +235,13 @@ export class HeartbeatSchedulerService {
 
       while (!options.signal?.aborted) {
         HeartbeatSchedulerService.emitRunRequestWakeEvents(options, wakeController.drain());
-        await HeartbeatSchedulerService.runDueTasks({
+        await HeartbeatSchedulerService.runDueTasksWithLifecycle({
           ...options,
           executionOwnerId,
           maxConcurrentTasks,
           admissionSignal: options.signal,
           signal: options.executionSignal ?? options.signal,
-        });
+        }, taskLifecycle);
         if (options.signal?.aborted) {
           break;
         }
@@ -309,6 +336,19 @@ export class HeartbeatSchedulerService {
 
   private static createExecutionOwnerId(): string {
     return `heartbeat-worker:${randomUUID()}`;
+  }
+
+  private static composeExecutionSignal(
+    schedulerSignal: AbortSignal | undefined,
+    taskSignal: AbortSignal | undefined,
+  ): AbortSignal | undefined {
+    if (!schedulerSignal) {
+      return taskSignal;
+    }
+    if (!taskSignal) {
+      return schedulerSignal;
+    }
+    return AbortSignal.any([schedulerSignal, taskSignal]);
   }
 
   // Sleeps between polling cycles and resolves early when the host aborts the scheduler.

--- a/src/core/heartbeat/scheduler/task-lifecycle.ts
+++ b/src/core/heartbeat/scheduler/task-lifecycle.ts
@@ -1,0 +1,232 @@
+/**
+ * Process-local task lifecycle for one background scheduler handle.
+ *
+ * Durable ownership and fencing stay in `HeartbeatTaskStore`. This registry
+ * owns only admission invalidation, delivery of a task-scoped abort signal to
+ * executions started by this handle, and awaiting their outer settlement.
+ */
+import {
+  MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH,
+  type HeartbeatTask,
+  type HeartbeatTaskRunRecord,
+  type HeartbeatTaskStore,
+} from '../tasks/index.js';
+import type {
+  CancelHeartbeatTaskOptions,
+  HeartbeatTaskCancellationResult,
+} from './types.js';
+
+type HeartbeatTaskSettlement = {
+  record?: HeartbeatTaskRunRecord;
+  failed: boolean;
+};
+
+type ActiveHeartbeatTask = {
+  controller: AbortController;
+  settlement: Promise<HeartbeatTaskSettlement | undefined>;
+};
+
+class HeartbeatTaskCancellationSignal extends Error {
+  readonly #operatorReason: string;
+
+  constructor(operatorReason: string) {
+    super('Heartbeat task cancellation requested by the scheduler host.');
+    this.name = 'HeartbeatTaskCancellationSignal';
+    this.#operatorReason = operatorReason;
+  }
+
+  get operatorReason(): string {
+    return this.#operatorReason;
+  }
+}
+
+export function heartbeatTaskCancellationReason(signal: AbortSignal | undefined): string | undefined {
+  return signal?.reason instanceof HeartbeatTaskCancellationSignal ? signal.reason.operatorReason : undefined;
+}
+
+export class HeartbeatSchedulerTaskLifecycle {
+  private readonly activeTasks = new Map<string, ActiveHeartbeatTask>();
+  private readonly admissionGenerations = new Map<string, number>();
+  private readonly cancellations = new Map<string, Promise<HeartbeatTaskCancellationResult>>();
+
+  constructor(private readonly store: HeartbeatTaskStore) {}
+
+  /** Captures the current admission generation when a due task enters the bounded queue. */
+  createAdmission(taskId: string): number {
+    return this.admissionGenerations.get(taskId) ?? 0;
+  }
+
+  /**
+   * Runs one admitted task with a task-scoped signal. A cancellation invalidates
+   * queued admissions before they can claim and aborts only this active entry.
+   */
+  runTask(
+    taskId: string,
+    admissionGeneration: number,
+    run: (signal: AbortSignal) => Promise<HeartbeatTaskSettlement | undefined>,
+  ): Promise<HeartbeatTaskSettlement | undefined> {
+    if (admissionGeneration !== (this.admissionGenerations.get(taskId) ?? 0)) {
+      return Promise.resolve(undefined);
+    }
+    if (this.activeTasks.has(taskId)) {
+      return Promise.resolve(undefined);
+    }
+
+    const controller = new AbortController();
+    let resolveSettlement!: (value: HeartbeatTaskSettlement | undefined) => void;
+    let rejectSettlement!: (reason?: unknown) => void;
+    const settlement = new Promise<HeartbeatTaskSettlement | undefined>((resolve, reject) => {
+      resolveSettlement = resolve;
+      rejectSettlement = reject;
+    });
+    const activeTask = { controller, settlement };
+    this.activeTasks.set(taskId, activeTask);
+    void this.settleTask({
+      taskId,
+      activeTask,
+      run,
+      resolve: resolveSettlement,
+      reject: rejectSettlement,
+    });
+    return settlement;
+  }
+
+  cancelTask(taskId: string, options: CancelHeartbeatTaskOptions): Promise<HeartbeatTaskCancellationResult> {
+    const activeCancellation = this.cancellations.get(taskId);
+    if (activeCancellation) {
+      return activeCancellation;
+    }
+
+    let reason: string;
+    try {
+      reason = HeartbeatSchedulerTaskLifecycle.normalizeCancellationReason(options.reason);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+
+    const cancellation = this.cancelTaskOnce(taskId, reason);
+    this.cancellations.set(taskId, cancellation);
+    void cancellation.finally(() => {
+      if (this.cancellations.get(taskId) === cancellation) {
+        this.cancellations.delete(taskId);
+      }
+    }).catch(() => undefined);
+    return cancellation;
+  }
+
+  private async settleTask(args: {
+    taskId: string;
+    activeTask: ActiveHeartbeatTask;
+    run: (signal: AbortSignal) => Promise<HeartbeatTaskSettlement | undefined>;
+    resolve: (value: HeartbeatTaskSettlement | undefined) => void;
+    reject: (reason?: unknown) => void;
+  }): Promise<void> {
+    try {
+      args.resolve(await args.run(args.activeTask.controller.signal));
+    } catch (error) {
+      args.reject(error);
+    } finally {
+      if (this.activeTasks.get(args.taskId) === args.activeTask) {
+        this.activeTasks.delete(args.taskId);
+      }
+    }
+  }
+
+  private async cancelTaskOnce(taskId: string, reason: string): Promise<HeartbeatTaskCancellationResult> {
+    this.invalidateAdmissions(taskId);
+    const activeTask = this.activeTasks.get(taskId);
+    if (!activeTask) {
+      return await this.classifyInactiveTask(taskId, reason);
+    }
+
+    activeTask.controller.abort(new HeartbeatTaskCancellationSignal(reason));
+    const settlement = await activeTask.settlement;
+    const result = HeartbeatSchedulerTaskLifecycle.cancellationResult({
+      taskId,
+      reason,
+      settlement,
+    });
+    return result.disposition === 'not-running' ?
+      await this.classifyInactiveTask(taskId, reason)
+    : result;
+  }
+
+  private invalidateAdmissions(taskId: string): void {
+    const generation = (this.admissionGenerations.get(taskId) ?? 0) + 1;
+    if (!Number.isSafeInteger(generation)) {
+      throw new Error(`Heartbeat task ${taskId} admission generation is exhausted.`);
+    }
+    this.admissionGenerations.set(taskId, generation);
+  }
+
+  private async classifyInactiveTask(taskId: string, reason: string): Promise<HeartbeatTaskCancellationResult> {
+    const task = (await this.store.listTasks()).find((candidate) => candidate.id === taskId);
+    const disposition = HeartbeatSchedulerTaskLifecycle.inactiveDisposition(task);
+    return { taskId, disposition, reason };
+  }
+
+  private static inactiveDisposition(
+    task: HeartbeatTask | undefined,
+  ): HeartbeatTaskCancellationResult['disposition'] {
+    if (!task) {
+      return 'not-found';
+    }
+    if (task.state?.status === 'running') {
+      return 'not-owned';
+    }
+    if (task.state?.status === 'blocked') {
+      return 'blocked';
+    }
+    if (task.state?.status === 'complete') {
+      return 'completed';
+    }
+    if (!task.enabled) {
+      return 'disabled';
+    }
+    return 'not-running';
+  }
+
+  private static cancellationResult(args: {
+    taskId: string;
+    reason: string;
+    settlement: HeartbeatTaskSettlement | undefined;
+  }): HeartbeatTaskCancellationResult {
+    const record = args.settlement?.record;
+    if (record?.outcome?.kind === 'cancelled') {
+      return {
+        taskId: args.taskId,
+        disposition: 'cancelled',
+        reason: args.reason,
+        executionId: record.outcome.executionId,
+        record,
+      };
+    }
+    if (record || args.settlement?.failed) {
+      return {
+        taskId: args.taskId,
+        disposition: 'completion-won',
+        reason: args.reason,
+        executionId: record?.outcome?.executionId,
+        record,
+      };
+    }
+    return {
+      taskId: args.taskId,
+      disposition: 'not-running',
+      reason: args.reason,
+    };
+  }
+
+  private static normalizeCancellationReason(reason: string): string {
+    const normalized = reason.trim().replace(/\s+/g, ' ');
+    if (!normalized) {
+      throw new Error('Heartbeat cancellation reason cannot be empty.');
+    }
+    if (normalized.length > MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH) {
+      throw new Error(
+        `Heartbeat cancellation reason must be at most ${MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH} characters.`,
+      );
+    }
+    return normalized;
+  }
+}

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -89,6 +89,8 @@ export type HeartbeatSchedulerEvent =
       type: 'heartbeat.task.cancelled';
       taskId: string;
       executionId: string;
+      /** Bounded operator reason for targeted cancellation, when supplied. */
+      reason?: string;
       record: HeartbeatTaskNonAgentRunRecord & { outcome: { kind: 'cancelled' } };
       timestamp: string;
     }
@@ -224,8 +226,36 @@ export type StopHeartbeatSchedulerOptions = {
   cancelRunning?: boolean;
 };
 
+export type CancelHeartbeatTaskOptions = {
+  /** Bounded, operator-facing reason. Task input must not be copied here. */
+  reason: string;
+};
+
+export type HeartbeatTaskCancellationDisposition =
+  | 'cancelled'
+  | 'completion-won'
+  | 'not-running'
+  | 'not-owned'
+  | 'not-found'
+  | 'disabled'
+  | 'blocked'
+  | 'completed';
+
+export type HeartbeatTaskCancellationResult = {
+  taskId: string;
+  disposition: HeartbeatTaskCancellationDisposition;
+  reason: string;
+  executionId?: string;
+  record?: HeartbeatTaskRunRecord;
+};
+
 export type HeartbeatSchedulerHandle = {
   stop: (options?: StopHeartbeatSchedulerOptions) => Promise<void>;
+  /** Cancels and awaits only a task execution owned by this scheduler handle. */
+  cancelTask: (
+    taskId: string,
+    options: CancelHeartbeatTaskOptions,
+  ) => Promise<HeartbeatTaskCancellationResult>;
 };
 
 export type StartHeartbeatSchedulerOptions = {

--- a/src/core/heartbeat/tasks/index.ts
+++ b/src/core/heartbeat/tasks/index.ts
@@ -29,4 +29,7 @@ export type {
   HeartbeatTaskStore,
   RequestHeartbeatTaskRunOptions,
 } from './types.js';
-export { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './types.js';
+export {
+  MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH,
+  MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH,
+} from './types.js';

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -7,7 +7,10 @@
  */
 import { z } from 'zod';
 import { LlmUsageSchema } from '@/core/llm/usage/index.js';
-import { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './types.js';
+import {
+  MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH,
+  MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH,
+} from './types.js';
 
 export const HeartbeatTaskStatusSchema = z.enum(['idle', 'running', 'waiting', 'blocked', 'complete', 'failed']);
 export const HeartbeatDecisionSchema = z.enum(['continue', 'pause', 'complete', 'escalate']);
@@ -39,6 +42,8 @@ export const HeartbeatTaskExecutionOutcomeSchema = z.object({
   kind: z.enum(['agent', 'skipped', 'cancelled', 'failed']).describe('How this outer heartbeat execution settled.'),
   executionId: z.string().describe('Outer heartbeat execution fencing identity.'),
   summary: z.string().describe('Operator-facing execution outcome summary.'),
+  reason: z.string().min(1).max(MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH).optional()
+    .describe('Bounded operator reason for targeted cancellation.'),
   finishedAt: z.string().describe('Timestamp when the outer heartbeat execution settled.'),
   runRequestGeneration: z.number().int().nonnegative().optional().describe('Run-request generation claimed by this execution.'),
 });

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -293,6 +293,7 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
           task: currentTask,
           execution,
           summary: input.summary,
+          reason: input.reason,
           now: input.finishedAt,
         }),
       } satisfies Record<typeof input.kind, () => HeartbeatTask>;

--- a/src/core/heartbeat/tasks/task-state.ts
+++ b/src/core/heartbeat/tasks/task-state.ts
@@ -272,6 +272,7 @@ export class HeartbeatTaskStateProjector {
     task: HeartbeatTask;
     execution: HeartbeatTaskExecution;
     summary: string;
+    reason?: string;
     now: Date;
   }): HeartbeatTask {
     const finishedAt = dayjs(args.now).toISOString();
@@ -295,6 +296,7 @@ export class HeartbeatTaskStateProjector {
           kind: 'cancelled',
           execution: args.execution,
           summary: args.summary,
+          reason: args.reason,
           finishedAt,
         }),
         recovery: args.task.state?.recovery,
@@ -456,14 +458,16 @@ export class HeartbeatTaskStateProjector {
     kind: HeartbeatTaskExecutionOutcome['kind'];
     execution: HeartbeatTaskExecution;
     summary: string;
+    reason?: string;
     finishedAt: string;
   }): HeartbeatTaskExecutionOutcome {
-    return {
+    const outcome = {
       kind: args.kind,
       executionId: args.execution.executionId,
       summary: args.summary,
       finishedAt: args.finishedAt,
       runRequestGeneration: args.execution.runRequestGeneration,
     };
+    return args.kind === 'cancelled' ? { ...outcome, kind: 'cancelled', reason: args.reason } : outcome;
   }
 }

--- a/src/core/heartbeat/tasks/types.ts
+++ b/src/core/heartbeat/tasks/types.ts
@@ -17,6 +17,7 @@ export type HeartbeatTaskSchedule = {
 export type HeartbeatTaskContinuationMode = 'operator' | 'agent';
 
 export const MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH = 200;
+export const MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH = 200;
 
 /**
  * Durable level-triggered intent to run a task promptly.
@@ -91,12 +92,15 @@ type HeartbeatTaskExecutionOutcomeBase = {
   runRequestGeneration?: number;
 };
 
-export type HeartbeatTaskExecutionOutcome = HeartbeatTaskExecutionOutcomeBase & (
-  | { kind: 'agent' }
-  | { kind: 'skipped' }
-  | { kind: 'cancelled' }
-  | { kind: 'failed' }
-);
+export type HeartbeatTaskExecutionOutcome =
+  | (HeartbeatTaskExecutionOutcomeBase & { kind: 'agent' })
+  | (HeartbeatTaskExecutionOutcomeBase & { kind: 'skipped' })
+  | (HeartbeatTaskExecutionOutcomeBase & { kind: 'failed' })
+  | (HeartbeatTaskExecutionOutcomeBase & {
+      kind: 'cancelled';
+      /** Bounded, operator-provided reason for targeted cancellation. */
+      reason?: string;
+    });
 
 export type HeartbeatTaskState = {
   status?: HeartbeatTaskStatus;
@@ -206,6 +210,8 @@ export type HeartbeatTaskStore = {
     taskId: string;
     kind: 'skipped' | 'cancelled';
     summary: string;
+    /** Supplied only for a targeted `cancelled` outcome. */
+    reason?: string;
     finishedAt: Date;
     signal?: AbortSignal;
   }) => Promise<HeartbeatTaskExecutionWriteResult>;


### PR DESCRIPTION
PR #312 was reviewed and merged into its stacked feature-branch base after #311 had already merged into `main`. As a result, the default branch contains #308 but not #307.

This catch-up PR carries only the already-reviewed targeted heartbeat cancellation change into `main`.

Validation already completed on the implementation branch:
- `yarn build`
- full `yarn test` (807 unit, 385 integration)
- 29 focused scheduler tests
- no-model heartbeat scheduler example

Closes #307.