### PR TITLE
feat: show changed files in terminal activity

### DIFF
--- a/src/__tests__/unit/cli-v2/changed-files-panel.test.tsx
+++ b/src/__tests__/unit/cli-v2/changed-files-panel.test.tsx
@@ -1,0 +1,41 @@
+/** @vitest-environment jsdom */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ChangedFilesPanel } from '@/cli-v2/components/ChangedFilesPanel.js';
+
+describe('cli-v2 ChangedFilesPanel', () => {
+  it('renders workspace-relative paths with their control-plane statuses', () => {
+    const view = render(
+      <ChangedFilesPanel files={[
+        { path: 'src/changed.ts', status: 'modified' },
+        { path: 'docs/new-guide.md', status: 'untracked' },
+        { path: 'src/new-name.ts', oldPath: 'src/old-name.ts', status: 'renamed' },
+      ]} />,
+    );
+
+    expect(view.container.textContent).toContain('Changed files · 3');
+    expect(view.container.textContent).toContain('modified ./src/changed.ts');
+    expect(view.container.textContent).toContain('untracked ./docs/new-guide.md');
+    expect(view.container.textContent).toContain('renamed ./src/new-name.ts ← ./src/old-name.ts');
+  });
+
+  it('caps the terminal list and reports omitted files', () => {
+    const files = Array.from({ length: 10 }, (_, index) => ({
+      path: `src/file-${index + 1}.ts`,
+      status: 'modified' as const,
+    }));
+    const view = render(<ChangedFilesPanel files={files} />);
+
+    expect(view.container.textContent).toContain('./src/file-8.ts');
+    expect(view.container.textContent).not.toContain('./src/file-9.ts');
+    expect(view.container.textContent).toContain('… and 2 more');
+  });
+
+  it('does not render when the workspace is clean', () => {
+    const view = render(<ChangedFilesPanel files={[]} />);
+
+    expect(view.container.textContent).toBe('');
+  });
+});

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -10,6 +10,7 @@ import type {
   ControlPlaneSessionSendPromptAsyncResult,
   ControlPlaneSessionView,
   ControlPlaneSessionsEventEnvelope,
+  ControlPlaneWorkspaceChanges,
 } from '../../../client-shared/api/types.js';
 import { createControlPlaneRequestContext } from '../../../client-shared/api/links.js';
 import { SLASH_COMMAND_REQUEST_TIMEOUT_MS } from '../../../cli-v2/services/sessions/control-plane-session-api-service.js';
@@ -28,6 +29,7 @@ describe('ControlPlaneSessionStore', () => {
     expect(fixture.calls.slashCommandCatalogQuery).toHaveBeenCalledTimes(1);
     expect(fixture.calls.slashCommandCatalogQuery).toHaveBeenCalledWith({ workspaceId: 'workspace-1' });
     expect(fixture.calls.sessionsQuery).toHaveBeenCalledWith({ workspaceId: 'workspace-1' });
+    expect(fixture.calls.workspaceChangesQuery).toHaveBeenCalledWith({ workspaceId: 'workspace-1' });
     expect(fixture.calls.sessionQuery).toHaveBeenCalledWith({ id: 'session-1', workspaceId: 'workspace-1' });
     expect(fixture.calls.sessionRuntimeContextQuery).toHaveBeenCalledWith({
       sessionId: 'session-1',
@@ -47,6 +49,35 @@ describe('ControlPlaneSessionStore', () => {
     expect(store.getSnapshot().activeSession?.messages).toEqual([
       { id: 'message-1', role: 'assistant', text: 'Ready.' },
     ]);
+    store.dispose();
+  });
+
+  it('refreshes the canonical workspace change list after a live workspace-changing activity', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+    fixture.calls.workspaceChangesQuery.mockResolvedValueOnce(createWorkspaceChanges([
+      { path: 'src/changed.ts', status: 'modified' },
+    ]));
+
+    fixture.emitRunActivity({
+      source: 'agent-loop',
+      type: 'tool.completed',
+      runId: 'run-1',
+      step: 1,
+      tool: 'edit_file',
+      toolCallId: 'call-1',
+      durationMs: 8,
+      result: { path: 'src/changed.ts' },
+      timestamp: new Date().toISOString(),
+    });
+
+    await vi.waitFor(() => {
+      expect(store.getSnapshot().workspaceChanges).toEqual([
+        expect.objectContaining({ path: 'src/changed.ts', status: 'modified' }),
+      ]);
+    });
+    expect(fixture.calls.workspaceChangesQuery).toHaveBeenCalledTimes(2);
     store.dispose();
   });
 
@@ -1095,6 +1126,7 @@ function createClientFixture(options: {
       workspaceId: 'workspace-1',
       files: [{ path: 'src/example.ts' }],
     })),
+    workspaceChangesQuery: vi.fn(async () => createWorkspaceChanges()),
     sessionContinueMutate: vi.fn(async () => ({
       outcome: 'done',
       summary: 'Continued.',
@@ -1140,6 +1172,7 @@ function createClientFixture(options: {
       slashCommandCatalog: { query: calls.slashCommandCatalogQuery },
       slashCommandExecute: { mutate: calls.slashCommandExecuteMutate },
       workspaceFileSearch: { query: calls.workspaceFileSearchQuery },
+      workspaceChanges: { query: calls.workspaceChangesQuery },
       sessionContinue: { mutate: calls.sessionContinueMutate },
       sessionCancel: { mutate: calls.sessionCancelMutate },
       sessionResolveApproval: { mutate: calls.sessionResolveApprovalMutate },
@@ -1365,6 +1398,17 @@ function createAcceptedResult(): ControlPlaneSessionSendPromptAsyncResult {
     sessionId: 'session-1',
     runId: 'session-run-1',
     acceptedAt: '2026-05-27T00:00:00.000Z',
+  };
+}
+
+function createWorkspaceChanges(
+  files: ControlPlaneWorkspaceChanges['files'] = [],
+): ControlPlaneWorkspaceChanges {
+  return {
+    workspaceId: 'workspace-1',
+    vcs: 'git',
+    clean: files.length === 0,
+    files,
   };
 }
 

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -7,6 +7,7 @@ import { ApprovalPanel } from './components/ApprovalPanel.js';
 import { AgentPlanPanel } from './components/AgentPlanPanel.js';
 import { ComposerPanel } from './components/ComposerPanel.js';
 import { CommandResultPanel } from './components/CommandResultPanel.js';
+import { ChangedFilesPanel } from './components/ChangedFilesPanel.js';
 import { ConversationPanel } from './components/ConversationPanel.js';
 import { DirectShellConfirmationPanel } from './components/DirectShellConfirmationPanel.js';
 import { PromptStatusPanel } from './components/PromptStatusPanel.js';
@@ -149,6 +150,7 @@ export function App({
         onCancel={cancelRun}
       />
       <AgentPlanPanel plan={snapshot.activePlan} />
+      <ChangedFilesPanel files={snapshot.workspaceChanges} />
       <PromptStatusPanel
         currentActivity={snapshot.currentActivity}
         latestActivity={PromptActivityService.build(snapshot)}

--- a/src/cli-v2/README.md
+++ b/src/cli-v2/README.md
@@ -35,6 +35,9 @@
   compaction/workspace behavior, or when web-v2 and programmatic hosts should
   observe the same command semantics.
 - `components/`: terminal rendering components.
+- The Changed files panel renders the control-plane's canonical Git workspace
+  projection. It refreshes from shared workspace-change activity triggers and
+  deliberately bounds the visible list for terminal readability.
 - `main.ts`: public terminal bootstrap and command routing.
 - `index.tsx`: interactive TUI entrypoint that receives a tRPC URL from
   `main.ts` or another terminal host bootstrap.

--- a/src/cli-v2/components/ChangedFilesPanel.tsx
+++ b/src/cli-v2/components/ChangedFilesPanel.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { ControlPlaneWorkspaceChangedFile } from '@/client-shared/api/types.js';
+
+const MAX_VISIBLE_CHANGED_FILES = 8;
+
+const statusColors: Record<ControlPlaneWorkspaceChangedFile['status'], 'blue' | 'cyan' | 'green' | 'red' | 'yellow'> = {
+  added: 'green',
+  copied: 'cyan',
+  deleted: 'red',
+  modified: 'yellow',
+  renamed: 'blue',
+  unknown: 'yellow',
+  untracked: 'green',
+};
+
+type ChangedFilesPanelProps = {
+  files: ControlPlaneWorkspaceChangedFile[];
+};
+
+/** Renders the current control-plane Git change set in a bounded terminal view. */
+export function ChangedFilesPanel({ files }: ChangedFilesPanelProps) {
+  if (files.length === 0) {
+    return null;
+  }
+
+  const visibleFiles = files.slice(0, MAX_VISIBLE_CHANGED_FILES);
+  const hiddenCount = files.length - visibleFiles.length;
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text>
+        <Text bold>Changed files</Text>
+        <Text dimColor> · {files.length}</Text>
+      </Text>
+      {visibleFiles.map((file) => (
+        <Text key={`${file.status}:${file.oldPath ?? ''}:${file.path}`}>
+          <Text color={statusColors[file.status]}>{file.status}</Text>
+          <Text> </Text>
+          <Text color="cyan">{formatWorkspacePath(file.path)}</Text>
+          {file.status === 'renamed' && file.oldPath ? (
+            <Text dimColor> ← {formatWorkspacePath(file.oldPath)}</Text>
+          ) : null}
+        </Text>
+      ))}
+      {hiddenCount > 0 ? <Text dimColor>… and {hiddenCount} more</Text> : null}
+    </Box>
+  );
+}
+
+function formatWorkspacePath(path: string): string {
+  return path.startsWith('./') ? path : `./${path}`;
+}

--- a/src/cli-v2/components/PromptStatusPanel.tsx
+++ b/src/cli-v2/components/PromptStatusPanel.tsx
@@ -29,6 +29,7 @@ export function PromptStatusPanel({ currentActivity, latestActivity }: PromptSta
 
   return (
     <Box flexDirection="column" marginTop={1}>
+      <Text bold>Current Activity</Text>
       {latestActivity ? <Text color={latestActivity.color}>{latestActivity.text}</Text> : null}
       {currentActivity ? (
         <Text color={currentActivity.tone === 'warning' ? 'yellow' : 'cyan'}>

--- a/src/cli-v2/services/sessions/control-plane-session-api-service.ts
+++ b/src/cli-v2/services/sessions/control-plane-session-api-service.ts
@@ -104,6 +104,10 @@ export class ControlPlaneSessionApiService {
     return this.client.controlPlane.workspaceFileSearch.query(input);
   }
 
+  async getWorkspaceChanges(workspaceId: string) {
+    return this.client.controlPlane.workspaceChanges.query({ workspaceId });
+  }
+
   async sendPrompt(input: Pick<
     SessionSendPromptInput,
     'workspaceId' | 'sessionId' | 'prompt' | 'agentProfileId' | 'includePlanTool' | 'memoryMaintenanceMode'

--- a/src/cli-v2/state/README.md
+++ b/src/cli-v2/state/README.md
@@ -33,6 +33,10 @@ snapshot and call user-intent methods.
 - `control-plane-live-event-reducer.ts` owns reduction of control-plane live
   events into the TUI snapshot. Shared activity semantics stay in
   `client-shared`.
+- `control-plane-workspace-changes-controller.ts` owns coalesced refresh of the
+  control-plane's canonical Git workspace-change projection after shared
+  workspace-change activity triggers. It does not infer changes from terminal
+  output or create a second mutation ledger.
 
 ## Invariants
 

--- a/src/cli-v2/state/control-plane-live-event-reducer.ts
+++ b/src/cli-v2/state/control-plane-live-event-reducer.ts
@@ -16,6 +16,7 @@ type ControlPlaneLiveEventReducerOptions = {
   loader: ControlPlaneSessionLoader;
   assistantStreamBuffer: AssistantStreamBufferService;
   refreshPendingApproval: (sessionId: string) => Promise<void>;
+  refreshWorkspaceChanges: () => Promise<void>;
   notificationService?: ControlPlaneTerminalNotificationService;
 };
 
@@ -141,6 +142,9 @@ export class ControlPlaneLiveEventReducer {
       },
       onPendingApprovalChanged: () => {
         void this.options.refreshPendingApproval(sessionId);
+      },
+      onWorkspaceChanged: () => {
+        void this.options.refreshWorkspaceChanges();
       },
       onPlanUpdated: (plan) => {
         this.options.state.patch({ activePlan: plan });

--- a/src/cli-v2/state/control-plane-session-state.ts
+++ b/src/cli-v2/state/control-plane-session-state.ts
@@ -15,6 +15,7 @@ import type {
   ControlPlaneSessionView,
   ControlPlaneSlashCommandCatalog,
   ControlPlaneSlashCommandResult,
+  ControlPlaneWorkspaceChangedFile,
 } from '@/client-shared/api/types.js';
 import type { ControlPlaneSessionLatestUpdate } from '../services/activities/session-activity-service.js';
 import type { ControlPlaneTerminalNotificationService } from '../services/notifications/index.js';
@@ -55,6 +56,7 @@ export type ControlPlaneSessionStoreSnapshot = {
   currentActivity?: ClientSharedAgentActivityStatus;
   activePlan?: ClientSharedSessionPlan;
   recentEditDiffs: ClientSharedRecentEditDiff[];
+  workspaceChanges: ControlPlaneWorkspaceChangedFile[];
   latestUpdate?: ControlPlaneSessionLatestUpdate;
   slashCommandCatalog?: ControlPlaneSlashCommandCatalog;
   commandResults: ControlPlaneSlashCommandResult[];
@@ -81,6 +83,7 @@ export const INITIAL_CONTROL_PLANE_SESSION_SNAPSHOT: ControlPlaneSessionStoreSna
   cancelling: false,
   streamConnected: false,
   recentEditDiffs: [],
+  workspaceChanges: [],
   commandResults: [],
   commandResultExpanded: false,
 };

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -30,6 +30,7 @@ import { ControlPlanePromptController } from './control-plane-prompt-controller.
 import { ControlPlaneLiveEventReducer } from './control-plane-live-event-reducer.js';
 import { ControlPlaneApprovalController } from './control-plane-approval-controller.js';
 import { ControlPlaneRunController } from './control-plane-run-controller.js';
+import { ControlPlaneWorkspaceChangesController } from './control-plane-workspace-changes-controller.js';
 
 const ASSISTANT_STREAM_RENDER_INTERVAL_MS = 75;
 const RUN_STATE_POLL_INTERVAL_MS = 750;
@@ -61,6 +62,7 @@ export class ControlPlaneSessionStore {
   private readonly liveEvents: ControlPlaneLiveEventReducer;
   private readonly approvals: ControlPlaneApprovalController;
   private readonly runs: ControlPlaneRunController;
+  private readonly workspaceChanges: ControlPlaneWorkspaceChangesController;
 
   constructor(options: ControlPlaneSessionStoreOptions) {
     this.api = new ControlPlaneSessionApiService(options);
@@ -112,6 +114,11 @@ export class ControlPlaneSessionStore {
       poll: (address) => this.runs.pollRunState(address),
       onError: (error) => this.state.patch({ error: formatError(error) }),
     });
+    this.workspaceChanges = new ControlPlaneWorkspaceChangesController({
+      api: this.api,
+      state: this.state,
+      formatError,
+    });
     this.loader = new ControlPlaneSessionLoader({
       api: this.api,
       state: this.state,
@@ -130,6 +137,7 @@ export class ControlPlaneSessionStore {
       loader: this.loader,
       assistantStreamBuffer: this.assistantStreamBuffer,
       refreshPendingApproval: (sessionId) => this.approvals.refresh(sessionId),
+      refreshWorkspaceChanges: () => this.workspaceChanges.refresh(),
       notificationService: options.notificationService,
     });
     this.runs = new ControlPlaneRunController({
@@ -185,8 +193,11 @@ export class ControlPlaneSessionStore {
       const workspaceId = await this.api.resolveWorkspaceId(input.workspaceId);
       const modelOptions = await this.api.getModelOptions();
 
-      this.state.patch({ workspaceId, modelOptions });
-      await this.refreshSlashCommandCatalog(workspaceId);
+      this.state.patch({ workspaceId, modelOptions, workspaceChanges: [] });
+      await Promise.all([
+        this.refreshSlashCommandCatalog(workspaceId),
+        this.workspaceChanges.refresh(workspaceId),
+      ]);
       this.subscriptions.subscribeToSessionList(workspaceId);
       const sessions = await this.refreshSessions();
       const sessionId = input.sessionId ?? sessions[0]?.id ?? (await this.createSession()).id;

--- a/src/cli-v2/state/control-plane-workspace-changes-controller.ts
+++ b/src/cli-v2/state/control-plane-workspace-changes-controller.ts
@@ -1,0 +1,58 @@
+import type { ControlPlaneSessionApiService } from '../services/sessions/control-plane-session-api-service.js';
+import type { ControlPlaneSessionState } from './control-plane-session-state.js';
+
+type ControlPlaneWorkspaceChangesControllerOptions = {
+  api: ControlPlaneSessionApiService;
+  state: ControlPlaneSessionState;
+  formatError: (error: unknown) => string;
+};
+
+/**
+ * Refreshes the terminal's workspace-change view from the control-plane Git
+ * projection. It coalesces activity bursts and ignores responses for a
+ * workspace that is no longer selected before they reach render state.
+ */
+export class ControlPlaneWorkspaceChangesController {
+  private refreshPromise: Promise<void> | undefined;
+  private refreshRequested = false;
+  private requestedWorkspaceId: string | undefined;
+
+  constructor(private readonly options: ControlPlaneWorkspaceChangesControllerOptions) {}
+
+  refresh(workspaceId = this.options.state.requireWorkspaceId()): Promise<void> {
+    this.requestedWorkspaceId = workspaceId;
+    this.refreshRequested = true;
+    if (!this.refreshPromise) {
+      this.refreshPromise = this.drainRefreshes();
+    }
+    return this.refreshPromise;
+  }
+
+  private async drainRefreshes(): Promise<void> {
+    try {
+      while (this.refreshRequested) {
+        this.refreshRequested = false;
+        const workspaceId = this.requestedWorkspaceId;
+        if (!workspaceId) {
+          continue;
+        }
+
+        try {
+          const changes = await this.options.api.getWorkspaceChanges(workspaceId);
+          if (
+            changes.workspaceId === workspaceId
+            && this.options.state.getSnapshot().workspaceId === workspaceId
+          ) {
+            this.options.state.patch({ workspaceChanges: changes.files });
+          }
+        } catch (error) {
+          if (this.options.state.getSnapshot().workspaceId === workspaceId) {
+            this.options.state.patch({ error: this.options.formatError(error) });
+          }
+        }
+      }
+    } finally {
+      this.refreshPromise = undefined;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a bounded changed-files panel above CLI V2 current activity
- load the canonical control-plane workspace change projection on startup and after workspace-mutating activity
- coalesce refresh bursts, ignore stale workspace responses, and render terminal-friendly workspace-relative paths
- document the service and state ownership boundaries

## Why

The active terminal UI exposed tool activity but not the resulting workspace change set. Users had to leave the conversation to discover which files changed.

## Verification

- `yarn vitest run src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/unit/cli-v2/changed-files-panel.test.tsx` (39 tests)
- `yarn typecheck`
- `yarn lint`
- `yarn build`

Closes #66
