### PR TITLE
Block request-scoped MCP redirects

### DIFF
--- a/src/__tests__/unit/core/mcp-client-lifecycle.test.ts
+++ b/src/__tests__/unit/core/mcp-client-lifecycle.test.ts
@@ -90,6 +90,7 @@ describe('MCP client lifecycle', () => {
 
   afterEach(() => {
     delete process.env.REQUEST_SCOPED_FALLBACK;
+    vi.unstubAllGlobals();
   });
 
   it.each(servers)('closes client and $transport transport after successful discovery', async (server) => {
@@ -141,6 +142,32 @@ describe('MCP client lifecycle', () => {
     const requestInit = (mocks.transportCreated.mock.calls[0]?.[1] as { requestInit: RequestInit }).requestInit;
     expect(new Headers(requestInit.headers).get('authorization')).toBe('Bearer discovery-capability');
     expect(requestInit.redirect).toBe('error');
+  });
+
+  it.each(servers.slice(1))('rejects redirects through every $transport fetch path', async (server) => {
+    const fetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetch);
+
+    await new McpClientService().listTools(
+      server,
+      undefined,
+      async () => ({ Authorization: 'Bearer request-capability' }),
+    );
+
+    const transportOptions = mocks.transportCreated.mock.calls[0]?.[1] as {
+      fetch?: (url: string | URL, init?: RequestInit) => Promise<Response>;
+    };
+    expect(transportOptions.fetch).toEqual(expect.any(Function));
+
+    await transportOptions.fetch?.('https://redirect.example.com/mcp', {
+      method: 'GET',
+      redirect: 'follow',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://redirect.example.com/mcp',
+      expect.objectContaining({ method: 'GET', redirect: 'error' }),
+    );
   });
 
   it('resolves fresh headers for every tool-call transport', async () => {

--- a/src/core/mcp/client-service.ts
+++ b/src/core/mcp/client-service.ts
@@ -2,7 +2,10 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type {
+  FetchLike,
+  Transport,
+} from '@modelcontextprotocol/sdk/shared/transport.js';
 import type {
   McpCallToolResult,
   McpClientSessionInfo,
@@ -124,13 +127,22 @@ async function createTransport(
   if (server.transport === 'sse') {
     return new SSEClientTransport(new URL(server.url), {
       requestInit: await resolveHttpRequestInit(server, operation, requestHeaders),
+      fetch: requestHeaders ? rejectRedirectsFetch : undefined,
     });
   }
 
   return new StreamableHTTPClientTransport(new URL(server.url), {
     requestInit: await resolveHttpRequestInit(server, operation, requestHeaders),
+    fetch: requestHeaders ? rejectRedirectsFetch : undefined,
   });
 }
+
+// The MCP SDK does not apply requestInit to every SSE GET, so enforce the
+// capability boundary at the fetch function shared by every HTTP method.
+const rejectRedirectsFetch: FetchLike = (url, init) => fetch(url, {
+  ...init,
+  redirect: 'error',
+});
 
 async function resolveHttpRequestInit(
   server: McpHttpServerConfig,


### PR DESCRIPTION
## Summary

- install a no-redirect fetch boundary for request-scoped Streamable HTTP and legacy SSE MCP transports
- enforce `redirect: "error"` for every SDK HTTP method, including SSE GET and reconnect paths that do not inherit `requestInit`
- keep workspace-backed MCP transport behavior unchanged
- cover both authenticated transport variants with regression tests

## Why

The MCP SDK does not apply `requestInit` to every GET/SSE path. Relying on `requestInit.redirect` alone could therefore forward a short-lived request-scoped capability to a redirect target. The custom fetch hook is used by every SDK request and overrides any caller or SDK redirect policy fail-closed.

## Verification

- `yarn install --frozen-lockfile` (including production build)
- `yarn typecheck`
- `yarn lint`
- focused MCP lifecycle suite: 15/15
- unit suite: 135 files, 859/859 tests
- integration suite: 47 files, 415/415 tests
- `git diff --check`
