### PR TITLE
fix: hide plans when final response streams

### DIFF
--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -936,6 +936,84 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('hides the active plan with the first visible final assistant response, but not commentary, reasoning, or tool progress', async () => {
+    vi.useFakeTimers();
+    try {
+      const fixture = createClientFixture();
+      const store = new ControlPlaneSessionStore({ client: fixture.client });
+      await store.start();
+
+      fixture.emitRunActivity({
+        source: 'agent-loop',
+        type: 'plan.updated',
+        runId: 'run-1',
+        step: 1,
+        timestamp: new Date().toISOString(),
+        explanation: 'Tracking current work.',
+        items: [{ step: 'Implement', status: 'in_progress' }],
+      });
+      fixture.emitRunActivity({
+        source: 'agent-loop',
+        type: 'assistant.commentary',
+        runId: 'run-1',
+        step: 2,
+        text: 'Checking the implementation.',
+        timestamp: new Date().toISOString(),
+      });
+      fixture.emitRunActivity({
+        source: 'agent-loop',
+        type: 'reasoning.summary',
+        runId: 'run-1',
+        step: 3,
+        text: 'The plan remains useful while the agent reasons.',
+        done: false,
+        timestamp: new Date().toISOString(),
+      });
+      fixture.emitRunActivity({
+        source: 'agent-loop',
+        type: 'tool.calling',
+        runId: 'run-1',
+        step: 4,
+        tool: 'read_file',
+        toolCallId: 'call-1',
+        input: { path: 'README.md' },
+        requiresApproval: false,
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(store.getSnapshot().activePlan).toEqual(expect.objectContaining({
+        items: [{ step: 'Implement', status: 'in_progress' }],
+      }));
+
+      fixture.emitRunActivity({
+        source: 'agent-loop',
+        type: 'assistant.stream',
+        runId: 'run-1',
+        text: 'The implementation is complete.',
+        done: false,
+        timestamp: new Date().toISOString(),
+      });
+
+      await vi.advanceTimersByTimeAsync(75);
+      expect(store.getSnapshot().activeSession?.messages.at(-1)?.text).toBe('The implementation is complete.');
+      expect(store.getSnapshot().activePlan).toBeUndefined();
+
+      fixture.emitRunActivity({
+        source: 'agent-loop',
+        type: 'assistant.stream',
+        runId: 'run-1',
+        text: 'The implementation is complete.',
+        done: true,
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(store.getSnapshot().activePlan).toBeUndefined();
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps the final run outcome visible after loop completion', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });

--- a/src/__tests__/unit/client-shared/session-activity-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-activity-service.test.ts
@@ -180,6 +180,56 @@ describe('ClientSharedSessionActivityService', () => {
     });
   });
 
+  it('clears the active plan only when visible final-answer text starts streaming', () => {
+    const effects: string[] = [];
+    const handlers = {
+      onPlanCleared: () => effects.push('plan cleared'),
+    };
+
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'assistant.commentary',
+      runId: 'run-1',
+      source: 'agent-loop',
+      step: 1,
+      messageId: 'commentary-1',
+      text: 'Checking the implementation.',
+      done: false,
+      timestamp: '2026-06-03T00:00:00.000Z',
+    } as ControlPlaneSessionActivity, handlers);
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'reasoning.summary',
+      runId: 'run-1',
+      source: 'agent-loop',
+      step: 2,
+      text: 'The plan is still useful while reasoning.',
+      done: false,
+      timestamp: '2026-06-03T00:00:01.000Z',
+    } as ControlPlaneSessionActivity, handlers);
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'assistant.stream',
+      runId: 'run-1',
+      source: 'agent-loop',
+      step: 3,
+      text: '',
+      done: false,
+      timestamp: '2026-06-03T00:00:02.000Z',
+    } as ControlPlaneSessionActivity, handlers);
+
+    expect(effects).toEqual([]);
+
+    ClientSharedSessionActivityService.applyActivity({
+      type: 'assistant.stream',
+      runId: 'run-1',
+      source: 'agent-loop',
+      step: 3,
+      text: 'The implementation is complete.',
+      done: false,
+      timestamp: '2026-06-03T00:00:03.000Z',
+    } as ControlPlaneSessionActivity, handlers);
+
+    expect(effects).toEqual(['plan cleared']);
+  });
+
   it('projects recent edit diffs from successful edit_file completions', () => {
     const diffs: string[] = [];
 

--- a/src/client-shared/services/session-activities/README.md
+++ b/src/client-shared/services/session-activities/README.md
@@ -12,7 +12,9 @@ after they receive API-provided live events.
 - Shared effects for final-answer, commentary, and reasoning-summary streams;
   each remains a distinct activity so clients can present them independently.
 - Active plan lifetime at the client edge: `plan.updated` sets the visible plan,
-  `loop.started` and `loop.finished` clear it.
+  the first non-empty `assistant.stream` chunk clears it as the final answer
+  becomes visible, and `loop.started` or `loop.finished` clear it as lifecycle
+  fallbacks.
 
 ## Does Not Own
 

--- a/src/client-shared/services/session-activities/session-activity-service.ts
+++ b/src/client-shared/services/session-activities/session-activity-service.ts
@@ -75,8 +75,9 @@ export type ClientSharedSessionActivityEffects = {
  *
  * Core/live owns the activity vocabulary and facts. This service owns only the
  * frontend-neutral consequences shared by web-v2 and cli-v2, including active
- * plan lifetime: a plan is visible after `plan.updated` and cleared when a new
- * run starts or the current run finishes.
+ * plan lifetime: a plan is visible after `plan.updated` and cleared when the
+ * first visible final response arrives, a new run starts, or the current run
+ * finishes.
  */
 export class ClientSharedSessionActivityService {
   // Dispatches raw control-plane activity facts into frontend-neutral effects.
@@ -87,6 +88,9 @@ export class ClientSharedSessionActivityService {
   private static readonly effectHandlers: SessionActivityEffectHandlers = {
     'assistant.stream': (activity, effects) => {
       effects.onAssistantStream?.(activity, activity.done ? undefined : 'Receiving assistant response...');
+      if (activity.text.trim().length > 0) {
+        effects.onPlanCleared?.();
+      }
       effects.onCurrentActivityChanged?.(undefined);
     },
     'assistant.commentary': (activity, effects) => {


### PR DESCRIPTION
## Summary

- clear the active plan as soon as the first non-empty final-assistant response chunk arrives
- keep the plan visible through commentary, reasoning summaries, and tool progress
- put the lifecycle rule in the shared session-activity service so web-v2 and cli-v2 behave consistently
- retain run-start and run-finish clearing as lifecycle fallbacks

## Root cause

Plan lifetime was cleared only at coarse run lifecycle boundaries, so the completed plan remained visible while final answer text was already streaming.

## Verification

- `yarn vitest run src/__tests__/unit/client-shared/session-activity-service.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts` (47 tests)
- `yarn typecheck`
- `yarn lint`
- `yarn build`

Closes #19
