### PR TITLE
Release Heddle v5.12.0

### DIFF
--- a/docs/releases/v5.12.0.md
+++ b/docs/releases/v5.12.0.md
@@ -1,0 +1,55 @@
+# Heddle v5.12.0
+
+Heddle v5.12 adds an executable local contract fixture for adopter backends.
+Products can now test their real execution-authority, MCP, invocation, stream,
+and result-projection integration without running a model, Docker, AWS, or the
+private Execution Host.
+
+## Adopter Contract Testing
+
+- **`@roackb2/heddle-adopter/testing` is a new explicit test-only subpath.**
+  `LocalExecutionHostContractFixture` serves the real v1 HTTP/SSE boundary on
+  loopback and accepts the same signed execution assertion and optional MCP
+  capability used by an Execution Host integration.
+- **Tests retain product ownership.** An adopter supplies its real authority,
+  capability, request, MCP callback, and terminal projection while the fixture
+  provides deterministic accepted, activity, result, cancellation, failure,
+  and interrupted-stream behavior.
+- **Protocol failures remain observable.** The fixture can exercise strict
+  ordering, clean terminal settlement, ambiguous EOF, request rejection, and
+  cancellation without hiding those cases behind a fake application service.
+- **The boundary is deliberately narrow.** The testing subpath is not
+  re-exported from the package root and has no dependency on Heddle, an MCP
+  server SDK, Docker, AWS SDKs, or model providers.
+
+## Upgrade Notes
+
+- Existing Heddle runtime, Heddle Remote, and Heddle Adopter production APIs do
+  not require code changes.
+- Install the lockstep `5.12.0` packages when consuming this release.
+- Import the fixture only in backend tests:
+
+  ```ts
+  import {LocalExecutionHostContractFixture} from '@roackb2/heddle-adopter/testing';
+  ```
+
+- A passing local fixture proves the adopter-facing wire and product callback.
+  It does not run Heddle or prove model behavior, shell/filesystem capability,
+  JWT verification inside the real host, container or microVM isolation,
+  AgentCore routing, or managed-runtime recovery. Keep real-host and managed
+  tests for those evidence boundaries.
+
+## Verification
+
+- `yarn build`
+- `yarn test`
+- `npm pack --dry-run --cache /tmp/heddle-npm-cache`
+- `npm pack ./packages/heddle-remote --dry-run --cache /tmp/heddle-npm-cache`
+- `npm pack ./packages/heddle-adopter --dry-run --cache /tmp/heddle-npm-cache`
+
+## Release State
+
+- Package versions are `5.12.0` in all three manifests.
+- npm and GitHub publish Heddle, Heddle Remote, and Heddle Adopter at `5.11.0`
+  before this release.
+- The canonical release context is `v5.11.0..HEAD`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "description": "An open-source AI coding agent runtime and terminal CLI for real repositories, with persistent memory, sessions, approvals, heartbeat, and a browser control plane",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/packages/heddle-adopter/package.json
+++ b/packages/heddle-adopter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle-adopter",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "description": "Backend contracts, execution authority, MCP verification, and clients for Heddle Execution Host adopters",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/packages/heddle-remote/package.json
+++ b/packages/heddle-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roackb2/heddle-remote",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "description": "Browser-safe protocol and run-consumer services for remotely hosted Heddle conversations",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- release the new `@roackb2/heddle-adopter/testing` contract fixture
- bump the three lockstep packages to 5.12.0
- add curated release and evidence-boundary notes

## Why 5.12

This is a backward-compatible minor release because it adds a new explicit public package subpath. Existing runtime, remote, and adopter production APIs are unchanged.

## Verification

- `yarn build`
- `yarn test` — 859 unit, 418 integration, 53 adopter tests
- root, remote, and adopter `npm pack --dry-run`
- adopter tarball contains the compiled `dist/testing` surface

## After merge

The release commit must be tagged and published before Lucid can consume `@roackb2/heddle-adopter@5.12.0`.