### PR TITLE
Release Heddle v5.8.0

### DIFF
--- a/docs/releases/v5.8.0.md
+++ b/docs/releases/v5.8.0.md
@@ -1,0 +1,68 @@
+# Heddle v5.8.0
+
+Heddle v5.8 makes heartbeat scheduling easier to embed in product hosts. The
+supported scheduler lifecycle can now use a caller-provided task store, and a
+host can cancel one task without stopping unrelated scheduled work.
+
+## Custom task stores in the managed lifecycle
+
+- **`HeartbeatSchedulerService.start()` accepts a `store`.** Startup recovery,
+  run-request wakes, due-task reads, claims, fenced settlement, and run history
+  all use the exact caller-provided `HeartbeatTaskStore` instance.
+- **The file-backed default remains unchanged.** Omitting `store` keeps the
+  existing local persistence path. `stateRoot` still locates agent runtime
+  state and only locates heartbeat persistence when Heddle creates the default
+  file store.
+- **Hosts keep the high-level lifecycle.** Custom persistence no longer forces
+  an adopter to reconstruct recovery, wake handling, bounded execution,
+  cancellation, error capture, and awaitable shutdown around `runLoop()`.
+
+## Targeted, awaitable cancellation
+
+- **`scheduler.cancelTask(taskId, { reason })` cancels one task.** It
+  invalidates queued admission for that task, aborts an active execution owned
+  by the scheduler handle, and resolves after claim-fenced settlement.
+- **Cancellation outcomes are explicit.** Callers can distinguish cancellation
+  from completion winning the race, inactive task states, missing tasks, and
+  executions owned by another scheduler.
+- **Concurrent requests coalesce.** Multiple callers share one in-flight
+  cancellation attempt instead of producing duplicate cancellation records.
+- **Durable intent is preserved.** Cancellation retains the latest checkpoint
+  and any newer run-request generation. It does not silently disable or delete
+  the task.
+- **Reasons are bounded and observable.** A normalized one-line reason of at
+  most 200 characters is recorded on the cancellation event and run outcome.
+
+## Upgrade notes
+
+- Install `@roackb2/heddle@5.8.0`.
+  `@roackb2/heddle-remote@5.8.0` releases in lockstep.
+- No persisted data migration is required for the built-in file adapter.
+- A custom store remains responsible for atomic claims, fencing, interrupted
+  recovery, and any cross-process wake delivery required by its deployment.
+- Targeted cancellation is process-local: a scheduler does not report remote
+  cancellation success for an execution owned by another worker.
+- Cancellation is cooperative and cannot roll back product-owned effects.
+  Host tools should honor `AbortSignal`, and external mutations should remain
+  idempotent.
+- To retire a task safely, await `cancelTask()` and then disable or delete it
+  through the task service.
+
+## Verification
+
+- `yarn build`
+- `yarn test` (132 unit files / 807 tests, 43 integration files / 385 tests)
+- focused heartbeat scheduler regression set (29 tests)
+- `HEDDLE_EXAMPLE_NO_WORK=true yarn example:heartbeat-scheduler`
+- `npm pack --dry-run --cache /tmp/heddle-npm-cache`
+- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`
+
+## Release state
+
+- Package versions are `5.8.0` in both manifests.
+- The latest published npm version before this release is `5.7.0` for both
+  packages.
+- GitHub's latest tag and release before this release are `v5.6.0`; 5.7.0 was
+  published to npm without a matching Git tag or GitHub release.
+- The canonical tagged release context is `v5.6.0..HEAD`. The user-facing delta
+  from the npm 5.7.0 artifact is `f1aa30f2..HEAD`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle",
-  "version": "5.6.1",
+  "version": "5.8.0",
   "description": "An open-source AI coding agent runtime and terminal CLI for real repositories, with persistent memory, sessions, approvals, heartbeat, and a browser control plane",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/packages/heddle-remote/package.json
+++ b/packages/heddle-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle-remote",
-  "version": "5.6.1",
+  "version": "5.8.0",
   "description": "Browser-safe protocol and run-consumer services for remotely hosted Heddle conversations",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Prepares Heddle v5.8.0 after #311 and the #307 catch-up merge (#313).

Release-owned changes only:
- bump `@roackb2/heddle` to 5.8.0
- bump `@roackb2/heddle-remote` to 5.8.0
- add curated `docs/releases/v5.8.0.md`

Verified on the exact release tree:
- `yarn build`
- `yarn test` (807 unit, 385 integration)
- 29 focused heartbeat scheduler tests from the implementation branch
- `HEDDLE_EXAMPLE_NO_WORK=true yarn example:heartbeat-scheduler`
- main package `npm pack --dry-run`
- remote package `npm pack --dry-run`

The release note records that npm 5.7.0 exists without a matching Git tag/GitHub release. After this PR merges, v5.8.0 will be tagged on the merged SHA and both npm packages will be published in remote-first order.