### PR TITLE
Add reusable local Execution Host contract fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ that already owns the mechanics your host needs:
 | Conventional Node HTTP/SSE | `@roackb2/heddle/hosted/http-sse` | Replay cursor parsing, SSE framing, backpressure, and disconnect cleanup |
 | A remote browser or client | `@roackb2/heddle-remote` | Browser-safe protocol validation and transport-neutral run consumption |
 | Conventional browser REST/SSE | `@roackb2/heddle-remote/http-sse` | Authenticated fetch, incremental SSE parsing, and transport validation |
-| A backend invoking a separate Execution Host | `@roackb2/heddle-adopter` | v1 contracts, ES256 authority/JWKS, product-MCP verification, and an `ExecutionHost` client port |
+| A backend invoking a separate Execution Host | `@roackb2/heddle-adopter` | v1 contracts, ES256 authority/JWKS, product-MCP verification, an `ExecutionHost` client port, and a local contract fixture |
 | Lower-level runtime assembly | `@roackb2/heddle/advanced` | Model adapters, individual tools, trace, memory, heartbeat, and core runtime services |
 
 Existing tRPC, Fastify, Hono, Nest, WebSocket, IPC, queue, React, or other stacks

--- a/docs/guides/programmatic/execution-host-adopters.md
+++ b/docs/guides/programmatic/execution-host-adopters.md
@@ -62,7 +62,9 @@ Its subpaths separate responsibility:
 - `/mcp` independently verifies product-MCP capabilities against a fixed
   deployment and supported-tool set;
 - `/http-sse` provides the provider-neutral `ExecutionHost` port and strict
-  direct-development transport.
+  direct-development transport;
+- `/testing` provides a Node-only loopback v1 fixture for local product/MCP
+  integration tests without a model or AWS.
 
 See the [package README](../../../packages/heddle-adopter/README.md) for
 copyable code.
@@ -106,6 +108,21 @@ the AWS SDK and SigV4 while preserving the same v1 body, forwarded custom
 headers, ordered stream semantics, and no-ambiguous-retry rule. Keeping that
 adapter separate prevents AWS types from leaking into the product application
 service.
+
+## Local contract verification
+
+`LocalExecutionHostContractFixture` exercises the real v1 request and SSE
+parsers while delegating execution to an adopter callback. Use that callback to
+call the product's real local MCP endpoint, then return a deterministic result,
+cancellation, error, or intentionally interrupted stream. The fixture owns a
+hidden local token and aborts active callbacks during client or fixture
+shutdown.
+
+This test proves request/header placement, product callback reachability,
+ordered streaming, terminal handling, and ambiguous-EOF behavior. It does not
+prove Heddle execution, JWT verification inside the real host, shell or
+filesystem behavior, tenant isolation, or AgentCore. Keep at least one real
+Execution Host integration test for those properties.
 
 ## Language-neutral contract
 

--- a/packages/heddle-adopter/README.md
+++ b/packages/heddle-adopter/README.md
@@ -21,6 +21,7 @@ Terraform, MCP server, or product logic. It depends only on `jose`, `zod`, and
 | `@roackb2/heddle-adopter/authority` | ES256 execution assertion and optional MCP capability issuance plus public JWKS projection |
 | `@roackb2/heddle-adopter/mcp` | Independent capability verification at the adopter's MCP edge |
 | `@roackb2/heddle-adopter/http-sse` | Transport-neutral `ExecutionHost` port and strict direct-development HTTP/SSE client |
+| `@roackb2/heddle-adopter/testing` | Node-only loopback v1 fixture for local product/MCP integration tests |
 
 The adopter still owns:
 
@@ -138,6 +139,38 @@ for await (const event of host.streamConversationTurn({
 The client refuses redirects, bounds parser and error bodies, validates ordered
 SSE identity, streams accepted/activity events incrementally, and withholds the
 terminal event until clean EOF. It never retries an ambiguous invocation.
+
+## Verify an adopter integration locally
+
+The explicit `testing` subpath provides a real loopback implementation of the
+v1 request/SSE boundary. Its callback can call the adopter's real local MCP
+server, while the fixture supplies deterministic success, cancellation,
+failure, and interrupted-EOF behavior without invoking a model or AWS.
+
+```ts
+import {
+  LocalExecutionHostContractFixture,
+} from '@roackb2/heddle-adopter/testing'
+
+const fixture = await LocalExecutionHostContractFixture.start({
+  execute: async (invocation) => {
+    await callProductMcp(invocation.mcpCapability(), invocation.signal)
+    return { kind: 'result', result: { outcome: 'done' } }
+  },
+})
+
+try {
+  const host = fixture.createExecutionHost()
+  await consume(host.streamConversationTurn(input))
+} finally {
+  await fixture.close()
+}
+```
+
+This proves the adopter-facing wire and product callback, not the Heddle loop,
+real-host JWT verification, shell/filesystem behavior, tenant isolation, or
+managed AgentCore behavior. See the [testing boundary](src/testing/README.md)
+for the exact evidence limit.
 
 ## Language-neutral posture
 

--- a/packages/heddle-adopter/package.json
+++ b/packages/heddle-adopter/package.json
@@ -44,6 +44,10 @@
       "types": "./dist/http-sse/index.d.ts",
       "import": "./dist/http-sse/index.js"
     },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/heddle-adopter/src/README.md
+++ b/packages/heddle-adopter/src/README.md
@@ -1,7 +1,7 @@
 # Heddle adopter SDK source
 
 This package is a backend-side reference implementation for products which
-invoke a separately deployed Heddle Execution Host. Its four modules are kept
+invoke a separately deployed Heddle Execution Host. Its modules are kept
 independent so an adopter can use only the machinery it needs:
 
 - `contracts`: language-neutral v1 claim and wire semantics, expressed as
@@ -11,7 +11,9 @@ independent so an adopter can use only the machinery it needs:
 - `mcp`: independent product-edge capability verification against a fixed
   deployment and supported-tool set;
 - `http-sse`: a strict direct-development client behind a transport-neutral
-  `ExecutionHost` port.
+  `ExecutionHost` port;
+- `testing`: a Node-only loopback v1 contract fixture for adopter integration
+  tests. It is intentionally available only through its explicit subpath.
 
 The package must never import the Heddle runtime, Execution Host internals, AWS
 SDK, MCP server SDK, a database adapter, or product domain code. New reusable

--- a/packages/heddle-adopter/src/__tests__/local-execution-host-fixture.test.ts
+++ b/packages/heddle-adopter/src/__tests__/local-execution-host-fixture.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DirectHttpExecutionHost,
+  ExecutionHostInvocationCancelledError,
+  ExecutionHostRejectedError,
+  ExecutionHostStreamInterruptedError,
+  type ExecutionHostConversationTurn,
+} from '../http-sse/index.js';
+import { LocalExecutionHostContractFixture } from '../testing/index.js';
+import type { ExecutionHostStreamEvent } from '../contracts/index.js';
+
+const fixtures = new Set<LocalExecutionHostContractFixture>();
+const TIMESTAMP = new Date('2026-08-10T12:00:00.000Z');
+
+afterEach(async () => {
+  await Promise.all([...fixtures].map((fixture) => fixture.close()));
+  fixtures.clear();
+});
+
+describe('local Execution Host contract fixture', () => {
+  it('runs an adopter callback through the real request and SSE clients', async () => {
+    const execute = vi.fn(async (invocation) => {
+      expect(invocation.request).toEqual({
+        schemaVersion: 1,
+        kind: 'conversation-turn',
+        invocationId: 'invocation-001',
+        prompt: 'Read product state through MCP.',
+      });
+      expect(invocation.runtimeSessionId).toBe(runtimeSessionId());
+      expect(invocation.mcpCapability()).toBe(mcpCapability());
+      expect(JSON.parse(JSON.stringify(invocation))).toEqual({
+        schemaVersion: 1,
+        kind: 'conversation-turn',
+        invocationId: 'invocation-001',
+        runtimeSessionId: runtimeSessionId(),
+      });
+      expect(JSON.stringify(invocation)).not.toContain('product state');
+      expect(JSON.stringify(invocation)).not.toContain(mcpCapability());
+      await invocation.publishActivity({
+        type: 'product_mcp_call_completed',
+      });
+      return {
+        kind: 'result' as const,
+        result: { outcome: 'done' as const, summary: 'complete' },
+      };
+    });
+    const fixture = await startFixture(execute);
+
+    const events = await collect(
+      fixture.createExecutionHost().streamConversationTurn(input()),
+    );
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(events.map((event) => event.kind)).toEqual([
+      'accepted',
+      'activity',
+      'result',
+    ]);
+    expect(events.map((event) => event.sequence)).toEqual([0, 1, 2]);
+    expect(new Set(events.map((event) => event.runId))).toEqual(
+      new Set(['run-001']),
+    );
+  });
+
+  it('streams accepted before the adopter callback settles', async () => {
+    let settle!: () => void;
+    const fixture = await startFixture(async () => {
+      await new Promise<void>((resolve) => { settle = resolve; });
+      return { kind: 'result', result: { outcome: 'done' } };
+    });
+    const iterator = fixture.createExecutionHost()
+      .streamConversationTurn(input())[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'accepted', sequence: 0 },
+    });
+    settle();
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'result', sequence: 1 },
+    });
+  });
+
+  it('supports an intentional ambiguous EOF recovery case', async () => {
+    const fixture = await startFixture(async (invocation) => {
+      await invocation.publishActivity({ type: 'checkpointed' });
+      return { kind: 'interrupted' };
+    });
+    const observed: ExecutionHostStreamEvent[] = [];
+
+    await expect(async () => {
+      for await (const event of fixture.createExecutionHost()
+        .streamConversationTurn(input())) {
+        observed.push(event);
+      }
+    }).rejects.toBeInstanceOf(ExecutionHostStreamInterruptedError);
+    expect(observed.map((event) => event.kind)).toEqual([
+      'accepted',
+      'activity',
+    ]);
+  });
+
+  it('supports an invocation without product MCP authority', async () => {
+    const fixture = await startFixture((invocation) => {
+      expect(invocation.mcpCapability()).toBeUndefined();
+      return { kind: 'result', result: { outcome: 'done' } };
+    });
+
+    const events = await collect(
+      fixture.createExecutionHost().streamConversationTurn(input({
+        mcpCapability: undefined,
+      })),
+    );
+
+    expect(events.map((event) => event.kind)).toEqual(['accepted', 'result']);
+  });
+
+  it('sanitizes executor failures instead of reflecting their messages', async () => {
+    const secret = 'secret-from-product-mcp';
+    const fixture = await startFixture(() => {
+      throw new Error(secret);
+    });
+
+    const events = await collect(
+      fixture.createExecutionHost().streamConversationTurn(input()),
+    );
+
+    expect(events.at(-1)).toMatchObject({
+      kind: 'error',
+      error: {
+        code: 'fixture_execution_failed',
+        message: 'Local fixture execution failed.',
+      },
+    });
+    expect(JSON.stringify(events)).not.toContain(secret);
+  });
+
+  it('rejects a client which does not possess the hidden local token', async () => {
+    const execute = vi.fn();
+    const fixture = await startFixture(execute);
+    const unpairedClient = new DirectHttpExecutionHost({
+      baseUrl: fixture.baseUrl(),
+      localToken: 'incorrect-local-token',
+    });
+
+    await expect(collect(unpairedClient.streamConversationTurn(input())))
+      .rejects.toEqual(new ExecutionHostRejectedError(
+        401,
+        'invalid_local_token',
+      ));
+    expect(execute).not.toHaveBeenCalled();
+    expect(JSON.stringify(fixture)).toBe('{}');
+  });
+
+  it('propagates caller cancellation into the adopter callback', async () => {
+    let callbackAborted = false;
+    const entered = deferred();
+    const fixture = await startFixture(async (invocation) => {
+      entered.resolve();
+      await new Promise<void>((resolve) => {
+        invocation.signal.addEventListener('abort', () => {
+          callbackAborted = true;
+          resolve();
+        }, { once: true });
+      });
+      return { kind: 'interrupted' };
+    });
+    const controller = new AbortController();
+    const running = collect(fixture.createExecutionHost().streamConversationTurn(
+      input({ signal: controller.signal }),
+    ));
+    await entered.promise;
+
+    controller.abort();
+
+    await expect(running).rejects.toBeInstanceOf(
+      ExecutionHostInvocationCancelledError,
+    );
+    await vi.waitFor(() => expect(callbackAborted).toBe(true));
+  });
+
+  it('aborts active callbacks when the fixture closes', async () => {
+    const entered = deferred();
+    let callbackAborted = false;
+    const fixture = await startFixture(async (invocation) => {
+      entered.resolve();
+      await new Promise<void>((resolve) => {
+        invocation.signal.addEventListener('abort', () => {
+          callbackAborted = true;
+          resolve();
+        }, { once: true });
+      });
+      return { kind: 'interrupted' };
+    });
+    const running = collect(
+      fixture.createExecutionHost().streamConversationTurn(input()),
+    );
+    await entered.promise;
+
+    await fixture.close();
+
+    await expect(running).rejects.toBeInstanceOf(
+      ExecutionHostStreamInterruptedError,
+    );
+    expect(callbackAborted).toBe(true);
+  });
+
+  it('validates explicit cancelled and error terminals', async () => {
+    const cancelled = await startFixture(() => ({
+      kind: 'cancelled',
+      reason: 'product_cancelled',
+    }));
+    const cancelledEvents = await collect(
+      cancelled.createExecutionHost().streamConversationTurn(input()),
+    );
+    expect(cancelledEvents.at(-1)).toMatchObject({
+      kind: 'cancelled',
+      reason: 'product_cancelled',
+    });
+
+    const rejected = await startFixture(() => ({
+      kind: 'error',
+      error: { code: 'product_unavailable', message: 'Try later.' },
+    }));
+    const errorEvents = await collect(
+      rejected.createExecutionHost().streamConversationTurn(input()),
+    );
+    expect(errorEvents.at(-1)).toMatchObject({
+      kind: 'error',
+      error: { code: 'product_unavailable', message: 'Try later.' },
+    });
+  });
+});
+
+async function startFixture(
+  execute: Parameters<
+    typeof LocalExecutionHostContractFixture.start
+  >[0]['execute'],
+): Promise<LocalExecutionHostContractFixture> {
+  const fixture = await LocalExecutionHostContractFixture.start({
+    execute,
+    now: () => new Date(TIMESTAMP),
+    createRunId: () => 'run-001',
+  });
+  fixtures.add(fixture);
+  return fixture;
+}
+
+function input(
+  overrides: Partial<ExecutionHostConversationTurn> = {},
+): ExecutionHostConversationTurn {
+  return {
+    invocationId: 'invocation-001',
+    runtimeSessionId: runtimeSessionId(),
+    prompt: 'Read product state through MCP.',
+    executionAssertion: executionAssertion(),
+    mcpCapability: mcpCapability(),
+    modelApiKey: 'model-api-key',
+    ...overrides,
+  };
+}
+
+function executionAssertion(): string {
+  return 'execution-assertion'.padEnd(32, 'x');
+}
+
+function mcpCapability(): string {
+  return 'mcp-capability'.padEnd(32, 'x');
+}
+
+function runtimeSessionId(): string {
+  return 'runtime-session-'.padEnd(33, 's');
+}
+
+async function collect(
+  stream: AsyncIterable<ExecutionHostStreamEvent>,
+): Promise<ExecutionHostStreamEvent[]> {
+  const events: ExecutionHostStreamEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/packages/heddle-adopter/src/testing/README.md
+++ b/packages/heddle-adopter/src/testing/README.md
@@ -1,0 +1,69 @@
+# Local Execution Host contract fixture
+
+This test-only Node.js boundary lets an adopter exercise its integration
+through the real v1 HTTP/SSE contract without running a model, Heddle, Docker,
+or AWS. Import it explicitly from `@roackb2/heddle-adopter/testing`; it is not
+re-exported from the package root.
+
+The fixture owns:
+
+- a loopback-only HTTP server and a hidden, randomly generated local token;
+- strict request/header validation and sensitive-header redaction;
+- ordered `accepted`, `activity`, and terminal SSE events;
+- request, connection, and fixture-shutdown cancellation;
+- a callback that can call the adopter's real local MCP server or product API;
+- explicit interrupted EOF for recovery-path tests.
+
+The fixture does **not** run Heddle or prove model behavior, shell/filesystem
+capability, JWT verification inside the real Execution Host, container or
+microVM tenant isolation, AgentCore routing, or managed-runtime recovery.
+Those require the real host at the corresponding evidence boundary.
+
+## Code ownership
+
+- `types.ts` is the only public fixture contract.
+- `local-execution-host-contract-fixture.ts` owns server and invocation
+  lifecycle orchestration.
+- `request.ts` owns HTTP validation, body bounds, local authentication, and
+  early sensitive-header redaction.
+- `invocation.ts` owns non-enumerable request credential access.
+- `event-stream.ts` owns ordered SSE envelopes, validation, and backpressure.
+
+Keep adopter product policy, MCP tool implementations, and real-host behavior
+out of this directory. Add another fixture only when it proves a distinct
+public contract rather than one product's scenario.
+
+```ts
+import {
+  LocalExecutionHostContractFixture,
+} from '@roackb2/heddle-adopter/testing'
+
+const fixture = await LocalExecutionHostContractFixture.start({
+  execute: async (invocation) => {
+    // This callback may invoke the adopter's real MCP endpoint with the opaque
+    // capability. Identity must still be verified independently by that MCP.
+    await callProductMcp(invocation.mcpCapability(), invocation.signal)
+    await invocation.publishActivity({ type: 'product_state_read' })
+    return {
+      kind: 'result',
+      result: { outcome: 'done', summary: 'Local contract path completed.' },
+    }
+  },
+})
+
+try {
+  const host = fixture.createExecutionHost()
+  for await (const event of host.streamConversationTurn(input)) {
+    observe(event)
+  }
+} finally {
+  await fixture.close()
+}
+```
+
+The model key and execution assertion are validated and discarded before the
+callback. The product MCP capability is available only through an explicit
+accessor. `JSON.stringify(invocation)` returns data-minimized,
+credential-free metadata and never includes the prompt or capability. Those
+identifiers can still be product data and remain subject to normal logging
+policy.

--- a/packages/heddle-adopter/src/testing/event-stream.ts
+++ b/packages/heddle-adopter/src/testing/event-stream.ts
@@ -1,0 +1,116 @@
+import { once } from 'node:events';
+import type { ServerResponse } from 'node:http';
+import { z } from 'zod';
+import {
+  EXECUTION_CONTRACT_VERSION,
+  ExecutionHostStreamEventSchema,
+  OpaqueIdSchema,
+  RuntimePublicResultSchema,
+} from '../contracts/index.js';
+import type { LocalExecutionHostTerminal } from './types.js';
+
+const ErrorCodeSchema = z.string().min(1).max(128).regex(/^[a-z0-9_]+$/);
+const TerminalSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('result'),
+    result: RuntimePublicResultSchema,
+  }).strict(),
+  z.object({
+    kind: z.literal('cancelled'),
+    reason: z.string().min(1).max(1_600),
+  }).strict(),
+  z.object({
+    kind: z.literal('error'),
+    error: z.object({
+      code: ErrorCodeSchema,
+      message: z.string().min(1).max(1_600),
+    }).strict(),
+  }).strict(),
+  z.object({ kind: z.literal('interrupted') }).strict(),
+]);
+
+type EventBody =
+  | { kind: 'accepted' }
+  | { kind: 'activity'; activity: unknown }
+  | Exclude<LocalExecutionHostTerminal, { kind: 'interrupted' }>;
+
+export class LocalExecutionHostEventStream {
+  readonly #response: ServerResponse;
+  readonly #signal: AbortSignal;
+  readonly #invocationId: string;
+  readonly #runId: string;
+  readonly #now: () => Date;
+  #sequence = 0;
+
+  private constructor(input: {
+    response: ServerResponse;
+    signal: AbortSignal;
+    invocationId: string;
+    runId: string;
+    now: () => Date;
+  }) {
+    this.#response = input.response;
+    this.#signal = input.signal;
+    this.#invocationId = input.invocationId;
+    this.#runId = OpaqueIdSchema.parse(input.runId);
+    this.#now = input.now;
+  }
+
+  static async open(input: {
+    response: ServerResponse;
+    signal: AbortSignal;
+    invocationId: string;
+    runId: string;
+    now: () => Date;
+  }): Promise<LocalExecutionHostEventStream> {
+    const stream = new LocalExecutionHostEventStream(input);
+    input.response.writeHead(200, {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+    });
+    await stream.#write({ kind: 'accepted' });
+    return stream;
+  }
+
+  publishActivity(activity: unknown): Promise<void> {
+    return this.#write({ kind: 'activity', activity });
+  }
+
+  async settle(terminal: LocalExecutionHostTerminal): Promise<void> {
+    this.#signal.throwIfAborted();
+    if (terminal.kind !== 'interrupted') {
+      await this.#write(terminal);
+    }
+    this.#response.end();
+  }
+
+  async #write(body: EventBody): Promise<void> {
+    this.#signal.throwIfAborted();
+    const event = ExecutionHostStreamEventSchema.parse({
+      schemaVersion: EXECUTION_CONTRACT_VERSION,
+      invocationId: this.#invocationId,
+      runId: this.#runId,
+      sequence: this.#sequence,
+      timestamp: this.#now().toISOString(),
+      ...body,
+    });
+    this.#sequence += 1;
+    const frame = [
+      `id: ${event.sequence}`,
+      `event: ${event.kind}`,
+      `data: ${JSON.stringify(event)}`,
+      '',
+      '',
+    ].join('\n');
+    if (!this.#response.write(frame)) {
+      await once(this.#response, 'drain', { signal: this.#signal });
+    }
+  }
+}
+
+export function parseLocalExecutionHostTerminal(
+  value: unknown,
+): LocalExecutionHostTerminal {
+  return TerminalSchema.parse(value);
+}

--- a/packages/heddle-adopter/src/testing/index.ts
+++ b/packages/heddle-adopter/src/testing/index.ts
@@ -1,0 +1,10 @@
+export {
+  LocalExecutionHostContractFixture,
+} from './local-execution-host-contract-fixture.js';
+export type {
+  LocalExecutionHostExecutor,
+  LocalExecutionHostContractFixtureOptions,
+  LocalExecutionHostInvocation,
+  LocalExecutionHostInvocationMetadata,
+  LocalExecutionHostTerminal,
+} from './types.js';

--- a/packages/heddle-adopter/src/testing/invocation.ts
+++ b/packages/heddle-adopter/src/testing/invocation.ts
@@ -1,0 +1,58 @@
+import type { ExecutionHostConversationTurnRequest } from '../contracts/index.js';
+import type {
+  LocalExecutionHostInvocation,
+  LocalExecutionHostInvocationMetadata,
+} from './types.js';
+
+/** Keeps request-scoped authority out of enumerable object properties. */
+export class CredentialBoundLocalInvocation
+implements LocalExecutionHostInvocation {
+  readonly #request: ExecutionHostConversationTurnRequest;
+  readonly #runtimeSessionId: string;
+  readonly #signal: AbortSignal;
+  readonly #mcpCapability: string | undefined;
+  readonly #publishActivity: (activity: unknown) => Promise<void>;
+
+  constructor(input: {
+    request: ExecutionHostConversationTurnRequest;
+    runtimeSessionId: string;
+    signal: AbortSignal;
+    mcpCapability?: string;
+    publishActivity: (activity: unknown) => Promise<void>;
+  }) {
+    this.#request = Object.freeze({ ...input.request });
+    this.#runtimeSessionId = input.runtimeSessionId;
+    this.#signal = input.signal;
+    this.#mcpCapability = input.mcpCapability;
+    this.#publishActivity = input.publishActivity;
+  }
+
+  get request(): ExecutionHostConversationTurnRequest {
+    return this.#request;
+  }
+
+  get runtimeSessionId(): string {
+    return this.#runtimeSessionId;
+  }
+
+  get signal(): AbortSignal {
+    return this.#signal;
+  }
+
+  mcpCapability(): string | undefined {
+    return this.#mcpCapability;
+  }
+
+  publishActivity(activity: unknown): Promise<void> {
+    return this.#publishActivity(activity);
+  }
+
+  toJSON(): LocalExecutionHostInvocationMetadata {
+    return {
+      schemaVersion: this.#request.schemaVersion,
+      kind: this.#request.kind,
+      invocationId: this.#request.invocationId,
+      runtimeSessionId: this.#runtimeSessionId,
+    };
+  }
+}

--- a/packages/heddle-adopter/src/testing/local-execution-host-contract-fixture.ts
+++ b/packages/heddle-adopter/src/testing/local-execution-host-contract-fixture.ts
@@ -1,0 +1,252 @@
+import {
+  randomBytes,
+  randomUUID,
+} from 'node:crypto';
+import { once } from 'node:events';
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import { DirectHttpExecutionHost } from '../http-sse/index.js';
+import {
+  LocalExecutionHostEventStream,
+  parseLocalExecutionHostTerminal,
+} from './event-stream.js';
+import { CredentialBoundLocalInvocation } from './invocation.js';
+import {
+  parseLocalExecutionHostRequest,
+  writeLocalExecutionHostRejection,
+  type ParsedLocalExecutionHostRequest,
+} from './request.js';
+import type {
+  LocalExecutionHostContractFixtureOptions,
+  LocalExecutionHostTerminal,
+} from './types.js';
+
+/**
+ * Real loopback implementation of the Execution Host v1 HTTP/SSE boundary.
+ *
+ * It is intentionally a contract fixture, not a fake Heddle runtime. The
+ * supplied executor can call product APIs or MCP tools, while this class owns
+ * request validation, credential containment, SSE ordering, and lifecycle.
+ */
+export class LocalExecutionHostContractFixture {
+  readonly #execute: LocalExecutionHostContractFixtureOptions['execute'];
+  readonly #now: () => Date;
+  readonly #createRunId: () => string;
+  readonly #localToken: string;
+  readonly #server: Server;
+  readonly #activeInvocations = new Set<ActiveInvocation>();
+  #baseUrl: URL | undefined;
+  #closePromise: Promise<void> | undefined;
+  #closing = false;
+
+  private constructor(options: LocalExecutionHostContractFixtureOptions) {
+    if (typeof options.execute !== 'function') {
+      throw new TypeError('Local Execution Host fixture requires an executor.');
+    }
+    this.#execute = options.execute;
+    this.#now = options.now ?? (() => new Date());
+    this.#createRunId = options.createRunId ?? randomUUID;
+    this.#localToken = randomBytes(32).toString('base64url');
+    this.#server = createServer((request, response) => {
+      this.#dispatch(request, response);
+    });
+  }
+
+  static async start(
+    options: LocalExecutionHostContractFixtureOptions,
+  ): Promise<LocalExecutionHostContractFixture> {
+    const fixture = new LocalExecutionHostContractFixture(options);
+    await fixture.#listen();
+    return fixture;
+  }
+
+  /** Return a fresh client paired with this fixture's hidden local token. */
+  createExecutionHost(): DirectHttpExecutionHost {
+    return new DirectHttpExecutionHost({
+      baseUrl: this.baseUrl(),
+      localToken: this.#localToken,
+    });
+  }
+
+  /** A copy of the loopback URL, useful for explicit negative protocol tests. */
+  baseUrl(): URL {
+    if (!this.#baseUrl) {
+      throw new Error('Local Execution Host fixture has not started.');
+    }
+    return new URL(this.#baseUrl);
+  }
+
+  /** Abort active invocations, close sockets, and wait for handler cleanup. */
+  close(): Promise<void> {
+    this.#closePromise ??= this.#close();
+    return this.#closePromise;
+  }
+
+  async #listen(): Promise<void> {
+    this.#server.listen(0, '127.0.0.1');
+    await once(this.#server, 'listening');
+    const address = this.#server.address();
+    if (!address || typeof address === 'string') {
+      await this.close();
+      throw new Error('Local Execution Host fixture did not bind a TCP port.');
+    }
+    this.#baseUrl = new URL(`http://127.0.0.1:${address.port}/`);
+  }
+
+  #dispatch(request: IncomingMessage, response: ServerResponse): void {
+    const controller = new AbortController();
+    if (this.#closing) {
+      controller.abort();
+      request.destroy();
+      response.destroy();
+      return;
+    }
+    const active: ActiveInvocation = {
+      controller,
+      completed: Promise.resolve(),
+    };
+    const completed = this.#handle(request, response, controller)
+      .catch(() => {
+        response.destroy();
+      })
+      .finally(() => {
+        this.#activeInvocations.delete(active);
+      });
+    active.completed = completed;
+    this.#activeInvocations.add(active);
+  }
+
+  async #handle(
+    request: IncomingMessage,
+    response: ServerResponse,
+    controller: AbortController,
+  ): Promise<void> {
+    const abort = () => controller.abort();
+    const abortIncompleteResponse = () => {
+      if (!response.writableEnded) {
+        abort();
+      }
+    };
+    request.once('aborted', abort);
+    response.once('close', abortIncompleteResponse);
+
+    try {
+      const parsed = await parseLocalExecutionHostRequest(
+        request,
+        this.#localToken,
+        controller.signal,
+      );
+      controller.signal.throwIfAborted();
+      await this.#streamInvocation(parsed, response, controller);
+    } catch (error) {
+      if (controller.signal.aborted) {
+        response.destroy();
+        return;
+      }
+      if (!response.headersSent) {
+        writeLocalExecutionHostRejection(response, error);
+        return;
+      }
+      response.destroy();
+    } finally {
+      request.off('aborted', abort);
+      response.off('close', abortIncompleteResponse);
+    }
+  }
+
+  async #streamInvocation(
+    input: ParsedLocalExecutionHostRequest,
+    response: ServerResponse,
+    controller: AbortController,
+  ): Promise<void> {
+    const stream = await LocalExecutionHostEventStream.open({
+      response,
+      signal: controller.signal,
+      invocationId: input.request.invocationId,
+      runId: this.#createRunId(),
+      now: this.#now,
+    });
+    let acceptingActivities = true;
+    let activityWrites = Promise.resolve();
+    let activityFailure: unknown;
+    const publishActivity = (activity: unknown): Promise<void> => {
+      if (!acceptingActivities) {
+        return Promise.reject(new Error(
+          'Cannot publish activity after local invocation settlement.',
+        ));
+      }
+      const write = activityWrites.then(
+        () => stream.publishActivity(activity),
+      );
+      activityWrites = write.catch((error: unknown) => {
+        activityFailure ??= error;
+      });
+      return write;
+    };
+    const invocation = new CredentialBoundLocalInvocation({
+      ...input,
+      signal: controller.signal,
+      publishActivity,
+    });
+
+    let terminal: LocalExecutionHostTerminal;
+    try {
+      terminal = parseLocalExecutionHostTerminal(
+        await this.#execute(invocation),
+      );
+    } catch {
+      controller.signal.throwIfAborted();
+      terminal = {
+        kind: 'error',
+        error: {
+          code: 'fixture_execution_failed',
+          message: 'Local fixture execution failed.',
+        },
+      };
+    } finally {
+      acceptingActivities = false;
+    }
+
+    await activityWrites;
+    if (activityFailure) {
+      throw activityFailure;
+    }
+    await stream.settle(terminal);
+  }
+
+  async #close(): Promise<void> {
+    this.#closing = true;
+    for (const invocation of this.#activeInvocations) {
+      invocation.controller.abort();
+    }
+    const serverClosed = new Promise<void>((resolve, reject) => {
+      this.#server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+    this.#server.closeAllConnections();
+    await serverClosed;
+    while (this.#activeInvocations.size > 0) {
+      const active = [...this.#activeInvocations];
+      for (const invocation of active) {
+        invocation.controller.abort();
+      }
+      await Promise.allSettled(
+        active.map((invocation) => invocation.completed),
+      );
+    }
+  }
+}
+
+type ActiveInvocation = {
+  controller: AbortController;
+  completed: Promise<void>;
+};

--- a/packages/heddle-adopter/src/testing/request.ts
+++ b/packages/heddle-adopter/src/testing/request.ts
@@ -1,0 +1,241 @@
+import {
+  createHash,
+  timingSafeEqual,
+} from 'node:crypto';
+import type {
+  IncomingMessage,
+  ServerResponse,
+} from 'node:http';
+import { z } from 'zod';
+import {
+  AGENTCORE_RUNTIME_SESSION_HEADER,
+  EXECUTION_ASSERTION_HEADER,
+  EXECUTION_HOST_LOCAL_TOKEN_HEADER,
+  ExecutionHostConversationTurnRequestSchema,
+  MCP_CAPABILITY_HEADER,
+  MODEL_API_KEY_HEADER,
+  RuntimeSessionIdSchema,
+  type ExecutionHostConversationTurnRequest,
+} from '../contracts/index.js';
+
+const MAX_REQUEST_BODY_BYTES = 262_144;
+const REDACTED_HEADER_VALUE = '[REDACTED]';
+const SecretSchema = z.string().min(8).max(4_096);
+const AssertionSchema = z.string().min(32).max(4_096);
+const ErrorCodeSchema = z.string().min(1).max(128).regex(/^[a-z0-9_]+$/);
+
+export type ParsedLocalExecutionHostRequest = {
+  request: ExecutionHostConversationTurnRequest;
+  runtimeSessionId: string;
+  mcpCapability?: string;
+};
+
+export async function parseLocalExecutionHostRequest(
+  request: IncomingMessage,
+  expectedLocalToken: string,
+  signal: AbortSignal,
+): Promise<ParsedLocalExecutionHostRequest> {
+  const headers = takeInvocationHeaders(request);
+  assertInvocationRoute(request);
+  assertLocalToken(headers.localToken, expectedLocalToken);
+  const runtimeSessionId = parseRequestValue(
+    RuntimeSessionIdSchema,
+    headers.runtimeSessionId,
+    400,
+    'invalid_runtime_session',
+  );
+  parseRequestValue(
+    AssertionSchema,
+    headers.executionAssertion,
+    401,
+    'invalid_execution_identity',
+  );
+  parseRequestValue(
+    SecretSchema,
+    headers.modelApiKey,
+    401,
+    'invalid_model_credential',
+  );
+  const mcpCapability = headers.mcpCapability === undefined
+    ? undefined
+    : parseRequestValue(
+      AssertionSchema,
+      headers.mcpCapability,
+      401,
+      'invalid_mcp_capability',
+    );
+  const parsedRequest = parseRequestValue(
+    ExecutionHostConversationTurnRequestSchema,
+    await readJsonBody(request, signal),
+    400,
+    'invalid_request',
+  );
+  return {
+    request: parsedRequest,
+    runtimeSessionId,
+    mcpCapability,
+  };
+}
+
+export function writeLocalExecutionHostRejection(
+  response: ServerResponse,
+  error: unknown,
+): void {
+  const rejection = error instanceof LocalExecutionHostRequestError
+    ? { status: error.status, code: error.code }
+    : { status: 500, code: 'fixture_internal_error' };
+  const safeCode = ErrorCodeSchema.parse(rejection.code);
+  const body = JSON.stringify({
+    error: {
+      code: safeCode,
+      message: 'Local Execution Host fixture rejected the request.',
+    },
+  });
+  response.writeHead(rejection.status, {
+    'Cache-Control': 'no-store',
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': 'application/json; charset=utf-8',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  response.end(body);
+}
+
+type InvocationHeaders = {
+  localToken: string | undefined;
+  runtimeSessionId: string | undefined;
+  executionAssertion: string | undefined;
+  mcpCapability: string | undefined;
+  modelApiKey: string | undefined;
+};
+
+class LocalExecutionHostRequestError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+  ) {
+    super(code);
+  }
+}
+
+function takeInvocationHeaders(request: IncomingMessage): InvocationHeaders {
+  const extracted = {
+    localToken: extractSensitiveHeader(
+      request,
+      EXECUTION_HOST_LOCAL_TOKEN_HEADER,
+    ),
+    runtimeSessionId: extractSensitiveHeader(
+      request,
+      AGENTCORE_RUNTIME_SESSION_HEADER,
+    ),
+    executionAssertion: extractSensitiveHeader(
+      request,
+      EXECUTION_ASSERTION_HEADER,
+    ),
+    mcpCapability: extractSensitiveHeader(request, MCP_CAPABILITY_HEADER),
+    modelApiKey: extractSensitiveHeader(request, MODEL_API_KEY_HEADER),
+  };
+  if (Object.values(extracted).some((header) => header.duplicate)) {
+    throw new LocalExecutionHostRequestError(
+      400,
+      'duplicate_sensitive_header',
+    );
+  }
+  return Object.fromEntries(
+    Object.entries(extracted).map(([name, header]) => [name, header.value]),
+  ) as InvocationHeaders;
+}
+
+function extractSensitiveHeader(
+  request: IncomingMessage,
+  name: string,
+): { value: string | undefined; duplicate: boolean } {
+  const occurrences = request.rawHeaders.reduce(
+    (count, headerName, index) => count
+      + (index % 2 === 0 && headerName.toLowerCase() === name ? 1 : 0),
+    0,
+  );
+  const value = request.headers[name];
+  request.headers[name] = value === undefined
+    ? undefined
+    : REDACTED_HEADER_VALUE;
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index]?.toLowerCase() === name) {
+      request.rawHeaders[index + 1] = REDACTED_HEADER_VALUE;
+    }
+  }
+  return {
+    value: Array.isArray(value) ? undefined : value,
+    duplicate: occurrences > 1 || Array.isArray(value),
+  };
+}
+
+function assertInvocationRoute(request: IncomingMessage): void {
+  if (request.method !== 'POST') {
+    throw new LocalExecutionHostRequestError(405, 'method_not_allowed');
+  }
+  if (request.url !== '/invocations') {
+    throw new LocalExecutionHostRequestError(404, 'not_found');
+  }
+  const contentType = request.headers['content-type']
+    ?.split(';', 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== 'application/json') {
+    throw new LocalExecutionHostRequestError(
+      415,
+      'unsupported_media_type',
+    );
+  }
+}
+
+function assertLocalToken(actual: string | undefined, expected: string): void {
+  if (!actual || !constantTimeEqual(actual, expected)) {
+    throw new LocalExecutionHostRequestError(401, 'invalid_local_token');
+  }
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const leftHash = createHash('sha256').update(left).digest();
+  const rightHash = createHash('sha256').update(right).digest();
+  return timingSafeEqual(leftHash, rightHash);
+}
+
+async function readJsonBody(
+  request: IncomingMessage,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const rawChunk of request) {
+    signal.throwIfAborted();
+    const chunk = Buffer.isBuffer(rawChunk)
+      ? rawChunk
+      : Buffer.from(rawChunk as Uint8Array);
+    totalBytes += chunk.byteLength;
+    if (totalBytes > MAX_REQUEST_BODY_BYTES) {
+      throw new LocalExecutionHostRequestError(413, 'request_too_large');
+    }
+    chunks.push(chunk);
+  }
+  if (totalBytes === 0) {
+    throw new LocalExecutionHostRequestError(400, 'invalid_request');
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks, totalBytes).toString('utf8'));
+  } catch {
+    throw new LocalExecutionHostRequestError(400, 'invalid_request');
+  }
+}
+
+function parseRequestValue<T>(
+  schema: z.ZodType<T>,
+  value: unknown,
+  status: number,
+  code: string,
+): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    throw new LocalExecutionHostRequestError(status, code);
+  }
+  return parsed.data;
+}

--- a/packages/heddle-adopter/src/testing/types.ts
+++ b/packages/heddle-adopter/src/testing/types.ts
@@ -1,0 +1,55 @@
+import type {
+  ExecutionHostConversationTurnRequest,
+  RuntimePublicResult,
+} from '../contracts/index.js';
+
+/**
+ * One locally admitted invocation. Credentials remain behind explicit methods
+ * so ordinary object inspection and JSON serialization cannot reveal them.
+ */
+export interface LocalExecutionHostInvocation {
+  readonly request: ExecutionHostConversationTurnRequest;
+  readonly runtimeSessionId: string;
+  readonly signal: AbortSignal;
+  mcpCapability(): string | undefined;
+  publishActivity(activity: unknown): Promise<void>;
+  toJSON(): LocalExecutionHostInvocationMetadata;
+}
+
+export type LocalExecutionHostInvocationMetadata = {
+  schemaVersion: 1;
+  kind: 'conversation-turn';
+  invocationId: string;
+  runtimeSessionId: string;
+};
+
+export type LocalExecutionHostTerminal =
+  | {
+    kind: 'result';
+    result: RuntimePublicResult;
+  }
+  | {
+    kind: 'cancelled';
+    reason: string;
+  }
+  | {
+    kind: 'error';
+    error: {
+      code: string;
+      message: string;
+    };
+  }
+  | {
+    /** End the SSE response without a terminal event to exercise recovery. */
+    kind: 'interrupted';
+  };
+
+export type LocalExecutionHostExecutor = (
+  invocation: LocalExecutionHostInvocation,
+) => LocalExecutionHostTerminal | Promise<LocalExecutionHostTerminal>;
+
+export type LocalExecutionHostContractFixtureOptions = {
+  execute: LocalExecutionHostExecutor;
+  now?: () => Date;
+  createRunId?: () => string;
+};

--- a/scripts/verify-adopter-package.mjs
+++ b/scripts/verify-adopter-package.mjs
@@ -27,7 +27,15 @@ assert.deepEqual(
 );
 assert.deepEqual(
   Object.keys(adopterPackage.exports),
-  ['.', './contracts', './authority', './mcp', './http-sse', './package.json'],
+  [
+    '.',
+    './contracts',
+    './authority',
+    './mcp',
+    './http-sse',
+    './testing',
+    './package.json',
+  ],
   '@roackb2/heddle-adopter public subpaths must stay deliberate.',
 );
 assert.equal(

--- a/src/__tests__/integration/sdk/adopter-package-boundary.test.ts
+++ b/src/__tests__/integration/sdk/adopter-package-boundary.test.ts
@@ -23,13 +23,14 @@ describe('@roackb2/heddle-adopter package boundary', () => {
       .toBeUndefined();
   });
 
-  it('publishes only its intentional capability subpaths', () => {
+  it('publishes only its intentional subpaths', () => {
     expect(Object.keys(adopterPackage.exports)).toEqual([
       '.',
       './contracts',
       './authority',
       './mcp',
       './http-sse',
+      './testing',
       './package.json',
     ]);
   });


### PR DESCRIPTION
## Summary

- add an explicit `@roackb2/heddle-adopter/testing` subpath
- provide a loopback `LocalExecutionHostContractFixture` with strict v1 request validation, hidden local authentication, ordered SSE, cancellation, and ambiguous-EOF behavior
- keep HTTP admission, credential-bound invocation state, SSE projection, and fixture lifecycle in separate internal modules
- document exactly what local contract evidence proves and what still requires the real Heddle Execution Host or AgentCore

## Why

Adopter backends should not each build a bespoke fake HTTP/SSE host to test their control-plane and product-MCP integration. This moves the generic contract machinery into the lightweight public adopter package while keeping product tools, Heddle execution, AWS, and database code out.

The callback receives only the optional MCP capability. The model key and execution assertion are validated and discarded at admission rather than exposed to adopter test code.

## Verification

- `yarn test` — 859 unit, 418 integration, and 53 adopter-package tests
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `npm pack ./packages/heddle-adopter --dry-run --cache /tmp/heddle-adopter-npm-cache`

## Deliberate limits

This fixture verifies the adopter-facing v1 JSON/SSE boundary and product callback. It does not claim to verify the Heddle loop, real-host JWT policy, model behavior, shell/filesystem capability, tenant isolation, or managed AgentCore behavior.