### PR TITLE
Add low-volume targeted heartbeat host

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -224,6 +224,48 @@ expiry. Remote stores need an explicit lease-expiry or operator recovery policy,
 and `runTask()` never recovers or steals another worker's claim. Late settlement
 writes remain fenced after an explicit recovery.
 
+### Use the standard low-volume targeted host
+
+Most product pilots do not need to build a queue dispatcher around `runTask()`.
+`HeartbeatTargetedTaskHost` supplies an in-process default with notification
+coalescing, a polling fallback, bounded concurrency, per-invocation timeouts,
+pause/resume, cancellation, and periodic interrupted-owner recovery:
+
+```ts
+import {
+  HeartbeatTargetedTaskHost,
+  HeartbeatTargetedTaskWorker,
+} from '@roackb2/heddle/advanced';
+
+const host = new HeartbeatTargetedTaskHost({
+  store: heartbeatTasks,
+  createTarget: (handler) => new HeartbeatTargetedTaskWorker({
+    store: heartbeatTasks,
+    handler,
+    runtime: { workspaceRoot, stateDir },
+  }),
+  pollIntervalMs: 30_000,
+  recoveryIntervalMs: 30_000,
+  invocationTimeoutMs: 15 * 60_000,
+  maxConcurrentInvocations: 1,
+  isAdmissionEnabled: readDurableProductGate,
+});
+
+host.start({ handler, admissionEnabled: true });
+```
+
+The store must already be scoped to the task or tenant namespace this process
+may execute. An optional `taskIdPrefix` is defense in depth, not authorization.
+Notifications are latency hints; polling durable state is the correctness path.
+Only `busy` and `claim-lost` receive short delivery retries. Normal Heddle retry,
+failure, not-due, and cancellation results wait for their persisted schedule.
+
+This host is intentionally for low-volume single-process admission. It is not a
+distributed queue, leader election service, or cross-replica concurrency limit.
+Replace its invocation target or the dispatcher itself when production scale
+requires a durable queue or workflow engine; keep the same targeted worker and
+task-store contracts.
+
 ### Certify a custom targeted store
 
 Before using a remote adapter with ephemeral or replicated workers, run the

--- a/src/__tests__/integration/core/heartbeat-targeted-dispatcher.test.ts
+++ b/src/__tests__/integration/core/heartbeat-targeted-dispatcher.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  HeartbeatTargetedTaskDispatcher,
+  resolveHeartbeatTargetedTaskDispatchDecision,
+  type HeartbeatTargetedTaskInvocation,
+  type HeartbeatTargetedTaskInvocationTarget,
+  type HeartbeatTask,
+  type HeartbeatTaskRunRequestSignal,
+  type RunHeartbeatTaskResult,
+} from '../../../advanced.js';
+
+describe('targeted heartbeat task dispatcher', () => {
+  const dispatchers: HeartbeatTargetedTaskDispatcher[] = [];
+
+  afterEach(async () => {
+    await Promise.all(dispatchers.map((dispatcher) => dispatcher.stop()));
+    dispatchers.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it('coalesces duplicate generations without concurrent work for one task', async () => {
+    const firstRun = deferred<void>();
+    const invocations: HeartbeatTargetedTaskInvocation[] = [];
+    const target: HeartbeatTargetedTaskInvocationTarget = {
+      invoke: vi.fn(async (invocation) => {
+        invocations.push(invocation);
+        if (invocations.length === 1) {
+          await firstRun.promise;
+        }
+        return noWork(invocation.taskId);
+      }),
+    };
+    const dispatcher = createDispatcher({ target });
+    dispatcher.start();
+
+    expect(dispatcher.notify(runRequest('managed-a', 1)).status).toBe('queued');
+    await vi.waitFor(() => expect(invocations).toHaveLength(1));
+    expect(dispatcher.notify(runRequest('managed-a', 1)).status)
+      .toBe('coalesced');
+    expect(dispatcher.notify(runRequest('managed-a', 2)).status).toBe('queued');
+    expect(invocations).toHaveLength(1);
+
+    firstRun.resolve();
+    await vi.waitFor(() => expect(invocations).toHaveLength(2));
+    expect(invocations.map(({ runRequestGeneration }) => runRequestGeneration))
+      .toEqual([1, 2]);
+  });
+
+  it('coalesces generation-free polling hints while a task is represented', async () => {
+    const firstRun = deferred<void>();
+    const target: HeartbeatTargetedTaskInvocationTarget = {
+      invoke: vi.fn(async ({ taskId }) => {
+        await firstRun.promise;
+        return noWork(taskId);
+      }),
+    };
+    const dispatcher = createDispatcher({ target });
+    dispatcher.start();
+
+    expect(dispatcher.notify({
+      ...runRequest('managed-scheduled', 1),
+      generation: undefined,
+    }).status).toBe('queued');
+    await vi.waitFor(() => expect(target.invoke).toHaveBeenCalledOnce());
+    expect(dispatcher.notify({
+      ...runRequest('managed-scheduled', 1),
+      generation: undefined,
+    }).status).toBe('coalesced');
+
+    firstRun.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(target.invoke).toHaveBeenCalledOnce();
+  });
+
+  it('uses the durable admission gate and polling correctness fallback', async () => {
+    let enabled = false;
+    const task = createDueTask('managed-polled');
+    const store = { listTasks: vi.fn(async () => [task]) };
+    const target: HeartbeatTargetedTaskInvocationTarget = {
+      invoke: vi.fn(async ({ taskId }) => {
+        task.enabled = false;
+        return noWork(taskId);
+      }),
+    };
+    const dispatcher = createDispatcher({
+      store,
+      target,
+      pollIntervalMs: 10,
+      isAdmissionEnabled: async () => enabled,
+    });
+    dispatcher.start();
+    dispatcher.notify(runRequest(task.id, 1));
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(store.listTasks).not.toHaveBeenCalled();
+    expect(target.invoke).not.toHaveBeenCalled();
+
+    enabled = true;
+    await vi.waitFor(() => expect(target.invoke).toHaveBeenCalledOnce());
+    expect(store.listTasks).toHaveBeenCalled();
+  });
+
+  it('bounds independent concurrency and rejects unmanaged notifications', async () => {
+    const releases = new Map<string, Deferred<void>>();
+    let active = 0;
+    let maximumActive = 0;
+    const target: HeartbeatTargetedTaskInvocationTarget = {
+      invoke: vi.fn(async ({ taskId }) => {
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        const release = deferred<void>();
+        releases.set(taskId, release);
+        await release.promise;
+        active -= 1;
+        return noWork(taskId);
+      }),
+    };
+    const dispatcher = createDispatcher({
+      target,
+      maxConcurrentInvocations: 2,
+    });
+    dispatcher.start();
+    expect(dispatcher.notify(runRequest('outside-a', 1)).status)
+      .toBe('not-managed');
+    ['a', 'b', 'c'].forEach((suffix) => {
+      dispatcher.notify(runRequest(`managed-${suffix}`, 1));
+    });
+
+    await vi.waitFor(() => expect(target.invoke).toHaveBeenCalledTimes(2));
+    expect(maximumActive).toBe(2);
+    releases.get('managed-a')?.resolve();
+    await vi.waitFor(() => expect(target.invoke).toHaveBeenCalledTimes(3));
+    expect(maximumActive).toBe(2);
+    releases.forEach((release) => release.resolve());
+  });
+
+  it('retries contention but respects Heddle durable schedules', async () => {
+    const outcomes: RunHeartbeatTaskResult['status'][] = [];
+    let attempts = 0;
+    const target: HeartbeatTargetedTaskInvocationTarget = {
+      invoke: vi.fn(async ({ taskId }) => {
+        attempts += 1;
+        return attempts === 1
+          ? { taskId, status: 'busy', failed: false }
+          : noWork(taskId);
+      }),
+    };
+    const dispatcher = createDispatcher({
+      target,
+      contentionRetryMs: 10,
+      onOutcome: ({ result }) => outcomes.push(result.status),
+    });
+    dispatcher.start();
+    dispatcher.notify(runRequest('managed-contention', 1));
+
+    await vi.waitFor(() => expect(target.invoke).toHaveBeenCalledTimes(2));
+    expect(outcomes).toEqual(['busy', 'not-found']);
+    expect(resolveHeartbeatTargetedTaskDispatchDecision('claim-lost', 25))
+      .toEqual({ kind: 'retry-transiently', delayMs: 25 });
+    for (const status of ['retry', 'failed', 'not-due', 'cancelled'] as const) {
+      expect(resolveHeartbeatTargetedTaskDispatchDecision(status, 25))
+        .toEqual({ kind: 'wait-for-durable-schedule' });
+    }
+    for (const status of ['settled', 'not-found', 'disabled'] as const) {
+      expect(resolveHeartbeatTargetedTaskDispatchDecision(status, 25))
+        .toEqual({ kind: 'complete-delivery' });
+    }
+  });
+
+  it('retains paused notifications and cancels active work on demand', async () => {
+    const invocations = new Map<string, HeartbeatTargetedTaskInvocation>();
+    const target: HeartbeatTargetedTaskInvocationTarget = {
+      invoke: vi.fn(async (invocation) => {
+        invocations.set(invocation.taskId, invocation);
+        await aborted(invocation.signal);
+        return {
+          taskId: invocation.taskId,
+          status: 'cancelled',
+          failed: false,
+        };
+      }),
+    };
+    const dispatcher = createDispatcher({ target });
+    dispatcher.start({ admissionPaused: true });
+    expect(dispatcher.notify(runRequest('managed-paused', 1)).status)
+      .toBe('queued');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(target.invoke).not.toHaveBeenCalled();
+
+    dispatcher.resume();
+    await vi.waitFor(() => expect(target.invoke).toHaveBeenCalledOnce());
+    const cancellation = await dispatcher.cancelTask(
+      'managed-paused',
+      'Operator paused this task.',
+    );
+    expect(cancellation).toMatchObject({
+      taskId: 'managed-paused',
+      disposition: 'cancelled',
+    });
+    expect(invocations.get('managed-paused')?.signal.aborted).toBe(true);
+  });
+
+  it('cancels invocations that exceed their wall-clock bound', async () => {
+    const target: HeartbeatTargetedTaskInvocationTarget = {
+      invoke: vi.fn(async (invocation) => {
+        await aborted(invocation.signal);
+        return {
+          taskId: invocation.taskId,
+          status: 'cancelled',
+          failed: false,
+        };
+      }),
+    };
+    const dispatcher = createDispatcher({
+      target,
+      invocationTimeoutMs: 10,
+    });
+    dispatcher.start();
+    dispatcher.notify(runRequest('managed-timeout', 1));
+
+    await vi.waitFor(() => {
+      const invocation = vi.mocked(target.invoke).mock.calls[0]?.[0];
+      expect(invocation?.signal.aborted).toBe(true);
+      expect(invocation?.signal.reason).toBeInstanceOf(Error);
+    });
+  });
+
+  function createDispatcher(
+    overrides: Partial<
+      ConstructorParameters<typeof HeartbeatTargetedTaskDispatcher>[0]
+    > = {},
+  ): HeartbeatTargetedTaskDispatcher {
+    const dispatcher = new HeartbeatTargetedTaskDispatcher({
+      store: { listTasks: async () => [] },
+      target: { invoke: async ({ taskId }) => noWork(taskId) },
+      taskIdPrefix: 'managed-',
+      pollIntervalMs: 1_000,
+      maxConcurrentInvocations: 1,
+      invocationTimeoutMs: 60_000,
+      contentionRetryMs: 25,
+      ...overrides,
+    });
+    dispatchers.push(dispatcher);
+    return dispatcher;
+  }
+});
+
+function runRequest(
+  taskId: string,
+  generation: number,
+): HeartbeatTaskRunRequestSignal {
+  return {
+    taskId,
+    generation,
+    disposition: generation === 1 ? 'requested' : 'coalesced',
+    requestedAt: '2026-08-08T08:00:00.000Z',
+    reason: 'test-work-arrived',
+  };
+}
+
+function createDueTask(id: string): HeartbeatTask {
+  return {
+    id,
+    task: `Process work for ${id}.`,
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt: '2000-01-01T00:00:00.000Z',
+    },
+    state: {
+      status: 'waiting',
+      runRequest: {
+        generation: 1,
+        claimedGeneration: 0,
+        requestedAt: '2000-01-01T00:00:00.000Z',
+      },
+    },
+  };
+}
+
+function noWork(taskId: string): RunHeartbeatTaskResult {
+  return { taskId, status: 'not-found', failed: false };
+}
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value?: T | PromiseLike<T>): void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+async function aborted(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}

--- a/src/__tests__/integration/core/heartbeat-targeted-host.test.ts
+++ b/src/__tests__/integration/core/heartbeat-targeted-host.test.ts
@@ -1,0 +1,229 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  FileHeartbeatTaskService,
+  HeartbeatTargetedTaskHost,
+  HeartbeatTargetedTaskWorker,
+  type HeartbeatTargetedTaskInvocation,
+  type HeartbeatTask,
+} from '../../../advanced.js';
+
+describe('targeted heartbeat task host', () => {
+  const roots: string[] = [];
+  const hosts: HeartbeatTargetedTaskHost[] = [];
+
+  afterEach(async () => {
+    await Promise.all(hosts.map((host) => (
+      host.stop({ cancelRunning: true })
+    )));
+    roots.splice(0).forEach((root) => {
+      rmSync(root, { recursive: true, force: true });
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('subscribes to run requests, recovers, and reports the durable cancellation id', async () => {
+    const store = createStore();
+    await store.createTask({
+      id: 'managed-local',
+      task: 'Run one targeted task.',
+      intervalMs: 60_000,
+      defer: true,
+    });
+    const recoverInterruptedTasks = vi.spyOn(store, 'recoverInterruptedTasks');
+    const invocations: HeartbeatTargetedTaskInvocation[] = [];
+    const host = new HeartbeatTargetedTaskHost({
+      store,
+      createTarget: () => ({
+        invoke: vi.fn(async (invocation) => {
+          invocations.push(invocation);
+          await aborted(invocation.signal);
+          return {
+            taskId: invocation.taskId,
+            status: 'cancelled',
+            executionId: 'durable-execution-id',
+            failed: false,
+          };
+        }),
+      }),
+      taskIdPrefix: 'managed-',
+      pollIntervalMs: 60_000,
+      maxConcurrentInvocations: 1,
+      invocationTimeoutMs: 60_000,
+      recoveryIntervalMs: 60_000,
+    });
+    hosts.push(host);
+    host.start({
+      handler: async (execution) => execution.skip({ summary: 'Unused.' }),
+    });
+    await vi.waitFor(() => expect(recoverInterruptedTasks).toHaveBeenCalled());
+
+    await store.requestTaskRun('managed-local', { reason: 'test-notification' });
+    await vi.waitFor(() => expect(invocations).toHaveLength(1));
+
+    await expect(host.cancelTask('managed-local', {
+      reason: 'Operator paused this task.',
+    })).resolves.toMatchObject({
+      taskId: 'managed-local',
+      disposition: 'cancelled',
+      executionId: 'durable-execution-id',
+    });
+    expect(invocations[0]?.signal.aborted).toBe(true);
+
+    await store.saveTask(remoteRunningTask());
+    await expect(host.cancelTask('remote-running', {
+      reason: 'Operator paused this task.',
+    })).resolves.toMatchObject({
+      taskId: 'remote-running',
+      disposition: 'not-owned',
+    });
+  });
+
+  it('classifies a completion race without claiming cancellation won', async () => {
+    const store = createStore();
+    await store.createTask({
+      id: 'managed-race',
+      task: 'Complete while cancellation races.',
+      intervalMs: 60_000,
+      defer: true,
+    });
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const host = new HeartbeatTargetedTaskHost({
+      store,
+      createTarget: () => ({
+        invoke: async ({ taskId }) => {
+          entered.resolve();
+          await release.promise;
+          return {
+            taskId,
+            status: 'failed',
+            executionId: 'completed-execution',
+            error: 'Already settled.',
+            task: (await store.loadTask(taskId))!,
+            failed: true,
+          };
+        },
+      }),
+      pollIntervalMs: 60_000,
+      maxConcurrentInvocations: 1,
+      invocationTimeoutMs: 60_000,
+      recoveryIntervalMs: 60_000,
+    });
+    hosts.push(host);
+    host.start({
+      handler: async (execution) => execution.skip({ summary: 'Unused.' }),
+    });
+    await store.requestTaskRun('managed-race', { reason: 'test-race' });
+    await entered.promise;
+
+    const cancellation = host.cancelTask('managed-race', {
+      reason: 'Operator cancelled.',
+    });
+    release.resolve();
+
+    await expect(cancellation).resolves.toMatchObject({
+      taskId: 'managed-race',
+      disposition: 'completion-won',
+      executionId: 'completed-execution',
+    });
+  });
+
+  it('runs only the routed task through the standard targeted worker', async () => {
+    const now = new Date('2026-08-08T08:00:00.000Z');
+    const store = createStore();
+    const tasks = [createTask('worker-a'), createTask('worker-b')];
+    await store.reconcileTasks({ namespace: 'worker-', desired: tasks });
+    await Promise.all(tasks.map((task) => store.requestTaskRun(task.id, {
+      requestedAt: now,
+      reason: 'test-work-arrived',
+    })));
+    const listTasks = vi.spyOn(store, 'listTasks');
+    const recoverInterruptedTasks = vi.spyOn(store, 'recoverInterruptedTasks');
+    const handledTaskIds: string[] = [];
+    const worker = new HeartbeatTargetedTaskWorker({
+      store,
+      now: () => now,
+      handler: async (execution) => {
+        handledTaskIds.push(execution.task.id);
+        return execution.skip({ summary: 'Deterministic worker test.' });
+      },
+    });
+
+    const result = await worker.invoke({
+      taskId: 'worker-a',
+      invocationId: 'invocation-a',
+      runRequestGeneration: 1,
+      signal: new AbortController().signal,
+    });
+
+    expect(result.status).toBe('settled');
+    expect(handledTaskIds).toEqual(['worker-a']);
+    expect(listTasks).not.toHaveBeenCalled();
+    expect(recoverInterruptedTasks).not.toHaveBeenCalled();
+    await expect(store.loadTask('worker-b')).resolves.toMatchObject({
+      state: {
+        runRequest: { generation: 1, claimedGeneration: 0 },
+      },
+    });
+  });
+
+  function createStore(): FileHeartbeatTaskService {
+    const root = mkdtempSync(join(tmpdir(), 'heddle-targeted-host-'));
+    roots.push(root);
+    return new FileHeartbeatTaskService({ dir: root });
+  }
+});
+
+function createTask(id: string): HeartbeatTask {
+  return {
+    id,
+    task: `Process work for ${id}.`,
+    enabled: true,
+    schedule: {
+      intervalMs: 60_000,
+      nextRunAt: '2099-01-01T00:00:00.000Z',
+    },
+  };
+}
+
+function remoteRunningTask(): HeartbeatTask {
+  return {
+    id: 'remote-running',
+    task: 'Owned by another targeted task host.',
+    enabled: true,
+    schedule: { intervalMs: 60_000 },
+    state: {
+      status: 'running',
+      execution: {
+        executionId: 'remote-execution',
+        ownerId: 'remote-owner',
+        claimedAt: '2026-08-08T08:00:00.000Z',
+      },
+    },
+  };
+}
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value?: T | PromiseLike<T>): void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+async function aborted(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -334,6 +334,28 @@ export type {
   HeartbeatTaskView,
 } from './core/heartbeat/views/index.js';
 export {
+  HeartbeatTargetedTaskDispatcher,
+  HeartbeatTargetedTaskHost,
+  HeartbeatTargetedTaskWorker,
+  resolveHeartbeatTargetedTaskDispatchDecision,
+} from './core/heartbeat/targeted-host/index.js';
+export type {
+  HeartbeatTargetedTaskDispatchDecision,
+  HeartbeatTargetedTaskDispatchError,
+  HeartbeatTargetedTaskDispatchOutcome,
+  HeartbeatTargetedTaskDispatcherOptions,
+  HeartbeatTargetedTaskHostHandle,
+  HeartbeatTargetedTaskHostOptions,
+  HeartbeatTargetedTaskInvocation,
+  HeartbeatTargetedTaskInvocationTarget,
+  HeartbeatTargetedTaskLocalCancellationResult,
+  HeartbeatTargetedTaskNotificationResult,
+  HeartbeatTargetedTaskWorkerOptions,
+  StartHeartbeatTargetedTaskDispatcherOptions,
+  StartHeartbeatTargetedTaskHostInput,
+  StopHeartbeatTargetedTaskDispatcherOptions,
+} from './core/heartbeat/targeted-host/index.js';
+export {
   HeartbeatLucidPresenter,
   HeartbeatTaskViewProjector,
 } from './core/heartbeat/views/index.js';

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -96,11 +96,15 @@ operator-facing heartbeat views.
   catalog. The method reads durable eligibility and makes the final due claim
   through the store; its typed result distinguishes settlement, normal failure,
   missing/disabled/not-due/busy work, a lost claim, and cancellation.
-- Targeted execution does not scan unrelated tasks, start polling, subscribe to
-  run requests, or recover interrupted executions. Queue delivery, tenant
-  authorization, retries, visibility timeouts, and host-domain idempotency stay
-  with the host. The store's atomic claim fences duplicate at-least-once worker
-  deliveries; it does not make host tool side effects exactly once.
+- The one-shot `runTask()` method does not scan unrelated tasks, poll, subscribe,
+  or recover interrupted executions. `HeartbeatTargetedTaskHost` is the
+  low-volume in-process default around that primitive: it owns notification
+  coalescing, polling fallback, bounded local delivery, cancellation, and
+  recovery cadence. It is not a distributed queue or authorization boundary.
+  Queue visibility, cross-replica admission, tenant authorization, and
+  host-domain idempotency remain host responsibilities. The store's atomic
+  claim fences duplicate at-least-once worker deliveries; it does not make host
+  tool side effects exactly once.
 - The file service serializes task/checkpoint/run mutations with a shared
   in-process mutex for one resolved heartbeat root. Task, checkpoint, and run
   JSON files are replaced atomically, so readers see a complete previous or next

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -97,3 +97,25 @@ export type {
   LucidAgentStatus,
   LucidAgentStatusNotification,
 } from './views/index.js';
+export {
+  HeartbeatTargetedTaskDispatcher,
+  HeartbeatTargetedTaskHost,
+  HeartbeatTargetedTaskWorker,
+  resolveHeartbeatTargetedTaskDispatchDecision,
+} from './targeted-host/index.js';
+export type {
+  HeartbeatTargetedTaskDispatchDecision,
+  HeartbeatTargetedTaskDispatchError,
+  HeartbeatTargetedTaskDispatchOutcome,
+  HeartbeatTargetedTaskDispatcherOptions,
+  HeartbeatTargetedTaskHostHandle,
+  HeartbeatTargetedTaskHostOptions,
+  HeartbeatTargetedTaskInvocation,
+  HeartbeatTargetedTaskInvocationTarget,
+  HeartbeatTargetedTaskLocalCancellationResult,
+  HeartbeatTargetedTaskNotificationResult,
+  HeartbeatTargetedTaskWorkerOptions,
+  StartHeartbeatTargetedTaskDispatcherOptions,
+  StartHeartbeatTargetedTaskHostInput,
+  StopHeartbeatTargetedTaskDispatcherOptions,
+} from './targeted-host/index.js';

--- a/src/core/heartbeat/scheduler/cancellation-policy.ts
+++ b/src/core/heartbeat/scheduler/cancellation-policy.ts
@@ -1,0 +1,68 @@
+import {
+  MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH,
+  type HeartbeatTask,
+} from '../tasks/index.js';
+import type { HeartbeatTaskCancellationResult } from './types.js';
+
+class HeartbeatTaskCancellationSignal extends Error {
+  readonly #operatorReason: string;
+
+  constructor(operatorReason: string) {
+    super('Heartbeat task cancellation requested by its host.');
+    this.name = 'HeartbeatTaskCancellationSignal';
+    this.#operatorReason = operatorReason;
+  }
+
+  get operatorReason(): string {
+    return this.#operatorReason;
+  }
+}
+
+/** Shared operator-cancellation validation and inactive-task classification. */
+export class HeartbeatTaskCancellationPolicy {
+  static normalizeReason(reason: string): string {
+    const normalized = reason.trim().replace(/\s+/g, ' ');
+    if (!normalized) {
+      throw new Error('Heartbeat cancellation reason cannot be empty.');
+    }
+    if (normalized.length > MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH) {
+      throw new Error(
+        `Heartbeat cancellation reason must be at most ${MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH} characters.`,
+      );
+    }
+    return normalized;
+  }
+
+  static inactiveDisposition(
+    task: HeartbeatTask | undefined,
+  ): HeartbeatTaskCancellationResult['disposition'] {
+    if (!task) {
+      return 'not-found';
+    }
+    if (task.state?.status === 'running') {
+      return 'not-owned';
+    }
+    if (task.state?.status === 'blocked') {
+      return 'blocked';
+    }
+    if (task.state?.status === 'complete') {
+      return 'completed';
+    }
+    if (!task.enabled) {
+      return 'disabled';
+    }
+    return 'not-running';
+  }
+
+  static createSignal(reason: string): Error {
+    return new HeartbeatTaskCancellationSignal(this.normalizeReason(reason));
+  }
+
+  static readSignalReason(
+    signal: AbortSignal | undefined,
+  ): string | undefined {
+    return signal?.reason instanceof HeartbeatTaskCancellationSignal
+      ? signal.reason.operatorReason
+      : undefined;
+  }
+}

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -38,7 +38,7 @@ import {
   MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH,
   MAX_HEARTBEAT_HANDLER_RETRY_MS,
 } from './types.js';
-import { heartbeatTaskCancellationReason } from './task-lifecycle.js';
+import { HeartbeatTaskCancellationPolicy } from './cancellation-policy.js';
 
 const DEFAULT_FAILURE_RETRY_MS = 5 * 60_000;
 const CANCELLATION_SUMMARY = 'Heartbeat execution cancelled by its scheduler host.';
@@ -498,7 +498,7 @@ export class HeartbeatTaskRunnerService {
     execution: HeartbeatTaskExecution;
   }): Promise<HeartbeatTaskExecutionResult> {
     const settledAt = args.now?.() ?? dayjs().toDate();
-    const reason = heartbeatTaskCancellationReason(args.signal);
+    const reason = HeartbeatTaskCancellationPolicy.readSignalReason(args.signal);
     const completion = await args.store.recordTaskExecutionOutcome({
       execution: args.execution,
       taskId: args.task.id,

--- a/src/core/heartbeat/scheduler/task-lifecycle.ts
+++ b/src/core/heartbeat/scheduler/task-lifecycle.ts
@@ -6,11 +6,10 @@
  * executions started by this handle, and awaiting their outer settlement.
  */
 import {
-  MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH,
-  type HeartbeatTask,
   type HeartbeatTaskRunRecord,
   type HeartbeatTaskStore,
 } from '../tasks/index.js';
+import { HeartbeatTaskCancellationPolicy } from './cancellation-policy.js';
 import type {
   CancelHeartbeatTaskOptions,
   HeartbeatTaskCancellationResult,
@@ -25,24 +24,6 @@ type ActiveHeartbeatTask = {
   controller: AbortController;
   settlement: Promise<HeartbeatTaskSettlement | undefined>;
 };
-
-class HeartbeatTaskCancellationSignal extends Error {
-  readonly #operatorReason: string;
-
-  constructor(operatorReason: string) {
-    super('Heartbeat task cancellation requested by the scheduler host.');
-    this.name = 'HeartbeatTaskCancellationSignal';
-    this.#operatorReason = operatorReason;
-  }
-
-  get operatorReason(): string {
-    return this.#operatorReason;
-  }
-}
-
-export function heartbeatTaskCancellationReason(signal: AbortSignal | undefined): string | undefined {
-  return signal?.reason instanceof HeartbeatTaskCancellationSignal ? signal.reason.operatorReason : undefined;
-}
 
 export class HeartbeatSchedulerTaskLifecycle {
   private readonly activeTasks = new Map<string, ActiveHeartbeatTask>();
@@ -99,7 +80,7 @@ export class HeartbeatSchedulerTaskLifecycle {
 
     let reason: string;
     try {
-      reason = HeartbeatSchedulerTaskLifecycle.normalizeCancellationReason(options.reason);
+      reason = HeartbeatTaskCancellationPolicy.normalizeReason(options.reason);
     } catch (error) {
       return Promise.reject(error);
     }
@@ -139,7 +120,7 @@ export class HeartbeatSchedulerTaskLifecycle {
       return await this.classifyInactiveTask(taskId, reason);
     }
 
-    activeTask.controller.abort(new HeartbeatTaskCancellationSignal(reason));
+    activeTask.controller.abort(HeartbeatTaskCancellationPolicy.createSignal(reason));
     const settlement = await activeTask.settlement;
     const result = HeartbeatSchedulerTaskLifecycle.cancellationResult({
       taskId,
@@ -161,29 +142,8 @@ export class HeartbeatSchedulerTaskLifecycle {
 
   private async classifyInactiveTask(taskId: string, reason: string): Promise<HeartbeatTaskCancellationResult> {
     const task = (await this.store.listTasks()).find((candidate) => candidate.id === taskId);
-    const disposition = HeartbeatSchedulerTaskLifecycle.inactiveDisposition(task);
+    const disposition = HeartbeatTaskCancellationPolicy.inactiveDisposition(task);
     return { taskId, disposition, reason };
-  }
-
-  private static inactiveDisposition(
-    task: HeartbeatTask | undefined,
-  ): HeartbeatTaskCancellationResult['disposition'] {
-    if (!task) {
-      return 'not-found';
-    }
-    if (task.state?.status === 'running') {
-      return 'not-owned';
-    }
-    if (task.state?.status === 'blocked') {
-      return 'blocked';
-    }
-    if (task.state?.status === 'complete') {
-      return 'completed';
-    }
-    if (!task.enabled) {
-      return 'disabled';
-    }
-    return 'not-running';
   }
 
   private static cancellationResult(args: {
@@ -217,16 +177,4 @@ export class HeartbeatSchedulerTaskLifecycle {
     };
   }
 
-  private static normalizeCancellationReason(reason: string): string {
-    const normalized = reason.trim().replace(/\s+/g, ' ');
-    if (!normalized) {
-      throw new Error('Heartbeat cancellation reason cannot be empty.');
-    }
-    if (normalized.length > MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH) {
-      throw new Error(
-        `Heartbeat cancellation reason must be at most ${MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH} characters.`,
-      );
-    }
-    return normalized;
-  }
 }

--- a/src/core/heartbeat/targeted-host/README.md
+++ b/src/core/heartbeat/targeted-host/README.md
@@ -1,0 +1,50 @@
+# Targeted heartbeat task host
+
+This subdomain is Heddle's low-volume default for request-driven heartbeat
+execution. It saves adopters from rebuilding durable notification coalescing,
+polling fallback, bounded local concurrency, invocation timeouts, cancellation,
+and expired-owner recovery around `HeartbeatSchedulerService.runTask()`.
+
+## Responsibilities
+
+- `HeartbeatTargetedTaskWorker` executes exactly one routed task through
+  Heddle's direct lookup, due claim, checkpoint, handler, and fenced settlement.
+- `HeartbeatTargetedTaskDispatcher` treats run-request notifications as a fast
+  hint, polls durable task state as the correctness fallback, coalesces task
+  generations, and retries only transient `busy` or `claim-lost` deliveries.
+- `HeartbeatTargetedTaskHost` adds store subscription, recovery cadence,
+  process-local pause/resume, and cancellation classification.
+
+## Boundaries
+
+The task store remains the durable authority. A product remains responsible for
+creating/reconciling tasks, its durable global admission gate, domain input and
+idempotency, and deciding which task namespace this host may see. The host does
+not provide a distributed queue, leader election, or cross-process concurrency
+limit. Use a queue-backed dispatcher when scale or availability requires it;
+the replaceable invocation-target port preserves that migration seam.
+
+`taskIdPrefix` is an optional defense-in-depth filter, not an authorization
+boundary. Prefer giving each host a store already scoped to its tenant or task
+namespace. `recoveryIntervalMs` must be shorter than the remote store's
+execution lease so expired ownership is revisited promptly.
+
+## Typical composition
+
+```ts
+const host = new HeartbeatTargetedTaskHost({
+  store,
+  createTarget: (handler) => new HeartbeatTargetedTaskWorker({
+    store,
+    handler,
+    runtime: { workspaceRoot, stateDir },
+  }),
+  pollIntervalMs: 30_000,
+  recoveryIntervalMs: 30_000,
+  invocationTimeoutMs: 15 * 60_000,
+  maxConcurrentInvocations: 1,
+  isAdmissionEnabled: readDurableOperatorGate,
+})
+
+host.start({ handler, admissionEnabled: true })
+```

--- a/src/core/heartbeat/targeted-host/dispatcher.ts
+++ b/src/core/heartbeat/targeted-host/dispatcher.ts
@@ -1,0 +1,553 @@
+import { randomUUID } from 'node:crypto';
+import { HeartbeatTaskCancellationPolicy } from '../scheduler/cancellation-policy.js';
+import {
+  HeartbeatTaskExecutionEligibilityPolicy,
+  type HeartbeatTaskRunRequestSignal,
+} from '../tasks/index.js';
+import type {
+  HeartbeatTargetedTaskDispatchDecision,
+  HeartbeatTargetedTaskDispatchError,
+  HeartbeatTargetedTaskDispatchOutcome,
+  HeartbeatTargetedTaskDispatcherOptions,
+  HeartbeatTargetedTaskInvocation,
+  HeartbeatTargetedTaskLocalCancellationResult,
+  HeartbeatTargetedTaskNotificationResult,
+  StartHeartbeatTargetedTaskDispatcherOptions,
+  StopHeartbeatTargetedTaskDispatcherOptions,
+} from './types.js';
+
+type DispatcherState = 'idle' | 'running' | 'stopping' | 'stopped';
+type DrainDisposition = 'drained' | 'paused' | 'saturated' | 'stopped';
+
+type ActiveInvocation = {
+  invocation: HeartbeatTargetedTaskInvocation;
+  controller: AbortController;
+  promise: Promise<HeartbeatTargetedTaskDispatchOutcome['result'] | undefined>;
+  suppressRetry: boolean;
+};
+
+type PendingInvocation = {
+  runRequestGeneration?: number;
+};
+
+const DEFAULT_CONTENTION_RETRY_MS = 1_000;
+
+/**
+ * Low-volume in-process dispatcher for durable targeted heartbeat requests.
+ *
+ * Notifications are a latency hint; non-overlapping catalog polling is the
+ * correctness fallback. Heddle's targeted worker still performs the final due
+ * check, atomic claim, checkpoint handling, and claim-fenced settlement.
+ */
+export class HeartbeatTargetedTaskDispatcher {
+  readonly #pending = new Map<string, PendingInvocation>();
+  readonly #active = new Map<string, ActiveInvocation>();
+  readonly #retryTimers = new Map<string, NodeJS.Timeout>();
+  readonly #taskIdPrefix: string | undefined;
+  #state: DispatcherState = 'idle';
+  #pollTimer: NodeJS.Timeout | undefined;
+  #pollPromise: Promise<void> | undefined;
+  #drainPromise: Promise<void> | undefined;
+  #admissionPaused = false;
+
+  constructor(private readonly options: HeartbeatTargetedTaskDispatcherOptions) {
+    assertPositiveInteger(options.pollIntervalMs, 'pollIntervalMs');
+    assertPositiveInteger(
+      options.maxConcurrentInvocations,
+      'maxConcurrentInvocations',
+    );
+    assertPositiveInteger(options.invocationTimeoutMs, 'invocationTimeoutMs');
+    assertPositiveInteger(
+      options.contentionRetryMs ?? DEFAULT_CONTENTION_RETRY_MS,
+      'contentionRetryMs',
+    );
+    const prefix = options.taskIdPrefix?.trim();
+    if (options.taskIdPrefix !== undefined && !prefix) {
+      throw new Error('taskIdPrefix must be omitted or non-empty.');
+    }
+    this.#taskIdPrefix = prefix;
+  }
+
+  /** Starts an immediate durable scan, optionally with admission paused. */
+  start(options: StartHeartbeatTargetedTaskDispatcherOptions = {}): void {
+    if (this.#state === 'running') {
+      return;
+    }
+    if (this.#state !== 'idle') {
+      throw new Error('A stopped targeted task dispatcher cannot restart.');
+    }
+    this.#state = 'running';
+    this.#admissionPaused = options.admissionPaused ?? false;
+    this.#schedulePoll(0);
+  }
+
+  /** Pauses admission, preserves queued hints, and cancels locally active work. */
+  async pause(reason: string): Promise<void> {
+    const cancellation = HeartbeatTaskCancellationPolicy.createSignal(reason);
+    if (this.#state === 'stopped') {
+      return;
+    }
+    this.#admissionPaused = true;
+    this.#clearPollTimer();
+    this.#retryTimers.forEach((timer) => clearTimeout(timer));
+    this.#retryTimers.clear();
+
+    const active = [...this.#active.values()];
+    active.forEach((invocation) => {
+      invocation.suppressRetry = true;
+      invocation.controller.abort(cancellation);
+    });
+    await Promise.allSettled(active.map(({ promise }) => promise));
+  }
+
+  /** Resumes admission and immediately revisits durable and queued work. */
+  resume(): void {
+    if (this.#state !== 'running' || !this.#admissionPaused) {
+      return;
+    }
+    this.#admissionPaused = false;
+    this.scanNow();
+    this.#kickDrain();
+  }
+
+  /** Requests a non-overlapping immediate correctness scan. */
+  scanNow(): void {
+    if (
+      this.#state !== 'running'
+      || this.#admissionPaused
+      || this.#pollPromise
+    ) {
+      return;
+    }
+    this.#clearPollTimer();
+    this.#schedulePoll(0);
+  }
+
+  /** Adds one persisted run request to the low-latency delivery path. */
+  notify(
+    request: HeartbeatTaskRunRequestSignal,
+  ): HeartbeatTargetedTaskNotificationResult {
+    if (!this.#isManagedTask(request.taskId)) {
+      return { taskId: request.taskId, status: 'not-managed' };
+    }
+    if (this.#state !== 'running') {
+      return { taskId: request.taskId, status: 'not-running' };
+    }
+
+    this.#clearRetryTimer(request.taskId);
+    const status = this.#enqueue(request.taskId, request.generation);
+    this.#kickDrain();
+    return { taskId: request.taskId, status };
+  }
+
+  /** Cancels and awaits only work owned by this dispatcher process. */
+  async cancelTask(
+    taskId: string,
+    reason: string,
+  ): Promise<HeartbeatTargetedTaskLocalCancellationResult> {
+    const cancellation = HeartbeatTaskCancellationPolicy.createSignal(reason);
+    const removedPending = this.#pending.delete(taskId);
+    const removedRetry = this.#clearRetryTimer(taskId);
+    const active = this.#active.get(taskId);
+    if (!active) {
+      return {
+        taskId,
+        disposition: removedPending || removedRetry ? 'cancelled' : 'not-active',
+      };
+    }
+
+    active.suppressRetry = true;
+    active.controller.abort(cancellation);
+    const result = await active.promise;
+    return {
+      taskId,
+      disposition: 'cancelled',
+      invocationId: active.invocation.invocationId,
+      ...(result ? { result } : {}),
+    };
+  }
+
+  /** Stops admission and awaits polling, draining, and active settlement. */
+  async stop(
+    options: StopHeartbeatTargetedTaskDispatcherOptions = {},
+  ): Promise<void> {
+    if (this.#state === 'stopped') {
+      return;
+    }
+    if (this.#state === 'idle') {
+      this.#state = 'stopped';
+      return;
+    }
+    if (this.#state === 'stopping') {
+      await this.#awaitOutstanding();
+      return;
+    }
+
+    this.#state = 'stopping';
+    this.#clearPollTimer();
+    this.#pending.clear();
+    this.#retryTimers.forEach((timer) => clearTimeout(timer));
+    this.#retryTimers.clear();
+
+    if (options.cancelActive !== false) {
+      const cancellation = HeartbeatTaskCancellationPolicy.createSignal(
+        'Targeted heartbeat task dispatcher stopped.',
+      );
+      this.#active.forEach((invocation) => {
+        invocation.suppressRetry = true;
+        invocation.controller.abort(cancellation);
+      });
+    }
+    await this.#awaitOutstanding();
+    this.#state = 'stopped';
+  }
+
+  async #awaitOutstanding(): Promise<void> {
+    await Promise.allSettled([
+      ...[...this.#active.values()].map(({ promise }) => promise),
+      this.#drainPromise,
+      this.#pollPromise,
+    ].filter((promise) => promise !== undefined));
+  }
+
+  #enqueue(
+    taskId: string,
+    runRequestGeneration: number | undefined,
+  ): 'queued' | 'coalesced' {
+    const active = this.#active.get(taskId);
+    const pending = this.#pending.get(taskId);
+    const activeGeneration = active
+      ?.invocation.runRequestGeneration;
+    const pendingGeneration = pending
+      ?.runRequestGeneration;
+    const latestGeneration = latestRunRequestGeneration(
+      pendingGeneration,
+      runRequestGeneration,
+    );
+    const alreadyRepresented = runRequestGeneration === undefined
+      ? active !== undefined || pending !== undefined
+      : generationIncludes(activeGeneration, runRequestGeneration)
+        || generationIncludes(pendingGeneration, runRequestGeneration);
+
+    if (
+      !alreadyRepresented
+      || (active === undefined && pending === undefined)
+    ) {
+      this.#pending.set(taskId, { runRequestGeneration: latestGeneration });
+    }
+    return alreadyRepresented ? 'coalesced' : 'queued';
+  }
+
+  #kickDrain(): void {
+    if (
+      this.#state !== 'running'
+      || this.#admissionPaused
+      || this.#drainPromise
+      || this.#active.size >= this.options.maxConcurrentInvocations
+    ) {
+      return;
+    }
+    const drainPromise = this.#drainPending().then((disposition) => {
+      if (this.#drainPromise === drainPromise) {
+        this.#drainPromise = undefined;
+      }
+      if (
+        disposition !== 'paused'
+        && disposition !== 'stopped'
+        && this.#state === 'running'
+        && this.#pending.size > 0
+        && this.#active.size < this.options.maxConcurrentInvocations
+      ) {
+        this.#kickDrain();
+      }
+    });
+    this.#drainPromise = drainPromise;
+  }
+
+  async #drainPending(): Promise<DrainDisposition> {
+    if (!await this.#readAdmissionGate()) {
+      return 'paused';
+    }
+    while (
+      this.#state === 'running'
+      && !this.#admissionPaused
+      && this.#pending.size > 0
+      && this.#active.size < this.options.maxConcurrentInvocations
+    ) {
+      const entry = this.#pending.entries().next().value as
+        | [string, PendingInvocation]
+        | undefined;
+      if (!entry) {
+        return 'drained';
+      }
+      const [taskId, pending] = entry;
+      this.#pending.delete(taskId);
+      try {
+        this.#startInvocation(taskId, pending.runRequestGeneration);
+      } catch (error) {
+        this.#reportError({ phase: 'invoke', error, taskId });
+        this.#scheduleRetry(
+          taskId,
+          pending.runRequestGeneration,
+          this.#contentionRetryMs,
+        );
+      }
+    }
+    if (this.#state !== 'running') {
+      return 'stopped';
+    }
+    if (this.#admissionPaused) {
+      return 'paused';
+    }
+    return this.#pending.size > 0 ? 'saturated' : 'drained';
+  }
+
+  #startInvocation(
+    taskId: string,
+    runRequestGeneration: number | undefined,
+  ): void {
+    const controller = new AbortController();
+    const invocation: HeartbeatTargetedTaskInvocation = {
+      taskId,
+      invocationId: this.options.createInvocationId?.(
+        taskId,
+        runRequestGeneration,
+      ) ?? `heddle-targeted:${randomUUID()}`,
+      runRequestGeneration,
+      signal: controller.signal,
+    };
+    const active: ActiveInvocation = {
+      invocation,
+      controller,
+      promise: Promise.resolve(undefined),
+      suppressRetry: false,
+    };
+    this.#active.set(taskId, active);
+    const timeout = setTimeout(() => {
+      controller.abort(HeartbeatTaskCancellationPolicy.createSignal(
+        `Targeted heartbeat invocation exceeded ${this.options.invocationTimeoutMs}ms.`,
+      ));
+    }, this.options.invocationTimeoutMs);
+    timeout.unref();
+    active.promise = this.#invoke(active).finally(() => {
+      clearTimeout(timeout);
+      if (this.#active.get(taskId) === active) {
+        this.#active.delete(taskId);
+      }
+      this.#kickDrain();
+    });
+  }
+
+  async #invoke(
+    active: ActiveInvocation,
+  ): Promise<HeartbeatTargetedTaskDispatchOutcome['result'] | undefined> {
+    try {
+      const result = await this.options.target.invoke(active.invocation);
+      const decision = resolveHeartbeatTargetedTaskDispatchDecision(
+        result.status,
+        this.#contentionRetryMs,
+      );
+      this.#reportOutcome({
+        taskId: active.invocation.taskId,
+        invocationId: active.invocation.invocationId,
+        runRequestGeneration: active.invocation.runRequestGeneration,
+        result,
+        decision,
+      });
+      if (decision.kind === 'retry-transiently' && !active.suppressRetry) {
+        this.#scheduleRetry(
+          active.invocation.taskId,
+          active.invocation.runRequestGeneration,
+          decision.delayMs,
+        );
+      }
+      return result;
+    } catch (error) {
+      this.#reportError({
+        phase: 'invoke',
+        error,
+        taskId: active.invocation.taskId,
+        invocationId: active.invocation.invocationId,
+      });
+      if (!active.suppressRetry) {
+        this.#scheduleRetry(
+          active.invocation.taskId,
+          active.invocation.runRequestGeneration,
+          this.#contentionRetryMs,
+        );
+      }
+      return undefined;
+    }
+  }
+
+  #scheduleRetry(
+    taskId: string,
+    runRequestGeneration: number | undefined,
+    delayMs: number,
+  ): void {
+    if (
+      this.#state !== 'running'
+      || this.#admissionPaused
+      || this.#pending.has(taskId)
+      || this.#retryTimers.has(taskId)
+    ) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.#retryTimers.delete(taskId);
+      if (this.#state !== 'running' || this.#admissionPaused) {
+        return;
+      }
+      this.#enqueue(taskId, runRequestGeneration);
+      this.#kickDrain();
+    }, delayMs);
+    timer.unref();
+    this.#retryTimers.set(taskId, timer);
+  }
+
+  #schedulePoll(delayMs: number): void {
+    if (this.#state !== 'running' || this.#admissionPaused) {
+      return;
+    }
+    this.#pollTimer = setTimeout(() => {
+      this.#pollTimer = undefined;
+      const pollPromise = this.#poll();
+      this.#pollPromise = pollPromise;
+      void pollPromise.finally(() => {
+        if (this.#pollPromise === pollPromise) {
+          this.#pollPromise = undefined;
+        }
+      });
+    }, delayMs);
+    this.#pollTimer.unref();
+  }
+
+  async #poll(): Promise<void> {
+    try {
+      if (!this.#admissionPaused && await this.#readAdmissionGate()) {
+        const now = this.options.now?.() ?? new Date();
+        const tasks = await this.options.store.listTasks();
+        if (this.#state !== 'running' || this.#admissionPaused) {
+          return;
+        }
+        tasks
+          .filter((task) => (
+            this.#isManagedTask(task.id)
+            && HeartbeatTaskExecutionEligibilityPolicy.isDue(task, now)
+          ))
+          .forEach((task) => {
+            this.#enqueue(task.id, task.state?.runRequest?.generation);
+          });
+        this.#kickDrain();
+      }
+    } catch (error) {
+      this.#reportError({ phase: 'poll', error });
+    } finally {
+      this.#schedulePoll(this.options.pollIntervalMs);
+    }
+  }
+
+  async #readAdmissionGate(): Promise<boolean> {
+    try {
+      return await (this.options.isAdmissionEnabled?.() ?? true);
+    } catch (error) {
+      this.#reportError({ phase: 'admission-gate', error });
+      return false;
+    }
+  }
+
+  #clearRetryTimer(taskId: string): boolean {
+    const timer = this.#retryTimers.get(taskId);
+    if (!timer) {
+      return false;
+    }
+    clearTimeout(timer);
+    this.#retryTimers.delete(taskId);
+    return true;
+  }
+
+  #clearPollTimer(): void {
+    if (!this.#pollTimer) {
+      return;
+    }
+    clearTimeout(this.#pollTimer);
+    this.#pollTimer = undefined;
+  }
+
+  #isManagedTask(taskId: string): boolean {
+    return this.#taskIdPrefix === undefined
+      || taskId.startsWith(this.#taskIdPrefix);
+  }
+
+  #reportOutcome(outcome: HeartbeatTargetedTaskDispatchOutcome): void {
+    try {
+      this.options.onOutcome?.(outcome);
+    } catch (error) {
+      this.#reportError({
+        phase: 'invoke',
+        error,
+        taskId: outcome.taskId,
+        invocationId: outcome.invocationId,
+      });
+    }
+  }
+
+  #reportError(error: HeartbeatTargetedTaskDispatchError): void {
+    try {
+      this.options.onError?.(error);
+    } catch {
+      // Observability callbacks cannot invalidate durable dispatch state.
+    }
+  }
+
+  get #contentionRetryMs(): number {
+    return this.options.contentionRetryMs ?? DEFAULT_CONTENTION_RETRY_MS;
+  }
+}
+
+/** Maps one durable Heddle outcome to host delivery settlement. */
+export function resolveHeartbeatTargetedTaskDispatchDecision(
+  status: HeartbeatTargetedTaskDispatchOutcome['result']['status'],
+  contentionRetryMs: number,
+): HeartbeatTargetedTaskDispatchDecision {
+  if (status === 'busy' || status === 'claim-lost') {
+    return { kind: 'retry-transiently', delayMs: contentionRetryMs };
+  }
+  if (
+    status === 'retry'
+    || status === 'failed'
+    || status === 'not-due'
+    || status === 'cancelled'
+  ) {
+    return { kind: 'wait-for-durable-schedule' };
+  }
+  return { kind: 'complete-delivery' };
+}
+
+function latestRunRequestGeneration(
+  current: number | undefined,
+  candidate: number | undefined,
+): number | undefined {
+  if (current === undefined) {
+    return candidate;
+  }
+  if (candidate === undefined) {
+    return current;
+  }
+  return Math.max(current, candidate);
+}
+
+function generationIncludes(
+  current: number | undefined,
+  candidate: number | undefined,
+): boolean {
+  return candidate !== undefined
+    && current !== undefined
+    && current >= candidate;
+}
+
+function assertPositiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+}

--- a/src/core/heartbeat/targeted-host/host.ts
+++ b/src/core/heartbeat/targeted-host/host.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from 'node:crypto';
+import { HeartbeatTaskCancellationPolicy } from '../scheduler/cancellation-policy.js';
+import type {
+  CancelHeartbeatTaskOptions,
+  HeartbeatTaskCancellationResult,
+  StopHeartbeatSchedulerOptions,
+} from '../scheduler/index.js';
+import type { HeartbeatTaskRunRequestSignal } from '../tasks/index.js';
+import { HeartbeatTargetedTaskDispatcher } from './dispatcher.js';
+import type {
+  HeartbeatTargetedTaskHostHandle,
+  HeartbeatTargetedTaskHostOptions,
+  HeartbeatTargetedTaskNotificationResult,
+  StartHeartbeatTargetedTaskHostInput,
+} from './types.js';
+
+/**
+ * Complete low-volume lifecycle around the targeted dispatcher.
+ *
+ * It owns run-request subscription, periodic expired-owner recovery,
+ * process-local pause/cancellation, and inactive cancellation classification.
+ * The store remains the durable authority and the target remains replaceable.
+ */
+export class HeartbeatTargetedTaskHost
+implements HeartbeatTargetedTaskHostHandle {
+  readonly #recoveryOwnerId: string;
+  #dispatcher: HeartbeatTargetedTaskDispatcher | undefined;
+  #unsubscribe: (() => void) | undefined;
+  #recoveryTimer: NodeJS.Timeout | undefined;
+  #recoveryPromise: Promise<void> | undefined;
+  #started = false;
+  #paused = false;
+  #stopped = false;
+
+  constructor(private readonly options: HeartbeatTargetedTaskHostOptions) {
+    assertPositiveInteger(options.recoveryIntervalMs, 'recoveryIntervalMs');
+    this.#recoveryOwnerId = options.recoveryOwnerId
+      ?? `heddle-targeted-recovery:${randomUUID()}`;
+  }
+
+  start(input: StartHeartbeatTargetedTaskHostInput): void {
+    if (this.#stopped) {
+      throw new Error('A stopped targeted task host cannot restart.');
+    }
+    if (this.#started) {
+      return;
+    }
+
+    const {
+      store,
+      createTarget,
+      recoveryIntervalMs: _recoveryIntervalMs,
+      recoveryOwnerId: _recoveryOwnerId,
+      onRecoveryError: _onRecoveryError,
+      ...dispatcherOptions
+    } = this.options;
+    this.#started = true;
+    this.#paused = input.admissionEnabled === false;
+    this.#dispatcher = new HeartbeatTargetedTaskDispatcher({
+      ...dispatcherOptions,
+      store,
+      target: createTarget(input.handler),
+    });
+    this.#dispatcher.start({ admissionPaused: this.#paused });
+    this.#unsubscribe = store.subscribeToRunRequests?.(
+      (request) => this.notify(request),
+    );
+    if (!this.#paused) {
+      this.#scheduleRecovery(0);
+    }
+  }
+
+  notify(
+    request: HeartbeatTaskRunRequestSignal,
+  ): HeartbeatTargetedTaskNotificationResult | undefined {
+    return this.#dispatcher?.notify(request);
+  }
+
+  async cancelTask(
+    taskId: string,
+    options: CancelHeartbeatTaskOptions,
+  ): Promise<HeartbeatTaskCancellationResult> {
+    const reason = HeartbeatTaskCancellationPolicy.normalizeReason(
+      options.reason,
+    );
+    const localResult = await this.#dispatcher?.cancelTask(taskId, reason);
+    if (localResult?.disposition === 'cancelled') {
+      const result = localResult.result;
+      if (result?.status === 'cancelled' && result.executionId) {
+        return {
+          taskId,
+          disposition: 'cancelled',
+          reason,
+          executionId: result.executionId,
+          ...(result.record ? { record: result.record } : {}),
+        };
+      }
+      if (result?.record || result?.failed) {
+        const executionId = 'executionId' in result
+          ? result.executionId
+          : undefined;
+        return {
+          taskId,
+          disposition: 'completion-won',
+          reason,
+          ...(executionId ? { executionId } : {}),
+          ...(result.record ? { record: result.record } : {}),
+        };
+      }
+    }
+    const task = await this.options.store.loadTask(taskId);
+    return {
+      taskId,
+      disposition: HeartbeatTaskCancellationPolicy.inactiveDisposition(task),
+      reason,
+    };
+  }
+
+  async pause(options: CancelHeartbeatTaskOptions): Promise<void> {
+    const reason = HeartbeatTaskCancellationPolicy.normalizeReason(
+      options.reason,
+    );
+    this.#paused = true;
+    this.#clearRecoveryTimer();
+    await this.#dispatcher?.pause(reason);
+    await this.#recoveryPromise;
+  }
+
+  resume(): void {
+    if (!this.#started || this.#stopped || !this.#paused) {
+      return;
+    }
+    this.#paused = false;
+    this.#dispatcher?.resume();
+    this.#scheduleRecovery(0);
+  }
+
+  async stop(options: StopHeartbeatSchedulerOptions = {}): Promise<void> {
+    if (this.#stopped) {
+      return;
+    }
+    this.#stopped = true;
+    this.#paused = true;
+    this.#clearRecoveryTimer();
+    this.#unsubscribe?.();
+    this.#unsubscribe = undefined;
+    await this.#dispatcher?.stop({
+      cancelActive: options.cancelRunning !== false,
+    });
+    await this.#recoveryPromise;
+  }
+
+  #scheduleRecovery(delayMs: number): void {
+    if (this.#paused || this.#stopped || this.#recoveryTimer) {
+      return;
+    }
+    this.#recoveryTimer = setTimeout(() => {
+      this.#recoveryTimer = undefined;
+      const recoveryPromise = this.#recoverExpiredExecutions();
+      this.#recoveryPromise = recoveryPromise;
+      void recoveryPromise.finally(() => {
+        if (this.#recoveryPromise === recoveryPromise) {
+          this.#recoveryPromise = undefined;
+        }
+      });
+    }, delayMs);
+    this.#recoveryTimer.unref();
+  }
+
+  async #recoverExpiredExecutions(): Promise<void> {
+    try {
+      await this.options.store.recoverInterruptedTasks({
+        ownerId: this.#recoveryOwnerId,
+        recoveredAt: this.options.now?.() ?? new Date(),
+        reason: 'host-restart',
+      });
+      if (!this.#paused && !this.#stopped) {
+        this.#dispatcher?.scanNow();
+      }
+    } catch (error) {
+      try {
+        this.options.onRecoveryError?.(error);
+      } catch {
+        // Observability callbacks cannot invalidate durable recovery state.
+      }
+    } finally {
+      this.#scheduleRecovery(this.options.recoveryIntervalMs);
+    }
+  }
+
+  #clearRecoveryTimer(): void {
+    if (!this.#recoveryTimer) {
+      return;
+    }
+    clearTimeout(this.#recoveryTimer);
+    this.#recoveryTimer = undefined;
+  }
+}
+
+function assertPositiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+}

--- a/src/core/heartbeat/targeted-host/index.ts
+++ b/src/core/heartbeat/targeted-host/index.ts
@@ -1,0 +1,22 @@
+export {
+  HeartbeatTargetedTaskDispatcher,
+  resolveHeartbeatTargetedTaskDispatchDecision,
+} from './dispatcher.js';
+export { HeartbeatTargetedTaskHost } from './host.js';
+export { HeartbeatTargetedTaskWorker } from './worker.js';
+export type {
+  HeartbeatTargetedTaskDispatchDecision,
+  HeartbeatTargetedTaskDispatchError,
+  HeartbeatTargetedTaskDispatchOutcome,
+  HeartbeatTargetedTaskDispatcherOptions,
+  HeartbeatTargetedTaskHostHandle,
+  HeartbeatTargetedTaskHostOptions,
+  HeartbeatTargetedTaskInvocation,
+  HeartbeatTargetedTaskInvocationTarget,
+  HeartbeatTargetedTaskLocalCancellationResult,
+  HeartbeatTargetedTaskNotificationResult,
+  HeartbeatTargetedTaskWorkerOptions,
+  StartHeartbeatTargetedTaskDispatcherOptions,
+  StartHeartbeatTargetedTaskHostInput,
+  StopHeartbeatTargetedTaskDispatcherOptions,
+} from './types.js';

--- a/src/core/heartbeat/targeted-host/types.ts
+++ b/src/core/heartbeat/targeted-host/types.ts
@@ -1,0 +1,146 @@
+import type {
+  CancelHeartbeatTaskOptions,
+  HeartbeatTaskCancellationResult,
+  HeartbeatTaskHandler,
+  RunHeartbeatTaskOptions,
+  RunHeartbeatTaskResult,
+  StopHeartbeatSchedulerOptions,
+} from '../scheduler/index.js';
+import type {
+  HeartbeatTargetedTaskStore,
+  HeartbeatTaskRunRequestSignal,
+} from '../tasks/index.js';
+
+/** One process-local delivery of an already persisted heartbeat task request. */
+export type HeartbeatTargetedTaskInvocation = {
+  taskId: string;
+  invocationId: string;
+  runRequestGeneration?: number;
+  signal: AbortSignal;
+};
+
+/** Replaceable delivery target used by the low-volume dispatcher. */
+export interface HeartbeatTargetedTaskInvocationTarget {
+  invoke(
+    invocation: HeartbeatTargetedTaskInvocation,
+  ): Promise<RunHeartbeatTaskResult>;
+}
+
+export type HeartbeatTargetedTaskDispatchDecision =
+  | { kind: 'complete-delivery' }
+  | { kind: 'retry-transiently'; delayMs: number }
+  | { kind: 'wait-for-durable-schedule' };
+
+export type HeartbeatTargetedTaskDispatchOutcome = {
+  taskId: string;
+  invocationId: string;
+  runRequestGeneration?: number;
+  result: RunHeartbeatTaskResult;
+  decision: HeartbeatTargetedTaskDispatchDecision;
+};
+
+export type HeartbeatTargetedTaskDispatchError = {
+  phase: 'admission-gate' | 'poll' | 'invoke';
+  error: unknown;
+  taskId?: string;
+  invocationId?: string;
+};
+
+export type HeartbeatTargetedTaskNotificationResult = {
+  taskId: string;
+  status: 'queued' | 'coalesced' | 'not-managed' | 'not-running';
+};
+
+export type HeartbeatTargetedTaskLocalCancellationResult = {
+  taskId: string;
+  disposition: 'cancelled' | 'not-active';
+  invocationId?: string;
+  result?: RunHeartbeatTaskResult;
+};
+
+type HeartbeatTargetedTaskCatalog = Pick<
+  HeartbeatTargetedTaskStore,
+  'listTasks'
+>;
+
+export type HeartbeatTargetedTaskDispatcherOptions = {
+  store: HeartbeatTargetedTaskCatalog;
+  target: HeartbeatTargetedTaskInvocationTarget;
+  /** Omit to manage every task visible through this store namespace. */
+  taskIdPrefix?: string;
+  pollIntervalMs: number;
+  maxConcurrentInvocations: number;
+  /** Cooperative wall-clock bound for one invocation. */
+  invocationTimeoutMs: number;
+  /** Retry delay only for transient ownership contention. */
+  contentionRetryMs?: number;
+  /** Durable product/operator gate. Errors fail closed. */
+  isAdmissionEnabled?: () => boolean | Promise<boolean>;
+  now?: () => Date;
+  createInvocationId?: (
+    taskId: string,
+    runRequestGeneration: number | undefined,
+  ) => string;
+  onOutcome?: (outcome: HeartbeatTargetedTaskDispatchOutcome) => void;
+  onError?: (error: HeartbeatTargetedTaskDispatchError) => void;
+};
+
+export type StartHeartbeatTargetedTaskDispatcherOptions = {
+  admissionPaused?: boolean;
+};
+
+export type StopHeartbeatTargetedTaskDispatcherOptions = {
+  cancelActive?: boolean;
+};
+
+type HeartbeatTargetedTaskWorkerExecutionOptions = Omit<
+  RunHeartbeatTaskOptions,
+  | 'taskId'
+  | 'store'
+  | 'executionOwnerId'
+  | 'signal'
+  | 'handler'
+  | 'runner'
+>;
+
+export type HeartbeatTargetedTaskWorkerOptions =
+  HeartbeatTargetedTaskWorkerExecutionOptions & {
+    store: HeartbeatTargetedTaskStore;
+    handler: HeartbeatTaskHandler;
+  };
+
+type HeartbeatTargetedTaskHostDispatcherOptions = Omit<
+  HeartbeatTargetedTaskDispatcherOptions,
+  'store' | 'target'
+>;
+
+export type HeartbeatTargetedTaskHostOptions =
+  HeartbeatTargetedTaskHostDispatcherOptions & {
+    store: HeartbeatTargetedTaskStore;
+    createTarget: (
+      handler: HeartbeatTaskHandler,
+    ) => HeartbeatTargetedTaskInvocationTarget;
+    /** Must be shorter than the store's execution lease. */
+    recoveryIntervalMs: number;
+    recoveryOwnerId?: string;
+    onRecoveryError?: (error: unknown) => void;
+  };
+
+export type StartHeartbeatTargetedTaskHostInput = {
+  handler: HeartbeatTaskHandler;
+  admissionEnabled?: boolean;
+};
+
+export interface HeartbeatTargetedTaskHostHandle {
+  start(input: StartHeartbeatTargetedTaskHostInput): void;
+  notify(
+    request: HeartbeatTaskRunRequestSignal,
+  ): HeartbeatTargetedTaskNotificationResult | undefined;
+  cancelTask(
+    taskId: string,
+    options: CancelHeartbeatTaskOptions,
+  ): Promise<HeartbeatTaskCancellationResult>;
+  pause(options: CancelHeartbeatTaskOptions): Promise<void>;
+  resume(): void;
+  stop(options?: StopHeartbeatSchedulerOptions): Promise<void>;
+}

--- a/src/core/heartbeat/targeted-host/worker.ts
+++ b/src/core/heartbeat/targeted-host/worker.ts
@@ -1,0 +1,24 @@
+import { HeartbeatSchedulerService } from '../scheduler/index.js';
+import type {
+  HeartbeatTargetedTaskInvocation,
+  HeartbeatTargetedTaskInvocationTarget,
+  HeartbeatTargetedTaskWorkerOptions,
+} from './types.js';
+
+/** Executes one routed task through Heddle's claim-fenced task pipeline. */
+export class HeartbeatTargetedTaskWorker
+implements HeartbeatTargetedTaskInvocationTarget {
+  constructor(private readonly options: HeartbeatTargetedTaskWorkerOptions) {}
+
+  async invoke(invocation: HeartbeatTargetedTaskInvocation) {
+    const { store, handler, ...executionOptions } = this.options;
+    return await HeartbeatSchedulerService.runTask({
+      ...executionOptions,
+      store,
+      handler,
+      taskId: invocation.taskId,
+      executionOwnerId: invocation.invocationId,
+      signal: invocation.signal,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a standard in-process targeted heartbeat worker, dispatcher, and lifecycle host
- keep durable task state authoritative with notification coalescing and polling fallback
- support bounded concurrency, timeouts, pause/resume, cancellation, and expired-owner recovery
- extract shared cancellation policy so operator reasons survive targeted execution

## Boundary
This is the low-volume single-process default around HeartbeatSchedulerService.runTask. It is not a distributed queue, tenant authorization boundary, leader election service, or cross-replica concurrency limit.

## Verification
- yarn lint
- yarn test: 859 unit, 428 integration, 53 adopter-package tests
- yarn build
- git diff --check