### PR TITLE
feat: add scriptable ask JSONL contract

### DIFF
--- a/docs/architecture/control-plane-chat-submission.md
+++ b/docs/architecture/control-plane-chat-submission.md
@@ -55,6 +55,16 @@ If another run already owns the session, a normal prompt can instead return a
 `session.run.updated` when it is admitted later; clients do not invent an ID or
 reuse the preceding run's stream.
 
+Exact-run supervisors may send `queueIfBusy: false`. The server then performs
+a server-side do-not-queue admission check: it either returns an accepted run
+with its exact identity, or rejects while the session has an active or queued
+run.
+This option exists for completion supervisors such as
+`heddle ask --output jsonl`, which cannot safely exit or reconnect to an
+anonymous queue item. The option does not change the default interactive
+queueing behavior and clients must not emulate the check by reading session
+state before submitting.
+
 ### `controlPlane.sessionSendPrompt`
 
 Use this for completion-oriented callers that intentionally want to wait for the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,6 +68,69 @@ heddle ask "Summarize the test strategy in this repository"
 
 `ask` still behaves like a one-shot command from the terminal, but Heddle stores the run as a one-off session under `.heddle/` so traces, memory maintenance, and later review use the same persisted conversation path as other session-backed runs.
 
+Pass a multiline prompt without shell quoting:
+
+```bash
+heddle ask --prompt-file implementation-request.md
+heddle ask --prompt-file - < implementation-request.md
+```
+
+`--prompt-file -` is the explicit stdin mode. Heddle never reads stdin merely
+because it is piped, so an accidentally inherited or open stdin stream cannot
+make an otherwise normal invocation hang. A positional prompt and
+`--prompt-file` are mutually exclusive.
+
+For a supervisor process, request the versioned JSON Lines protocol:
+
+```bash
+heddle ask --prompt-file - --output jsonl < implementation-request.md
+```
+
+In `jsonl` mode, stdout contains only one JSON object per line. Diagnostics and
+runtime attachment notices go to stderr. Every record includes
+`schemaVersion: 1`, a `type`, and `terminal`. The current record types are:
+
+- `run.accepted`, containing the exact workspace, session, and run IDs;
+- `run.activity`, containing the shared control-plane activity and its ordered
+  sequence number;
+- `run.stream.reconnecting`, reporting bounded transport recovery;
+- exactly one terminal `run.result`, `run.cancelled`, `run.error`,
+  `run.stream.error`, or `command.error` record.
+
+`run.result` includes the final outcome and summary, the persisted trace path,
+and changed-file paths when the run trace contains edit or Git-diff evidence.
+Heddle intentionally does not label every dirty workspace file as created by
+the run: if a tool did not record per-run evidence, inspect the workspace diff
+after completion instead of treating a shared working-tree snapshot as
+attribution.
+
+The process exits with status `0` only when the terminal run result has
+`outcome: "done"`. Rejected input, a busy target session, cancellation, stream
+failure, provider failure, and other non-done outcomes exit nonzero. A
+scriptable invocation does not enter the interactive prompt queue: when a
+selected reusable session is already running or queued, it fails admission so
+the supervisor never loses the exact run identity it must observe.
+
+Approval policy is unchanged. `run.activity` records can show an approval wait,
+but JSONL mode does not silently auto-approve it. Configure a suitable host
+permission policy before launching, or let another attached TUI/web/API client
+resolve the approval for that session.
+
+Choose the smallest integration surface that fits the host:
+
+- use `heddle ask --output jsonl` for a zero-code subprocess integration;
+- use the conversation SDK for an in-process TypeScript host that needs typed
+  callbacks and lifecycle composition;
+- use the control-plane API for a remote or multi-client product integration.
+
+For a Codex-supervised implementation workflow, let Codex plan or review the
+task, invoke `heddle ask --output jsonl` for the Heddle-owned implementation
+step, and keep consuming records until the single terminal record arrives.
+Treat a zero process exit as completed work, then review the reported trace,
+changed-file evidence, and the repository diff before committing. A nonzero
+exit is not a completed implementation even if earlier activity records showed
+useful progress.
+
 Run against another workspace:
 
 ```bash

--- a/src/__tests__/integration/control-plane/session-lifecycle.test.ts
+++ b/src/__tests__/integration/control-plane/session-lifecycle.test.ts
@@ -634,6 +634,11 @@ description: Research web pages through a browser.
       });
       await expect(caller.sessionSendPromptAsync({
         sessionId: session.id,
+        prompt: 'Machine prompt requiring an exact run identity',
+        queueIfBusy: false,
+      })).rejects.toThrow('The session is busy. Retry after its active and queued runs have settled.');
+      await expect(caller.sessionSendPromptAsync({
+        sessionId: session.id,
         prompt: 'Second prompt',
       })).resolves.toMatchObject({
         queued: true,

--- a/src/__tests__/integration/tui/ask-cli.test.ts
+++ b/src/__tests__/integration/tui/ask-cli.test.ts
@@ -41,7 +41,7 @@ describe('AskCliV2CommandEdgeService integration', () => {
     };
 
     try {
-      await AskCliV2CommandEdgeService.run('describe this workspace', {
+      const result = await AskCliV2CommandEdgeService.run('describe this workspace', {
         workspaceRoot,
         activeWorkspaceId: workspace.id,
         model: 'gpt-5.4',
@@ -50,6 +50,7 @@ describe('AskCliV2CommandEdgeService integration', () => {
         stateDir: '.heddle',
         runtimeHost,
       });
+      expect(result).toEqual({ exitCode: 0 });
     } finally {
       await closeServer(server);
     }
@@ -69,6 +70,68 @@ describe('AskCliV2CommandEdgeService integration', () => {
     });
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining(`Session: ${sessions[0]?.id}`));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('Outcome: done'));
+  });
+
+  it('streams an accepted run and one terminal result as JSONL', async () => {
+    vi.stubEnv('HEDDLE_BROWSER_INTEGRATION_FAKE_AGENT', '1');
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-ask-cli-v2-jsonl-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const workspace = RuntimeWorkspaceService.resolveContext({
+      workspaceRoot,
+      stateRoot,
+    }).activeWorkspace;
+    const stdoutLines: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdoutLines.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const server = createHeddleServerApp({ workspaceRoot, stateRoot }).listen(0, '127.0.0.1');
+    await onceListening(server);
+    const address = server.address() as AddressInfo;
+    const runtimeHost: ResolvedRuntimeHost = {
+      kind: 'server',
+      registryPath: join(workspaceRoot, 'daemon-registry.json'),
+      serverId: 'server-ask-jsonl-test',
+      mode: 'daemon',
+      endpoint: { host: '127.0.0.1', port: address.port },
+      startedAt: '2026-06-03T00:00:00.000Z',
+      lastSeenAt: '2026-06-03T00:00:01.000Z',
+      stale: false,
+      ageMs: 100,
+    };
+
+    try {
+      const result = await AskCliV2CommandEdgeService.run('describe this workspace', {
+        workspaceRoot,
+        activeWorkspaceId: workspace.id,
+        model: 'gpt-5.4',
+        maxSteps: 7,
+        preferApiKey: false,
+        stateDir: '.heddle',
+        runtimeHost,
+        output: 'jsonl',
+      });
+      expect(result).toEqual({ exitCode: 0 });
+    } finally {
+      await closeServer(server);
+    }
+
+    const records = stdoutLines.map((line) => JSON.parse(line));
+    expect(records[0]).toMatchObject({
+      schemaVersion: 1,
+      type: 'run.accepted',
+      terminal: false,
+      workspaceId: workspace.id,
+    });
+    expect(records.some((record) => record.type === 'run.activity')).toBe(true);
+    expect(records.at(-1)).toMatchObject({
+      schemaVersion: 1,
+      type: 'run.result',
+      terminal: true,
+      result: { outcome: 'done' },
+    });
+    expect(records.filter((record) => record.terminal)).toHaveLength(1);
   });
 });
 

--- a/src/__tests__/unit/cli-v2/ask-command.test.ts
+++ b/src/__tests__/unit/cli-v2/ask-command.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
 import { ClientSharedProxyApiService } from '@/client-shared/api/proxy.js';
 import { AskCliV2CommandEdgeService } from '@/cli-v2/commands/ask-command.js';
@@ -53,7 +57,7 @@ describe('AskCliV2CommandEdgeService', () => {
         stateDir: '.heddle',
         heartbeatScheduler: { enabled: false },
       }));
-      expect(createClient).toHaveBeenCalledWith({ url: runtime.trpcUrl });
+      expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ url: runtime.trpcUrl }));
       const client = createClient.mock.results[0]?.value as ReturnType<typeof createClientFixture>['client'];
       expect(client.controlPlane.sessionCreate.mutate).toHaveBeenCalledWith(expect.objectContaining({
         workspaceId: 'workspace-1',
@@ -173,6 +177,171 @@ describe('AskCliV2CommandEdgeService', () => {
       resolve.mockRestore();
     }
   });
+
+  it('preserves multiline prompts read from a file', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-ask-prompt-file-'));
+    const prompt = 'Inspect these files:\n\n- src/a.ts\n- src/b.ts\n';
+    writeFileSync(join(workspaceRoot, 'prompt.md'), prompt, 'utf8');
+    const runtime = createRuntime();
+    const resolveRuntime = vi.spyOn(ControlPlaneCommandRuntimeService, 'resolve').mockResolvedValue(runtime);
+    const fixture = createClientFixture({
+      sendPromptResult: {
+        outcome: 'done',
+        summary: 'Inspected files.',
+        session: null,
+      },
+    });
+    const createClient = vi.spyOn(ClientSharedProxyApiService, 'createClient').mockReturnValue(fixture.client);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const result = await AskCliV2CommandEdgeService.run('', {
+        ...defaultOptions(),
+        workspaceRoot,
+        promptFile: 'prompt.md',
+      });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(fixture.client.controlPlane.sessionSendPrompt.mutate).toHaveBeenCalledWith(expect.objectContaining({
+        prompt,
+      }));
+    } finally {
+      resolveRuntime.mockRestore();
+      createClient.mockRestore();
+      stdout.mockRestore();
+    }
+  });
+
+  it('streams one versioned JSONL record sequence for an exact accepted run', async () => {
+    const runtime = createRuntime();
+    const resolveRuntime = vi.spyOn(ControlPlaneCommandRuntimeService, 'resolve').mockResolvedValue(runtime);
+    const fixture = createClientFixture({
+      sendPromptResult: {
+        outcome: 'done',
+        summary: 'Unused synchronous result.',
+        session: null,
+      },
+      sendPromptAsyncResult: {
+        accepted: true,
+        workspaceId: 'workspace-1',
+        sessionId: 'session-created',
+        runId: 'run-jsonl',
+        acceptedAt: '2026-06-03T00:00:00.000Z',
+      },
+      runEvents: [
+        {
+          kind: 'activity',
+          runId: 'run-jsonl',
+          sequence: 1,
+          timestamp: '2026-06-03T00:00:01.000Z',
+          activity: {
+            type: 'assistant.commentary',
+            runId: 'run-jsonl',
+            source: 'agent-loop',
+            step: 1,
+            messageId: 'commentary-1',
+            text: 'Inspecting repository.',
+            done: true,
+            timestamp: '2026-06-03T00:00:01.000Z',
+          },
+        },
+        {
+          kind: 'result',
+          runId: 'run-jsonl',
+          sequence: 2,
+          timestamp: '2026-06-03T00:00:02.000Z',
+          result: {
+            outcome: 'done',
+            summary: 'Done.',
+            traceFile: '/workspace/.heddle/traces/trace-1.json',
+            changedFiles: [{ path: 'src/a.ts', status: 'modified', source: 'edit_file' }],
+          },
+        },
+      ],
+    });
+    const createClient = vi.spyOn(ClientSharedProxyApiService, 'createClient').mockReturnValue(fixture.client);
+    const stdoutLines: string[] = [];
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdoutLines.push(String(chunk));
+      return true;
+    });
+    const prompt = 'Inspect these files:\n\n- src/a.ts\n- src/b.ts\n';
+
+    try {
+      const result = await AskCliV2CommandEdgeService.run('', {
+        ...defaultOptions(),
+        output: 'jsonl',
+        promptFile: '-',
+        stdin: Readable.from(['Inspect these files:\n\n', '- src/a.ts\n', '- src/b.ts\n']),
+      });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(fixture.client.controlPlane.sessionSendPromptAsync.mutate).toHaveBeenCalledWith(expect.objectContaining({
+        prompt,
+        queueIfBusy: false,
+      }));
+      expect(fixture.client.controlPlane.sessionSendPrompt.mutate).not.toHaveBeenCalled();
+      const records = stdoutLines.map((line) => JSON.parse(line));
+      expect(records.map((record) => record.type)).toEqual([
+        'run.accepted',
+        'run.activity',
+        'run.result',
+      ]);
+      expect(records.every((record) => record.schemaVersion === 1)).toBe(true);
+      expect(records.filter((record) => record.terminal)).toHaveLength(1);
+      expect(records[1]).toMatchObject({
+        runId: 'run-jsonl',
+        sequence: 1,
+        activity: { text: 'Inspecting repository.' },
+      });
+      expect(records[2]).toMatchObject({
+        result: {
+          traceFile: '/workspace/.heddle/traces/trace-1.json',
+          changedFiles: [{ path: 'src/a.ts', status: 'modified', source: 'edit_file' }],
+        },
+      });
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining('ask'));
+    } finally {
+      resolveRuntime.mockRestore();
+      createClient.mockRestore();
+      stdout.mockRestore();
+      stderr.mockRestore();
+    }
+  });
+
+  it('emits one terminal command error for invalid JSONL input', async () => {
+    const resolveRuntime = vi.spyOn(ControlPlaneCommandRuntimeService, 'resolve');
+    const stdoutLines: string[] = [];
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdoutLines.push(String(chunk));
+      return true;
+    });
+
+    try {
+      const result = await AskCliV2CommandEdgeService.run('positional prompt', {
+        ...defaultOptions(),
+        output: 'jsonl',
+        promptFile: 'prompt.md',
+      });
+
+      expect(result).toEqual({ exitCode: 1 });
+      expect(resolveRuntime).not.toHaveBeenCalled();
+      expect(stdoutLines).toHaveLength(1);
+      expect(JSON.parse(stdoutLines[0] ?? '')).toMatchObject({
+        schemaVersion: 1,
+        type: 'command.error',
+        terminal: true,
+        error: {
+          code: 'ASK_COMMAND_FAILED',
+          message: 'Usage: pass either a positional goal or --prompt-file, not both.',
+        },
+      });
+    } finally {
+      resolveRuntime.mockRestore();
+      stdout.mockRestore();
+    }
+  });
 });
 
 function defaultOptions() {
@@ -209,6 +378,8 @@ function createClientFixture(input: {
   sessions?: unknown[];
   createSessionResult?: unknown;
   sendPromptResult: unknown;
+  sendPromptAsyncResult?: unknown;
+  runEvents?: unknown[];
 }) {
   const client = {
     controlPlane: {
@@ -233,6 +404,21 @@ function createClientFixture(input: {
       },
       sessionSendPrompt: {
         mutate: vi.fn(async () => input.sendPromptResult),
+      },
+      sessionSendPromptAsync: {
+        mutate: vi.fn(async () => input.sendPromptAsyncResult),
+      },
+      sessionRunEvents: {
+        subscribe: vi.fn((_input, handlers) => {
+          handlers.onStarted?.();
+          queueMicrotask(() => {
+            for (const event of input.runEvents ?? []) {
+              handlers.onData?.(event);
+            }
+            handlers.onComplete?.();
+          });
+          return { unsubscribe: vi.fn() };
+        }),
       },
     },
   };

--- a/src/__tests__/unit/control-plane/session-list-events.test.ts
+++ b/src/__tests__/unit/control-plane/session-list-events.test.ts
@@ -87,6 +87,17 @@ describe('ControlPlaneChatSessionsController session list events', () => {
 
   it('observes the terminal from run acceptance even when replay trims early activity', async () => {
     const eventBus = new EventEmitter();
+    const traceFile = join(mkdtempSync(join(tmpdir(), 'heddle-run-result-trace-')), 'trace.json');
+    writeFileSync(traceFile, JSON.stringify([{
+      type: 'tool.completed',
+      call: { id: 'call-1', tool: 'edit_file', input: {} },
+      step: 1,
+      timestamp: '2026-06-12T00:00:00.000Z',
+      result: {
+        ok: true,
+        output: { path: 'src/updated.ts', action: 'replaced' },
+      },
+    }]));
     const runService = new ConversationRunService<{ workspaceId: string; sessionId: string }>({
       addressKey: ({ workspaceId, sessionId }) => `${workspaceId}:${sessionId}`,
       replay: { maxEventsPerRun: 2, retentionMs: 60_000 },
@@ -111,7 +122,7 @@ describe('ControlPlaneChatSessionsController session list events', () => {
           done: false,
           timestamp: new Date().toISOString(),
         }));
-        return { outcome: 'done', summary: 'Finished.', internal: 'not public' };
+        return { outcome: 'done', summary: 'Finished.', traceFile, internal: 'not public' };
       },
     });
 
@@ -125,7 +136,12 @@ describe('ControlPlaneChatSessionsController session list events', () => {
         terminal: expect.objectContaining({
           kind: 'result',
           sequence: 4,
-          result: { outcome: 'done', summary: 'Finished.' },
+          result: {
+            outcome: 'done',
+            summary: 'Finished.',
+            traceFile,
+            changedFiles: [{ path: 'src/updated.ts', status: 'modified', source: 'edit_file' }],
+          },
         }),
       }),
       expect.objectContaining({ type: 'session.run.updated', status: 'settled' }),

--- a/src/cli-v2/commands/README.md
+++ b/src/cli-v2/commands/README.md
@@ -49,7 +49,7 @@ domain should have:
 | --- | --- | --- |
 | `heddle`, `heddle chat`, `heddle chat-v2` | Already routed to `cli-v2`; attach to a live server or start an embedded control-plane server. | Keep as the reference API-backed runtime command pattern. |
 | `heddle chat-v1` | Removed from the public CLI route; the command edge reports a migration error instead of falling through to `ask`. | Keep the removed-command guard so retired names do not silently become prompts. |
-| `heddle ask` | `cli-v2` command adapter attaches/embeds the control-plane server, selects or creates a session, and submits through session APIs. | API-backed runtime command. Keep one-shot asks on the same session/run path as TUI and web. |
+| `heddle ask` | `cli-v2` command adapter attaches/embeds the control-plane server, selects or creates a session, and submits through session APIs. Text mode waits for the shared completion result; JSONL mode accepts and observes one exact shared run. | API-backed runtime command. Keep one-shot asks on the same session/run path as TUI and web. |
 | Unknown first argument fallback | Unknown non-command text becomes `ask`; removed command names are blocked explicitly. | Keep only if documented as shorthand; do not let retired command names become prompts. |
 | `heddle daemon` | `cli-v2` command adapter over runtime discovery and `src/server` lifecycle. | Direct discovery/lifecycle calls remain acceptable because the command manages the server. |
 | `heddle auth` | `cli-v2` command adapter delegates credential status/login/logout semantics to `ProviderCredentialCommandService`. | Direct management adapter over the core auth command service. |
@@ -61,6 +61,27 @@ domain should have:
 | `heddle heartbeat run` | `cli-v2` command adapter requests task execution or due-task execution through the live/embedded control-plane server. | Server-backed runtime command; no local CLI scheduler worker. |
 | `heddle heartbeat start` | `cli-v2` command adapter creates/updates a task through API and reports the server-backed scheduler. Embedded mode keeps the control-plane server alive until Ctrl+C. | Server-backed lifecycle command; do not run a separate CLI scheduler loop. |
 | `heddle eval` | `cli-v2` command adapter over core eval harness modules. | Direct dev/management adapter unless remote/API evals become a product goal. |
+
+## Scriptable Ask Boundary
+
+`heddle ask --output jsonl` is the zero-code subprocess adapter for hosts that
+cannot or do not want to embed the TypeScript SDK. It deliberately reuses
+`sessionSendPromptAsync` and the ordered `sessionRunEvents` replay contract; it
+must not grow a second agent execution loop, approval policy, or stream cursor.
+
+The command edge owns:
+
+- explicit positional, UTF-8 prompt-file, and `--prompt-file -` stdin input;
+- keeping stdout as a versioned JSONL protocol and sending diagnostics to
+  stderr;
+- converting shared accepted/activity/terminal envelopes into protocol
+  records;
+- process exit status and the exactly-one-terminal-record invariant.
+
+The server still owns session admission, execution, approvals, persistence,
+cancellation, and replay. Machine-mode submissions set `queueIfBusy: false`
+because a subprocess supervisor needs the exact run ID in the admission
+response. Interactive clients keep the default queueing behavior.
 
 ## Migration Order
 

--- a/src/cli-v2/commands/ask-command.ts
+++ b/src/cli-v2/commands/ask-command.ts
@@ -1,9 +1,19 @@
+import { Buffer } from 'node:buffer';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import dayjs from 'dayjs';
 import compact from 'lodash/compact.js';
+import { EventSource } from 'eventsource';
 import { ClientSharedProxyApiService } from '@/client-shared/api/proxy.js';
 import type { ResolvedRuntimeHost } from '@/core/runtime/daemon/index.js';
 import { ControlPlaneSessionApiService } from '@/cli-v2/services/sessions/control-plane-session-api-service.js';
+import {
+  AskJsonlProtocolWriter,
+  AskJsonlRunService,
+} from './ask-jsonl-run-service.js';
 import { ControlPlaneCommandRuntimeService } from './control-plane-command-runtime.js';
+
+export type AskCliV2OutputFormat = 'text' | 'jsonl';
 
 export type AskCliV2CommandOptions = {
   workspaceRoot: string;
@@ -21,6 +31,13 @@ export type AskCliV2CommandOptions = {
   latestSession?: boolean;
   createSessionName?: string;
   agentProfileId?: string;
+  promptFile?: string;
+  output?: AskCliV2OutputFormat | string;
+  stdin?: AsyncIterable<string | Uint8Array>;
+};
+
+export type AskCliV2CommandResult = {
+  exitCode: number;
 };
 
 type AskSessionSelection = {
@@ -41,14 +58,30 @@ type AskSessionSelection = {
  * behind the shared control-plane session API and its server/core owners.
  */
 export class AskCliV2CommandEdgeService {
-  static async run(goal: string, options: AskCliV2CommandOptions): Promise<void> {
-    const prompt = goal.trim();
-    if (!prompt) {
-      throw new Error('Usage: heddle ask "<goal>"');
+  static async run(goal: string, options: AskCliV2CommandOptions): Promise<AskCliV2CommandResult> {
+    const output = AskCliV2CommandEdgeService.resolveOutputFormat(options.output);
+    const jsonlWriter = output === 'jsonl' ? new AskJsonlProtocolWriter() : undefined;
+
+    try {
+      const prompt = await AskCliV2CommandEdgeService.resolvePrompt(goal, options);
+      AskCliV2CommandEdgeService.assertSingleSessionSelection(options);
+      return await AskCliV2CommandEdgeService.runPrompt(prompt, options, output, jsonlWriter);
+    } catch (error) {
+      if (!jsonlWriter) {
+        throw error;
+      }
+
+      jsonlWriter.writeCommandError(error);
+      return { exitCode: 1 };
     }
+  }
 
-    AskCliV2CommandEdgeService.assertSingleSessionSelection(options);
-
+  private static async runPrompt(
+    prompt: string,
+    options: AskCliV2CommandOptions,
+    output: AskCliV2OutputFormat,
+    jsonlWriter?: AskJsonlProtocolWriter,
+  ): Promise<AskCliV2CommandResult> {
     const runtime = await ControlPlaneCommandRuntimeService.resolve({
       workspaceRoot: options.workspaceRoot,
       stateDir: options.stateDir,
@@ -61,10 +94,15 @@ export class AskCliV2CommandEdgeService {
       runtime.kind === 'embedded' ? ControlPlaneCommandRuntimeService.installEmbeddedShutdown(runtime, 'ask') : () => undefined;
 
     try {
-      process.stdout.write(`${ControlPlaneCommandRuntimeService.formatNotice(runtime, 'ask')}\n`);
+      const notice = `${ControlPlaneCommandRuntimeService.formatNotice(runtime, 'ask')}\n`;
+      (output === 'jsonl' ? process.stderr : process.stdout).write(notice);
 
+      const client = ClientSharedProxyApiService.createClient({
+        url: runtime.trpcUrl,
+        eventSource: EventSource,
+      });
       const sessionApi = new ControlPlaneSessionApiService({
-        client: ClientSharedProxyApiService.createClient({ url: runtime.trpcUrl }),
+        client,
         defaultModel: options.model,
         maxSteps: options.maxSteps,
         searchIgnoreDirs: options.searchIgnoreDirs,
@@ -74,6 +112,24 @@ export class AskCliV2CommandEdgeService {
       });
       const workspaceId = options.activeWorkspaceId ?? await sessionApi.resolveWorkspaceId();
       const sessionId = await AskCliV2CommandEdgeService.resolveSessionId(sessionApi, workspaceId, options);
+      if (output === 'jsonl') {
+        if (!jsonlWriter) {
+          throw new Error('The JSONL protocol writer was not initialized.');
+        }
+
+        const exitCode = await new AskJsonlRunService({
+          client,
+          sessionApi,
+          writer: jsonlWriter,
+        }).run({
+          workspaceId,
+          sessionId,
+          prompt,
+          agentProfileId: options.agentProfileId ?? 'builtin:ask',
+        });
+        return { exitCode };
+      }
+
       const result = await sessionApi.sendPrompt({
         workspaceId,
         sessionId,
@@ -91,10 +147,51 @@ export class AskCliV2CommandEdgeService {
         traceFile: result.session?.turns.at(-1)?.traceFile,
         latestArchivePath: result.session?.context?.archive?.lastArchivePath,
       });
+      return { exitCode: result.outcome === 'done' ? 0 : 1 };
     } finally {
       uninstallRuntimeShutdown();
       await runtime.close();
     }
+  }
+
+  private static resolveOutputFormat(output: string | undefined): AskCliV2OutputFormat {
+    const resolved = output ?? 'text';
+    if (resolved === 'text' || resolved === 'jsonl') {
+      return resolved;
+    }
+
+    throw new Error('Usage: --output must be one of text or jsonl.');
+  }
+
+  private static async resolvePrompt(goal: string, options: AskCliV2CommandOptions): Promise<string> {
+    const positionalPrompt = goal.trim();
+    if (options.promptFile !== undefined && positionalPrompt) {
+      throw new Error('Usage: pass either a positional goal or --prompt-file, not both.');
+    }
+
+    if (options.promptFile === undefined) {
+      if (!positionalPrompt) {
+        throw new Error('Usage: heddle ask "<goal>" or heddle ask --prompt-file <path>');
+      }
+      return positionalPrompt;
+    }
+
+    const prompt = options.promptFile === '-'
+      ? await AskCliV2CommandEdgeService.readStdin(options.stdin ?? process.stdin)
+      : await readFile(resolve(options.workspaceRoot, options.promptFile), 'utf8');
+    if (!prompt.trim()) {
+      throw new Error('The ask prompt cannot be empty.');
+    }
+
+    return prompt;
+  }
+
+  private static async readStdin(stdin: AsyncIterable<string | Uint8Array>): Promise<string> {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of stdin) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+    }
+    return Buffer.concat(chunks).toString('utf8');
   }
 
   private static assertSingleSessionSelection(selection: AskSessionSelection): void {

--- a/src/cli-v2/commands/ask-jsonl-run-service.ts
+++ b/src/cli-v2/commands/ask-jsonl-run-service.ts
@@ -1,0 +1,281 @@
+import dayjs from 'dayjs';
+import type { ControlPlaneProxyClient } from '@/client-shared/api/proxy.js';
+import type { ControlPlaneSessionRunEventEnvelope } from '@/client-shared/api/types.js';
+import { ControlPlaneSessionApiService } from '@/cli-v2/services/sessions/control-plane-session-api-service.js';
+import { ControlPlaneSessionSubscriptionService } from '@/cli-v2/services/sessions/control-plane-session-subscription-service.js';
+
+const ASK_JSONL_SCHEMA_VERSION = 1 as const;
+
+type AskJsonlRunAddress = {
+  workspaceId: string;
+  sessionId: string;
+  runId: string;
+};
+
+type AskJsonlRecord =
+  | ({
+    type: 'run.accepted';
+    terminal: false;
+    timestamp: string;
+  } & AskJsonlRunAddress)
+  | ({
+    type: 'run.activity';
+    terminal: false;
+    sequence: number;
+    timestamp: string;
+    activity: Extract<ControlPlaneSessionRunEventEnvelope, { kind: 'activity' }>['activity'];
+  } & AskJsonlRunAddress)
+  | ({
+    type: 'run.result';
+    terminal: true;
+    sequence: number;
+    timestamp: string;
+    result: Extract<ControlPlaneSessionRunEventEnvelope, { kind: 'result' }>['result'];
+  } & AskJsonlRunAddress)
+  | ({
+    type: 'run.cancelled';
+    terminal: true;
+    sequence: number;
+    timestamp: string;
+    reason: string;
+  } & AskJsonlRunAddress)
+  | ({
+    type: 'run.error';
+    terminal: true;
+    sequence: number;
+    timestamp: string;
+    error: Extract<ControlPlaneSessionRunEventEnvelope, { kind: 'error' }>['error'];
+  } & AskJsonlRunAddress)
+  | ({
+    type: 'run.stream.reconnecting';
+    terminal: false;
+    timestamp: string;
+    attempt: number;
+    delayMs: number;
+    error: { code: 'RUN_STREAM_INTERRUPTED'; message: string };
+  } & AskJsonlRunAddress)
+  | ({
+    type: 'run.stream.error';
+    terminal: true;
+    timestamp: string;
+    error: { code: 'RUN_STREAM_UNAVAILABLE'; message: string };
+  } & AskJsonlRunAddress)
+  | {
+    type: 'command.error';
+    terminal: true;
+    timestamp: string;
+    error: { code: 'ASK_COMMAND_FAILED'; message: string };
+  };
+
+type VersionedAskJsonlRecord = AskJsonlRecord & {
+  schemaVersion: typeof ASK_JSONL_SCHEMA_VERSION;
+};
+
+export type AskJsonlRunServiceOptions = {
+  client: ControlPlaneProxyClient;
+  sessionApi: ControlPlaneSessionApiService;
+  writer: AskJsonlProtocolWriter;
+};
+
+export type AskJsonlRunInput = {
+  workspaceId: string;
+  sessionId: string;
+  prompt: string;
+  agentProfileId: string;
+};
+
+/**
+ * Writes the versioned `heddle ask --output jsonl` protocol and guarantees
+ * that a command process emits no more than one terminal record.
+ */
+export class AskJsonlProtocolWriter {
+  private terminalWritten = false;
+
+  constructor(
+    private readonly writeLine: (line: string) => void = (line) => {
+      process.stdout.write(line);
+    },
+  ) {}
+
+  write(record: AskJsonlRecord): boolean {
+    if (this.terminalWritten) {
+      return false;
+    }
+
+    this.terminalWritten = record.terminal;
+    const versioned: VersionedAskJsonlRecord = {
+      schemaVersion: ASK_JSONL_SCHEMA_VERSION,
+      ...record,
+    };
+    this.writeLine(`${JSON.stringify(versioned)}\n`);
+    return true;
+  }
+
+  writeCommandError(error: unknown): void {
+    this.write({
+      type: 'command.error',
+      terminal: true,
+      timestamp: dayjs().toISOString(),
+      error: {
+        code: 'ASK_COMMAND_FAILED',
+        message: AskJsonlProtocolWriter.errorMessage(error),
+      },
+    });
+  }
+
+  private static errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+/**
+ * Supervises one exact control-plane run for the scriptable ask command.
+ * Run execution, replay ordering, retry policy, and approval semantics remain
+ * owned by the shared control-plane and conversation-run services.
+ */
+export class AskJsonlRunService {
+  private readonly writer: AskJsonlProtocolWriter;
+  private subscriptions?: ControlPlaneSessionSubscriptionService;
+  private settle?: (exitCode: number) => void;
+
+  constructor(private readonly options: AskJsonlRunServiceOptions) {
+    this.writer = options.writer;
+  }
+
+  async run(input: AskJsonlRunInput): Promise<number> {
+    const accepted = await this.options.sessionApi.sendPromptAsync({
+      ...input,
+      includePlanTool: false,
+      memoryMaintenanceMode: 'inline',
+      queueIfBusy: false,
+    });
+    if (!('accepted' in accepted)) {
+      throw new Error('The scriptable ask could not acquire an exact run identity. Retry after the session queue settles.');
+    }
+
+    const run = {
+      workspaceId: accepted.workspaceId,
+      sessionId: accepted.sessionId,
+      runId: accepted.runId,
+    };
+    this.writer.write({
+      type: 'run.accepted',
+      terminal: false,
+      ...run,
+      timestamp: accepted.acceptedAt,
+    });
+
+    return await new Promise<number>((resolve) => {
+      this.settle = resolve;
+      this.subscriptions = new ControlPlaneSessionSubscriptionService({
+        client: this.options.client,
+        onSessionsUpdated: () => undefined,
+        onSessionEvent: () => undefined,
+        onRunEvent: (_workspaceId, _sessionId, event) => this.handleRunEvent(run, event),
+        onSessionListError: () => undefined,
+        onSessionStreamError: () => undefined,
+        onSessionStreamStarted: () => undefined,
+        onSessionStreamComplete: () => undefined,
+        onRunStreamError: (error) => this.finish(1, {
+          type: 'run.stream.error',
+          terminal: true,
+          ...run,
+          timestamp: dayjs().toISOString(),
+          error: {
+            code: 'RUN_STREAM_UNAVAILABLE',
+            message: error.message,
+          },
+        }),
+        onRunStreamStarted: () => undefined,
+        onRunStreamReconnecting: ({ attempt, delayMs, error }) => {
+          this.writer.write({
+            type: 'run.stream.reconnecting',
+            terminal: false,
+            ...run,
+            timestamp: dayjs().toISOString(),
+            attempt,
+            delayMs,
+            error: {
+              code: 'RUN_STREAM_INTERRUPTED',
+              message: error.message,
+            },
+          });
+        },
+        onRunStreamComplete: () => undefined,
+      });
+
+      try {
+        this.subscriptions.subscribeToAcceptedRun(run);
+      } catch (error) {
+        this.finish(1, {
+          type: 'run.stream.error',
+          terminal: true,
+          ...run,
+          timestamp: dayjs().toISOString(),
+          error: {
+            code: 'RUN_STREAM_UNAVAILABLE',
+            message: error instanceof Error ? error.message : String(error),
+          },
+        });
+      }
+    });
+  }
+
+  private handleRunEvent(run: AskJsonlRunAddress, event: ControlPlaneSessionRunEventEnvelope): void {
+    if (event.kind === 'activity') {
+      this.writer.write({
+        type: 'run.activity',
+        terminal: false,
+        ...run,
+        sequence: event.sequence,
+        timestamp: event.timestamp,
+        activity: event.activity,
+      });
+      return;
+    }
+
+    if (event.kind === 'result') {
+      this.finish(event.result.outcome === 'done' ? 0 : 1, {
+        type: 'run.result',
+        terminal: true,
+        ...run,
+        sequence: event.sequence,
+        timestamp: event.timestamp,
+        result: event.result,
+      });
+      return;
+    }
+
+    if (event.kind === 'cancelled') {
+      this.finish(1, {
+        type: 'run.cancelled',
+        terminal: true,
+        ...run,
+        sequence: event.sequence,
+        timestamp: event.timestamp,
+        reason: event.reason,
+      });
+      return;
+    }
+
+    this.finish(1, {
+      type: 'run.error',
+      terminal: true,
+      ...run,
+      sequence: event.sequence,
+      timestamp: event.timestamp,
+      error: event.error,
+    });
+  }
+
+  private finish(exitCode: number, record: Extract<AskJsonlRecord, { terminal: true }>): void {
+    if (!this.writer.write(record)) {
+      return;
+    }
+
+    this.subscriptions?.dispose();
+    this.subscriptions = undefined;
+    this.settle?.(exitCode);
+    this.settle = undefined;
+  }
+}

--- a/src/cli-v2/main.ts
+++ b/src/cli-v2/main.ts
@@ -82,16 +82,20 @@ async function main() {
     .option('--new-session [name]', 'create a fresh chat session and run this ask inside it')
     .option('--agent <id>', 'custom agent id for this ask turn')
     .option('--mode <mode>', 'built-in custom agent mode: ask, code, or review')
+    .option('--prompt-file <path>', 'read the prompt from a UTF-8 file; use - for stdin')
+    .option('--output <format>', 'output format: text or jsonl', 'text')
     .action(async (goalParts: string[], askOptions: {
       session?: string;
       latest?: boolean;
       newSession?: string | boolean;
       agent?: string;
       mode?: string;
+      promptFile?: string;
+      output?: string;
     }) => {
       const resolved = resolveCliOptions(program.opts<RootCliOptions>());
       chdir(resolved.workspaceRoot);
-      await AskCliV2CommandEdgeService.run(goalParts.join(' ').trim(), {
+      const result = await AskCliV2CommandEdgeService.run(goalParts.join(' ').trim(), {
         workspaceRoot: resolved.workspaceRoot,
         activeWorkspaceId: resolved.activeWorkspaceId,
         model: resolved.model,
@@ -109,7 +113,10 @@ async function main() {
           : askOptions.newSession === true ? ''
           : askOptions.newSession,
         agentProfileId: resolveAskAgentProfileId(askOptions),
+        promptFile: askOptions.promptFile,
+        output: askOptions.output,
       });
+      process.exitCode = result.exitCode;
     });
 
   program
@@ -322,7 +329,7 @@ async function main() {
   if (knownCommand && !isKnownCommand(knownCommand) && !knownCommand.startsWith('-')) {
     const resolved = resolveCliOptions(program.opts<RootCliOptions>());
     chdir(resolved.workspaceRoot);
-    await AskCliV2CommandEdgeService.run(argv.join(' ').trim(), {
+    const result = await AskCliV2CommandEdgeService.run(argv.join(' ').trim(), {
       workspaceRoot: resolved.workspaceRoot,
       activeWorkspaceId: resolved.activeWorkspaceId,
       model: resolved.model,
@@ -334,6 +341,7 @@ async function main() {
       forceOwnerConflict: resolved.forceOwnerConflict,
       preferApiKey: resolved.preferApiKey,
     });
+    process.exitCode = result.exitCode;
     return;
   }
 

--- a/src/cli-v2/services/sessions/control-plane-session-api-service.ts
+++ b/src/cli-v2/services/sessions/control-plane-session-api-service.ts
@@ -124,7 +124,13 @@ export class ControlPlaneSessionApiService {
 
   async sendPromptAsync(input: Pick<
     SessionSendPromptAsyncInput,
-    'workspaceId' | 'sessionId' | 'prompt' | 'agentProfileId' | 'includePlanTool' | 'memoryMaintenanceMode'
+    | 'workspaceId'
+    | 'sessionId'
+    | 'prompt'
+    | 'agentProfileId'
+    | 'includePlanTool'
+    | 'memoryMaintenanceMode'
+    | 'queueIfBusy'
   >) {
     return this.client.controlPlane.sessionSendPromptAsync.mutate({
       ...input,

--- a/src/cli-v2/services/sessions/control-plane-session-subscription-service.ts
+++ b/src/cli-v2/services/sessions/control-plane-session-subscription-service.ts
@@ -82,6 +82,30 @@ export class ControlPlaneSessionSubscriptionService {
     });
   }
 
+  /**
+   * Observes one already accepted run without depending on session lifecycle
+   * discovery. Completion-oriented command clients use this when the submit
+   * response already supplied the exact run address they must supervise.
+   */
+  subscribeToAcceptedRun(run: ControlPlaneConversationRunReference): void {
+    const sessionAddress = this.sessionAddress;
+    if (
+      !sessionAddress
+      || sessionAddress.workspaceId !== run.workspaceId
+      || sessionAddress.sessionId !== run.sessionId
+    ) {
+      this.sessionSubscription?.unsubscribe();
+      this.stopRunSubscription();
+      this.sessionSubscription = undefined;
+      this.sessionAddress = {
+        workspaceId: run.workspaceId,
+        sessionId: run.sessionId,
+      };
+    }
+
+    this.subscribeToRun(run);
+  }
+
   subscribeToRun(run: ControlPlaneConversationRunReference): void {
     const sessionAddress = this.sessionAddress;
     if (

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -228,6 +228,8 @@ export type ControlPlaneSessionRunReference = {
 export type ControlPlaneSessionRunResult = {
   outcome?: string;
   summary?: string;
+  traceFile?: string;
+  changedFiles?: Array<Pick<ChangedFileReviewView, 'path' | 'status' | 'source'>>;
 };
 
 export type ControlPlaneSessionRunEventEnvelope = ConversationRunStreamItem<ControlPlaneSessionRunResult>;

--- a/src/server/controllers/trpc/control-plane/chat-session-run-stream.ts
+++ b/src/server/controllers/trpc/control-plane/chat-session-run-stream.ts
@@ -11,6 +11,7 @@ import type {
   ControlPlaneSessionRunReference,
   ControlPlaneSessionRunResult,
 } from '@/server/control-plane-types.js';
+import { ControlPlaneChatTurnReviewPresenter } from './chat-turn-review-presenter.js';
 import { ControlPlaneChatSessionEventsController } from './chat-session-events.js';
 
 export type ControlPlaneSessionAddress = {
@@ -128,9 +129,19 @@ export class ControlPlaneChatSessionRunStreamController {
       return {};
     }
 
-    return pickBy(
-      pick(result as Record<string, unknown>, ['outcome', 'summary']),
+    const publicResult = pickBy(
+      pick(result as Record<string, unknown>, ['outcome', 'summary', 'traceFile']),
       isString,
     ) as ControlPlaneSessionRunResult;
+    const review = publicResult.traceFile
+      ? ControlPlaneChatTurnReviewPresenter.load(publicResult.traceFile)
+      : undefined;
+
+    return {
+      ...publicResult,
+      ...(review?.files.length
+        ? { changedFiles: review.files.map((file) => pick(file, ['path', 'status', 'source'])) }
+        : {}),
+    };
   }
 }

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -122,6 +122,7 @@ type SubmitChatPromptArgs = ControlPlaneSessionReadArgs & {
   maxSteps?: number;
   searchIgnoreDirs?: string[];
   includePlanTool?: boolean;
+  queueIfBusy?: boolean;
   leaseOwner: ChatSessionLeaseOwner;
   logger?: Pick<Logger, 'debug'>;
 };
@@ -299,7 +300,11 @@ export class ControlPlaneChatSessionsController {
 
   async submitPromptAsync(args: SubmitChatPromptArgs): Promise<ControlPlaneAcceptedSessionRun> {
     const preparedArgs = this.prepareSubmitPromptArgs(args);
-    if (this.isRunning(preparedArgs) || await this.hasQueuedPrompts(preparedArgs)) {
+    const sessionBusy = this.isRunning(preparedArgs) || await this.hasQueuedPrompts(preparedArgs);
+    if (sessionBusy && preparedArgs.queueIfBusy === false) {
+      throw new Error('The session is busy. Retry after its active and queued runs have settled.');
+    }
+    if (sessionBusy) {
       const queued = await this.enqueuePrompt(preparedArgs);
       if (!this.isRunning(preparedArgs)) {
         await this.startNextQueuedPrompt(preparedArgs);

--- a/src/server/routes/trpc/schema.ts
+++ b/src/server/routes/trpc/schema.ts
@@ -67,6 +67,7 @@ export const sessionMessageInputSchema = z.object({
   maxSteps: z.number().int().min(1).max(500).optional(),
   searchIgnoreDirs: z.array(z.string().min(1)).optional(),
   includePlanTool: z.boolean().optional(),
+  queueIfBusy: z.boolean().optional(),
   apiKey: z.string().min(1).optional(),
   preferApiKey: z.boolean().optional(),
   systemContext: z.string().min(1).optional(),


### PR DESCRIPTION
## Summary

- add explicit UTF-8 `--prompt-file` and opt-in stdin input to `heddle ask`
- add a versioned JSONL protocol with exact run identity, ordered activity, one terminal record, and reliable process exit status
- preserve interactive queueing while rejecting busy sessions for exact-run machine supervisors
- surface trace and run-attributed changed-file evidence in terminal results, and document subprocess, SDK, remote API, and approval boundaries

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `yarn test` — 135 unit files / 840 tests; 47 integration files / 415 tests

Closes #67
