### PR TITLE
Add official AgentCore Execution Host client

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Start here:
 | Heddle coding agent | Use the CLI and browser control plane built on the same runtime | `@heddleagent/cli` (`heddle` command) |
 
 The stable separate-host package is
-`@heddleagent/execution-host-client@6.0.0`. The former
+`@heddleagent/execution-host-client@6.1.0`. The former
 `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 installable only for existing consumers.
 
@@ -224,7 +224,7 @@ that already owns the mechanics your host needs:
 | Conventional Node HTTP/SSE | `@heddleagent/runtime/runs/http-sse` | Replay cursor parsing, SSE framing, backpressure, and disconnect cleanup |
 | A remote browser or client | `@heddleagent/run-client` | Browser-safe protocol validation and transport-neutral run consumption |
 | Conventional browser REST/SSE | `@heddleagent/run-client/http-sse` | Authenticated fetch, incremental SSE parsing, and transport validation |
-| A backend invoking a separate Execution Host | `@heddleagent/execution-host-client` | Contracts, authority/JWKS, hosted-turn orchestration, durable requested/accepted/terminal persistence semantics, product-MCP verification, an `ExecutionHost` client port, Node conveniences, store conformance, and shared TypeScript/Python fixtures |
+| A backend invoking a separate Execution Host | `@heddleagent/execution-host-client` | Contracts, authority/JWKS, hosted-turn orchestration, durable requested/accepted/terminal persistence semantics, product-MCP verification, direct and AgentCore clients, Node conveniences, store conformance, and shared TypeScript/Python fixtures |
 | Durable Execution Host lifecycle in PostgreSQL | `@heddleagent/postgres/execution-host/conversations` | Atomic scope-fenced lifecycle store, ordered adopter-run migrations, SQL constraints, expiry, and real-PostgreSQL conformance |
 | Durable PostgreSQL heartbeat workers | `@heddleagent/postgres/heartbeat` | Claim-fenced task execution, lease recovery, checkpoints, history, and atomic operator controls over an injected Drizzle database |
 | Lower-level runtime assembly | `@heddleagent/runtime/advanced` | Model adapters, individual tools, trace, memory, heartbeat, and core runtime services |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -35,7 +35,7 @@ conversation 與 run 基礎之上。
 | Heddle coding agent | 使用建立在相同 runtime 上的 CLI 與 browser control plane | `@heddleagent/cli`（`heddle` command） |
 
 獨立 Execution Host 的穩定套件是
-`@heddleagent/execution-host-client@6.0.0`。舊的
+`@heddleagent/execution-host-client@6.1.0`。舊的
 `@roackb2/heddle-adopter@5.13.0` coordinate 已 deprecated，只為既有使用者保留安裝能力。
 
 穩定的 coding-agent 套件是 `@heddleagent/cli@6.0.0`，安裝後提供
@@ -214,7 +214,7 @@ mechanics 的最低層即可：
 | 一般 Node HTTP/SSE | `@heddleagent/runtime/runs/http-sse` | Replay cursor parsing、SSE framing、backpressure 與 disconnect cleanup |
 | Remote browser 或 client | `@heddleagent/run-client` | Browser-safe protocol validation 與 transport-neutral run consumption |
 | 一般 browser REST/SSE | `@heddleagent/run-client/http-sse` | Authenticated fetch、incremental SSE parsing 與 transport validation |
-| Backend 呼叫獨立 Execution Host | `@heddleagent/execution-host-client` | Contract、authority/JWKS、hosted-turn orchestration、durable requested/accepted/terminal persistence、product-MCP verification、provider-neutral client port、store conformance 與 TypeScript/Python fixture |
+| Backend 呼叫獨立 Execution Host | `@heddleagent/execution-host-client` | Contract、authority/JWKS、hosted-turn orchestration、durable requested/accepted/terminal persistence、product-MCP verification、direct 與 AgentCore client、store conformance 與 TypeScript/Python fixture |
 | 以 PostgreSQL 保存 Execution Host lifecycle | `@heddleagent/postgres/execution-host/conversations` | Atomic scope fencing、由 adopter 執行的 ordered migration、SQL constraint、expiry 與 real-PostgreSQL conformance |
 | PostgreSQL heartbeat worker | `@heddleagent/postgres/heartbeat` | Heartbeat task 的 claim fencing、lease recovery、checkpoint、history 與 atomic operator control；不是一般 product database adapter |
 | 更底層的 runtime 組裝 | `@heddleagent/runtime/advanced` | Model adapter、individual tool、trace、memory、heartbeat 與 core runtime service |

--- a/docs/guides/programmatic/execution-host-adopters.md
+++ b/docs/guides/programmatic/execution-host-adopters.md
@@ -2,14 +2,15 @@
 
 Use the Execution Host integration contract when your product backend does not
 embed Heddle and instead invokes a separately deployed Heddle Execution Host.
-The package is small on purpose: it provides the security-sensitive contract
-machinery while your product keeps its language stack and domain ownership.
+The package is focused on purpose: it provides the security-sensitive contract
+and transport machinery while your product keeps its language stack and domain
+ownership.
 
 The package is currently an experimental public contract and local proving
 surface. Heddle does not distribute the compatible Execution Host or offer a
 hosted service today.
 
-The stable coordinate is `@heddleagent/execution-host-client@6.0.0`. The
+The stable coordinate is `@heddleagent/execution-host-client@6.1.0`. The
 former `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 installable only for existing consumers. It does not include the durable
 lifecycle described below.
@@ -80,6 +81,8 @@ Its subpaths separate responsibility:
   an adopter-defined product toolset;
 - `/http-sse` provides the provider-neutral `ExecutionHost` port and strict
   direct-development transport;
+- `/agentcore` provides the official AWS SDK/SigV4 implementation of that port
+  for an adopter-provisioned AgentCore Runtime;
 - `/testing` provides a Node-only loopback v1 fixture for local product/MCP
   integration tests without a model or AWS, plus real-store lifecycle
   conformance.
@@ -120,7 +123,7 @@ The package deliberately excludes:
 - production signing-key storage and rotation, route placement, and key
   revocation;
 - MCP tool registration, product APIs, or database access;
-- AWS AgentCore/SigV4 transport and deployment;
+- AWS account configuration, AgentCore Runtime deployment, and IAM policy;
 - Heddle's loop, tools, model runtime, workspace, or state serialization;
 - invocation-ID allocation, database implementation, explicit result lookup or
   retry after ambiguity, billing, and UI.
@@ -148,13 +151,15 @@ minimization.
 
 `DirectHttpExecutionHost` targets local development and reviewed direct HTTPS
 deployments. It owns strict request/SSE validation but uses the Execution Host
-local-token ingress. It is not an AgentCore client.
+local-token ingress.
 
-A managed AgentCore adapter should implement the same `ExecutionHost` port with
-the AWS SDK and SigV4 while preserving the same v1 body, forwarded custom
-headers, ordered stream semantics, and no-ambiguous-retry rule. Keeping that
-adapter separate prevents AWS types from leaking into the product application
-service.
+`AgentCoreExecutionHost` from
+`@heddleagent/execution-host-client/agentcore` is the official AWS SDK/SigV4
+transport. It preserves the same v1 body, forwards only the required custom
+headers before signing, validates ordered stream semantics, and never retries
+an ambiguous streaming invocation. The adopter supplies its AWS region,
+Runtime ARN, optional qualifier, credential environment, IAM policy, and
+Runtime deployment.
 
 ## Progressive Node adoption
 

--- a/docs/project-posture.md
+++ b/docs/project-posture.md
@@ -79,9 +79,9 @@ At the distribution boundary:
   run lifecycle and remote-consumption mechanics, not a managed service;
 - `@heddleagent/execution-host-client` defines the public, language-neutral
   boundary for a backend invoking a separate compatible Execution Host. It
-  owns authority, wire, transport, base turn, MCP, Node, testing, and the
-  reusable durable-turn lifecycle over an adopter-implemented atomic store,
-  with shared TypeScript/Python lifecycle fixtures. The former
+  owns authority, wire, direct and AgentCore transports, base turn, MCP, Node,
+  testing, and the reusable durable-turn lifecycle over an adopter-implemented
+  atomic store, with shared TypeScript/Python lifecycle fixtures. The former
   `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
   installable only for existing consumers;
 - `@heddleagent/postgres` is the official PostgreSQL adapter family. Its

--- a/docs/releases/execution-host-client-v6.1.0.md
+++ b/docs/releases/execution-host-client-v6.1.0.md
@@ -1,0 +1,30 @@
+# Execution Host Client v6.1.0
+
+`@heddleagent/execution-host-client@6.1.0` adds Heddle's official AWS
+AgentCore transport for invoking a separately deployed compatible Execution
+Host.
+
+```bash
+npm install @heddleagent/execution-host-client@6.1.0
+```
+
+## What changed
+
+- add `@heddleagent/execution-host-client/agentcore`;
+- move the production-exercised `AgentCoreExecutionHost` behavior out of the
+  Lucid adopter and into the reusable Heddle integration package;
+- validate AgentCore Runtime session IDs;
+- add Heddle authority headers before SigV4 signing;
+- stream AWS response bodies through the existing strict request/SSE client;
+- preserve one-attempt behavior for ambiguously interrupted invocations; and
+- map bounded AgentCore service failures to safe rejection codes.
+
+The package does not deploy AgentCore Runtime or bind to an AWS account.
+Adopters still own account configuration, Runtime provisioning, IAM policy,
+region, Runtime ARN, credentials, product authority, persistence, and result
+application.
+
+## Publication
+
+Publish manually after the reviewed release commit is merged. This repository
+does not automatically publish packages from `main`.

--- a/package.json
+++ b/package.json
@@ -227,9 +227,9 @@
     }
   },
   "dependencies": {
-    "@heddleagent/run-client": "^6.0.0",
     "@anthropic-ai/sdk": "^0.54.0",
     "@fontsource-variable/inter": "^5.2.8",
+    "@heddleagent/run-client": "^6.0.0",
     "@hookform/resolvers": "^5.4.0",
     "@inkjs/ui": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -288,8 +288,10 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@aws-sdk/client-bedrock-agentcore": "3.1107.0",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.59.1",
+    "@smithy/protocol-http": "5.5.16",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/express": "^5.0.6",
@@ -311,8 +313,8 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "eventsource-parser": "^3.1.0",
     "globals": "^17.5.0",
-    "jsdom": "^29.0.2",
     "jose": "^6.2.8",
+    "jsdom": "^29.0.2",
     "pg": "8.22.0",
     "react-dom": "^19.2.5",
     "streamdown": "^2.5.0",

--- a/packages/README.md
+++ b/packages/README.md
@@ -3,7 +3,7 @@
 Status: **five stable packages**
 
 This directory records the v6 package identities and responsibility boundaries.
-`@heddleagent/execution-host-client@6.0.0` contains its canonical
+`@heddleagent/execution-host-client@6.1.0` contains its canonical
 implementation as a stable package. `@heddleagent/postgres@6.1.0` ships the
 Execution Host lifecycle and heartbeat adapters. `@heddleagent/run-client@6.0.0`
 ships the existing browser-safe run client under its final coordinate.
@@ -20,7 +20,7 @@ keep running; new integrations should use the `@heddleagent/*` packages.
 | `@heddleagent/runtime` | Embeddable TypeScript/Node agent runtime and SDK | Stable `6.1.0`; `/runs` replaces the former `/hosted` package-path name and `/cli` is the package-to-package bridge for the official CLI |
 | `@heddleagent/cli` | Installable Heddle coding-agent product and `heddle` executable | Existing CLI, TUI, daemon, and browser control plane activated at stable `6.0.0` |
 | `@heddleagent/run-client` | Browser-safe JavaScript run protocol consumer | Existing implementation activated at stable `6.0.0` |
-| `@heddleagent/execution-host-client` | Product-backend contracts and helpers for invoking a separate compatible Execution Host | Canonical implementation moved; stable version `6.0.0` |
+| `@heddleagent/execution-host-client` | Product-backend contracts and direct/AgentCore clients for invoking a separate compatible Execution Host | Stable `6.1.0`; official AgentCore transport at `/agentcore` |
 | `@heddleagent/postgres` | Official PostgreSQL implementations for supported Heddle-owned durable ports | Stable `6.1.0`; Execution Host conversation lifecycle and heartbeat task authority are explicit subpaths |
 
 The in-process run service is exposed from

--- a/packages/execution-host-client/README.md
+++ b/packages/execution-host-client/README.md
@@ -1,11 +1,11 @@
 # `@heddleagent/execution-host-client`
 
-`@heddleagent/execution-host-client` is the lightweight backend-side SDK for
+`@heddleagent/execution-host-client` is the backend-side SDK for
 products that invoke a separately deployed Heddle Execution Host. It lets an
 adopter keep its own language stack, authentication, database, product policy,
 MCP tools, and UI while reusing the security-sensitive v1 contract machinery.
 
-> **Current availability:** stable version `6.0.0`. The former
+> **Current availability:** stable version `6.1.0`. The former
 > `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 > installable only for existing consumers. Heddle does not currently distribute
 > the compatible Execution Host implementation or offer a hosted service. The
@@ -18,10 +18,10 @@ Install the package:
 npm install @heddleagent/execution-host-client
 ```
 
-The package does **not** contain Heddle's agent loop, AgentCore deployment,
-Terraform, product MCP tools, or product logic. It uses the official MCP SDK,
-plus `jose`, `zod`, `dayjs`, and `eventsource-parser`, for its optional
-reference edges.
+The package does **not** contain Heddle's agent loop, AgentCore Runtime
+deployment, Terraform, product MCP tools, or product logic. It uses the
+modular AWS SDK for its AgentCore transport and the official MCP SDK, plus
+`jose`, `zod`, `dayjs`, and `eventsource-parser`, for its other edges.
 
 ## What it owns
 
@@ -33,6 +33,7 @@ reference edges.
 | `@heddleagent/execution-host-client/mcp` | Independent capability verification at the adopter's MCP edge |
 | `@heddleagent/execution-host-client/mcp/node` | Stateless official-SDK Streamable HTTP lifecycle around adopter-defined toolsets |
 | `@heddleagent/execution-host-client/http-sse` | Transport-neutral `ExecutionHost` port and strict direct-development HTTP/SSE client |
+| `@heddleagent/execution-host-client/agentcore` | Official AWS AgentCore/SigV4 implementation of the same `ExecutionHost` port |
 | `@heddleagent/execution-host-client/testing` | Node-only loopback v1 fixture plus durable-turn store conformance for real adapters |
 | `@heddleagent/execution-host-client/node` | Optional Node JWKS/conversation HTTP edge plus safe local signing-key helpers |
 
@@ -53,7 +54,8 @@ The adopter still owns:
   allocation, the lifecycle-store implementation/schema/migrations, retention,
   and history queries;
 - implementing and hosting product MCP tools against its own APIs and data;
-- choosing an AgentCore/SigV4 transport, applying results, and rendering UI.
+- choosing and provisioning its AgentCore Runtime, applying results, and
+  rendering UI.
 
 ## Issue one invocation's authority
 
@@ -225,11 +227,32 @@ const productMcp = new NodeStreamableHttpMcpService({
 Use the lower-level `NodeMcpToolset` interface only when a tool needs custom MCP
 content or lifecycle semantics.
 
-## Invoke the direct development host
+## Invoke an Execution Host
 
-The direct client is useful for local and reviewed HTTPS deployments. A
-managed AgentCore deployment should supply a separate SigV4/AWS SDK transport
-which implements the same `ExecutionHost` port.
+Use the official AgentCore client for a Runtime deployed in the adopter's AWS
+account. It uses the normal AWS credential chain, signs the required Heddle
+authority headers, streams the response through the same strict protocol
+validation as the direct client, and deliberately makes only one ambiguous
+streaming attempt.
+
+```ts
+import {
+  AgentCoreExecutionHost,
+} from '@heddleagent/execution-host-client/agentcore'
+
+const host = new AgentCoreExecutionHost({
+  region: process.env.AWS_REGION!,
+  runtimeArn: process.env.AGENTCORE_RUNTIME_ARN!,
+  qualifier: process.env.AGENTCORE_RUNTIME_QUALIFIER,
+})
+```
+
+The product still owns the AWS account, Runtime deployment, IAM policy,
+configuration, and credentials environment. Heddle owns only the reusable
+invocation transport.
+
+For local development and reviewed direct HTTPS deployments, use the direct
+client:
 
 ```ts
 import { DirectHttpExecutionHost } from '@heddleagent/execution-host-client/http-sse'

--- a/packages/execution-host-client/package.json
+++ b/packages/execution-host-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/execution-host-client",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Backend contracts, execution authority, lifecycle services, and clients for compatible Heddle Execution Hosts",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",
@@ -54,6 +54,10 @@
       "types": "./dist/http-sse/index.d.ts",
       "import": "./dist/http-sse/index.js"
     },
+    "./agentcore": {
+      "types": "./dist/agentcore/index.d.ts",
+      "import": "./dist/agentcore/index.js"
+    },
     "./testing": {
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js"
@@ -83,7 +87,9 @@
     "streaming"
   ],
   "dependencies": {
+    "@aws-sdk/client-bedrock-agentcore": "^3.1107.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@smithy/protocol-http": "^5.5.16",
     "dayjs": "^1.11.20",
     "eventsource-parser": "^3.1.0",
     "jose": "^6.2.8",

--- a/packages/execution-host-client/src/agentcore/README.md
+++ b/packages/execution-host-client/src/agentcore/README.md
@@ -1,0 +1,37 @@
+# AWS AgentCore Execution Host client
+
+This module is the official AWS AgentCore transport for the public
+`ExecutionHost` port. It sends the versioned invocation contract through
+`InvokeAgentRuntime`, adds Heddle authority headers before SigV4 signing, and
+delegates strict request/SSE validation to the shared Execution Host client.
+
+It owns:
+
+- AgentCore Runtime session-ID validation;
+- AWS SDK client construction through the default credential chain;
+- one-attempt invocation semantics because a disconnected streaming request
+  has ambiguous settlement;
+- command-scoped, SigV4-signed Heddle authority headers;
+- AWS streaming-body conversion; and
+- bounded provider-error mapping into Execution Host rejection codes.
+
+It does not own AWS account configuration, Runtime provisioning, product
+authentication, authority issuance, model credentials, MCP tools, persistence,
+result application, or UI. Adopters provide their region, Runtime ARN, optional
+qualifier, and normal AWS credential environment at composition.
+
+```ts
+import {
+  AgentCoreExecutionHost,
+} from '@heddleagent/execution-host-client/agentcore'
+
+const executionHost = new AgentCoreExecutionHost({
+  region: process.env.AWS_REGION!,
+  runtimeArn: process.env.AGENTCORE_RUNTIME_ARN!,
+  qualifier: process.env.AGENTCORE_RUNTIME_QUALIFIER,
+})
+```
+
+The Runtime deployment must allowlist the names exported as
+`AGENTCORE_FORWARDED_HEADER_NAMES`. The direct-host local token is deliberately
+excluded and never reaches AWS.

--- a/packages/execution-host-client/src/agentcore/agentcore-execution-host.test.ts
+++ b/packages/execution-host-client/src/agentcore/agentcore-execution-host.test.ts
@@ -1,0 +1,236 @@
+import { BedrockAgentCoreClient } from '@aws-sdk/client-bedrock-agentcore';
+import {
+  createServer,
+  type IncomingMessage,
+  type RequestListener,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  AGENTCORE_RUNTIME_SESSION_HEADER,
+  EXECUTION_ASSERTION_HEADER,
+  EXECUTION_HOST_LOCAL_TOKEN_HEADER,
+  MCP_CAPABILITY_HEADER,
+  MODEL_API_KEY_HEADER,
+  type ExecutionHostStreamEvent,
+} from '../contracts/index.js';
+import {
+  ExecutionHostInvocationCancelledError,
+  ExecutionHostStreamInterruptedError,
+  type ExecutionHostConversationTurn,
+} from '../http-sse/index.js';
+import { AgentCoreExecutionHost } from './agentcore-execution-host.js';
+import type { AgentCoreRuntimeClient } from './types.js';
+
+const RUNTIME_ARN =
+  'arn:aws:bedrock-agentcore:us-east-2:123456789012:runtime/example_runtime';
+const servers = new Set<ReturnType<typeof createServer>>();
+
+afterEach(async () => {
+  await Promise.all([...servers].map((server) => new Promise<void>((resolve) => {
+    server.close(() => resolve());
+    server.closeAllConnections();
+  })));
+  servers.clear();
+});
+
+describe('AgentCoreExecutionHost', () => {
+  it('signs and streams the portable Execution Host contract through the AWS SDK', async () => {
+    const observed = {
+      headers: {} as IncomingMessage['headers'],
+      body: '',
+    };
+    const origin = await listen(async (request, response) => {
+      observed.headers = request.headers;
+      observed.body = await readBody(request);
+      response.writeHead(200, {
+        'content-type': 'text/event-stream',
+        [AGENTCORE_RUNTIME_SESSION_HEADER]: input().runtimeSessionId,
+      });
+      response.end(toSse([accepted(), result()]));
+    });
+    const client = new BedrockAgentCoreClient({
+      region: 'us-east-2',
+      endpoint: origin.toString(),
+      credentials: {
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret-key',
+      },
+      maxAttempts: 1,
+    });
+    const host = new AgentCoreExecutionHost({
+      region: 'us-east-2',
+      runtimeArn: RUNTIME_ARN,
+      qualifier: 'pilot',
+      client,
+    });
+
+    const events = await collect(host.streamConversationTurn(input()));
+
+    expect(events.map(({ kind }) => kind)).toEqual(['accepted', 'result']);
+    expect(observed.headers[EXECUTION_ASSERTION_HEADER])
+      .toBe(input().executionAssertion);
+    expect(observed.headers[MCP_CAPABILITY_HEADER]).toBe(input().mcpCapability);
+    expect(observed.headers[MODEL_API_KEY_HEADER]).toBe(input().modelApiKey);
+    expect(observed.headers[AGENTCORE_RUNTIME_SESSION_HEADER])
+      .toBe(input().runtimeSessionId);
+    expect(observed.headers[EXECUTION_HOST_LOCAL_TOKEN_HEADER]).toBeUndefined();
+    expect(observed.headers.authorization).toContain('AWS4-HMAC-SHA256');
+    expect(observed.headers.authorization).toContain(
+      EXECUTION_ASSERTION_HEADER,
+    );
+    expect(observed.headers.authorization).toContain(MCP_CAPABILITY_HEADER);
+    expect(observed.headers.authorization).toContain(MODEL_API_KEY_HEADER);
+    expect(JSON.parse(observed.body)).toEqual({
+      schemaVersion: 1,
+      kind: 'conversation-turn',
+      invocationId: input().invocationId,
+      prompt: input().prompt,
+    });
+
+    host.close();
+  });
+
+  it('keeps a clean EOF without a terminal event interrupted', async () => {
+    const origin = await listen(async (_request, response) => {
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.end(toSse([accepted()]));
+    });
+    const client = new BedrockAgentCoreClient({
+      region: 'us-east-2',
+      endpoint: origin.toString(),
+      credentials: {
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret-key',
+      },
+      maxAttempts: 1,
+    });
+    const host = new AgentCoreExecutionHost({
+      region: 'us-east-2',
+      runtimeArn: RUNTIME_ARN,
+      client,
+    });
+
+    await expect(collect(host.streamConversationTurn(input())))
+      .rejects.toBeInstanceOf(ExecutionHostStreamInterruptedError);
+
+    host.close();
+  });
+
+  it('propagates caller cancellation into the AWS invocation', async () => {
+    const client: AgentCoreRuntimeClient = {
+      send: async (_command, options) => await new Promise((_resolve, reject) => {
+        options?.abortSignal?.addEventListener('abort', () => {
+          reject(new DOMException('cancelled', 'AbortError'));
+        }, { once: true });
+      }),
+    };
+    const host = new AgentCoreExecutionHost({
+      region: 'us-east-2',
+      runtimeArn: RUNTIME_ARN,
+      client,
+    });
+    const controller = new AbortController();
+
+    const running = collect(host.streamConversationTurn(input({
+      signal: controller.signal,
+    })));
+    controller.abort();
+
+    await expect(running).rejects.toBeInstanceOf(
+      ExecutionHostInvocationCancelledError,
+    );
+  });
+
+  it('rejects a provider-incompatible session ID before calling AWS', () => {
+    const send = vi.fn<AgentCoreRuntimeClient['send']>();
+    const host = new AgentCoreExecutionHost({
+      region: 'us-east-2',
+      runtimeArn: RUNTIME_ARN,
+      client: { send },
+    });
+
+    expect(() => host.streamConversationTurn(input({
+      runtimeSessionId: `runtime-session:${'a'.repeat(40)}`,
+    }))).toThrow('AgentCore runtime session ID is not provider-compatible.');
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+async function listen(
+  handler: RequestListener,
+): Promise<URL> {
+  const server = createServer(handler);
+  servers.add(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return new URL(`http://127.0.0.1:${address.port}`);
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function input(
+  overrides: Partial<ExecutionHostConversationTurn> = {},
+): ExecutionHostConversationTurn {
+  return {
+    invocationId: 'invocation_agentcore_test',
+    runtimeSessionId: 'runtime-session-agentcore-test-000000000001',
+    prompt: 'Read the workspace and summarize it.',
+    executionAssertion: 'execution-assertion-value'.padEnd(48, 'x'),
+    mcpCapability: 'mcp-capability-value'.padEnd(48, 'x'),
+    modelApiKey: 'model-api-key-value',
+    ...overrides,
+  };
+}
+
+function accepted(): ExecutionHostStreamEvent {
+  return {
+    schemaVersion: 1,
+    invocationId: input().invocationId,
+    runId: 'run_agentcore_test',
+    timestamp: '2026-08-11T00:00:00.000Z',
+    sequence: 0,
+    kind: 'accepted',
+  };
+}
+
+function result(): ExecutionHostStreamEvent {
+  return {
+    schemaVersion: 1,
+    invocationId: input().invocationId,
+    runId: 'run_agentcore_test',
+    timestamp: '2026-08-11T00:00:01.000Z',
+    sequence: 1,
+    kind: 'result',
+    result: { outcome: 'done', summary: 'Complete.' },
+  };
+}
+
+function toSse(events: ExecutionHostStreamEvent[]): string {
+  return events.map((event) => [
+    `event: ${event.kind}`,
+    `id: ${event.sequence}`,
+    `data: ${JSON.stringify(event)}`,
+    '',
+    '',
+  ].join('\n')).join('');
+}
+
+async function collect(
+  events: AsyncIterable<ExecutionHostStreamEvent>,
+): Promise<ExecutionHostStreamEvent[]> {
+  const collected: ExecutionHostStreamEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}

--- a/packages/execution-host-client/src/agentcore/agentcore-execution-host.ts
+++ b/packages/execution-host-client/src/agentcore/agentcore-execution-host.ts
@@ -1,0 +1,251 @@
+import {
+  BedrockAgentCoreClient,
+  InvokeAgentRuntimeCommand,
+  type InvokeAgentRuntimeCommandOutput,
+} from '@aws-sdk/client-bedrock-agentcore';
+import { HttpRequest } from '@smithy/protocol-http';
+import {
+  AGENTCORE_RUNTIME_SESSION_HEADER,
+  EXECUTION_ASSERTION_HEADER,
+  EXECUTION_HOST_LOCAL_TOKEN_HEADER,
+  MCP_CAPABILITY_HEADER,
+  MODEL_API_KEY_HEADER,
+  type ExecutionHostStreamEvent,
+} from '../contracts/index.js';
+import {
+  DirectHttpExecutionHost,
+  type ExecutionHost,
+  type ExecutionHostConversationTurn,
+} from '../http-sse/index.js';
+import type {
+  AgentCoreExecutionHostConfig,
+  AgentCoreRuntimeClient,
+} from './types.js';
+
+const CONTENT_TYPE = 'application/json';
+const ACCEPT = 'text/event-stream';
+const MIN_RUNTIME_SESSION_ID_LENGTH = 33;
+const MAX_RUNTIME_SESSION_ID_LENGTH = 256;
+const RUNTIME_SESSION_ID_PATTERN = /^[A-Za-z0-9](?:-*[A-Za-z0-9])+$/;
+const WIRE_BRIDGE_URL = new URL('http://127.0.0.1/agentcore-bridge');
+const NON_FORWARDED_LOCAL_TOKEN = 'agentcore-bridge-token-never-forwarded';
+const SERVICE_ERROR_CODES = new Map<string, string>([
+  ['AccessDeniedException', 'access_denied'],
+  ['InternalServerException', 'runtime_internal'],
+  ['ResourceNotFoundException', 'runtime_not_found'],
+  ['RetryableConflictException', 'runtime_conflict'],
+  ['RuntimeClientError', 'runtime_client_error'],
+  ['ServiceQuotaExceededException', 'quota_exceeded'],
+  ['ThrottlingException', 'throttled'],
+  ['ValidationException', 'invalid_request'],
+]);
+
+/**
+ * Invokes one compatible Heddle Execution Host through AWS AgentCore while
+ * reusing the package's strict request and SSE protocol validation.
+ */
+export class AgentCoreExecutionHost implements ExecutionHost {
+  readonly #client: AgentCoreRuntimeClient;
+  readonly #runtimeArn: string;
+  readonly #qualifier?: string;
+  readonly #wire: DirectHttpExecutionHost;
+
+  constructor(config: AgentCoreExecutionHostConfig) {
+    this.#runtimeArn = config.runtimeArn;
+    this.#qualifier = config.qualifier;
+    this.#client = config.client ?? new BedrockAgentCoreClient({
+      region: config.region,
+      // Invocation settlement is ambiguous after a transport interruption.
+      // Product policy, not the AWS client, decides whether a turn may retry.
+      maxAttempts: 1,
+    });
+    this.#wire = new DirectHttpExecutionHost({
+      baseUrl: WIRE_BRIDGE_URL,
+      localToken: NON_FORWARDED_LOCAL_TOKEN,
+      fetch: (_input, init) => this.#invoke(init),
+    });
+  }
+
+  streamConversationTurn(
+    input: ExecutionHostConversationTurn,
+  ): AsyncIterable<ExecutionHostStreamEvent> {
+    assertAgentCoreRuntimeSessionId(input.runtimeSessionId);
+    return this.#wire.streamConversationTurn(input);
+  }
+
+  close(): void {
+    this.#client.destroy?.();
+  }
+
+  async #invoke(init?: RequestInit): Promise<Response> {
+    if (init?.method !== 'POST' || typeof init.body !== 'string') {
+      throw new Error('AgentCore wire bridge received an invalid request.');
+    }
+    const headers = new Headers(init.headers);
+    const runtimeSessionId = requireHeader(
+      headers,
+      AGENTCORE_RUNTIME_SESSION_HEADER,
+    );
+    const customHeaders = Object.fromEntries([
+      [
+        EXECUTION_ASSERTION_HEADER,
+        requireHeader(headers, EXECUTION_ASSERTION_HEADER),
+      ],
+      [MODEL_API_KEY_HEADER, requireHeader(headers, MODEL_API_KEY_HEADER)],
+      ...(headers.has(MCP_CAPABILITY_HEADER)
+        ? [[MCP_CAPABILITY_HEADER, headers.get(MCP_CAPABILITY_HEADER)!]]
+        : []),
+    ]);
+    const command = new InvokeAgentRuntimeCommand({
+      agentRuntimeArn: this.#runtimeArn,
+      runtimeSessionId,
+      qualifier: this.#qualifier,
+      contentType: CONTENT_TYPE,
+      accept: ACCEPT,
+      payload: new TextEncoder().encode(init.body),
+    });
+    addSignedCustomHeaders(command, customHeaders);
+    const signal = init.signal ?? undefined;
+
+    try {
+      const output = await this.#client.send(command, { abortSignal: signal });
+      return new Response(
+        output.response ? toReadableStream(output.response) : null,
+        {
+          status: output.statusCode ?? output.$metadata.httpStatusCode ?? 200,
+          headers: {
+            'content-type': output.contentType ?? 'application/octet-stream',
+          },
+        },
+      );
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
+      const status = readServiceStatus(error);
+      if (!status) {
+        throw error;
+      }
+      const code = SERVICE_ERROR_CODES.get(readErrorName(error)) ?? 'unknown';
+      return new Response(JSON.stringify({
+        error: {
+          code,
+          message: 'AgentCore rejected the invocation.',
+        },
+      }), {
+        status,
+        headers: { 'content-type': CONTENT_TYPE },
+      });
+    }
+  }
+}
+
+function assertAgentCoreRuntimeSessionId(value: string): void {
+  if (
+    value.length < MIN_RUNTIME_SESSION_ID_LENGTH
+    || value.length > MAX_RUNTIME_SESSION_ID_LENGTH
+    || !RUNTIME_SESSION_ID_PATTERN.test(value)
+  ) {
+    throw new Error('AgentCore runtime session ID is not provider-compatible.');
+  }
+}
+
+function addSignedCustomHeaders(
+  command: InvokeAgentRuntimeCommand,
+  headers: Readonly<Record<string, string>>,
+): void {
+  command.middlewareStack.add(
+    (next) => async (args) => {
+      if (!HttpRequest.isInstance(args.request)) {
+        throw new Error('AgentCore invocation did not produce an HTTP request.');
+      }
+      Object.assign(args.request.headers, headers);
+      return await next(args);
+    },
+    {
+      step: 'build',
+      priority: 'low',
+      name: 'heddleAgentCoreCustomHeaders',
+    },
+  );
+}
+
+function requireHeader(headers: Headers, name: string): string {
+  const value = headers.get(name);
+  if (!value) {
+    throw new Error('AgentCore wire bridge omitted required authority.');
+  }
+  return value;
+}
+
+function toReadableStream(
+  source: NonNullable<InvokeAgentRuntimeCommandOutput['response']>,
+): ReadableStream<Uint8Array> {
+  if (source instanceof Blob) {
+    return source.stream();
+  }
+  if (source instanceof ReadableStream) {
+    return source;
+  }
+  if (!isAsyncIterable(source)) {
+    throw new Error('AgentCore returned an unsupported stream type.');
+  }
+  const iterator = source[Symbol.asyncIterator]();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const item = await iterator.next();
+        if (item.done) {
+          controller.close();
+          return;
+        }
+        if (!(item.value instanceof Uint8Array)) {
+          throw new Error('AgentCore returned a non-binary stream chunk.');
+        }
+        controller.enqueue(item.value);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel() {
+      await iterator.return?.();
+    },
+  });
+}
+
+function isAsyncIterable(
+  value: unknown,
+): value is AsyncIterable<Uint8Array> {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && Symbol.asyncIterator in value
+    && typeof value[Symbol.asyncIterator] === 'function',
+  );
+}
+
+function readServiceStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object' || !('$metadata' in error)) {
+    return undefined;
+  }
+  const metadata = (error as { $metadata?: { httpStatusCode?: unknown } })
+    .$metadata;
+  const status = metadata?.httpStatusCode;
+  return typeof status === 'number' && status >= 400 && status <= 599
+    ? status
+    : undefined;
+}
+
+function readErrorName(error: unknown): string {
+  return error instanceof Error ? error.name : '';
+}
+
+export const AGENTCORE_FORWARDED_HEADER_NAMES = Object.freeze([
+  EXECUTION_ASSERTION_HEADER,
+  MCP_CAPABILITY_HEADER,
+  MODEL_API_KEY_HEADER,
+] as const);
+
+export const AGENTCORE_EXCLUDED_HEADER_NAMES = Object.freeze([
+  EXECUTION_HOST_LOCAL_TOKEN_HEADER,
+] as const);

--- a/packages/execution-host-client/src/agentcore/index.ts
+++ b/packages/execution-host-client/src/agentcore/index.ts
@@ -1,0 +1,9 @@
+export {
+  AGENTCORE_EXCLUDED_HEADER_NAMES,
+  AGENTCORE_FORWARDED_HEADER_NAMES,
+  AgentCoreExecutionHost,
+} from './agentcore-execution-host.js';
+export type {
+  AgentCoreExecutionHostConfig,
+  AgentCoreRuntimeClient,
+} from './types.js';

--- a/packages/execution-host-client/src/agentcore/types.ts
+++ b/packages/execution-host-client/src/agentcore/types.ts
@@ -1,0 +1,19 @@
+import type {
+  InvokeAgentRuntimeCommand,
+  InvokeAgentRuntimeCommandOutput,
+} from '@aws-sdk/client-bedrock-agentcore';
+
+export interface AgentCoreRuntimeClient {
+  send(
+    command: InvokeAgentRuntimeCommand,
+    options?: { abortSignal?: AbortSignal },
+  ): Promise<InvokeAgentRuntimeCommandOutput>;
+  destroy?(): void;
+}
+
+export type AgentCoreExecutionHostConfig = {
+  region: string;
+  runtimeArn: string;
+  qualifier?: string;
+  client?: AgentCoreRuntimeClient;
+};

--- a/packages/execution-host-client/src/http-sse/README.md
+++ b/packages/execution-host-client/src/http-sse/README.md
@@ -9,5 +9,5 @@ host rejection, invalid protocol, and ambiguous interruption remain distinct.
 
 The adapter uses the Execution Host's direct local-token ingress. It does not
 implement AWS AgentCore invocation, SigV4, retries, durable result recovery, or
-product result projection. A future AgentCore transport can implement the same
-`ExecutionHost` port without changing the adopter's application service.
+product result projection. The official `../agentcore` module implements the
+same `ExecutionHost` port without changing the adopter's application service.

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,199 @@
   resolved "https://registry.yarnpkg.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz#ad5549322dfe9d153d4b4dd6f7ff2ae234b06e24"
   integrity sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==
 
+"@aws-sdk/client-bedrock-agentcore@3.1107.0":
+  version "3.1107.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-bedrock-agentcore/-/client-bedrock-agentcore-3.1107.0.tgz#e448a316dc36273e5535a103f65efdbad8f8b40b"
+  integrity sha512-ccLsXGzYXkJuEtPaxm54mHg5JnKIxnmib418SBQPngntXUEk3kfDfy6oZef2d8GUAPa8WhSjLzkHdmR9RCLhnQ==
+  dependencies:
+    "@aws-sdk/core" "^3.977.6"
+    "@aws-sdk/credential-provider-node" "^3.972.78"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/fetch-http-handler" "^5.6.13"
+    "@smithy/node-http-handler" "^4.9.13"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@^3.977.6", "@aws-sdk/core@^3.977.8":
+  version "3.977.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.977.8.tgz#b2860d6d6bd4b147dbf906c5e3c8155337742657"
+  integrity sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==
+  dependencies:
+    "@aws-sdk/types" "^3.974.4"
+    "@aws-sdk/xml-builder" "^3.972.39"
+    "@aws/lambda-invoke-store" "^0.3.0"
+    "@smithy/core" "^3.31.1"
+    "@smithy/signature-v4" "^5.6.12"
+    "@smithy/types" "^4.16.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@^3.972.69":
+  version "3.972.69"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz#9ef8e8e6abd048ae4c9bd8ea71fe8e79bcb48204"
+  integrity sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==
+  dependencies:
+    "@aws-sdk/core" "^3.977.8"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.71":
+  version "3.972.71"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz#94f74f2e145df28b0b15849330b99f9c83c3f978"
+  integrity sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==
+  dependencies:
+    "@aws-sdk/core" "^3.977.8"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/fetch-http-handler" "^5.6.13"
+    "@smithy/node-http-handler" "^4.9.13"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@^3.973.14":
+  version "3.973.14"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz#650d856227a36fbfb954f8b93b89f747e8430dd4"
+  integrity sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==
+  dependencies:
+    "@aws-sdk/core" "^3.977.8"
+    "@aws-sdk/credential-provider-env" "^3.972.69"
+    "@aws-sdk/credential-provider-http" "^3.972.71"
+    "@aws-sdk/credential-provider-login" "^3.972.76"
+    "@aws-sdk/credential-provider-process" "^3.972.69"
+    "@aws-sdk/credential-provider-sso" "^3.973.13"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.75"
+    "@aws-sdk/nested-clients" "^3.997.43"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/credential-provider-imds" "^4.4.16"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.76":
+  version "3.972.76"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz#83dc4012f8d218c6867ecea389103c4ab78f4f7f"
+  integrity sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==
+  dependencies:
+    "@aws-sdk/core" "^3.977.8"
+    "@aws-sdk/nested-clients" "^3.997.43"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-node@^3.972.78":
+  version "3.972.80"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz#1a3db0a35091468c5cd32d869f031fc6a2420d8e"
+  integrity sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.69"
+    "@aws-sdk/credential-provider-http" "^3.972.71"
+    "@aws-sdk/credential-provider-ini" "^3.973.14"
+    "@aws-sdk/credential-provider-process" "^3.972.69"
+    "@aws-sdk/credential-provider-sso" "^3.973.13"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.75"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/credential-provider-imds" "^4.4.16"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.69":
+  version "3.972.69"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz#d97e64a37d25662913f6314562781a9c9e95516b"
+  integrity sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==
+  dependencies:
+    "@aws-sdk/core" "^3.977.8"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@^3.973.13":
+  version "3.973.13"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz#005f76bf069e78089c79ec2c1b9d50a07eddabb3"
+  integrity sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==
+  dependencies:
+    "@aws-sdk/core" "^3.977.8"
+    "@aws-sdk/nested-clients" "^3.997.43"
+    "@aws-sdk/token-providers" "3.1111.0"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.75":
+  version "3.972.75"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz#c0a5980c55301aabfbf5f9938f2ba78444ee026e"
+  integrity sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==
+  dependencies:
+    "@aws-sdk/core" "^3.977.8"
+    "@aws-sdk/nested-clients" "^3.997.43"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@^3.997.43":
+  version "3.997.43"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz#6fa60e5fad1e97267b2773f0750d37511f9d698a"
+  integrity sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==
+  dependencies:
+    "@aws-sdk/core" "^3.977.8"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.45"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/fetch-http-handler" "^5.6.13"
+    "@smithy/node-http-handler" "^4.9.13"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/signature-v4-multi-region@^3.996.45":
+  version "3.996.45"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz#7d8d1d2c769327b9b5c624ee577ea1248826af7a"
+  integrity sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==
+  dependencies:
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/signature-v4" "^5.6.12"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.1111.0":
+  version "3.1111.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz#0a91fe03ab928b32032d0d30c8a191eccb91b3a5"
+  integrity sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==
+  dependencies:
+    "@aws-sdk/core" "^3.977.8"
+    "@aws-sdk/nested-clients" "^3.997.43"
+    "@aws-sdk/types" "^3.974.4"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.974.2", "@aws-sdk/types@^3.974.4":
+  version "3.974.4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.974.4.tgz#c68582caa8568de90d106e4717f1559164b6949a"
+  integrity sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==
+  dependencies:
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.39":
+  version "3.972.39"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz#d55108a214b60f1bf88429dc952cb4e9ba9e0632"
+  integrity sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==
+  dependencies:
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws/lambda-invoke-store@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz#708802d987f8e17bdf4af4de1031660ce1cdd65f"
+  integrity sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==
+
 "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
@@ -1882,6 +2075,65 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
+"@smithy/core@^3.31.1", "@smithy/core@^3.32.0", "@smithy/core@^3.33.0":
+  version "3.33.0"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.33.0.tgz#b2010aa95a5f82d5f8b9734040eb7bca634ee6ce"
+  integrity sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg==
+  dependencies:
+    "@smithy/types" "^4.17.0"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.4.16":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz#8ca70d4289a8dae9206b72670ffb31ab5e73d108"
+  integrity sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==
+  dependencies:
+    "@smithy/core" "^3.32.0"
+    "@smithy/types" "^4.17.0"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.6.13":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz#d5bfe197b1fe6b20bb2e6ce1e8368349f369f441"
+  integrity sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==
+  dependencies:
+    "@smithy/core" "^3.32.0"
+    "@smithy/types" "^4.17.0"
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.9.13":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz#2b6d74e54dfa30dd9e3fcd498e3f45f95caa38e4"
+  integrity sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==
+  dependencies:
+    "@smithy/core" "^3.33.0"
+    "@smithy/types" "^4.17.0"
+    tslib "^2.6.2"
+
+"@smithy/protocol-http@5.5.16":
+  version "5.5.16"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.5.16.tgz#d47bedeed692e6c099861c7a34856666dd1957d7"
+  integrity sha512-iPaxIe9mTyidyhM6WF2/gSLPezyCwSlZcqlDBj2KCoSS994iw4yf1se1xmZkWsY98ZpwjDR/ZMubOSVx+Nrokw==
+  dependencies:
+    "@smithy/core" "^3.31.1"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.6.12":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.7.0.tgz#611a1da9d9b1e22c9d814563de58536172e1a197"
+  integrity sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==
+  dependencies:
+    "@smithy/core" "^3.32.0"
+    "@smithy/types" "^4.17.0"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.16.1", "@smithy/types@^4.17.0":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.17.0.tgz#038b1522f69201ae6b616697b16074ac50989b7f"
+  integrity sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==
+  dependencies:
+    tslib "^2.6.2"
+
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
@@ -2905,6 +3157,11 @@ body-parser@^2.2.1:
     qs "^6.14.1"
     raw-body "^3.0.1"
     type-is "^2.0.1"
+
+bowser@^2.11.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
+  integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 brace-expansion@^5.0.5:
   version "5.0.5"
@@ -7020,7 +7277,7 @@ tsc-alias@^1.8.17:
     normalize-path "^3.0.0"
     plimit-lit "^1.2.6"
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.1:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Summary
- add the public `@heddleagent/execution-host-client/agentcore` transport
- move the production-exercised AgentCore invocation bridge out of Lucid
- sign Heddle authority headers through the AWS SDK and reuse strict SSE validation
- prepare `@heddleagent/execution-host-client@6.1.0` for manual publication

## Ownership
Heddle owns the reusable AgentCore transport mechanics. Adopters continue to own AWS credentials, account configuration, region, Runtime ARN/qualifier, IAM, Runtime deployment, product authority, persistence, and result application.

## Validation
- `yarn execution-host-client:test` (114 tests)
- `yarn execution-host-client:build`
- `yarn typecheck`
- `yarn lint`
- `git diff --check`