### PR TITLE
Expose provider-neutral heartbeat task administration

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -160,6 +160,7 @@ boundary for a queue or serverless host that first persists domain input, calls
 ```ts
 import {
   HeartbeatSchedulerService,
+  HeartbeatTaskStateProjector,
   type HeartbeatTaskHandler,
   type HeartbeatTargetedTaskStore,
 } from '@roackb2/heddle/advanced';
@@ -192,6 +193,12 @@ if (outcome.status === 'settled') {
 `loadTask(taskId)`. A remote adapter must resolve that one task directly; do not
 wrap `listTasks()` with a host-side filter, which would turn a tenant routing and
 authorization boundary into a best-effort convention.
+
+Inside each backend transaction, use `HeartbeatTaskStateProjector` to derive
+the next task from the latest locked row. The projector owns Heddle's request,
+claim, settlement, recovery, and normalization rules; the adapter owns atomic
+persistence, execution fencing, and lease policy. Do not reimplement those
+framework transitions in the host.
 
 The result is typed so the dispatcher can make an explicit decision:
 
@@ -258,6 +265,43 @@ the adapter declares those optional capabilities.
 This suite certifies the store contract, not the surrounding system. It does
 not prove exactly-once domain effects, tenant authorization, queue delivery,
 visibility timeout handling, or infrastructure lease correctness.
+
+### Provider-neutral task administration
+
+Use `HeartbeatTaskAdministrationService` as the application boundary for task
+creation, configuration, pause/resume, deletion, reconciliation, and
+operator-facing reads. `FileHeartbeatTaskService` implements it for local
+single-process state; a relational adapter can implement the same contract for
+hosted state.
+
+```ts
+import type {
+  HeartbeatTaskAdministrationService,
+} from '@roackb2/heddle/advanced';
+
+declare const heartbeatTasks: HeartbeatTaskAdministrationService;
+
+const task = await heartbeatTasks.createTask({
+  id: 'representative-alice',
+  task: 'Process new information for Alice.',
+  intervalMs: 60_000,
+});
+
+await heartbeatTasks.setTaskEnabled(task.taskId, false);
+```
+
+Remote implementations should reuse `HeartbeatTaskControlPolicy` for task
+projections and `HeartbeatTaskViewProjector` for public views. Apply the control
+policy to the latest locked row inside the same database transaction that
+persists the result. The pure policy deliberately owns no transaction, lease,
+tenant authorization, or notification mechanism; reading through
+`loadTask()` and later writing through `saveTask()` is not an atomic
+administration implementation.
+
+The administration contract is separate from `HeartbeatTargetedTaskStore` so
+execution adapters do not accidentally promise a control plane. One concrete
+class may implement both when it can uphold both atomicity contracts, as the
+built-in file service does for one Node.js process.
 
 ### Durable event-driven run requests
 

--- a/src/__tests__/integration/core/heartbeat-custom-store-start.test.ts
+++ b/src/__tests__/integration/core/heartbeat-custom-store-start.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   HeartbeatSchedulerService,
+  HeartbeatTaskStateProjector,
   type HeartbeatTask,
   type HeartbeatTaskExecution,
   type HeartbeatTaskRunRecord,
   type HeartbeatTaskRunRequestSignal,
   type HeartbeatTaskStore,
 } from '../../../advanced.js';
-import { HeartbeatTaskStateProjector } from '@/core/heartbeat/index.js';
 
 const NOW = new Date('2026-08-04T06:00:00.000Z');
 

--- a/src/__tests__/unit/core/heartbeat-task-control-policy.test.ts
+++ b/src/__tests__/unit/core/heartbeat-task-control-policy.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FileHeartbeatTaskService,
+  HeartbeatTaskControlPolicy,
+  type HeartbeatTask,
+  type HeartbeatTaskAdministrationService,
+} from '../../../advanced.js';
+
+const NOW = new Date('2026-08-08T00:00:00.000Z');
+
+describe('HeartbeatTaskControlPolicy', () => {
+  it('creates deterministic task defaults without replacing an existing id', () => {
+    const task = HeartbeatTaskControlPolicy.createTask({
+      input: {
+        name: 'Weekly Digest',
+        task: '  Summarize the week.  ',
+        intervalMs: 60_000,
+        defer: false,
+      },
+      existingTasks: [createTask({ id: 'weekly-digest' })],
+      now: NOW,
+    });
+
+    expect(task).toMatchObject({
+      id: 'weekly-digest-2',
+      name: 'Weekly Digest',
+      task: 'Summarize the week.',
+      enabled: true,
+      continuationMode: 'operator',
+      schedule: {
+        intervalMs: 60_000,
+        nextRunAt: '2026-08-07T23:59:59.000Z',
+      },
+      state: {
+        status: 'waiting',
+        updatedAt: NOW.toISOString(),
+      },
+    });
+    expect(() => HeartbeatTaskControlPolicy.createTask({
+      input: { id: 'weekly-digest', task: 'Replace it.' },
+      existingTasks: [createTask({ id: 'weekly-digest' })],
+      now: NOW,
+    })).toThrow(/already exists/i);
+  });
+
+  it('updates the latest running task without erasing its claim or pending request', () => {
+    const running = createTask({
+      id: 'representative-live',
+      state: {
+        status: 'running',
+        execution: {
+          executionId: 'execution-live',
+          ownerId: 'worker-live',
+          claimedAt: NOW.toISOString(),
+          runRequestGeneration: 1,
+        },
+        runRequest: {
+          generation: 2,
+          claimedGeneration: 1,
+          requestedAt: NOW.toISOString(),
+        },
+      },
+    });
+
+    const updated = HeartbeatTaskControlPolicy.updateTask({
+      task: running,
+      input: { name: 'Updated representative', intervalMs: 120_000 },
+      now: NOW,
+    });
+    expect(updated).toMatchObject({
+      name: 'Updated representative',
+      enabled: true,
+      schedule: {
+        intervalMs: 120_000,
+        nextRunAt: running.schedule.nextRunAt,
+      },
+      state: {
+        status: 'running',
+        execution: { executionId: 'execution-live' },
+        runRequest: { generation: 2, claimedGeneration: 1 },
+      },
+    });
+
+    const disabled = HeartbeatTaskControlPolicy.updateTask({
+      task: updated,
+      input: { enabled: false },
+      now: NOW,
+    });
+    expect(disabled.schedule.nextRunAt).toBeUndefined();
+    expect(disabled.state?.execution?.executionId).toBe('execution-live');
+    expect(disabled.state?.runRequest).toMatchObject({ generation: 2, claimedGeneration: 2 });
+  });
+
+  it('projects pause and resume semantics including blocked-task protection', () => {
+    const pending = createTask({
+      state: {
+        status: 'waiting',
+        runRequest: {
+          generation: 3,
+          claimedGeneration: 2,
+          requestedAt: NOW.toISOString(),
+        },
+      },
+    });
+    const paused = HeartbeatTaskControlPolicy.setTaskEnabled({ task: pending, enabled: false, now: NOW });
+    expect(paused).toMatchObject({
+      enabled: false,
+      schedule: { nextRunAt: undefined },
+      state: {
+        status: 'idle',
+        progress: 'Heartbeat task paused by operator.',
+        runRequest: { generation: 3, claimedGeneration: 3 },
+      },
+    });
+
+    const blocked = createTask({
+      enabled: false,
+      schedule: { intervalMs: 60_000, nextRunAt: undefined },
+      state: { status: 'blocked', resumable: true, error: 'Needs review.' },
+    });
+    expect(() => HeartbeatTaskControlPolicy.setTaskEnabled({ task: blocked, enabled: true, now: NOW }))
+      .toThrow(/use resume/i);
+
+    const resumed = HeartbeatTaskControlPolicy.resumeTask({ task: blocked, now: NOW });
+    expect(resumed).toMatchObject({
+      enabled: true,
+      schedule: { nextRunAt: '2026-08-07T23:59:59.000Z' },
+      state: {
+        status: 'waiting',
+        progress: 'Heartbeat task resumed. Waiting for the next scheduler poll.',
+      },
+    });
+    expect(resumed.state?.error).toBeUndefined();
+  });
+
+  it('plans namespace reconciliation while preserving running tasks', () => {
+    const live = createTask({
+      id: 'representative-live',
+      state: {
+        status: 'running',
+        execution: {
+          executionId: 'execution-live',
+          ownerId: 'worker-live',
+          claimedAt: NOW.toISOString(),
+        },
+      },
+    });
+    const obsolete = createTask({ id: 'representative-obsolete' });
+    const outside = createTask({ id: 'outside' });
+    const replacement = createTask({ id: 'representative-live', task: 'Do not overwrite live state.' });
+    const added = createTask({ id: 'representative-new' });
+
+    const reconciliation = HeartbeatTaskControlPolicy.reconcileTasks({
+      currentTasks: [live, obsolete, outside],
+      input: { namespace: 'representative-', desired: [replacement, added] },
+    });
+    expect(reconciliation.created).toEqual([added]);
+    expect(reconciliation.deleted).toEqual([obsolete]);
+    expect(reconciliation.preservedRunning).toEqual([live]);
+    expect(() => HeartbeatTaskControlPolicy.assertTaskCanBeDeleted(live)).toThrow(/running/i);
+    expect(() => HeartbeatTaskControlPolicy.reconcileTasks({
+      currentTasks: [],
+      input: { namespace: 'representative-', desired: [outside] },
+    })).toThrow(/must start with namespace/i);
+  });
+
+  it('validates and projects a durable run request for adapters', () => {
+    const task = createTask();
+    const requested = HeartbeatTaskControlPolicy.requestTaskRun({
+      task,
+      options: { reason: '  new-work  ', requestedAt: NOW },
+      now: new Date('2099-01-01T00:00:00.000Z'),
+    });
+
+    expect(requested).toMatchObject({
+      taskId: task.id,
+      generation: 1,
+      disposition: 'requested',
+      requestedAt: NOW.toISOString(),
+      reason: 'new-work',
+      task: {
+        state: { runRequest: { generation: 1, claimedGeneration: 0 } },
+      },
+    });
+    expect(() => HeartbeatTaskControlPolicy.requestTaskRun({
+      task: { ...task, enabled: false },
+      now: NOW,
+    })).toThrow(/disabled/i);
+  });
+
+  it('keeps the file service assignable to the public administration contract', () => {
+    const service: HeartbeatTaskAdministrationService = new FileHeartbeatTaskService({
+      dir: '/tmp/heddle-heartbeat-administration-contract',
+    });
+    expect(service).toBeInstanceOf(FileHeartbeatTaskService);
+  });
+});
+
+function createTask(overrides: Partial<HeartbeatTask> = {}): HeartbeatTask {
+  return {
+    id: 'representative',
+    task: 'Process representative work.',
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt: '2026-08-08T00:01:00.000Z',
+    },
+    state: {
+      status: 'waiting',
+      resumable: true,
+    },
+    ...overrides,
+  };
+}

--- a/src/__tests__/unit/core/heartbeat-views.test.ts
+++ b/src/__tests__/unit/core/heartbeat-views.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   FileHeartbeatTaskService,
+  HeartbeatTaskViewProjector,
   type AgentHeartbeatResult,
   type AgentLoopState,
   type HeartbeatTask,
@@ -12,8 +13,7 @@ import {
 
 describe('heartbeat task service views', () => {
   it('projects heartbeat task state into a host-facing view', () => {
-    const service = new FileHeartbeatTaskService({ dir: '/tmp/heddle-heartbeat-view-test' });
-    const view = service.projectTaskView({
+    const view = HeartbeatTaskViewProjector.projectTask({
       id: 'repo-check',
       workspaceId: 'workspace-1',
       task: 'Inspect repo state',
@@ -72,8 +72,7 @@ describe('heartbeat task service views', () => {
   });
 
   it('projects heartbeat runs into a host-facing view', () => {
-    const service = new FileHeartbeatTaskService({ dir: '/tmp/heddle-heartbeat-view-test' });
-    const view = service.projectRunView(createRunEntry());
+    const view = HeartbeatTaskViewProjector.projectRun(createRunEntry());
 
     expect(view).toMatchObject({
       id: 'run_1',
@@ -109,7 +108,6 @@ describe('heartbeat task service views', () => {
   });
 
   it('projects skipped execution records without fabricating an agent run', () => {
-    const service = new FileHeartbeatTaskService({ dir: '/tmp/heddle-heartbeat-view-test' });
     const outcome = {
       kind: 'skipped' as const,
       executionId: 'execution_skip',
@@ -125,7 +123,7 @@ describe('heartbeat task service views', () => {
         lastExecution: outcome,
       },
     };
-    const view = service.projectRunView({
+    const view = HeartbeatTaskViewProjector.projectRun({
       id: '2026-04-14T00-00-00.000Z-repo-check',
       path: '/tmp/2026-04-14T00-00-00.000Z-repo-check.json',
       taskId: task.id,

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -261,11 +261,18 @@ export type {
 } from './core/heartbeat/checkpoint/index.js';
 export {
   FileHeartbeatTaskService,
+  HeartbeatTaskControlPolicy,
   HeartbeatTaskExecutionEligibilityPolicy,
+  HeartbeatTaskStateProjector,
   MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH,
 } from './core/heartbeat/tasks/index.js';
 export type {
+  CreateHeartbeatTaskInput,
   FileHeartbeatTaskServiceOptions,
+  HeartbeatTaskAdministrationService,
+  HeartbeatTaskDetail,
+  ListHeartbeatRunViewsOptions,
+  ReadHeartbeatTaskOptions,
   ReconcileHeartbeatTasksInput,
   ReconcileHeartbeatTasksResult,
   HeartbeatTask,
@@ -288,6 +295,7 @@ export type {
   HeartbeatTargetedTaskStore,
   HeartbeatTaskExecutionEligibility,
   RequestHeartbeatTaskRunOptions,
+  UpdateHeartbeatTaskInput,
 } from './core/heartbeat/tasks/index.js';
 export {
   DEFAULT_HEARTBEAT_HANDLER_RETRY_MS,
@@ -321,10 +329,12 @@ export type {
 export type {
   HeartbeatRunView,
   HeartbeatTaskRunRequestView,
+  HeartbeatTaskResultView,
   HeartbeatTaskView,
 } from './core/heartbeat/views/index.js';
 export {
   HeartbeatLucidPresenter,
+  HeartbeatTaskViewProjector,
 } from './core/heartbeat/views/index.js';
 export type {
   LucidAgentMessage,

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -15,15 +15,18 @@ operator-facing heartbeat views.
 - `checkpoint/`: `StoredHeartbeatService` and
   `FileHeartbeatCheckpointRepository` own checkpoint-backed one-off heartbeat
   execution.
-- `tasks/`: `FileHeartbeatTaskService` is the persistence boundary for durable
-  task/checkpoint/run storage and task/run projections. It is the only
-  non-repository service that should instantiate `FileHeartbeatTaskRepository`.
-  It also owns process-local execution claims, recovery of interrupted
-  single-host executions, and fencing of late completion/failure/outcome
-  writes. Durable run-request generations and the file adapter's process-local
-  scheduler wake signal also live here. `HeartbeatTaskStateProjector` owns task
-  state transitions after agent success, no-work skip, cancellation, failure,
-  request, claim, or recovery.
+- `tasks/`: `HeartbeatTaskAdministrationService` is the provider-neutral
+  operator boundary for task creation, updates, pause/resume, deletion,
+  reconciliation, and task/run reads. `HeartbeatTaskControlPolicy` owns the
+  pure task projections behind those operations. `FileHeartbeatTaskService`
+  implements that boundary together with task/checkpoint/run persistence. It is
+  the only non-repository service that should instantiate
+  `FileHeartbeatTaskRepository`. It also owns process-local execution claims,
+  recovery of interrupted single-host executions, fencing of late completion/
+  failure/outcome writes, durable run-request generations, and the file
+  adapter's process-local scheduler wake signal. `HeartbeatTaskStateProjector`
+  owns task state transitions after agent success, no-work skip, cancellation,
+  failure, request, claim, or recovery.
 - `scheduler/`: `HeartbeatSchedulerService` owns due-task selection and the
   periodic scheduler loop. It selects due work in stable oldest-due-first order
   and uses `p-limit` to enforce the configured task concurrency ceiling. It delegates execution to
@@ -43,8 +46,8 @@ operator-facing heartbeat views.
   receiving or translating provider credentials. `context.skip()` records
   explicit no-work without fabricating agent state.
 - `views/`: `HeartbeatLucidPresenter` owns Lucid-specific adapter messages.
-  Generic task/run view projection belongs to `FileHeartbeatTaskService`,
-  because that service owns the task persistence boundary.
+  `HeartbeatTaskViewProjector` owns provider-neutral task/run views and stable
+  task ordering without depending on a persistence adapter.
 
 ## Does Not Own
 
@@ -69,6 +72,16 @@ operator-facing heartbeat views.
 - Execution settlement must read and project from the latest stored task inside
   the same atomic store transition. Saving a projection derived from the
   pre-run snapshot can erase newer run requests or operator control changes.
+- Custom adapters should use the public `HeartbeatTaskStateProjector` exported
+  from `@roackb2/heddle/advanced` for normalization, request, claim,
+  settlement, and recovery transitions. The adapter still owns the backend
+  transaction and fencing predicate; it must not copy Heddle's transition
+  rules into provider-specific persistence code.
+- Operator-facing adapters should implement the public
+  `HeartbeatTaskAdministrationService` and use `HeartbeatTaskControlPolicy`
+  plus `HeartbeatTaskViewProjector`. Every mutation must lock or compare-and-set
+  the latest durable task before applying the policy. The pure policy does not
+  make a separate `loadTask()` followed by `saveTask()` atomic.
 - `executionOwnerId` identifies one scheduler process/worker generation. Do not
   reuse it across process restarts: scheduler startup uses it to distinguish a
   current claim from an execution interrupted by the prior single-host process.
@@ -123,10 +136,11 @@ operator-facing heartbeat views.
   effects.
 - Heartbeat may depend on runtime's public `AgentLoopRuntimeService.run` and checkpoint types.
   Runtime should not import heartbeat.
-- Interface adapters should use `FileHeartbeatTaskService` methods or the
-  control-plane heartbeat API as the public task/run contract. Terminal command
-  code should not construct `HeartbeatTask` objects, write heartbeat JSON, or run
-  its own scheduler loop.
+- Local interface adapters should use `FileHeartbeatTaskService` methods or the
+  control-plane heartbeat API. Remote operator surfaces should depend on
+  `HeartbeatTaskAdministrationService` and keep backend transaction mechanics
+  behind their implementation. Terminal command code should not construct
+  `HeartbeatTask` objects, write heartbeat JSON, or run its own scheduler loop.
 - A custom scheduler handler may claim domain work before model execution. It
   must either delegate model work to execution-scoped `context.runAgent()` or
   return `context.skip()` when no work exists. The context owns model credential

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -35,12 +35,20 @@ export type {
   StartHeartbeatSchedulerOptions,
   StopHeartbeatSchedulerOptions,
 } from './scheduler/index.js';
-export { FileHeartbeatTaskService, HeartbeatTaskStateProjector } from './tasks/index.js';
+export {
+  FileHeartbeatTaskService,
+  HeartbeatTaskControlPolicy,
+  HeartbeatTaskStateProjector,
+} from './tasks/index.js';
 export { HeartbeatTaskExecutionEligibilityPolicy } from './tasks/index.js';
 export { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './tasks/index.js';
 export type {
   CreateHeartbeatTaskInput,
   FileHeartbeatTaskServiceOptions,
+  HeartbeatTaskAdministrationService,
+  HeartbeatTaskDetail,
+  ListHeartbeatRunViewsOptions,
+  ReadHeartbeatTaskOptions,
   ReconcileHeartbeatTasksInput,
   ReconcileHeartbeatTasksResult,
   HeartbeatTask,
@@ -76,10 +84,11 @@ export type {
   HeartbeatEscalationEvent,
   RunAgentHeartbeatOptions,
 } from './agent/index.js';
-export { HeartbeatLucidPresenter } from './views/index.js';
+export { HeartbeatLucidPresenter, HeartbeatTaskViewProjector } from './views/index.js';
 export type {
   HeartbeatRunView,
   HeartbeatTaskRunRequestView,
+  HeartbeatTaskResultView,
   HeartbeatTaskView,
   LucidAdapterOptions,
   LucidAgentMessage,

--- a/src/core/heartbeat/tasks/administration.ts
+++ b/src/core/heartbeat/tasks/administration.ts
@@ -1,0 +1,81 @@
+import type { HeartbeatRunView, HeartbeatTaskView } from '../views/types.js';
+import type { HeartbeatTask } from './types.js';
+
+export type CreateHeartbeatTaskInput = {
+  workspaceId?: string;
+  id?: string;
+  name?: string;
+  task: string;
+  enabled?: boolean;
+  continuationMode?: HeartbeatTask['continuationMode'];
+  intervalMs?: number;
+  defer?: boolean;
+  model?: string;
+  maxSteps?: number;
+  workspaceRoot?: string;
+  stateDir?: string;
+  searchIgnoreDirs?: string[];
+  systemContext?: string;
+};
+
+export type UpdateHeartbeatTaskInput = {
+  name?: string;
+  task?: string;
+  enabled?: boolean;
+  continuationMode?: HeartbeatTask['continuationMode'];
+  intervalMs?: number;
+  model?: string | null;
+  maxSteps?: number | null;
+  searchIgnoreDirs?: string[];
+  systemContext?: string;
+};
+
+export type ReconcileHeartbeatTasksInput = {
+  /** Prefix that limits this reconciliation to tasks owned by one host concern. */
+  namespace: string;
+  /** Desired members of the namespace. Existing members retain their stored configuration and state. */
+  desired: readonly HeartbeatTask[];
+};
+
+export type ReconcileHeartbeatTasksResult = {
+  created: HeartbeatTask[];
+  deleted: HeartbeatTask[];
+  /** Running tasks retained without rewriting their execution claim or state. */
+  preservedRunning: HeartbeatTask[];
+};
+
+export type ListHeartbeatRunViewsOptions = {
+  taskId?: string;
+  limit?: number;
+};
+
+export type ReadHeartbeatTaskOptions = {
+  runLimit?: number;
+};
+
+export type HeartbeatTaskDetail = {
+  task: HeartbeatTaskView;
+  runs: HeartbeatRunView[];
+};
+
+/**
+ * Provider-neutral operator-facing heartbeat task boundary.
+ *
+ * Implementations own their persistence transaction. Every mutation must read
+ * the latest durable task, apply `HeartbeatTaskControlPolicy`, and persist the
+ * result atomically with competing claims and settlements. This contract does
+ * not make a separate `loadTask()` followed by `saveTask()` safe.
+ */
+export interface HeartbeatTaskAdministrationService {
+  listTaskViews(): Promise<HeartbeatTaskView[]>;
+  listRunViews(options?: ListHeartbeatRunViewsOptions): Promise<HeartbeatRunView[]>;
+  createTask(input: CreateHeartbeatTaskInput): Promise<HeartbeatTaskView>;
+  reconcileTasks(input: ReconcileHeartbeatTasksInput): Promise<ReconcileHeartbeatTasksResult>;
+  updateTask(taskId: string, input: UpdateHeartbeatTaskInput): Promise<HeartbeatTaskView>;
+  deleteTask(taskId: string): Promise<HeartbeatTaskView>;
+  resumeTask(taskId: string): Promise<HeartbeatTaskView>;
+  readTask(taskId: string, options?: ReadHeartbeatTaskOptions): Promise<HeartbeatTaskDetail>;
+  readRun(taskId: string, runId: string): Promise<HeartbeatRunView | undefined>;
+  setTaskEnabled(taskId: string, enabled: boolean): Promise<HeartbeatTaskView>;
+  triggerTaskRun(taskId: string): Promise<HeartbeatTaskView>;
+}

--- a/src/core/heartbeat/tasks/control-policy.ts
+++ b/src/core/heartbeat/tasks/control-policy.ts
@@ -1,0 +1,326 @@
+/**
+ * Provider-neutral heartbeat task administration policy.
+ *
+ * These projections are intentionally persistence-free. File and remote
+ * adapters must apply them to the latest durable task inside their own atomic
+ * mutation boundary.
+ */
+import dayjs from 'dayjs';
+import omit from 'lodash/omit.js';
+import type {
+  CreateHeartbeatTaskInput,
+  ReconcileHeartbeatTasksInput,
+  ReconcileHeartbeatTasksResult,
+  UpdateHeartbeatTaskInput,
+} from './administration.js';
+import { HeartbeatTaskStateProjector } from './task-state.js';
+import { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './types.js';
+import type {
+  HeartbeatTask,
+  HeartbeatTaskRunRequestResult,
+  HeartbeatTaskState,
+  RequestHeartbeatTaskRunOptions,
+} from './types.js';
+
+export class HeartbeatTaskControlPolicy {
+  static createTask(args: {
+    input: CreateHeartbeatTaskInput;
+    existingTasks: readonly HeartbeatTask[];
+    now: Date;
+  }): HeartbeatTask {
+    const now = HeartbeatTaskControlPolicy.requireValidDate(args.now, 'Heartbeat task creation timestamp');
+    const existingIds = args.existingTasks.map((task) => task.id);
+    const id = args.input.id ?? HeartbeatTaskControlPolicy.createTaskId(
+      args.input.name ?? args.input.task,
+      existingIds,
+    );
+    if (existingIds.includes(id)) {
+      throw new Error(`Heartbeat task already exists: ${id}`);
+    }
+
+    const intervalMs = args.input.intervalMs ?? 60 * 60_000;
+    return {
+      id,
+      workspaceId: args.input.workspaceId,
+      name: args.input.name,
+      task: args.input.task.trim(),
+      enabled: args.input.enabled ?? true,
+      continuationMode: args.input.continuationMode ?? 'operator',
+      schedule: {
+        intervalMs,
+        nextRunAt: (
+          args.input.defer === false ? now.subtract(1, 'second') : now.add(intervalMs, 'millisecond')
+        ).toISOString(),
+      },
+      runtime: {
+        model: args.input.model,
+        maxSteps: args.input.maxSteps,
+        workspaceRoot: args.input.workspaceRoot,
+        stateDir: args.input.stateDir,
+        searchIgnoreDirs: args.input.searchIgnoreDirs,
+        systemContext: args.input.systemContext,
+      },
+      state: {
+        status: args.input.enabled === false ? 'idle' : 'waiting',
+        updatedAt: now.toISOString(),
+      },
+    };
+  }
+
+  static updateTask(args: {
+    task: HeartbeatTask;
+    input: UpdateHeartbeatTaskInput;
+    now: Date;
+  }): HeartbeatTask {
+    const now = HeartbeatTaskControlPolicy.requireValidDate(args.now, 'Heartbeat task update timestamp');
+    const intervalMs = args.input.intervalMs ?? args.task.schedule.intervalMs;
+    const running = args.task.state?.status === 'running';
+    const enabled = args.input.enabled ?? args.task.enabled;
+    const pendingRunRequest = HeartbeatTaskStateProjector.hasPendingRunRequest(args.task);
+
+    return {
+      ...args.task,
+      name: args.input.name ?? args.task.name,
+      task: args.input.task?.trim() ?? args.task.task,
+      enabled,
+      continuationMode: args.input.continuationMode ?? args.task.continuationMode ?? 'operator',
+      schedule: {
+        ...args.task.schedule,
+        intervalMs,
+        nextRunAt:
+          !enabled ? undefined
+          : running || pendingRunRequest ? args.task.schedule.nextRunAt
+          : now.add(intervalMs, 'millisecond').toISOString(),
+      },
+      runtime: {
+        ...args.task.runtime,
+        model: args.input.model === undefined ? args.task.runtime?.model : args.input.model ?? undefined,
+        maxSteps: args.input.maxSteps === undefined ? args.task.runtime?.maxSteps : args.input.maxSteps ?? undefined,
+        searchIgnoreDirs: args.input.searchIgnoreDirs ?? args.task.runtime?.searchIgnoreDirs,
+        systemContext: args.input.systemContext ?? args.task.runtime?.systemContext,
+      },
+      state: {
+        ...args.task.state,
+        runRequest:
+          enabled ? args.task.state?.runRequest
+          : HeartbeatTaskControlPolicy.consumePendingRunRequest(args.task.state?.runRequest),
+        updatedAt: now.toISOString(),
+      },
+    };
+  }
+
+  static setTaskEnabled(args: {
+    task: HeartbeatTask;
+    enabled: boolean;
+    now: Date;
+  }): HeartbeatTask {
+    const now = HeartbeatTaskControlPolicy.requireValidDate(args.now, 'Heartbeat task enablement timestamp');
+    if (args.enabled && args.task.state?.status === 'blocked') {
+      throw new Error(`Heartbeat task ${args.task.id} is blocked. Use resume to unblock it.`);
+    }
+
+    return {
+      ...args.task,
+      enabled: args.enabled,
+      schedule: {
+        ...args.task.schedule,
+        nextRunAt:
+          args.enabled ? args.task.schedule.nextRunAt ?? now.subtract(1, 'second').toISOString()
+          : undefined,
+      },
+      state: {
+        ...args.task.state,
+        status: HeartbeatTaskControlPolicy.resolveEnabledStatus(args.task, args.enabled),
+        progress: HeartbeatTaskControlPolicy.resolveEnabledProgress(args.task, args.enabled),
+        resumable: args.enabled ? true : args.task.state?.resumable,
+        runRequest:
+          args.enabled ? args.task.state?.runRequest
+          : HeartbeatTaskControlPolicy.consumePendingRunRequest(args.task.state?.runRequest),
+        updatedAt: now.toISOString(),
+      },
+    };
+  }
+
+  static resumeTask(args: { task: HeartbeatTask; now: Date }): HeartbeatTask {
+    const now = HeartbeatTaskControlPolicy.requireValidDate(args.now, 'Heartbeat task resume timestamp');
+    if (args.task.state?.status === 'running') {
+      throw new Error(`Heartbeat task ${args.task.id} is already running.`);
+    }
+    if (args.task.state?.resumable === false) {
+      throw new Error(`Heartbeat task ${args.task.id} cannot be resumed.`);
+    }
+
+    return {
+      ...args.task,
+      enabled: true,
+      schedule: {
+        ...args.task.schedule,
+        nextRunAt: now.subtract(1, 'second').toISOString(),
+      },
+      state: {
+        ...omit(args.task.state, ['error']),
+        status: 'waiting',
+        progress: 'Heartbeat task resumed. Waiting for the next scheduler poll.',
+        updatedAt: now.toISOString(),
+      },
+    };
+  }
+
+  static assertTaskCanBeDeleted(task: HeartbeatTask): void {
+    if (task.state?.status === 'running') {
+      throw new Error(`Heartbeat task ${task.id} is running. Wait for the run to finish before deleting it.`);
+    }
+  }
+
+  static reconcileTasks(args: {
+    currentTasks: readonly HeartbeatTask[];
+    input: ReconcileHeartbeatTasksInput;
+  }): ReconcileHeartbeatTasksResult {
+    HeartbeatTaskControlPolicy.assertReconciliationInput(args.input);
+
+    const currentById = new Map(args.currentTasks.map((task) => [task.id, task]));
+    const desiredById = new Map(args.input.desired.map((task) => [task.id, task]));
+    const namespaceTasks = args.currentTasks.filter((task) => task.id.startsWith(args.input.namespace));
+    const created = [...desiredById.values()].filter((task) => !currentById.has(task.id));
+    const obsolete = namespaceTasks.filter((task) => !desiredById.has(task.id));
+
+    return {
+      created,
+      deleted: obsolete.filter((task) => task.state?.status !== 'running'),
+      preservedRunning: namespaceTasks.filter((task) => task.state?.status === 'running'),
+    };
+  }
+
+  static requestTaskRun(args: {
+    task: HeartbeatTask;
+    options?: RequestHeartbeatTaskRunOptions;
+    now: Date;
+  }): HeartbeatTaskRunRequestResult {
+    const reason = HeartbeatTaskControlPolicy.normalizeRunRequestReason(args.options?.reason);
+    const requestedAt = HeartbeatTaskControlPolicy.requireValidDate(
+      args.options?.requestedAt ?? args.now,
+      'Heartbeat run-request timestamp',
+    ).toDate();
+    HeartbeatTaskControlPolicy.assertTaskAcceptsRunRequest(args.task);
+    const projection = HeartbeatTaskStateProjector.requestRun({
+      task: args.task,
+      now: requestedAt,
+      reason,
+    });
+    const request = projection.task.state?.runRequest;
+    if (!request) {
+      throw new Error(`Heartbeat task ${args.task.id} did not project its run request.`);
+    }
+
+    return {
+      task: projection.task,
+      taskId: args.task.id,
+      generation: request.generation,
+      disposition: projection.disposition,
+      requestedAt: request.requestedAt,
+      reason: request.reason,
+    };
+  }
+
+  private static assertTaskAcceptsRunRequest(task: HeartbeatTask): void {
+    if (task.state?.status === 'blocked') {
+      throw new Error(`Heartbeat task ${task.id} is blocked. Resume it before requesting a run.`);
+    }
+    if (task.state?.status === 'complete') {
+      throw new Error(`Heartbeat task ${task.id} is complete. Resume it before requesting a run.`);
+    }
+    if (!task.enabled) {
+      throw new Error(`Heartbeat task ${task.id} is disabled. Enable it before requesting a run.`);
+    }
+  }
+
+  private static normalizeRunRequestReason(reason: string | undefined): string | undefined {
+    if (reason === undefined) {
+      return undefined;
+    }
+
+    const normalized = reason.trim();
+    if (!normalized) {
+      throw new Error('Heartbeat run-request reason cannot be empty.');
+    }
+    if (normalized.length > MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH) {
+      throw new Error(`Heartbeat run-request reason must be at most ${MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH} characters.`);
+    }
+    return normalized;
+  }
+
+  private static assertReconciliationInput(input: ReconcileHeartbeatTasksInput): void {
+    if (!input.namespace) {
+      throw new Error('Heartbeat reconciliation namespace cannot be empty.');
+    }
+
+    const desiredIds = input.desired.map((task) => task.id);
+    if (new Set(desiredIds).size !== desiredIds.length) {
+      throw new Error(`Heartbeat reconciliation namespace ${input.namespace} contains duplicate task IDs.`);
+    }
+    if (desiredIds.some((taskId) => !taskId.startsWith(input.namespace))) {
+      throw new Error(`Heartbeat reconciliation desired task IDs must start with namespace ${input.namespace}.`);
+    }
+  }
+
+  private static consumePendingRunRequest(
+    runRequest: HeartbeatTaskState['runRequest'],
+  ): HeartbeatTaskState['runRequest'] {
+    return runRequest ? {
+      ...runRequest,
+      claimedGeneration: runRequest.generation,
+    } : undefined;
+  }
+
+  private static resolveEnabledStatus(
+    task: HeartbeatTask,
+    enabled: boolean,
+  ): NonNullable<NonNullable<HeartbeatTask['state']>['status']> {
+    if (task.state?.status === 'running') {
+      return 'running';
+    }
+    if (!enabled && task.state?.status === 'blocked') {
+      return 'blocked';
+    }
+    return enabled ? 'waiting' : 'idle';
+  }
+
+  private static resolveEnabledProgress(task: HeartbeatTask, enabled: boolean): string | undefined {
+    if (task.state?.status === 'running' || task.state?.status === 'blocked') {
+      return task.state.progress;
+    }
+    return enabled ?
+      'Heartbeat task enabled. Waiting for the next scheduled run.'
+    : 'Heartbeat task paused by operator.';
+  }
+
+  private static createTaskId(value: string, existingIds: readonly string[]): string {
+    const base = value
+      .toLowerCase()
+      .replace(/[`'"]/g, '')
+      .replace(/[^a-z0-9._-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 64)
+      .replace(/-+$/g, '') || 'heartbeat-task';
+    if (!existingIds.includes(base)) {
+      return base;
+    }
+
+    for (let index = 2; index < 1_000; index++) {
+      const candidate = `${base}-${index}`;
+      if (!existingIds.includes(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw new Error(`Unable to create a unique heartbeat task id for ${base}`);
+  }
+
+  private static requireValidDate(value: Date, label: string) {
+    const date = dayjs(value);
+    if (!date.isValid()) {
+      throw new Error(`${label} must be a valid date.`);
+    }
+    return date;
+  }
+}

--- a/src/core/heartbeat/tasks/index.ts
+++ b/src/core/heartbeat/tasks/index.ts
@@ -1,14 +1,19 @@
 export { FileHeartbeatTaskService } from './service.js';
+export { HeartbeatTaskControlPolicy } from './control-policy.js';
 export { HeartbeatTaskExecutionEligibilityPolicy } from './execution-eligibility.js';
 export { HeartbeatTaskStateProjector } from './task-state.js';
 export type { HeartbeatTaskExecutionEligibility } from './execution-eligibility.js';
 export type {
   CreateHeartbeatTaskInput,
-  FileHeartbeatTaskServiceOptions,
+  HeartbeatTaskAdministrationService,
+  HeartbeatTaskDetail,
+  ListHeartbeatRunViewsOptions,
+  ReadHeartbeatTaskOptions,
   ReconcileHeartbeatTasksInput,
   ReconcileHeartbeatTasksResult,
   UpdateHeartbeatTaskInput,
-} from './service.js';
+} from './administration.js';
+export type { FileHeartbeatTaskServiceOptions } from './service.js';
 export type {
   HeartbeatTask,
   HeartbeatTaskAgentRunRecord,

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -2,78 +2,47 @@ import { EventEmitter } from 'node:events';
 import { resolve } from 'node:path';
 import { Mutex } from 'async-mutex';
 import dayjs from 'dayjs';
-import omit from 'lodash/omit.js';
-import orderBy from 'lodash/orderBy.js';
+import type {
+  CreateHeartbeatTaskInput,
+  HeartbeatTaskAdministrationService,
+  ListHeartbeatRunViewsOptions,
+  ReadHeartbeatTaskOptions,
+  ReconcileHeartbeatTasksInput,
+  ReconcileHeartbeatTasksResult,
+  UpdateHeartbeatTaskInput,
+} from './administration.js';
+import { HeartbeatTaskControlPolicy } from './control-policy.js';
 import { FileHeartbeatTaskRepository } from './repository.js';
 import { HeartbeatTaskExecutionEligibilityPolicy } from './execution-eligibility.js';
 import { HeartbeatTaskStateProjector } from './task-state.js';
 import {
   MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH,
   MAX_HEARTBEAT_HANDLER_RETRY_MS,
-  MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH,
 } from './types.js';
 import type {
   FileHeartbeatTaskRepositoryOptions,
   HeartbeatTask,
   HeartbeatTaskExecution,
-  HeartbeatTaskExecutionOutcome,
-  HeartbeatTaskState,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
   HeartbeatTaskRunRequestResult,
   HeartbeatTaskRunRequestSignal,
   HeartbeatTargetedTaskStore,
 } from './types.js';
-import type { HeartbeatRunView, HeartbeatTaskResultView, HeartbeatTaskView } from '../views/index.js';
-import type { AgentHeartbeatResult } from '../agent/index.js';
+import { HeartbeatTaskViewProjector } from '../views/projector.js';
+import type { HeartbeatRunView, HeartbeatTaskView } from '../views/types.js';
 
 export type FileHeartbeatTaskServiceOptions =
   | { stateRoot: string }
   | { workspaceRoot: string; stateDir?: string }
   | FileHeartbeatTaskRepositoryOptions;
 
-export type CreateHeartbeatTaskInput = {
-  workspaceId?: string;
-  id?: string;
-  name?: string;
-  task: string;
-  enabled?: boolean;
-  continuationMode?: HeartbeatTask['continuationMode'];
-  intervalMs?: number;
-  defer?: boolean;
-  model?: string;
-  maxSteps?: number;
-  workspaceRoot?: string;
-  stateDir?: string;
-  searchIgnoreDirs?: string[];
-  systemContext?: string;
-};
-
-export type UpdateHeartbeatTaskInput = {
-  name?: string;
-  task?: string;
-  enabled?: boolean;
-  continuationMode?: HeartbeatTask['continuationMode'];
-  intervalMs?: number;
-  model?: string | null;
-  maxSteps?: number | null;
-  searchIgnoreDirs?: string[];
-  systemContext?: string;
-};
-
-export type ReconcileHeartbeatTasksInput = {
-  /** Prefix that limits this reconciliation to tasks owned by one host concern. */
-  namespace: string;
-  /** Desired members of the namespace. Existing members retain their stored configuration and state. */
-  desired: readonly HeartbeatTask[];
-};
-
-export type ReconcileHeartbeatTasksResult = {
-  created: HeartbeatTask[];
-  deleted: HeartbeatTask[];
-  /** Running tasks retained without rewriting their execution claim or state. */
-  preservedRunning: HeartbeatTask[];
-};
+export type {
+  CreateHeartbeatTaskInput,
+  ReconcileHeartbeatTasksInput,
+  ReconcileHeartbeatTasksResult,
+  UpdateHeartbeatTaskInput,
+} from './administration.js';
 
 /**
  * Heartbeat task service.
@@ -82,7 +51,7 @@ export type ReconcileHeartbeatTasksResult = {
  * run records, and operator-facing task/run projections. Hosts should call this
  * service, not the file repository.
  */
-export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
+export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore, HeartbeatTaskAdministrationService {
   private static readonly mutationMutexes = new Map<string, Mutex>();
   private static readonly activeExecutions = new Set<string>();
   private static readonly runRequestEventBuses = new Map<string, EventEmitter>();
@@ -131,37 +100,18 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
     taskId: string,
     options: Parameters<HeartbeatTargetedTaskStore['requestTaskRun']>[1] = {},
   ): Promise<HeartbeatTaskRunRequestResult> {
-    const reason = FileHeartbeatTaskService.normalizeRunRequestReason(options.reason);
-    const requestedAt = options.requestedAt ?? dayjs().toDate();
-    if (!dayjs(requestedAt).isValid()) {
-      throw new Error('Heartbeat run-request timestamp must be a valid date.');
-    }
     const result = await this.mutationMutex.runExclusive(async () => {
       const task = await this.findTask(taskId);
       if (!task) {
         throw new Error(`Heartbeat task not found: ${taskId}`);
       }
-      FileHeartbeatTaskService.assertTaskAcceptsRunRequest(task);
-
-      const projection = HeartbeatTaskStateProjector.requestRun({
+      const projection = HeartbeatTaskControlPolicy.requestTaskRun({
         task,
-        now: requestedAt,
-        reason,
+        options,
+        now: dayjs().toDate(),
       });
       await this.repository.saveTask(projection.task);
-      const request = projection.task.state?.runRequest;
-      if (!request) {
-        throw new Error(`Heartbeat task ${taskId} did not persist its run request.`);
-      }
-
-      return {
-        task: projection.task,
-        taskId,
-        generation: request.generation,
-        disposition: projection.disposition,
-        requestedAt: request.requestedAt,
-        reason: request.reason,
-      } as const;
+      return projection;
     });
 
     this.publishRunRequest(FileHeartbeatTaskService.toRunRequestSignal(result));
@@ -398,55 +348,25 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
   }
 
   async listTaskViews() {
-    return orderBy(
-      (await this.listTasks()).map((task) => FileHeartbeatTaskService.projectTaskView(task)),
-      [(task) => FileHeartbeatTaskService.taskLastRunTime(task)],
-      ['desc'],
-    );
+    return HeartbeatTaskViewProjector.projectTasks(await this.listTasks());
   }
 
-  async listRunViews(options: { taskId?: string; limit?: number } = {}) {
+  async listRunViews(options: ListHeartbeatRunViewsOptions = {}) {
     const runs = await this.listRunRecords(options);
-    return runs.map((run) => FileHeartbeatTaskService.projectRunView(run));
+    return runs.map((run) => HeartbeatTaskViewProjector.projectRun(run));
   }
 
   async createTask(input: CreateHeartbeatTaskInput) {
     return await this.mutationMutex.runExclusive(async () => {
       const tasks = await this.repository.listTasks();
-      const now = dayjs();
-      const id = input.id ?? FileHeartbeatTaskService.createTaskId(input.name ?? input.task, tasks.map((task) => task.id));
-      if (tasks.some((task) => task.id === id)) {
-        throw new Error(`Heartbeat task already exists: ${id}`);
-      }
-
-      const intervalMs = input.intervalMs ?? 60 * 60_000;
-      const task: HeartbeatTask = {
-        id,
-        workspaceId: input.workspaceId,
-        name: input.name,
-        task: input.task.trim(),
-        enabled: input.enabled ?? true,
-        continuationMode: input.continuationMode ?? 'operator',
-        schedule: {
-          intervalMs,
-          nextRunAt: (input.defer === false ? now.subtract(1, 'second') : now.add(intervalMs, 'millisecond')).toISOString(),
-        },
-        runtime: {
-          model: input.model,
-          maxSteps: input.maxSteps,
-          workspaceRoot: input.workspaceRoot,
-          stateDir: input.stateDir,
-          searchIgnoreDirs: input.searchIgnoreDirs,
-          systemContext: input.systemContext,
-        },
-        state: {
-          status: input.enabled === false ? 'idle' : 'waiting',
-          updatedAt: now.toISOString(),
-        },
-      };
+      const task = HeartbeatTaskControlPolicy.createTask({
+        input,
+        existingTasks: tasks,
+        now: dayjs().toDate(),
+      });
 
       await this.repository.saveTask(task);
-      return FileHeartbeatTaskService.projectTaskView(task);
+      return HeartbeatTaskViewProjector.projectTask(task);
     });
   }
 
@@ -461,61 +381,24 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
    * needs to change an existing task's configuration.
    */
   async reconcileTasks(input: ReconcileHeartbeatTasksInput): Promise<ReconcileHeartbeatTasksResult> {
-    FileHeartbeatTaskService.assertReconciliationInput(input);
-
     return await this.mutationMutex.runExclusive(async () => {
       const currentTasks = await this.repository.listTasks();
-      const currentById = new Map(currentTasks.map((task) => [task.id, task]));
-      const desiredById = new Map(input.desired.map((task) => [task.id, task]));
-      const namespaceTasks = currentTasks.filter((task) => task.id.startsWith(input.namespace));
-      const created = [...desiredById.values()].filter((task) => !currentById.has(task.id));
-      const obsolete = namespaceTasks.filter((task) => !desiredById.has(task.id));
-      const preservedRunning = namespaceTasks.filter((task) => task.state?.status === 'running');
-      const deleted = obsolete.filter((task) => task.state?.status !== 'running');
+      const reconciliation = HeartbeatTaskControlPolicy.reconcileTasks({ currentTasks, input });
 
-      await Promise.all(created.map(async (task) => await this.repository.saveTask(task)));
-      await Promise.all(deleted.map(async (task) => await this.repository.deleteTask(task)));
+      await Promise.all(reconciliation.created.map(async (task) => await this.repository.saveTask(task)));
+      await Promise.all(reconciliation.deleted.map(async (task) => await this.repository.deleteTask(task)));
 
-      return { created, deleted, preservedRunning };
+      return reconciliation;
     });
   }
 
   async updateTask(taskId: string, input: UpdateHeartbeatTaskInput) {
-    const nextTask = await this.updateStoredTask(taskId, (task) => {
-      const now = dayjs();
-      const intervalMs = input.intervalMs ?? task.schedule.intervalMs;
-      const running = task.state?.status === 'running';
-      const enabled = input.enabled ?? task.enabled;
-      const pendingRunRequest = HeartbeatTaskStateProjector.hasPendingRunRequest(task);
-      return {
-        ...task,
-        name: input.name ?? task.name,
-        task: input.task?.trim() ?? task.task,
-        enabled,
-        continuationMode: input.continuationMode ?? task.continuationMode ?? 'operator',
-        schedule: {
-          ...task.schedule,
-          intervalMs,
-          nextRunAt:
-            !enabled ? undefined
-            : running || pendingRunRequest ? task.schedule.nextRunAt
-            : now.add(intervalMs, 'millisecond').toISOString(),
-        },
-        runtime: {
-          ...task.runtime,
-          model: input.model === undefined ? task.runtime?.model : input.model ?? undefined,
-          maxSteps: input.maxSteps === undefined ? task.runtime?.maxSteps : input.maxSteps ?? undefined,
-          searchIgnoreDirs: input.searchIgnoreDirs ?? task.runtime?.searchIgnoreDirs,
-          systemContext: input.systemContext ?? task.runtime?.systemContext,
-        },
-        state: {
-          ...task.state,
-          runRequest: !enabled ? FileHeartbeatTaskService.consumePendingRunRequest(task.state?.runRequest) : task.state?.runRequest,
-          updatedAt: now.toISOString(),
-        },
-      };
-    });
-    return FileHeartbeatTaskService.projectTaskView(nextTask);
+    const nextTask = await this.updateStoredTask(taskId, (task) => HeartbeatTaskControlPolicy.updateTask({
+      task,
+      input,
+      now: dayjs().toDate(),
+    }));
+    return HeartbeatTaskViewProjector.projectTask(nextTask);
   }
 
   async deleteTask(taskId: string) {
@@ -524,45 +407,23 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
       if (!currentTask) {
         throw new Error(`Heartbeat task not found: ${taskId}`);
       }
-      if (currentTask.state?.status === 'running') {
-        throw new Error(`Heartbeat task ${taskId} is running. Wait for the run to finish before deleting it.`);
-      }
+      HeartbeatTaskControlPolicy.assertTaskCanBeDeleted(currentTask);
 
       await this.repository.deleteTask(currentTask);
       return currentTask;
     });
-    return FileHeartbeatTaskService.projectTaskView(task);
+    return HeartbeatTaskViewProjector.projectTask(task);
   }
 
   async resumeTask(taskId: string) {
-    const nextTask = await this.updateStoredTask(taskId, (task) => {
-      if (task.state?.status === 'running') {
-        throw new Error(`Heartbeat task ${taskId} is already running.`);
-      }
-      if (task.state?.resumable === false) {
-        throw new Error(`Heartbeat task ${taskId} cannot be resumed.`);
-      }
-
-      const now = dayjs();
-      return {
-        ...task,
-        enabled: true,
-        schedule: {
-          ...task.schedule,
-          nextRunAt: now.subtract(1, 'second').toISOString(),
-        },
-        state: {
-          ...omit(task.state, ['error']),
-          status: 'waiting',
-          progress: 'Heartbeat task resumed. Waiting for the next scheduler poll.',
-          updatedAt: now.toISOString(),
-        },
-      };
-    });
-    return FileHeartbeatTaskService.projectTaskView(nextTask);
+    const nextTask = await this.updateStoredTask(taskId, (task) => HeartbeatTaskControlPolicy.resumeTask({
+      task,
+      now: dayjs().toDate(),
+    }));
+    return HeartbeatTaskViewProjector.projectTask(nextTask);
   }
 
-  async readTask(taskId: string, options: { runLimit?: number } = {}) {
+  async readTask(taskId: string, options: ReadHeartbeatTaskOptions = {}) {
     const task = await this.requireTask(taskId);
     const runs = await this.listRunViews({
       taskId,
@@ -570,7 +431,7 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
     });
 
     return {
-      task: FileHeartbeatTaskService.projectTaskView(task),
+      task: HeartbeatTaskViewProjector.projectTask(task),
       runs,
     };
   }
@@ -584,44 +445,21 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
     if (!run || run.taskId !== taskId) {
       return undefined;
     }
-    return FileHeartbeatTaskService.projectRunView(run);
+    return HeartbeatTaskViewProjector.projectRun(run);
   }
 
   async setTaskEnabled(taskId: string, enabled: boolean) {
-    const nextTask = await this.updateStoredTask(taskId, (task) => {
-      const now = dayjs();
-      if (enabled && task.state?.status === 'blocked') {
-        throw new Error(`Heartbeat task ${taskId} is blocked. Use resume to unblock it.`);
-      }
-
-      const status = FileHeartbeatTaskService.resolveTaskEnabledStatus(task, enabled);
-      const progress = FileHeartbeatTaskService.resolveTaskEnabledProgress(task, enabled);
-      return {
-        ...task,
-        enabled,
-        schedule: {
-          ...task.schedule,
-          nextRunAt:
-            enabled ?
-              task.schedule.nextRunAt ?? now.subtract(1, 'second').toISOString()
-            : undefined,
-        },
-        state: {
-          ...task.state,
-          status,
-          progress,
-          resumable: enabled ? true : task.state?.resumable,
-          runRequest: enabled ? task.state?.runRequest : FileHeartbeatTaskService.consumePendingRunRequest(task.state?.runRequest),
-          updatedAt: now.toISOString(),
-        },
-      };
-    });
-    return FileHeartbeatTaskService.projectTaskView(nextTask);
+    const nextTask = await this.updateStoredTask(taskId, (task) => HeartbeatTaskControlPolicy.setTaskEnabled({
+      task,
+      enabled,
+      now: dayjs().toDate(),
+    }));
+    return HeartbeatTaskViewProjector.projectTask(nextTask);
   }
 
   async triggerTaskRun(taskId: string) {
     const result = await this.requestTaskRun(taskId, { reason: 'manual-trigger' });
-    return FileHeartbeatTaskService.projectTaskView(result.task);
+    return HeartbeatTaskViewProjector.projectTask(result.task);
   }
 
   async requireTask(taskId: string): Promise<HeartbeatTask> {
@@ -633,122 +471,23 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
   }
 
   projectTaskView(task: HeartbeatTask): HeartbeatTaskView {
-    return FileHeartbeatTaskService.projectTaskView(task);
+    return HeartbeatTaskViewProjector.projectTask(task);
   }
 
   projectRunView(run: HeartbeatTaskRunRecordEntry): HeartbeatRunView {
-    return FileHeartbeatTaskService.projectRunView(run);
+    return HeartbeatTaskViewProjector.projectRun(run);
   }
 
   static projectTaskView(task: HeartbeatTask): HeartbeatTaskView {
-    const state = FileHeartbeatTaskService.projectTaskStateView(task.state);
-    return {
-      ...task,
-      taskId: task.id,
-      state,
-    };
+    return HeartbeatTaskViewProjector.projectTask(task);
   }
 
   static projectRunView(run: HeartbeatTaskRunRecordEntry): HeartbeatRunView {
-    return {
-      ...omit(run, ['record', 'path']),
-      ...FileHeartbeatTaskService.projectRunRecordView(run.record),
-    };
+    return HeartbeatTaskViewProjector.projectRun(run);
   }
 
   static projectRunRecordView(record: HeartbeatTaskRunRecord): HeartbeatRunView {
-    const outcome = FileHeartbeatTaskService.resolveRecordOutcome(record);
-    const runId = record.result?.state.runId;
-    return {
-      id: runId ?? outcome.executionId,
-      taskId: record.task.id,
-      executionId: outcome.executionId,
-      runId,
-      workspaceId: record.task.workspaceId,
-      createdAt: outcome.finishedAt,
-      task: FileHeartbeatTaskService.projectTaskView(record.task),
-      result: record.result ?
-        FileHeartbeatTaskService.projectResultView(record.result)
-      : FileHeartbeatTaskService.projectOutcomeView(outcome),
-      loadedCheckpoint: record.loadedCheckpoint,
-    };
-  }
-
-  private static projectTaskStateView(state: HeartbeatTaskState | undefined): HeartbeatTaskView['state'] {
-    const result =
-      state?.lastExecution && state.lastExecution.kind !== 'agent' ?
-        FileHeartbeatTaskService.projectOutcomeView(state.lastExecution)
-      : state?.result ? FileHeartbeatTaskService.projectResultView(state.result)
-      : state?.lastExecution ? FileHeartbeatTaskService.projectOutcomeView(state.lastExecution)
-      : undefined;
-    return {
-      ...omit(state ?? {}, ['result', 'runRequest']),
-      status: state?.status ?? 'idle',
-      result,
-      runRequest: state?.runRequest ? {
-        ...state.runRequest,
-        pending: state.runRequest.generation > state.runRequest.claimedGeneration,
-      } : undefined,
-    };
-  }
-
-  private static projectResultView(result: AgentHeartbeatResult): HeartbeatTaskResultView {
-    return {
-      kind: 'agent',
-      decision: result.decision,
-      summary: result.summary,
-      outcome: result.state.outcome,
-      usage: result.state.usage,
-    };
-  }
-
-  private static projectOutcomeView(outcome: HeartbeatTaskExecutionOutcome): HeartbeatTaskResultView {
-    return {
-      kind: outcome.kind,
-      summary: outcome.summary,
-      outcome: outcome.kind,
-      agentRunId: outcome.kind === 'retry' || outcome.kind === 'blocked' ? outcome.agentRunId : undefined,
-    };
-  }
-
-  private static resolveRecordOutcome(record: HeartbeatTaskRunRecord): HeartbeatTaskExecutionOutcome {
-    if (record.outcome) {
-      return record.outcome;
-    }
-    if (!record.result) {
-      throw new Error(`Heartbeat record for task ${record.task.id} has no execution outcome.`);
-    }
-
-    return {
-      kind: 'agent',
-      executionId: record.result.state.runId,
-      summary: record.result.summary,
-      finishedAt: record.result.state.finishedAt,
-    };
-  }
-
-  private static taskLastRunTime(task: HeartbeatTaskView): number {
-    const runAt = task.state.runAt ? dayjs(task.state.runAt) : undefined;
-    return runAt?.isValid() ? runAt.valueOf() : 0;
-  }
-
-  private static resolveTaskEnabledStatus(task: HeartbeatTask, enabled: boolean): NonNullable<HeartbeatTaskState['status']> {
-    if (task.state?.status === 'running') {
-      return 'running';
-    }
-    if (!enabled && task.state?.status === 'blocked') {
-      return 'blocked';
-    }
-    return enabled ? 'waiting' : 'idle';
-  }
-
-  private static resolveTaskEnabledProgress(task: HeartbeatTask, enabled: boolean): string | undefined {
-    if (task.state?.status === 'running' || task.state?.status === 'blocked') {
-      return task.state.progress;
-    }
-    return enabled ?
-      'Heartbeat task enabled. Waiting for the next scheduled run.'
-    : 'Heartbeat task paused by operator.';
+    return HeartbeatTaskViewProjector.projectRunRecord(record);
   }
 
   private static resolveHeartbeatRoot(options: FileHeartbeatTaskServiceOptions): string {
@@ -761,47 +500,6 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
     }
 
     return resolve(options.workspaceRoot, options.stateDir ?? '.heddle', 'heartbeat');
-  }
-
-  private static assertTaskAcceptsRunRequest(task: HeartbeatTask): void {
-    if (task.state?.status === 'blocked') {
-      throw new Error(`Heartbeat task ${task.id} is blocked. Resume it before requesting a run.`);
-    }
-    if (task.state?.status === 'complete') {
-      throw new Error(`Heartbeat task ${task.id} is complete. Resume it before requesting a run.`);
-    }
-    if (!task.enabled) {
-      throw new Error(`Heartbeat task ${task.id} is disabled. Enable it before requesting a run.`);
-    }
-  }
-
-  private static normalizeRunRequestReason(reason: string | undefined): string | undefined {
-    if (reason === undefined) {
-      return undefined;
-    }
-
-    const normalized = reason.trim();
-    if (!normalized) {
-      throw new Error('Heartbeat run-request reason cannot be empty.');
-    }
-    if (normalized.length > MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH) {
-      throw new Error(`Heartbeat run-request reason must be at most ${MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH} characters.`);
-    }
-    return normalized;
-  }
-
-  private static assertReconciliationInput(input: ReconcileHeartbeatTasksInput): void {
-    if (!input.namespace) {
-      throw new Error('Heartbeat reconciliation namespace cannot be empty.');
-    }
-
-    const desiredIds = input.desired.map((task) => task.id);
-    if (new Set(desiredIds).size !== desiredIds.length) {
-      throw new Error(`Heartbeat reconciliation namespace ${input.namespace} contains duplicate task IDs.`);
-    }
-    if (desiredIds.some((taskId) => !taskId.startsWith(input.namespace))) {
-      throw new Error(`Heartbeat reconciliation desired task IDs must start with namespace ${input.namespace}.`);
-    }
   }
 
   private static requireOutcomeAgentRunId(input: {
@@ -834,15 +532,6 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
       throw new Error(`Heartbeat retry and blocked summaries must be non-empty and at most ${MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH} characters.`);
     }
     return normalized;
-  }
-
-  private static consumePendingRunRequest(
-    runRequest: HeartbeatTaskState['runRequest'],
-  ): HeartbeatTaskState['runRequest'] {
-    return runRequest ? {
-      ...runRequest,
-      claimedGeneration: runRequest.generation,
-    } : undefined;
   }
 
   private static toRunRequestSignal(
@@ -937,25 +626,4 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore {
     };
   }
 
-  private static createTaskId(value: string, existingIds: string[]): string {
-    const base = value
-      .toLowerCase()
-      .replace(/[`'"]/g, '')
-      .replace(/[^a-z0-9._-]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 64)
-      .replace(/-+$/g, '') || 'heartbeat-task';
-    if (!existingIds.includes(base)) {
-      return base;
-    }
-
-    for (let index = 2; index < 1_000; index++) {
-      const candidate = `${base}-${index}`;
-      if (!existingIds.includes(candidate)) {
-        return candidate;
-      }
-    }
-
-    throw new Error(`Unable to create a unique heartbeat task id for ${base}`);
-  }
 }

--- a/src/core/heartbeat/views/index.ts
+++ b/src/core/heartbeat/views/index.ts
@@ -1,4 +1,5 @@
 export { HeartbeatLucidPresenter } from './lucid-presenter.js';
+export { HeartbeatTaskViewProjector } from './projector.js';
 export type {
   HeartbeatRunView,
   HeartbeatTaskRunRequestView,

--- a/src/core/heartbeat/views/projector.ts
+++ b/src/core/heartbeat/views/projector.ts
@@ -1,0 +1,114 @@
+/** Provider-neutral projection from durable heartbeat records to host-facing views. */
+import dayjs from 'dayjs';
+import omit from 'lodash/omit.js';
+import orderBy from 'lodash/orderBy.js';
+import type { AgentHeartbeatResult } from '../agent/index.js';
+import type {
+  HeartbeatTask,
+  HeartbeatTaskExecutionOutcome,
+  HeartbeatTaskRunRecord,
+  HeartbeatTaskRunRecordEntry,
+  HeartbeatTaskState,
+} from '../tasks/types.js';
+import type { HeartbeatRunView, HeartbeatTaskResultView, HeartbeatTaskView } from './types.js';
+
+export class HeartbeatTaskViewProjector {
+  static projectTasks(tasks: readonly HeartbeatTask[]): HeartbeatTaskView[] {
+    return orderBy(
+      tasks.map((task) => HeartbeatTaskViewProjector.projectTask(task)),
+      [(task) => HeartbeatTaskViewProjector.taskLastRunTime(task)],
+      ['desc'],
+    );
+  }
+
+  static projectTask(task: HeartbeatTask): HeartbeatTaskView {
+    return {
+      ...task,
+      taskId: task.id,
+      state: HeartbeatTaskViewProjector.projectTaskState(task.state),
+    };
+  }
+
+  static projectRun(run: HeartbeatTaskRunRecordEntry): HeartbeatRunView {
+    return {
+      ...omit(run, ['record', 'path']),
+      ...HeartbeatTaskViewProjector.projectRunRecord(run.record),
+    };
+  }
+
+  static projectRunRecord(record: HeartbeatTaskRunRecord): HeartbeatRunView {
+    const outcome = HeartbeatTaskViewProjector.resolveRecordOutcome(record);
+    const runId = record.result?.state.runId;
+    return {
+      id: runId ?? outcome.executionId,
+      taskId: record.task.id,
+      executionId: outcome.executionId,
+      runId,
+      workspaceId: record.task.workspaceId,
+      createdAt: outcome.finishedAt,
+      task: HeartbeatTaskViewProjector.projectTask(record.task),
+      result:
+        record.result ? HeartbeatTaskViewProjector.projectResult(record.result)
+        : HeartbeatTaskViewProjector.projectOutcome(outcome),
+      loadedCheckpoint: record.loadedCheckpoint,
+    };
+  }
+
+  private static projectTaskState(state: HeartbeatTaskState | undefined): HeartbeatTaskView['state'] {
+    const result =
+      state?.lastExecution && state.lastExecution.kind !== 'agent' ?
+        HeartbeatTaskViewProjector.projectOutcome(state.lastExecution)
+      : state?.result ? HeartbeatTaskViewProjector.projectResult(state.result)
+      : state?.lastExecution ? HeartbeatTaskViewProjector.projectOutcome(state.lastExecution)
+      : undefined;
+    return {
+      ...omit(state ?? {}, ['result', 'runRequest']),
+      status: state?.status ?? 'idle',
+      result,
+      runRequest: state?.runRequest ? {
+        ...state.runRequest,
+        pending: state.runRequest.generation > state.runRequest.claimedGeneration,
+      } : undefined,
+    };
+  }
+
+  private static projectResult(result: AgentHeartbeatResult): HeartbeatTaskResultView {
+    return {
+      kind: 'agent',
+      decision: result.decision,
+      summary: result.summary,
+      outcome: result.state.outcome,
+      usage: result.state.usage,
+    };
+  }
+
+  private static projectOutcome(outcome: HeartbeatTaskExecutionOutcome): HeartbeatTaskResultView {
+    return {
+      kind: outcome.kind,
+      summary: outcome.summary,
+      outcome: outcome.kind,
+      agentRunId: outcome.kind === 'retry' || outcome.kind === 'blocked' ? outcome.agentRunId : undefined,
+    };
+  }
+
+  private static resolveRecordOutcome(record: HeartbeatTaskRunRecord): HeartbeatTaskExecutionOutcome {
+    if (record.outcome) {
+      return record.outcome;
+    }
+    if (!record.result) {
+      throw new Error(`Heartbeat record for task ${record.task.id} has no execution outcome.`);
+    }
+
+    return {
+      kind: 'agent',
+      executionId: record.result.state.runId,
+      summary: record.result.summary,
+      finishedAt: record.result.state.finishedAt,
+    };
+  }
+
+  private static taskLastRunTime(task: HeartbeatTaskView): number {
+    const runAt = task.state.runAt ? dayjs(task.state.runAt) : undefined;
+    return runAt?.isValid() ? runAt.valueOf() : 0;
+  }
+}


### PR DESCRIPTION
## Summary

- add a provider-neutral `HeartbeatTaskAdministrationService` for create, update, enable, resume, delete, reconcile, and read operations
- extract pure task-control and task-view projectors so remote stores can apply Heddle-owned policy inside their own atomic transaction
- make the file task service delegate to the same policy and projection path
- export the new advanced API and document the custom-store boundary

## Why

Lucid's PostgreSQL task authority needs to administer tasks atomically without importing Heddle internals or duplicating framework lifecycle rules. The existing targeted execution store intentionally did not provide that control-plane contract.

## Impact

This is additive for SDK consumers. The built-in file service retains its existing API and mutex/repository boundary while sharing the provider-neutral policy.

## Validation

- focused heartbeat suite: 3 files, 13 tests passed
- `yarn typecheck`
- `yarn lint`
- canonical `yarn build`
- consumer verification through Lucid's real PostgreSQL conformance and service suites

## Follow-up

A package release from this PR is required before Lucid can replace its temporary local Yarn link and run clean-install CI.