### PR TITLE
Simplify Execution Host adopter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ that already owns the mechanics your host needs:
 | Conventional Node HTTP/SSE | `@roackb2/heddle/hosted/http-sse` | Replay cursor parsing, SSE framing, backpressure, and disconnect cleanup |
 | A remote browser or client | `@roackb2/heddle-remote` | Browser-safe protocol validation and transport-neutral run consumption |
 | Conventional browser REST/SSE | `@roackb2/heddle-remote/http-sse` | Authenticated fetch, incremental SSE parsing, and transport validation |
-| A backend invoking a separate Execution Host | `@roackb2/heddle-adopter` | v1 contracts, ES256 authority/JWKS, product-MCP verification, an `ExecutionHost` client port, and a local contract fixture |
+| A backend invoking a separate Execution Host | `@roackb2/heddle-adopter` | v1 contracts, authority/JWKS, hosted-turn orchestration, product-MCP verification, an `ExecutionHost` client port, Node conveniences, and a local fixture |
 | Lower-level runtime assembly | `@roackb2/heddle/advanced` | Model adapters, individual tools, trace, memory, heartbeat, and core runtime services |
 
 Existing tRPC, Fastify, Hono, Nest, WebSocket, IPC, queue, React, or other stacks
@@ -350,8 +350,10 @@ Heddle is designed to make assumptions and limitations visible:
 - `@roackb2/heddle-remote` validates the run protocol but does not own product
   messages, UI state, authentication, or result rendering;
 - `@roackb2/heddle-adopter` helps a backend invoke a separately deployed
-  Execution Host without importing Heddle, AWS, an MCP server, or product data
-  adapters; the adopter still owns identity, policy, keys, tools, and results;
+  Execution Host without importing Heddle, AWS, or product data
+  adapters; optional Node helpers own generic HTTP/key mechanics, while the
+  adopter still owns identity, policy, production key operations, tools, and
+  results;
 - the SDK is actively evolving, so review
   [release notes](docs/releases/README.md) before upgrading public APIs.
 

--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -24,7 +24,8 @@ hosting assumptions.
   transport validation for the conventional REST run resource.
 - `@roackb2/heddle-adopter` — an independently installable backend reference
   SDK for invoking a separate Execution Host: v1 contracts, ES256 authority,
-  product-MCP verification, and a provider-neutral client port.
+  hosted-turn orchestration, product-MCP verification, a provider-neutral
+  client port, and optional Node HTTP/key conveniences.
 - `@roackb2/heddle/advanced` — the **deep core customization** surface: the curated exports plus
   lower-level building blocks (LLM adapters, individual tools, trace, memory,
   models, awareness) and specialized runtimes (agent loop, heartbeat,

--- a/docs/guides/programmatic/execution-host-adopters.md
+++ b/docs/guides/programmatic/execution-host-adopters.md
@@ -5,6 +5,10 @@ and instead invokes a separately deployed Heddle Execution Host. The package is
 small on purpose: it provides the security-sensitive contract machinery while
 your product keeps its language stack and domain ownership.
 
+The package is currently an experimental public contract and local proving
+surface. Heddle does not distribute the compatible Execution Host or offer a
+hosted service today.
+
 ```text
 ADOPTER BACKEND
   product authentication and authorization
@@ -59,12 +63,18 @@ Its subpaths separate responsibility:
 
 - `/contracts` provides executable TypeScript/Zod v1 claim and wire contracts;
 - `/authority` issues ES256 assertions/capabilities and projects public JWKS;
+- `/conversation` composes assertion/capability issuance, model credentials,
+  fixed tool policy, and one `ExecutionHost` turn;
 - `/mcp` independently verifies product-MCP capabilities against a fixed
   deployment and supported-tool set;
+- `/mcp/node` owns a stateless official-SDK Streamable HTTP lifecycle around
+  an adopter-defined product toolset;
 - `/http-sse` provides the provider-neutral `ExecutionHost` port and strict
   direct-development transport;
 - `/testing` provides a Node-only loopback v1 fixture for local product/MCP
   integration tests without a model or AWS.
+- `/node` provides an optional standard Node JWKS/conversation HTTP edge and
+  owner-only local signing-key file helpers.
 
 See the [package README](../../../packages/heddle-adopter/README.md) for
 copyable code.
@@ -72,7 +82,8 @@ copyable code.
 The package deliberately excludes:
 
 - end-user authentication, authorization, or tenant lookup;
-- signing-key storage, rotation, and JWKS route registration;
+- production signing-key storage and rotation, route placement, and key
+  revocation;
 - MCP tool registration, product APIs, or database access;
 - AWS AgentCore/SigV4 transport and deployment;
 - Heddle's loop, tools, model runtime, workspace, or state serialization;
@@ -108,6 +119,34 @@ the AWS SDK and SigV4 while preserving the same v1 body, forwarded custom
 headers, ordered stream semantics, and no-ambiguous-retry rule. Keeping that
 adapter separate prevents AWS types from leaking into the product application
 service.
+
+## Progressive Node adoption
+
+Node adopters can start with `NodeExecutionAdopterHttpService`. It handles the
+two generic inbound routes, bounded JSON, authorization-header scrubbing, safe
+errors, SSE framing/backpressure, disconnect cancellation, and shutdown. Pass
+it the authority, product authenticator, and a product admission service. The
+admission service is the small intentional product seam: it decides the
+authorized scope and durable invocation identity, then delegates to
+`HostedConversationTurnService`.
+
+Teams with an existing router that exposes Node `IncomingMessage` and
+`ServerResponse`—including raw Node, Express, or a framework's raw adapter—can
+call `handleJwks` and `handleConversationTurn` directly instead of using the
+default path matcher. Fetch-native and non-Node adopters implement the same
+small wire contract in their normal framework; the Node helper is convenience,
+not protocol authority.
+
+The package can generate and load an owner-only local private-JWK file. That is
+appropriate for development and a carefully managed single-host pilot. It does
+not replace production secret management, rotation, KMS/HSM policy, Windows
+ACL review, or durable revocation.
+
+When product tools use MCP, `NodeStreamableHttpMcpService` owns the generic
+official-SDK request lifecycle. The adopter supplies a `NodeMcpToolset`, which
+is the intentionally product-specific place for names, schemas, descriptions,
+handlers, and scoped data access. This keeps protocol and cleanup mechanics out
+of each product without moving its capabilities into Heddle.
 
 ## Local contract verification
 

--- a/docs/guides/programmatic/integration-layers.md
+++ b/docs/guides/programmatic/integration-layers.md
@@ -165,9 +165,11 @@ normal client architecture.
 Use `@roackb2/heddle-adopter` when Heddle runs in a separate Execution Host
 rather than inside the product backend. The package owns v1 validation, short-
 lived execution authority, independent MCP capability verification, and the
-`ExecutionHost` outbound port. The adopter retains product authentication,
-tenant mapping, signing-key operations, durable invocation identity, product
-MCP behavior, database access, and result application. The Execution Host alone
+`ExecutionHost` outbound port. Its optional conversation and Node surfaces also
+own generic turn orchestration, JWKS/conversation HTTP mechanics, and safe local
+key-file loading. The adopter retains product authentication, tenant mapping,
+production key storage/rotation, durable invocation identity, product MCP
+behavior, database access, and result application. The Execution Host alone
 imports Heddle and receives no adopter database credential. See
 [Build an Execution Host adopter backend](execution-host-adopters.md).
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "adopter:compile": "yarn adopter:verify && tsc -p packages/heddle-adopter/tsconfig.build.json",
     "adopter:build": "yarn adopter:clean && yarn adopter:compile",
     "adopter:test": "vitest run --config packages/heddle-adopter/vitest.config.ts",
+    "adopter:example:node-control-plane": "yarn adopter:build && tsx packages/heddle-adopter/examples/node-control-plane.ts",
     "adopter:pack": "yarn adopter:build && npm pack ./packages/heddle-adopter",
     "adopter:publish": "yarn adopter:build && npm publish ./packages/heddle-adopter",
     "typecheck": "tsc -p tsconfig.build.json --noEmit && tsc -p packages/heddle-adopter/tsconfig.test.json --noEmit",

--- a/packages/heddle-adopter/README.md
+++ b/packages/heddle-adopter/README.md
@@ -165,6 +165,40 @@ assertMcpCapabilityActive(capability)
 await readWorkspaceSnapshot(capability.scope)
 ```
 
+For Node adopters, the declarative JSON-tool path also removes the repetitive
+allowlist, expiry, cancellation, serialization, and safe-error code:
+
+```ts
+import {
+  defineNodeMcpJsonTool,
+  NodeMcpJsonToolset,
+  NodeStreamableHttpMcpService,
+} from '@roackb2/heddle-adopter/mcp/node'
+import { z } from 'zod'
+
+const toolset = new NodeMcpJsonToolset({
+  serverInfo: { name: 'example-product', version: '1.0.0' },
+  tools: [defineNodeMcpJsonTool({
+    name: 'read_workspace_snapshot' as const,
+    description: 'Read the authenticated subject workspace.',
+    inputSchema: z.object({}).strict(),
+    annotations: { readOnlyHint: true },
+    failureMessage: 'The workspace is unavailable.',
+    execute: async (_input, { capability, signal }) => (
+      readWorkspaceSnapshot(capability.scope, signal)
+    ),
+  })],
+})
+
+const productMcp = new NodeStreamableHttpMcpService({
+  capabilityVerifier: verifier,
+  toolset,
+})
+```
+
+Use the lower-level `NodeMcpToolset` interface only when a tool needs custom MCP
+content or lifecycle semantics.
+
 ## Invoke the direct development host
 
 The direct client is useful for local and reviewed HTTPS deployments. A

--- a/packages/heddle-adopter/README.md
+++ b/packages/heddle-adopter/README.md
@@ -5,13 +5,19 @@ which invoke a separately deployed Heddle Execution Host. It lets an adopter
 keep its own language stack, authentication, database, product policy, MCP
 tools, and UI while reusing the security-sensitive v1 contract machinery.
 
+> **Current availability:** this package publishes an experimental integration
+> contract and local verification tools. Heddle does not currently distribute
+> the compatible Execution Host implementation or offer a hosted service. The
+> public surface documents and tests the adopter boundary without implying a
+> generally available deployment.
+
 ```bash
 npm install @roackb2/heddle-adopter
 ```
 
 The package does **not** contain Heddle's agent loop, AgentCore deployment,
-Terraform, MCP server, or product logic. It depends only on `jose`, `zod`, and
-`eventsource-parser`.
+Terraform, product MCP tools, or product logic. It uses the official MCP SDK,
+plus `jose`, `zod`, and `eventsource-parser`, for its optional reference edges.
 
 ## What it owns
 
@@ -19,16 +25,19 @@ Terraform, MCP server, or product logic. It depends only on `jose`, `zod`, and
 | --- | --- |
 | `@roackb2/heddle-adopter/contracts` | Runtime-validated v1 request, stream, identity, capability, and header contracts |
 | `@roackb2/heddle-adopter/authority` | ES256 execution assertion and optional MCP capability issuance plus public JWKS projection |
+| `@roackb2/heddle-adopter/conversation` | Turn orchestration across authority, model credentials, optional MCP policy, and an `ExecutionHost` |
 | `@roackb2/heddle-adopter/mcp` | Independent capability verification at the adopter's MCP edge |
+| `@roackb2/heddle-adopter/mcp/node` | Stateless official-SDK Streamable HTTP lifecycle around adopter-defined toolsets |
 | `@roackb2/heddle-adopter/http-sse` | Transport-neutral `ExecutionHost` port and strict direct-development HTTP/SSE client |
 | `@roackb2/heddle-adopter/testing` | Node-only loopback v1 fixture for local product/MCP integration tests |
+| `@roackb2/heddle-adopter/node` | Optional Node JWKS/conversation HTTP edge plus safe local signing-key helpers |
 
 The adopter still owns:
 
 - authenticating its users and mapping them to tenant, subject, and product
   session IDs;
 - deciding which product capabilities that identity may use;
-- loading and rotating signing keys, publishing JWKS, and retaining durable
+- production signing-key storage and rotation, route placement, and durable
   invocation/replay records;
 - implementing and hosting product MCP tools against its own APIs and data;
 - choosing an AgentCore/SigV4 transport, applying results, and rendering UI.
@@ -80,6 +89,52 @@ and issue input. The execution assertion remains available through
 `issued.mcpCapability()`. JSON serialization emits only credential-free
 metadata, although those identifiers still require normal logging
 minimization.
+
+## Use the lowest-code Node path
+
+The optional Node surface removes generic HTTP and local key-file code without
+taking product decisions away from the adopter:
+
+```ts
+import { JoseExecutionAuthority } from '@roackb2/heddle-adopter/authority'
+import { HostedConversationTurnService } from '@roackb2/heddle-adopter/conversation'
+import {
+  loadExecutionAuthorityKeyPairFromFile,
+  NodeExecutionAdopterHttpService,
+} from '@roackb2/heddle-adopter/node'
+
+const authority = await JoseExecutionAuthority.create(
+  authorityConfig,
+  await loadExecutionAuthorityKeyPairFromFile(signingJwkPath),
+)
+const turns = new HostedConversationTurnService({
+  authority,
+  executionHost,
+  modelCredentials,
+  mcp: { allowedTools: ['read_workspace_snapshot'] },
+})
+const hostedHttp = new NodeExecutionAdopterHttpService({
+  authority,
+  authenticator: productAuthenticator,
+  conversations: productAdmissionService(turns),
+})
+
+// In a raw Node server, call this before the application's fallback router.
+if (hostedHttp.handle(request, response)) return
+```
+
+`productAdmissionService` is intentionally product-owned: it maps an
+authenticated principal to authorized tenant, subject, product-session,
+Runtime-session, and invocation IDs before calling `turns.streamTurn(...)`.
+The Node service owns bounded JSON parsing, `Authorization` redaction, JWKS,
+SSE framing/backpressure, disconnect cancellation, safe failures, and graceful
+shutdown. Its individual `handleJwks` and `handleConversationTurn` methods are
+also available when a framework already owns route matching.
+
+For local setup, `generateExecutionAuthorityKeyFile(path)` creates a new
+owner-only JWK without overwriting an existing file. The loader imports its
+private key as non-exportable. Production KMS/HSM or secret-manager storage,
+rotation, revocation, and Windows ACL policy still belong to deployment.
 
 ## Verify product authority again at MCP
 
@@ -180,3 +235,7 @@ language-neutral. Future Python and Go packages can implement the same compact
 surface without importing Heddle or the private Execution Host code. Canonical
 JSON Schema/OpenAPI and golden conformance fixtures are the next step for
 preventing language-specific drift.
+
+The runnable
+[`node-control-plane.ts`](examples/node-control-plane.ts) example composes the
+default Node path against the local fixture.

--- a/packages/heddle-adopter/examples/README.md
+++ b/packages/heddle-adopter/examples/README.md
@@ -1,0 +1,17 @@
+# Adopter examples
+
+`node-control-plane.ts` is the lowest-code Node reference for an adopter
+backend. It composes the public authority, hosted-conversation orchestration,
+Node HTTP edge, and local Execution Host contract fixture without importing the
+Heddle runtime or private host implementation.
+
+Run it from the repository root:
+
+```bash
+yarn adopter:example:node-control-plane
+```
+
+The example uses an ephemeral signing key, a fake user, a placeholder model
+credential, and the local contract fixture. It proves composition and the
+adopter-facing wire only; it is not a production key, identity, model, Heddle,
+or AgentCore integration.

--- a/packages/heddle-adopter/examples/node-control-plane.ts
+++ b/packages/heddle-adopter/examples/node-control-plane.ts
@@ -1,0 +1,110 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  JoseExecutionAuthority,
+} from '@roackb2/heddle-adopter/authority';
+import {
+  HostedConversationTurnService,
+} from '@roackb2/heddle-adopter/conversation';
+import {
+  generateEphemeralExecutionAuthorityKeyPair,
+  NodeExecutionAdopterHttpService,
+} from '@roackb2/heddle-adopter/node';
+import {
+  LocalExecutionHostContractFixture,
+} from '@roackb2/heddle-adopter/testing';
+
+const keyPair = await generateEphemeralExecutionAuthorityKeyPair();
+const authority = await JoseExecutionAuthority.create({
+  issuer: 'http://127.0.0.1:3000',
+  adopterId: 'example-product',
+  executionAudience: 'urn:heddle-execution-host:local',
+  keyId: 'local-example-key',
+  executionTtlSeconds: 300,
+}, keyPair);
+const executionHost = await LocalExecutionHostContractFixture.start({
+  execute: async () => ({
+    kind: 'result',
+    result: {
+      outcome: 'done',
+      summary: 'The local adopter contract completed.',
+    },
+  }),
+});
+const hostedTurns = new HostedConversationTurnService({
+  authority,
+  executionHost: executionHost.createExecutionHost(),
+  modelCredentials: {
+    resolveModelApiKey: async () => 'local-model-api-key',
+  },
+});
+const httpEdge = new NodeExecutionAdopterHttpService({
+  authority,
+  authenticator: {
+    authenticate: ({ authorization }) => authorization === 'Bearer local-user'
+      ? { subjectId: 'user-001' }
+      : undefined,
+  },
+  conversations: {
+    streamTurn: ({ principal, prompt, signal }) => hostedTurns.streamTurn({
+      scope: {
+        tenantId: 'tenant-001',
+        subjectId: principal.subjectId,
+        productSessionId: 'conversation-001',
+      },
+      runtimeSessionId: 'runtime-session-001-abcdefghijklmnop',
+      invocationId: 'invocation-001',
+      prompt,
+      signal,
+    }),
+  },
+});
+const server = createServer((request, response) => {
+  if (!httpEdge.handle(request, response)) {
+    response.writeHead(404).end();
+  }
+});
+
+try {
+  await listen(server);
+  const address = server.address() as AddressInfo;
+  const response = await fetch(
+    `http://127.0.0.1:${address.port}/hosted-execution/conversation-turns`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer local-user',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ prompt: 'Run one local contract turn.' }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Adopter example failed with HTTP ${response.status}.`);
+  }
+  const eventKinds = (await response.text())
+    .split('\n')
+    .filter((line) => line.startsWith('event: '))
+    .map((line) => line.slice('event: '.length));
+  console.log(JSON.stringify({ status: response.status, eventKinds }, null, 2));
+} finally {
+  await httpEdge.close();
+  await executionHost.close();
+  await close(server);
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}

--- a/packages/heddle-adopter/package.json
+++ b/packages/heddle-adopter/package.json
@@ -36,9 +36,17 @@
       "types": "./dist/authority/index.d.ts",
       "import": "./dist/authority/index.js"
     },
+    "./conversation": {
+      "types": "./dist/conversation/index.d.ts",
+      "import": "./dist/conversation/index.js"
+    },
     "./mcp": {
       "types": "./dist/mcp/index.d.ts",
       "import": "./dist/mcp/index.js"
+    },
+    "./mcp/node": {
+      "types": "./dist/mcp/node/index.d.ts",
+      "import": "./dist/mcp/node/index.js"
     },
     "./http-sse": {
       "types": "./dist/http-sse/index.d.ts",
@@ -47,6 +55,10 @@
     "./testing": {
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js"
+    },
+    "./node": {
+      "types": "./dist/node/index.d.ts",
+      "import": "./dist/node/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -65,6 +77,7 @@
     "streaming"
   ],
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "eventsource-parser": "^3.1.0",
     "jose": "^6.2.8",
     "zod": "^4.3.6"

--- a/packages/heddle-adopter/src/README.md
+++ b/packages/heddle-adopter/src/README.md
@@ -8,14 +8,21 @@ independent so an adopter can use only the machinery it needs:
   executable TypeScript/Zod schemas;
 - `authority`: short-lived ES256 execution assertion and optional MCP
   capability issuance plus public JWKS projection;
+- `conversation`: provider-neutral authority, credential, tool-policy, and
+  Execution Host turn orchestration;
 - `mcp`: independent product-edge capability verification against a fixed
   deployment and supported-tool set;
+- `mcp/node`: optional official-SDK Streamable HTTP lifecycle around an
+  adopter-owned product toolset;
 - `http-sse`: a strict direct-development client behind a transport-neutral
   `ExecutionHost` port;
 - `testing`: a Node-only loopback v1 contract fixture for adopter integration
   tests. It is intentionally available only through its explicit subpath.
+- `node`: optional Node HTTP edge and safe local signing-key conveniences. It
+  owns generic mechanics, never product identity or tool policy.
 
 The package must never import the Heddle runtime, Execution Host internals, AWS
-SDK, MCP server SDK, a database adapter, or product domain code. New reusable
+SDK, a database adapter, or product domain code. The explicit `mcp/node`
+surface may import the official MCP SDK, but owns no model-visible tools. New reusable
 machinery belongs here only when it is required by more than one adopter and
 can preserve that dependency boundary.

--- a/packages/heddle-adopter/src/__tests__/conversation.test.ts
+++ b/packages/heddle-adopter/src/__tests__/conversation.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ExecutionAuthority,
+  ExecutionAuthorityIssueInput,
+  IssuedExecutionAuthority,
+} from '../authority/index.js';
+import type { ExecutionHostConversationTurn } from '../http-sse/index.js';
+import {
+  HostedConversationConfigurationError,
+  HostedConversationTurnService,
+} from '../conversation/index.js';
+import type { ExecutionHostStreamEvent } from '../contracts/index.js';
+
+describe('hosted conversation turn service', () => {
+  it('binds authority, model credentials, MCP policy, and host streaming', async () => {
+    let issuedInput: ExecutionAuthorityIssueInput | undefined;
+    let hostInput: ExecutionHostConversationTurn | undefined;
+    const resolveModelApiKey = vi.fn(async () => 'model-api-key');
+    const service = new HostedConversationTurnService({
+      authority: authority((input) => {
+        issuedInput = input;
+        return issued('execution-assertion', 'mcp-capability');
+      }),
+      executionHost: {
+        streamConversationTurn: async function* (input) {
+          hostInput = input;
+          yield accepted();
+          yield result();
+        },
+      },
+      modelCredentials: { resolveModelApiKey },
+      mcp: { allowedTools: ['read_snapshot'] },
+    });
+
+    const events = await collect(service.streamTurn(turnInput()));
+
+    expect(issuedInput).toEqual({
+      scope: {
+        tenantId: 'company-a',
+        subjectId: 'user-a',
+        productSessionId: 'conversation-a',
+      },
+      runtimeSessionId: runtimeSessionId(),
+      invocationId: 'invocation-001',
+      workflow: 'conversation-turn',
+      mcp: { allowedTools: ['read_snapshot'] },
+    });
+    expect(resolveModelApiKey).toHaveBeenCalledWith({
+      scope: turnInput().scope,
+      invocationId: 'invocation-001',
+      signal: undefined,
+    });
+    expect(hostInput).toEqual({
+      invocationId: 'invocation-001',
+      runtimeSessionId: runtimeSessionId(),
+      prompt: 'Summarize the product state.',
+      executionAssertion: 'execution-assertion',
+      mcpCapability: 'mcp-capability',
+      modelApiKey: 'model-api-key',
+    });
+    expect(events.map((event) => event.kind)).toEqual(['accepted', 'result']);
+    expect(JSON.stringify(service)).toBe('{}');
+  });
+
+  it('supports an execution-only workflow without MCP policy', async () => {
+    let issuedInput: ExecutionAuthorityIssueInput | undefined;
+    let hostInput: ExecutionHostConversationTurn | undefined;
+    const service = new HostedConversationTurnService({
+      authority: authority((input) => {
+        issuedInput = input;
+        return issued('execution-assertion');
+      }),
+      executionHost: {
+        streamConversationTurn: async function* (input) {
+          hostInput = input;
+          yield accepted();
+          yield result();
+        },
+      },
+      modelCredentials: {
+        resolveModelApiKey: async () => 'model-api-key',
+      },
+    });
+
+    await collect(service.streamTurn(turnInput()));
+
+    expect(issuedInput).not.toHaveProperty('mcp');
+    expect(hostInput).not.toHaveProperty('mcpCapability');
+  });
+
+  it('copies tool policy and rejects missing configured capability', async () => {
+    const allowedTools = ['read_snapshot'];
+    const service = new HostedConversationTurnService({
+      authority: authority(() => issued('execution-assertion')),
+      executionHost: {
+        streamConversationTurn: async function* () {
+          yield accepted();
+        },
+      },
+      modelCredentials: {
+        resolveModelApiKey: async () => 'model-api-key',
+      },
+      mcp: { allowedTools },
+    });
+    allowedTools[0] = 'write_everything';
+
+    await expect(collect(service.streamTurn(turnInput())))
+      .rejects.toBeInstanceOf(HostedConversationConfigurationError);
+  });
+
+  it('honors cancellation before minting authority', async () => {
+    const issue = vi.fn();
+    const controller = new AbortController();
+    controller.abort();
+    const service = new HostedConversationTurnService({
+      authority: { issue, publicJwks: () => ({ keys: [] }) },
+      executionHost: {
+        streamConversationTurn: async function* () {
+          yield accepted();
+        },
+      },
+      modelCredentials: {
+        resolveModelApiKey: async () => 'model-api-key',
+      },
+    });
+
+    await expect(collect(service.streamTurn({
+      ...turnInput(),
+      signal: controller.signal,
+    }))).rejects.toMatchObject({ name: 'AbortError' });
+    expect(issue).not.toHaveBeenCalled();
+  });
+});
+
+function authority(
+  issue: (
+    input: ExecutionAuthorityIssueInput,
+  ) => IssuedExecutionAuthority,
+): ExecutionAuthority {
+  return {
+    issue: async (input) => issue(input),
+    publicJwks: () => ({ keys: [] }),
+  };
+}
+
+function issued(
+  executionAssertion: string,
+  mcpCapability?: string,
+): IssuedExecutionAuthority {
+  const metadata = {
+    scope: {
+      adopterId: 'example-adopter',
+      tenantId: 'company-a',
+      subjectId: 'user-a',
+      productSessionId: 'conversation-a',
+    },
+    runtimeSessionId: runtimeSessionId(),
+    invocationId: 'invocation-001',
+    workflow: 'conversation-turn' as const,
+    issuedAt: '2026-08-10T12:00:00.000Z',
+    executionExpiresAt: '2026-08-10T12:05:00.000Z',
+  };
+  return {
+    metadata,
+    executionAssertion: () => executionAssertion,
+    mcpCapability: () => mcpCapability,
+    toJSON: () => metadata,
+  };
+}
+
+function turnInput() {
+  return {
+    scope: {
+      tenantId: 'company-a',
+      subjectId: 'user-a',
+      productSessionId: 'conversation-a',
+    },
+    runtimeSessionId: runtimeSessionId(),
+    invocationId: 'invocation-001',
+    prompt: 'Summarize the product state.',
+  };
+}
+
+function accepted(): ExecutionHostStreamEvent {
+  return {
+    schemaVersion: 1,
+    invocationId: 'invocation-001',
+    runId: 'run-001',
+    sequence: 0,
+    timestamp: '2026-08-10T12:00:00.000Z',
+    kind: 'accepted',
+  };
+}
+
+function result(): ExecutionHostStreamEvent {
+  return {
+    schemaVersion: 1,
+    invocationId: 'invocation-001',
+    runId: 'run-001',
+    sequence: 1,
+    timestamp: '2026-08-10T12:00:01.000Z',
+    kind: 'result',
+    result: { outcome: 'done' },
+  };
+}
+
+async function collect(
+  stream: AsyncIterable<ExecutionHostStreamEvent>,
+): Promise<ExecutionHostStreamEvent[]> {
+  const events: ExecutionHostStreamEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+function runtimeSessionId(): string {
+  return 'runtime-session-001-abcdefghijklmnop';
+}

--- a/packages/heddle-adopter/src/__tests__/node-authority-key.test.ts
+++ b/packages/heddle-adopter/src/__tests__/node-authority-key.test.ts
@@ -1,0 +1,144 @@
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { JoseExecutionAuthority } from '../authority/index.js';
+import {
+  DirectExecutionHostCredentials,
+  ExecutionAuthorityKeyFileError,
+  generateEphemeralExecutionAuthorityKeyPair,
+  generateExecutionAuthorityKeyFile,
+  loadExecutionAuthorityKeyPairFromFile,
+} from '../node/index.js';
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'heddle-adopter-key-'));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('Node execution-authority key utilities', () => {
+  it('generates an owner-only file and loads a non-exportable signing key', async () => {
+    const filePath = join(root, 'execution-authority.jwk');
+
+    await generateExecutionAuthorityKeyFile(filePath);
+    const metadata = await stat(filePath);
+    const encoded = await readFile(filePath, 'utf8');
+    const pair = await loadExecutionAuthorityKeyPairFromFile(filePath);
+    const authority = await JoseExecutionAuthority.create({
+      issuer: 'https://api.example.test',
+      adopterId: 'example-adopter',
+      executionAudience: 'urn:heddle-execution-host:example',
+      keyId: 'execution-key-001',
+      executionTtlSeconds: 300,
+    }, pair);
+
+    if (process.platform !== 'win32') {
+      expect(metadata.mode & 0o777).toBe(0o600);
+    }
+    expect(JSON.parse(encoded)).toMatchObject({
+      kty: 'EC',
+      crv: 'P-256',
+      x: expect.any(String),
+      y: expect.any(String),
+      d: expect.any(String),
+    });
+    expect(pair.privateKey.extractable).toBe(false);
+    expect(authority.publicJwks().keys).toHaveLength(1);
+  });
+
+  it('never overwrites an existing path', async () => {
+    const filePath = join(root, 'existing.jwk');
+    await writeFile(filePath, 'keep-me', { mode: 0o600 });
+
+    await expect(generateExecutionAuthorityKeyFile(filePath))
+      .rejects.toThrow(/could not be generated/);
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('keep-me');
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'rejects a group-readable private key',
+    async () => {
+      const filePath = join(root, 'broad.jwk');
+      await generateExecutionAuthorityKeyFile(filePath);
+      await chmod(filePath, 0o640);
+
+      await expect(loadExecutionAuthorityKeyPairFromFile(filePath))
+        .rejects.toThrow(/group- or world-accessible/);
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'rejects a symlink instead of following it',
+    async () => {
+      const target = join(root, 'target.jwk');
+      const link = join(root, 'link.jwk');
+      await generateExecutionAuthorityKeyFile(target);
+      await symlink(target, link);
+
+      await expect(loadExecutionAuthorityKeyPairFromFile(link))
+        .rejects.toBeInstanceOf(ExecutionAuthorityKeyFileError);
+    },
+  );
+
+  it('generates a disposable non-exportable pair for tests', async () => {
+    const pair = await generateEphemeralExecutionAuthorityKeyPair();
+
+    expect(pair.privateKey.type).toBe('private');
+    expect(pair.privateKey.extractable).toBe(false);
+    expect(pair.publicKey.type).toBe('public');
+  });
+});
+
+describe('direct Execution Host credentials', () => {
+  it('takes secrets out of the environment and keeps them non-enumerable', async () => {
+    const environment = {
+      PRODUCT_HOST_TOKEN: 'local-token-'.padEnd(32, 'x'),
+      PRODUCT_MODEL_KEY: 'model-key-value',
+    };
+
+    const credentials = DirectExecutionHostCredentials.takeFromEnvironment(
+      environment,
+      {
+        localToken: 'PRODUCT_HOST_TOKEN',
+        modelApiKey: 'PRODUCT_MODEL_KEY',
+      },
+    );
+
+    expect(environment).toEqual({});
+    expect(credentials.localToken()).toHaveLength(32);
+    await expect(credentials.resolveModelApiKey()).resolves.toBe(
+      'model-key-value',
+    );
+    expect(Object.keys(credentials)).toEqual([]);
+    expect(JSON.stringify(credentials)).toBe('{}');
+  });
+
+  it('removes present secrets even when validation fails', () => {
+    const environment = {
+      PRODUCT_HOST_TOKEN: 'short',
+      PRODUCT_MODEL_KEY: 'model-key-value',
+    };
+
+    expect(() => DirectExecutionHostCredentials.takeFromEnvironment(
+      environment,
+      {
+        localToken: 'PRODUCT_HOST_TOKEN',
+        modelApiKey: 'PRODUCT_MODEL_KEY',
+      },
+    )).toThrow('credentials are invalid');
+    expect(environment).toEqual({});
+  });
+});

--- a/packages/heddle-adopter/src/__tests__/node-http.test.ts
+++ b/packages/heddle-adopter/src/__tests__/node-http.test.ts
@@ -1,0 +1,347 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ExecutionHostStreamEvent } from '../contracts/index.js';
+import {
+  DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH,
+  DEFAULT_ADOPTER_JWKS_PATH,
+  NodeExecutionAdopterHttpService,
+} from '../node/index.js';
+
+const running = new Set<RunningService>();
+
+afterEach(async () => {
+  await Promise.all([...running].map((service) => service.close()));
+  running.clear();
+});
+
+describe('Node execution-adopter HTTP service', () => {
+  it('serves JWKS, leaves unknown routes alone, and streams a valid turn', async () => {
+    let activeRequest: IncomingMessage | undefined;
+    const authenticate = vi.fn((input: { authorization?: string }) => {
+      expect(input.authorization).toBe('Bearer user-token');
+      expect(activeRequest?.headers.authorization).toBe('[REDACTED]');
+      expect(activeRequest?.rawHeaders).not.toContain('Bearer user-token');
+      return { subjectId: 'user-a' };
+    });
+    const service = new NodeExecutionAdopterHttpService({
+      authority: {
+        publicJwks: () => ({ keys: [{ kty: 'EC', kid: 'key-001' }] }),
+      },
+      authenticator: { authenticate },
+      conversations: {
+        streamTurn: async function* ({ principal, prompt }) {
+          expect(principal).toEqual({ subjectId: 'user-a' });
+          expect(prompt).toBe('Summarize this workspace.');
+          yield accepted();
+          yield result();
+        },
+      },
+    });
+    const app = await start(service, (request) => {
+      activeRequest = request;
+    });
+
+    const jwks = await fetch(new URL(DEFAULT_ADOPTER_JWKS_PATH, app.baseUrl));
+    expect(jwks.status).toBe(200);
+    expect(jwks.headers.get('cache-control')).toBe('public, max-age=60');
+    await expect(jwks.json()).resolves.toEqual({
+      keys: [{ kty: 'EC', kid: 'key-001' }],
+    });
+
+    const missing = await fetch(new URL('/product-route', app.baseUrl));
+    expect(missing.status).toBe(404);
+
+    const response = await invoke(app.baseUrl, {
+      headers: { Authorization: 'Bearer user-token' },
+    });
+    const stream = await response.text();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    expect(stream).toContain('event: accepted');
+    expect(stream).toContain('event: result');
+    expect(authenticate).toHaveBeenCalledOnce();
+    expect(JSON.stringify(service)).toBe('{}');
+  });
+
+  it('owns safe authentication and request-validation failures', async () => {
+    const service = new NodeExecutionAdopterHttpService({
+      authority: { publicJwks: () => ({ keys: [] }) },
+      authenticator: {
+        authenticate: ({ authorization }) => authorization === 'Bearer valid'
+          ? { subjectId: 'user-a' }
+          : undefined,
+      },
+      conversations: {
+        streamTurn: async function* () {
+          yield accepted();
+        },
+      },
+      maxBodyBytes: 64,
+    });
+    const app = await start(service);
+
+    const unauthenticated = await invoke(app.baseUrl);
+    expect(unauthenticated.status).toBe(401);
+    expect(unauthenticated.headers.get('www-authenticate')).toBe('Bearer');
+
+    const wrongMedia = await fetch(
+      new URL(DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH, app.baseUrl),
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer valid',
+          'Content-Type': 'text/plain',
+        },
+        body: 'hello',
+      },
+    );
+    expect(wrongMedia.status).toBe(415);
+
+    const oversized = await invoke(app.baseUrl, {
+      headers: { Authorization: 'Bearer valid' },
+      body: JSON.stringify({ prompt: 'x'.repeat(100) }),
+    });
+    expect(oversized.status).toBe(413);
+
+    const invalidShape = await invoke(app.baseUrl, {
+      headers: { Authorization: 'Bearer valid' },
+      body: JSON.stringify({ prompt: 'valid', identity: 'caller-selected' }),
+    });
+    expect(invalidShape.status).toBe(400);
+  });
+
+  it('projects adopter-domain failures without exposing unknown errors', async () => {
+    class ProductAuthorizationError extends Error {}
+    const secret = 'internal-product-secret';
+    const failures: unknown[] = [];
+    let attempt = 0;
+    const service = new NodeExecutionAdopterHttpService({
+      authority: { publicJwks: () => ({ keys: [] }) },
+      authenticator: { authenticate: () => ({ subjectId: 'user-a' }) },
+      conversations: {
+        streamTurn: () => {
+          attempt += 1;
+          return attempt === 1
+            ? failingStream(new ProductAuthorizationError())
+            : failingStream(new Error(secret));
+        },
+      },
+      projectError: (error) => error instanceof ProductAuthorizationError
+        ? { statusCode: 403, message: 'This action is not allowed.' }
+        : undefined,
+      reportFailure: (failure) => failures.push(failure),
+    });
+    const app = await start(service);
+
+    const denied = await invoke(app.baseUrl, {
+      headers: { Authorization: 'Bearer valid' },
+    });
+    expect(denied.status).toBe(403);
+    expect(await denied.text()).toContain('This action is not allowed.');
+
+    const failed = await invoke(app.baseUrl, {
+      headers: { Authorization: 'Bearer valid' },
+    });
+    const failedBody = await failed.text();
+    expect(failed.status).toBe(502);
+    expect(failedBody).toContain('Execution Host conversation failed.');
+    expect(failedBody).not.toContain(secret);
+    expect(JSON.stringify(failures)).not.toContain(secret);
+    expect(failures).toContainEqual({
+      phase: 'conversation',
+      errorType: 'Error',
+      streamAccepted: false,
+    });
+  });
+
+  it('ends an accepted stream ambiguously when a later failure occurs', async () => {
+    const service = new NodeExecutionAdopterHttpService({
+      authority: { publicJwks: () => ({ keys: [] }) },
+      authenticator: { authenticate: () => ({ subjectId: 'user-a' }) },
+      conversations: {
+        streamTurn: async function* () {
+          yield accepted();
+          throw new Error('do-not-reflect');
+        },
+      },
+    });
+    const app = await start(service);
+
+    const response = await invoke(app.baseUrl, {
+      headers: { Authorization: 'Bearer valid' },
+    });
+    const stream = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(stream).toContain('event: accepted');
+    expect(stream).not.toContain('event: error');
+    expect(stream).not.toContain('do-not-reflect');
+  });
+
+  it('reports an empty host stream as unavailable', async () => {
+    const service = new NodeExecutionAdopterHttpService({
+      authority: { publicJwks: () => ({ keys: [] }) },
+      authenticator: { authenticate: () => ({ subjectId: 'user-a' }) },
+      conversations: { streamTurn: async function* () {} },
+    });
+    const app = await start(service);
+
+    const response = await invoke(app.baseUrl, {
+      headers: { Authorization: 'Bearer valid' },
+    });
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toContain('returned no events');
+  });
+
+  it('aborts active product work during graceful shutdown', async () => {
+    let observedAbort = false;
+    let enter!: () => void;
+    const entered = new Promise<void>((resolve) => { enter = resolve; });
+    const service = new NodeExecutionAdopterHttpService({
+      authority: { publicJwks: () => ({ keys: [] }) },
+      authenticator: { authenticate: () => ({ subjectId: 'user-a' }) },
+      conversations: {
+        streamTurn: async function* ({ signal }) {
+          yield* [] as ExecutionHostStreamEvent[];
+          enter();
+          await new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => {
+              observedAbort = true;
+              resolve();
+            }, { once: true });
+          });
+        },
+      },
+    });
+    const app = await start(service);
+    const invocation = invoke(app.baseUrl, {
+      headers: { Authorization: 'Bearer valid' },
+    }).catch((error: unknown) => error);
+    await entered;
+
+    await service.close();
+    await invocation;
+
+    expect(observedAbort).toBe(true);
+  });
+
+  it('validates route and limit configuration once at construction', () => {
+    const base = {
+      authority: { publicJwks: () => ({ keys: [] }) },
+      authenticator: { authenticate: () => undefined },
+      conversations: { streamTurn: async function* () {} },
+    };
+
+    expect(() => new NodeExecutionAdopterHttpService({
+      ...base,
+      paths: { jwks: 'relative' },
+    })).toThrow(/absolute path/);
+    expect(() => new NodeExecutionAdopterHttpService({
+      ...base,
+      paths: { jwks: '/same', conversationTurns: '/same' },
+    })).toThrow(/distinct/);
+    expect(() => new NodeExecutionAdopterHttpService({
+      ...base,
+      maxBodyBytes: 0,
+    })).toThrow();
+  });
+});
+
+type RunningService = {
+  baseUrl: URL;
+  close(): Promise<void>;
+};
+
+async function start(
+  service: NodeExecutionAdopterHttpService<unknown>,
+  observeRequest?: (request: IncomingMessage) => void,
+): Promise<RunningService> {
+  const server = createServer((request, response) => {
+    observeRequest?.(request);
+    if (!service.handle(request, response)) {
+      response.writeHead(404).end();
+    }
+  });
+  await listen(server);
+  const address = server.address() as AddressInfo;
+  const runningService = {
+    baseUrl: new URL(`http://127.0.0.1:${address.port}`),
+    close: async () => {
+      await service.close();
+      await closeServer(server);
+    },
+  };
+  running.add(runningService);
+  return runningService;
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+function invoke(
+  baseUrl: URL,
+  options: { headers?: Record<string, string>; body?: string } = {},
+): Promise<Response> {
+  return fetch(
+    new URL(DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH, baseUrl),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+      body: options.body ?? JSON.stringify({
+        prompt: 'Summarize this workspace.',
+      }),
+    },
+  );
+}
+
+function accepted(): ExecutionHostStreamEvent {
+  return {
+    schemaVersion: 1,
+    invocationId: 'invocation-001',
+    runId: 'run-001',
+    sequence: 0,
+    timestamp: '2026-08-10T12:00:00.000Z',
+    kind: 'accepted',
+  };
+}
+
+function result(): ExecutionHostStreamEvent {
+  return {
+    schemaVersion: 1,
+    invocationId: 'invocation-001',
+    runId: 'run-001',
+    sequence: 1,
+    timestamp: '2026-08-10T12:00:01.000Z',
+    kind: 'result',
+    result: { outcome: 'done' },
+  };
+}
+
+async function* failingStream(error: Error): AsyncIterable<
+  ExecutionHostStreamEvent
+> {
+  yield* [] as ExecutionHostStreamEvent[];
+  throw error;
+}

--- a/packages/heddle-adopter/src/__tests__/node-mcp.test.ts
+++ b/packages/heddle-adopter/src/__tests__/node-mcp.test.ts
@@ -1,0 +1,279 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import {
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { z } from 'zod';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  McpCapabilityUnavailableError,
+  McpCapabilityVerificationError,
+  type McpCapabilityVerifier,
+  type VerifiedMcpCapability,
+} from '../mcp/index.js';
+import {
+  NodeStreamableHttpMcpService,
+  type NodeMcpToolset,
+} from '../mcp/node/index.js';
+
+const running = new Set<RunningMcpService>();
+
+afterEach(async () => {
+  await Promise.all([...running].map((service) => service.close()));
+  running.clear();
+});
+
+describe('Node Streamable HTTP MCP service', () => {
+  it('verifies every request and exposes only capability-selected tools', async () => {
+    let currentRequest: IncomingMessage | undefined;
+    const verify = vi.fn(async (assertion: string) => {
+      expect(assertion).toBe('aaa.bbb.ccc');
+      expect(currentRequest?.headers.authorization).toBe('[REDACTED]');
+      expect(currentRequest?.rawHeaders).not.toContain('Bearer aaa.bbb.ccc');
+      return capability(['read_scope']);
+    });
+    const service = new NodeStreamableHttpMcpService<ToolName>({
+      capabilityVerifier: { verify },
+      toolset: toolset(),
+    });
+    const app = await start(service, (request) => {
+      currentRequest = request;
+    });
+    const client = await connect(app.endpoint);
+    app.clients.add(client);
+
+    const tools = await client.listTools();
+    const result = await client.callTool({ name: 'read_scope', arguments: {} });
+
+    expect(tools.tools.map(({ name }) => name)).toEqual(['read_scope']);
+    expect(JSON.stringify(result)).toContain('company-a');
+    expect(verify.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('returns safe auth failures before creating product tools', async () => {
+    const registerAllowedTools = vi.fn();
+    const service = new NodeStreamableHttpMcpService<ToolName>({
+      capabilityVerifier: {
+        verify: async () => { throw new McpCapabilityVerificationError(); },
+      },
+      toolset: {
+        serverInfo: { name: 'test-product', version: '1.0.0' },
+        registerAllowedTools,
+      },
+    });
+    const app = await start(service);
+
+    const response = await postJsonRpc(app.endpoint, 'Bearer aaa.bbb.ccc');
+    const body = await response.text();
+
+    expect(response.status).toBe(401);
+    expect(body).toContain('Authentication failed.');
+    expect(body).not.toContain('aaa.bbb.ccc');
+    expect(registerAllowedTools).not.toHaveBeenCalled();
+  });
+
+  it('distinguishes a temporarily unavailable verifier', async () => {
+    const service = new NodeStreamableHttpMcpService<ToolName>({
+      capabilityVerifier: {
+        verify: async () => { throw new McpCapabilityUnavailableError('jwks'); },
+      },
+      toolset: toolset(),
+    });
+    const app = await start(service);
+
+    const response = await postJsonRpc(app.endpoint, 'Bearer aaa.bbb.ccc');
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('1');
+  });
+
+  it('bounds request bodies before constructing SDK resources', async () => {
+    const registerAllowedTools = vi.fn();
+    const service = new NodeStreamableHttpMcpService<ToolName>({
+      capabilityVerifier: verifier(),
+      toolset: {
+        serverInfo: { name: 'test-product', version: '1.0.0' },
+        registerAllowedTools,
+      },
+      maxBodyBytes: 32,
+    });
+    const app = await start(service);
+
+    const response = await postJsonRpc(app.endpoint, 'Bearer aaa.bbb.ccc');
+
+    expect(response.status).toBe(413);
+    expect(registerAllowedTools).not.toHaveBeenCalled();
+  });
+
+  it('aborts an in-flight product tool during service shutdown', async () => {
+    let aborted = false;
+    let enter!: () => void;
+    const entered = new Promise<void>((resolve) => { enter = resolve; });
+    const service = new NodeStreamableHttpMcpService<ToolName>({
+      capabilityVerifier: verifier(['wait_for_shutdown']),
+      toolset: {
+        serverInfo: { name: 'test-product', version: '1.0.0' },
+        registerAllowedTools: ({ server, requestSignal }) => {
+          server.registerTool(
+            'wait_for_shutdown',
+            { inputSchema: z.object({}).strict() },
+            async (_input, extra) => {
+              enter();
+              const signal = AbortSignal.any([requestSignal, extra.signal]);
+              await new Promise<void>((resolve) => {
+                signal.addEventListener('abort', () => {
+                  aborted = true;
+                  resolve();
+                }, { once: true });
+              });
+              return {
+                isError: true,
+                content: [{ type: 'text', text: 'cancelled' }],
+              };
+            },
+          );
+        },
+      },
+    });
+    const app = await start(service);
+    const client = await connect(app.endpoint);
+    app.clients.add(client);
+    const call = client.callTool({ name: 'wait_for_shutdown', arguments: {} });
+    await entered;
+
+    const closing = service.close();
+    await vi.waitFor(() => expect(aborted).toBe(true));
+    await client.close();
+    app.clients.delete(client);
+    await call.catch(() => undefined);
+    await closing;
+  });
+});
+
+type ToolName = 'read_scope' | 'wait_for_shutdown';
+
+function toolset(): NodeMcpToolset<ToolName> {
+  return {
+    serverInfo: { name: 'test-product', version: '1.0.0' },
+    registerAllowedTools: ({ server, capability: verified }) => {
+      if (verified.allowedTools.includes('read_scope')) {
+        server.registerTool(
+          'read_scope',
+          { inputSchema: z.object({}).strict() },
+          async () => ({
+            content: [{
+              type: 'text',
+              text: JSON.stringify(verified.scope),
+            }],
+          }),
+        );
+      }
+    },
+  };
+}
+
+function verifier(
+  tools: readonly ToolName[] = ['read_scope'],
+): McpCapabilityVerifier<ToolName> {
+  return { verify: async () => capability(tools) };
+}
+
+function capability(
+  tools: readonly ToolName[],
+): VerifiedMcpCapability<ToolName> {
+  return Object.freeze({
+    capabilityId: 'capability-001',
+    serverId: 'product_capabilities',
+    allowedTools: Object.freeze([...tools]),
+    scope: Object.freeze({
+      adopterId: 'example-adopter',
+      tenantId: 'company-a',
+      subjectId: 'user-a',
+      productSessionId: 'conversation-a',
+      runtimeSessionId: 'runtime-session-001-abcdefghijklmnop',
+      invocationId: 'invocation-001',
+      workflow: 'conversation-turn',
+    }),
+    issuedAt: '2026-08-10T12:00:00.000Z',
+    expiresAt: '2026-08-10T12:10:00.000Z',
+  });
+}
+
+type RunningMcpService = {
+  endpoint: URL;
+  clients: Set<Client>;
+  close(): Promise<void>;
+};
+
+async function start(
+  service: NodeStreamableHttpMcpService<ToolName>,
+  observeRequest?: (request: IncomingMessage) => void,
+): Promise<RunningMcpService> {
+  const server = createServer((request, response) => {
+    observeRequest?.(request);
+    void service.handle(request, response);
+  });
+  await listen(server);
+  const address = server.address() as AddressInfo;
+  const clients = new Set<Client>();
+  const app = {
+    endpoint: new URL(`http://127.0.0.1:${address.port}/mcp`),
+    clients,
+    close: async () => {
+      await Promise.all([...clients].map((client) => (
+        client.close().catch(() => undefined)
+      )));
+      await service.close();
+      await closeServer(server);
+    },
+  };
+  running.add(app);
+  return app;
+}
+
+async function connect(endpoint: URL): Promise<Client> {
+  const client = new Client({ name: 'adopter-test', version: '1.0.0' });
+  await client.connect(new StreamableHTTPClientTransport(endpoint, {
+    requestInit: {
+      headers: { Authorization: 'Bearer aaa.bbb.ccc' },
+    },
+  }));
+  return client;
+}
+
+function postJsonRpc(endpoint: URL, authorization: string): Promise<Response> {
+  return fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {},
+    }),
+  });
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}

--- a/packages/heddle-adopter/src/__tests__/node-mcp.test.ts
+++ b/packages/heddle-adopter/src/__tests__/node-mcp.test.ts
@@ -17,6 +17,9 @@ import {
   type VerifiedMcpCapability,
 } from '../mcp/index.js';
 import {
+  defineNodeMcpJsonTool,
+  NodeMcpJsonToolset,
+  NodeMcpJsonToolsetConfigurationError,
   NodeStreamableHttpMcpService,
   type NodeMcpToolset,
 } from '../mcp/node/index.js';
@@ -152,6 +155,120 @@ describe('Node Streamable HTTP MCP service', () => {
     app.clients.delete(client);
     await call.catch(() => undefined);
     await closing;
+  });
+
+  it('turns product declarations into capability-scoped JSON tools', async () => {
+    const readScope = defineNodeMcpJsonTool({
+      name: 'read_scope' as const,
+      description: 'Read the authenticated product scope.',
+      inputSchema: z.object({ detail: z.boolean() }).strict(),
+      annotations: { readOnlyHint: true },
+      failureMessage: 'Product scope is unavailable.',
+      execute: ({ detail }, { capability: verified }) => ({
+        tenantId: verified.scope.tenantId,
+        detail,
+      }),
+    });
+    const hidden = defineNodeMcpJsonTool({
+      name: 'wait_for_shutdown' as const,
+      description: 'A second configured tool.',
+      inputSchema: z.object({}).strict(),
+      failureMessage: 'The second tool failed.',
+      execute: () => ({ hidden: false }),
+    });
+    const service = new NodeStreamableHttpMcpService<ToolName>({
+      capabilityVerifier: verifier(['read_scope']),
+      toolset: new NodeMcpJsonToolset({
+        serverInfo: { name: 'test-product', version: '1.0.0' },
+        tools: [readScope, hidden],
+        now: () => new Date('2026-08-10T12:00:00.000Z'),
+      }),
+    });
+    const app = await start(service);
+    const client = await connect(app.endpoint);
+    app.clients.add(client);
+
+    const tools = await client.listTools();
+    const result = await client.callTool({
+      name: 'read_scope',
+      arguments: { detail: true },
+    });
+
+    expect(tools.tools.map(({ name }) => name)).toEqual(['read_scope']);
+    expect(result).toMatchObject({
+      content: [{
+        type: 'text',
+        text: JSON.stringify({ tenantId: 'company-a', detail: true }),
+      }],
+    });
+  });
+
+  it('rechecks declarative tool authority and hides product failures', async () => {
+    const secret = 'database-password';
+    let now = new Date('2026-08-10T12:00:00.000Z');
+    const toolset = new NodeMcpJsonToolset<ToolName>({
+      serverInfo: { name: 'test-product', version: '1.0.0' },
+      now: () => now,
+      tools: [defineNodeMcpJsonTool({
+        name: 'read_scope' as const,
+        description: 'Read a product projection.',
+        inputSchema: z.object({ fail: z.boolean() }).strict(),
+        failureMessage: 'Product projection is unavailable.',
+        execute: ({ fail }) => {
+          if (fail) {
+            throw new Error(secret);
+          }
+          now = new Date('2026-08-10T12:11:00.000Z');
+          return { shouldNotBeReturned: true };
+        },
+      })],
+    });
+    const service = new NodeStreamableHttpMcpService<ToolName>({
+      capabilityVerifier: verifier(['read_scope']),
+      toolset,
+    });
+    const app = await start(service);
+    const client = await connect(app.endpoint);
+    app.clients.add(client);
+
+    const failed = await client.callTool({
+      name: 'read_scope',
+      arguments: { fail: true },
+    });
+    expect(JSON.stringify(failed)).toContain('Product projection is unavailable.');
+    expect(JSON.stringify(failed)).not.toContain(secret);
+
+    now = new Date('2026-08-10T12:00:00.000Z');
+    const expiredAfterWork = await client.callTool({
+      name: 'read_scope',
+      arguments: { fail: false },
+    });
+    expect(JSON.stringify(expiredAfterWork)).toContain('Product tool authority expired.');
+    expect(JSON.stringify(expiredAfterWork)).not.toContain('shouldNotBeReturned');
+  });
+
+  it('rejects duplicate and capability-selected missing declarations', () => {
+    const definition = defineNodeMcpJsonTool({
+      name: 'read_scope' as const,
+      description: 'Read scope.',
+      inputSchema: z.object({}).strict(),
+      failureMessage: 'Unavailable.',
+      execute: () => ({}),
+    });
+    expect(() => new NodeMcpJsonToolset({
+      serverInfo: { name: 'test-product', version: '1.0.0' },
+      tools: [definition, definition],
+    })).toThrow(NodeMcpJsonToolsetConfigurationError);
+
+    const toolset = new NodeMcpJsonToolset<ToolName>({
+      serverInfo: { name: 'test-product', version: '1.0.0' },
+      tools: [definition],
+    });
+    expect(() => toolset.registerAllowedTools({
+      server: { registerTool: vi.fn() } as never,
+      capability: capability(['wait_for_shutdown']),
+      requestSignal: new AbortController().signal,
+    })).toThrow(NodeMcpJsonToolsetConfigurationError);
   });
 });
 

--- a/packages/heddle-adopter/src/conversation/README.md
+++ b/packages/heddle-adopter/src/conversation/README.md
@@ -1,0 +1,18 @@
+# Hosted conversation orchestration
+
+This domain owns the reusable middle of one adopter-initiated conversation
+turn: issue short-lived authority, resolve a model credential through a narrow
+port, and invoke the provider-neutral `ExecutionHost` stream.
+
+It deliberately does not own:
+
+- end-user authentication or product authorization;
+- tenant, subject, session, Runtime-session, or invocation-ID selection;
+- which product MCP tools a particular user may receive;
+- result persistence, idempotency, retry, billing, or UI projection;
+- HTTP routing or AWS transport.
+
+The adopter supplies those decisions, then calls `HostedConversationTurnService`
+with already authorized IDs. Configure `mcp.allowedTools` once when every turn
+through that service shares the same bounded tool policy. Omit it for an
+execution-only workflow.

--- a/packages/heddle-adopter/src/conversation/hosted-conversation-turn-service.ts
+++ b/packages/heddle-adopter/src/conversation/hosted-conversation-turn-service.ts
@@ -1,0 +1,78 @@
+import {
+  CONVERSATION_TURN_WORKFLOW,
+  McpAllowedToolsSchema,
+} from '../contracts/index.js';
+import type {
+  HostedConversationTurnInput,
+  HostedConversationTurnRunner,
+  HostedConversationTurnServiceConfig,
+} from './types.js';
+
+export class HostedConversationConfigurationError extends Error {
+  readonly name = 'HostedConversationConfigurationError';
+}
+
+/**
+ * Provider-neutral application service for one externally hosted turn.
+ *
+ * It binds authority, optional product-tool policy, model credentials, and the
+ * Execution Host stream while leaving product admission and settlement to the
+ * adopter.
+ */
+export class HostedConversationTurnService
+implements HostedConversationTurnRunner {
+  readonly #authority: HostedConversationTurnServiceConfig['authority'];
+  readonly #executionHost: HostedConversationTurnServiceConfig['executionHost'];
+  readonly #modelCredentials: HostedConversationTurnServiceConfig[
+    'modelCredentials'
+  ];
+  readonly #allowedTools: readonly string[] | undefined;
+
+  constructor(config: HostedConversationTurnServiceConfig) {
+    this.#authority = config.authority;
+    this.#executionHost = config.executionHost;
+    this.#modelCredentials = config.modelCredentials;
+    this.#allowedTools = config.mcp
+      ? Object.freeze(McpAllowedToolsSchema.parse(config.mcp.allowedTools))
+      : undefined;
+  }
+
+  async *streamTurn(
+    input: HostedConversationTurnInput,
+  ): ReturnType<HostedConversationTurnRunner['streamTurn']> {
+    input.signal?.throwIfAborted();
+    const issued = await this.#authority.issue({
+      scope: input.scope,
+      runtimeSessionId: input.runtimeSessionId,
+      invocationId: input.invocationId,
+      workflow: CONVERSATION_TURN_WORKFLOW,
+      ...(this.#allowedTools
+        ? { mcp: { allowedTools: this.#allowedTools } }
+        : {}),
+    });
+    const mcpCapability = issued.mcpCapability();
+    if (this.#allowedTools && !mcpCapability) {
+      throw new HostedConversationConfigurationError(
+        'Hosted conversation tool policy requires an MCP-capable execution authority.',
+      );
+    }
+
+    const modelApiKey = await this.#modelCredentials.resolveModelApiKey({
+      scope: input.scope,
+      invocationId: input.invocationId,
+      signal: input.signal,
+    });
+    input.signal?.throwIfAborted();
+
+    yield* this.#executionHost.streamConversationTurn({
+      invocationId: input.invocationId,
+      runtimeSessionId: input.runtimeSessionId,
+      prompt: input.prompt,
+      ...(input.deadlineAt ? { deadlineAt: input.deadlineAt } : {}),
+      ...(input.signal ? { signal: input.signal } : {}),
+      executionAssertion: issued.executionAssertion(),
+      ...(mcpCapability ? { mcpCapability } : {}),
+      modelApiKey,
+    });
+  }
+}

--- a/packages/heddle-adopter/src/conversation/index.ts
+++ b/packages/heddle-adopter/src/conversation/index.ts
@@ -1,0 +1,11 @@
+export {
+  HostedConversationConfigurationError,
+  HostedConversationTurnService,
+} from './hosted-conversation-turn-service.js';
+export type {
+  HostedConversationCredentialContext,
+  HostedConversationModelCredentialProvider,
+  HostedConversationTurnInput,
+  HostedConversationTurnRunner,
+  HostedConversationTurnServiceConfig,
+} from './types.js';

--- a/packages/heddle-adopter/src/conversation/types.ts
+++ b/packages/heddle-adopter/src/conversation/types.ts
@@ -1,0 +1,43 @@
+import type {
+  ExecutionHostStreamEvent,
+  ExecutionScope,
+} from '../contracts/index.js';
+import type { ExecutionAuthority } from '../authority/index.js';
+import type { ExecutionHost } from '../http-sse/index.js';
+
+export type HostedConversationTurnInput = {
+  scope: Omit<ExecutionScope, 'adopterId'>;
+  runtimeSessionId: string;
+  invocationId: string;
+  prompt: string;
+  deadlineAt?: string;
+  signal?: AbortSignal;
+};
+
+export type HostedConversationCredentialContext = Pick<
+  HostedConversationTurnInput,
+  'scope' | 'invocationId' | 'signal'
+>;
+
+/** Resolves model authority without exposing it to HTTP or product data. */
+export interface HostedConversationModelCredentialProvider {
+  resolveModelApiKey(
+    context: HostedConversationCredentialContext,
+  ): Promise<string>;
+}
+
+export interface HostedConversationTurnRunner {
+  streamTurn(
+    input: HostedConversationTurnInput,
+  ): AsyncIterable<ExecutionHostStreamEvent>;
+}
+
+export type HostedConversationTurnServiceConfig = {
+  authority: ExecutionAuthority;
+  executionHost: ExecutionHost;
+  modelCredentials: HostedConversationModelCredentialProvider;
+  /** Omit this policy when the hosted workflow needs no product MCP tools. */
+  mcp?: {
+    allowedTools: readonly string[];
+  };
+};

--- a/packages/heddle-adopter/src/index.ts
+++ b/packages/heddle-adopter/src/index.ts
@@ -1,4 +1,5 @@
 export * from './contracts/index.js';
 export * from './authority/index.js';
+export * from './conversation/index.js';
 export * from './mcp/index.js';
 export * from './http-sse/index.js';

--- a/packages/heddle-adopter/src/mcp/node/README.md
+++ b/packages/heddle-adopter/src/mcp/node/README.md
@@ -5,11 +5,18 @@ adopter product tools: bounded JSON, bearer extraction/redaction, independent
 capability verification, safe HTTP/JSON-RPC errors, one stateless server and
 transport per request, cancellation, and shutdown.
 
-The injected `NodeMcpToolset` owns every model-visible tool name, description,
-schema, annotation, handler, and product operation. Tool handlers must derive
-identity from `context.capability.scope`, never model-controlled arguments, and
-should call `assertMcpCapabilityActive` again immediately before sensitive or
-long-running operations.
+For the common JSON-tool path, use `NodeMcpJsonToolset` with declarations made
+through `defineNodeMcpJsonTool`. The generic registry exposes exactly the names
+in the signed capability, combines request and operation cancellation, checks
+capability lifetime before and after product work, serializes results as JSON,
+and replaces thrown errors with each declaration's static public failure text.
+The adopter declares only product names, descriptions, Zod input schemas,
+annotations, and behavior. Handlers derive identity from
+`context.capability.scope`, never model-controlled arguments.
+
+The lower-level `NodeMcpToolset` remains the advanced escape hatch for custom
+MCP content, non-JSON results, or product-specific lifecycle behavior. In that
+mode the adopter owns allowlist enforcement and repeated lifetime checks.
 
 The service does not register its own route, authenticate product users, select
 the signed allowlist, read a database, or decide product authorization. Those

--- a/packages/heddle-adopter/src/mcp/node/README.md
+++ b/packages/heddle-adopter/src/mcp/node/README.md
@@ -1,0 +1,16 @@
+# Node Streamable HTTP MCP edge
+
+This optional subpath owns the generic official-SDK server lifecycle around
+adopter product tools: bounded JSON, bearer extraction/redaction, independent
+capability verification, safe HTTP/JSON-RPC errors, one stateless server and
+transport per request, cancellation, and shutdown.
+
+The injected `NodeMcpToolset` owns every model-visible tool name, description,
+schema, annotation, handler, and product operation. Tool handlers must derive
+identity from `context.capability.scope`, never model-controlled arguments, and
+should call `assertMcpCapabilityActive` again immediately before sensitive or
+long-running operations.
+
+The service does not register its own route, authenticate product users, select
+the signed allowlist, read a database, or decide product authorization. Those
+remain adopter responsibilities.

--- a/packages/heddle-adopter/src/mcp/node/index.ts
+++ b/packages/heddle-adopter/src/mcp/node/index.ts
@@ -1,0 +1,6 @@
+export { NodeStreamableHttpMcpService } from './streamable-http-mcp-service.js';
+export type {
+  NodeMcpToolRegistrationContext,
+  NodeMcpToolset,
+  NodeStreamableHttpMcpServiceConfig,
+} from './types.js';

--- a/packages/heddle-adopter/src/mcp/node/index.ts
+++ b/packages/heddle-adopter/src/mcp/node/index.ts
@@ -1,5 +1,14 @@
 export { NodeStreamableHttpMcpService } from './streamable-http-mcp-service.js';
+export {
+  defineNodeMcpJsonTool,
+  NodeMcpJsonToolset,
+  NodeMcpJsonToolsetConfigurationError,
+} from './json-toolset.js';
 export type {
+  AnyNodeMcpJsonToolDefinition,
+  NodeMcpJsonToolDefinition,
+  NodeMcpJsonToolExecutionContext,
+  NodeMcpJsonToolsetConfig,
   NodeMcpToolRegistrationContext,
   NodeMcpToolset,
   NodeStreamableHttpMcpServiceConfig,

--- a/packages/heddle-adopter/src/mcp/node/json-toolset.ts
+++ b/packages/heddle-adopter/src/mcp/node/json-toolset.ts
@@ -1,0 +1,136 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import {
+  assertMcpCapabilityActive,
+  McpCapabilityVerificationError,
+} from '../index.js';
+import type {
+  AnyNodeMcpJsonToolDefinition,
+  NodeMcpJsonToolDefinition,
+  NodeMcpJsonToolsetConfig,
+  NodeMcpToolRegistrationContext,
+  NodeMcpToolset,
+} from './types.js';
+
+const ToolDefinitionSchema = z.object({
+  name: z.string().min(1).max(64).regex(/^[A-Za-z][A-Za-z0-9_]*$/),
+  description: z.string().trim().min(1).max(4_096),
+  failureMessage: z.string().trim().min(1).max(1_600),
+}).passthrough();
+
+export class NodeMcpJsonToolsetConfigurationError extends Error {
+  readonly name = 'NodeMcpJsonToolsetConfigurationError';
+}
+
+/** Preserves a definition's inferred input type without adding runtime work. */
+export function defineNodeMcpJsonTool<
+  TTool extends string,
+  TInput extends Record<string, unknown>,
+>(
+  definition: NodeMcpJsonToolDefinition<TTool, TInput>,
+): NodeMcpJsonToolDefinition<TTool, TInput> {
+  return definition;
+}
+
+/**
+ * Capability-aware declarative tool registry for the common JSON-tool path.
+ *
+ * The signed capability is the only source of exposed tool names. Every call
+ * checks authority before and after product work and converts unknown failures
+ * into the definition's static public message.
+ */
+export class NodeMcpJsonToolset<TTool extends string>
+implements NodeMcpToolset<TTool> {
+  readonly serverInfo: Readonly<{ name: string; version: string }>;
+  readonly #tools: ReadonlyMap<TTool, AnyNodeMcpJsonToolDefinition<TTool>>;
+  readonly #now: () => Date;
+
+  constructor(config: NodeMcpJsonToolsetConfig<TTool>) {
+    this.serverInfo = Object.freeze({
+      name: z.string().trim().min(1).max(128).parse(config.serverInfo.name),
+      version: z.string().trim().min(1).max(128).parse(config.serverInfo.version),
+    });
+    const definitions = config.tools.map((definition) => {
+      ToolDefinitionSchema.parse(definition);
+      return definition;
+    });
+    const names = definitions.map(({ name }) => name);
+    if (new Set(names).size !== names.length) {
+      throw new NodeMcpJsonToolsetConfigurationError(
+        'Node MCP JSON tool names must be unique.',
+      );
+    }
+    this.#tools = new Map(definitions.map((definition) => [
+      definition.name,
+      definition,
+    ]));
+    this.#now = config.now ?? (() => new Date());
+  }
+
+  registerAllowedTools(
+    context: NodeMcpToolRegistrationContext<TTool>,
+  ): void {
+    context.capability.allowedTools.forEach((toolName) => {
+      const definition = this.#tools.get(toolName);
+      if (!definition) {
+        throw new NodeMcpJsonToolsetConfigurationError(
+          'The signed MCP capability names an unconfigured product tool.',
+        );
+      }
+      context.server.registerTool(
+        definition.name,
+        {
+          ...(definition.title ? { title: definition.title } : {}),
+          description: definition.description,
+          inputSchema: definition.inputSchema,
+          ...(definition.annotations
+            ? { annotations: definition.annotations }
+            : {}),
+        },
+        async (input, extra) => await this.#execute(
+          definition,
+          input as Record<string, unknown>,
+          context,
+          extra.signal,
+        ),
+      );
+    });
+  }
+
+  async #execute(
+    definition: AnyNodeMcpJsonToolDefinition<TTool>,
+    input: Record<string, unknown>,
+    context: NodeMcpToolRegistrationContext<TTool>,
+    operationSignal: AbortSignal,
+  ): Promise<CallToolResult> {
+    const signal = AbortSignal.any([
+      context.requestSignal,
+      operationSignal,
+    ]);
+    try {
+      signal.throwIfAborted();
+      assertMcpCapabilityActive(context.capability, this.#now());
+      const result = await definition.execute(input, {
+        capability: context.capability,
+        signal,
+      });
+      signal.throwIfAborted();
+      assertMcpCapabilityActive(context.capability, this.#now());
+      const text = JSON.stringify(result);
+      if (text === undefined) {
+        throw new TypeError('MCP JSON tools must return a serializable value.');
+      }
+      return { content: [{ type: 'text', text }] };
+    } catch (error) {
+      const message = signal.aborted
+        ? 'Product tool execution was cancelled.'
+        : error instanceof McpCapabilityVerificationError
+          ? 'Product tool authority expired.'
+          : definition.failureMessage;
+      return {
+        isError: true,
+        content: [{ type: 'text', text: message }],
+      };
+    }
+  }
+}

--- a/packages/heddle-adopter/src/mcp/node/streamable-http-mcp-service.ts
+++ b/packages/heddle-adopter/src/mcp/node/streamable-http-mcp-service.ts
@@ -1,0 +1,297 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  StreamableHTTPServerTransport,
+} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+import { McpCapabilityUnavailableError } from '../errors.js';
+import type { VerifiedMcpCapability } from '../types.js';
+import type {
+  NodeStreamableHttpMcpServiceConfig,
+} from './types.js';
+
+const DEFAULT_MAX_BODY_BYTES = 64 * 1_024;
+const MAX_CAPABILITY_CHARACTERS = 4_096;
+const REDACTED_HEADER_VALUE = '[REDACTED]';
+
+type ActiveMcpRequest = {
+  abortController: AbortController;
+  request: IncomingMessage;
+  response: ServerResponse;
+  server?: McpServer;
+  transport?: StreamableHTTPServerTransport;
+  closing?: Promise<void>;
+};
+
+class McpRequestBodyError extends Error {
+  constructor(readonly statusCode: 400 | 413 | 415) {
+    super('Invalid MCP request body.');
+  }
+}
+
+/**
+ * Stateless official-SDK Streamable HTTP edge for adopter-owned MCP tools.
+ *
+ * Every request verifies the capability independently and owns fresh SDK
+ * resources. The injected toolset remains the sole owner of model-visible
+ * names, schemas, descriptions, and product operations.
+ */
+export class NodeStreamableHttpMcpService<TTool extends string> {
+  readonly #capabilityVerifier: NodeStreamableHttpMcpServiceConfig<TTool>[
+    'capabilityVerifier'
+  ];
+  readonly #toolset: NodeStreamableHttpMcpServiceConfig<TTool>['toolset'];
+  readonly #maxBodyBytes: number;
+  readonly #activeRequests = new Set<ActiveMcpRequest>();
+  #closed = false;
+  #closePromise: Promise<void> | undefined;
+
+  constructor(config: NodeStreamableHttpMcpServiceConfig<TTool>) {
+    this.#capabilityVerifier = config.capabilityVerifier;
+    this.#toolset = config.toolset;
+    this.#maxBodyBytes = z.number().int().min(1).max(1_048_576).parse(
+      config.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+    );
+  }
+
+  /** Handles one authenticated stateless MCP request at an adopter-owned path. */
+  async handle(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    response.setHeader('Cache-Control', 'no-store');
+    response.setHeader('Vary', 'Authorization');
+    response.setHeader('X-Content-Type-Options', 'nosniff');
+    if (this.#closed) {
+      request.resume();
+      writeJsonRpcError(response, 503, 'MCP service is unavailable.');
+      return;
+    }
+    if (request.method !== 'POST') {
+      request.resume();
+      writeJsonRpcError(response, 405, 'Method not allowed.');
+      return;
+    }
+
+    const assertion = takeBearer(request);
+    if (!assertion) {
+      request.resume();
+      writeJsonRpcError(response, 401, 'Authentication is required.', {
+        'WWW-Authenticate': 'Bearer',
+      });
+      return;
+    }
+
+    const active: ActiveMcpRequest = {
+      abortController: new AbortController(),
+      request,
+      response,
+    };
+    const cleanup = () => void this.#closeRequest(active);
+    request.once('aborted', cleanup);
+    response.once('close', cleanup);
+    this.#activeRequests.add(active);
+
+    try {
+      const capability = await this.#verifyCapability(assertion, response);
+      if (!capability) {
+        request.resume();
+        return;
+      }
+
+      let body: unknown;
+      try {
+        body = await readJsonBody(
+          request,
+          this.#maxBodyBytes,
+          active.abortController.signal,
+        );
+      } catch (error) {
+        const statusCode = error instanceof McpRequestBodyError
+          ? error.statusCode
+          : 400;
+        writeJsonRpcError(response, statusCode, 'Invalid MCP request.');
+        return;
+      }
+
+      active.server = new McpServer(this.#toolset.serverInfo);
+      active.transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      this.#toolset.registerAllowedTools({
+        server: active.server,
+        capability,
+        requestSignal: active.abortController.signal,
+      });
+      await active.server.connect(active.transport);
+      await active.transport.handleRequest(request, response, body);
+    } catch {
+      if (!response.headersSent && !response.destroyed) {
+        writeJsonRpcError(response, 500, 'MCP request failed.');
+      }
+    } finally {
+      request.removeListener('aborted', cleanup);
+      response.removeListener('close', cleanup);
+      await this.#closeRequest(active);
+    }
+  }
+
+  /** Aborts active tools and closes their official SDK resources. */
+  close(): Promise<void> {
+    if (!this.#closePromise) {
+      this.#closed = true;
+      this.#closePromise = Promise.all(
+        [...this.#activeRequests].map((request) => this.#closeRequest(
+          request,
+          true,
+        )),
+      ).then(() => undefined);
+    }
+    return this.#closePromise;
+  }
+
+  async #verifyCapability(
+    assertion: string,
+    response: ServerResponse,
+  ): Promise<VerifiedMcpCapability<TTool> | undefined> {
+    try {
+      return await this.#capabilityVerifier.verify(assertion);
+    } catch (error) {
+      if (error instanceof McpCapabilityUnavailableError) {
+        writeJsonRpcError(
+          response,
+          503,
+          'Authentication is temporarily unavailable.',
+          { 'Retry-After': '1' },
+        );
+        return undefined;
+      }
+      writeJsonRpcError(response, 401, 'Authentication failed.', {
+        'WWW-Authenticate': 'Bearer error="invalid_token"',
+      });
+      return undefined;
+    }
+  }
+
+  #closeRequest(
+    resources: ActiveMcpRequest,
+    destroyIo = false,
+  ): Promise<void> {
+    resources.abortController.abort(
+      new Error('The owning MCP HTTP request closed.'),
+    );
+    if (destroyIo) {
+      resources.request.destroy();
+      resources.response.destroy();
+    }
+    resources.closing ??= Promise.all([
+      resources.transport?.close().catch(() => undefined),
+      resources.server?.close().catch(() => undefined),
+    ]).then(() => {
+      this.#activeRequests.delete(resources);
+    });
+    return resources.closing;
+  }
+}
+
+function takeBearer(request: IncomingMessage): string | undefined {
+  const occurrences = request.rawHeaders.reduce(
+    (count, headerName, index) => count
+      + (index % 2 === 0 && headerName.toLowerCase() === 'authorization' ? 1 : 0),
+    0,
+  );
+  const value = request.headers.authorization;
+  request.headers.authorization = value === undefined
+    ? undefined
+    : REDACTED_HEADER_VALUE;
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index]?.toLowerCase() === 'authorization') {
+      request.rawHeaders[index + 1] = REDACTED_HEADER_VALUE;
+    }
+  }
+  if (occurrences !== 1 || Array.isArray(value)) {
+    return undefined;
+  }
+  const match = /^Bearer ([^\s]+)$/i.exec(value?.trim() ?? '');
+  const assertion = match?.[1];
+  return assertion
+    && assertion.length <= MAX_CAPABILITY_CHARACTERS
+    && /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(assertion)
+    ? assertion
+    : undefined;
+}
+
+async function readJsonBody(
+  request: IncomingMessage,
+  maxBodyBytes: number,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const contentType = request.headers['content-type']
+    ?.split(';', 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== 'application/json') {
+    request.resume();
+    throw new McpRequestBodyError(415);
+  }
+  const contentLength = request.headers['content-length'];
+  if (contentLength !== undefined) {
+    const declaredLength = Number(contentLength);
+    if (!Number.isSafeInteger(declaredLength) || declaredLength < 0) {
+      request.resume();
+      throw new McpRequestBodyError(400);
+    }
+    if (declaredLength > maxBodyBytes) {
+      request.resume();
+      throw new McpRequestBodyError(413);
+    }
+  }
+
+  const chunks: Buffer[] = [];
+  let receivedBytes = 0;
+  for await (const chunk of request) {
+    signal.throwIfAborted();
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    receivedBytes += buffer.byteLength;
+    if (receivedBytes > maxBodyBytes) {
+      request.resume();
+      throw new McpRequestBodyError(413);
+    }
+    chunks.push(buffer);
+  }
+  if (!request.complete || receivedBytes === 0) {
+    throw new McpRequestBodyError(400);
+  }
+  try {
+    return JSON.parse(
+      Buffer.concat(chunks, receivedBytes).toString('utf8'),
+    ) as unknown;
+  } catch {
+    throw new McpRequestBodyError(400);
+  }
+}
+
+function writeJsonRpcError(
+  response: ServerResponse,
+  statusCode: number,
+  message: string,
+  headers: Record<string, string> = {},
+): void {
+  if (response.headersSent || response.destroyed) {
+    return;
+  }
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    error: { code: -32_000, message },
+    id: null,
+  });
+  response.writeHead(statusCode, {
+    'Cache-Control': 'no-store',
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': 'application/json; charset=utf-8',
+    'X-Content-Type-Options': 'nosniff',
+    ...headers,
+  });
+  response.end(body);
+}

--- a/packages/heddle-adopter/src/mcp/node/types.ts
+++ b/packages/heddle-adopter/src/mcp/node/types.ts
@@ -1,0 +1,25 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type {
+  McpCapabilityVerifier,
+  VerifiedMcpCapability,
+} from '../types.js';
+
+export type NodeMcpToolRegistrationContext<TTool extends string> = {
+  server: McpServer;
+  capability: VerifiedMcpCapability<TTool>;
+  requestSignal: AbortSignal;
+};
+
+/** Product-owned model-visible tools plugged into the generic MCP edge. */
+export interface NodeMcpToolset<TTool extends string> {
+  readonly serverInfo: Readonly<{ name: string; version: string }>;
+  registerAllowedTools(
+    context: NodeMcpToolRegistrationContext<TTool>,
+  ): void;
+}
+
+export type NodeStreamableHttpMcpServiceConfig<TTool extends string> = {
+  capabilityVerifier: McpCapabilityVerifier<TTool>;
+  toolset: NodeMcpToolset<TTool>;
+  maxBodyBytes?: number;
+};

--- a/packages/heddle-adopter/src/mcp/node/types.ts
+++ b/packages/heddle-adopter/src/mcp/node/types.ts
@@ -1,4 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { z } from 'zod';
 import type {
   McpCapabilityVerifier,
   VerifiedMcpCapability,
@@ -17,6 +19,44 @@ export interface NodeMcpToolset<TTool extends string> {
     context: NodeMcpToolRegistrationContext<TTool>,
   ): void;
 }
+
+export type NodeMcpJsonToolExecutionContext<TTool extends string> = {
+  capability: VerifiedMcpCapability<TTool>;
+  signal: AbortSignal;
+};
+
+/**
+ * One product-owned JSON tool exposed through the standard Node MCP edge.
+ *
+ * The generic toolset owns capability admission, cancellation composition,
+ * lifetime checks, safe failures, and JSON result projection. The definition
+ * owns only product vocabulary, validation, annotations, and behavior.
+ */
+export type NodeMcpJsonToolDefinition<
+  TTool extends string,
+  TInput extends Record<string, unknown>,
+> = {
+  name: TTool;
+  title?: string;
+  description: string;
+  inputSchema: z.ZodType<TInput>;
+  annotations?: ToolAnnotations;
+  /** Stable model-visible text; thrown product errors are never reflected. */
+  failureMessage: string;
+  execute(
+    input: TInput,
+    context: NodeMcpJsonToolExecutionContext<TTool>,
+  ): unknown | Promise<unknown>;
+};
+
+export type AnyNodeMcpJsonToolDefinition<TTool extends string> =
+  NodeMcpJsonToolDefinition<TTool, Record<string, unknown>>;
+
+export type NodeMcpJsonToolsetConfig<TTool extends string> = {
+  serverInfo: Readonly<{ name: string; version: string }>;
+  tools: readonly AnyNodeMcpJsonToolDefinition<TTool>[];
+  now?: () => Date;
+};
 
 export type NodeStreamableHttpMcpServiceConfig<TTool extends string> = {
   capabilityVerifier: McpCapabilityVerifier<TTool>;

--- a/packages/heddle-adopter/src/node/README.md
+++ b/packages/heddle-adopter/src/node/README.md
@@ -1,0 +1,29 @@
+# Node adopter conveniences
+
+This optional subpath removes repetitive Node backend plumbing while keeping
+product policy in adopter code.
+
+`NodeExecutionAdopterHttpService` owns:
+
+- a public JWKS route and a prompt-only hosted-conversation route;
+- bounded JSON parsing and stable safe errors;
+- `Authorization` extraction plus normalized/raw-header redaction;
+- SSE headers, framing, validation, and backpressure;
+- request-disconnect cancellation and graceful active-request shutdown.
+
+The service accepts callbacks for authentication, product admission, and turn
+streaming. Those callbacks remain responsible for product authorization,
+tenant/subject/session selection, durable invocation identity, result
+settlement, and privacy-aware logging. Product MCP HTTP routing remains beside
+the product's MCP tool implementation rather than inside this generic edge.
+
+The key helpers generate disposable in-memory pairs, create owner-only local
+development JWK files without overwriting, and load a private JWK into a
+non-exportable signing key. Production secret storage, ACLs on Windows, key
+rotation, revocation, and KMS/HSM policy remain deployment responsibilities.
+
+`DirectExecutionHostCredentials` keeps the direct-host token and model API key
+behind explicit methods and can take them out of caller-selected environment
+variables at startup. The adopter still decides where production credentials
+come from and whether passing a model key per invocation matches its trust
+model.

--- a/packages/heddle-adopter/src/node/authority-key.ts
+++ b/packages/heddle-adopter/src/node/authority-key.ts
@@ -1,0 +1,138 @@
+import { constants } from 'node:fs';
+import {
+  open,
+  unlink,
+  type FileHandle,
+} from 'node:fs/promises';
+import { webcrypto } from 'node:crypto';
+import { z } from 'zod';
+import type { ExecutionAuthorityKeyPair } from '../authority/index.js';
+
+const MAX_PRIVATE_JWK_BYTES = 16 * 1_024;
+const ECDSA_P256 = { name: 'ECDSA', namedCurve: 'P-256' } as const;
+const Base64UrlSchema = z.string().min(1).regex(/^[A-Za-z0-9_-]+$/);
+const PrivateP256JwkSchema = z.object({
+  kty: z.literal('EC'),
+  crv: z.literal('P-256'),
+  x: Base64UrlSchema,
+  y: Base64UrlSchema,
+  d: Base64UrlSchema,
+}).passthrough();
+
+/** Generates a non-persisted ES256 pair for tests and disposable local demos. */
+export async function generateEphemeralExecutionAuthorityKeyPair(): Promise<
+  ExecutionAuthorityKeyPair
+> {
+  return webcrypto.subtle.generateKey(
+    ECDSA_P256,
+    false,
+    ['sign', 'verify'],
+  );
+}
+
+/**
+ * Creates a new owner-only ES256 private-JWK file for local development.
+ * Existing paths are never overwritten.
+ */
+export async function generateExecutionAuthorityKeyFile(
+  filePath: string,
+): Promise<void> {
+  const keyPair = await webcrypto.subtle.generateKey(
+    ECDSA_P256,
+    true,
+    ['sign', 'verify'],
+  );
+  const jwk = PrivateP256JwkSchema.parse(
+    await webcrypto.subtle.exportKey('jwk', keyPair.privateKey),
+  );
+  const body = `${JSON.stringify({
+    kty: jwk.kty,
+    crv: jwk.crv,
+    x: jwk.x,
+    y: jwk.y,
+    d: jwk.d,
+  })}\n`;
+
+  let file: FileHandle | undefined;
+  let created = false;
+  try {
+    file = await open(filePath, 'wx', 0o600);
+    created = true;
+    await file.writeFile(body, 'utf8');
+    await file.sync();
+    await file.close();
+    file = undefined;
+  } catch {
+    if (created) {
+      await file?.close().catch(() => undefined);
+      file = undefined;
+      await unlink(filePath).catch(() => undefined);
+    }
+    throw new ExecutionAuthorityKeyFileError(
+      'Execution authority signing JWK could not be generated at the requested path.',
+    );
+  } finally {
+    await file?.close().catch(() => undefined);
+  }
+}
+
+/** Loads a non-exportable ES256 signing pair from an owner-only private JWK. */
+export async function loadExecutionAuthorityKeyPairFromFile(
+  filePath: string,
+): Promise<ExecutionAuthorityKeyPair> {
+  let file: FileHandle | undefined;
+  try {
+    file = await open(
+      filePath,
+      constants.O_RDONLY | constants.O_NOFOLLOW,
+    );
+    const metadata = await file.stat();
+    if (
+      !metadata.isFile()
+      || metadata.size <= 0
+      || metadata.size > MAX_PRIVATE_JWK_BYTES
+    ) {
+      throw new ExecutionAuthorityKeyFileError(
+        'Execution authority signing JWK must be a small regular file.',
+      );
+    }
+    if (process.platform !== 'win32' && (metadata.mode & 0o077) !== 0) {
+      throw new ExecutionAuthorityKeyFileError(
+        'Execution authority signing JWK must not be group- or world-accessible.',
+      );
+    }
+    const jwk = PrivateP256JwkSchema.parse(
+      JSON.parse(await file.readFile('utf8')) as unknown,
+    );
+    const privateKey = await webcrypto.subtle.importKey(
+      'jwk',
+      { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y, d: jwk.d },
+      ECDSA_P256,
+      false,
+      ['sign'],
+    );
+    const publicKey = await webcrypto.subtle.importKey(
+      'jwk',
+      { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y },
+      ECDSA_P256,
+      true,
+      ['verify'],
+    );
+    await file.close();
+    file = undefined;
+    return { privateKey, publicKey };
+  } catch (error) {
+    if (error instanceof ExecutionAuthorityKeyFileError) {
+      throw error;
+    }
+    throw new ExecutionAuthorityKeyFileError(
+      'Execution authority signing JWK could not be loaded.',
+    );
+  } finally {
+    await file?.close().catch(() => undefined);
+  }
+}
+
+export class ExecutionAuthorityKeyFileError extends Error {
+  readonly name = 'ExecutionAuthorityKeyFileError';
+}

--- a/packages/heddle-adopter/src/node/direct-credentials.ts
+++ b/packages/heddle-adopter/src/node/direct-credentials.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+import type {
+  HostedConversationModelCredentialProvider,
+} from '../conversation/index.js';
+
+const LocalTokenSchema = z.string().trim().min(32).max(4_096);
+const ModelApiKeySchema = z.string().trim().min(8).max(4_096);
+const EnvironmentNameSchema = z.string().min(1).max(128).regex(
+  /^[A-Za-z_][A-Za-z0-9_]*$/,
+  'must be an environment variable name',
+);
+
+export type DirectExecutionHostCredentialEnvironmentNames = {
+  localToken: string;
+  modelApiKey: string;
+};
+
+/**
+ * Non-enumerable direct-host and model credentials for a local/reviewed
+ * deployment. Production secret retrieval may construct the same class.
+ */
+export class DirectExecutionHostCredentials
+implements HostedConversationModelCredentialProvider {
+  readonly #localToken: string;
+  readonly #modelApiKey: string;
+
+  constructor(input: { localToken: string; modelApiKey: string }) {
+    try {
+      this.#localToken = LocalTokenSchema.parse(input.localToken);
+      this.#modelApiKey = ModelApiKeySchema.parse(input.modelApiKey);
+    } catch {
+      throw new Error('Direct Execution Host credentials are invalid.');
+    }
+  }
+
+  /** Takes configured values out of the process environment before parsing. */
+  static takeFromEnvironment(
+    environment: NodeJS.ProcessEnv,
+    rawNames: DirectExecutionHostCredentialEnvironmentNames,
+  ): DirectExecutionHostCredentials {
+    const names = z.object({
+      localToken: EnvironmentNameSchema,
+      modelApiKey: EnvironmentNameSchema,
+    }).strict().refine((value) => value.localToken !== value.modelApiKey, {
+      message: 'credential environment names must be distinct',
+    }).parse(rawNames);
+    const input = {
+      localToken: environment[names.localToken],
+      modelApiKey: environment[names.modelApiKey],
+    };
+    delete environment[names.localToken];
+    delete environment[names.modelApiKey];
+    return new DirectExecutionHostCredentials({
+      localToken: input.localToken ?? '',
+      modelApiKey: input.modelApiKey ?? '',
+    });
+  }
+
+  localToken(): string {
+    return this.#localToken;
+  }
+
+  async resolveModelApiKey(): Promise<string> {
+    return this.#modelApiKey;
+  }
+}

--- a/packages/heddle-adopter/src/node/http-service.ts
+++ b/packages/heddle-adopter/src/node/http-service.ts
@@ -1,0 +1,487 @@
+import { once } from 'node:events';
+import type {
+  IncomingMessage,
+  ServerResponse,
+} from 'node:http';
+import { z } from 'zod';
+import { ExecutionHostStreamEventSchema } from '../contracts/index.js';
+import { ExecutionHostInvocationCancelledError } from '../http-sse/index.js';
+import type {
+  NodeExecutionAdopterFailure,
+  NodeExecutionAdopterHttpHandler,
+  NodeExecutionAdopterHttpPaths,
+  NodeExecutionAdopterHttpServiceConfig,
+  NodeExecutionAdopterPublicError,
+} from './types.js';
+
+export const DEFAULT_ADOPTER_JWKS_PATH = '/.well-known/jwks.json';
+export const DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH =
+  '/hosted-execution/conversation-turns';
+
+const DEFAULT_MAX_BODY_BYTES = 64 * 1_024;
+const DEFAULT_MAX_PROMPT_CHARACTERS = 20_000;
+const REDACTED_HEADER_VALUE = '[REDACTED]';
+const MAX_AUTHORIZATION_CHARACTERS = 8_192;
+const PathSchema = z.string().min(1).max(256).regex(
+  /^\/(?:[^?#\s]*)$/,
+  'must be an absolute path without query, fragment, or whitespace',
+);
+const PublicErrorSchema = z.object({
+  statusCode: z.number().int().min(400).max(599),
+  message: z.string().min(1).max(1_600),
+}).strict();
+
+type ActiveConversation = {
+  abortController: AbortController;
+  request: IncomingMessage;
+  response: ServerResponse;
+  pending: Promise<void>;
+};
+
+class AdopterHttpRequestError extends Error {
+  constructor(readonly statusCode: 400 | 413 | 415) {
+    super('Invalid adopter HTTP request.');
+  }
+}
+
+/**
+ * Standard Node HTTP edge for adopter-side JWKS and hosted conversations.
+ *
+ * The service owns bounded parsing, credential-header scrubbing, SSE framing,
+ * disconnect cancellation, safe failures, and graceful shutdown. Product
+ * authentication, authorization, identity selection, and persistence stay in
+ * adopter callbacks.
+ */
+export class NodeExecutionAdopterHttpService<Principal>
+implements NodeExecutionAdopterHttpHandler {
+  readonly #authority: NodeExecutionAdopterHttpServiceConfig<Principal>[
+    'authority'
+  ];
+  readonly #authenticator: NodeExecutionAdopterHttpServiceConfig<Principal>[
+    'authenticator'
+  ];
+  readonly #conversations: NodeExecutionAdopterHttpServiceConfig<
+    Principal
+  >['conversations'];
+  readonly #projectError: NodeExecutionAdopterHttpServiceConfig<Principal>[
+    'projectError'
+  ];
+  readonly #reportFailure: NodeExecutionAdopterHttpServiceConfig<Principal>[
+    'reportFailure'
+  ];
+  readonly #paths: Readonly<NodeExecutionAdopterHttpPaths>;
+  readonly #maxBodyBytes: number;
+  readonly #maxPromptCharacters: number;
+  readonly #jwksMaxAgeSeconds: number;
+  readonly #activeConversations = new Set<ActiveConversation>();
+  #closed = false;
+  #closePromise: Promise<void> | undefined;
+
+  constructor(config: NodeExecutionAdopterHttpServiceConfig<Principal>) {
+    this.#authority = config.authority;
+    this.#authenticator = config.authenticator;
+    this.#conversations = config.conversations;
+    this.#projectError = config.projectError;
+    this.#reportFailure = config.reportFailure;
+    this.#paths = parsePaths(config.paths);
+    this.#maxBodyBytes = z.number().int().min(1).max(1_048_576).parse(
+      config.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+    );
+    this.#maxPromptCharacters = z.number().int().min(1).max(200_000).parse(
+      config.maxPromptCharacters ?? DEFAULT_MAX_PROMPT_CHARACTERS,
+    );
+    this.#jwksMaxAgeSeconds = z.number().int().min(0).max(86_400).parse(
+      config.jwksMaxAgeSeconds ?? 60,
+    );
+  }
+
+  handle(request: IncomingMessage, response: ServerResponse): boolean {
+    const pathname = readPathname(request.url);
+    if (pathname === this.#paths.jwks) {
+      this.handleJwks(request, response);
+      return true;
+    }
+    if (pathname === this.#paths.conversationTurns) {
+      this.handleConversationTurn(request, response);
+      return true;
+    }
+    return false;
+  }
+
+  handleJwks(request: IncomingMessage, response: ServerResponse): void {
+    request.resume();
+    if (this.#closed) {
+      writeJsonError(response, 503, 'Hosted execution is unavailable.');
+      return;
+    }
+    if (request.method !== 'GET') {
+      writeJsonError(response, 405, 'Method not allowed.');
+      return;
+    }
+    try {
+      writeJson(response, 200, this.#authority.publicJwks(), {
+        'Cache-Control': `public, max-age=${this.#jwksMaxAgeSeconds}`,
+      });
+    } catch (error) {
+      this.#report({
+        phase: 'jwks',
+        errorType: errorType(error),
+        streamAccepted: false,
+      });
+      writeJsonError(response, 500, 'Verification keys are unavailable.');
+    }
+  }
+
+  handleConversationTurn(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): void {
+    if (this.#closed) {
+      request.resume();
+      writeJsonError(response, 503, 'Hosted execution is unavailable.');
+      return;
+    }
+
+    const abortController = new AbortController();
+    const abort = () => abortController.abort(
+      new Error('The owning adopter HTTP request closed.'),
+    );
+    request.once('aborted', abort);
+    response.once('close', abort);
+    const active: ActiveConversation = {
+      abortController,
+      request,
+      response,
+      pending: Promise.resolve(),
+    };
+    active.pending = this.#serveConversation(
+      request,
+      response,
+      abortController.signal,
+    ).catch((error) => {
+      this.#report({
+        phase: 'conversation',
+        errorType: errorType(error),
+        streamAccepted: response.headersSent,
+      });
+      if (!response.headersSent) {
+        writeJsonError(response, 500, 'Hosted execution request failed.');
+      } else if (!response.destroyed && !response.writableEnded) {
+        response.end();
+      }
+    }).finally(() => {
+      request.removeListener('aborted', abort);
+      response.removeListener('close', abort);
+      this.#activeConversations.delete(active);
+    });
+    this.#activeConversations.add(active);
+  }
+
+  close(): Promise<void> {
+    if (!this.#closePromise) {
+      this.#closed = true;
+      this.#closePromise = this.#closeActiveConversations();
+    }
+    return this.#closePromise;
+  }
+
+  async #closeActiveConversations(): Promise<void> {
+    const active = [...this.#activeConversations];
+    active.forEach(({ abortController, request, response }) => {
+      abortController.abort(new Error('The adopter HTTP service is stopping.'));
+      request.destroy();
+      response.destroy();
+    });
+    await Promise.allSettled(active.map(({ pending }) => pending));
+  }
+
+  async #serveConversation(
+    request: IncomingMessage,
+    response: ServerResponse,
+    signal: AbortSignal,
+  ): Promise<void> {
+    let authorization: string | undefined;
+    try {
+      authorization = takeAuthorization(request);
+      if (request.method !== 'POST') {
+        request.resume();
+        writeJsonError(response, 405, 'Method not allowed.');
+        return;
+      }
+    } catch (error) {
+      request.resume();
+      writeJsonError(
+        response,
+        error instanceof AdopterHttpRequestError ? error.statusCode : 400,
+        'Invalid conversation request.',
+      );
+      return;
+    }
+
+    let principal: Principal | undefined;
+    try {
+      principal = await this.#authenticator.authenticate({
+        authorization,
+        remoteAddress: request.socket.remoteAddress,
+        signal,
+      });
+    } catch (error) {
+      this.#report({
+        phase: 'authentication',
+        errorType: errorType(error),
+        streamAccepted: false,
+      });
+      request.resume();
+      writeJsonError(response, 500, 'Authentication could not be completed.');
+      return;
+    }
+    if (!principal) {
+      request.resume();
+      writeJsonError(response, 401, 'Authentication is required.', {
+        'WWW-Authenticate': 'Bearer',
+      });
+      return;
+    }
+
+    let prompt: string;
+    try {
+      const body = await readJsonBody(request, this.#maxBodyBytes, signal);
+      prompt = z.object({
+        prompt: z.string().trim().min(1).max(this.#maxPromptCharacters),
+      }).strict().parse(body).prompt;
+    } catch (error) {
+      const statusCode = error instanceof AdopterHttpRequestError
+        ? error.statusCode
+        : 400;
+      writeJsonError(response, statusCode, 'Invalid conversation request.');
+      return;
+    }
+
+    let streamed = false;
+    try {
+      for await (const rawEvent of this.#conversations.streamTurn({
+        principal,
+        prompt,
+        signal,
+      })) {
+        const event = ExecutionHostStreamEventSchema.parse(rawEvent);
+        if (!streamed) {
+          writeEventStreamHeaders(response);
+          streamed = true;
+        }
+        await writeSseEvent(response, event, signal);
+      }
+      if (!streamed) {
+        writeJsonError(response, 502, 'Execution Host returned no events.');
+        return;
+      }
+      response.end();
+    } catch (error) {
+      const publicError = !streamed ? this.#project(error) : undefined;
+      if (publicError) {
+        writeJsonError(response, publicError.statusCode, publicError.message);
+        return;
+      }
+      if (
+        error instanceof ExecutionHostInvocationCancelledError
+        || signal.aborted
+      ) {
+        if (!response.headersSent && !response.destroyed) {
+          writeJsonError(response, 499, 'Hosted conversation was cancelled.');
+        }
+        return;
+      }
+      this.#report({
+        phase: 'conversation',
+        errorType: errorType(error),
+        streamAccepted: streamed,
+      });
+      if (!response.headersSent) {
+        writeJsonError(response, 502, 'Execution Host conversation failed.');
+      } else if (!response.destroyed && !response.writableEnded) {
+        // A post-acceptance failure deliberately ends without a terminal event.
+        response.end();
+      }
+    }
+  }
+
+  #project(error: unknown): NodeExecutionAdopterPublicError | undefined {
+    if (!this.#projectError) {
+      return undefined;
+    }
+    try {
+      const projected = this.#projectError(error);
+      return projected ? PublicErrorSchema.parse(projected) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  #report(failure: NodeExecutionAdopterFailure): void {
+    try {
+      this.#reportFailure?.(Object.freeze({ ...failure }));
+    } catch {
+      // Observability must not change request settlement.
+    }
+  }
+}
+
+function parsePaths(
+  paths: Partial<NodeExecutionAdopterHttpPaths> | undefined,
+): Readonly<NodeExecutionAdopterHttpPaths> {
+  const parsed = {
+    jwks: PathSchema.parse(paths?.jwks ?? DEFAULT_ADOPTER_JWKS_PATH),
+    conversationTurns: PathSchema.parse(
+      paths?.conversationTurns ?? DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH,
+    ),
+  };
+  if (parsed.jwks === parsed.conversationTurns) {
+    throw new Error('Adopter HTTP paths must be distinct.');
+  }
+  return Object.freeze(parsed);
+}
+
+function readPathname(rawUrl: string | undefined): string | undefined {
+  try {
+    return new URL(rawUrl ?? '/', 'http://localhost').pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+function takeAuthorization(request: IncomingMessage): string | undefined {
+  const occurrences = request.rawHeaders.reduce(
+    (count, headerName, index) => count
+      + (index % 2 === 0 && headerName.toLowerCase() === 'authorization' ? 1 : 0),
+    0,
+  );
+  const raw = request.headers.authorization;
+  request.headers.authorization = raw === undefined
+    ? undefined
+    : REDACTED_HEADER_VALUE;
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index]?.toLowerCase() === 'authorization') {
+      request.rawHeaders[index + 1] = REDACTED_HEADER_VALUE;
+    }
+  }
+  if (occurrences > 1 || Array.isArray(raw)) {
+    throw new AdopterHttpRequestError(400);
+  }
+  if (raw && raw.length > MAX_AUTHORIZATION_CHARACTERS) {
+    throw new AdopterHttpRequestError(400);
+  }
+  return raw;
+}
+
+async function readJsonBody(
+  request: IncomingMessage,
+  maxBodyBytes: number,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const contentType = request.headers['content-type']
+    ?.split(';', 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== 'application/json') {
+    request.resume();
+    throw new AdopterHttpRequestError(415);
+  }
+  const contentLength = request.headers['content-length'];
+  if (contentLength !== undefined) {
+    const declaredLength = Number(contentLength);
+    if (!Number.isSafeInteger(declaredLength) || declaredLength < 0) {
+      request.resume();
+      throw new AdopterHttpRequestError(400);
+    }
+    if (declaredLength > maxBodyBytes) {
+      request.resume();
+      throw new AdopterHttpRequestError(413);
+    }
+  }
+
+  const chunks: Buffer[] = [];
+  let receivedBytes = 0;
+  for await (const chunk of request) {
+    signal.throwIfAborted();
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    receivedBytes += buffer.byteLength;
+    if (receivedBytes > maxBodyBytes) {
+      request.resume();
+      throw new AdopterHttpRequestError(413);
+    }
+    chunks.push(buffer);
+  }
+  if (!request.complete || receivedBytes === 0) {
+    throw new AdopterHttpRequestError(400);
+  }
+  try {
+    return JSON.parse(
+      Buffer.concat(chunks, receivedBytes).toString('utf8'),
+    ) as unknown;
+  } catch {
+    throw new AdopterHttpRequestError(400);
+  }
+}
+
+function writeEventStreamHeaders(response: ServerResponse): void {
+  response.writeHead(200, {
+    'Cache-Control': 'no-store',
+    'Content-Type': 'text/event-stream; charset=utf-8',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no',
+    'X-Content-Type-Options': 'nosniff',
+  });
+}
+
+async function writeSseEvent(
+  response: ServerResponse,
+  event: z.infer<typeof ExecutionHostStreamEventSchema>,
+  signal: AbortSignal,
+): Promise<void> {
+  const frame = [
+    `event: ${event.kind}`,
+    `id: ${event.sequence}`,
+    `data: ${JSON.stringify(event)}`,
+    '',
+    '',
+  ].join('\n');
+  if (!response.write(frame)) {
+    await once(response, 'drain', { signal });
+  }
+}
+
+function writeJsonError(
+  response: ServerResponse,
+  statusCode: number,
+  message: string,
+  headers: Record<string, string> = {},
+): void {
+  writeJson(response, statusCode, { error: { message } }, {
+    'Cache-Control': 'no-store',
+    ...headers,
+  });
+}
+
+function writeJson(
+  response: ServerResponse,
+  statusCode: number,
+  value: unknown,
+  headers: Record<string, string> = {},
+): void {
+  if (response.headersSent || response.destroyed) {
+    return;
+  }
+  const body = JSON.stringify(value);
+  response.writeHead(statusCode, {
+    'Cache-Control': 'no-store',
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': 'application/json; charset=utf-8',
+    'X-Content-Type-Options': 'nosniff',
+    ...headers,
+  });
+  response.end(body);
+}
+
+function errorType(error: unknown): string {
+  return error instanceof Error ? error.name : 'unknown';
+}

--- a/packages/heddle-adopter/src/node/index.ts
+++ b/packages/heddle-adopter/src/node/index.ts
@@ -1,0 +1,26 @@
+export {
+  ExecutionAuthorityKeyFileError,
+  generateEphemeralExecutionAuthorityKeyPair,
+  generateExecutionAuthorityKeyFile,
+  loadExecutionAuthorityKeyPairFromFile,
+} from './authority-key.js';
+export { DirectExecutionHostCredentials } from './direct-credentials.js';
+export type {
+  DirectExecutionHostCredentialEnvironmentNames,
+} from './direct-credentials.js';
+export {
+  DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH,
+  DEFAULT_ADOPTER_JWKS_PATH,
+  NodeExecutionAdopterHttpService,
+} from './http-service.js';
+export type {
+  NodeExecutionAdopterAuthenticationInput,
+  NodeExecutionAdopterAuthenticator,
+  NodeExecutionAdopterConversationInput,
+  NodeExecutionAdopterConversationService,
+  NodeExecutionAdopterFailure,
+  NodeExecutionAdopterHttpHandler,
+  NodeExecutionAdopterHttpPaths,
+  NodeExecutionAdopterHttpServiceConfig,
+  NodeExecutionAdopterPublicError,
+} from './types.js';

--- a/packages/heddle-adopter/src/node/types.ts
+++ b/packages/heddle-adopter/src/node/types.ts
@@ -1,0 +1,72 @@
+import type {
+  IncomingMessage,
+  ServerResponse,
+} from 'node:http';
+import type { ExecutionAuthority } from '../authority/index.js';
+import type { ExecutionHostStreamEvent } from '../contracts/index.js';
+
+export type NodeExecutionAdopterAuthenticationInput = {
+  authorization?: string;
+  remoteAddress?: string;
+  signal: AbortSignal;
+};
+
+export type NodeExecutionAdopterConversationInput<Principal> = {
+  principal: Principal;
+  prompt: string;
+  signal: AbortSignal;
+};
+
+export interface NodeExecutionAdopterAuthenticator<Principal> {
+  authenticate(
+    input: NodeExecutionAdopterAuthenticationInput,
+  ): Principal | undefined | Promise<Principal | undefined>;
+}
+
+export interface NodeExecutionAdopterConversationService<Principal> {
+  streamTurn(
+    input: NodeExecutionAdopterConversationInput<Principal>,
+  ): AsyncIterable<ExecutionHostStreamEvent>;
+}
+
+export type NodeExecutionAdopterPublicError = {
+  statusCode: number;
+  message: string;
+};
+
+export type NodeExecutionAdopterFailure = {
+  phase: 'jwks' | 'authentication' | 'conversation';
+  errorType: string;
+  streamAccepted: boolean;
+};
+
+export type NodeExecutionAdopterHttpPaths = {
+  jwks: string;
+  conversationTurns: string;
+};
+
+export type NodeExecutionAdopterHttpServiceConfig<Principal> = {
+  authority: Pick<ExecutionAuthority, 'publicJwks'>;
+  authenticator: NodeExecutionAdopterAuthenticator<Principal>;
+  conversations: NodeExecutionAdopterConversationService<Principal>;
+  /** Maps adopter-domain failures to intentionally public HTTP errors. */
+  projectError?: (
+    error: unknown,
+  ) => NodeExecutionAdopterPublicError | undefined;
+  /** Receives credential-free operational metadata, never the raw error. */
+  reportFailure?: (failure: NodeExecutionAdopterFailure) => void;
+  paths?: Partial<NodeExecutionAdopterHttpPaths>;
+  maxBodyBytes?: number;
+  maxPromptCharacters?: number;
+  jwksMaxAgeSeconds?: number;
+};
+
+export interface NodeExecutionAdopterHttpHandler {
+  handle(request: IncomingMessage, response: ServerResponse): boolean;
+  handleJwks(request: IncomingMessage, response: ServerResponse): void;
+  handleConversationTurn(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): void;
+  close(): Promise<void>;
+}

--- a/packages/heddle-adopter/tsconfig.json
+++ b/packages/heddle-adopter/tsconfig.json
@@ -8,6 +8,6 @@
     "sourceMap": true,
     "inlineSources": true
   },
-  "include": ["src/**/*.ts", "vitest.config.ts"],
+  "include": ["src/**/*.ts", "examples/**/*.ts", "vitest.config.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/heddle-adopter/tsconfig.test.json
+++ b/packages/heddle-adopter/tsconfig.test.json
@@ -4,6 +4,6 @@
     "noEmit": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/**/*.ts", "vitest.config.ts"],
+  "include": ["src/**/*.ts", "examples/**/*.ts", "vitest.config.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/scripts/verify-adopter-package.mjs
+++ b/scripts/verify-adopter-package.mjs
@@ -19,6 +19,7 @@ assert.equal(
 assert.deepEqual(
   adopterPackage.dependencies,
   {
+    '@modelcontextprotocol/sdk': rootPackage.dependencies['@modelcontextprotocol/sdk'],
     'eventsource-parser': rootPackage.devDependencies['eventsource-parser'],
     jose: rootPackage.devDependencies.jose,
     zod: rootPackage.dependencies.zod,
@@ -31,9 +32,12 @@ assert.deepEqual(
     '.',
     './contracts',
     './authority',
+    './conversation',
     './mcp',
+    './mcp/node',
     './http-sse',
     './testing',
+    './node',
     './package.json',
   ],
   '@roackb2/heddle-adopter public subpaths must stay deliberate.',

--- a/src/__tests__/integration/sdk/adopter-package-boundary.test.ts
+++ b/src/__tests__/integration/sdk/adopter-package-boundary.test.ts
@@ -10,16 +10,16 @@ describe('@roackb2/heddle-adopter package boundary', () => {
     expect(rootPackage.exports['./adopter']).toBeUndefined();
   });
 
-  it('keeps only the contract, JOSE, and SSE dependencies', () => {
+  it('keeps a bounded contract, JOSE, SSE, and official MCP boundary', () => {
     expect(adopterPackage.dependencies).toEqual({
+      '@modelcontextprotocol/sdk':
+        rootPackage.dependencies['@modelcontextprotocol/sdk'],
       'eventsource-parser': rootPackage.devDependencies['eventsource-parser'],
       jose: rootPackage.devDependencies.jose,
       zod: rootPackage.dependencies.zod,
     });
     expect(adopterPackage.dependencies['@roackb2/heddle']).toBeUndefined();
     expect(adopterPackage.dependencies['@aws-sdk/client-bedrock-agentcore'])
-      .toBeUndefined();
-    expect(adopterPackage.dependencies['@modelcontextprotocol/sdk'])
       .toBeUndefined();
   });
 
@@ -28,9 +28,12 @@ describe('@roackb2/heddle-adopter package boundary', () => {
       '.',
       './contracts',
       './authority',
+      './conversation',
       './mcp',
+      './mcp/node',
       './http-sse',
       './testing',
+      './node',
       './package.json',
     ]);
   });


### PR DESCRIPTION
## What changed

- add a provider-neutral `HostedConversationTurnService` that composes execution authority, optional MCP capability issuance, model credentials, and one `ExecutionHost` stream
- add an optional Node adopter edge for public JWKS, prompt-only conversation HTTP/SSE, bounded parsing, credential-header redaction, disconnect cancellation, backpressure, safe failures, and graceful shutdown
- add local ES256 key-file helpers and non-enumerable direct-host credentials
- add a generic official-SDK Streamable HTTP MCP service around adopter-owned toolsets
- add a runnable Node control-plane example and document the progressive adoption layers

## Why

The adopter contract previously provided the secure primitives, but every Node adopter still had to reconstruct substantial HTTP, SSE, signing-key, credential, and MCP lifecycle machinery. These additions move the domain-neutral heavy lifting into `@roackb2/heddle-adopter` while preserving the product boundary.

Adopters still own user authentication and authorization, tenant/session identity, product MCP tools and data access, durable invocation identity and settlement, production key management, and deployment-specific transport.

## Validation

- `yarn test` — 1,277 Heddle tests and 76 adopter-package tests passed
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- `yarn adopter:example:node-control-plane`
- `npm pack ./packages/heddle-adopter --dry-run --json --cache /tmp/heddle-adopter-npm-cache`
- `git diff --check`

The package dry run contains only compiled output, package metadata, README, and license; examples and test helpers are excluded from the publication.
