### PR TITLE
fix: serialize file-backed heartbeat mutations

### DIFF
--- a/src/__tests__/integration/core/heartbeat-file-concurrency.test.ts
+++ b/src/__tests__/integration/core/heartbeat-file-concurrency.test.ts
@@ -1,0 +1,215 @@
+import { mkdtempSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  FileHeartbeatTaskService,
+  HeartbeatSchedulerService,
+  type HeartbeatTask,
+} from '../../../advanced.js';
+import { AgentLoopCheckpointService } from '@/core/runtime/loop/index.js';
+
+const NOW = new Date('2026-08-08T00:00:00.000Z');
+
+describe('file-backed heartbeat task concurrency', () => {
+  it('keeps concurrent distinct creates valid and listable', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-file-create-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    const taskIds = ['host-alpha', 'host-bravo', 'host-charlie', 'host-delta'];
+
+    await Promise.all(taskIds.map(async (id) => await store.createTask({
+      id,
+      task: `Run ${id}.`,
+    })));
+
+    await expect(store.listTasks()).resolves.toEqual(expect.arrayContaining(
+      taskIds.map((id) => expect.objectContaining({ id })),
+    ));
+    expectValidTaskFiles(dir);
+  });
+
+  it('serializes overlapping supported mutations and readers without losing unrelated tasks', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-file-stress-'));
+    const firstStore = new FileHeartbeatTaskService({ dir });
+    const secondStore = new FileHeartbeatTaskService({ dir });
+    await firstStore.createTask({ id: 'mutable', task: 'Toggle this task.' });
+    await firstStore.createTask({ id: 'requestable', task: 'Request this task.' });
+    const createdTaskIds = ['created-0', 'created-1', 'created-2', 'created-3'];
+    const savedTaskIds = ['saved-0', 'saved-1', 'saved-2', 'saved-3'];
+
+    await Promise.all([
+      ...createdTaskIds.map(async (id) => await firstStore.createTask({ id, task: `Create ${id}.` })),
+      ...savedTaskIds.map(async (id) => await secondStore.saveTask(createTask(id))),
+      ...Array.from({ length: 12 }, async (_, index) => await firstStore.setTaskEnabled('mutable', index % 2 === 0)),
+      ...Array.from({ length: 12 }, async (_, index) => await secondStore.requestTaskRun('requestable', {
+        reason: `request-${index}`,
+        requestedAt: new Date(NOW.getTime() + index),
+      })),
+      ...Array.from({ length: 24 }, async () => await firstStore.listTasks()),
+    ]);
+
+    const listedIds = new Set((await secondStore.listTasks()).map((task) => task.id));
+    [...createdTaskIds, ...savedTaskIds, 'mutable', 'requestable'].forEach((id) => {
+      expect(listedIds.has(id)).toBe(true);
+    });
+    await expect(secondStore.requireTask('requestable')).resolves.toMatchObject({
+      state: {
+        runRequest: {
+          generation: 12,
+          claimedGeneration: 0,
+        },
+      },
+    });
+    expectValidTaskFiles(dir);
+  });
+
+  it('rejects one of two same-ID creates without replacing the winning task', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-file-conflict-'));
+    const firstStore = new FileHeartbeatTaskService({ dir });
+    const secondStore = new FileHeartbeatTaskService({ dir });
+
+    const results = await Promise.allSettled([
+      firstStore.createTask({ id: 'same-id', task: 'First task.' }),
+      secondStore.createTask({ id: 'same-id', task: 'Second task.' }),
+    ]);
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    await expect(firstStore.listTasks()).resolves.toEqual([
+      expect.objectContaining({ id: 'same-id', task: expect.stringMatching(/task\.$/) }),
+    ]);
+    await expect(secondStore.createTask({ id: 'same-id', task: 'Third task.' })).rejects.toThrow(/already exists/i);
+  });
+
+  it('reconciles one namespace without deleting or rewriting a running claimed task', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-file-reconcile-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    const liveTask = {
+      ...createTask('representative-live'),
+      task: 'Keep this claimed task intact.',
+      state: {
+        status: 'running' as const,
+        execution: {
+          executionId: 'live-execution',
+          ownerId: 'live-worker',
+          claimedAt: NOW.toISOString(),
+        },
+        runRequest: {
+          generation: 3,
+          claimedGeneration: 3,
+          requestedAt: NOW.toISOString(),
+        },
+      },
+    };
+    const checkpoint = AgentLoopCheckpointService.createCheckpoint({
+      status: 'running',
+      runId: 'live-run',
+      goal: 'Keep the claim.',
+      model: 'gpt-test',
+      provider: 'openai',
+      workspaceRoot: '/tmp/heartbeat-reconcile',
+      startedAt: NOW.toISOString(),
+      transcript: [],
+      trace: [],
+    }, { createdAt: NOW.toISOString() });
+    await store.saveTask(liveTask);
+    await store.saveCheckpoint(liveTask, checkpoint);
+    await store.saveTask(createTask('representative-obsolete'));
+    await store.saveTask(createTask('outside-namespace'));
+
+    const result = await store.reconcileTasks({
+      namespace: 'representative-',
+      desired: [
+        { ...createTask('representative-live'), task: 'Do not replace the live task.' },
+        createTask('representative-new'),
+      ],
+    });
+
+    expect(result.created).toEqual([expect.objectContaining({ id: 'representative-new' })]);
+    expect(result.deleted).toEqual([expect.objectContaining({ id: 'representative-obsolete' })]);
+    expect(result.preservedRunning).toEqual([expect.objectContaining({
+      id: 'representative-live',
+      state: expect.objectContaining({
+        execution: expect.objectContaining({ executionId: 'live-execution' }),
+      }),
+    })]);
+    await expect(store.requireTask('representative-live')).resolves.toMatchObject({
+      task: 'Keep this claimed task intact.',
+      state: {
+        status: 'running',
+        execution: { executionId: 'live-execution' },
+        runRequest: { generation: 3, claimedGeneration: 3 },
+      },
+    });
+    await expect(store.loadCheckpoint(liveTask)).resolves.toEqual(checkpoint);
+    await expect(store.listTasks()).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'representative-live' }),
+      expect.objectContaining({ id: 'representative-new' }),
+      expect.objectContaining({ id: 'outside-namespace' }),
+    ]));
+    await expect(store.requireTask('representative-obsolete')).rejects.toThrow(/not found/i);
+  });
+
+  it('allows scheduler polling to overlap host mutations without malformed reads', async () => {
+    const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-file-scheduler-'));
+    const store = new FileHeartbeatTaskService({ stateRoot });
+    await store.saveTask(createTask('polling-task'));
+    const started = deferred<void>();
+    const release = deferred<void>();
+    const scheduler = HeartbeatSchedulerService.start({
+      workspaceRoot: stateRoot,
+      stateRoot,
+      store,
+      pollIntervalMs: 60_000,
+      now: () => NOW,
+      handler: async (context) => {
+        started.resolve();
+        await release.promise;
+        return context.skip({ summary: 'No work available.' });
+      },
+    });
+    await started.promise;
+
+    await expect(Promise.all([
+      store.createTask({ id: 'host-added', task: 'Add while polling.' }),
+      store.requestTaskRun('polling-task', { reason: 'new-work', requestedAt: NOW }),
+      store.listTasks(),
+      store.listTaskViews(),
+    ])).resolves.toHaveLength(4);
+
+    release.resolve();
+    await scheduler.stop({ cancelRunning: true });
+    await expect(store.requireTask('host-added')).resolves.toMatchObject({ id: 'host-added' });
+    expectValidTaskFiles(join(stateRoot, 'heartbeat'));
+  });
+});
+
+function createTask(id: string): HeartbeatTask {
+  return {
+    id,
+    task: `Run ${id}.`,
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt: '2000-01-01T00:00:00.000Z',
+    },
+    state: {
+      status: 'waiting',
+      resumable: true,
+    },
+  };
+}
+
+function expectValidTaskFiles(heartbeatRoot: string): void {
+  readdirSync(join(heartbeatRoot, 'tasks'))
+    .filter((entry) => entry.endsWith('.json'))
+    .forEach((entry) => expect(() => JSON.parse(readFileSync(join(heartbeatRoot, 'tasks', entry), 'utf8'))).not.toThrow());
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -260,6 +260,8 @@ export {
 } from './core/heartbeat/tasks/index.js';
 export type {
   FileHeartbeatTaskServiceOptions,
+  ReconcileHeartbeatTasksInput,
+  ReconcileHeartbeatTasksResult,
   HeartbeatTask,
   HeartbeatTaskAgentRunRecord,
   HeartbeatTaskClaimResult,

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -76,12 +76,19 @@ operator-facing heartbeat views.
   concurrently, but every execution still passes through the store's atomic
   claim and fencing contract. Aggregate records retain selected-task order even
   when completion events arrive in another order.
-- The file service serializes claim/recover/complete/fail transitions with a
-  shared in-process mutex, serializes task control read-transform-write
-  transitions, and tracks live executions in process memory. Its process-local
-  wake signal reduces event latency; polling remains the restart fallback. This is
-  reliable for one Node.js process owning a state root; it is not a distributed
-  lease. Multiple processes or replicas must provide a remote
+- The file service serializes task/checkpoint/run mutations with a shared
+  in-process mutex for one resolved heartbeat root. Task, checkpoint, and run
+  JSON files are replaced atomically, so readers see a complete previous or next
+  document rather than a partial write. Concurrent
+  `createTask` calls for the same ID produce one creation and one explicit
+  conflict; distinct IDs are independent. `reconcileTasks({ namespace, desired
+  })` atomically creates missing members and removes obsolete non-running members
+  from one host-owned namespace, while retaining existing configuration/state and
+  never rewriting a live running claim. Use the explicit task update APIs for
+  existing-task configuration changes. Its process-local wake signal reduces event
+  latency; polling remains the restart fallback. This is reliable for one Node.js
+  process owning a state root; it is not a distributed lease. Multiple processes
+  or replicas must provide a remote
   `HeartbeatTaskStore` that implements atomic claim, fencing, and recovery with
   database compare-and-swap, leases, or transactions.
 - Recovery preserves the latest checkpoint and run history, records the

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -34,6 +34,8 @@ export { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './tasks/index.js';
 export type {
   CreateHeartbeatTaskInput,
   FileHeartbeatTaskServiceOptions,
+  ReconcileHeartbeatTasksInput,
+  ReconcileHeartbeatTasksResult,
   HeartbeatTask,
   HeartbeatTaskAgentRunRecord,
   HeartbeatTaskClaimResult,

--- a/src/core/heartbeat/tasks/index.ts
+++ b/src/core/heartbeat/tasks/index.ts
@@ -3,6 +3,8 @@ export { HeartbeatTaskStateProjector } from './task-state.js';
 export type {
   CreateHeartbeatTaskInput,
   FileHeartbeatTaskServiceOptions,
+  ReconcileHeartbeatTasksInput,
+  ReconcileHeartbeatTasksResult,
   UpdateHeartbeatTaskInput,
 } from './service.js';
 export type {

--- a/src/core/heartbeat/tasks/repository.ts
+++ b/src/core/heartbeat/tasks/repository.ts
@@ -5,7 +5,8 @@
  * Scheduler and host code should depend on this repository contract instead of
  * reading heartbeat JSON files directly.
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { basename, dirname, join } from 'node:path';
 import dayjs from 'dayjs';
 import type { AgentLoopCheckpoint } from '@/core/runtime/loop/index.js';
@@ -42,8 +43,7 @@ export class FileHeartbeatTaskRepository {
 
   async saveTask(task: HeartbeatTask): Promise<void> {
     const path = join(this.tasksDir, `${FileHeartbeatTaskRepository.safeTaskFileName(task.id)}.json`);
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, `${JSON.stringify(HeartbeatTaskSchema.parse(HeartbeatTaskStateProjector.normalize(task)), null, 2)}\n`);
+    this.writeJsonAtomically(path, HeartbeatTaskSchema.parse(HeartbeatTaskStateProjector.normalize(task)));
   }
 
   async deleteTask(task: HeartbeatTask): Promise<void> {
@@ -69,15 +69,16 @@ export class FileHeartbeatTaskRepository {
 
   async saveCheckpoint(task: HeartbeatTask, checkpoint: AgentLoopCheckpoint): Promise<void> {
     const path = this.checkpointPathForTask(task);
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, `${JSON.stringify(AgentLoopCheckpointSchema.parse(checkpoint), null, 2)}\n`);
+    this.writeJsonAtomically(path, AgentLoopCheckpointSchema.parse(checkpoint));
   }
 
   async saveRunRecord(record: HeartbeatTaskRunRecord): Promise<void> {
     const timestamp = dayjs().toISOString().replaceAll(':', '-');
-    const path = join(this.runsDir, `${timestamp}-${FileHeartbeatTaskRepository.safeTaskFileName(record.task.id)}.json`);
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, `${JSON.stringify(HeartbeatTaskRunRecordSchema.parse(record), null, 2)}\n`);
+    const path = join(
+      this.runsDir,
+      `${timestamp}-${FileHeartbeatTaskRepository.safeTaskFileName(record.task.id)}-${randomUUID()}.json`,
+    );
+    this.writeJsonAtomically(path, HeartbeatTaskRunRecordSchema.parse(record));
   }
 
   async listRunRecords(options: { taskId?: string; limit?: number } = {}): Promise<HeartbeatTaskRunRecordEntry[]> {
@@ -133,6 +134,23 @@ export class FileHeartbeatTaskRepository {
       this.checkpointsDir,
       `${FileHeartbeatTaskRepository.safeTaskFileName(task.id)}.json`,
     );
+  }
+
+  /**
+   * Replaces one JSON document through a sibling temporary file so readers see
+   * either the previous complete document or the next complete document.
+   */
+  private writeJsonAtomically(path: string, value: unknown): void {
+    const directory = dirname(path);
+    const temporaryPath = join(directory, `.${basename(path)}.${randomUUID()}.tmp`);
+    mkdirSync(directory, { recursive: true });
+
+    try {
+      writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`);
+      renameSync(temporaryPath, path);
+    } finally {
+      rmSync(temporaryPath, { force: true });
+    }
   }
 
   private static safeTaskFileName(id: string): string {

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -56,6 +56,20 @@ export type UpdateHeartbeatTaskInput = {
   systemContext?: string;
 };
 
+export type ReconcileHeartbeatTasksInput = {
+  /** Prefix that limits this reconciliation to tasks owned by one host concern. */
+  namespace: string;
+  /** Desired members of the namespace. Existing members retain their stored configuration and state. */
+  desired: readonly HeartbeatTask[];
+};
+
+export type ReconcileHeartbeatTasksResult = {
+  created: HeartbeatTask[];
+  deleted: HeartbeatTask[];
+  /** Running tasks retained without rewriting their execution claim or state. */
+  preservedRunning: HeartbeatTask[];
+};
+
 /**
  * Heartbeat task service.
  *
@@ -399,6 +413,36 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
     });
   }
 
+  /**
+   * Reconciles membership for one host-owned task namespace under the same
+   * mutation boundary used by scheduler claims and task control operations.
+   *
+   * It only creates missing desired tasks and deletes obsolete non-running
+   * tasks. Existing tasks are left intact so reconciliation cannot erase an
+   * operator change, run-request generation, checkpoint association, or live
+   * execution fencing token. Call the explicit task update APIs when a host
+   * needs to change an existing task's configuration.
+   */
+  async reconcileTasks(input: ReconcileHeartbeatTasksInput): Promise<ReconcileHeartbeatTasksResult> {
+    FileHeartbeatTaskService.assertReconciliationInput(input);
+
+    return await this.mutationMutex.runExclusive(async () => {
+      const currentTasks = await this.repository.listTasks();
+      const currentById = new Map(currentTasks.map((task) => [task.id, task]));
+      const desiredById = new Map(input.desired.map((task) => [task.id, task]));
+      const namespaceTasks = currentTasks.filter((task) => task.id.startsWith(input.namespace));
+      const created = [...desiredById.values()].filter((task) => !currentById.has(task.id));
+      const obsolete = namespaceTasks.filter((task) => !desiredById.has(task.id));
+      const preservedRunning = namespaceTasks.filter((task) => task.state?.status === 'running');
+      const deleted = obsolete.filter((task) => task.state?.status !== 'running');
+
+      await Promise.all(created.map(async (task) => await this.repository.saveTask(task)));
+      await Promise.all(deleted.map(async (task) => await this.repository.deleteTask(task)));
+
+      return { created, deleted, preservedRunning };
+    });
+  }
+
   async updateTask(taskId: string, input: UpdateHeartbeatTaskInput) {
     const nextTask = await this.updateStoredTask(taskId, (task) => {
       const now = dayjs();
@@ -671,7 +715,7 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
 
   private static resolveHeartbeatRoot(options: FileHeartbeatTaskServiceOptions): string {
     if ('dir' in options) {
-      return options.dir;
+      return resolve(options.dir);
     }
 
     if ('stateRoot' in options) {
@@ -706,6 +750,20 @@ export class FileHeartbeatTaskService implements HeartbeatTaskStore {
       throw new Error(`Heartbeat run-request reason must be at most ${MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH} characters.`);
     }
     return normalized;
+  }
+
+  private static assertReconciliationInput(input: ReconcileHeartbeatTasksInput): void {
+    if (!input.namespace) {
+      throw new Error('Heartbeat reconciliation namespace cannot be empty.');
+    }
+
+    const desiredIds = input.desired.map((task) => task.id);
+    if (new Set(desiredIds).size !== desiredIds.length) {
+      throw new Error(`Heartbeat reconciliation namespace ${input.namespace} contains duplicate task IDs.`);
+    }
+    if (desiredIds.some((taskId) => !taskId.startsWith(input.namespace))) {
+      throw new Error(`Heartbeat reconciliation desired task IDs must start with namespace ${input.namespace}.`);
+    }
   }
 
   private static consumePendingRunRequest(


### PR DESCRIPTION
## Summary

- serialize file-backed heartbeat mutations across service instances sharing the same root
- replace JSON documents atomically so readers observe either the previous or next complete state
- add an atomic namespace reconciliation operation that preserves running and live-claimed tasks
- document the same-process safety boundary and the need for a remote store across replicas

## Verification

- `yarn vitest run src/__tests__/integration/core/heartbeat-run-requests.test.ts src/__tests__/integration/core/heartbeat-file-concurrency.test.ts`
- `yarn typecheck`
- `yarn lint`

Closes #315