### PR TITLE
Fix npm 12 package publication recovery

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -151,6 +151,15 @@ jobs:
       - name: Verify packed Execution Host client
         run: yarn execution-host-client:pack:verify
 
+      - name: Set up release Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Pin release npm
+        run: npm install --global npm@12.0.2
+
       - name: Verify npm release state
         run: node scripts/verify-execution-host-client-pack.mjs --verify-registry
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -10,6 +10,7 @@ on:
       - package.json
       - packages/execution-host-client/**
       - scripts/execution-host-client-release-state.mjs
+      - scripts/execution-host-client-pack-result.mjs
       - scripts/finalize-execution-host-client-release.mjs
       - scripts/verify-execution-host-client-package.mjs
       - scripts/verify-execution-host-client-pack.mjs
@@ -83,6 +84,9 @@ jobs:
       - name: Select release state
         id: release
         run: node scripts/execution-host-client-release-state.mjs
+
+      - name: Verify release artifact
+        run: node scripts/verify-execution-host-client-pack.mjs
 
       - name: Create immutable release tag
         if: steps.release.outputs.publication_needed == 'true'

--- a/scripts/execution-host-client-pack-result.mjs
+++ b/scripts/execution-host-client-pack-result.mjs
@@ -1,0 +1,67 @@
+/**
+ * Normalize the single-package JSON envelopes emitted by npm 10 (array) and
+ * npm 12 (object keyed by package name), rejecting ambiguous results.
+ */
+export function parseNpmPackResult(stdout, expectedPackageName) {
+  const parsed = parseJson(stdout);
+  const packed = Array.isArray(parsed)
+    ? readArrayResult(parsed)
+    : readObjectResult(parsed, expectedPackageName);
+
+  if (!isRecord(packed)) {
+    throw new Error('npm pack --json returned a non-object package result.');
+  }
+  if (packed.name !== expectedPackageName) {
+    throw new Error(
+      `npm pack --json returned ${String(packed.name)} instead of ${expectedPackageName}.`,
+    );
+  }
+
+  return packed;
+}
+
+function parseJson(stdout) {
+  try {
+    return JSON.parse(stdout);
+  } catch (cause) {
+    throw new Error('npm pack --json did not return valid JSON.', { cause });
+  }
+}
+
+function readArrayResult(results) {
+  if (results.length !== 1) {
+    throw new Error(
+      `npm pack --json returned ${results.length} package results; expected exactly one.`,
+    );
+  }
+
+  return results[0];
+}
+
+function readObjectResult(result, expectedPackageName) {
+  if (!isRecord(result)) {
+    throw new Error(
+      'npm pack --json returned neither an array nor a package-keyed object.',
+    );
+  }
+
+  const entries = Object.entries(result);
+  if (entries.length !== 1) {
+    throw new Error(
+      `npm pack --json returned ${entries.length} package results; expected exactly one.`,
+    );
+  }
+
+  const [[packageName, packed]] = entries;
+  if (packageName !== expectedPackageName) {
+    throw new Error(
+      `npm pack --json keyed its result as ${packageName} instead of ${expectedPackageName}.`,
+    );
+  }
+
+  return packed;
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/scripts/verify-execution-host-client-pack.mjs
+++ b/scripts/verify-execution-host-client-pack.mjs
@@ -23,6 +23,7 @@ import {
   createExecutionHostClientReleaseMetadata,
   parseRegistryArtifactResult,
 } from './execution-host-client-release-state.mjs';
+import { parseNpmPackResult } from './execution-host-client-pack-result.mjs';
 
 const repositoryDirectory = fileURLToPath(new URL('../', import.meta.url));
 const packageDirectory = fileURLToPath(
@@ -69,7 +70,7 @@ try {
     ],
     repositoryDirectory,
   );
-  const [packed] = JSON.parse(pack.stdout);
+  const packed = parseNpmPackResult(pack.stdout, EXECUTION_HOST_CLIENT_NAME);
 
   assert.equal(packed.name, EXECUTION_HOST_CLIENT_NAME);
   assert.equal(packed.version, EXECUTION_HOST_CLIENT_VERSION);

--- a/src/__tests__/unit/scripts/execution-host-client-pack-result.test.ts
+++ b/src/__tests__/unit/scripts/execution-host-client-pack-result.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { parseNpmPackResult } from '../../../../scripts/execution-host-client-pack-result.mjs';
+
+const PACKAGE_NAME = '@heddleagent/execution-host-client';
+const packed = {
+  name: PACKAGE_NAME,
+  version: '6.0.0',
+  filename: 'heddleagent-execution-host-client-6.0.0.tgz',
+  files: [],
+};
+
+describe('parseNpmPackResult', () => {
+  it('accepts the npm 10 array result', () => {
+    expect(parseNpmPackResult(JSON.stringify([packed]), PACKAGE_NAME)).toEqual(
+      packed,
+    );
+  });
+
+  it('accepts the npm 12 package-keyed result', () => {
+    expect(
+      parseNpmPackResult(
+        JSON.stringify({ [PACKAGE_NAME]: packed }),
+        PACKAGE_NAME,
+      ),
+    ).toEqual(packed);
+  });
+
+  it.each([
+    ['invalid JSON', 'not-json'],
+    ['an empty array', '[]'],
+    ['multiple array entries', JSON.stringify([packed, packed])],
+    ['a scalar', 'null'],
+    ['an empty object', '{}'],
+    [
+      'the wrong package key',
+      JSON.stringify({ '@heddleagent/other': packed }),
+    ],
+    [
+      'multiple object entries',
+      JSON.stringify({
+        [PACKAGE_NAME]: packed,
+        '@heddleagent/other': packed,
+      }),
+    ],
+    [
+      'a mismatched package name',
+      JSON.stringify([{ ...packed, name: '@heddleagent/other' }]),
+    ],
+  ])('rejects %s', (_label, stdout) => {
+    expect(() => parseNpmPackResult(stdout, PACKAGE_NAME)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- normalize the npm pack JSON envelopes emitted by npm 10 and npm 12
- fail closed on missing, ambiguous, or mismatched package results
- verify the release artifact with pinned npm 12 before creating the immutable tag
- run the registry release check under the same Node 24 and npm 12 toolchain in PR CI

## Verification
- 892 unit tests passed
- 110 Execution Host client tests passed
- typecheck and lint passed
- package family verification passed
- npm 12 pack, fresh runtime consumer, fresh TypeScript consumer, and release-ready registry check passed
- Python conformance was not run locally because ruff is not installed; the dedicated PR job remains required

## Recovery gate
The failed main workflow created execution-host-client-v6.0.0 before npm publication. Do not merge this PR until the registry and GitHub release are reconfirmed absent and that orphan tag is explicitly deleted. The fixed main workflow will recreate the annotated tag on the release commit before publishing.