### PR TITLE
fix: preserve heartbeat example lifecycle

### DIFF
--- a/examples/heartbeat/01-one-cycle.ts
+++ b/examples/heartbeat/01-one-cycle.ts
@@ -30,7 +30,7 @@ const task: HeartbeatTask = {
 };
 
 const store = new FileHeartbeatTaskService({ stateRoot });
-await store.saveTask(task);
+await store.reconcileTasks({ namespace: 'one-cycle', desired: [task] });
 
 const result = await HeartbeatSchedulerService.runDueTasks({
   store,

--- a/examples/heartbeat/02-long-lived-worker.ts
+++ b/examples/heartbeat/02-long-lived-worker.ts
@@ -29,7 +29,7 @@ const task: HeartbeatTask = {
     workspaceRoot: process.cwd(),
   },
 };
-await store.saveTask(task);
+await store.reconcileTasks({ namespace: 'long-lived-worker', desired: [task] });
 
 const scheduler = HeartbeatSchedulerService.start({
   workspaceRoot: process.cwd(),
@@ -40,29 +40,15 @@ const scheduler = HeartbeatSchedulerService.start({
   onError: (error) => console.error('Heartbeat scheduler error:', error),
 });
 
-let stopping: Promise<void> | undefined;
-const stop = () => {
-  stopping ??= scheduler.stop({ cancelRunning: true });
-  return stopping;
-};
-
-for (const signal of ['SIGINT', 'SIGTERM'] as const) {
-  process.once(signal, () => {
-    void stop();
-  });
-}
+const shutdownRequested = new Promise<void>((resolve) => {
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.once(signal, () => resolve());
+  }
+});
 
 console.log(`Heartbeat worker started. State: ${stateRoot}`);
-await new Promise<void>((resolve) => {
-  const waitForStop = () => {
-    if (stopping) {
-      void stopping.finally(resolve);
-      return;
-    }
-    setTimeout(waitForStop, 100);
-  };
-  waitForStop();
-});
+await shutdownRequested;
+await scheduler.stop({ cancelRunning: true });
 
 // Next: 03-domain-handler.ts adds host-owned claim and acknowledgement logic
 // while leaving Heddle's runtime credentials and execution persistence inside Heddle.

--- a/examples/heartbeat/03-domain-handler.ts
+++ b/examples/heartbeat/03-domain-handler.ts
@@ -22,14 +22,17 @@ type ClaimedWork = { id: string; instruction: string; status: 'claimed' };
 
 const stateRoot = join(process.cwd(), '.heddle', 'examples', 'heartbeat-domain-handler');
 const store = new FileHeartbeatTaskService({ stateRoot });
-await store.saveTask({
-  id: 'domain-handler',
-  name: 'Domain handler heartbeat',
-  task: 'Complete the host-claimed work with the host-provided constraints.',
-  enabled: true,
-  schedule: { intervalMs: 60_000, nextRunAt: new Date().toISOString() },
-  runtime: { model: process.env.HEDDLE_EXAMPLE_MODEL ?? 'gpt-5.1-codex-mini', maxSteps: 2, workspaceRoot: process.cwd() },
-} satisfies HeartbeatTask);
+await store.reconcileTasks({
+  namespace: 'domain-handler',
+  desired: [{
+    id: 'domain-handler',
+    name: 'Domain handler heartbeat',
+    task: 'Complete the host-claimed work with the host-provided constraints.',
+    enabled: true,
+    schedule: { intervalMs: 60_000, nextRunAt: new Date().toISOString() },
+    runtime: { model: process.env.HEDDLE_EXAMPLE_MODEL ?? 'gpt-5.1-codex-mini', maxSteps: 2, workspaceRoot: process.cwd() },
+  } satisfies HeartbeatTask],
+});
 
 const handler: HeartbeatTaskHandler = async (context) => {
   const claim = claimWork();

--- a/examples/heartbeat/04-event-driven-wake.ts
+++ b/examples/heartbeat/04-event-driven-wake.ts
@@ -21,29 +21,34 @@ type IncomingEvent = { id: string; instruction: string };
 
 const stateRoot = join(process.cwd(), '.heddle', 'examples', 'heartbeat-event-wake');
 const store = new FileHeartbeatTaskService({ stateRoot });
+// This in-memory map demonstrates ownership only. Use a durable inbox in a
+// production host so process restarts cannot discard event payloads.
 const pendingEvents = new Map<string, IncomingEvent>();
-await store.saveTask({
-  id: 'event-driven-work',
-  name: 'Event-driven heartbeat',
-  task: 'Process one host-provided event safely and report the result.',
-  enabled: true,
-  schedule: { intervalMs: 60_000, nextRunAt: '2099-01-01T00:00:00.000Z' },
-  runtime: { model: process.env.HEDDLE_EXAMPLE_MODEL ?? 'gpt-5.1-codex-mini', maxSteps: 2, workspaceRoot: process.cwd() },
-} satisfies HeartbeatTask);
+await store.reconcileTasks({
+  namespace: 'event-driven-work',
+  desired: [{
+    id: 'event-driven-work',
+    name: 'Event-driven heartbeat',
+    task: 'Process one host-provided event safely and report the result.',
+    enabled: true,
+    schedule: { intervalMs: 60_000, nextRunAt: '2099-01-01T00:00:00.000Z' },
+    runtime: { model: process.env.HEDDLE_EXAMPLE_MODEL ?? 'gpt-5.1-codex-mini', maxSteps: 2, workspaceRoot: process.cwd() },
+  } satisfies HeartbeatTask],
+});
 
 const handler: HeartbeatTaskHandler = async (context) => {
   const event = pendingEvents.values().next().value as IncomingEvent | undefined;
   if (!event) {
     return context.skip({ summary: 'No host event remained after the coalesced wake-up.' });
   }
-  pendingEvents.delete(event.id);
-
-  return await context.runAgent({
+  const result = await context.runAgent({
     task: `${context.task.task}\n\nHost event: ${event.instruction}`,
     systemContext: `Operate only on host event ${event.id}.`,
     includeDefaultTools: false,
     maxSteps: 2,
   });
+  pendingEvents.delete(event.id); // Acknowledge only after successful agent work.
+  return result;
 };
 
 const scheduler = HeartbeatSchedulerService.start({
@@ -54,6 +59,11 @@ const scheduler = HeartbeatSchedulerService.start({
   maxSteps: 2,
   handler,
   onError: (error) => console.error('Heartbeat scheduler error:', error),
+});
+const shutdownRequested = new Promise<void>((resolve) => {
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.once(signal, () => resolve());
+  }
 });
 
 async function onHostEvent(event: IncomingEvent): Promise<void> {
@@ -67,8 +77,8 @@ await Promise.all([
 ]);
 
 console.log(`Event-driven scheduler started. State: ${stateRoot}`);
-process.once('SIGINT', () => void scheduler.stop({ cancelRunning: true }));
-process.once('SIGTERM', () => void scheduler.stop({ cancelRunning: true }));
+await shutdownRequested;
+await scheduler.stop({ cancelRunning: true });
 
 // Next: keep the payload store and its idempotency keys host-owned. Move to a
 // custom heartbeat store only when its atomic claims, fenced settlement, and

--- a/examples/heartbeat/README.md
+++ b/examples/heartbeat/README.md
@@ -15,6 +15,11 @@ Stages that call `runAgent()` use that credential. Their model budget is capped
 at two steps only to keep the examples inexpensive; choose a production budget
 for the work and controls you actually operate.
 
+Every stage uses `reconcileTasks()` at startup. Re-running an example therefore
+creates a missing task without overwriting its durable state, pending request,
+checkpoint association, or operator changes. Use the explicit task update APIs
+when the host intentionally changes an existing task.
+
 ## Choose by two independent axes
 
 First choose the **host topology**. Then choose how deeply the host needs to
@@ -47,11 +52,13 @@ distributed-systems guarantee.
    host postcondition → acknowledgement. Heddle never exposes credential
    records to the handler. **Next:** stage 04 when product events should wake
    work promptly.
-4. `04-event-driven-wake.ts` places event data in a host `Map`; the Heddle
-   task receives only a bounded reason and durable generation. Repeated wakes
-   coalesce, but the host must retain every payload and make its effects
-   idempotent. **Next:** replace the built-in store only after designing its
-   atomic claim, fencing, lease recovery, and payload-delivery contracts.
+4. `04-event-driven-wake.ts` uses an in-memory host `Map` only to illustrate
+   ownership; a production host needs a durable inbox. The Heddle task receives
+   only a bounded reason and durable generation, and the example removes a
+   payload only after the agent succeeds. Repeated wakes coalesce, so the host
+   must retain every payload and make its effects idempotent. **Next:** replace
+   the built-in store only after designing its atomic claim, fencing, lease
+   recovery, and payload-delivery contracts.
 
 ## Commands
 

--- a/src/__tests__/integration/examples/heartbeat-sdk-examples.test.ts
+++ b/src/__tests__/integration/examples/heartbeat-sdk-examples.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../advanced.js';
 
 describe('heartbeat SDK examples', () => {
-  it('creates a task, persists a no-work skip, wakes on a durable request, and stops gracefully without a model', async () => {
+  it('reconciles a task, preserves its state, wakes on a durable request, and stops gracefully without a model', async () => {
     const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-sdk-example-'));
     const store = new FileHeartbeatTaskService({ stateRoot });
     const task: HeartbeatTask = {
@@ -20,7 +20,7 @@ describe('heartbeat SDK examples', () => {
       schedule: { intervalMs: 60_000, nextRunAt: '2000-01-01T00:00:00.000Z' },
       runtime: { model: 'gpt-test', maxSteps: 2, workspaceRoot: stateRoot },
     };
-    await store.saveTask(task);
+    await store.reconcileTasks({ namespace: 'example-', desired: [task] });
     await expect(store.requireTask(task.id)).resolves.toMatchObject({ id: task.id, enabled: true });
 
     const runAgent = vi.spyOn(HeartbeatRunnerAgent, 'run');
@@ -31,6 +31,16 @@ describe('heartbeat SDK examples', () => {
     });
     expect(firstCycle).toMatchObject({ checked: 1, ran: 1, failed: 0 });
     await expect(store.requireTask(task.id)).resolves.toMatchObject({
+      task: task.task,
+      state: { lastExecution: { kind: 'skipped', summary: 'No host work is available.' } },
+    });
+
+    await store.reconcileTasks({
+      namespace: 'example-',
+      desired: [{ ...task, task: 'A startup reconciliation must not replace the stored task.' }],
+    });
+    await expect(store.requireTask(task.id)).resolves.toMatchObject({
+      task: task.task,
       state: { lastExecution: { kind: 'skipped', summary: 'No host work is available.' } },
     });
 


### PR DESCRIPTION
## Summary

- reconcile desired example tasks at startup instead of overwriting durable task state
- acknowledge host event payloads only after successful agent work
- await graceful shutdown directly in long-lived examples and document the durable inbox boundary

## Why

The progressive examples should be safe to restart and should model the lifecycle behavior we recommend to hosts. Startup must not erase checkpoints, pending requests, skip history, or operator changes, and a failed agent run must not consume its host-owned event payload.

## Verification

- `yarn example:heartbeat:smoke`
- `yarn vitest run src/__tests__/integration/examples/heartbeat-sdk-examples.test.ts src/__tests__/integration/core/heartbeat-file-concurrency.test.ts`
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `yarn test` (132 unit files / 807 tests; 45 integration files / 391 tests)
- ran `03-domain-handler.ts` twice against the same isolated state root: the first cycle ran once; the restarted process preserved state and did not rerun before due

Follow-up hardening for #317.
