### PR TITLE
Document the stable Heddle package family

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ Start here:
 
 The stable separate-host package is
 `@heddleagent/execution-host-client@6.0.0`. The former
-`@roackb2/heddle-adopter@5.13.0` coordinate remains installable during
-migration.
+`@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
+installable only for existing consumers.
 
 The stable coding-agent package is `@heddleagent/cli@6.0.0`; it installs the
 `heddle` command. The former `@roackb2/heddle@5.13.0` coordinate remains
-installable during migration.
+installable only for existing consumers and is deprecated for new installs.
 
 The **runtime** is library code. The **hosted run layer** runs inside
 infrastructure you operate; it is not a Heddle cloud service. A compatible
@@ -226,7 +226,7 @@ that already owns the mechanics your host needs:
 | Conventional browser REST/SSE | `@heddleagent/run-client/http-sse` | Authenticated fetch, incremental SSE parsing, and transport validation |
 | A backend invoking a separate Execution Host | `@heddleagent/execution-host-client` | Contracts, authority/JWKS, hosted-turn orchestration, durable requested/accepted/terminal persistence semantics, product-MCP verification, an `ExecutionHost` client port, Node conveniences, store conformance, and shared TypeScript/Python fixtures |
 | Durable Execution Host lifecycle in PostgreSQL | `@heddleagent/postgres/execution-host/conversations` | Atomic scope-fenced lifecycle store, ordered adopter-run migrations, SQL constraints, expiry, and real-PostgreSQL conformance |
-| Durable PostgreSQL heartbeat workers | `@roackb2/heddle-postgres` | Claim-fenced task execution, lease recovery, checkpoints, history, and atomic operator controls over an injected Drizzle database |
+| Existing PostgreSQL heartbeat workers | Deprecated `@roackb2/heddle-postgres` | Legacy claim-fenced task execution, lease recovery, checkpoints, history, and atomic operator controls over an injected Drizzle database |
 | Lower-level runtime assembly | `@heddleagent/runtime/advanced` | Model adapters, individual tools, trace, memory, heartbeat, and core runtime services |
 
 Existing tRPC, Fastify, Hono, Nest, WebSocket, IPC, queue, React, or other stacks
@@ -394,13 +394,13 @@ Heddle is designed to make assumptions and limitations visible:
   adopter still owns identity, policy, production key operations, tools, and
   results; canonical OpenAPI/JSON Schema/golden fixtures and a clean-room
   Python proof keep this boundary language-neutral;
-- the legacy `@roackb2/heddle-adopter@5.13.0` package remains installable for
-  migration but is no longer the canonical implementation;
-- the legacy `@roackb2/heddle@5.13.0` package remains installable while SDK and
-  CLI users migrate to the independently versioned v6 packages;
-- `@roackb2/heddle-postgres` implements Heddle's heartbeat persistence policy,
-  but the adopter still owns PostgreSQL operations, migration rollout, trusted
-  namespace resolution, delivery, and product-side idempotency;
+- the deprecated `@roackb2/heddle-adopter@5.13.0` package remains installable
+  only so existing consumers keep running;
+- the deprecated `@roackb2/heddle@5.13.0` package remains installable only so
+  existing SDK and CLI consumers keep running;
+- the deprecated `@roackb2/heddle-postgres` package implements the existing
+  heartbeat persistence policy but is not a new-integration entry point or a
+  capability of `@heddleagent/postgres@6.0.0`;
 - the SDK is actively evolving, so review
   [release notes](docs/releases/README.md) before upgrading public APIs.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -36,10 +36,10 @@ conversation 與 run 基礎之上。
 
 獨立 Execution Host 的穩定套件是
 `@heddleagent/execution-host-client@6.0.0`。舊的
-`@roackb2/heddle-adopter@5.13.0` coordinate 在遷移期間仍可安裝。
+`@roackb2/heddle-adopter@5.13.0` coordinate 已 deprecated，只為既有使用者保留安裝能力。
 
 穩定的 coding-agent 套件是 `@heddleagent/cli@6.0.0`，安裝後提供
-`heddle` command。舊的 `@roackb2/heddle@5.13.0` coordinate 在遷移期間仍可安裝。
+`heddle` command。舊的 `@roackb2/heddle@5.13.0` coordinate 已 deprecated，只為既有使用者保留安裝能力。
 
 **Runtime** 是 library code。**Hosted run layer** 在你營運的 infrastructure
 內執行，並不是 Heddle cloud service。Compatible **Execution Host** 則是另一個
@@ -216,7 +216,7 @@ mechanics 的最低層即可：
 | 一般 browser REST/SSE | `@heddleagent/run-client/http-sse` | Authenticated fetch、incremental SSE parsing 與 transport validation |
 | Backend 呼叫獨立 Execution Host | `@heddleagent/execution-host-client` | Contract、authority/JWKS、hosted-turn orchestration、durable requested/accepted/terminal persistence、product-MCP verification、provider-neutral client port、store conformance 與 TypeScript/Python fixture |
 | 以 PostgreSQL 保存 Execution Host lifecycle | `@heddleagent/postgres/execution-host/conversations` | Atomic scope fencing、由 adopter 執行的 ordered migration、SQL constraint、expiry 與 real-PostgreSQL conformance |
-| PostgreSQL heartbeat worker | `@roackb2/heddle-postgres` | Heartbeat task 的 claim fencing、lease recovery、checkpoint、history 與 atomic operator control；不是一般 product database adapter |
+| 既有 PostgreSQL heartbeat worker | Deprecated `@roackb2/heddle-postgres` | Legacy heartbeat task 的 claim fencing、lease recovery、checkpoint、history 與 atomic operator control；不是新的 integration 起點，也不是 `@heddleagent/postgres@6.0.0` 的能力 |
 | 更底層的 runtime 組裝 | `@heddleagent/runtime/advanced` | Model adapter、individual tool、trace、memory、heartbeat 與 core runtime service |
 
 既有的 tRPC、Fastify、Hono、Nest、WebSocket、IPC、queue、React 或其他技術棧，

--- a/docs/guides/programmatic/README.md
+++ b/docs/guides/programmatic/README.md
@@ -27,8 +27,8 @@ hosting assumptions.
   hosted-turn orchestration, durable lifecycle semantics, product-MCP
   verification, a provider-neutral client port, optional Node HTTP/key
   conveniences, and canonical OpenAPI/JSON Schema/golden artifacts for other
-  languages. The former `@roackb2/heddle-adopter@5.13.0` coordinate remains
-  installable during migration.
+  languages. The former `@roackb2/heddle-adopter@5.13.0` coordinate is
+  deprecated and remains installable only for existing consumers.
 - `@heddleagent/runtime/advanced` — the **deep core customization** surface: the curated exports plus
   lower-level building blocks (LLM adapters, individual tools, trace, memory,
   models, awareness) and specialized runtimes (agent loop, heartbeat,

--- a/docs/guides/programmatic/component-model.md
+++ b/docs/guides/programmatic/component-model.md
@@ -104,7 +104,7 @@ adopter database credential.
 | `@heddleagent/runtime` | Heddle runs inside a TypeScript/Node process | This is the supported runtime and SDK |
 | `@heddleagent/runtime/runs` | That same Node process needs addressable runs, replay, cancel, or reconnect | This is an in-process run service, not the separate Execution Host |
 | `@heddleagent/run-client` | A browser or JavaScript client consumes hosted-run envelopes | It consumes execution; it does not run an agent |
-| `@roackb2/heddle-postgres` | Heddle heartbeat tasks need PostgreSQL leases, checkpoints, and history | It is heartbeat-specific, not a general product DB or conversation-history adapter |
+| Deprecated `@roackb2/heddle-postgres` | An existing deployment still uses the current PostgreSQL heartbeat adapter | It is the legacy heartbeat-only coordinate, not a general product DB or a capability of `@heddleagent/postgres@6.0.0` |
 | `@heddleagent/execution-host-client` | A product invokes a separate compatible Execution Host | Authority, transport, turn orchestration, durable lifecycle semantics, Node helpers, and cross-language conformance |
 | `@heddleagent/postgres/execution-host/conversations` | That product stores the generic lifecycle in PostgreSQL | Official atomic store and ordered migrations; no product history/query policy or pool ownership |
 | v1 OpenAPI, JSON Schema, and fixtures | The adopter backend is Python, Go, Java, or another stack | Implement the network and optional durable-lifecycle profiles; never port Heddle's agent loop |

--- a/docs/guides/programmatic/execution-host-adopters.md
+++ b/docs/guides/programmatic/execution-host-adopters.md
@@ -10,8 +10,9 @@ surface. Heddle does not distribute the compatible Execution Host or offer a
 hosted service today.
 
 The stable coordinate is `@heddleagent/execution-host-client@6.0.0`. The
-former `@roackb2/heddle-adopter@5.13.0` coordinate remains installable during
-migration, but it does not include the durable lifecycle described below.
+former `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
+installable only for existing consumers. It does not include the durable
+lifecycle described below.
 
 ```text
 ADOPTER BACKEND
@@ -99,7 +100,10 @@ Use `@heddleagent/postgres/execution-host/conversations`, apply its ordered SQL
 migrations through the product's normal migration system, and inject the
 resulting store into `DurableHostedConversationTurnService`. The product still
 owns its pool, authenticated scope, history queries, retention, and product
-result transaction.
+result transaction. Follow the package's
+[migration adoption steps](../../../packages/postgres/README.md#copy-the-migration-into-your-application)
+to locate the installed SQL, copy it into the application's checked-in
+sequence, and apply it before constructing the store.
 
 Backends outside TypeScript can use the versioned
 [OpenAPI, JSON Schema, and golden fixtures](../../../packages/execution-host-client/spec/v1/README.md)

--- a/docs/guides/programmatic/integration-layers.md
+++ b/docs/guides/programmatic/integration-layers.md
@@ -91,8 +91,8 @@ disconnect as implicit cancellation.
 | A backend invoking a separately deployed Execution Host | `@heddleagent/execution-host-client` plus a direct or AgentCore transport | [Execution Host adopter backend](execution-host-adopters.md) |
 | That backend needs the generic lifecycle in PostgreSQL | `@heddleagent/postgres/execution-host/conversations` plus the lifecycle service | [Execution Host adopter backend](execution-host-adopters.md) |
 
-The former `@roackb2/heddle-adopter@5.13.0` coordinate remains installable
-during migration.
+The former `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and
+remains installable only for existing consumers.
 
 For tRPC, Fastify, Hono, Nest, WebSocket, Electron IPC, queues, or another
 transport, stop at the hosted-service layer and implement the adapter in the

--- a/docs/project-posture.md
+++ b/docs/project-posture.md
@@ -73,7 +73,8 @@ At the distribution boundary:
   official CLI consumes its package-to-package `/cli` bridge;
 - `@heddleagent/cli` ships the `heddle` command, terminal/TUI workflows,
   daemon, and local browser control plane. The former
-  `@roackb2/heddle@5.13.0` coordinate remains installable during migration;
+  `@roackb2/heddle@5.13.0` coordinate is deprecated and remains installable
+  only for existing consumers;
 - `@heddleagent/runtime/runs` and `@heddleagent/run-client` add adopter-operated
   run lifecycle and remote-consumption mechanics, not a managed service;
 - `@heddleagent/execution-host-client` defines the public, language-neutral
@@ -81,8 +82,8 @@ At the distribution boundary:
   owns authority, wire, transport, base turn, MCP, Node, testing, and the
   reusable durable-turn lifecycle over an adopter-implemented atomic store,
   with shared TypeScript/Python lifecycle fixtures. The former
-  `@roackb2/heddle-adopter@5.13.0` coordinate remains installable during
-  migration;
+  `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
+  installable only for existing consumers;
 - `@heddleagent/postgres/execution-host/conversations` is the official
   PostgreSQL implementation of that lifecycle store port. It owns atomic SQL
   fencing, constraints, ordered migrations, and real-database conformance;

--- a/packages/README.md
+++ b/packages/README.md
@@ -9,9 +9,9 @@ first official v6 database adapter. `@heddleagent/run-client@6.0.0` ships the
 existing browser-safe run client under its final coordinate.
 `@heddleagent/runtime@6.1.0` ships the existing embeddable SDK and the bridge
 used by the official CLI. `@heddleagent/cli@6.0.0` ships the existing `heddle`
-command, TUI, daemon, and browser control plane. Existing
-`@roackb2/*` packages remain supported until each replacement is independently
-verified and released.
+command, TUI, daemon, and browser control plane. The former `@roackb2/*`
+coordinates are deprecated and remain installable only so existing applications
+keep running; new integrations should use the `@heddleagent/*` packages.
 
 ## Initial v6 family
 
@@ -21,7 +21,7 @@ verified and released.
 | `@heddleagent/cli` | Installable Heddle coding-agent product and `heddle` executable | Existing CLI, TUI, daemon, and browser control plane activated at stable `6.0.0` |
 | `@heddleagent/run-client` | Browser-safe JavaScript run protocol consumer | Existing implementation activated at stable `6.0.0` |
 | `@heddleagent/execution-host-client` | Product-backend contracts and helpers for invoking a separate compatible Execution Host | Canonical implementation moved; stable version `6.0.0` |
-| `@heddleagent/postgres` | Official PostgreSQL implementations for supported Heddle-owned durable ports | Stable `6.0.0`; first entrypoint implements the Execution Host conversation lifecycle; heartbeat remains in `@roackb2/heddle-postgres` until its separate migration |
+| `@heddleagent/postgres` | Official PostgreSQL implementations for supported Heddle-owned durable ports | Stable `6.0.0`; the first entrypoint implements the Execution Host conversation lifecycle |
 
 The in-process run service is exposed from
 `@heddleagent/runtime/runs`; it is not a sixth package. Its conventional Node
@@ -88,22 +88,16 @@ flowchart LR
 - Future adapter packages follow the same one-way dependency rule. They are not
   part of the initial release merely because their names appear in this design.
 
-## Activation rules
+## Legacy coordinates
 
-All five packages are activated and independently versioned. Each package
-compiles one canonical implementation path, declares only its own runtime
-dependencies, and has a packed-consumer verification before publication.
+The `@roackb2/heddle`, `@roackb2/heddle-remote`, and
+`@roackb2/heddle-adopter` packages are deprecated. They are not the starting
+point for new applications and do not receive a new v5 release line. Existing
+published versions remain on npm so already-installed applications continue to
+resolve them.
 
-Run `yarn package-family:verify` to enforce all of the following:
-
-- exactly the five selected package identities exist;
-- all five activated packages have exact reviewed stable manifests, dependency
-  boundaries, exports, source ownership, and release tags;
-- package licenses and repository metadata remain consistent; and
-- the two remaining local v5 package identities stay present, while the
-  published former adopter and remote-client tarballs remain installable
-  during migration.
-
-Future package changes preserve one canonical code path, the existing build,
-and one packed-consumer smoke. Do not create file dependencies, duplicate
-implementations, or introduce a workspace/build-tool migration.
+The deprecated `@roackb2/heddle-postgres` package still contains the existing
+heartbeat PostgreSQL adapter. That capability has not yet moved into
+`@heddleagent/postgres`; do not infer heartbeat support from the new package's
+name. Its eventual move is a separate mechanical package slice, not part of the
+Execution Host lifecycle adapter shipped in `6.0.0`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,7 +29,7 @@ package compiles the canonical `src/cli-v2` product surfaces and bundles the
 canonical browser control-plane assets; it does not contain a second copy of
 the runtime.
 
-`@roackb2/heddle@5.13.0` remains installable for existing users. Version 6
-changes the package coordinate while intentionally preserving the current CLI,
-TUI, daemon, and browser control-plane feature set. See the
+`@roackb2/heddle@5.13.0` is deprecated and remains installable only for
+existing users. Version 6 changes the package coordinate while intentionally
+preserving the current CLI, TUI, daemon, and browser control-plane feature set. See the
 [package-family boundary](../README.md) before changing this responsibility.

--- a/packages/execution-host-client/README.md
+++ b/packages/execution-host-client/README.md
@@ -6,8 +6,8 @@ adopter keep its own language stack, authentication, database, product policy,
 MCP tools, and UI while reusing the security-sensitive v1 contract machinery.
 
 > **Current availability:** stable version `6.0.0`. The former
-> `@roackb2/heddle-adopter@5.13.0` coordinate remains installable during
-> migration. Heddle does not currently distribute
+> `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
+> installable only for existing consumers. Heddle does not currently distribute
 > the compatible Execution Host implementation or offer a hosted service. The
 > public surface documents and tests the adopter boundary without implying a
 > generally available deployment.

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -82,6 +82,37 @@ them before constructing the store. Runtime startup deliberately performs no
 schema mutation. The first migration owns only
 `heddle.execution_host_conversation_turns` and its constraints/index.
 
+### Copy the migration into your application
+
+The adapter exports migration URLs so your build or release tooling can locate
+the exact SQL shipped with the installed package:
+
+```bash
+node --input-type=module -e "import('@heddleagent/postgres/execution-host/conversations').then(({ executionHostConversationPostgresMigrationSqlUrls: urls }) => console.log(urls.map(String).join('\\n')))"
+```
+
+For a normal `node_modules` install, the current file is also available at:
+
+```text
+node_modules/@heddleagent/postgres/migrations/execution-host/conversations/0000_turn_lifecycle.sql
+```
+
+Copy every exported migration, in array order, into your application's own
+checked-in migration directory. Rename the file only to fit the application's
+sequence; do not rewrite the SQL. For example:
+
+```bash
+cp node_modules/@heddleagent/postgres/migrations/execution-host/conversations/0000_turn_lifecycle.sql \
+  apps/server/drizzle/0005_execution_host_conversations.sql
+```
+
+Commit that copy and let the application's existing migration command apply it
+before deploying code that constructs the store. This explicit adoption is
+required because the application—not a library running at startup—owns schema
+review, rollout order, rollback policy, and production database credentials.
+When upgrading `@heddleagent/postgres`, compare the exported ordered list with
+the migrations already adopted and copy only newly published files.
+
 ## Correctness promise
 
 - `invocation_id` is globally unique, so a duplicate request cannot execute

--- a/packages/run-client/README.md
+++ b/packages/run-client/README.md
@@ -33,8 +33,8 @@ CLI, React, authentication, authorization, timers, or product UI state. It
 remains independent of `@heddleagent/runtime` and requires adopters to supply
 their own public event schemas and credentials.
 
-`@roackb2/heddle-remote@5.13.0` remains installable for existing consumers.
-Version 6 changes the package coordinate but intentionally preserves the
-current feature set and public entrypoints.
+`@roackb2/heddle-remote@5.13.0` is deprecated and remains installable only for
+existing consumers. Version 6 changes the package coordinate but intentionally
+preserves the current feature set and public entrypoints.
 
 See the complete [remote conversation run guide](https://github.com/roackb2/heddle/blob/main/docs/guides/programmatic/remote-runs.md).

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -69,6 +69,6 @@ not maintain a second copy of the runtime implementation. The
 depend on the CLI. Technology-specific packages implement public runtime ports
 one way and are never imported by the runtime itself.
 
-The former `@roackb2/heddle@5.13.0` package remains installable while consumers
-migrate. It also contains the former package location of the `heddle`
-executable; new installations use `@heddleagent/cli`.
+The former `@roackb2/heddle@5.13.0` package is deprecated and remains
+installable only for existing consumers. New SDK installations use this
+package; new coding-agent installations use `@heddleagent/cli`.


### PR DESCRIPTION
## Summary

- document the five published `@heddleagent/*` packages as the default package family
- mark former `@roackb2/*` coordinates as deprecated while preserving the current heartbeat-adapter caveat
- explain the workshop/component ownership model consistently across package and programmatic guides
- document exactly why and how adopters copy ordered PostgreSQL lifecycle SQL into their own migration sequence

## Impact

New users get one stable package map and no longer receive migration-era guidance for the former scope. Existing applications remain unaffected because this PR changes documentation only.

## Validation

- verified live npm versions for all five packages
- `git diff --check`
