### PR TITLE
Add remote heartbeat execution for hosted coordinators

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Start here:
 | Heddle coding agent | Use the CLI and browser control plane built on the same runtime | `@heddleagent/cli` (`heddle` command) |
 
 The stable separate-host package is
-`@heddleagent/execution-host-client@6.1.0`. The former
+`@heddleagent/execution-host-client@6.2.0`. The former
 `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 installable only for existing consumers.
 
@@ -224,7 +224,7 @@ that already owns the mechanics your host needs:
 | Conventional Node HTTP/SSE | `@heddleagent/runtime/runs/http-sse` | Replay cursor parsing, SSE framing, backpressure, and disconnect cleanup |
 | A remote browser or client | `@heddleagent/run-client` | Browser-safe protocol validation and transport-neutral run consumption |
 | Conventional browser REST/SSE | `@heddleagent/run-client/http-sse` | Authenticated fetch, incremental SSE parsing, and transport validation |
-| A backend invoking a separate Execution Host | `@heddleagent/execution-host-client` | Contracts, authority/JWKS, hosted-turn orchestration, durable requested/accepted/terminal persistence semantics, product-MCP verification, direct and AgentCore clients, Node conveniences, store conformance, and shared TypeScript/Python fixtures |
+| A backend invoking a separate Execution Host | `@heddleagent/execution-host-client` | Contracts, authority/JWKS, conversation and heartbeat orchestration, durable conversation persistence semantics, product-MCP verification, direct and AgentCore clients, Node conveniences, store conformance, and shared TypeScript/Python fixtures |
 | Durable Execution Host lifecycle in PostgreSQL | `@heddleagent/postgres/execution-host/conversations` | Atomic scope-fenced lifecycle store, ordered adopter-run migrations, SQL constraints, expiry, and real-PostgreSQL conformance |
 | Durable PostgreSQL heartbeat workers | `@heddleagent/postgres/heartbeat` | Claim-fenced task execution, lease recovery, checkpoints, history, and atomic operator controls over an injected Drizzle database |
 | Lower-level runtime assembly | `@heddleagent/runtime/advanced` | Model adapters, individual tools, trace, memory, heartbeat, and core runtime services |
@@ -389,8 +389,8 @@ Heddle is designed to make assumptions and limitations visible:
 - `@heddleagent/run-client` validates the run protocol but does not own product
   messages, UI state, authentication, or result rendering;
 - `@heddleagent/execution-host-client` helps a backend invoke a separately deployed
-  Execution Host without importing Heddle, AWS, or product data
-  adapters; optional Node helpers own generic HTTP/key mechanics, while the
+  Execution Host without importing the Heddle runtime or implementing AWS and
+  protocol mechanics itself; optional Node helpers own generic HTTP/key mechanics, while the
   adopter still owns identity, policy, production key operations, tools, and
   results; canonical OpenAPI/JSON Schema/golden fixtures and a clean-room
   Python proof keep this boundary language-neutral;

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -35,7 +35,7 @@ conversation 與 run 基礎之上。
 | Heddle coding agent | 使用建立在相同 runtime 上的 CLI 與 browser control plane | `@heddleagent/cli`（`heddle` command） |
 
 獨立 Execution Host 的穩定套件是
-`@heddleagent/execution-host-client@6.1.0`。舊的
+`@heddleagent/execution-host-client@6.2.0`。舊的
 `@roackb2/heddle-adopter@5.13.0` coordinate 已 deprecated，只為既有使用者保留安裝能力。
 
 穩定的 coding-agent 套件是 `@heddleagent/cli@6.0.0`，安裝後提供
@@ -214,7 +214,7 @@ mechanics 的最低層即可：
 | 一般 Node HTTP/SSE | `@heddleagent/runtime/runs/http-sse` | Replay cursor parsing、SSE framing、backpressure 與 disconnect cleanup |
 | Remote browser 或 client | `@heddleagent/run-client` | Browser-safe protocol validation 與 transport-neutral run consumption |
 | 一般 browser REST/SSE | `@heddleagent/run-client/http-sse` | Authenticated fetch、incremental SSE parsing 與 transport validation |
-| Backend 呼叫獨立 Execution Host | `@heddleagent/execution-host-client` | Contract、authority/JWKS、hosted-turn orchestration、durable requested/accepted/terminal persistence、product-MCP verification、direct 與 AgentCore client、store conformance 與 TypeScript/Python fixture |
+| Backend 呼叫獨立 Execution Host | `@heddleagent/execution-host-client` | Contract、authority/JWKS、conversation 與 heartbeat orchestration、durable conversation persistence、product-MCP verification、direct 與 AgentCore client、store conformance 與 TypeScript/Python fixture |
 | 以 PostgreSQL 保存 Execution Host lifecycle | `@heddleagent/postgres/execution-host/conversations` | Atomic scope fencing、由 adopter 執行的 ordered migration、SQL constraint、expiry 與 real-PostgreSQL conformance |
 | PostgreSQL heartbeat worker | `@heddleagent/postgres/heartbeat` | Heartbeat task 的 claim fencing、lease recovery、checkpoint、history 與 atomic operator control；不是一般 product database adapter |
 | 更底層的 runtime 組裝 | `@heddleagent/runtime/advanced` | Model adapter、individual tool、trace、memory、heartbeat 與 core runtime service |

--- a/docs/guides/programmatic/component-model.md
+++ b/docs/guides/programmatic/component-model.md
@@ -105,7 +105,7 @@ adopter database credential.
 | `@heddleagent/runtime/runs` | That same Node process needs addressable runs, replay, cancel, or reconnect | This is an in-process run service, not the separate Execution Host |
 | `@heddleagent/run-client` | A browser or JavaScript client consumes hosted-run envelopes | It consumes execution; it does not run an agent |
 | `@heddleagent/postgres/heartbeat` | Heddle heartbeat tasks need PostgreSQL leases, checkpoints, and history | It is one explicit adapter subpath, not a general product DB or conversation-history adapter |
-| `@heddleagent/execution-host-client` | A product invokes a separate compatible Execution Host | Authority, transport, turn orchestration, durable lifecycle semantics, Node helpers, and cross-language conformance |
+| `@heddleagent/execution-host-client` | A product or Heddle coordinator invokes a separate compatible Execution Host | Authority, conversation and heartbeat transports, turn orchestration, durable conversation lifecycle semantics, Node helpers, and cross-language conformance |
 | `@heddleagent/postgres/execution-host/conversations` | That product stores the generic lifecycle in PostgreSQL | Official atomic store and ordered migrations; no product history/query policy or pool ownership |
 | v1 OpenAPI, JSON Schema, and fixtures | The adopter backend is Python, Go, Java, or another stack | Implement the network and optional durable-lifecycle profiles; never port Heddle's agent loop |
 
@@ -122,7 +122,7 @@ SDK and not a promise to mirror every TypeScript convenience.
 | --- | --- | --- |
 | `@heddleagent/runtime` and `/runs` | Public | TypeScript/Node SDK and runtime surfaces for adopter-owned processes |
 | `@heddleagent/run-client` | Public | Browser-safe run protocol and optional HTTP/SSE client |
-| `@heddleagent/execution-host-client` | Public | The canonical product-backend integration kit, including durable lifecycle semantics, store conformance, and shared TypeScript/Python fixtures |
+| `@heddleagent/execution-host-client` | Public | The canonical backend integration kit, including conversation and heartbeat workflows, durable conversation lifecycle semantics, store conformance, and shared TypeScript/Python fixtures |
 | `@heddleagent/postgres/execution-host/conversations` | Public | Official PostgreSQL lifecycle adapter over an adopter-managed database and migration process |
 | Compatible Heddle Execution Host | Private research | A proving ground for isolated hosted execution and deployment evidence; it is not distributed or offered as a service |
 | AWS AgentCore deployment | Private research target | One way to test managed session isolation and lifecycle behavior, not a requirement of the public contract |

--- a/docs/guides/programmatic/execution-host-adopters.md
+++ b/docs/guides/programmatic/execution-host-adopters.md
@@ -10,7 +10,7 @@ The package is currently an experimental public contract and local proving
 surface. Heddle does not distribute the compatible Execution Host or offer a
 hosted service today.
 
-The stable coordinate is `@heddleagent/execution-host-client@6.1.0`. The
+The stable coordinate is `@heddleagent/execution-host-client@6.2.0`. The
 former `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 installable only for existing consumers. It does not include the durable
 lifecycle described below.
@@ -75,14 +75,17 @@ Its subpaths separate responsibility:
 - `/conversation` composes assertion/capability issuance, model credentials,
   fixed tool policy, one `ExecutionHost` turn, and the optional durable
   lifecycle over an adopter-implemented store;
+- `/heartbeat` connects Heddle's provider-neutral heartbeat scheduler to one
+  remotely executed agent cycle while keeping durable task authority in the
+  coordinator;
 - `/mcp` independently verifies product-MCP capabilities against a fixed
   deployment and supported-tool set;
 - `/mcp/node` owns a stateless official-SDK Streamable HTTP lifecycle around
   an adopter-defined product toolset;
-- `/http-sse` provides the provider-neutral `ExecutionHost` port and strict
-  direct-development transport;
-- `/agentcore` provides the official AWS SDK/SigV4 implementation of that port
-  for an adopter-provisioned AgentCore Runtime;
+- `/http-sse` provides provider-neutral conversation and heartbeat ports plus
+  the strict direct-development transport;
+- `/agentcore` provides the official AWS SDK/SigV4 implementation of both
+  ports for an adopter-provisioned AgentCore Runtime;
 - `/testing` provides a Node-only loopback v1 fixture for local product/MCP
   integration tests without a model or AWS, plus real-store lifecycle
   conformance.
@@ -161,6 +164,22 @@ an ambiguous streaming invocation. The adopter supplies its AWS region,
 Runtime ARN, optional qualifier, credential environment, IAM policy, and
 Runtime deployment.
 
+## Autonomous heartbeat composition
+
+The `heartbeat-task` workflow is intentionally narrower than a general control
+plane. One long-running coordinator owns the heartbeat PostgreSQL store,
+scheduler, claims, fencing, checkpoints, settlement, recovery, and shutdown.
+It supplies `HostedHeartbeatAgentExecutionTransport` to the runtime scheduler.
+The transport resolves an already-authorized product scope, Runtime session,
+and deadline, then `HostedHeartbeatTaskService` owns assertion issuance, model
+credentials, optional product MCP, AgentCore/direct invocation, ordered
+activity, cancellation, and terminal classification.
+
+Only the nested agent cycle runs in the Execution Host. The Runtime receives
+neither the Heddle database credential nor product database access. Omitting
+the transport preserves the existing local heartbeat runner, so embedded and
+hosted deployments use the same scheduler/task semantics.
+
 ## Progressive Node adoption
 
 Node adopters can start with `NodeExecutionAdopterHttpService`. It handles the
@@ -213,8 +232,9 @@ Execution Host integration test for those properties.
 TypeScript is the first reference implementation, not a requirement for
 adopters. Python, Go, Java, or other backends can implement the same compact
 claim, wire, and optional durable-lifecycle semantics without porting Heddle.
-Canonical OpenAPI 3.1.1, JSON Schema Draft 2020-12, golden event/authority/
-lifecycle fixtures, TypeScript conformance, and one independent Python
+Canonical OpenAPI 3.1.1, JSON Schema Draft 2020-12, golden conversation,
+heartbeat, authority, and lifecycle fixtures, TypeScript conformance, and one
+independent Python
 implementation now form the executable reference.
 
 This is also the deliberate stop line. More languages, generated clients,
@@ -224,10 +244,11 @@ work.
 
 ## Current limits
 
-- v1 supports `conversation-turn`; autonomous/heartbeat workflow contracts are
-  not generalized yet;
+- v1 supports explicit `conversation-turn` and `heartbeat-task` profiles; it is
+  not a general workflow protocol;
 - MCP capability refresh and durable early revocation are not implemented;
-- managed AgentCore transport and isolation evidence live outside this package;
+- the AgentCore transport is public, while Runtime deployment and managed
+  isolation evidence remain adopter/private-host responsibilities;
 - the direct stream has no reconnect/result-lookup protocol;
 - adopters remain responsible for choosing unique invocation IDs, key rotation,
   implementing the lifecycle store, data retention, and idempotent product

--- a/docs/project-posture.md
+++ b/docs/project-posture.md
@@ -79,9 +79,10 @@ At the distribution boundary:
   run lifecycle and remote-consumption mechanics, not a managed service;
 - `@heddleagent/execution-host-client` defines the public, language-neutral
   boundary for a backend invoking a separate compatible Execution Host. It
-  owns authority, wire, direct and AgentCore transports, base turn, MCP, Node,
-  testing, and the reusable durable-turn lifecycle over an adopter-implemented
-  atomic store, with shared TypeScript/Python lifecycle fixtures. The former
+  owns authority, wire, direct and AgentCore transports, explicit conversation
+  and heartbeat workflows, MCP, Node, testing, and the reusable durable-turn
+  lifecycle over an adopter-implemented atomic store, with shared
+  TypeScript/Python fixtures. The former
   `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
   installable only for existing consumers;
 - `@heddleagent/postgres` is the official PostgreSQL adapter family. Its

--- a/docs/releases/execution-host-client-v6.2.0.md
+++ b/docs/releases/execution-host-client-v6.2.0.md
@@ -1,0 +1,25 @@
+# Execution Host Client v6.2.0
+
+`@heddleagent/execution-host-client@6.2.0` adds an explicit
+`heartbeat-task` workflow so a Heddle coordinator can delegate one agent cycle
+to a compatible Execution Host without sharing its durable database.
+
+## What changed
+
+- add `@heddleagent/execution-host-client/heartbeat` with reusable authority,
+  model-credential, optional MCP, cancellation, and result orchestration;
+- extend the direct HTTP/SSE and AgentCore transports with a strict heartbeat
+  port using the same one-attempt, clean-EOF protocol rules as conversations;
+- add the heartbeat request and stream profiles to the v1 OpenAPI, JSON Schema,
+  golden fixtures, and clean-room Python conformance reference; and
+- keep product scope/Runtime-session resolution as the small adopter callback
+  while Heddle owns the security-sensitive hosted mechanics.
+
+The package does not deploy an Execution Host, allocate AgentCore sessions,
+store heartbeat tasks, or receive PostgreSQL credentials. The coordinator owns
+durable scheduling and settlement; the isolated Runtime owns only execution.
+
+## Publication
+
+Publish manually from the reviewed release commit. This repository does not
+automatically publish packages from `main`.

--- a/docs/releases/runtime-v6.2.0.md
+++ b/docs/releases/runtime-v6.2.0.md
@@ -1,0 +1,25 @@
+# `@heddleagent/runtime` 6.2.0
+
+This release adds an optional provider-neutral execution port for one heartbeat
+agent cycle. A long-running scheduler can keep durable task authority, claims,
+checkpoints, settlement, history, and recovery in its own process while a
+separate execution process runs only the nested agent loop.
+
+The existing local `HeartbeatRunnerAgent` remains the default when no transport
+is supplied. Results returned across the transport are runtime-validated before
+the scheduler persists a checkpoint or successful settlement.
+
+## What changed
+
+- add `HeartbeatAgentExecutionTransport` to the public heartbeat scheduler;
+- project only bounded task, checkpoint, run-context, and runtime preference
+  fields across the execution boundary;
+- keep credentials, tools, approval callbacks, filesystem paths, model
+  adapters, and PostgreSQL access inside their owning process;
+- expose remote agent activity through the existing scheduler event channel;
+  and
+- preserve claim fencing, cancellation, checkpoint, and settlement semantics
+  in the coordinator.
+
+This is an execution seam, not a queue, workflow engine, storage adapter, or
+hosted control plane.

--- a/packages/README.md
+++ b/packages/README.md
@@ -3,12 +3,13 @@
 Status: **five stable packages**
 
 This directory records the v6 package identities and responsibility boundaries.
-`@heddleagent/execution-host-client@6.1.0` contains its canonical
+`@heddleagent/execution-host-client@6.2.0` contains its canonical
 implementation as a stable package. `@heddleagent/postgres@6.1.0` ships the
 Execution Host lifecycle and heartbeat adapters. `@heddleagent/run-client@6.0.0`
 ships the existing browser-safe run client under its final coordinate.
-`@heddleagent/runtime@6.1.0` ships the existing embeddable SDK and the bridge
-used by the official CLI. `@heddleagent/cli@6.0.0` ships the existing `heddle`
+`@heddleagent/runtime@6.2.0` ships the existing embeddable SDK, the bridge
+used by the official CLI, and an optional remote heartbeat-execution seam.
+`@heddleagent/cli@6.0.0` ships the existing `heddle`
 command, TUI, daemon, and browser control plane. The former `@roackb2/*`
 coordinates are deprecated and remain installable only so existing applications
 keep running; new integrations should use the `@heddleagent/*` packages.
@@ -17,10 +18,10 @@ keep running; new integrations should use the `@heddleagent/*` packages.
 
 | Package | Responsibility | Migration status |
 | --- | --- | --- |
-| `@heddleagent/runtime` | Embeddable TypeScript/Node agent runtime and SDK | Stable `6.1.0`; `/runs` replaces the former `/hosted` package-path name and `/cli` is the package-to-package bridge for the official CLI |
+| `@heddleagent/runtime` | Embeddable TypeScript/Node agent runtime and SDK | Stable `6.2.0`; `/runs` replaces the former `/hosted` package-path name, `/cli` is the official CLI bridge, and heartbeat execution may be delegated through a provider-neutral port |
 | `@heddleagent/cli` | Installable Heddle coding-agent product and `heddle` executable | Existing CLI, TUI, daemon, and browser control plane activated at stable `6.0.0` |
 | `@heddleagent/run-client` | Browser-safe JavaScript run protocol consumer | Existing implementation activated at stable `6.0.0` |
-| `@heddleagent/execution-host-client` | Product-backend contracts and direct/AgentCore clients for invoking a separate compatible Execution Host | Stable `6.1.0`; official AgentCore transport at `/agentcore` |
+| `@heddleagent/execution-host-client` | Backend contracts and direct/AgentCore clients for invoking a separate compatible Execution Host | Stable `6.2.0`; explicit conversation and heartbeat workflows with hosted heartbeat composition at `/heartbeat` |
 | `@heddleagent/postgres` | Official PostgreSQL implementations for supported Heddle-owned durable ports | Stable `6.1.0`; Execution Host conversation lifecycle and heartbeat task authority are explicit subpaths |
 
 The in-process run service is exposed from

--- a/packages/execution-host-client/README.md
+++ b/packages/execution-host-client/README.md
@@ -5,7 +5,7 @@ products that invoke a separately deployed Heddle Execution Host. It lets an
 adopter keep its own language stack, authentication, database, product policy,
 MCP tools, and UI while reusing the security-sensitive v1 contract machinery.
 
-> **Current availability:** stable version `6.1.0`. The former
+> **Current availability:** stable version `6.2.0`. The former
 > `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 > installable only for existing consumers. Heddle does not currently distribute
 > the compatible Execution Host implementation or offer a hosted service. The
@@ -30,10 +30,11 @@ modular AWS SDK for its AgentCore transport and the official MCP SDK, plus
 | `@heddleagent/execution-host-client/contracts` | Runtime-validated v1 request, stream, identity, capability, and header contracts |
 | `@heddleagent/execution-host-client/authority` | ES256 execution assertion and optional MCP capability issuance plus public JWKS projection |
 | `@heddleagent/execution-host-client/conversation` | Turn orchestration across authority, model credentials, optional MCP policy, an `ExecutionHost`, and an optional adopter-implemented durable lifecycle store |
+| `@heddleagent/execution-host-client/heartbeat` | Remote heartbeat orchestration that keeps durable task authority in a coordinator while a compatible Execution Host runs the agent cycle |
 | `@heddleagent/execution-host-client/mcp` | Independent capability verification at the adopter's MCP edge |
 | `@heddleagent/execution-host-client/mcp/node` | Stateless official-SDK Streamable HTTP lifecycle around adopter-defined toolsets |
-| `@heddleagent/execution-host-client/http-sse` | Transport-neutral `ExecutionHost` port and strict direct-development HTTP/SSE client |
-| `@heddleagent/execution-host-client/agentcore` | Official AWS AgentCore/SigV4 implementation of the same `ExecutionHost` port |
+| `@heddleagent/execution-host-client/http-sse` | Transport-neutral conversation and heartbeat ports plus the strict direct-development HTTP/SSE client |
+| `@heddleagent/execution-host-client/agentcore` | Official AWS AgentCore/SigV4 implementation of the same conversation and heartbeat ports |
 | `@heddleagent/execution-host-client/testing` | Node-only loopback v1 fixture plus durable-turn store conformance for real adapters |
 | `@heddleagent/execution-host-client/node` | Optional Node JWKS/conversation HTTP edge plus safe local signing-key helpers |
 
@@ -277,6 +278,44 @@ for await (const event of host.streamConversationTurn({
 The client refuses redirects, bounds parser and error bodies, validates ordered
 SSE identity, streams accepted/activity events incrementally, and withholds the
 terminal event until clean EOF. It never retries an ambiguous invocation.
+
+## Delegate heartbeat agent cycles
+
+For autonomous work, keep the durable task store and scheduler in one
+long-running coordinator. Inject the hosted transport only at the point where
+the scheduler would otherwise run the local heartbeat agent:
+
+```ts
+import { HeartbeatSchedulerService } from '@heddleagent/runtime/advanced'
+import {
+  HostedHeartbeatAgentExecutionTransport,
+  HostedHeartbeatTaskService,
+} from '@heddleagent/execution-host-client/heartbeat'
+
+const hostedHeartbeat = new HostedHeartbeatTaskService({
+  authority,
+  executionHost: agentCoreExecutionHost,
+  modelCredentials,
+  mcp: { allowedTools: ['read_workspace_snapshot'] },
+})
+const agentExecutionTransport = new HostedHeartbeatAgentExecutionTransport({
+  runner: hostedHeartbeat,
+  resolveInvocationContext: ({ taskId, executionId, signal }) => (
+    resolveAuthorizedHeartbeatInvocation({ taskId, executionId, signal })
+  ),
+})
+
+const scheduler = HeartbeatSchedulerService.start({
+  store: heddleHeartbeatStore,
+  agentExecutionTransport,
+})
+```
+
+The coordinator still owns task lookup, claims, checkpoint loading, cancellation,
+claim-fenced settlement, history, and recovery. The Runtime receives a bounded
+task/checkpoint request plus invocation-scoped authority and model credentials;
+it receives no Heddle database credential. Omitting `agentExecutionTransport`
+preserves the existing in-process runner.
 
 ## Verify an adopter integration locally
 

--- a/packages/execution-host-client/conformance/reference-adopters/python-v1/src/heddle_adopter_reference/authority.py
+++ b/packages/execution-host-client/conformance/reference-adopters/python-v1/src/heddle_adopter_reference/authority.py
@@ -19,6 +19,7 @@ from .contracts import (
     EXECUTION_ASSERTION_TYPE,
     EXECUTION_CONTRACT_VERSION,
     MCP_CAPABILITY_TYPE,
+    SUPPORTED_EXECUTION_WORKFLOWS,
     ExecutionScope,
     validate_allowed_tools,
     validate_mcp_server_id,
@@ -77,7 +78,7 @@ class ExecutionAuthorityInput:
     def __post_init__(self) -> None:
         validate_runtime_session_id(self.runtime_session_id)
         validate_opaque_id(self.invocation_id)
-        if self.workflow != CONVERSATION_TURN_WORKFLOW:
+        if self.workflow not in SUPPORTED_EXECUTION_WORKFLOWS:
             raise ValueError("Unsupported execution workflow.")
         if self.allowed_tools is not None:
             object.__setattr__(self, "allowed_tools", validate_allowed_tools(self.allowed_tools))

--- a/packages/execution-host-client/conformance/reference-adopters/python-v1/src/heddle_adopter_reference/contracts.py
+++ b/packages/execution-host-client/conformance/reference-adopters/python-v1/src/heddle_adopter_reference/contracts.py
@@ -14,6 +14,8 @@ from jsonschema import Draft202012Validator, FormatChecker
 
 EXECUTION_CONTRACT_VERSION = 1
 CONVERSATION_TURN_WORKFLOW = "conversation-turn"
+HEARTBEAT_TASK_WORKFLOW = "heartbeat-task"
+SUPPORTED_EXECUTION_WORKFLOWS = frozenset({CONVERSATION_TURN_WORKFLOW, HEARTBEAT_TASK_WORKFLOW})
 EXECUTION_ASSERTION_TYPE = "heddle-execution+jwt"
 MCP_CAPABILITY_TYPE = "heddle-mcp-capability+jwt"
 

--- a/packages/execution-host-client/conformance/reference-adopters/python-v1/src/heddle_adopter_reference/mcp.py
+++ b/packages/execution-host-client/conformance/reference-adopters/python-v1/src/heddle_adopter_reference/mcp.py
@@ -12,9 +12,9 @@ import jwt
 from mcp.server.auth.provider import AccessToken
 
 from .contracts import (
-    CONVERSATION_TURN_WORKFLOW,
     EXECUTION_CONTRACT_VERSION,
     MCP_CAPABILITY_TYPE,
+    SUPPORTED_EXECUTION_WORKFLOWS,
     validate_allowed_tools,
     validate_mcp_server_id,
     validate_opaque_id,
@@ -199,7 +199,7 @@ class JwtMcpCapabilityVerifier:
             contract_version == EXECUTION_CONTRACT_VERSION
             and adopter_id == self._config.trusted_adopter_id
             and server_id == self._config.server_id
-            and workflow == CONVERSATION_TURN_WORKFLOW
+            and workflow in SUPPORTED_EXECUTION_WORKFLOWS
             and capability_id != invocation_id
             and all(tool in self._supported_tools for tool in allowed_tools)
         )

--- a/packages/execution-host-client/conformance/reference-adopters/python-v1/tests/test_contracts.py
+++ b/packages/execution-host-client/conformance/reference-adopters/python-v1/tests/test_contracts.py
@@ -21,6 +21,15 @@ def test_checked_in_schema_accepts_only_the_authority_free_request() -> None:
         contract.validate("ConversationTurnRequest", invalid)
 
 
+def test_checked_in_schema_accepts_the_heartbeat_request() -> None:
+    contract = ContractBundle.load(SPEC_ROOT / "schema-bundle.json")
+    request = json.loads(
+        (FIXTURE_ROOT / "valid-heartbeat-request.json").read_text(encoding="utf-8")
+    )
+
+    contract.validate("HeartbeatTaskRequest", request)
+
+
 def test_schema_bundle_validates_stream_and_authority_examples(
     authority_fixture: dict[str, object],
 ) -> None:

--- a/packages/execution-host-client/package.json
+++ b/packages/execution-host-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/execution-host-client",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Backend contracts, execution authority, lifecycle services, and clients for compatible Heddle Execution Hosts",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",
@@ -41,6 +41,10 @@
     "./conversation": {
       "types": "./dist/conversation/index.d.ts",
       "import": "./dist/conversation/index.js"
+    },
+    "./heartbeat": {
+      "types": "./dist/heartbeat/index.d.ts",
+      "import": "./dist/heartbeat/index.js"
     },
     "./mcp": {
       "types": "./dist/mcp/index.d.ts",

--- a/packages/execution-host-client/scripts/contract-artifacts.ts
+++ b/packages/execution-host-client/scripts/contract-artifacts.ts
@@ -8,8 +8,11 @@ import {
   EXECUTION_HOST_LOCAL_TOKEN_HEADER,
   ExecutionAssertionClaimsSchema,
   ExecutionHostConversationTurnRequestSchema,
+  ExecutionHostHeartbeatStreamEventSchema,
+  ExecutionHostHeartbeatTaskRequestSchema,
   ExecutionHostStreamEventSchema,
   ExecutionScopeSchema,
+  HEARTBEAT_TASK_WORKFLOW,
   MCP_CAPABILITY_HEADER,
   MCP_CAPABILITY_TYPE,
   MODEL_API_KEY_HEADER,
@@ -47,10 +50,14 @@ export function createContractArtifacts(): ReadonlyMap<string, string> {
       fixtures.durableConversationLifecycle,
     )],
     ['fixtures/valid-request.json', serialize(fixtures.validRequest)],
+    ['fixtures/valid-heartbeat-request.json', serialize(
+      fixtures.validHeartbeatRequest,
+    )],
     ['fixtures/invalid-request-extra-field.json', serialize(
       fixtures.invalidRequestExtraField,
     )],
     ['fixtures/valid-result.sse', fixtures.validStream],
+    ['fixtures/valid-heartbeat-result.sse', fixtures.validHeartbeatStream],
     ['fixtures/cancelled.sse', fixtures.cancelledStream],
     ['fixtures/ambiguous-eof.sse', fixtures.ambiguousEofStream],
     ['fixtures/invalid-sequence-gap.sse', fixtures.invalidSequenceGapStream],
@@ -76,7 +83,7 @@ export function createSchemaBundle(): JsonObject {
 }
 
 export function createOpenApi(validStream: string): JsonObject {
-  const schemas = createExecutionSchemaDefinitions();
+  const schemas = createExecutionSchemaDefinitions('#/components/schemas');
   annotateSemantics(schemas);
   return {
     openapi: '3.1.1',
@@ -95,10 +102,11 @@ export function createOpenApi(validStream: string): JsonObject {
     paths: {
       '/invocations': {
         post: {
-          operationId: 'streamConversationTurn',
-          summary: 'Run one hosted conversation turn',
+          operationId: 'streamExecutionHostInvocation',
+          summary: 'Run one supported Execution Host workflow',
           description: [
-            'Starts one conversation turn and holds one SSE response open until',
+            'Starts one conversation turn or heartbeat task and holds one SSE',
+            'response open until',
             'a terminal event or an ambiguous interruption. A clean HTTP EOF is',
             'required before a terminal frame may be committed as final.',
           ].join(' '),
@@ -107,7 +115,13 @@ export function createOpenApi(validStream: string): JsonObject {
             required: true,
             content: {
               'application/json': {
-                schema: { $ref: '#/components/schemas/ConversationTurnRequest' },
+                schema: {
+                  oneOf: [
+                    { $ref: '#/components/schemas/ConversationTurnRequest' },
+                    { $ref: '#/components/schemas/HeartbeatTaskRequest' },
+                  ],
+                  discriminator: { propertyName: 'kind' },
+                },
               },
             },
           },
@@ -151,7 +165,7 @@ export function createOpenApi(validStream: string): JsonObject {
 
 function createSchemaDefinitions(): JsonObject {
   const definitions: JsonObject = {
-    ...createExecutionSchemaDefinitions(),
+    ...createExecutionSchemaDefinitions('#/$defs'),
     HostedConversationPersistenceScope: jsonSchema(
       HostedConversationPersistenceScopeSchema,
     ),
@@ -175,16 +189,48 @@ function createSchemaDefinitions(): JsonObject {
   return definitions;
 }
 
-function createExecutionSchemaDefinitions(): JsonObject {
+function createExecutionSchemaDefinitions(referenceRoot: string): JsonObject {
   return {
-    ExecutionScope: jsonSchema(ExecutionScopeSchema),
-    ConversationTurnRequest: jsonSchema(
-      ExecutionHostConversationTurnRequestSchema,
+    ExecutionScope: componentSchema(
+      'ExecutionScope',
+      ExecutionScopeSchema,
+      referenceRoot,
     ),
-    RuntimePublicResult: jsonSchema(RuntimePublicResultSchema),
-    StreamEvent: jsonSchema(ExecutionHostStreamEventSchema),
-    ExecutionAssertionClaims: jsonSchema(ExecutionAssertionClaimsSchema),
-    McpCapabilityClaims: jsonSchema(McpCapabilityClaimsSchema),
+    ConversationTurnRequest: componentSchema(
+      'ConversationTurnRequest',
+      ExecutionHostConversationTurnRequestSchema,
+      referenceRoot,
+    ),
+    HeartbeatTaskRequest: componentSchema(
+      'HeartbeatTaskRequest',
+      ExecutionHostHeartbeatTaskRequestSchema,
+      referenceRoot,
+    ),
+    RuntimePublicResult: componentSchema(
+      'RuntimePublicResult',
+      RuntimePublicResultSchema,
+      referenceRoot,
+    ),
+    StreamEvent: componentSchema(
+      'StreamEvent',
+      ExecutionHostStreamEventSchema,
+      referenceRoot,
+    ),
+    HeartbeatStreamEvent: componentSchema(
+      'HeartbeatStreamEvent',
+      ExecutionHostHeartbeatStreamEventSchema,
+      referenceRoot,
+    ),
+    ExecutionAssertionClaims: componentSchema(
+      'ExecutionAssertionClaims',
+      ExecutionAssertionClaimsSchema,
+      referenceRoot,
+    ),
+    McpCapabilityClaims: componentSchema(
+      'McpCapabilityClaims',
+      McpCapabilityClaimsSchema,
+      referenceRoot,
+    ),
     ExecutionAssertionProtectedHeader: protectedHeaderSchema(
       EXECUTION_ASSERTION_TYPE,
     ),
@@ -309,6 +355,42 @@ function jsonSchema(schema: z.ZodType): JsonObject {
   return component;
 }
 
+function componentSchema(
+  name: string,
+  schema: z.ZodType,
+  referenceRoot: string,
+): JsonObject {
+  return rewriteNestedSchemaReferences(
+    jsonSchema(schema),
+    `${referenceRoot}/${name}/$defs`,
+  ) as JsonObject;
+}
+
+function rewriteNestedSchemaReferences(
+  value: unknown,
+  nestedDefinitionsPath: string,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      rewriteNestedSchemaReferences(item, nestedDefinitionsPath),
+    );
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      key,
+      key === '$ref' &&
+      typeof item === 'string' &&
+      item.startsWith('#/$defs/')
+        ? `${nestedDefinitionsPath}/${item.slice('#/$defs/'.length)}`
+        : rewriteNestedSchemaReferences(item, nestedDefinitionsPath),
+    ]),
+  );
+}
+
 function annotateSemantics(definitions: JsonObject): void {
   for (const definitionName of [
     'ExecutionAssertionClaims',
@@ -319,6 +401,9 @@ function annotateSemantics(definitions: JsonObject): void {
     ] = true;
   }
   property(definitions.ConversationTurnRequest, 'prompt')[
+    'x-heddle-trimmed'
+  ] = true;
+  property(definitions.HeartbeatTaskRequest, 'task')[
     'x-heddle-trimmed'
   ] = true;
   const allowedTools = property(
@@ -346,6 +431,27 @@ function createFixtures() {
     ...validRequest,
     tenantId: 'caller-must-not-select-authority-in-body',
   };
+  const validHeartbeatRequest = {
+    schemaVersion: EXECUTION_CONTRACT_VERSION,
+    kind: HEARTBEAT_TASK_WORKFLOW,
+    invocationId: 'heartbeat-execution-001',
+    taskId: 'heartbeat-task-001',
+    task: 'Review the workspace for actionable changes.',
+    checkpoint: {
+      version: 1,
+      createdAt: FIXTURE_TIMESTAMP,
+      state: { runId: 'prior-run-001' },
+    },
+    runContext: {
+      currentDateTime: FIXTURE_TIMESTAMP,
+      intervalMs: 60_000,
+      continuationMode: 'operator',
+      previousRunId: 'prior-run-001',
+    },
+    model: 'openai:gpt-5.6',
+    maxSteps: 24,
+    deadlineAt: '2026-08-10T04:10:00.000Z',
+  };
   const accepted = streamEvent(0, { kind: 'accepted' });
   const activity = streamEvent(1, {
     kind: 'activity',
@@ -358,6 +464,33 @@ function createFixtures() {
       kind: 'result',
       result: { outcome: 'done', summary: 'Complete.' },
     }),
+  ]);
+  const heartbeatAccepted = streamEvent(0, {
+    kind: 'accepted',
+  }, 'heartbeat-execution-001', 'heartbeat-run-001');
+  const validHeartbeatStream = toSse([
+    heartbeatAccepted,
+    streamEvent(1, {
+      kind: 'activity',
+      activity: { type: 'heartbeat.decision', decision: 'continue' },
+    }, 'heartbeat-execution-001', 'heartbeat-run-001'),
+    streamEvent(2, {
+      kind: 'result',
+      result: {
+        decision: 'continue',
+        summary: 'No operator action required.',
+        checkpoint: {
+          version: 1,
+          createdAt: FIXTURE_TIMESTAMP,
+          state: { runId: 'heartbeat-run-001' },
+        },
+        state: {
+          runId: 'heartbeat-run-001',
+          outcome: 'done',
+          summary: 'No operator action required.',
+        },
+      },
+    }, 'heartbeat-execution-001', 'heartbeat-run-001'),
   ]);
   const cancelledStream = toSse([
     accepted,
@@ -375,12 +508,24 @@ function createFixtures() {
     cases: [
       fixtureCase('valid-request', 'valid-request.json', 'json-schema', 'valid'),
       fixtureCase(
+        'valid-heartbeat-request',
+        'valid-heartbeat-request.json',
+        'json-schema',
+        'valid',
+      ),
+      fixtureCase(
         'request-authority-in-body',
         'invalid-request-extra-field.json',
         'json-schema',
         'invalid',
       ),
       fixtureCase('valid-result', 'valid-result.sse', 'sse', 'complete'),
+      fixtureCase(
+        'valid-heartbeat-result',
+        'valid-heartbeat-result.sse',
+        'sse',
+        'complete',
+      ),
       fixtureCase('cancelled', 'cancelled.sse', 'sse', 'cancelled'),
       fixtureCase('ambiguous-eof', 'ambiguous-eof.sse', 'sse', 'interrupted'),
       fixtureCase(
@@ -403,8 +548,10 @@ function createFixtures() {
     authority,
     durableConversationLifecycle,
     validRequest,
+    validHeartbeatRequest,
     invalidRequestExtraField,
     validStream,
+    validHeartbeatStream,
     cancelledStream,
     ambiguousEofStream,
     invalidSequenceGapStream,
@@ -775,11 +922,16 @@ function createAuthorityFixture(): JsonObject {
   };
 }
 
-function streamEvent(sequence: number, body: JsonObject): JsonObject {
+function streamEvent(
+  sequence: number,
+  body: JsonObject,
+  invocationId = 'invocation-001',
+  runId = 'run-001',
+): JsonObject {
   return {
     schemaVersion: EXECUTION_CONTRACT_VERSION,
-    invocationId: 'invocation-001',
-    runId: 'run-001',
+    invocationId,
+    runId,
     sequence,
     timestamp: FIXTURE_TIMESTAMP,
     ...body,

--- a/packages/execution-host-client/spec/v1/README.md
+++ b/packages/execution-host-client/spec/v1/README.md
@@ -13,7 +13,9 @@ JavaScript or TypeScript.
   safe API errors, and the optional durable conversation-lifecycle profile.
 - `fixtures/` contains executable examples for valid and invalid requests,
   complete and interrupted streams, cancellation, sequence validation, and
-  execution/MCP authority. `durable-conversation-lifecycle.json` supplies the
+  execution/MCP authority. It includes distinct valid request/result examples
+  for `conversation-turn` and `heartbeat-task`.
+  `durable-conversation-lifecycle.json` supplies the
   shared TypeScript/Python terminal and store-transition vectors.
 - `durable-hosted-conversation-lifecycle.md` defines persistence ordering,
   transition fencing, safe projection, interruption, and reconciliation for a
@@ -63,6 +65,11 @@ also enforce these relationships:
    before each operation.
 10. `allowedTools` is unique, contains at most 16 collision-free names, and the
     aggregate tool-name length is at most 512 characters.
+11. The request `kind`, execution assertion `workflow`, optional MCP capability
+    `workflow`, and selected event schema all name the same workflow.
+12. A heartbeat terminal `result` remains JSON on the wire; the Heddle
+    scheduler validates the complete `AgentHeartbeatResult` before durable
+    checkpoint or success settlement.
 
 The optional durable profile adds control-plane semantics around this stream.
 It does not add a database endpoint to the Execution Host or make product
@@ -89,9 +96,12 @@ not adopter-domain contracts.
 
 ## Compatibility and stop line
 
-Version 1 supports `conversation-turn`. New workflows, transports, or identity
-forms require an explicit contract version decision; they are not silently
-added to this surface.
+Version 1 supports the explicit `conversation-turn` and `heartbeat-task`
+profiles. The heartbeat profile is additive: existing conversation requests and
+events are unchanged, while implementations opt into the new discriminator and
+schemas. Any further workflow, transport, incompatible field, or identity form
+requires another explicit contract-version decision; it is not silently added
+to this surface.
 
 The repository deliberately stops after this schema, fixture set, the
 TypeScript implementation, and one Python clean-room reference pass. It does

--- a/packages/execution-host-client/spec/v1/fixtures/manifest.json
+++ b/packages/execution-host-client/spec/v1/fixtures/manifest.json
@@ -8,6 +8,12 @@
       "expected": "valid"
     },
     {
+      "id": "valid-heartbeat-request",
+      "file": "valid-heartbeat-request.json",
+      "kind": "json-schema",
+      "expected": "valid"
+    },
+    {
       "id": "request-authority-in-body",
       "file": "invalid-request-extra-field.json",
       "kind": "json-schema",
@@ -16,6 +22,12 @@
     {
       "id": "valid-result",
       "file": "valid-result.sse",
+      "kind": "sse",
+      "expected": "complete"
+    },
+    {
+      "id": "valid-heartbeat-result",
+      "file": "valid-heartbeat-result.sse",
       "kind": "sse",
       "expected": "complete"
     },

--- a/packages/execution-host-client/spec/v1/fixtures/valid-heartbeat-request.json
+++ b/packages/execution-host-client/spec/v1/fixtures/valid-heartbeat-request.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "kind": "heartbeat-task",
+  "invocationId": "heartbeat-execution-001",
+  "taskId": "heartbeat-task-001",
+  "task": "Review the workspace for actionable changes.",
+  "checkpoint": {
+    "version": 1,
+    "createdAt": "2026-08-10T04:00:00.000Z",
+    "state": {
+      "runId": "prior-run-001"
+    }
+  },
+  "runContext": {
+    "currentDateTime": "2026-08-10T04:00:00.000Z",
+    "intervalMs": 60000,
+    "continuationMode": "operator",
+    "previousRunId": "prior-run-001"
+  },
+  "model": "openai:gpt-5.6",
+  "maxSteps": 24,
+  "deadlineAt": "2026-08-10T04:10:00.000Z"
+}

--- a/packages/execution-host-client/spec/v1/fixtures/valid-heartbeat-result.sse
+++ b/packages/execution-host-client/spec/v1/fixtures/valid-heartbeat-result.sse
@@ -1,0 +1,13 @@
+id: 0
+event: accepted
+data: {"schemaVersion":1,"invocationId":"heartbeat-execution-001","runId":"heartbeat-run-001","sequence":0,"timestamp":"2026-08-10T04:00:00.000Z","kind":"accepted"}
+
+id: 1
+event: activity
+data: {"schemaVersion":1,"invocationId":"heartbeat-execution-001","runId":"heartbeat-run-001","sequence":1,"timestamp":"2026-08-10T04:00:00.000Z","kind":"activity","activity":{"type":"heartbeat.decision","decision":"continue"}}
+
+id: 2
+event: result
+data: {"schemaVersion":1,"invocationId":"heartbeat-execution-001","runId":"heartbeat-run-001","sequence":2,"timestamp":"2026-08-10T04:00:00.000Z","kind":"result","result":{"decision":"continue","summary":"No operator action required.","checkpoint":{"version":1,"createdAt":"2026-08-10T04:00:00.000Z","state":{"runId":"heartbeat-run-001"}},"state":{"runId":"heartbeat-run-001","outcome":"done","summary":"No operator action required."}}}
+
+: fixture-clean-eof

--- a/packages/execution-host-client/spec/v1/openapi.json
+++ b/packages/execution-host-client/spec/v1/openapi.json
@@ -10,9 +10,9 @@
   "paths": {
     "/invocations": {
       "post": {
-        "operationId": "streamConversationTurn",
-        "summary": "Run one hosted conversation turn",
-        "description": "Starts one conversation turn and holds one SSE response open until a terminal event or an ambiguous interruption. A clean HTTP EOF is required before a terminal frame may be committed as final.",
+        "operationId": "streamExecutionHostInvocation",
+        "summary": "Run one supported Execution Host workflow",
+        "description": "Starts one conversation turn or heartbeat task and holds one SSE response open until a terminal event or an ambiguous interruption. A clean HTTP EOF is required before a terminal frame may be committed as final.",
         "parameters": [
           {
             "name": "x-amzn-bedrock-agentcore-runtime-session-id",
@@ -77,7 +77,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ConversationTurnRequest"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ConversationTurnRequest"
+                  },
+                  {
+                    "$ref": "#/components/schemas/HeartbeatTaskRequest"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "kind"
+                }
               }
             }
           }
@@ -266,6 +276,170 @@
           "prompt"
         ],
         "additionalProperties": false
+      },
+      "HeartbeatTaskRequest": {
+        "type": "object",
+        "properties": {
+          "schemaVersion": {
+            "type": "number",
+            "const": 1
+          },
+          "kind": {
+            "type": "string",
+            "const": "heartbeat-task"
+          },
+          "invocationId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+          },
+          "taskId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+          },
+          "task": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200000,
+            "x-heddle-trimmed": true
+          },
+          "checkpoint": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/HeartbeatTaskRequest/$defs/__schema0"
+            }
+          },
+          "runContext": {
+            "type": "object",
+            "properties": {
+              "currentDateTime": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "intervalMs": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "continuationMode": {
+                "type": "string",
+                "enum": [
+                  "operator",
+                  "agent"
+                ]
+              },
+              "nextRunAt": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "previousRunAt": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "previousRunId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              }
+            },
+            "required": [
+              "currentDateTime",
+              "intervalMs"
+            ],
+            "additionalProperties": false
+          },
+          "model": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512
+          },
+          "reasoningEffort": {
+            "type": "string",
+            "enum": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "ultrahigh",
+              "max"
+            ]
+          },
+          "maxSteps": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 10000
+          },
+          "searchIgnoreDirs": {
+            "maxItems": 1000,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 1024
+            }
+          },
+          "systemContext": {
+            "type": "string",
+            "maxLength": 200000
+          },
+          "deadlineAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          }
+        },
+        "required": [
+          "schemaVersion",
+          "kind",
+          "invocationId",
+          "taskId",
+          "task",
+          "runContext"
+        ],
+        "additionalProperties": false,
+        "$defs": {
+          "__schema0": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/HeartbeatTaskRequest/$defs/__schema0"
+                }
+              },
+              {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/HeartbeatTaskRequest/$defs/__schema0"
+                }
+              }
+            ]
+          }
+        }
       },
       "RuntimePublicResult": {
         "type": "object",
@@ -617,6 +791,333 @@
           }
         ]
       },
+      "HeartbeatStreamEvent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "schemaVersion": {
+                "type": "number",
+                "const": 1
+              },
+              "invocationId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "runId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "sequence": {
+                "type": "number",
+                "const": 0
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "kind": {
+                "type": "string",
+                "const": "accepted"
+              }
+            },
+            "required": [
+              "schemaVersion",
+              "invocationId",
+              "runId",
+              "sequence",
+              "timestamp",
+              "kind"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "schemaVersion": {
+                "type": "number",
+                "const": 1
+              },
+              "invocationId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "runId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "sequence": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "kind": {
+                "type": "string",
+                "const": "activity"
+              },
+              "activity": {
+                "$ref": "#/components/schemas/HeartbeatStreamEvent/$defs/__schema0"
+              }
+            },
+            "required": [
+              "schemaVersion",
+              "invocationId",
+              "runId",
+              "sequence",
+              "timestamp",
+              "kind",
+              "activity"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "schemaVersion": {
+                "type": "number",
+                "const": 1
+              },
+              "invocationId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "runId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "sequence": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "kind": {
+                "type": "string",
+                "const": "result"
+              },
+              "result": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/HeartbeatStreamEvent/$defs/__schema1"
+                }
+              }
+            },
+            "required": [
+              "schemaVersion",
+              "invocationId",
+              "runId",
+              "sequence",
+              "timestamp",
+              "kind",
+              "result"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "schemaVersion": {
+                "type": "number",
+                "const": 1
+              },
+              "invocationId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "runId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "sequence": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "kind": {
+                "type": "string",
+                "const": "cancelled"
+              },
+              "reason": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schemaVersion",
+              "invocationId",
+              "runId",
+              "sequence",
+              "timestamp",
+              "kind",
+              "reason"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "schemaVersion": {
+                "type": "number",
+                "const": 1
+              },
+              "invocationId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "runId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+              },
+              "sequence": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "kind": {
+                "type": "string",
+                "const": "error"
+              },
+              "error": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "pattern": "^[a-z0-9_]+$"
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1600
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "schemaVersion",
+              "invocationId",
+              "runId",
+              "sequence",
+              "timestamp",
+              "kind",
+              "error"
+            ],
+            "additionalProperties": false
+          }
+        ],
+        "$defs": {
+          "__schema0": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/HeartbeatStreamEvent/$defs/__schema0"
+                }
+              },
+              {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/HeartbeatStreamEvent/$defs/__schema0"
+                }
+              }
+            ]
+          },
+          "__schema1": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/HeartbeatStreamEvent/$defs/__schema1"
+                }
+              },
+              {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/HeartbeatStreamEvent/$defs/__schema1"
+                }
+              }
+            ]
+          }
+        }
+      },
       "ExecutionAssertionClaims": {
         "type": "object",
         "properties": {
@@ -659,7 +1160,10 @@
           },
           "workflow": {
             "type": "string",
-            "const": "conversation-turn"
+            "enum": [
+              "conversation-turn",
+              "heartbeat-task"
+            ]
           },
           "sub": {
             "type": "string",
@@ -748,7 +1252,10 @@
           },
           "workflow": {
             "type": "string",
-            "const": "conversation-turn"
+            "enum": [
+              "conversation-turn",
+              "heartbeat-task"
+            ]
           },
           "serverId": {
             "type": "string",

--- a/packages/execution-host-client/spec/v1/schema-bundle.json
+++ b/packages/execution-host-client/spec/v1/schema-bundle.json
@@ -78,6 +78,170 @@
       ],
       "additionalProperties": false
     },
+    "HeartbeatTaskRequest": {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "number",
+          "const": 1
+        },
+        "kind": {
+          "type": "string",
+          "const": "heartbeat-task"
+        },
+        "invocationId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+        },
+        "taskId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+        },
+        "task": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200000,
+          "x-heddle-trimmed": true
+        },
+        "checkpoint": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/HeartbeatTaskRequest/$defs/__schema0"
+          }
+        },
+        "runContext": {
+          "type": "object",
+          "properties": {
+            "currentDateTime": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+            },
+            "intervalMs": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "continuationMode": {
+              "type": "string",
+              "enum": [
+                "operator",
+                "agent"
+              ]
+            },
+            "nextRunAt": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+            },
+            "previousRunAt": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+            },
+            "previousRunId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            }
+          },
+          "required": [
+            "currentDateTime",
+            "intervalMs"
+          ],
+          "additionalProperties": false
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "reasoningEffort": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "ultrahigh",
+            "max"
+          ]
+        },
+        "maxSteps": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 10000
+        },
+        "searchIgnoreDirs": {
+          "maxItems": 1000,
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          }
+        },
+        "systemContext": {
+          "type": "string",
+          "maxLength": 200000
+        },
+        "deadlineAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "kind",
+        "invocationId",
+        "taskId",
+        "task",
+        "runContext"
+      ],
+      "additionalProperties": false,
+      "$defs": {
+        "__schema0": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/HeartbeatTaskRequest/$defs/__schema0"
+              }
+            },
+            {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "$ref": "#/$defs/HeartbeatTaskRequest/$defs/__schema0"
+              }
+            }
+          ]
+        }
+      }
+    },
     "RuntimePublicResult": {
       "type": "object",
       "properties": {
@@ -428,6 +592,333 @@
         }
       ]
     },
+    "HeartbeatStreamEvent": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "schemaVersion": {
+              "type": "number",
+              "const": 1
+            },
+            "invocationId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "runId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "sequence": {
+              "type": "number",
+              "const": 0
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+            },
+            "kind": {
+              "type": "string",
+              "const": "accepted"
+            }
+          },
+          "required": [
+            "schemaVersion",
+            "invocationId",
+            "runId",
+            "sequence",
+            "timestamp",
+            "kind"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "schemaVersion": {
+              "type": "number",
+              "const": 1
+            },
+            "invocationId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "runId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "sequence": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+            },
+            "kind": {
+              "type": "string",
+              "const": "activity"
+            },
+            "activity": {
+              "$ref": "#/$defs/HeartbeatStreamEvent/$defs/__schema0"
+            }
+          },
+          "required": [
+            "schemaVersion",
+            "invocationId",
+            "runId",
+            "sequence",
+            "timestamp",
+            "kind",
+            "activity"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "schemaVersion": {
+              "type": "number",
+              "const": 1
+            },
+            "invocationId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "runId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "sequence": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+            },
+            "kind": {
+              "type": "string",
+              "const": "result"
+            },
+            "result": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "$ref": "#/$defs/HeartbeatStreamEvent/$defs/__schema1"
+              }
+            }
+          },
+          "required": [
+            "schemaVersion",
+            "invocationId",
+            "runId",
+            "sequence",
+            "timestamp",
+            "kind",
+            "result"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "schemaVersion": {
+              "type": "number",
+              "const": 1
+            },
+            "invocationId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "runId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "sequence": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+            },
+            "kind": {
+              "type": "string",
+              "const": "cancelled"
+            },
+            "reason": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "schemaVersion",
+            "invocationId",
+            "runId",
+            "sequence",
+            "timestamp",
+            "kind",
+            "reason"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "schemaVersion": {
+              "type": "number",
+              "const": 1
+            },
+            "invocationId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "runId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+            },
+            "sequence": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+            },
+            "kind": {
+              "type": "string",
+              "const": "error"
+            },
+            "error": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128,
+                  "pattern": "^[a-z0-9_]+$"
+                },
+                "message": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 1600
+                }
+              },
+              "required": [
+                "code",
+                "message"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "schemaVersion",
+            "invocationId",
+            "runId",
+            "sequence",
+            "timestamp",
+            "kind",
+            "error"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "$defs": {
+        "__schema0": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/HeartbeatStreamEvent/$defs/__schema0"
+              }
+            },
+            {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "$ref": "#/$defs/HeartbeatStreamEvent/$defs/__schema0"
+              }
+            }
+          ]
+        },
+        "__schema1": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/HeartbeatStreamEvent/$defs/__schema1"
+              }
+            },
+            {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "$ref": "#/$defs/HeartbeatStreamEvent/$defs/__schema1"
+              }
+            }
+          ]
+        }
+      }
+    },
     "ExecutionAssertionClaims": {
       "type": "object",
       "properties": {
@@ -470,7 +961,10 @@
         },
         "workflow": {
           "type": "string",
-          "const": "conversation-turn"
+          "enum": [
+            "conversation-turn",
+            "heartbeat-task"
+          ]
         },
         "sub": {
           "type": "string",
@@ -559,7 +1053,10 @@
         },
         "workflow": {
           "type": "string",
-          "const": "conversation-turn"
+          "enum": [
+            "conversation-turn",
+            "heartbeat-task"
+          ]
         },
         "serverId": {
           "type": "string",

--- a/packages/execution-host-client/src/__tests__/contract-artifacts.test.ts
+++ b/packages/execution-host-client/src/__tests__/contract-artifacts.test.ts
@@ -22,7 +22,7 @@ describe('versioned language-neutral contract artifacts', () => {
       paths: {
         '/invocations': {
           post: {
-            operationId: 'streamConversationTurn',
+            operationId: 'streamExecutionHostInvocation',
             responses: { 200: expect.any(Object) },
           },
         },
@@ -32,7 +32,9 @@ describe('versioned language-neutral contract artifacts', () => {
       $schema: 'https://json-schema.org/draft/2020-12/schema',
       $defs: {
         ConversationTurnRequest: expect.any(Object),
+        HeartbeatTaskRequest: expect.any(Object),
         StreamEvent: expect.any(Object),
+        HeartbeatStreamEvent: expect.any(Object),
         ExecutionAssertionClaims: expect.any(Object),
         McpCapabilityClaims: expect.any(Object),
       },

--- a/packages/execution-host-client/src/__tests__/golden-contract.test.ts
+++ b/packages/execution-host-client/src/__tests__/golden-contract.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 import { JoseExecutionAuthority } from '../authority/index.js';
 import {
   ExecutionHostConversationTurnRequestSchema,
+  ExecutionHostHeartbeatTaskRequestSchema,
   MCP_CAPABILITY_TYPE,
   type ExecutionAssertionClaims,
   type ExecutionHostStreamEvent,
@@ -46,6 +47,17 @@ describe('language-neutral golden fixtures', () => {
       .toBe(true);
     expect(ExecutionHostConversationTurnRequestSchema.safeParse(invalid).success)
       .toBe(false);
+  });
+
+  it('accepts the portable heartbeat request fixture', async () => {
+    const request = await readJson('valid-heartbeat-request.json');
+
+    expect(ExecutionHostHeartbeatTaskRequestSchema.safeParse(request).success)
+      .toBe(true);
+    expect(ExecutionHostHeartbeatTaskRequestSchema.safeParse({
+      ...request,
+      kind: 'conversation-turn',
+    }).success).toBe(false);
   });
 
   it.each([

--- a/packages/execution-host-client/src/__tests__/heartbeat.test.ts
+++ b/packages/execution-host-client/src/__tests__/heartbeat.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ExecutionAuthority } from '../authority/index.js';
+import {
+  EXECUTION_CONTRACT_VERSION,
+  HEARTBEAT_TASK_WORKFLOW,
+  type ExecutionHostHeartbeatStreamEvent,
+} from '../contracts/index.js';
+import {
+  HostedHeartbeatAgentExecutionTransport,
+  HostedHeartbeatTaskService,
+  type HostedHeartbeatTaskInput,
+} from '../heartbeat/index.js';
+import {
+  DirectHttpExecutionHost,
+  type HeartbeatExecutionHost,
+} from '../http-sse/index.js';
+
+const NOW = '2026-08-18T04:00:00.000Z';
+const RUNTIME_SESSION_ID = `runtime-session-${'a'.repeat(40)}`;
+
+describe('hosted heartbeat execution', () => {
+  it('binds authority and credentials while returning activity and the terminal result', async () => {
+    const issue = vi.fn<ExecutionAuthority['issue']>(async (authority) => {
+      const metadata = {
+        scope: { adopterId: 'adopter-a', ...authority.scope },
+        runtimeSessionId: authority.runtimeSessionId,
+        invocationId: authority.invocationId,
+        workflow: authority.workflow,
+        issuedAt: NOW,
+        executionExpiresAt: '2026-08-18T04:05:00.000Z',
+      } as const;
+      return {
+        metadata,
+        executionAssertion: () => 'execution-assertion-value'.repeat(2),
+        mcpCapability: () => undefined,
+        toJSON: () => metadata,
+      };
+    });
+    let hostInput: Parameters<HeartbeatExecutionHost['streamHeartbeatTask']>[0]
+      | undefined;
+    const result = { decision: 'continue', summary: 'Complete.' };
+    const executionHost: HeartbeatExecutionHost = {
+      streamHeartbeatTask: async function* (input) {
+        hostInput = input;
+        yield event(0, { kind: 'accepted' });
+        yield event(1, { kind: 'activity', activity: { type: 'progress' } });
+        yield event(2, { kind: 'result', result });
+      },
+    };
+    const service = new HostedHeartbeatTaskService({
+      authority: { issue, publicJwks: () => ({ keys: [] }) },
+      executionHost,
+      modelCredentials: {
+        resolveModelApiKey: async () => 'model-api-key-value',
+      },
+    });
+    const activities: unknown[] = [];
+
+    await expect(service.execute(input({
+      publishActivity: (activity) => {
+        activities.push(activity);
+      },
+    }))).resolves.toEqual(result);
+
+    expect(issue).toHaveBeenCalledWith(expect.objectContaining({
+      workflow: HEARTBEAT_TASK_WORKFLOW,
+      invocationId: 'execution-001',
+    }));
+    expect(hostInput).toMatchObject({
+      invocationId: 'execution-001',
+      taskId: 'task-001',
+      task: 'Review the workspace.',
+      executionAssertion: expect.stringContaining('execution-assertion'),
+      modelApiKey: 'model-api-key-value',
+    });
+    expect(activities).toEqual([{ type: 'progress' }]);
+  });
+
+  it('binds the scheduler execution id and leaves only scope/session resolution to the product', async () => {
+    let received: HostedHeartbeatTaskInput | undefined;
+    const transport = new HostedHeartbeatAgentExecutionTransport({
+      runner: {
+        execute: async (request) => {
+          received = request;
+          return { ok: true };
+        },
+      },
+      resolveInvocationContext: async ({ taskId, executionId }) => {
+        expect({ taskId, executionId }).toEqual({
+          taskId: 'task-001',
+          executionId: 'execution-001',
+        });
+        return {
+          scope: {
+            tenantId: 'tenant-a',
+            subjectId: 'subject-a',
+            productSessionId: 'product-session-a',
+          },
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          deadlineAt: '2026-08-18T04:10:00.000Z',
+        };
+      },
+    });
+    const publishActivity = vi.fn();
+
+    await expect(transport.execute({
+      request: {
+        executionId: 'execution-001',
+        taskId: 'task-001',
+        task: 'Review the workspace.',
+        runContext: {
+          currentDateTime: NOW,
+          intervalMs: 60_000,
+        },
+      },
+      signal: new AbortController().signal,
+      publishActivity,
+    })).resolves.toEqual({ ok: true });
+
+    expect(received).toMatchObject({
+      invocationId: 'execution-001',
+      taskId: 'task-001',
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      deadlineAt: '2026-08-18T04:10:00.000Z',
+      publishActivity,
+    });
+  });
+
+  it('uses the same strict ordered SSE protocol for direct heartbeat execution', async () => {
+    let requestBody: unknown;
+    const host = new DirectHttpExecutionHost({
+      baseUrl: new URL('http://127.0.0.1:3000/'),
+      localToken: 'local-token-value',
+      fetch: async (_url, init) => {
+        requestBody = JSON.parse(String(init?.body));
+        return new Response(toSse([
+          event(0, { kind: 'accepted' }),
+          event(1, { kind: 'result', result: { decision: 'complete' } }),
+        ]), {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      },
+    });
+
+    const events: ExecutionHostHeartbeatStreamEvent[] = [];
+    for await (const streamEvent of host.streamHeartbeatTask({
+      invocationId: 'execution-001',
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      taskId: 'task-001',
+      task: 'Review the workspace.',
+      runContext: {
+        currentDateTime: NOW,
+        intervalMs: 60_000,
+      },
+      executionAssertion: 'execution-assertion-value'.repeat(2),
+      modelApiKey: 'model-api-key-value',
+    })) {
+      events.push(streamEvent);
+    }
+
+    expect(requestBody).toMatchObject({
+      schemaVersion: EXECUTION_CONTRACT_VERSION,
+      kind: HEARTBEAT_TASK_WORKFLOW,
+      invocationId: 'execution-001',
+      taskId: 'task-001',
+    });
+    expect(events.map(({ kind }) => kind)).toEqual(['accepted', 'result']);
+  });
+});
+
+function input(
+  overrides: Partial<HostedHeartbeatTaskInput> = {},
+): HostedHeartbeatTaskInput {
+  return {
+    scope: {
+      tenantId: 'tenant-a',
+      subjectId: 'subject-a',
+      productSessionId: 'product-session-a',
+    },
+    runtimeSessionId: RUNTIME_SESSION_ID,
+    invocationId: 'execution-001',
+    taskId: 'task-001',
+    task: 'Review the workspace.',
+    runContext: {
+      currentDateTime: NOW,
+      intervalMs: 60_000,
+    },
+    ...overrides,
+  };
+}
+
+function event(
+  sequence: number,
+  body: Record<string, unknown>,
+): ExecutionHostHeartbeatStreamEvent {
+  return {
+    schemaVersion: EXECUTION_CONTRACT_VERSION,
+    invocationId: 'execution-001',
+    runId: 'run-001',
+    sequence,
+    timestamp: NOW,
+    ...body,
+  } as ExecutionHostHeartbeatStreamEvent;
+}
+
+function toSse(events: ExecutionHostHeartbeatStreamEvent[]): string {
+  return events.map((streamEvent) => [
+    `id: ${streamEvent.sequence}`,
+    `event: ${streamEvent.kind}`,
+    `data: ${JSON.stringify(streamEvent)}`,
+    '',
+    '',
+  ].join('\n')).join('\n');
+}

--- a/packages/execution-host-client/src/agentcore/README.md
+++ b/packages/execution-host-client/src/agentcore/README.md
@@ -1,7 +1,7 @@
 # AWS AgentCore Execution Host client
 
 This module is the official AWS AgentCore transport for the public
-`ExecutionHost` port. It sends the versioned invocation contract through
+`ExecutionHost` and `HeartbeatExecutionHost` ports. It sends the versioned invocation contract through
 `InvokeAgentRuntime`, adds Heddle authority headers before SigV4 signing, and
 delegates strict request/SSE validation to the shared Execution Host client.
 
@@ -19,6 +19,10 @@ It does not own AWS account configuration, Runtime provisioning, product
 authentication, authority issuance, model credentials, MCP tools, persistence,
 result application, or UI. Adopters provide their region, Runtime ARN, optional
 qualifier, and normal AWS credential environment at composition.
+
+Both conversation turns and heartbeat tasks use the same AgentCore client,
+Runtime-session validation, signed custom headers, one-attempt policy, and SSE
+validation. Their request and result schemas remain separate workflow profiles.
 
 ```ts
 import {

--- a/packages/execution-host-client/src/agentcore/agentcore-execution-host.test.ts
+++ b/packages/execution-host-client/src/agentcore/agentcore-execution-host.test.ts
@@ -12,12 +12,14 @@ import {
   EXECUTION_HOST_LOCAL_TOKEN_HEADER,
   MCP_CAPABILITY_HEADER,
   MODEL_API_KEY_HEADER,
+  type ExecutionHostHeartbeatStreamEvent,
   type ExecutionHostStreamEvent,
 } from '../contracts/index.js';
 import {
   ExecutionHostInvocationCancelledError,
   ExecutionHostStreamInterruptedError,
   type ExecutionHostConversationTurn,
+  type ExecutionHostHeartbeatTask,
 } from '../http-sse/index.js';
 import { AgentCoreExecutionHost } from './agentcore-execution-host.js';
 import type { AgentCoreRuntimeClient } from './types.js';
@@ -114,6 +116,39 @@ describe('AgentCoreExecutionHost', () => {
     await expect(collect(host.streamConversationTurn(input())))
       .rejects.toBeInstanceOf(ExecutionHostStreamInterruptedError);
 
+    host.close();
+  });
+
+  it('invokes the explicit heartbeat workflow through AgentCore', async () => {
+    let requestBody: unknown;
+    const origin = await listen(async (request, response) => {
+      requestBody = JSON.parse(await readBody(request));
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.end(toSse([heartbeatAccepted(), heartbeatResult()]));
+    });
+    const host = new AgentCoreExecutionHost({
+      region: 'us-east-2',
+      runtimeArn: RUNTIME_ARN,
+      client: new BedrockAgentCoreClient({
+        region: 'us-east-2',
+        endpoint: origin.toString(),
+        credentials: {
+          accessKeyId: 'test-access-key',
+          secretAccessKey: 'test-secret-key',
+        },
+        maxAttempts: 1,
+      }),
+    });
+
+    const events = await collect(host.streamHeartbeatTask(heartbeatInput()));
+
+    expect(requestBody).toMatchObject({
+      schemaVersion: 1,
+      kind: 'heartbeat-task',
+      invocationId: heartbeatInput().invocationId,
+      taskId: heartbeatInput().taskId,
+    });
+    expect(events.map(({ kind }) => kind)).toEqual(['accepted', 'result']);
     host.close();
   });
 
@@ -215,7 +250,47 @@ function result(): ExecutionHostStreamEvent {
   };
 }
 
-function toSse(events: ExecutionHostStreamEvent[]): string {
+function heartbeatInput(): ExecutionHostHeartbeatTask {
+  return {
+    invocationId: 'heartbeat_agentcore_test',
+    runtimeSessionId: input().runtimeSessionId,
+    taskId: 'heartbeat-task-001',
+    task: 'Review the workspace.',
+    runContext: {
+      currentDateTime: '2026-08-18T00:00:00.000Z',
+      intervalMs: 60_000,
+    },
+    executionAssertion: input().executionAssertion,
+    modelApiKey: input().modelApiKey,
+  };
+}
+
+function heartbeatAccepted(): ExecutionHostHeartbeatStreamEvent {
+  return {
+    schemaVersion: 1,
+    invocationId: heartbeatInput().invocationId,
+    runId: 'heartbeat-run-001',
+    timestamp: '2026-08-18T00:00:00.000Z',
+    sequence: 0,
+    kind: 'accepted',
+  };
+}
+
+function heartbeatResult(): ExecutionHostHeartbeatStreamEvent {
+  return {
+    schemaVersion: 1,
+    invocationId: heartbeatInput().invocationId,
+    runId: 'heartbeat-run-001',
+    timestamp: '2026-08-18T00:00:01.000Z',
+    sequence: 1,
+    kind: 'result',
+    result: { decision: 'continue', summary: 'Complete.' },
+  };
+}
+
+type StreamEvent = ExecutionHostStreamEvent | ExecutionHostHeartbeatStreamEvent;
+
+function toSse(events: StreamEvent[]): string {
   return events.map((event) => [
     `event: ${event.kind}`,
     `id: ${event.sequence}`,
@@ -226,9 +301,9 @@ function toSse(events: ExecutionHostStreamEvent[]): string {
 }
 
 async function collect(
-  events: AsyncIterable<ExecutionHostStreamEvent>,
-): Promise<ExecutionHostStreamEvent[]> {
-  const collected: ExecutionHostStreamEvent[] = [];
+  events: AsyncIterable<StreamEvent>,
+): Promise<StreamEvent[]> {
+  const collected: StreamEvent[] = [];
   for await (const event of events) {
     collected.push(event);
   }

--- a/packages/execution-host-client/src/agentcore/agentcore-execution-host.ts
+++ b/packages/execution-host-client/src/agentcore/agentcore-execution-host.ts
@@ -10,12 +10,15 @@ import {
   EXECUTION_HOST_LOCAL_TOKEN_HEADER,
   MCP_CAPABILITY_HEADER,
   MODEL_API_KEY_HEADER,
+  type ExecutionHostHeartbeatStreamEvent,
   type ExecutionHostStreamEvent,
 } from '../contracts/index.js';
 import {
   DirectHttpExecutionHost,
   type ExecutionHost,
   type ExecutionHostConversationTurn,
+  type ExecutionHostHeartbeatTask,
+  type HeartbeatExecutionHost,
 } from '../http-sse/index.js';
 import type {
   AgentCoreExecutionHostConfig,
@@ -44,7 +47,8 @@ const SERVICE_ERROR_CODES = new Map<string, string>([
  * Invokes one compatible Heddle Execution Host through AWS AgentCore while
  * reusing the package's strict request and SSE protocol validation.
  */
-export class AgentCoreExecutionHost implements ExecutionHost {
+export class AgentCoreExecutionHost
+implements ExecutionHost, HeartbeatExecutionHost {
   readonly #client: AgentCoreRuntimeClient;
   readonly #runtimeArn: string;
   readonly #qualifier?: string;
@@ -71,6 +75,13 @@ export class AgentCoreExecutionHost implements ExecutionHost {
   ): AsyncIterable<ExecutionHostStreamEvent> {
     assertAgentCoreRuntimeSessionId(input.runtimeSessionId);
     return this.#wire.streamConversationTurn(input);
+  }
+
+  streamHeartbeatTask(
+    input: ExecutionHostHeartbeatTask,
+  ): AsyncIterable<ExecutionHostHeartbeatStreamEvent> {
+    assertAgentCoreRuntimeSessionId(input.runtimeSessionId);
+    return this.#wire.streamHeartbeatTask(input);
   }
 
   close(): void {

--- a/packages/execution-host-client/src/authority/jose-execution-authority.ts
+++ b/packages/execution-host-client/src/authority/jose-execution-authority.ts
@@ -10,10 +10,10 @@ import {
 } from 'jose';
 import { z } from 'zod';
 import {
-  CONVERSATION_TURN_WORKFLOW,
   EXECUTION_ASSERTION_TYPE,
   EXECUTION_CONTRACT_VERSION,
   ExecutionScopeSchema,
+  HostedExecutionWorkflowSchema,
   JwtAudienceSchema,
   JwtIssuerSchema,
   MCP_CAPABILITY_TYPE,
@@ -70,7 +70,7 @@ const ExecutionAuthorityIssueInputSchema = z.object({
   scope: ExecutionIssueScopeSchema,
   runtimeSessionId: RuntimeSessionIdSchema,
   invocationId: OpaqueIdSchema,
-  workflow: z.literal(CONVERSATION_TURN_WORKFLOW),
+  workflow: HostedExecutionWorkflowSchema,
   mcp: z.object({
     allowedTools: McpAllowedToolsSchema,
   }).strict().optional(),

--- a/packages/execution-host-client/src/contracts/README.md
+++ b/packages/execution-host-client/src/contracts/README.md
@@ -6,6 +6,11 @@ ordered SSE events, execution identity claims, MCP capability claims, and the
 fixed header and token-type names shared by adopter backends and Execution Host
 deployments.
 
+The v1 binding has two explicit workflow profiles: `conversation-turn` and
+`heartbeat-task`. They share identity, credential headers, strict stream
+ordering, cancellation, and clean-EOF terminal truth, but keep distinct request,
+activity, and result schemas. A heartbeat request is not disguised as a prompt.
+
 It does not define product authentication, tenant lookup, authorization policy,
 MCP tool behavior, persistence, AWS transport, or the Heddle runtime loop. An
 adopter must derive scope from its authenticated product state before using

--- a/packages/execution-host-client/src/contracts/index.ts
+++ b/packages/execution-host-client/src/contracts/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const EXECUTION_CONTRACT_VERSION = 1 as const;
 export const CONVERSATION_TURN_WORKFLOW = 'conversation-turn' as const;
+export const HEARTBEAT_TASK_WORKFLOW = 'heartbeat-task' as const;
 export const EXECUTION_ASSERTION_TYPE = 'heddle-execution+jwt' as const;
 export const MCP_CAPABILITY_TYPE = 'heddle-mcp-capability+jwt' as const;
 
@@ -88,6 +89,38 @@ export const ExecutionHostConversationTurnRequestSchema = z.object({
   deadlineAt: TimestampSchema.optional(),
 }).strict();
 
+export const HeartbeatRunContextSchema = z.object({
+  currentDateTime: TimestampSchema,
+  intervalMs: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  continuationMode: z.enum(['operator', 'agent']).optional(),
+  nextRunAt: TimestampSchema.optional(),
+  previousRunAt: TimestampSchema.optional(),
+  previousRunId: OpaqueIdSchema.optional(),
+}).strict();
+
+export const ExecutionHostHeartbeatTaskRequestSchema = z.object({
+  schemaVersion: z.literal(EXECUTION_CONTRACT_VERSION),
+  kind: z.literal(HEARTBEAT_TASK_WORKFLOW),
+  invocationId: OpaqueIdSchema,
+  taskId: OpaqueIdSchema,
+  task: z.string().trim().min(1).max(200_000),
+  checkpoint: z.record(z.string(), z.json()).optional(),
+  runContext: HeartbeatRunContextSchema,
+  model: z.string().trim().min(1).max(512).optional(),
+  reasoningEffort: z.enum([
+    'none',
+    'low',
+    'medium',
+    'high',
+    'ultrahigh',
+    'max',
+  ]).optional(),
+  maxSteps: z.number().int().positive().max(10_000).optional(),
+  searchIgnoreDirs: z.array(z.string().min(1).max(1_024)).max(1_000).optional(),
+  systemContext: z.string().max(200_000).optional(),
+  deadlineAt: TimestampSchema.optional(),
+}).strict();
+
 export const RuntimePublicResultSchema = z.object({
   outcome: z.enum(['done', 'max_steps', 'error', 'interrupted']),
   summary: z.string().optional(),
@@ -141,6 +174,40 @@ export const ExecutionHostStreamEventSchema = z.discriminatedUnion('kind', [
   }).strict(),
 ]);
 
+export const ExecutionHostHeartbeatStreamEventSchema = z.discriminatedUnion(
+  'kind',
+  [
+    StreamEnvelopeSchema.extend({
+      sequence: z.literal(0),
+      kind: z.literal('accepted'),
+    }).strict(),
+    StreamEnvelopeSchema.extend({
+      kind: z.literal('activity'),
+      activity: z.json(),
+    }).strict(),
+    StreamEnvelopeSchema.extend({
+      kind: z.literal('result'),
+      result: z.record(z.string(), z.json()),
+    }).strict(),
+    StreamEnvelopeSchema.extend({
+      kind: z.literal('cancelled'),
+      reason: z.string(),
+    }).strict(),
+    StreamEnvelopeSchema.extend({
+      kind: z.literal('error'),
+      error: z.object({
+        code: z.string().min(1).max(128).regex(/^[a-z0-9_]+$/),
+        message: z.string().min(1).max(1_600),
+      }).strict(),
+    }).strict(),
+  ],
+);
+
+export const HostedExecutionWorkflowSchema = z.enum([
+  CONVERSATION_TURN_WORKFLOW,
+  HEARTBEAT_TASK_WORKFLOW,
+]);
+
 export const ExecutionAssertionClaimsSchema = z.object({
   iss: JwtIssuerSchema,
   aud: JwtAudienceSchema,
@@ -149,7 +216,7 @@ export const ExecutionAssertionClaimsSchema = z.object({
   tenantId: OpaqueIdSchema,
   productSessionId: OpaqueIdSchema,
   runtimeSessionId: RuntimeSessionIdSchema,
-  workflow: z.literal(CONVERSATION_TURN_WORKFLOW),
+  workflow: HostedExecutionWorkflowSchema,
   sub: OpaqueIdSchema,
   jti: OpaqueIdSchema,
   iat: z.number().int().nonnegative(),
@@ -165,7 +232,7 @@ export const McpCapabilityClaimsSchema = z.object({
   productSessionId: OpaqueIdSchema,
   runtimeSessionId: RuntimeSessionIdSchema,
   invocationId: OpaqueIdSchema,
-  workflow: z.literal(CONVERSATION_TURN_WORKFLOW),
+  workflow: HostedExecutionWorkflowSchema,
   serverId: McpServerIdSchema,
   allowedTools: McpAllowedToolsSchema,
   sub: OpaqueIdSchema,
@@ -178,6 +245,9 @@ export type ExecutionScope = z.infer<typeof ExecutionScopeSchema>;
 export type ExecutionHostConversationTurnRequest = z.infer<
   typeof ExecutionHostConversationTurnRequestSchema
 >;
+export type ExecutionHostHeartbeatTaskRequest = z.infer<
+  typeof ExecutionHostHeartbeatTaskRequestSchema
+>;
 export type RuntimePublicResult = z.infer<typeof RuntimePublicResultSchema>;
 export type ExecutionHostStreamEvent = z.infer<
   typeof ExecutionHostStreamEventSchema
@@ -186,15 +256,32 @@ export type ExecutionHostTerminalEvent = Extract<
   ExecutionHostStreamEvent,
   { kind: 'result' | 'cancelled' | 'error' }
 >;
+export type ExecutionHostHeartbeatStreamEvent = z.infer<
+  typeof ExecutionHostHeartbeatStreamEventSchema
+>;
+export type ExecutionHostHeartbeatTerminalEvent = Extract<
+  ExecutionHostHeartbeatStreamEvent,
+  { kind: 'result' | 'cancelled' | 'error' }
+>;
 export type ExecutionAssertionClaims = z.infer<
   typeof ExecutionAssertionClaimsSchema
 >;
 export type McpCapabilityClaims = z.infer<typeof McpCapabilityClaimsSchema>;
-export type HostedExecutionWorkflow = typeof CONVERSATION_TURN_WORKFLOW;
+export type HostedExecutionWorkflow = z.infer<
+  typeof HostedExecutionWorkflowSchema
+>;
 
 export function isExecutionHostTerminalEvent(
   event: ExecutionHostStreamEvent,
 ): event is ExecutionHostTerminalEvent {
+  return event.kind === 'result'
+    || event.kind === 'cancelled'
+    || event.kind === 'error';
+}
+
+export function isExecutionHostHeartbeatTerminalEvent(
+  event: ExecutionHostHeartbeatStreamEvent,
+): event is ExecutionHostHeartbeatTerminalEvent {
   return event.kind === 'result'
     || event.kind === 'cancelled'
     || event.kind === 'error';

--- a/packages/execution-host-client/src/conversation/index.ts
+++ b/packages/execution-host-client/src/conversation/index.ts
@@ -43,6 +43,7 @@ export { HostedConversationTurnInputSchema } from './types.js';
 export type {
   HostedConversationCredentialContext,
   HostedConversationModelCredentialProvider,
+  HostedModelCredentialProvider,
   HostedConversationTurnInput,
   HostedConversationTurnRunner,
   HostedConversationTurnServiceConfig,

--- a/packages/execution-host-client/src/conversation/types.ts
+++ b/packages/execution-host-client/src/conversation/types.ts
@@ -30,11 +30,15 @@ export type HostedConversationCredentialContext = Pick<
 >;
 
 /** Resolves model authority without exposing it to HTTP or product data. */
-export interface HostedConversationModelCredentialProvider {
+export interface HostedModelCredentialProvider {
   resolveModelApiKey(
     context: HostedConversationCredentialContext,
   ): Promise<string>;
 }
+
+/** @deprecated Use `HostedModelCredentialProvider`. */
+export type HostedConversationModelCredentialProvider =
+  HostedModelCredentialProvider;
 
 export interface HostedConversationTurnRunner {
   streamTurn(
@@ -45,7 +49,7 @@ export interface HostedConversationTurnRunner {
 export type HostedConversationTurnServiceConfig = {
   authority: ExecutionAuthority;
   executionHost: ExecutionHost;
-  modelCredentials: HostedConversationModelCredentialProvider;
+  modelCredentials: HostedModelCredentialProvider;
   /** Omit this policy when the hosted workflow needs no product MCP tools. */
   mcp?: {
     allowedTools: readonly string[];

--- a/packages/execution-host-client/src/heartbeat/README.md
+++ b/packages/execution-host-client/src/heartbeat/README.md
@@ -1,0 +1,38 @@
+# Hosted heartbeat execution
+
+This module connects Heddle's provider-neutral heartbeat scheduler to a
+compatible Execution Host. It lets one long-running coordinator retain durable
+task authority while an isolated Runtime performs only the agent cycle.
+
+## Owns
+
+- execution assertion and optional product-MCP capability issuance for the
+  `heartbeat-task` workflow;
+- request-scoped model credential resolution;
+- binding the durable scheduler `executionId` to the hosted `invocationId`;
+- bounded task, checkpoint, run-context, and deadline projection;
+- ordered activity/result consumption, cancellation, and safe public failure;
+  and
+- product-supplied resolution of authorized scope and Runtime session.
+
+## Does not own
+
+- heartbeat task lookup, due selection, claim fencing, checkpoint persistence,
+  settlement, history, or recovery;
+- the product's tenant/session authorization or AgentCore Runtime allocation;
+- PostgreSQL credentials inside the Runtime;
+- a general workflow engine, queue, foreground request relay, or hosted SaaS
+  control plane; or
+- memory, workspace, or filesystem checkpointing.
+
+The coordinator supplies `HostedHeartbeatAgentExecutionTransport` to
+`HeartbeatSchedulerService`. The scheduler's existing local runner remains the
+default when no transport is configured. The transport's
+`resolveInvocationContext` callback is deliberately small: it selects only the
+already-authorized product scope, Runtime session, and deadline for the claimed
+task. `HostedHeartbeatTaskService` owns the reusable authority, credential,
+MCP, transport, and stream behavior after that selection.
+
+The returned value crosses an untrusted network boundary. The runtime scheduler
+validates it as an `AgentHeartbeatResult` before any checkpoint or successful
+task settlement is committed.

--- a/packages/execution-host-client/src/heartbeat/hosted-heartbeat-agent-execution-transport.ts
+++ b/packages/execution-host-client/src/heartbeat/hosted-heartbeat-agent-execution-transport.ts
@@ -1,0 +1,51 @@
+import { OpaqueIdSchema } from '../contracts/index.js';
+import {
+  HostedHeartbeatInvocationContextSchema,
+  HostedHeartbeatTaskInputSchema,
+  type HostedHeartbeatAgentExecutionTransportConfig,
+  type HostedHeartbeatAgentExecutionTransportInput,
+} from './types.js';
+
+/**
+ * Binds Heddle's provider-neutral scheduler transport to hosted execution.
+ *
+ * Product code supplies only authorized scope/session resolution. This class
+ * owns execution-id correlation and delegates authority, credentials, and
+ * stream semantics to `HostedHeartbeatTaskService`.
+ */
+export class HostedHeartbeatAgentExecutionTransport {
+  readonly #runner: HostedHeartbeatAgentExecutionTransportConfig['runner'];
+  readonly #resolveInvocationContext: HostedHeartbeatAgentExecutionTransportConfig[
+    'resolveInvocationContext'
+  ];
+
+  constructor(config: HostedHeartbeatAgentExecutionTransportConfig) {
+    this.#runner = config.runner;
+    this.#resolveInvocationContext = config.resolveInvocationContext;
+  }
+
+  async execute(
+    input: HostedHeartbeatAgentExecutionTransportInput,
+  ): Promise<unknown> {
+    input.signal.throwIfAborted();
+    const { executionId: rawExecutionId, ...request } = input.request;
+    const executionId = OpaqueIdSchema.parse(rawExecutionId);
+    const context = HostedHeartbeatInvocationContextSchema.parse(
+      await this.#resolveInvocationContext({
+        taskId: input.request.taskId,
+        executionId,
+        signal: input.signal,
+      }),
+    );
+    input.signal.throwIfAborted();
+    return await this.#runner.execute(HostedHeartbeatTaskInputSchema.parse({
+      ...request,
+      invocationId: executionId,
+      scope: context.scope,
+      runtimeSessionId: context.runtimeSessionId,
+      ...(context.deadlineAt ? { deadlineAt: context.deadlineAt } : {}),
+      signal: input.signal,
+      publishActivity: input.publishActivity,
+    }));
+  }
+}

--- a/packages/execution-host-client/src/heartbeat/hosted-heartbeat-task-service.ts
+++ b/packages/execution-host-client/src/heartbeat/hosted-heartbeat-task-service.ts
@@ -1,0 +1,115 @@
+import {
+  HEARTBEAT_TASK_WORKFLOW,
+  McpAllowedToolsSchema,
+} from '../contracts/index.js';
+import { ExecutionHostInvocationCancelledError } from '../http-sse/index.js';
+import {
+  HostedHeartbeatTaskInputSchema,
+  type HostedHeartbeatTaskInput,
+  type HostedHeartbeatTaskRunner,
+  type HostedHeartbeatTaskServiceConfig,
+} from './types.js';
+
+export class HostedHeartbeatConfigurationError extends Error {
+  readonly name = 'HostedHeartbeatConfigurationError';
+}
+
+export class HostedHeartbeatExecutionError extends Error {
+  readonly name = 'HostedHeartbeatExecutionError';
+
+  constructor(readonly code: string) {
+    super('Execution Host heartbeat task failed.');
+  }
+}
+
+/**
+ * Provider-neutral application service for one remotely executed heartbeat.
+ *
+ * It owns authority issuance, optional product-tool policy, model credentials,
+ * ordered stream consumption, cancellation, and terminal classification. The
+ * caller owns product scope/session mapping and the durable heartbeat store.
+ */
+export class HostedHeartbeatTaskService
+implements HostedHeartbeatTaskRunner {
+  readonly #authority: HostedHeartbeatTaskServiceConfig['authority'];
+  readonly #executionHost: HostedHeartbeatTaskServiceConfig['executionHost'];
+  readonly #modelCredentials: HostedHeartbeatTaskServiceConfig[
+    'modelCredentials'
+  ];
+  readonly #allowedTools: readonly string[] | undefined;
+
+  constructor(config: HostedHeartbeatTaskServiceConfig) {
+    this.#authority = config.authority;
+    this.#executionHost = config.executionHost;
+    this.#modelCredentials = config.modelCredentials;
+    this.#allowedTools = config.mcp
+      ? Object.freeze(McpAllowedToolsSchema.parse(config.mcp.allowedTools))
+      : undefined;
+  }
+
+  async execute(
+    rawInput: HostedHeartbeatTaskInput,
+  ): Promise<unknown> {
+    const input = HostedHeartbeatTaskInputSchema.parse(rawInput);
+    input.signal?.throwIfAborted();
+    const issued = await this.#authority.issue({
+      scope: input.scope,
+      runtimeSessionId: input.runtimeSessionId,
+      invocationId: input.invocationId,
+      workflow: HEARTBEAT_TASK_WORKFLOW,
+      ...(this.#allowedTools
+        ? { mcp: { allowedTools: this.#allowedTools } }
+        : {}),
+    });
+    const mcpCapability = issued.mcpCapability();
+    if (this.#allowedTools && !mcpCapability) {
+      throw new HostedHeartbeatConfigurationError(
+        'Hosted heartbeat tool policy requires an MCP-capable execution authority.',
+      );
+    }
+    const modelApiKey = await this.#modelCredentials.resolveModelApiKey({
+      scope: input.scope,
+      invocationId: input.invocationId,
+      signal: input.signal,
+    });
+    input.signal?.throwIfAborted();
+
+    for await (const event of this.#executionHost.streamHeartbeatTask({
+      invocationId: input.invocationId,
+      runtimeSessionId: input.runtimeSessionId,
+      taskId: input.taskId,
+      task: input.task,
+      ...(input.checkpoint ? { checkpoint: input.checkpoint } : {}),
+      runContext: input.runContext,
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.reasoningEffort
+        ? { reasoningEffort: input.reasoningEffort }
+        : {}),
+      ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),
+      ...(input.searchIgnoreDirs
+        ? { searchIgnoreDirs: input.searchIgnoreDirs }
+        : {}),
+      ...(input.systemContext ? { systemContext: input.systemContext } : {}),
+      ...(input.deadlineAt ? { deadlineAt: input.deadlineAt } : {}),
+      ...(input.signal ? { signal: input.signal } : {}),
+      executionAssertion: issued.executionAssertion(),
+      ...(mcpCapability ? { mcpCapability } : {}),
+      modelApiKey,
+    })) {
+      if (event.kind === 'activity') {
+        input.publishActivity?.(event.activity);
+        continue;
+      }
+      if (event.kind === 'result') {
+        return event.result;
+      }
+      if (event.kind === 'cancelled') {
+        throw new ExecutionHostInvocationCancelledError();
+      }
+      if (event.kind === 'error') {
+        throw new HostedHeartbeatExecutionError(event.error.code);
+      }
+    }
+    throw new HostedHeartbeatExecutionError('missing_terminal_result');
+  }
+}

--- a/packages/execution-host-client/src/heartbeat/index.ts
+++ b/packages/execution-host-client/src/heartbeat/index.ts
@@ -1,0 +1,19 @@
+export {
+  HostedHeartbeatConfigurationError,
+  HostedHeartbeatExecutionError,
+  HostedHeartbeatTaskService,
+} from './hosted-heartbeat-task-service.js';
+export { HostedHeartbeatAgentExecutionTransport } from './hosted-heartbeat-agent-execution-transport.js';
+export {
+  HostedHeartbeatInvocationContextSchema,
+  HostedHeartbeatTaskInputSchema,
+} from './types.js';
+export type {
+  HostedHeartbeatAgentExecutionRequest,
+  HostedHeartbeatAgentExecutionTransportConfig,
+  HostedHeartbeatAgentExecutionTransportInput,
+  HostedHeartbeatInvocationContext,
+  HostedHeartbeatTaskInput,
+  HostedHeartbeatTaskRunner,
+  HostedHeartbeatTaskServiceConfig,
+} from './types.js';

--- a/packages/execution-host-client/src/heartbeat/types.ts
+++ b/packages/execution-host-client/src/heartbeat/types.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+import type { ExecutionAuthority } from '../authority/index.js';
+import {
+  ExecutionHostHeartbeatTaskRequestSchema,
+  ExecutionScopeSchema,
+  RuntimeSessionIdSchema,
+} from '../contracts/index.js';
+import type { HostedModelCredentialProvider } from '../conversation/index.js';
+import type { HeartbeatExecutionHost } from '../http-sse/index.js';
+
+export const HostedHeartbeatTaskInputSchema =
+  ExecutionHostHeartbeatTaskRequestSchema.omit({
+    schemaVersion: true,
+    kind: true,
+  }).extend({
+    scope: ExecutionScopeSchema.omit({ adopterId: true }),
+    runtimeSessionId: RuntimeSessionIdSchema,
+    signal: z.custom<AbortSignal>(
+      (value) => value instanceof AbortSignal,
+      'signal must be an AbortSignal',
+    ).optional(),
+    publishActivity: z.custom<(activity: unknown) => void>(
+      (value) => typeof value === 'function',
+      'publishActivity must be a function',
+    ).optional(),
+  }).strict();
+
+export type HostedHeartbeatTaskInput = z.infer<
+  typeof HostedHeartbeatTaskInputSchema
+>;
+
+export interface HostedHeartbeatTaskRunner {
+  execute(input: HostedHeartbeatTaskInput): Promise<unknown>;
+}
+
+export type HostedHeartbeatTaskServiceConfig = {
+  authority: ExecutionAuthority;
+  executionHost: HeartbeatExecutionHost;
+  modelCredentials: HostedModelCredentialProvider;
+  /** Omit this policy when the heartbeat workflow needs no product MCP tools. */
+  mcp?: {
+    allowedTools: readonly string[];
+  };
+};
+
+export const HostedHeartbeatInvocationContextSchema = z.object({
+  scope: ExecutionScopeSchema.omit({ adopterId: true }),
+  runtimeSessionId: RuntimeSessionIdSchema,
+  deadlineAt: ExecutionHostHeartbeatTaskRequestSchema.shape.deadlineAt,
+}).strict();
+
+export type HostedHeartbeatInvocationContext = z.infer<
+  typeof HostedHeartbeatInvocationContextSchema
+>;
+
+export type HostedHeartbeatAgentExecutionRequest = Omit<
+  HostedHeartbeatTaskInput,
+  | 'scope'
+  | 'runtimeSessionId'
+  | 'invocationId'
+  | 'deadlineAt'
+  | 'signal'
+  | 'publishActivity'
+  | 'checkpoint'
+> & {
+  executionId: string;
+  checkpoint?: unknown;
+};
+
+export type HostedHeartbeatAgentExecutionTransportInput = {
+  request: HostedHeartbeatAgentExecutionRequest;
+  signal: AbortSignal;
+  publishActivity: (activity: unknown) => void;
+};
+
+export type HostedHeartbeatAgentExecutionTransportConfig = {
+  runner: HostedHeartbeatTaskRunner;
+  resolveInvocationContext(input: {
+    taskId: string;
+    executionId: string;
+    signal: AbortSignal;
+  }): HostedHeartbeatInvocationContext
+    | Promise<HostedHeartbeatInvocationContext>;
+};

--- a/packages/execution-host-client/src/http-sse/direct-http-execution-host.ts
+++ b/packages/execution-host-client/src/http-sse/direct-http-execution-host.ts
@@ -7,14 +7,19 @@ import {
   EXECUTION_CONTRACT_VERSION,
   EXECUTION_HOST_LOCAL_TOKEN_HEADER,
   ExecutionHostConversationTurnRequestSchema,
+  ExecutionHostHeartbeatStreamEventSchema,
+  ExecutionHostHeartbeatTaskRequestSchema,
   ExecutionHostStreamEventSchema,
+  HEARTBEAT_TASK_WORKFLOW,
   MCP_CAPABILITY_HEADER,
   MODEL_API_KEY_HEADER,
   OpaqueIdSchema,
   RuntimeSessionIdSchema,
   TimestampSchema,
+  isExecutionHostHeartbeatTerminalEvent,
   isExecutionHostTerminalEvent,
   isSafeWebUrl,
+  type ExecutionHostHeartbeatStreamEvent,
   type ExecutionHostStreamEvent,
 } from '../contracts/index.js';
 import {
@@ -27,17 +32,16 @@ import type {
   DirectHttpExecutionHostConfig,
   ExecutionHost,
   ExecutionHostConversationTurn,
+  ExecutionHostHeartbeatTask,
+  HeartbeatExecutionHost,
 } from './types.js';
 
 const MAX_SSE_BUFFER_CHARACTERS = 1_048_576;
 const MAX_PENDING_SSE_FRAMES = 1_024;
 const MAX_ERROR_BODY_BYTES = 16_384;
 const SecretSchema = z.string().min(8).max(4_096);
-const ConversationTurnSchema = z.object({
-  invocationId: OpaqueIdSchema,
+const InvocationAuthoritySchema = z.object({
   runtimeSessionId: RuntimeSessionIdSchema,
-  prompt: z.string().trim().min(1).max(200_000),
-  deadlineAt: TimestampSchema.optional(),
   executionAssertion: z.string().min(32).max(4_096),
   mcpCapability: z.string().min(32).max(4_096).optional(),
   modelApiKey: SecretSchema,
@@ -46,6 +50,17 @@ const ConversationTurnSchema = z.object({
     'signal must be an AbortSignal',
   ).optional(),
 }).strict();
+const ConversationTurnSchema = InvocationAuthoritySchema.extend({
+  invocationId: OpaqueIdSchema,
+  prompt: z.string().trim().min(1).max(200_000),
+  deadlineAt: TimestampSchema.optional(),
+}).strict();
+const HeartbeatTaskSchema = InvocationAuthoritySchema.extend(
+  ExecutionHostHeartbeatTaskRequestSchema.omit({
+    schemaVersion: true,
+    kind: true,
+  }).shape,
+).strict();
 const ApiErrorSchema = z.object({
   error: z.object({
     code: z.string().min(1).max(128).regex(/^[a-z0-9_]+$/),
@@ -57,7 +72,8 @@ const ApiErrorSchema = z.object({
  * Strict direct-development HTTP/SSE adapter for the Execution Host v1 wire.
  * It deliberately owns neither AWS SDK nor SigV4 behavior.
  */
-export class DirectHttpExecutionHost implements ExecutionHost {
+export class DirectHttpExecutionHost
+implements ExecutionHost, HeartbeatExecutionHost {
   readonly #endpoint: URL;
   readonly #fetch: typeof fetch;
   readonly #localToken: string;
@@ -76,8 +92,62 @@ export class DirectHttpExecutionHost implements ExecutionHost {
     if (input.signal?.aborted) {
       throw new ExecutionHostInvocationCancelledError();
     }
+    const body = ExecutionHostConversationTurnRequestSchema.parse({
+      schemaVersion: EXECUTION_CONTRACT_VERSION,
+      kind: CONVERSATION_TURN_WORKFLOW,
+      invocationId: input.invocationId,
+      prompt: input.prompt,
+      ...(input.deadlineAt ? { deadlineAt: input.deadlineAt } : {}),
+    });
+    yield* this.#streamInvocation(
+      input,
+      body,
+      ExecutionHostStreamEventSchema,
+      isExecutionHostTerminalEvent,
+    );
+  }
 
-    const response = await this.#invoke(input);
+  async *streamHeartbeatTask(
+    rawInput: ExecutionHostHeartbeatTask,
+  ): AsyncIterable<ExecutionHostHeartbeatStreamEvent> {
+    const input = HeartbeatTaskSchema.parse(rawInput);
+    if (input.signal?.aborted) {
+      throw new ExecutionHostInvocationCancelledError();
+    }
+    const body = ExecutionHostHeartbeatTaskRequestSchema.parse({
+      schemaVersion: EXECUTION_CONTRACT_VERSION,
+      kind: HEARTBEAT_TASK_WORKFLOW,
+      invocationId: input.invocationId,
+      taskId: input.taskId,
+      task: input.task,
+      ...(input.checkpoint ? { checkpoint: input.checkpoint } : {}),
+      runContext: input.runContext,
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.reasoningEffort
+        ? { reasoningEffort: input.reasoningEffort }
+        : {}),
+      ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),
+      ...(input.searchIgnoreDirs
+        ? { searchIgnoreDirs: input.searchIgnoreDirs }
+        : {}),
+      ...(input.systemContext ? { systemContext: input.systemContext } : {}),
+      ...(input.deadlineAt ? { deadlineAt: input.deadlineAt } : {}),
+    });
+    yield* this.#streamInvocation(
+      input,
+      body,
+      ExecutionHostHeartbeatStreamEventSchema,
+      isExecutionHostHeartbeatTerminalEvent,
+    );
+  }
+
+  async *#streamInvocation<TEvent extends ValidatedStreamEvent>(
+    input: InvocationInput,
+    body: unknown,
+    schema: z.ZodType<TEvent>,
+    isTerminal: (event: TEvent) => boolean,
+  ): AsyncIterable<TEvent> {
+    const response = await this.#invoke(input, body);
     if (!response.ok) {
       throw new ExecutionHostRejectedError(
         response.status,
@@ -103,7 +173,7 @@ export class DirectHttpExecutionHost implements ExecutionHost {
     };
     const decoder = new TextDecoder();
     const pending: EventSourceMessage[] = [];
-    let terminalEvent: ExecutionHostStreamEvent | undefined;
+    let terminalEvent: TEvent | undefined;
     let parserError = false;
     const parser = createParser({
       maxBufferSize: MAX_SSE_BUFFER_CHARACTERS,
@@ -127,8 +197,13 @@ export class DirectHttpExecutionHost implements ExecutionHost {
           throw new ExecutionHostProtocolError();
         }
         while (pending.length > 0) {
-          const event = validateEvent(pending.shift()!, state);
-          if (isExecutionHostTerminalEvent(event)) {
+          const event = validateEvent(
+            pending.shift()!,
+            state,
+            schema,
+            isTerminal,
+          );
+          if (isTerminal(event)) {
             terminalEvent = event;
           } else {
             yield event;
@@ -141,8 +216,13 @@ export class DirectHttpExecutionHost implements ExecutionHost {
         throw new ExecutionHostProtocolError();
       }
       while (pending.length > 0) {
-        const event = validateEvent(pending.shift()!, state);
-        if (isExecutionHostTerminalEvent(event)) {
+        const event = validateEvent(
+          pending.shift()!,
+          state,
+          schema,
+          isTerminal,
+        );
+        if (isTerminal(event)) {
           terminalEvent = event;
         } else {
           yield event;
@@ -168,16 +248,7 @@ export class DirectHttpExecutionHost implements ExecutionHost {
     yield terminalEvent;
   }
 
-  async #invoke(
-    input: z.infer<typeof ConversationTurnSchema>,
-  ): Promise<Response> {
-    const body = ExecutionHostConversationTurnRequestSchema.parse({
-      schemaVersion: EXECUTION_CONTRACT_VERSION,
-      kind: CONVERSATION_TURN_WORKFLOW,
-      invocationId: input.invocationId,
-      prompt: input.prompt,
-      ...(input.deadlineAt ? { deadlineAt: input.deadlineAt } : {}),
-    });
+  async #invoke(input: InvocationInput, body: unknown): Promise<Response> {
     try {
       return await this.#fetch(this.#endpoint, {
         method: 'POST',
@@ -200,17 +271,36 @@ type StreamValidationState = {
   terminal: boolean;
 };
 
-function validateEvent(
+type InvocationInput = {
+  invocationId: string;
+  runtimeSessionId: string;
+  executionAssertion: string;
+  mcpCapability?: string;
+  modelApiKey: string;
+  signal?: AbortSignal;
+};
+
+type ValidatedStreamEvent = {
+  kind: string;
+  invocationId: string;
+  runId: string;
+  sequence: number;
+  timestamp: string;
+};
+
+function validateEvent<TEvent extends ValidatedStreamEvent>(
   frame: EventSourceMessage,
   state: StreamValidationState,
-): ExecutionHostStreamEvent {
+  schema: z.ZodType<TEvent>,
+  isTerminal: (event: TEvent) => boolean,
+): TEvent {
   let decoded: unknown;
   try {
     decoded = JSON.parse(frame.data);
   } catch {
     throw new ExecutionHostProtocolError();
   }
-  const parsed = ExecutionHostStreamEventSchema.safeParse(decoded);
+  const parsed = schema.safeParse(decoded);
   if (!parsed.success) {
     throw new ExecutionHostProtocolError();
   }
@@ -234,12 +324,12 @@ function validateEvent(
   }
 
   state.nextSequence += 1;
-  state.terminal = isExecutionHostTerminalEvent(event);
+  state.terminal = isTerminal(event);
   return event;
 }
 
 function createSensitiveHeaders(
-  input: z.infer<typeof ConversationTurnSchema>,
+  input: InvocationInput,
   localToken: string,
 ): Headers {
   const headers = new Headers({

--- a/packages/execution-host-client/src/http-sse/index.ts
+++ b/packages/execution-host-client/src/http-sse/index.ts
@@ -9,4 +9,6 @@ export type {
   DirectHttpExecutionHostConfig,
   ExecutionHost,
   ExecutionHostConversationTurn,
+  ExecutionHostHeartbeatTask,
+  HeartbeatExecutionHost,
 } from './types.js';

--- a/packages/execution-host-client/src/http-sse/types.ts
+++ b/packages/execution-host-client/src/http-sse/types.ts
@@ -1,4 +1,8 @@
-import type { ExecutionHostStreamEvent } from '../contracts/index.js';
+import type {
+  ExecutionHostHeartbeatStreamEvent,
+  ExecutionHostHeartbeatTaskRequest,
+  ExecutionHostStreamEvent,
+} from '../contracts/index.js';
 
 export type ExecutionHostConversationTurn = {
   invocationId: string;
@@ -15,6 +19,23 @@ export interface ExecutionHost {
   streamConversationTurn(
     input: ExecutionHostConversationTurn,
   ): AsyncIterable<ExecutionHostStreamEvent>;
+}
+
+export type ExecutionHostHeartbeatTask = Omit<
+  ExecutionHostHeartbeatTaskRequest,
+  'schemaVersion' | 'kind'
+> & {
+  runtimeSessionId: string;
+  executionAssertion: string;
+  mcpCapability?: string;
+  modelApiKey: string;
+  signal?: AbortSignal;
+};
+
+export interface HeartbeatExecutionHost {
+  streamHeartbeatTask(
+    input: ExecutionHostHeartbeatTask,
+  ): AsyncIterable<ExecutionHostHeartbeatStreamEvent>;
 }
 
 export type DirectHttpExecutionHostConfig = {

--- a/packages/execution-host-client/src/index.ts
+++ b/packages/execution-host-client/src/index.ts
@@ -1,5 +1,6 @@
 export * from './contracts/index.js';
 export * from './authority/index.js';
 export * from './conversation/index.js';
+export * from './heartbeat/index.js';
 export * from './mcp/index.js';
 export * from './http-sse/index.js';

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/runtime",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Embeddable TypeScript and Node.js agent runtime and SDK for Heddle-powered products",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/src/__tests__/integration/core/heartbeat-execution-context.test.ts
+++ b/src/__tests__/integration/core/heartbeat-execution-context.test.ts
@@ -10,6 +10,7 @@ import {
   HeartbeatSchedulerService,
   type AgentHeartbeatResult,
   type HeartbeatExecutionContext,
+  type HeartbeatAgentExecutionTransport,
   type HeartbeatSchedulerEvent,
   type HeartbeatTask,
   type RunAgentHeartbeatOptions,
@@ -171,6 +172,87 @@ describe('heartbeat execution context', () => {
         result: agentResult,
       },
     }]);
+  });
+
+  it('delegates portable agent work and validates the result before durable settlement', async () => {
+    const dir = createStateRoot('remote-transport');
+    const store = new FileHeartbeatTaskService({ dir });
+    const task: HeartbeatTask = {
+      ...createTask('remote-transport'),
+      runtime: {
+        model: 'gpt-remote',
+        maxSteps: 4,
+        systemContext: 'Use the hosted workspace.',
+      },
+    };
+    const priorCheckpoint = createHeartbeatResult('pause', 'remote-prior').checkpoint;
+    const remoteResult = createHeartbeatResult('continue', 'remote-result');
+    await store.saveTask(task);
+    await store.saveCheckpoint(task, priorCheckpoint);
+    const events: HeartbeatSchedulerEvent[] = [];
+    let received: Parameters<HeartbeatAgentExecutionTransport['execute']>[0] | undefined;
+    const transport: HeartbeatAgentExecutionTransport = {
+      execute: async (input) => {
+        received = input;
+        input.publishActivity({ type: 'assistant_text_delta', text: 'Working.' });
+        return structuredClone(remoteResult);
+      },
+    };
+    const localAgent = vi.spyOn(HeartbeatRunnerAgent, 'run');
+
+    await expect(HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      agentExecutionTransport: transport,
+      onEvent: (event) => events.push(event),
+    })).resolves.toMatchObject({ checked: 1, ran: 1, failed: 0 });
+
+    expect(localAgent).not.toHaveBeenCalled();
+    expect(received?.request).toMatchObject({
+      taskId: task.id,
+      executionId: expect.any(String),
+      task: task.task,
+      checkpoint: priorCheckpoint,
+      runContext: {
+        currentDateTime: NOW.toISOString(),
+        intervalMs: task.schedule.intervalMs,
+      },
+      model: 'gpt-remote',
+      maxSteps: 4,
+      systemContext: 'Use the hosted workspace.',
+    });
+    expect(received?.request).not.toHaveProperty('apiKey');
+    expect(received?.request).not.toHaveProperty('tools');
+    expect(received?.request).not.toHaveProperty('workspaceRoot');
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'heartbeat.task.agent_activity',
+      taskId: task.id,
+      activity: { type: 'assistant_text_delta', text: 'Working.' },
+    }));
+    await expect(store.loadCheckpoint(task)).resolves.toEqual(
+      remoteResult.checkpoint,
+    );
+
+    const invalidDir = createStateRoot('invalid-remote-result');
+    const invalidStore = new FileHeartbeatTaskService({ dir: invalidDir });
+    await invalidStore.saveTask(createTask('invalid-remote-result'));
+    await expect(HeartbeatSchedulerService.runDueTasks({
+      store: invalidStore,
+      now: () => NOW,
+      agentExecutionTransport: {
+        execute: async () => ({ status: 'pretend-success' }),
+      },
+    })).resolves.toMatchObject({ checked: 1, ran: 0, failed: 1 });
+    await expect(invalidStore.loadCheckpoint(
+      createTask('invalid-remote-result'),
+    )).resolves.toBeUndefined();
+    await expect(invalidStore.requireTask('invalid-remote-result'))
+      .resolves.toMatchObject({
+        state: {
+          status: 'failed',
+          error: 'Heartbeat agent execution transport returned an invalid result.',
+        },
+      });
   });
 
   it('cancels active work, awaits handler settlement, and persists cancellation after a late result', async () => {

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -249,6 +249,7 @@ export type {
   HeartbeatDecision,
   HeartbeatDecisionEvent,
   HeartbeatEscalationEvent,
+  HeartbeatRunnerAgentRunContext,
   RunAgentHeartbeatOptions,
 } from './core/heartbeat/agent/index.js';
 export {
@@ -308,6 +309,9 @@ export {
 } from './core/heartbeat/scheduler/index.js';
 export type {
   CancelHeartbeatTaskOptions,
+  HeartbeatAgentExecutionRequest,
+  HeartbeatAgentExecutionTransport,
+  HeartbeatAgentExecutionTransportInput,
   HeartbeatSchedulerHandle,
   HeartbeatSchedulerEvent,
   HeartbeatTaskCancellationDisposition,

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -45,6 +45,10 @@ operator-facing heartbeat views.
   `context.runAgent()` path, so hosts can add domain prompts and tools without
   receiving or translating provider credentials. `context.skip()` records
   explicit no-work without fabricating agent state.
+  An optional provider-neutral `HeartbeatAgentExecutionTransport` replaces only
+  the nested agent call. Task lookup, claim fencing, checkpoint load,
+  cancellation, settlement, history, and recovery remain in this service; when
+  omitted, the existing local `HeartbeatRunnerAgent` remains the default.
 - `views/`: `HeartbeatLucidPresenter` owns Lucid-specific adapter messages.
   `HeartbeatTaskViewProjector` owns provider-neutral task/run views and stable
   task ordering without depending on a persistence adapter.
@@ -73,7 +77,7 @@ operator-facing heartbeat views.
   the same atomic store transition. Saving a projection derived from the
   pre-run snapshot can erase newer run requests or operator control changes.
 - Custom adapters should use the public `HeartbeatTaskStateProjector` exported
-  from `@roackb2/heddle/advanced` for normalization, request, claim,
+  from `@heddleagent/runtime/advanced` for normalization, request, claim,
   settlement, and recovery transitions. The adapter still owns the backend
   transaction and fencing predicate; it must not copy Heddle's transition
   rules into provider-specific persistence code.
@@ -131,7 +135,7 @@ operator-facing heartbeat views.
   invocation never performs recovery or steals another worker's live claim;
   final writes remain fenced after an explicit recovery.
 - Custom remote adapters should run the executable contract scenarios from
-  `@roackb2/heddle/heartbeat/testing` against two fresh store instances sharing
+  `@heddleagent/runtime/heartbeat/testing` against two fresh store instances sharing
   one backend namespace. Required scenarios cover exact lookup, atomic due
   claims, coalesced requests, settlement, recovery, and stale-write fencing;
   history and subscription checks are capability-gated. The harness owns a
@@ -140,6 +144,11 @@ operator-facing heartbeat views.
   effects.
 - Heartbeat may depend on runtime's public `AgentLoopRuntimeService.run` and checkpoint types.
   Runtime should not import heartbeat.
+- A remote coordinator injects `HeartbeatAgentExecutionTransport` at scheduler
+  composition. The serialized request intentionally excludes API keys, tools,
+  approval callbacks, filesystem paths, loggers, and model adapters. The
+  execution process resolves those locally; the scheduler validates its
+  returned result before committing the new checkpoint or successful state.
 - Local interface adapters should use `FileHeartbeatTaskService` methods or the
   control-plane heartbeat API. Remote operator surfaces should depend on
   `HeartbeatTaskAdministrationService` and keep backend transaction mechanics

--- a/src/core/heartbeat/agent/index.ts
+++ b/src/core/heartbeat/agent/index.ts
@@ -7,5 +7,6 @@ export type {
   HeartbeatDecision,
   HeartbeatDecisionEvent,
   HeartbeatEscalationEvent,
+  HeartbeatRunnerAgentRunContext,
   RunAgentHeartbeatOptions,
 } from './types.js';

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -15,6 +15,9 @@ export {
 } from './scheduler/index.js';
 export type {
   CancelHeartbeatTaskOptions,
+  HeartbeatAgentExecutionRequest,
+  HeartbeatAgentExecutionTransport,
+  HeartbeatAgentExecutionTransportInput,
   HeartbeatSchedulerEvent,
   HeartbeatSchedulerHandle,
   HeartbeatTaskCancellationDisposition,
@@ -82,6 +85,7 @@ export type {
   HeartbeatDecision,
   HeartbeatDecisionEvent,
   HeartbeatEscalationEvent,
+  HeartbeatRunnerAgentRunContext,
   RunAgentHeartbeatOptions,
 } from './agent/index.js';
 export { HeartbeatLucidPresenter, HeartbeatTaskViewProjector } from './views/index.js';

--- a/src/core/heartbeat/scheduler/index.ts
+++ b/src/core/heartbeat/scheduler/index.ts
@@ -8,6 +8,9 @@ export {
 } from './types.js';
 export type {
   CancelHeartbeatTaskOptions,
+  HeartbeatAgentExecutionRequest,
+  HeartbeatAgentExecutionTransport,
+  HeartbeatAgentExecutionTransportInput,
   HeartbeatSchedulerEvent,
   HeartbeatSchedulerHandle,
   HeartbeatTaskCancellationDisposition,

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -9,9 +9,10 @@ import { randomUUID } from 'node:crypto';
 import dayjs from 'dayjs';
 import { ToolApprovalPolicies } from '@/core/approvals/index.js';
 import { DEFAULT_OPENAI_MODEL } from '@/core/config.js';
-import type { AgentLoopCheckpoint, AgentLoopState } from '@/core/runtime/loop/index.js';
+import type { AgentLoopCheckpoint } from '@/core/runtime/loop/index.js';
 import { HeartbeatRunnerAgent } from '../agent/index.js';
 import type { AgentHeartbeatResult, RunAgentHeartbeatOptions } from '../agent/index.js';
+import { AgentHeartbeatResultSchema } from '../tasks/schemas.js';
 import type {
   HeartbeatTask,
   HeartbeatTaskAgentRunRecord,
@@ -22,6 +23,7 @@ import type {
   HeartbeatTaskRunRecord,
 } from '../tasks/index.js';
 import type {
+  HeartbeatAgentExecutionTransport,
   HeartbeatExecutionContext,
   HeartbeatHandlerOutcome,
   HeartbeatSchedulerEvent,
@@ -42,6 +44,12 @@ import { HeartbeatTaskCancellationPolicy } from './cancellation-policy.js';
 
 const DEFAULT_FAILURE_RETRY_MS = 5 * 60_000;
 const CANCELLATION_SUMMARY = 'Heartbeat execution cancelled by its scheduler host.';
+type ResolvedHeartbeatRunnerAgentOptions = Omit<
+  RunAgentHeartbeatOptions,
+  'checkpoint'
+> & {
+  checkpoint?: AgentLoopCheckpoint;
+};
 
 export class HeartbeatTaskRunnerService {
   // Runs one already-selected task and persists its final claim-fenced outcome.
@@ -51,6 +59,7 @@ export class HeartbeatTaskRunnerService {
       | 'handler'
       | 'runner'
       | 'runtime'
+      | 'agentExecutionTransport'
       | 'now'
       | 'onEvent'
       | 'failureRetryMs'
@@ -118,6 +127,7 @@ export class HeartbeatTaskRunnerService {
         handler: options.handler,
         runner: options.runner,
         runtime: options.runtime,
+        agentExecutionTransport: options.agentExecutionTransport,
         onEvent: options.onEvent,
       });
       if (options.signal?.aborted) {
@@ -315,6 +325,7 @@ export class HeartbeatTaskRunnerService {
     handler?: HeartbeatTaskHandler;
     runner?: HeartbeatTaskRunner;
     runtime?: HeartbeatTaskRunnerRuntimeOptions;
+    agentExecutionTransport?: HeartbeatAgentExecutionTransport;
     onEvent?: (event: HeartbeatSchedulerEvent) => void;
   }): Promise<AgentHeartbeatResult | HeartbeatHandlerOutcome> {
     let active = true;
@@ -338,9 +349,17 @@ export class HeartbeatTaskRunnerService {
           throw new Error('Heartbeat execution context runAgent() may be called only once.');
         }
 
-        agentInvocation = HeartbeatRunnerAgent.run(
-          HeartbeatTaskRunnerService.resolveRunnerAgentOptions({ ...args, options }),
-        );
+        const runnerOptions = HeartbeatTaskRunnerService.resolveRunnerAgentOptions({
+          ...args,
+          options,
+        });
+        agentInvocation = args.agentExecutionTransport
+          ? HeartbeatTaskRunnerService.executeThroughTransport({
+            ...args,
+            runnerOptions,
+            transport: args.agentExecutionTransport,
+          })
+          : HeartbeatRunnerAgent.run(runnerOptions);
         agentResult = await agentInvocation;
         return agentResult;
       },
@@ -444,14 +463,14 @@ export class HeartbeatTaskRunnerService {
 
   private static resolveRunnerAgentOptions(args: {
     task: HeartbeatTask;
-    checkpoint: AgentLoopState | AgentLoopCheckpoint | undefined;
+    checkpoint: AgentLoopCheckpoint | undefined;
     execution: HeartbeatTaskExecution;
     runAt: Date;
     signal: AbortSignal;
     runtime?: HeartbeatTaskRunnerRuntimeOptions;
     onEvent?: (event: HeartbeatSchedulerEvent) => void;
     options?: HeartbeatTaskRunnerAgentOptions;
-  }): RunAgentHeartbeatOptions {
+  }): ResolvedHeartbeatRunnerAgentOptions {
     const model = args.options?.model ?? args.task.runtime?.model ?? args.runtime?.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
 
     return {
@@ -491,6 +510,57 @@ export class HeartbeatTaskRunnerService {
         });
       },
     };
+  }
+
+  private static async executeThroughTransport(args: {
+    task: HeartbeatTask;
+    execution: HeartbeatTaskExecution;
+    signal: AbortSignal;
+    runnerOptions: ResolvedHeartbeatRunnerAgentOptions;
+    transport: HeartbeatAgentExecutionTransport;
+    onEvent?: (event: HeartbeatSchedulerEvent) => void;
+  }): Promise<AgentHeartbeatResult> {
+    const runContext = args.runnerOptions.runContext;
+    if (!runContext) {
+      throw new Error('Remote heartbeat execution requires a run context.');
+    }
+    const result = await args.transport.execute({
+      request: {
+        taskId: args.task.id,
+        executionId: args.execution.executionId,
+        task: args.runnerOptions.task,
+        ...(args.runnerOptions.checkpoint
+          ? { checkpoint: structuredClone(args.runnerOptions.checkpoint) }
+          : {}),
+        runContext: structuredClone(runContext),
+        ...(args.runnerOptions.model ? { model: args.runnerOptions.model } : {}),
+        ...(args.runnerOptions.reasoningEffort
+          ? { reasoningEffort: args.runnerOptions.reasoningEffort }
+          : {}),
+        ...(args.runnerOptions.maxSteps !== undefined
+          ? { maxSteps: args.runnerOptions.maxSteps }
+          : {}),
+        ...(args.runnerOptions.searchIgnoreDirs
+          ? { searchIgnoreDirs: [...args.runnerOptions.searchIgnoreDirs] }
+          : {}),
+        ...(args.runnerOptions.systemContext
+          ? { systemContext: args.runnerOptions.systemContext }
+          : {}),
+      },
+      signal: args.signal,
+      publishActivity: (activity) => args.onEvent?.({
+        type: 'heartbeat.task.agent_activity',
+        taskId: args.task.id,
+        executionId: args.execution.executionId,
+        activity,
+        timestamp: dayjs().toISOString(),
+      }),
+    });
+    const parsed = AgentHeartbeatResultSchema.safeParse(result);
+    if (!parsed.success) {
+      throw new Error('Heartbeat agent execution transport returned an invalid result.');
+    }
+    return parsed.data as AgentHeartbeatResult;
   }
 
   private static async persistCancellation(args: Pick<RunDueHeartbeatTasksOptions, 'store' | 'now' | 'onEvent' | 'signal'> & {

--- a/src/core/heartbeat/scheduler/service.ts
+++ b/src/core/heartbeat/scheduler/service.ts
@@ -85,6 +85,7 @@ export class HeartbeatSchedulerService {
     let loopError: unknown;
     const settledLoop = HeartbeatSchedulerService.runLoopWithTaskLifecycle({
       store,
+      agentExecutionTransport: options.agentExecutionTransport,
       handler: options.handler,
       runner: options.runner,
       runtime: {

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -1,6 +1,11 @@
 import type { AgentLoopCheckpoint, AgentLoopState } from '@/core/runtime/loop/index.js';
 import type { LlmProvider } from '@/core/llm/types.js';
-import type { AgentHeartbeatEvent, AgentHeartbeatResult, RunAgentHeartbeatOptions } from '../agent/index.js';
+import type {
+  AgentHeartbeatEvent,
+  AgentHeartbeatResult,
+  HeartbeatRunnerAgentRunContext,
+  RunAgentHeartbeatOptions,
+} from '../agent/index.js';
 export {
   DEFAULT_HEARTBEAT_HANDLER_RETRY_MS,
   MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH,
@@ -75,6 +80,13 @@ export type HeartbeatSchedulerEvent =
       taskId: string;
       executionId: string;
       event: AgentHeartbeatEvent;
+      timestamp: string;
+    }
+  | {
+      type: 'heartbeat.task.agent_activity';
+      taskId: string;
+      executionId: string;
+      activity: unknown;
       timestamp: string;
     }
   | {
@@ -219,8 +231,45 @@ export type HeartbeatTaskRunnerRuntimeOptions = {
   onAgentEvent?: RunAgentHeartbeatOptions['onEvent'];
 };
 
+/**
+ * JSON-safe heartbeat work delegated to another execution process.
+ *
+ * The coordinator deliberately does not send credentials, tools, approval
+ * callbacks, filesystem paths, loggers, or model adapters. Those belong to
+ * the execution process selected by the transport.
+ */
+export type HeartbeatAgentExecutionRequest = {
+  taskId: string;
+  executionId: string;
+  task: string;
+  checkpoint?: AgentLoopCheckpoint;
+  runContext: HeartbeatRunnerAgentRunContext;
+  model?: string;
+  reasoningEffort?: RunAgentHeartbeatOptions['reasoningEffort'];
+  maxSteps?: number;
+  searchIgnoreDirs?: string[];
+  systemContext?: string;
+};
+
+export type HeartbeatAgentExecutionTransportInput = {
+  request: HeartbeatAgentExecutionRequest;
+  signal: AbortSignal;
+  publishActivity: (activity: unknown) => void;
+};
+
+/**
+ * Replaceable execution-plane seam for one heartbeat agent cycle.
+ *
+ * Results cross an untrusted serialization boundary. The scheduler validates
+ * the returned value as an `AgentHeartbeatResult` before durable settlement.
+ */
+export interface HeartbeatAgentExecutionTransport {
+  execute(input: HeartbeatAgentExecutionTransportInput): Promise<unknown>;
+}
+
 export type RunDueHeartbeatTasksOptions = {
   store: HeartbeatTaskStore;
+  agentExecutionTransport?: HeartbeatAgentExecutionTransport;
   handler?: HeartbeatTaskHandler;
   /** @deprecated Use `handler`. */
   runner?: HeartbeatTaskRunner;
@@ -345,6 +394,7 @@ export type StartHeartbeatSchedulerOptions = {
    * exact instance for recovery, wake subscriptions, claims, and settlement.
    */
   store?: HeartbeatTaskStore;
+  agentExecutionTransport?: HeartbeatAgentExecutionTransport;
   preferApiKey?: boolean;
   model?: string;
   maxSteps?: number;

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -99,7 +99,7 @@ export const AgentLoopCheckpointSchema = z.object({
   }).passthrough().describe('Runtime loop state snapshot.'),
 }).passthrough();
 
-const AgentHeartbeatResultSchema = z.object({
+export const AgentHeartbeatResultSchema = z.object({
   decision: HeartbeatDecisionSchema,
   summary: z.string(),
   checkpoint: AgentLoopCheckpointSchema,

--- a/src/core/heartbeat/views/lucid-presenter.ts
+++ b/src/core/heartbeat/views/lucid-presenter.ts
@@ -101,6 +101,7 @@ export class HeartbeatLucidPresenter {
           HeartbeatLucidPresenter.progressMessage(agentId, event.progress, event.timestamp),
         ];
       case 'heartbeat.task.agent_event':
+      case 'heartbeat.task.agent_activity':
         return [];
       case 'heartbeat.task.finished': {
         const { task, result } = event.record;

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -350,6 +350,13 @@ export type ControlPlaneHeartbeatEvent =
     timestamp: string;
   }
   | {
+    type: 'heartbeat.task.agent_activity';
+    taskId: string;
+    executionId: string;
+    activity: unknown;
+    timestamp: string;
+  }
+  | {
     type: 'heartbeat.task.finished';
     taskId: string;
     executionId: string;

--- a/src/server/lifecycle.ts
+++ b/src/server/lifecycle.ts
@@ -263,6 +263,7 @@ function logHeartbeatSchedulerEvent(
     'heartbeat.task.started': 'Heartbeat task started',
     'heartbeat.task.recovered': 'Heartbeat task recovered after interrupted execution',
     'heartbeat.task.agent_event': 'Heartbeat task agent event',
+    'heartbeat.task.agent_activity': 'Heartbeat task remote agent activity',
     'heartbeat.task.finished': 'Heartbeat task finished',
     'heartbeat.task.skipped': 'Heartbeat task skipped because no work was available',
     'heartbeat.task.cancelled': 'Heartbeat task execution cancelled',

--- a/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
@@ -163,6 +163,12 @@ function projectHeartbeatTaskEvent(
         progress: describeAgentEvent(event.event),
         runId: 'runId' in event.event && typeof event.event.runId === 'string' ? event.event.runId : base.runId,
       };
+    case 'heartbeat.task.agent_activity':
+      return {
+        ...base,
+        status: 'running',
+        progress: 'Remote heartbeat agent is working...',
+      };
     case 'heartbeat.task.finished':
       return {
         ...base,


### PR DESCRIPTION
## What changed

- add a provider-neutral heartbeat agent-execution transport while preserving the existing local runner as the default
- add an explicit `heartbeat-task` Execution Host workflow with direct HTTP/SSE and AgentCore clients
- centralize hosted heartbeat authority, request-scoped model credentials, optional product MCP, cancellation, and terminal handling
- extend the v1 OpenAPI, JSON Schema, golden fixtures, and independent Python reference
- prepare `@heddleagent/runtime@6.2.0` and `@heddleagent/execution-host-client@6.2.0` release notes

## Why

The hosted coordinator must retain PostgreSQL task authority, claims, checkpoints, and settlement while an isolated AgentCore Runtime performs only the agent cycle. This boundary keeps database credentials out of the Runtime and avoids disguising heartbeat work as an ordinary conversation turn.

## Validation

- focused runtime heartbeat integration: 12 tests passed
- Execution Host client: 119 tests passed
- clean-room Python reference: Ruff checks plus 36 tests passed
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`

## Deliberately left for the next slices

- consume the workflow in the private Runtime
- publish the two changed packages and prove one real AgentCore heartbeat
- compose the always-on coordinator around the PostgreSQL heartbeat store
- memory, S3, general workflow/control-plane, and Lucid product work
