### PR TITLE
Normalize npm 12 registry results

### DIFF
--- a/scripts/execution-host-client-release-state.mjs
+++ b/scripts/execution-host-client-release-state.mjs
@@ -43,7 +43,7 @@ export function createExecutionHostClientReleaseMetadata(packageJson) {
 
 export function parseRegistryArtifactResult(result, target) {
   if (result.status === 0) {
-    const artifact = JSON.parse(result.stdout);
+    const artifact = parseNpmViewResult(result.stdout, target);
     assert.equal(
       typeof artifact.version,
       'string',
@@ -68,6 +68,31 @@ export function parseRegistryArtifactResult(result, target) {
     `Registry lookup for ${target} failed for a reason other than an absent immutable version.`,
   );
   return { kind: 'missing' };
+}
+
+/**
+ * Normalize the single-result JSON envelopes emitted by npm 10 (object) and
+ * npm 12 (array), rejecting ambiguous or non-object registry responses.
+ */
+export function parseNpmViewResult(stdout, target) {
+  const parsed = JSON.parse(stdout);
+  const result = Array.isArray(parsed)
+    ? readSingleNpmViewResult(parsed, target)
+    : parsed;
+  assert.ok(
+    typeof result === 'object' && result !== null,
+    `Registry metadata for ${target} is not an object.`,
+  );
+  return result;
+}
+
+function readSingleNpmViewResult(results, target) {
+  assert.equal(
+    results.length,
+    1,
+    `Registry metadata for ${target} must contain exactly one result.`,
+  );
+  return results[0];
 }
 
 export function assertRegistryArtifactMatches(

--- a/scripts/verify-execution-host-client-pack.mjs
+++ b/scripts/verify-execution-host-client-pack.mjs
@@ -21,6 +21,7 @@ import {
   assertDistTagTransition,
   assertRegistryArtifactMatches,
   createExecutionHostClientReleaseMetadata,
+  parseNpmViewResult,
   parseRegistryArtifactResult,
 } from './execution-host-client-release-state.mjs';
 import { parseNpmPackResult } from './execution-host-client-pack-result.mjs';
@@ -416,7 +417,7 @@ async function waitForRegistryArtifact(target) {
 }
 
 function readDistTags(packageName) {
-  return JSON.parse(
+  return parseNpmViewResult(
     run(
       'npm',
       [
@@ -430,6 +431,7 @@ function readDistTags(packageName) {
       ],
       repositoryDirectory,
     ).stdout,
+    `${packageName} dist-tags`,
   );
 }
 
@@ -447,7 +449,12 @@ function readDistTagsIfPresent(packageName) {
     ],
     repositoryDirectory,
   );
-  if (result.status === 0) return JSON.parse(result.stdout);
+  if (result.status === 0) {
+    return parseNpmViewResult(
+      result.stdout,
+      `${packageName} dist-tags`,
+    );
+  }
 
   assert.match(
     `${result.stdout}\n${result.stderr}`,

--- a/src/__tests__/unit/scripts/execution-host-client-release-state.test.ts
+++ b/src/__tests__/unit/scripts/execution-host-client-release-state.test.ts
@@ -3,6 +3,7 @@ import {
   assertDistTagTransition,
   assertRegistryArtifactMatches,
   createExecutionHostClientReleaseMetadata,
+  parseNpmViewResult,
   parseRegistryArtifactResult,
   selectExecutionHostClientRelease,
 } from '../../../../scripts/execution-host-client-release-state.mjs';
@@ -53,14 +54,31 @@ describe('Execution Host client release state', () => {
     ).toThrow('failed for a reason other than an absent immutable version');
   });
 
-  it('parses and verifies immutable registry integrity', () => {
+  it.each([
+    [
+      'npm 10 object',
+      {
+        version: '6.0.0',
+        'dist.integrity': 'sha512-exact',
+      },
+    ],
+    [
+      'npm 12 array',
+      [
+        {
+          version: '6.0.0',
+          'dist.integrity': 'sha512-exact',
+        },
+      ],
+    ],
+  ])('parses and verifies immutable registry integrity from an %s', (
+    _label,
+    registryOutput,
+  ) => {
     const artifact = parseRegistryArtifactResult(
       {
         status: 0,
-        stdout: JSON.stringify({
-          version: '6.0.0',
-          'dist.integrity': 'sha512-exact',
-        }),
+        stdout: JSON.stringify(registryOutput),
         stderr: '',
       },
       '@heddleagent/execution-host-client@6.0.0',
@@ -78,6 +96,43 @@ describe('Execution Host client release state', () => {
         integrity: 'sha512-different',
       }),
     ).toThrow('differs from the verified local tarball');
+  });
+
+  it.each([
+    ['an empty npm 12 result', []],
+    [
+      'multiple npm 12 results',
+      [
+        { version: '6.0.0', 'dist.integrity': 'sha512-exact' },
+        { version: '6.0.1', 'dist.integrity': 'sha512-other' },
+      ],
+    ],
+  ])('rejects %s', (_label, registryOutput) => {
+    expect(() =>
+      parseRegistryArtifactResult(
+        {
+          status: 0,
+          stdout: JSON.stringify(registryOutput),
+          stderr: '',
+        },
+        '@heddleagent/execution-host-client@6.0.0',
+      ),
+    ).toThrow('must contain exactly one result');
+  });
+
+  it.each([
+    ['npm 10 object', { next: '6.0.0-next.0', latest: '6.0.0' }],
+    [
+      'npm 12 array',
+      [{ next: '6.0.0-next.0', latest: '6.0.0' }],
+    ],
+  ])('normalizes dist-tags from an %s', (_label, registryOutput) => {
+    expect(
+      parseNpmViewResult(
+        JSON.stringify(registryOutput),
+        '@heddleagent/execution-host-client dist-tags',
+      ),
+    ).toEqual({ next: '6.0.0-next.0', latest: '6.0.0' });
   });
 
   it('moves latest to the stable release while preserving other channels', () => {


### PR DESCRIPTION
## Summary
- normalize the single-result npm view JSON envelopes emitted by npm 10 and npm 12
- apply the compatibility boundary to immutable artifact metadata and dist-tags
- reject empty, multiple, and non-object registry results

## Verification
- 897 unit tests passed
- 110 Execution Host client tests passed
- typecheck and lint passed
- real npm 12 registry verification passed against the published 6.0.0 artifact
- exact integrity, latest and next tags, and fresh runtime and TypeScript consumers passed

## Release recovery
The stable package and signed provenance are already public. The stable annotated tag points to merge 15109e5b, and the stable GitHub release has been created from the checked-in release notes. This change prevents the npm 12 post-publication verifier failure on future releases.