### PR TITLE
Add request-scoped MCP capabilities

### DIFF
--- a/docs/guides/programmatic/mcp-host-extensions.md
+++ b/docs/guides/programmatic/mcp-host-extensions.md
@@ -55,3 +55,49 @@ description, capability, approval setting, or public tool name.
 return generated source, HTML, JSON, or other large text outputs. Heddle scans
 the MCP result, saves large strings as artifacts, and replaces duplicated
 structured/text mirrors with the same compact artifact reference.
+
+## Short-lived capabilities for hosted products
+
+Use request-scoped preparation when a trusted product backend gives one agent
+invocation a short-lived capability for a fixed remote MCP server:
+
+```ts
+import { prepareMcpHostExtension } from '@roackb2/heddle'
+
+const prepared = await prepareMcpHostExtension({
+  mode: 'request-scoped',
+  id: 'product-capabilities',
+  serverId: 'product_backend',
+  server: {
+    transport: 'http',
+    url: 'https://product.example.com/mcp',
+    tools: {
+      allow: ['read_workspace', 'publish_finding'],
+      approval: 'never',
+    },
+  },
+  includeTools: ['read_workspace', 'publish_finding'],
+  tenantId: verifiedIdentity.tenantId,
+  signal: invocationSignal,
+  resolveRequestHeaders: async ({ operation, serverId, signal }) => ({
+    Authorization: `Bearer ${await capabilities.forMcp({ operation, serverId, signal })}`,
+  }),
+})
+
+if (!prepared.ok) {
+  throw new Error(`MCP setup failed at ${prepared.step}: ${prepared.error}`)
+}
+```
+
+Request-scoped mode supports HTTP and SSE only. The server declaration has no
+`headers` field: `resolveRequestHeaders` returns the complete header set for a
+fresh transport, separately for discovery and each tool call. Heddle does not
+write the server, catalog, callback, or returned headers to `.heddle`, and it
+does not fall back to environment variables when resolution fails.
+
+Create the callback only after the product has authenticated the caller and
+verified an immutable adopter/tenant/user/session scope. Keep that identity in
+the closure rather than tool arguments, and bind the prepared extension to one
+scope (normally one engine invocation). The remote MCP server must independently
+verify expiry, audience, scope, and allowed tools. Heddle transports the
+capability but does not interpret the product's authorization claims.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -5,13 +5,19 @@ to user-configured MCP servers for services such as Notion, Anytype, GitHub, or
 other ecosystem tools without Heddle building a bespoke integration for each
 service.
 
-MCP support is workspace-scoped and operator-controlled:
+The local MCP surface is workspace-scoped and operator-controlled:
 
 1. configure servers in `.heddle/mcp.json` or Settings -> MCP;
 2. enable the server for the workspace;
 3. refresh its cached tool catalog;
 4. let the agent call cached MCP tools through Heddle's normal tool, approval,
    and trace path.
+
+Hosted products can instead use request-scoped MCP host extensions. That path
+discovers a fixed HTTP/SSE server in memory and obtains short-lived headers from
+a host callback immediately before each connection. It does not create or read
+the workspace MCP files described below. See
+[MCP host extensions](../guides/programmatic/mcp-host-extensions.md#short-lived-capabilities-for-hosted-products).
 
 ## Config
 
@@ -102,3 +108,8 @@ server.
 
 MCP tool descriptions, resources, prompts, and outputs are external content.
 Treat them as untrusted input, especially when connecting to community servers.
+
+Do not place per-request capabilities in `.heddle/mcp.json` or environment
+variables available to an agent shell. Use request-scoped host-extension
+preparation, keep the endpoint fixed by deployment configuration, and let the
+remote MCP server verify the signed capability independently.

--- a/src/__tests__/unit/core/mcp-client-lifecycle.test.ts
+++ b/src/__tests__/unit/core/mcp-client-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { McpServerConfig } from '@/core/mcp/index.js';
 
 const mocks = vi.hoisted(() => ({
@@ -23,8 +23,8 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
 
 vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
   StdioClientTransport: class {
-    constructor() {
-      mocks.transportCreated('stdio');
+    constructor(options: unknown) {
+      mocks.transportCreated('stdio', options);
     }
 
     close = () => mocks.transportClose('stdio');
@@ -33,8 +33,8 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
 
 vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
   SSEClientTransport: class {
-    constructor() {
-      mocks.transportCreated('sse');
+    constructor(_url: URL, options: unknown) {
+      mocks.transportCreated('sse', options);
     }
 
     close = () => mocks.transportClose('sse');
@@ -43,8 +43,8 @@ vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
 
 vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
   StreamableHTTPClientTransport: class {
-    constructor() {
-      mocks.transportCreated('http');
+    constructor(_url: URL, options: unknown) {
+      mocks.transportCreated('http', options);
     }
 
     close = () => mocks.transportClose('http');
@@ -88,6 +88,10 @@ describe('MCP client lifecycle', () => {
     mocks.transportClose.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    delete process.env.REQUEST_SCOPED_FALLBACK;
+  });
+
   it.each(servers)('closes client and $transport transport after successful discovery', async (server) => {
     const signal = new AbortController().signal;
 
@@ -95,7 +99,7 @@ describe('MCP client lifecycle', () => {
       expect.objectContaining({ tools: [] }),
     );
 
-    expect(mocks.transportCreated).toHaveBeenCalledWith(server.transport);
+    expect(mocks.transportCreated).toHaveBeenCalledWith(server.transport, expect.anything());
     expect(mocks.clientConnect).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ signal }),
@@ -117,5 +121,146 @@ describe('MCP client lifecycle', () => {
 
     expect(mocks.clientClose).toHaveBeenCalledTimes(1);
     expect(mocks.transportClose).toHaveBeenCalledWith('http');
+  });
+
+  it.each(servers.slice(1))('resolves request-scoped headers for $transport discovery', async (server) => {
+    const signal = new AbortController().signal;
+    const resolveRequestHeaders = vi.fn().mockResolvedValue({
+      Authorization: 'Bearer discovery-capability',
+    });
+
+    await new McpClientService().listTools(server, signal, resolveRequestHeaders);
+
+    expect(resolveRequestHeaders).toHaveBeenCalledWith(expect.objectContaining({
+      operation: 'list_tools',
+      serverId: server.id,
+    }));
+    const providerSignal = resolveRequestHeaders.mock.calls[0]?.[0].signal as AbortSignal;
+    expect(providerSignal).toBeInstanceOf(AbortSignal);
+    expect(providerSignal.aborted).toBe(false);
+    const requestInit = (mocks.transportCreated.mock.calls[0]?.[1] as { requestInit: RequestInit }).requestInit;
+    expect(new Headers(requestInit.headers).get('authorization')).toBe('Bearer discovery-capability');
+    expect(requestInit.redirect).toBe('error');
+  });
+
+  it('resolves fresh headers for every tool-call transport', async () => {
+    const resolveRequestHeaders = vi.fn()
+      .mockResolvedValueOnce({ Authorization: 'Bearer capability-a' })
+      .mockResolvedValueOnce({ Authorization: 'Bearer capability-b' });
+    const client = new McpClientService();
+
+    await client.callTool(servers[2]!, 'read_scope', {}, undefined, resolveRequestHeaders);
+    await client.callTool(servers[2]!, 'read_scope', {}, undefined, resolveRequestHeaders);
+
+    expect(resolveRequestHeaders).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      operation: 'call_tool',
+      serverId: 'http',
+      toolName: 'read_scope',
+    }));
+    const requestInits = mocks.transportCreated.mock.calls
+      .map((call) => (call[1] as { requestInit: RequestInit }).requestInit);
+    expect(requestInits.map((requestInit) => new Headers(requestInit.headers).get('authorization')))
+      .toEqual(['Bearer capability-a', 'Bearer capability-b']);
+  });
+
+  it('keeps concurrent request-scoped providers isolated', async () => {
+    const client = new McpClientService();
+
+    await Promise.all([
+      client.callTool(
+        servers[2]!,
+        'read_scope',
+        {},
+        undefined,
+        async () => ({ Authorization: 'Bearer tenant-a' }),
+      ),
+      client.callTool(
+        servers[2]!,
+        'read_scope',
+        {},
+        undefined,
+        async () => ({ Authorization: 'Bearer tenant-b' }),
+      ),
+    ]);
+
+    const authorizations = mocks.transportCreated.mock.calls
+      .map((call) => new Headers((call[1] as { requestInit: RequestInit }).requestInit.headers).get('authorization'));
+    expect(authorizations).toEqual(expect.arrayContaining(['Bearer tenant-a', 'Bearer tenant-b']));
+    expect(authorizations).toHaveLength(2);
+  });
+
+  it('never invokes a request-header provider for stdio', async () => {
+    const resolveRequestHeaders = vi.fn().mockResolvedValue({ Authorization: 'Bearer unused' });
+
+    await new McpClientService().listTools(servers[0]!, undefined, resolveRequestHeaders);
+
+    expect(resolveRequestHeaders).not.toHaveBeenCalled();
+  });
+
+  it('redacts provider failures without falling back to configured headers', async () => {
+    const server: McpServerConfig = {
+      ...servers[2]!,
+      headers: { Authorization: '${env:REQUEST_SCOPED_FALLBACK}' },
+    };
+    process.env.REQUEST_SCOPED_FALLBACK = 'forbidden-fallback';
+    const resolveRequestHeaders = vi.fn().mockRejectedValue(new Error('secret-capability-value'));
+
+    await expect(new McpClientService().listTools(server, undefined, resolveRequestHeaders))
+      .rejects.toThrow('Request-scoped MCP operation failed: http/list_tools');
+    await expect(new McpClientService().callTool(server, 'read_scope', {}, undefined, resolveRequestHeaders))
+      .resolves.toEqual({ ok: false, error: 'Request-scoped MCP operation failed: http/call_tool' });
+
+    expect(JSON.stringify(mocks.transportCreated.mock.calls)).not.toContain('forbidden-fallback');
+  });
+
+  it('does not invoke the provider for already-cancelled work', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled by owner'));
+    const resolveRequestHeaders = vi.fn(() => new Promise<Readonly<Record<string, string>>>(() => undefined));
+
+    await expect(new McpClientService().listTools(servers[2]!, controller.signal, resolveRequestHeaders))
+      .rejects.toThrow('Request-scoped MCP operation failed: http/list_tools');
+
+    expect(resolveRequestHeaders).not.toHaveBeenCalled();
+    expect(mocks.transportCreated).not.toHaveBeenCalled();
+  });
+
+  it('cancels request-header resolution already in flight', async () => {
+    const controller = new AbortController();
+    const resolveRequestHeaders = vi.fn(() => new Promise<Readonly<Record<string, string>>>(() => undefined));
+
+    const pending = new McpClientService().listTools(servers[2]!, controller.signal, resolveRequestHeaders);
+    controller.abort(new Error('cancelled by owner'));
+
+    await expect(pending).rejects.toThrow('Request-scoped MCP operation failed: http/list_tools');
+    expect(resolveRequestHeaders).toHaveBeenCalledTimes(1);
+    expect((resolveRequestHeaders.mock.calls[0]?.[0].signal as AbortSignal).aborted).toBe(true);
+    expect(mocks.transportCreated).not.toHaveBeenCalled();
+  });
+
+  it('redacts request-scoped MCP server response bodies', async () => {
+    const reflectedCapability = 'reflected-capability-secret';
+    const resolveRequestHeaders = vi.fn().mockResolvedValue({
+      Authorization: `Bearer ${reflectedCapability}`,
+    });
+    mocks.clientListTools.mockRejectedValueOnce(new Error(`backend echoed ${reflectedCapability}`));
+
+    await expect(new McpClientService().listTools(servers[2]!, undefined, resolveRequestHeaders))
+      .rejects.toThrow('Request-scoped MCP operation failed: http/list_tools');
+
+    mocks.clientCallTool.mockRejectedValueOnce(new Error(`backend echoed ${reflectedCapability}`));
+    const result = await new McpClientService().callTool(
+      servers[2]!,
+      'read_scope',
+      {},
+      undefined,
+      resolveRequestHeaders,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Request-scoped MCP operation failed: http/call_tool',
+    });
+    expect(JSON.stringify(result)).not.toContain(reflectedCapability);
   });
 });

--- a/src/__tests__/unit/core/mcp-host-extension.test.ts
+++ b/src/__tests__/unit/core/mcp-host-extension.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +15,7 @@ import {
   prepareMcpHostExtension,
   prepareMcpHostExtensionCatalog,
 } from '@/core/chat/engine/index.js';
+import type { PrepareRequestScopedMcpHostExtensionOptions } from '@/core/chat/engine/index.js';
 import type { ToolToolkitContext } from '@/core/tools/index.js';
 
 function contextFixture(): ToolToolkitContext {
@@ -110,6 +111,18 @@ function contextFixture(): ToolToolkitContext {
 describe('defineMcpHostExtension', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('preserves legacy prepareMcpHostExtension utility-type inference', () => {
+    const legacy: Parameters<typeof prepareMcpHostExtension>[0] = {
+      id: 'legacy',
+      workspaceRoot: '/workspace',
+      stateRoot: '/workspace/.heddle',
+      serverId: 'documents',
+      server: { type: 'stdio', command: 'documents-mcp' },
+    };
+
+    expect(legacy.workspaceRoot).toBe('/workspace');
   });
 
   it('creates host tools from cached MCP descriptors without manual schema mapping', () => {
@@ -261,6 +274,7 @@ describe('defineMcpHostExtension', () => {
       resolved.server,
       'create-deck',
       { title: 'Quarterly plan' },
+      undefined,
       undefined,
     );
     expect(stateCall).not.toHaveBeenCalled();
@@ -760,6 +774,174 @@ describe('defineMcpHostExtension', () => {
     });
 
     expect(extension.toolkits?.flatMap((toolkit) => toolkit.createTools(context))).toEqual([]);
+  });
+
+  it('prepares and executes a request-scoped HTTP extension without persistent MCP state', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-request-scoped-mcp-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    mkdirSync(stateRoot, { recursive: true });
+    const context: ToolToolkitContext = {
+      workspaceRoot,
+      stateRoot,
+      artifactRoot: join(stateRoot, 'artifacts'),
+      sessionId: 'request-scoped-session',
+      model: 'gpt-5.5',
+      memoryDir: join(stateRoot, 'memory'),
+      memoryMode: 'none',
+    };
+    const capability = 'request-scoped-capability-secret';
+    const resolveRequestHeaders = vi.fn().mockResolvedValue({
+      Authorization: `Bearer ${capability}`,
+    });
+    const listTools = vi.spyOn(McpClientService.prototype, 'listTools').mockResolvedValue({
+      tools: [{
+        name: 'read_scope',
+        description: 'Read the verified adopter scope.',
+        inputSchema: { type: 'object', properties: {} },
+      }],
+    });
+    const callTool = vi.spyOn(McpClientService.prototype, 'callTool').mockResolvedValue({
+      ok: true,
+      output: { tenantId: 'tenant-a' },
+    });
+    const stateCall = vi.spyOn(McpService.prototype, 'callTool');
+
+    const prepared = await prepareMcpHostExtension({
+      mode: 'request-scoped',
+      id: 'adopter-capabilities',
+      serverId: 'adopter_backend',
+      server: {
+        transport: 'http',
+        url: 'https://adopter.example/mcp',
+        tools: { allow: ['read_scope'], approval: 'never' },
+      },
+      resolveRequestHeaders,
+      includeTools: ['read_scope'],
+      tenantId: 'tenant-a',
+    });
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) {
+      throw new Error(prepared.error);
+    }
+    expect(prepared.extension.mcp).toEqual({ hideDefaultServers: ['adopter_backend'] });
+    expect(prepared.toolNames).toEqual(['read_scope']);
+    expect(JSON.stringify(prepared)).not.toContain(capability);
+    expect(listTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'adopter_backend',
+        transport: 'http',
+        headers: {},
+      }),
+      undefined,
+      resolveRequestHeaders,
+    );
+
+    const [tool] = prepared.extension.toolkits?.flatMap((toolkit) => toolkit.createTools(context)) ?? [];
+    const result = await tool?.execute({});
+
+    expect(result).toEqual({ ok: true, output: { tenantId: 'tenant-a' } });
+    expect(callTool).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'adopter_backend', headers: {} }),
+      'read_scope',
+      {},
+      undefined,
+      resolveRequestHeaders,
+    );
+    expect(stateCall).not.toHaveBeenCalled();
+    expect(existsSync(FileMcpConfigRepository.resolvePath(stateRoot))).toBe(false);
+    expect(existsSync(FileMcpCatalogRepository.resolvePath(stateRoot))).toBe(false);
+  });
+
+  it.each([
+    {
+      name: 'static headers',
+      server: {
+        transport: 'http',
+        url: 'https://adopter.example/mcp',
+        headers: { Authorization: 'Bearer persisted-secret' },
+      },
+    },
+    {
+      name: 'non-HTTP URL',
+      server: { transport: 'http', url: 'file:///tmp/mcp' },
+    },
+    {
+      name: 'URL credentials',
+      server: { transport: 'http', url: 'https://user:secret@adopter.example/mcp' },
+    },
+    {
+      name: 'stdio transport',
+      server: { transport: 'stdio', command: 'node' },
+    },
+  ])('rejects $name in request-scoped preparation', async ({ server }) => {
+    const listTools = vi.spyOn(McpClientService.prototype, 'listTools');
+    const prepared = await prepareMcpHostExtension({
+      mode: 'request-scoped',
+      id: 'adopter-capabilities',
+      serverId: 'adopter_backend',
+      server,
+      resolveRequestHeaders: async () => ({ Authorization: 'Bearer capability' }),
+    } as unknown as PrepareRequestScopedMcpHostExtensionOptions);
+
+    expect(prepared).toEqual(expect.objectContaining({
+      ok: false,
+      serverId: 'adopter_backend',
+      step: 'validate_server',
+    }));
+    expect(listTools).not.toHaveBeenCalled();
+  });
+
+  it('rejects mixed request-scoped and workspace preparation without persistence', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-mixed-scope-mcp-'));
+    const stateRoot = join(workspaceRoot, '.heddle');
+    const saveConfig = vi.spyOn(McpService.prototype, 'saveConfigDocument');
+    const listTools = vi.spyOn(McpClientService.prototype, 'listTools');
+
+    const prepared = await prepareMcpHostExtension({
+      mode: 'request-scoped',
+      id: 'adopter-capabilities',
+      serverId: 'adopter_backend',
+      server: { transport: 'http', url: 'https://adopter.example/mcp' },
+      resolveRequestHeaders: async () => ({ Authorization: 'Bearer capability' }),
+      workspaceRoot,
+      stateRoot,
+    } as unknown as PrepareRequestScopedMcpHostExtensionOptions);
+
+    expect(prepared).toEqual({
+      ok: false,
+      serverId: 'adopter_backend',
+      step: 'validate_server',
+      error: 'Request-scoped MCP preparation cannot use workspace or state roots.',
+    });
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(listTools).not.toHaveBeenCalled();
+    expect(existsSync(stateRoot)).toBe(false);
+  });
+
+  it('stops request-scoped discovery with the owning invocation signal', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('invocation cancelled'));
+    const resolveRequestHeaders = vi.fn().mockResolvedValue({
+      Authorization: 'Bearer unused-capability',
+    });
+
+    const prepared = await prepareMcpHostExtension({
+      mode: 'request-scoped',
+      id: 'adopter-capabilities',
+      serverId: 'adopter_backend',
+      server: { transport: 'http', url: 'https://adopter.example/mcp' },
+      resolveRequestHeaders,
+      signal: controller.signal,
+    });
+
+    expect(prepared).toEqual({
+      ok: false,
+      serverId: 'adopter_backend',
+      step: 'discover_tools',
+      error: 'Request-scoped MCP operation failed: adopter_backend/list_tools',
+    });
+    expect(resolveRequestHeaders).not.toHaveBeenCalled();
   });
 
   it('reports MCP catalog preparation failures with the failing setup step', async () => {

--- a/src/core/chat/engine/index.ts
+++ b/src/core/chat/engine/index.ts
@@ -45,10 +45,15 @@ export type {
   McpHostResultArtifactRule,
   McpHostResultArtifactsOptions,
   McpHostToolOverride,
+  McpRequestHeadersProvider,
+  McpRequestHeadersProviderInput,
+  McpRequestScopedHttpServer,
   PrepareMcpHostExtensionOptions,
   PrepareMcpHostExtensionResult,
   PrepareMcpHostExtensionCatalogOptions,
   PrepareMcpHostExtensionCatalogResult,
+  PrepareRequestScopedMcpHostExtensionOptions,
+  PrepareRequestScopedMcpHostExtensionResult,
 } from './mcp-host-extension.js';
 export { EngineConversationTurnService } from './turns/service.js';
 export type { RunConversationTurnArgs, RunConversationTurnResult } from './turns/types.js';

--- a/src/core/chat/engine/mcp-host-extension/README.md
+++ b/src/core/chat/engine/mcp-host-extension/README.md
@@ -16,6 +16,24 @@ defineMcpHostExtension(...)
 Those helpers are stable entrypoints. The implementation behind them is split
 into services so future changes have one clear owner.
 
+## Request-scoped remote MCP
+
+Hosted products should use `prepareMcpHostExtension({ mode: 'request-scoped' })`
+when an adopter backend authorizes each agent invocation with a short-lived
+capability. This mode validates and discovers the HTTP/SSE server entirely in
+memory. It never writes MCP config, activation, or catalog state.
+
+The host supplies `resolveRequestHeaders`, which runs immediately before
+discovery and before every tool-call transport. The callback returns the
+complete header set: request-scoped mode never falls back to static config or
+`process.env`. Provider failures are redacted, redirects are rejected, and the
+generic state-backed MCP surface is always hidden.
+
+Bind one prepared request-scoped extension to one verified adopter scope and
+normally one engine/invocation. Identity belongs in the host's closure and in
+the backend-verified capability, never in model-visible tool arguments. Heddle
+transports the capability; it does not decide adopter authorization.
+
 ## Self-contained (stateless) extensions
 
 `prepareMcpHostExtension(...)` returns a **self-contained** extension: it embeds
@@ -67,7 +85,8 @@ model claim.
 - `McpHostExtensionService` composes the Heddle host extension shell. Keep this
   as the facade only.
 - `McpHostExtensionPreparationService` owns setup state: write MCP config,
-  activate server, refresh catalog, and return a prepared extension.
+  activate server, refresh catalog, and return a prepared extension; or perform
+  the equivalent request-scoped discovery entirely in memory.
 - `McpHostToolDefinitionService` owns converting cached MCP descriptors into
   Heddle `ToolDefinition`s: filtering, host tool names, descriptions, approval
   defaults, host-owned policy provenance, and wrapping tool execution.

--- a/src/core/chat/engine/mcp-host-extension/index.ts
+++ b/src/core/chat/engine/mcp-host-extension/index.ts
@@ -15,19 +15,29 @@ export type {
   McpHostResultArtifactRule,
   McpHostResultArtifactsOptions,
   McpHostToolOverride,
+  McpRequestScopedHttpServer,
   PrepareMcpHostExtensionCatalogOptions,
   PrepareMcpHostExtensionCatalogResult,
   PrepareMcpHostExtensionOptions,
   PrepareMcpHostExtensionResult,
+  PrepareRequestScopedMcpHostExtensionOptions,
+  PrepareRequestScopedMcpHostExtensionResult,
 } from './types.js';
+export type {
+  McpRequestHeadersProvider,
+  McpRequestHeadersProviderInput,
+} from '@/core/mcp/index.js';
 
 import { McpHostExtensionPreparationService } from './preparation-service.js';
 import { McpHostExtensionService } from './service.js';
 import type {
   PrepareMcpHostExtensionCatalogOptions,
   PrepareMcpHostExtensionCatalogResult,
+  PrepareMcpHostExtensionInput,
   PrepareMcpHostExtensionOptions,
   PrepareMcpHostExtensionResult,
+  PrepareRequestScopedMcpHostExtensionOptions,
+  PrepareRequestScopedMcpHostExtensionResult,
 } from './types.js';
 
 export const defineMcpHostExtension = McpHostExtensionService.define;
@@ -36,8 +46,14 @@ export const prepareMcpHostExtensionCatalog = (
 ): Promise<PrepareMcpHostExtensionCatalogResult> => (
   McpHostExtensionPreparationService.prepareCatalog(options)
 );
-export const prepareMcpHostExtension = (
+export function prepareMcpHostExtension(
+  options: PrepareRequestScopedMcpHostExtensionOptions,
+): Promise<PrepareRequestScopedMcpHostExtensionResult>;
+export function prepareMcpHostExtension(
   options: PrepareMcpHostExtensionOptions,
-): Promise<PrepareMcpHostExtensionResult> => (
-  McpHostExtensionPreparationService.prepare(options)
-);
+): Promise<PrepareMcpHostExtensionResult>;
+export function prepareMcpHostExtension(
+  options: PrepareMcpHostExtensionInput,
+): Promise<PrepareMcpHostExtensionResult | PrepareRequestScopedMcpHostExtensionResult> {
+  return McpHostExtensionPreparationService.prepare(options);
+}

--- a/src/core/chat/engine/mcp-host-extension/preparation-service.ts
+++ b/src/core/chat/engine/mcp-host-extension/preparation-service.ts
@@ -1,19 +1,26 @@
-import { McpService } from '@/core/mcp/index.js';
+import dayjs from 'dayjs';
+import { McpClientService, McpService } from '@/core/mcp/index.js';
+import { McpSchemas } from '@/core/mcp/schemas.js';
+import { McpServerConfigService } from '@/core/mcp/server-config-service.js';
 import { McpHostExtensionService } from './service.js';
 import { McpHostValueService } from './value-service.js';
 import type {
   PrepareMcpHostExtensionCatalogOptions,
   PrepareMcpHostExtensionCatalogResult,
+  PrepareMcpHostExtensionInput,
   PrepareMcpHostExtensionOptions,
   PrepareMcpHostExtensionResult,
+  PrepareRequestScopedMcpHostExtensionOptions,
+  PrepareRequestScopedMcpHostExtensionResult,
 } from './types.js';
 
 /**
  * Owns the setup lifecycle for MCP-backed host extensions.
  *
- * Preparation writes the MCP server config, activates the server, refreshes its
- * catalog, then returns the host extension definition. Runtime tool execution
- * stays in `McpHostToolDefinitionService`; this service only owns setup state.
+ * Workspace preparation writes config, activation, and catalog state.
+ * Request-scoped preparation validates and discovers entirely in memory, then
+ * embeds the server, catalog, and credential resolver into one extension.
+ * Runtime execution stays in `McpHostToolDefinitionService`.
  */
 export class McpHostExtensionPreparationService {
   static async prepareCatalog(
@@ -91,6 +98,14 @@ export class McpHostExtensionPreparationService {
   }
 
   static async prepare(
+    options: PrepareMcpHostExtensionInput,
+  ): Promise<PrepareMcpHostExtensionResult | PrepareRequestScopedMcpHostExtensionResult> {
+    return this.isRequestScoped(options)
+      ? await this.prepareRequestScoped(options)
+      : await this.prepareWorkspace(options);
+  }
+
+  private static async prepareWorkspace(
     options: PrepareMcpHostExtensionOptions,
   ): Promise<PrepareMcpHostExtensionResult> {
     const prepared = await McpHostExtensionPreparationService.prepareCatalog({
@@ -109,6 +124,126 @@ export class McpHostExtensionPreparationService {
           }),
         }
       : prepared;
+  }
+
+  private static async prepareRequestScoped(
+    options: PrepareRequestScopedMcpHostExtensionOptions,
+  ): Promise<PrepareRequestScopedMcpHostExtensionResult> {
+    if ('workspaceRoot' in options || 'stateRoot' in options) {
+      return this.requestScopedFailure(
+        options.serverId,
+        'validate_server',
+        'Request-scoped MCP preparation cannot use workspace or state roots.',
+      );
+    }
+
+    if ('headers' in options.server) {
+      return this.requestScopedFailure(
+        options.serverId,
+        'validate_server',
+        'Request-scoped MCP servers must resolve all headers through resolveRequestHeaders.',
+      );
+    }
+
+    let parsed: ReturnType<typeof McpSchemas.parseRawConfig>;
+    try {
+      parsed = McpSchemas.parseRawConfig({
+        mcpServers: {
+          [options.serverId]: options.server,
+        },
+      });
+    } catch (error) {
+      return this.requestScopedFailure(options.serverId, 'validate_server', error);
+    }
+
+    const normalized = McpServerConfigService.normalizeConfig(parsed, {
+      configPath: 'request-scoped:mcp',
+      workspaceRoot: '',
+    });
+    const server = normalized.servers.find((candidate) => candidate.id === options.serverId);
+    if (!server || normalized.issues.length > 0) {
+      return this.requestScopedFailure(
+        options.serverId,
+        'validate_server',
+        normalized.issues.map((issue) => issue.message).join('; ') || 'MCP server configuration is invalid.',
+      );
+    }
+
+    if (server.transport === 'stdio') {
+      return this.requestScopedFailure(
+        options.serverId,
+        'validate_server',
+        'Request-scoped MCP preparation supports only HTTP and SSE servers.',
+      );
+    }
+
+    const url = new URL(server.url);
+    if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.username || url.password) {
+      return this.requestScopedFailure(
+        options.serverId,
+        'validate_server',
+        'Request-scoped MCP server URL must use HTTP(S) without embedded credentials.',
+      );
+    }
+
+    try {
+      const discovered = await new McpClientService().listTools(
+        server,
+        options.signal,
+        options.resolveRequestHeaders,
+      );
+      const record = {
+        serverId: options.serverId,
+        protocolVersion: discovered.protocolVersion,
+        serverName: discovered.serverName,
+        serverVersion: discovered.serverVersion,
+        instructions: discovered.instructions,
+        tools: discovered.tools,
+        refreshedAt: dayjs().toISOString(),
+      };
+      const {
+        mode: _mode,
+        server: _server,
+        resolveRequestHeaders,
+        signal: _signal,
+        ...extensionOptions
+      } = options;
+
+      return {
+        ok: true,
+        serverId: options.serverId,
+        toolNames: record.tools.map((tool) => tool.name),
+        extension: McpHostExtensionService.define({
+          ...extensionOptions,
+          hideDefaultMcpTools: true,
+        }, {
+          server,
+          catalog: record,
+          requestHeaders: resolveRequestHeaders,
+        }),
+      };
+    } catch (error) {
+      return this.requestScopedFailure(options.serverId, 'discover_tools', error);
+    }
+  }
+
+  private static isRequestScoped(
+    options: PrepareMcpHostExtensionInput,
+  ): options is PrepareRequestScopedMcpHostExtensionOptions {
+    return 'mode' in options && options.mode === 'request-scoped';
+  }
+
+  private static requestScopedFailure(
+    serverId: string,
+    step: Extract<PrepareRequestScopedMcpHostExtensionResult, { ok: false }>['step'],
+    error: unknown,
+  ): Extract<PrepareRequestScopedMcpHostExtensionResult, { ok: false }> {
+    return {
+      ok: false,
+      serverId,
+      step,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 
   private static buildConfigDocumentContent(input: {

--- a/src/core/chat/engine/mcp-host-extension/tool-definition-service.ts
+++ b/src/core/chat/engine/mcp-host-extension/tool-definition-service.ts
@@ -112,6 +112,7 @@ export class McpHostToolDefinitionService {
               args.tool.name,
               callArgs,
               execution?.signal,
+              args.resolved.requestHeaders,
             )
           : await McpHostToolDefinitionService.createMcpService(args.context)
               .callTool(args.options.serverId, args.tool.name, callArgs, execution?.signal);
@@ -161,10 +162,11 @@ export class McpHostToolDefinitionService {
     toolName: string,
     args: Record<string, unknown>,
     signal?: AbortSignal,
+    requestHeaders?: ResolvedMcpHostExtensionData['requestHeaders'],
   ): Promise<McpCallToolResult> {
     if (!isToolAllowed(server, toolName)) {
       return { ok: false, error: `MCP tool is denied by Heddle config: ${server.id}/${toolName}` };
     }
-    return await new McpClientService().callTool(server, toolName, args, signal);
+    return await new McpClientService().callTool(server, toolName, args, signal, requestHeaders);
   }
 }

--- a/src/core/chat/engine/mcp-host-extension/types.ts
+++ b/src/core/chat/engine/mcp-host-extension/types.ts
@@ -1,5 +1,12 @@
 import type { ArtifactKind, RuntimeArtifact } from '@/core/artifacts/index.js';
-import type { McpRefreshResult, McpServerCatalogRecord, McpServerConfig, McpToolDescriptor } from '@/core/mcp/index.js';
+import type {
+  McpRefreshResult,
+  McpRequestHeadersProvider,
+  McpServerCatalogRecord,
+  McpServerConfig,
+  McpToolDescriptor,
+  McpToolPolicy,
+} from '@/core/mcp/index.js';
 import type { ToolPolicyEnvironment, ToolPolicyOperation, ToolToolkitContext } from '@/core/tools/index.js';
 import type {
   ConversationEngineHostArtifactOptions,
@@ -125,6 +132,30 @@ export type PrepareMcpHostExtensionOptions = DefineMcpHostExtensionOptions & {
   server: Record<string, unknown>;
 };
 
+export type McpRequestScopedHttpServer = {
+  transport: 'http' | 'streamable-http' | 'sse';
+  url: string;
+  environment?: ToolPolicyEnvironment;
+  tools?: McpToolPolicy;
+};
+
+export type PrepareRequestScopedMcpHostExtensionOptions = Omit<
+  DefineMcpHostExtensionOptions,
+  'hideDefaultMcpTools'
+> & {
+  mode: 'request-scoped';
+  server: McpRequestScopedHttpServer;
+  resolveRequestHeaders: McpRequestHeadersProvider;
+  /** Owning invocation cancellation for request-scoped catalog discovery. */
+  signal?: AbortSignal;
+  /** The raw state-backed MCP path is always hidden in request-scoped mode. */
+  hideDefaultMcpTools?: true;
+};
+
+export type PrepareMcpHostExtensionInput =
+  | PrepareMcpHostExtensionOptions
+  | PrepareRequestScopedMcpHostExtensionOptions;
+
 export type PrepareMcpHostExtensionCatalogResult =
   | {
       ok: true;
@@ -148,6 +179,20 @@ export type PrepareMcpHostExtensionResult =
     })
   | Extract<PrepareMcpHostExtensionCatalogResult, { ok: false }>;
 
+export type PrepareRequestScopedMcpHostExtensionResult =
+  | {
+      ok: true;
+      serverId: string;
+      toolNames: string[];
+      extension: ConversationEngineHostExtension;
+    }
+  | {
+      ok: false;
+      serverId: string;
+      step: 'validate_server' | 'discover_tools';
+      error: string;
+    };
+
 export type ResolvedMcpTool = {
   server: McpServerConfig;
   tool: McpToolDescriptor;
@@ -163,6 +208,7 @@ export type ResolvedMcpTool = {
 export type ResolvedMcpHostExtensionData = {
   server: McpServerConfig;
   catalog: McpServerCatalogRecord;
+  requestHeaders?: McpRequestHeadersProvider;
 };
 
 export type ResolvedResultArtifactsOptions = {

--- a/src/core/mcp/README.md
+++ b/src/core/mcp/README.md
@@ -49,6 +49,10 @@ Do not store tokens or resolved secret values in these state files. Config may
 contain env references such as `${env:NOTION_TOKEN}`; runtime connection code
 resolves those at the boundary where the SDK transport is created.
 
+Hosted, tenant-scoped credentials are a different boundary. They use
+request-scoped MCP host-extension preparation and never enter these files or
+the process environment.
+
 ## Why Cached Catalogs Exist
 
 `RuntimeToolService.createDefaultAgentTools()` and `ToolToolkit.createTools()`
@@ -95,6 +99,13 @@ work inside a synchronous toolkit.
   - forwards the owning run's abort signal to connection and request calls;
   - closes client and transport resources after each operation, on both success
     and failure.
+  - accepts an optional request-header provider for capability-bearing HTTP/SSE
+    operations, resolves it once per fresh transport, rejects redirects, and
+    redacts provider failures without falling back to configured headers.
+- `McpServerConfigService`
+  - owns deterministic server id, transport, path, and URL normalization;
+  - is shared by file repositories and in-memory request-scoped preparation so
+    the two paths cannot drift.
 - `McpPolicyContextService`
   - converts configured server identity, transport, environment, and optional
     host-verified effects into immutable tool policy context;
@@ -154,6 +165,11 @@ then closes both in `finally`. Agent-exposed MCP tools forward
 and legacy SSE work before teardown. Do not introduce a persistent client pool
 without a separate ownership, health-check, reconnect, and shutdown design.
 
+Request-scoped HTTP/SSE connections receive their complete headers from the
+embedding host immediately before transport creation. The provider sees only
+the server id, operation, optional tool name, and abort signal. It never sees
+model arguments or claimed identity. Stdio never invokes this provider.
+
 ## Slash Commands And Web UI
 
 Shared slash commands live in `src/core/commands/slash/modules/mcp/`.
@@ -187,6 +203,8 @@ Keep these invariants:
 - Local stdio servers run commands with the user's OS permissions.
 - Secret values should be resolved at connection time and redacted from
   diagnostics/logs where possible.
+- Request-scoped credentials must fail closed: no static-header or environment
+  fallback, no redirect forwarding, and no generic state-backed MCP tool path.
 
 Server-level tool policy is intentionally small:
 

--- a/src/core/mcp/client-service.ts
+++ b/src/core/mcp/client-service.ts
@@ -3,26 +3,45 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { McpCallToolResult, McpClientSessionInfo, McpServerConfig, McpToolDescriptor } from './types.js';
+import type {
+  McpCallToolResult,
+  McpClientSessionInfo,
+  McpHttpServerConfig,
+  McpRequestHeadersProviderInput,
+  McpRequestHeadersProvider,
+  McpServerConfig,
+  McpToolDescriptor,
+} from './types.js';
 
 const DEFAULT_MCP_TIMEOUT_MS = 30_000;
 
 export class McpClientService {
-  async listTools(server: McpServerConfig, signal?: AbortSignal): Promise<McpClientSessionInfo> {
-    return await this.withClient(server, async (client) => {
-      const tools = await client.listTools({}, {
-        signal,
-        timeout: DEFAULT_MCP_TIMEOUT_MS,
-      });
-      const serverVersion = client.getServerVersion();
+  async listTools(
+    server: McpServerConfig,
+    signal?: AbortSignal,
+    requestHeaders?: McpRequestHeadersProvider,
+  ): Promise<McpClientSessionInfo> {
+    try {
+      return await this.withClient(server, async (client) => {
+        const tools = await client.listTools({}, {
+          signal,
+          timeout: DEFAULT_MCP_TIMEOUT_MS,
+        });
+        const serverVersion = client.getServerVersion();
 
-      return {
-        serverName: serverVersion?.name,
-        serverVersion: serverVersion?.version,
-        instructions: client.getInstructions(),
-        tools: tools.tools.map(toToolDescriptor),
-      };
-    }, signal);
+        return {
+          serverName: serverVersion?.name,
+          serverVersion: serverVersion?.version,
+          instructions: client.getInstructions(),
+          tools: tools.tools.map(toToolDescriptor),
+        };
+      }, { operation: 'list_tools', serverId: server.id, signal }, signal, requestHeaders);
+    } catch (error) {
+      if (requestHeaders) {
+        throw requestScopedOperationError(server.id, 'list_tools');
+      }
+      throw error;
+    }
   }
 
   async callTool(
@@ -30,6 +49,7 @@ export class McpClientService {
     toolName: string,
     args: Record<string, unknown>,
     signal?: AbortSignal,
+    requestHeaders?: McpRequestHeadersProvider,
   ): Promise<McpCallToolResult> {
     try {
       return await this.withClient(server, async (client) => {
@@ -45,11 +65,13 @@ export class McpClientService {
           ok: true,
           output: normalizeToolResult(result),
         };
-      }, signal);
+      }, { operation: 'call_tool', serverId: server.id, toolName, signal }, signal, requestHeaders);
     } catch (error) {
       return {
         ok: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: requestHeaders
+          ? requestScopedOperationError(server.id, 'call_tool').message
+          : error instanceof Error ? error.message : String(error),
       };
     }
   }
@@ -57,13 +79,15 @@ export class McpClientService {
   private async withClient<T>(
     server: McpServerConfig,
     callback: (client: Client) => Promise<T>,
+    operation: McpRequestHeadersProviderInput,
     signal?: AbortSignal,
+    requestHeaders?: McpRequestHeadersProvider,
   ): Promise<T> {
     const client = new Client({
       name: 'heddle',
       version: '0.0.0',
     });
-    const transport = createTransport(server);
+    const transport = await createTransport(server, operation, requestHeaders);
 
     try {
       await client.connect(transport, {
@@ -78,7 +102,15 @@ export class McpClientService {
   }
 }
 
-function createTransport(server: McpServerConfig): Transport {
+function requestScopedOperationError(serverId: string, operation: 'list_tools' | 'call_tool'): Error {
+  return new Error(`Request-scoped MCP operation failed: ${serverId}/${operation}`);
+}
+
+async function createTransport(
+  server: McpServerConfig,
+  operation: McpRequestHeadersProviderInput,
+  requestHeaders?: McpRequestHeadersProvider,
+): Promise<Transport> {
   if (server.transport === 'stdio') {
     return new StdioClientTransport({
       command: server.command,
@@ -91,16 +123,55 @@ function createTransport(server: McpServerConfig): Transport {
 
   if (server.transport === 'sse') {
     return new SSEClientTransport(new URL(server.url), {
-      requestInit: {
-        headers: resolveEnv(server.headers),
-      },
+      requestInit: await resolveHttpRequestInit(server, operation, requestHeaders),
     });
   }
 
   return new StreamableHTTPClientTransport(new URL(server.url), {
-    requestInit: {
-      headers: resolveEnv(server.headers),
-    },
+    requestInit: await resolveHttpRequestInit(server, operation, requestHeaders),
+  });
+}
+
+async function resolveHttpRequestInit(
+  server: McpHttpServerConfig,
+  operation: McpRequestHeadersProviderInput,
+  provider?: McpRequestHeadersProvider,
+): Promise<RequestInit> {
+  if (!provider) {
+    return { headers: new Headers(resolveEnv(server.headers)) };
+  }
+
+  try {
+    const timeoutSignal = AbortSignal.timeout(DEFAULT_MCP_TIMEOUT_MS);
+    const providerSignal = operation.signal
+      ? AbortSignal.any([operation.signal, timeoutSignal])
+      : timeoutSignal;
+    providerSignal.throwIfAborted();
+    const providerOperation = { ...operation, signal: providerSignal };
+    const provided = await settleWithSignal(
+      Promise.resolve(provider(providerOperation)),
+      providerSignal,
+    );
+    return {
+      headers: new Headers(provided),
+      redirect: 'error',
+    };
+  } catch {
+    throw new Error(`MCP request headers unavailable: ${server.id}/${operation.operation}`);
+  }
+}
+
+async function settleWithSignal<T>(pending: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    throw signal.reason;
+  }
+
+  return await new Promise<T>((resolve, reject) => {
+    const rejectOnAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', rejectOnAbort, { once: true });
+    pending.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', rejectOnAbort);
+    });
   });
 }
 

--- a/src/core/mcp/index.ts
+++ b/src/core/mcp/index.ts
@@ -27,6 +27,8 @@ export type {
   McpOpenConfigResult,
   McpOverview,
   McpRefreshResult,
+  McpRequestHeadersProvider,
+  McpRequestHeadersProviderInput,
   McpServerActivationRecord,
   McpServerActivationStatus,
   McpServerCatalogRecord,

--- a/src/core/mcp/repositories.ts
+++ b/src/core/mcp/repositories.ts
@@ -1,19 +1,15 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { McpSchemas, type McpRawServerConfig } from './schemas.js';
+import { McpSchemas } from './schemas.js';
+import { McpServerConfigService } from './server-config-service.js';
 import type {
   McpActivationStore,
   McpActivationStorePort,
   McpCatalogStore,
   McpCatalogStorePort,
   McpConfigDocument,
-  McpConfigIssue,
   McpConfigLoadResult,
   McpConfigStorePort,
-  McpHttpServerConfig,
-  McpServerConfig,
-  McpServerConfigSource,
-  McpStdioServerConfig,
 } from './types.js';
 
 const CONFIG_FILE_NAME = 'mcp.json';
@@ -46,7 +42,7 @@ export class FileMcpConfigRepository implements McpConfigStorePort {
       const parsed = McpSchemas.parseRawConfig(JSON.parse(readFileSync(configPath, 'utf8')) as unknown);
       return {
         configPath,
-        ...normalizeRawConfig(parsed, {
+        ...McpServerConfigService.normalizeConfig(parsed, {
           configPath,
           workspaceRoot: this.workspaceRoot,
         }),
@@ -161,155 +157,7 @@ export class FileMcpCatalogRepository implements McpCatalogStorePort {
   }
 }
 
-function normalizeRawConfig(
-  config: ReturnType<typeof McpSchemas.parseRawConfig>,
-  options: { configPath: string; workspaceRoot: string },
-): {
-  servers: McpServerConfig[];
-  issues: McpConfigIssue[];
-} {
-  const standardServers = config.mcpServers ?? {};
-  const vscodeServers = config.servers ?? {};
-  const standard = Object.entries(standardServers).map(([id, server]) => normalizeServer(id, server, {
-    source: 'standard',
-    ...options,
-  }));
-  const vscode = Object.entries(vscodeServers)
-    .filter(([id]) => standardServers[id] === undefined)
-    .map(([id, server]) => normalizeServer(id, server, {
-      source: 'vscode',
-      ...options,
-    }));
-  const normalized = [...standard, ...vscode];
-
-  return {
-    servers: normalized.flatMap((result) => result.server ? [result.server] : []),
-    issues: normalized.flatMap((result) => result.issues),
-  };
-}
-
 function formatConfigContent(content: string): string {
   const raw = content.trim().length > 0 ? JSON.parse(content) as unknown : { mcpServers: {} };
   return `${JSON.stringify(McpSchemas.parseRawConfig(raw), null, 2)}\n`;
-}
-
-function normalizeServer(
-  id: string,
-  raw: McpRawServerConfig,
-  options: {
-    configPath: string;
-    source: McpServerConfigSource;
-    workspaceRoot: string;
-  },
-): {
-  server?: McpServerConfig;
-  issues: McpConfigIssue[];
-} {
-  const transport = normalizeTransport(raw.type ?? raw.transport, raw);
-  const path = `${options.configPath}#${id}`;
-
-  if (!isSafeIdentifier(id)) {
-    return {
-      issues: [{
-        code: 'server_invalid',
-        path,
-        message: `MCP server id must use letters, numbers, underscores, or hyphens: ${id}`,
-      }],
-    };
-  }
-
-  if (!transport) {
-    return {
-      issues: [{
-        code: 'unsupported_transport',
-        path,
-        message: 'MCP server must define a supported transport: stdio, http, streamable-http, or sse.',
-      }],
-    };
-  }
-
-  if (transport === 'stdio') {
-    if (!raw.command) {
-      return {
-        issues: [{
-          code: 'server_invalid',
-          path,
-          message: 'Stdio MCP server requires command.',
-        }],
-      };
-    }
-
-    const server: McpStdioServerConfig = {
-      id,
-      transport,
-      source: options.source,
-      command: raw.command,
-      args: raw.args ?? [],
-      cwd: raw.cwd ? resolveTemplatePath(raw.cwd, options.workspaceRoot) : undefined,
-      env: raw.env ?? {},
-      envFile: raw.envFile,
-      environment: raw.environment,
-      tools: raw.tools,
-    };
-    return { server, issues: [] };
-  }
-
-  if (!raw.url) {
-    return {
-      issues: [{
-        code: 'server_invalid',
-        path,
-        message: 'HTTP MCP server requires url.',
-      }],
-    };
-  }
-
-  try {
-    const url = new URL(raw.url);
-    const server: McpHttpServerConfig = {
-      id,
-      transport,
-      source: options.source,
-      url: url.toString(),
-      headers: raw.headers ?? {},
-      environment: raw.environment,
-      tools: raw.tools,
-    };
-    return { server, issues: [] };
-  } catch {
-    return {
-      issues: [{
-        code: 'server_invalid',
-        path,
-        message: `Invalid MCP server URL: ${raw.url}`,
-      }],
-    };
-  }
-}
-
-function normalizeTransport(
-  value: string | undefined,
-  raw: McpRawServerConfig,
-): McpServerConfig['transport'] | undefined {
-  if (!value && raw.command) {
-    return 'stdio';
-  }
-
-  if (value === 'streamable-http') {
-    return 'http';
-  }
-
-  if (value === 'stdio' || value === 'http' || value === 'sse') {
-    return value;
-  }
-
-  return undefined;
-}
-
-function resolveTemplatePath(value: string, workspaceRoot: string): string {
-  return value.replaceAll('${workspaceFolder}', workspaceRoot);
-}
-
-function isSafeIdentifier(value: string): boolean {
-  return /^[A-Za-z0-9_-]+$/.test(value);
 }

--- a/src/core/mcp/server-config-service.ts
+++ b/src/core/mcp/server-config-service.ts
@@ -1,0 +1,185 @@
+import type { McpRawServerConfig } from './schemas.js';
+import type {
+  McpConfigIssue,
+  McpHttpServerConfig,
+  McpServerConfig,
+  McpServerConfigSource,
+  McpStdioServerConfig,
+} from './types.js';
+
+export type McpServerConfigNormalizationResult = {
+  server?: McpServerConfig;
+  issues: McpConfigIssue[];
+};
+
+/**
+ * Owns normalization of standard and VS Code MCP server definitions.
+ *
+ * File-backed configuration and request-scoped hosted preparation use
+ * the same validation path so transport and policy semantics cannot drift.
+ */
+export class McpServerConfigService {
+  static normalizeConfig(
+    config: {
+      mcpServers?: Record<string, McpRawServerConfig>;
+      servers?: Record<string, McpRawServerConfig>;
+    },
+    options: { configPath: string; workspaceRoot: string },
+  ): {
+    servers: McpServerConfig[];
+    issues: McpConfigIssue[];
+  } {
+    const standardServers = config.mcpServers ?? {};
+    const vscodeServers = config.servers ?? {};
+    const standard = Object.entries(standardServers).map(([id, server]) => this.normalizeServer(id, server, {
+      source: 'standard',
+      ...options,
+    }));
+    const vscode = Object.entries(vscodeServers)
+      .filter(([id]) => standardServers[id] === undefined)
+      .map(([id, server]) => this.normalizeServer(id, server, {
+        source: 'vscode',
+        ...options,
+      }));
+    const normalized = [...standard, ...vscode];
+
+    return {
+      servers: normalized.flatMap((result) => result.server ? [result.server] : []),
+      issues: normalized.flatMap((result) => result.issues),
+    };
+  }
+
+  static normalizeServer(
+    id: string,
+    raw: McpRawServerConfig,
+    options: {
+      configPath: string;
+      source: McpServerConfigSource;
+      workspaceRoot: string;
+    },
+  ): McpServerConfigNormalizationResult {
+    const transport = this.normalizeTransport(raw.type ?? raw.transport, raw);
+    const path = `${options.configPath}#${id}`;
+
+    if (!this.isSafeIdentifier(id)) {
+      return {
+        issues: [{
+          code: 'server_invalid',
+          path,
+          message: `MCP server id must use letters, numbers, underscores, or hyphens: ${id}`,
+        }],
+      };
+    }
+
+    if (!transport) {
+      return {
+        issues: [{
+          code: 'unsupported_transport',
+          path,
+          message: 'MCP server must define a supported transport: stdio, http, streamable-http, or sse.',
+        }],
+      };
+    }
+
+    if (transport === 'stdio') {
+      return this.normalizeStdioServer({ id, raw, options, path });
+    }
+
+    return this.normalizeHttpServer({ id, raw, options, path, transport });
+  }
+
+  private static normalizeStdioServer(input: {
+    id: string;
+    raw: McpRawServerConfig;
+    options: { source: McpServerConfigSource; workspaceRoot: string };
+    path: string;
+  }): McpServerConfigNormalizationResult {
+    if (!input.raw.command) {
+      return {
+        issues: [{
+          code: 'server_invalid',
+          path: input.path,
+          message: 'Stdio MCP server requires command.',
+        }],
+      };
+    }
+
+    const server: McpStdioServerConfig = {
+      id: input.id,
+      transport: 'stdio',
+      source: input.options.source,
+      command: input.raw.command,
+      args: input.raw.args ?? [],
+      cwd: input.raw.cwd ? this.resolveTemplatePath(input.raw.cwd, input.options.workspaceRoot) : undefined,
+      env: input.raw.env ?? {},
+      envFile: input.raw.envFile,
+      environment: input.raw.environment,
+      tools: input.raw.tools,
+    };
+    return { server, issues: [] };
+  }
+
+  private static normalizeHttpServer(input: {
+    id: string;
+    raw: McpRawServerConfig;
+    options: { source: McpServerConfigSource };
+    path: string;
+    transport: 'http' | 'sse';
+  }): McpServerConfigNormalizationResult {
+    if (!input.raw.url) {
+      return {
+        issues: [{
+          code: 'server_invalid',
+          path: input.path,
+          message: 'HTTP MCP server requires url.',
+        }],
+      };
+    }
+
+    try {
+      const server: McpHttpServerConfig = {
+        id: input.id,
+        transport: input.transport,
+        source: input.options.source,
+        url: new URL(input.raw.url).toString(),
+        headers: input.raw.headers ?? {},
+        environment: input.raw.environment,
+        tools: input.raw.tools,
+      };
+      return { server, issues: [] };
+    } catch {
+      return {
+        issues: [{
+          code: 'server_invalid',
+          path: input.path,
+          message: `Invalid MCP server URL: ${input.raw.url}`,
+        }],
+      };
+    }
+  }
+
+  private static normalizeTransport(
+    value: string | undefined,
+    raw: McpRawServerConfig,
+  ): McpServerConfig['transport'] | undefined {
+    if (!value && raw.command) {
+      return 'stdio';
+    }
+
+    if (value === 'streamable-http') {
+      return 'http';
+    }
+
+    return value === 'stdio' || value === 'http' || value === 'sse'
+      ? value
+      : undefined;
+  }
+
+  private static resolveTemplatePath(value: string, workspaceRoot: string): string {
+    return value.replaceAll('${workspaceFolder}', workspaceRoot);
+  }
+
+  private static isSafeIdentifier(value: string): boolean {
+    return /^[A-Za-z0-9_-]+$/.test(value);
+  }
+}

--- a/src/core/mcp/types.ts
+++ b/src/core/mcp/types.ts
@@ -37,6 +37,27 @@ export type McpHttpServerConfig = {
 
 export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig;
 
+export type McpRequestHeadersProviderInput =
+  | {
+      operation: 'list_tools';
+      serverId: string;
+      signal?: AbortSignal;
+    }
+  | {
+      operation: 'call_tool';
+      serverId: string;
+      toolName: string;
+      signal?: AbortSignal;
+    };
+
+/**
+ * Supplies host-owned HTTP headers immediately before an MCP client connection.
+ * Returned values stay in memory and are never added to MCP configuration.
+ */
+export type McpRequestHeadersProvider = (
+  input: McpRequestHeadersProviderInput,
+) => Readonly<Record<string, string>> | Promise<Readonly<Record<string, string>>>;
+
 export type McpConfigIssueCode =
   | 'config_missing'
   | 'config_invalid'

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,10 +113,15 @@ export type {
   McpHostResultArtifactRule,
   McpHostResultArtifactsOptions,
   McpHostToolOverride,
+  McpRequestHeadersProvider,
+  McpRequestHeadersProviderInput,
+  McpRequestScopedHttpServer,
   PrepareMcpHostExtensionOptions,
   PrepareMcpHostExtensionResult,
   PrepareMcpHostExtensionCatalogOptions,
   PrepareMcpHostExtensionCatalogResult,
+  PrepareRequestScopedMcpHostExtensionOptions,
+  PrepareRequestScopedMcpHostExtensionResult,
 } from './core/chat/engine/mcp-host-extension.js';
 export { defineHostExtension, ConversationEngineHostExtensionService } from './core/chat/engine/host-extension.js';
 export type {


### PR DESCRIPTION
## Summary

- add an in-memory request-scoped MCP host-extension mode for fixed HTTP/SSE servers
- resolve complete credential headers separately for discovery and every tool call
- fail closed on cancellation, mixed workspace state, redirects, provider failures, and remote response errors
- preserve the existing workspace-backed API and TypeScript utility-type inference
- share deterministic MCP server normalization and document the hosted security boundary

## Security boundary

Request-scoped preparation accepts no static headers, writes no MCP config/activation/catalog state, never falls back to process environment credentials, and always hides the raw state-backed MCP path. The adopter backend remains responsible for authenticating and authorizing its signed capability.

## Verification

- yarn typecheck
- yarn lint
- yarn test:unit: 135 files, 857 tests
- yarn test:integration: 47 files, 415 tests
- yarn build

No AWS resources or paid services were used.