### PR TITLE
fix: preserve multiline terminal prompts

### DIFF
--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -174,6 +174,41 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('preserves multiline normal prompts for the run and accepted user message', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    const prompt = '  Compare the implementation\nwith the tests.  ';
+    const preservedPrompt = 'Compare the implementation\nwith the tests.';
+    await store.start();
+    fixture.calls.sessionQuery.mockResolvedValueOnce({
+      ...createSessionDetail(),
+      messages: [
+        ...createSessionDetail().messages,
+        {
+          id: 'accepted-user-run-1',
+          role: 'user',
+          text: preservedPrompt,
+          isPending: true,
+        },
+      ],
+    });
+
+    await store.submitPrompt(prompt);
+
+    expect(fixture.calls.sessionSendPromptAsyncMutate).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceId: 'workspace-1',
+      sessionId: 'session-1',
+      prompt: preservedPrompt,
+    }));
+    expect(store.getSnapshot().activeSession?.messages.at(-1)).toEqual({
+      id: 'accepted-user-run-1',
+      role: 'user',
+      text: preservedPrompt,
+      isPending: true,
+    });
+    store.dispose();
+  });
+
   it('submits selected file mentions as user-authored @path text', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });
@@ -205,6 +240,26 @@ describe('ControlPlaneSessionStore', () => {
       preferApiKey: undefined,
       systemContext: undefined,
     });
+    expect(fixture.calls.sessionSendPromptAsyncMutate).not.toHaveBeenCalled();
+    store.dispose();
+  });
+
+  it('normalizes multiline slash and direct shell commands before routing them', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    await store.submitPrompt('  /model\n  ');
+    await store.submitPrompt(' !echo\n hello ');
+
+    expect(fixture.calls.slashCommandExecuteMutate).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      sessionId: 'session-1',
+      command: '/model',
+    }, slashCommandRequestOptions());
+    expect(fixture.calls.sessionDirectShellAsyncMutate).toHaveBeenCalledWith(expect.objectContaining({
+      command: 'echo hello',
+    }));
     expect(fixture.calls.sessionSendPromptAsyncMutate).not.toHaveBeenCalled();
     store.dispose();
   });

--- a/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
+++ b/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
@@ -37,7 +37,7 @@ describe('cli-v2 ConversationPanel', () => {
         session={createSessionDetail({
           messages: [
             { id: 'message-1', role: 'assistant', text: 'Ready.' },
-            { id: 'message-2', role: 'user', text: 'What changed?', isPending: true },
+            { id: 'message-2', role: 'user', text: 'What changed?\nThen inspect the tests.', isPending: true },
             {
               id: 'message-3',
               role: 'assistant',
@@ -60,6 +60,7 @@ describe('cli-v2 ConversationPanel', () => {
     expect(view.container.textContent).toContain('You');
     expect(view.container.textContent).not.toContain('You (queued)');
     expect(view.container.textContent).toContain('What changed?');
+    expect(view.container.textContent).toContain('Then inspect the tests.');
     expect(view.container.textContent).toContain('done shell git status --short');
     expect(view.container.textContent).toContain('local workspace inspection');
     expect(view.container.textContent).toContain('stdout');

--- a/src/__tests__/unit/client-shared/prompt-input-service.test.ts
+++ b/src/__tests__/unit/client-shared/prompt-input-service.test.ts
@@ -61,6 +61,18 @@ describe('ClientSharedPromptInputService', () => {
     expect(ClientSharedPromptInputService.canNavigateHistory('next', { value, cursor: value.length })).toBe(true);
   });
 
+  it('preserves internal line breaks in submitted prompt history', () => {
+    const prompt = 'First step\nSecond step';
+    const history = ClientSharedPromptInputService.recordPrompt({ entries: [] }, `  ${prompt}  `);
+
+    expect(history.entries).toEqual([prompt]);
+    expect(ClientSharedPromptInputService.navigateHistory({
+      state: history,
+      currentDraft: { value: '', cursor: 0 },
+      direction: 'previous',
+    })?.draft).toEqual({ value: prompt, cursor: prompt.length });
+  });
+
   it('tracks prompt undo and redo stacks without recording no-op edits', () => {
     const initial = { value: 'hello', cursor: 5 };
     const edited = { value: 'hello!', cursor: 6 };
@@ -98,5 +110,9 @@ describe('ClientSharedPromptInputService', () => {
       command: '',
     });
     expect(ClientSharedPromptInputService.parseDirectShellDraft('ask normally')).toBeUndefined();
+  });
+
+  it('normalizes whitespace only for inline command routing', () => {
+    expect(ClientSharedPromptInputService.normalizeInlineCommandDraft('  /model\n  gpt-5.4  ')).toBe('/model gpt-5.4');
   });
 });

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -976,7 +976,7 @@ describe('createConversationEngine', () => {
     await sessionRepository.update({
       session: {
         ...stored.session,
-        lastContinuePrompt: 'continue investigating',
+        lastContinuePrompt: 'continue investigating\nthen inspect the tests',
         history: [{ role: 'user', content: 'prior' }],
         updatedAt: '2026-05-03T00:00:00.000Z',
       },
@@ -985,7 +985,7 @@ describe('createConversationEngine', () => {
 
     await engine.turns.continue({ sessionId: session.id });
     const runSpy = vi.mocked(EngineConversationTurnService.run);
-    expect(runSpy.mock.calls[0]?.[0]?.prompt).toBe('continue investigating');
+    expect(runSpy.mock.calls[0]?.[0]?.prompt).toBe('continue investigating\nthen inspect the tests');
 
     await engine.turns.continue({ sessionId: session.id, prompt: 'override prompt' });
     expect(runSpy.mock.calls[1]?.[0]?.prompt).toBe('override prompt');

--- a/src/cli-v2/components/ComposerPanel.tsx
+++ b/src/cli-v2/components/ComposerPanel.tsx
@@ -57,11 +57,12 @@ export const ComposerPanel = React.memo(function ComposerPanel({
   } = usePromptDraft();
   const submitDisabled = snapshot.loading || snapshot.submitting || Boolean(snapshot.pendingDirectShellConfirmation);
   const inputDisabled = snapshot.loading || Boolean(snapshot.pendingDirectShellConfirmation) || Boolean(snapshot.pendingApproval);
+  const inlineCommandDraft = ClientSharedPromptInputService.normalizeInlineCommandDraft(draft);
   const slashCommandHints = [
-    ...SlashCommandAutocompleteService.filterHints(draft, localSlashCommandHints, { fallback: false }),
-    ...store.getSlashCommandHints(draft),
+    ...SlashCommandAutocompleteService.filterHints(inlineCommandDraft, localSlashCommandHints, { fallback: false }),
+    ...store.getSlashCommandHints(inlineCommandDraft),
   ];
-  const directShellDraft = ClientSharedPromptInputService.parseDirectShellDraft(draft);
+  const directShellDraft = ClientSharedPromptInputService.parseDirectShellDraft(inlineCommandDraft);
   const pickers = usePromptPickers({
     draft,
     snapshot,
@@ -87,10 +88,11 @@ export const ComposerPanel = React.memo(function ComposerPanel({
   });
 
   const submitPrompt = useCallback((value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) {
+    const preservedPrompt = value.trim();
+    if (!preservedPrompt) {
       return;
     }
+    const inlineCommandDraft = ClientSharedPromptInputService.normalizeInlineCommandDraft(preservedPrompt);
 
     if (pickers.submitSelection()) {
       return;
@@ -101,14 +103,14 @@ export const ComposerPanel = React.memo(function ComposerPanel({
     }
 
     clearDraft();
-    if (onLocalSlashCommand?.(trimmed)) {
+    if (onLocalSlashCommand?.(inlineCommandDraft)) {
       return;
     }
 
-    if (!trimmed.startsWith('/')) {
-      recordSubmittedPrompt(trimmed);
+    if (!inlineCommandDraft.startsWith('/')) {
+      recordSubmittedPrompt(preservedPrompt);
     }
-    void store.submitPrompt(value);
+    void store.submitPrompt(preservedPrompt);
   }, [
     clearDraft,
     onLocalSlashCommand,

--- a/src/cli-v2/state/control-plane-prompt-controller.ts
+++ b/src/cli-v2/state/control-plane-prompt-controller.ts
@@ -33,23 +33,24 @@ export class ControlPlanePromptController {
   constructor(private readonly options: ControlPlanePromptControllerOptions) {}
 
   async submitPrompt(prompt: string): Promise<void> {
-    const trimmed = prompt.trim();
-    if (!trimmed || this.options.state.getSnapshot().submitting) {
+    const preservedPrompt = prompt.trim();
+    if (!preservedPrompt || this.options.state.getSnapshot().submitting) {
+      return;
+    }
+    const inlineCommandDraft = ClientSharedPromptInputService.normalizeInlineCommandDraft(preservedPrompt);
+
+    if (SlashCommandAutocompleteService.isSlashDraft(inlineCommandDraft)) {
+      await this.options.slashCommands.execute(inlineCommandDraft);
       return;
     }
 
-    if (SlashCommandAutocompleteService.isSlashDraft(trimmed)) {
-      await this.options.slashCommands.execute(trimmed);
-      return;
-    }
-
-    const directShell = ClientSharedPromptInputService.parseDirectShellDraft(trimmed);
+    const directShell = ClientSharedPromptInputService.parseDirectShellDraft(inlineCommandDraft);
     if (directShell) {
       await this.options.directShell.submit(directShell.command);
       return;
     }
 
-    await this.submitNormalPrompt(trimmed);
+    await this.submitNormalPrompt(preservedPrompt);
   }
 
   private async submitNormalPrompt(prompt: string): Promise<void> {

--- a/src/client-shared/services/prompt-input/prompt-input-service.ts
+++ b/src/client-shared/services/prompt-input/prompt-input-service.ts
@@ -32,6 +32,14 @@ const DEFAULT_MAX_PROMPT_UNDO_STATES = 100;
  * draft that was in progress before browsing history.
  */
 export class ClientSharedPromptInputService {
+  /**
+   * Produces the one-line representation used only to recognize and execute
+   * interface commands. Normal prompts must keep their original line breaks.
+   */
+  static normalizeInlineCommandDraft(value: string): string {
+    return value.trim().replace(/\s+/g, ' ');
+  }
+
   static parseDirectShellDraft(value: string): ClientSharedDirectShellDraft | undefined {
     const trimmed = value.trim();
     if (!trimmed.startsWith('!')) {


### PR DESCRIPTION
## Summary

- preserve internal line breaks when normal prompts are submitted, displayed, stored in history, and sent to the conversation engine
- keep slash commands and direct-shell commands intentionally single-line through a shared command-only normalizer
- cover terminal rendering, prompt history, controller routing, and conversation-engine input

## Root cause

The terminal submit path reused trimmed/normalized command text for ordinary user prompts, collapsing multiline content before it reached visible history and the agent request.

## Verification

- `yarn vitest run src/__tests__/unit/cli-v2/control-plane-session-store.test.ts src/__tests__/unit/cli-v2/conversation-panel.test.tsx src/__tests__/unit/client-shared/prompt-input-service.test.ts src/__tests__/unit/core/conversation-engine.test.ts` (71 tests)
- `yarn typecheck`
- `yarn lint`
- `yarn build`

Closes #65
