### PR TITLE
Prepare Heddle v5.10.0 release

### DIFF
--- a/docs/releases/v5.10.0.md
+++ b/docs/releases/v5.10.0.md
@@ -1,0 +1,101 @@
+# Heddle v5.10.0
+
+Heddle v5.10 strengthens the boundary between Heddle and the products that
+host it. Hosted runtimes can attach short-lived MCP capabilities without
+persisting credentials, supervisors can drive one-shot CLI work through a
+versioned JSON Lines protocol, and remote heartbeat adapters can reuse Heddle's
+task administration policy instead of duplicating lifecycle rules. Conversation
+runs also recover more reliably when a provider rejects an oversized context.
+
+## Request-scoped MCP capabilities
+
+- **Hosted products can prepare MCP tools entirely in memory.**
+  `prepareMcpHostExtension({ mode: 'request-scoped', ... })` discovers a fixed
+  HTTP or SSE server and returns a normal host extension without writing the
+  server, catalog, callback, or resolved headers under `.heddle`.
+- **Credentials are resolved for each operation.** The host-provided
+  `resolveRequestHeaders` callback supplies the complete header set separately
+  for tool discovery and every tool call, allowing short-lived capability
+  rotation without environment variables or persisted static headers.
+- **The boundary fails closed.** Request-scoped preparation hides Heddle's raw
+  state-backed MCP path, rejects mixed workspace/request configuration, URL
+  credentials, and redirects, and never falls back to ambient configuration.
+  Provider and capability-bearing transport failures are normalized so remote
+  response bodies cannot expose credentials through tool results or logs.
+- **Cancellation follows the owning invocation.** Preparation accepts an
+  `AbortSignal`; pre-aborted work does not resolve credentials, and discovery
+  and tool calls propagate cancellation through their fresh transports.
+
+Heddle transports these headers but does not interpret a product's identity or
+authorization claims. The host must authenticate the caller, bind one prepared
+extension to one immutable scope, and have the remote MCP server independently
+verify audience, expiry, scope, and allowed tools.
+
+## Scriptable one-shot execution
+
+- **`heddle ask` accepts explicit prompt files and stdin.** Use
+  `--prompt-file <path>` or `--prompt-file -`; Heddle never consumes stdin only
+  because a pipe happens to be open.
+- **`--output jsonl` provides a versioned supervisor protocol.** Stdout contains
+  only `schemaVersion: 1` JSON records, diagnostics stay on stderr, activity
+  records retain their shared sequence numbers, and every invocation emits
+  exactly one terminal record.
+- **Process outcomes are truthful.** Exit status is zero only for a terminal
+  `done` result. Busy sessions, cancellation, stream failure, provider failure,
+  and rejected input remain nonzero, and machine submissions do not enter an
+  interactive session queue.
+- **Changed-file reporting remains evidence-based.** Terminal results include
+  trace-backed changed paths when available without claiming that every dirty
+  workspace file came from the run.
+
+## Provider-neutral heartbeat administration
+
+- **Remote stores can implement one high-level control contract.**
+  `HeartbeatTaskAdministrationService` covers task creation, configuration,
+  enable/disable, resume, deletion, reconciliation, and operator-facing reads.
+- **Framework lifecycle policy is reusable.** `HeartbeatTaskControlPolicy`,
+  `HeartbeatTaskStateProjector`, and `HeartbeatTaskViewProjector` are public so
+  a relational adapter can apply Heddle-owned transitions to its latest locked
+  row inside the same transaction that persists the result.
+- **Storage ownership stays explicit.** The policy owns no transaction, lease,
+  tenant authorization, or notification mechanism; hosts retain those
+  responsibilities and should not emulate administration with a non-atomic
+  load-then-save sequence.
+
+## Context-window recovery
+
+- When a provider confirms that a model request exceeded its context window,
+  Heddle force-compacts the rejected transcript under the active session lease
+  and retries that same model request once with the archive-backed replacement.
+- Tool effects completed before the rejection remain in the transcript and are
+  never replayed. Provider usage remains authoritative after a successful
+  request; local token estimates are still only an earlier optimization.
+
+## Upgrade notes
+
+- Install `@roackb2/heddle@5.10.0`.
+  `@roackb2/heddle-remote@5.10.0` releases in lockstep.
+- The changes are additive and require no persisted-data migration.
+- Existing workspace-backed MCP preparation remains supported. Request-scoped
+  mode is intentionally HTTP/SSE-only and does not accept static headers.
+- `ModelRunFailureCode` and the `model.retry` reason union now include
+  `context_window`. TypeScript consumers with exhaustive failure or trace-event
+  handling must add that case when upgrading.
+- The JSON Lines contract is versioned independently through
+  `schemaVersion: 1`; supervisors should reject unknown versions and keep
+  reading until the single terminal record.
+
+## Verification
+
+- `yarn build`
+- `yarn test`
+- `npm pack --dry-run --cache /tmp/heddle-npm-cache`
+- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`
+
+## Release state
+
+- Package versions are `5.10.0` in both manifests.
+- The latest published npm version before this release is `5.9.0` for both
+  packages.
+- GitHub's latest tag and release before this release are `v5.9.0`.
+- The canonical release context is `v5.9.0..HEAD`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "An open-source AI coding agent runtime and terminal CLI for real repositories, with persistent memory, sessions, approvals, heartbeat, and a browser control plane",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/packages/heddle-remote/package.json
+++ b/packages/heddle-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle-remote",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "Browser-safe protocol and run-consumer services for remotely hosted Heddle conversations",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `@roackb2/heddle` and `@roackb2/heddle-remote` in lockstep to 5.10.0
- add curated release notes grounded in the complete `v5.9.0..HEAD` range
- document request-scoped MCP capabilities, scriptable `heddle ask` JSONL, provider-neutral heartbeat administration, and context-window recovery
- call out the new `context_window` exhaustive-union case for TypeScript consumers

## Release base

PR #331 is merged. This branch is rebased onto merge commit `19bf4bee`, so the
PR diff against `main` contains only the three release-preparation files.

## Verification on the exact stacked candidate

- `yarn build`
- `yarn test` — 135 unit files / 859 tests and 47 integration files / 415 tests
- `npm pack --dry-run --silent --cache /tmp/heddle-npm-cache`
- `npm pack ./packages/heddle-remote --dry-run --silent --cache /tmp/heddle-npm-cache`
- `git diff --check`

## Release execution after merge

- create annotated tag `v5.10.0` on the merged release commit
- push and create the GitHub release from `docs/releases/v5.10.0.md`
- publish `@roackb2/heddle-remote@5.10.0`, then `@roackb2/heddle@5.10.0`
- verify both with fresh `npm view` results
