### PR TITLE
Add Heddle-owned heartbeat run lifecycle

### DIFF
--- a/docs/releases/runtime-v6.3.0.md
+++ b/docs/releases/runtime-v6.3.0.md
@@ -1,0 +1,18 @@
+# `@heddleagent/runtime` 6.3.0
+
+This release adds `HeartbeatRunService` for hosts that execute one explicit
+heartbeat cycle and need a cancellable ordered stream rather than the runner's
+callback-and-promise interface.
+
+The service owns:
+
+- process-local heartbeat run identity;
+- callback-to-`AsyncIterable` activity delivery;
+- cancellation propagation;
+- ordered stream envelopes; and
+- exactly one result, cancellation, or safe error terminal.
+
+The service deliberately does not schedule or claim tasks, persist checkpoints
+or run history, choose models and tools, prepare MCP access, or know about
+AgentCore and HTTP. Those responsibilities remain with the scheduler,
+persistence adapter, and deploying host.

--- a/packages/README.md
+++ b/packages/README.md
@@ -7,8 +7,9 @@ This directory records the v6 package identities and responsibility boundaries.
 implementation as a stable package. `@heddleagent/postgres@6.1.0` ships the
 Execution Host lifecycle and heartbeat adapters. `@heddleagent/run-client@6.0.0`
 ships the existing browser-safe run client under its final coordinate.
-`@heddleagent/runtime@6.2.0` ships the existing embeddable SDK, the bridge
-used by the official CLI, and an optional remote heartbeat-execution seam.
+`@heddleagent/runtime@6.3.0` ships the existing embeddable SDK, the bridge
+used by the official CLI, an optional remote heartbeat-execution seam, and the
+process-local heartbeat run lifecycle used by compatible Execution Hosts.
 `@heddleagent/cli@6.0.0` ships the existing `heddle`
 command, TUI, daemon, and browser control plane. The former `@roackb2/*`
 coordinates are deprecated and remain installable only so existing applications
@@ -18,7 +19,7 @@ keep running; new integrations should use the `@heddleagent/*` packages.
 
 | Package | Responsibility | Migration status |
 | --- | --- | --- |
-| `@heddleagent/runtime` | Embeddable TypeScript/Node agent runtime and SDK | Stable `6.2.0`; `/runs` replaces the former `/hosted` package-path name, `/cli` is the official CLI bridge, and heartbeat execution may be delegated through a provider-neutral port |
+| `@heddleagent/runtime` | Embeddable TypeScript/Node agent runtime and SDK | Stable `6.3.0`; `/runs` replaces the former `/hosted` package-path name, `/cli` is the official CLI bridge, and Heddle owns the lifecycle for explicit heartbeat runs |
 | `@heddleagent/cli` | Installable Heddle coding-agent product and `heddle` executable | Existing CLI, TUI, daemon, and browser control plane activated at stable `6.0.0` |
 | `@heddleagent/run-client` | Browser-safe JavaScript run protocol consumer | Existing implementation activated at stable `6.0.0` |
 | `@heddleagent/execution-host-client` | Backend contracts and direct/AgentCore clients for invoking a separate compatible Execution Host | Stable `6.2.0`; explicit conversation and heartbeat workflows with hosted heartbeat composition at `/heartbeat` |

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -21,7 +21,7 @@ Use the subpaths only when the host needs their additional assumptions:
 ```ts
 import { ConversationRunService } from '@heddleagent/runtime/runs'
 import { streamConversationRunSse } from '@heddleagent/runtime/runs/http-sse'
-import { OpenAiAdapter } from '@heddleagent/runtime/advanced'
+import { HeartbeatRunService, OpenAiAdapter } from '@heddleagent/runtime/advanced'
 import { HeartbeatTaskStoreConformance } from '@heddleagent/runtime/heartbeat/testing'
 ```
 
@@ -48,6 +48,13 @@ service.
   Heddle-owned persistence ports;
 - process-local run lifecycle mechanics; and
 - reusable heartbeat and low-level runtime composition.
+
+`HeartbeatRunService` starts one explicitly requested heartbeat cycle and
+returns its run id, result promise, ordered activity stream, and cancellation
+operation. A compatible Execution Host should use that handle rather than
+reimplementing callback buffering or terminal sequencing. Scheduling, task
+persistence, and deployment-specific model/tool/MCP preparation stay outside
+the service.
 
 ## Does not own
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/runtime",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Embeddable TypeScript and Node.js agent runtime and SDK for Heddle-powered products",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/src/__tests__/unit/core/heartbeat-run-service.test.ts
+++ b/src/__tests__/unit/core/heartbeat-run-service.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HeartbeatRunService } from '@/core/heartbeat/runs/index.js';
+import type {
+  AgentHeartbeatEvent,
+  AgentHeartbeatResult,
+  RunAgentHeartbeatOptions,
+} from '@/core/heartbeat/agent/index.js';
+
+describe('HeartbeatRunService', () => {
+  it('publishes ordered activity followed by one result terminal', async () => {
+    const activity = heartbeatActivity();
+    const heartbeatResult = result();
+    const runner = vi.fn(async (options: RunAgentHeartbeatOptions) => {
+      options.onEvent?.(activity);
+      return heartbeatResult;
+    });
+    const timestamps = ['2026-08-18T12:00:01.000Z', '2026-08-18T12:00:02.000Z'];
+    const service = new HeartbeatRunService({
+      createRunId: () => 'heartbeat-run-1',
+      now: () => timestamps.shift() ?? '2026-08-18T12:00:03.000Z',
+      runner,
+    });
+
+    const run = service.start({ task: 'Review the workspace.' });
+
+    await expect(run.result).resolves.toBe(heartbeatResult);
+    await expect(collect(run.events())).resolves.toEqual([
+      {
+        kind: 'activity',
+        activity,
+        runId: 'heartbeat-run-1',
+        sequence: 1,
+        timestamp: '2026-08-18T12:00:01.000Z',
+      },
+      {
+        kind: 'result',
+        result: heartbeatResult,
+        runId: 'heartbeat-run-1',
+        sequence: 2,
+        timestamp: '2026-08-18T12:00:02.000Z',
+      },
+    ]);
+    expect(run.cancel()).toBe(false);
+  });
+
+  it('aborts an active runner and publishes cancellation as the terminal', async () => {
+    let markStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const runner = vi.fn(async (options: RunAgentHeartbeatOptions) => {
+      markStarted?.();
+      return await new Promise<AgentHeartbeatResult>((_resolve, reject) => {
+        options.abortSignal?.addEventListener('abort', () => reject(options.abortSignal?.reason), {
+          once: true,
+        });
+      });
+    });
+    const service = new HeartbeatRunService({
+      createRunId: () => 'heartbeat-run-cancelled',
+      now: () => '2026-08-18T12:01:00.000Z',
+      runner,
+    });
+    const run = service.start({ task: 'Review the workspace.' });
+    await started;
+
+    expect(run.cancel()).toBe(true);
+    await expect(run.result).rejects.toThrow('Heartbeat run was cancelled.');
+    await expect(collect(run.events())).resolves.toEqual([
+      {
+        kind: 'cancelled',
+        reason: 'Heartbeat run was cancelled.',
+        runId: 'heartbeat-run-cancelled',
+        sequence: 1,
+        timestamp: '2026-08-18T12:01:00.000Z',
+      },
+    ]);
+    expect(run.cancel()).toBe(false);
+  });
+
+  it('keeps runner failures out of the public error terminal', async () => {
+    const runner = vi.fn(async () => {
+      throw new Error('provider response contained sensitive diagnostics');
+    });
+    const service = new HeartbeatRunService({
+      createRunId: () => 'heartbeat-run-failed',
+      now: () => '2026-08-18T12:02:00.000Z',
+      runner,
+    });
+    const run = service.start({ task: 'Review the workspace.' });
+
+    await expect(run.result).rejects.toThrow('sensitive diagnostics');
+    await expect(collect(run.events())).resolves.toEqual([
+      {
+        kind: 'error',
+        error: {
+          code: 'heartbeat_run_failed',
+          message: 'The heartbeat run could not complete.',
+        },
+        runId: 'heartbeat-run-failed',
+        sequence: 1,
+        timestamp: '2026-08-18T12:02:00.000Z',
+      },
+    ]);
+  });
+});
+
+function heartbeatActivity(): AgentHeartbeatEvent {
+  return {
+    type: 'heartbeat.decision',
+    runId: 'agent-run-1',
+    decision: 'complete',
+    outcome: 'done',
+    summary: 'Workspace reviewed.',
+    timestamp: '2026-08-18T12:00:00.000Z',
+  };
+}
+
+function result(): AgentHeartbeatResult {
+  const state = {
+    status: 'finished' as const,
+    runId: 'agent-run-1',
+    goal: 'Review the workspace.',
+    model: 'gpt-5',
+    provider: 'openai' as const,
+    workspaceRoot: '/workspace',
+    startedAt: '2026-08-18T11:59:00.000Z',
+    finishedAt: '2026-08-18T12:00:00.000Z',
+    outcome: 'done' as const,
+    summary: 'Workspace reviewed.',
+    transcript: [],
+    trace: [],
+  };
+
+  return {
+    decision: 'complete',
+    summary: state.summary,
+    state,
+    checkpoint: {
+      version: 1,
+      runId: state.runId,
+      createdAt: state.finishedAt,
+      state,
+    },
+  };
+}
+
+async function collect<Event>(events: AsyncIterable<Event>): Promise<Event[]> {
+  const collected: Event[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -252,6 +252,14 @@ export type {
   HeartbeatRunnerAgentRunContext,
   RunAgentHeartbeatOptions,
 } from './core/heartbeat/agent/index.js';
+export { HeartbeatRunService } from './core/heartbeat/runs/index.js';
+export type {
+  HeartbeatRunHandle,
+  HeartbeatRunPublicError,
+  HeartbeatRunServiceOptions,
+  HeartbeatRunStreamItem,
+  HeartbeatRunner,
+} from './core/heartbeat/runs/index.js';
 export {
   FileHeartbeatCheckpointRepository,
   StoredHeartbeatService,

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -12,6 +12,11 @@ operator-facing heartbeat views.
 - `agent/`: `HeartbeatRunnerAgent` owns one autonomous runner-agent cycle on top of
   `AgentLoopRuntimeService.run`, with prompt and decision policy classes kept
   beside it.
+- `runs/`: `HeartbeatRunService` owns the process-local lifecycle for one
+  explicitly requested heartbeat cycle: run identity, cancellation, ordered
+  activity, and exactly one terminal result, cancellation, or safe error.
+  Hosts provide resolved model/tool/MCP options and consume its handle instead
+  of rebuilding callback-to-stream coordination.
 - `checkpoint/`: `StoredHeartbeatService` and
   `FileHeartbeatCheckpointRepository` own checkpoint-backed one-off heartbeat
   execution.
@@ -65,6 +70,9 @@ operator-facing heartbeat views.
 ## Boundary Notes
 
 - Keep scheduler/task persistence concerns here, not in runtime.
+- `HeartbeatRunService` is an execution primitive, not a scheduler or durable
+  task authority. It must not claim tasks, persist checkpoints, or settle task
+  history.
 - `executionId` is the fencing token for one task attempt. A store must reject
   completion, failure, skip, or cancellation persistence when that execution
   no longer owns the task.

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -88,6 +88,14 @@ export type {
   HeartbeatRunnerAgentRunContext,
   RunAgentHeartbeatOptions,
 } from './agent/index.js';
+export { HeartbeatRunService } from './runs/index.js';
+export type {
+  HeartbeatRunHandle,
+  HeartbeatRunPublicError,
+  HeartbeatRunServiceOptions,
+  HeartbeatRunStreamItem,
+  HeartbeatRunner,
+} from './runs/index.js';
 export { HeartbeatLucidPresenter, HeartbeatTaskViewProjector } from './views/index.js';
 export type {
   HeartbeatRunView,

--- a/src/core/heartbeat/runs/README.md
+++ b/src/core/heartbeat/runs/README.md
@@ -1,0 +1,14 @@
+# Heartbeat Runs
+
+`HeartbeatRunService` owns the process-local lifecycle for one explicitly
+requested `HeartbeatRunnerAgent` execution.
+
+It turns the runner's callback events and result promise into one cancellable
+handle with ordered activity and exactly one result, cancellation, or safe
+error terminal. Hosts can stream that handle without implementing their own
+buffer, sequence counter, cancellation controller, or terminal state machine.
+
+The service does not schedule tasks, persist checkpoints or task state, select
+models and tools, prepare MCP access, or know about AgentCore and HTTP. Those
+responsibilities remain with the heartbeat scheduler, persistence adapter, and
+deploying host respectively.

--- a/src/core/heartbeat/runs/index.ts
+++ b/src/core/heartbeat/runs/index.ts
@@ -1,0 +1,8 @@
+export { HeartbeatRunService } from './service.js';
+export type {
+  HeartbeatRunHandle,
+  HeartbeatRunPublicError,
+  HeartbeatRunServiceOptions,
+  HeartbeatRunStreamItem,
+  HeartbeatRunner,
+} from './types.js';

--- a/src/core/heartbeat/runs/service.ts
+++ b/src/core/heartbeat/runs/service.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from 'node:crypto';
+import dayjs from 'dayjs';
+import { RuntimeSubscriptionStream } from '@/core/runtime/subscriptions/index.js';
+import { HeartbeatRunnerAgent } from '../agent/index.js';
+import type {
+  HeartbeatRunHandle,
+  HeartbeatRunServiceOptions,
+  HeartbeatRunStreamItem,
+  HeartbeatRunner,
+} from './types.js';
+import type { RunAgentHeartbeatOptions } from '../agent/index.js';
+
+const HEARTBEAT_CANCELLED_MESSAGE = 'Heartbeat run was cancelled.';
+const HEARTBEAT_FAILED_MESSAGE = 'The heartbeat run could not complete.';
+
+type HeartbeatRunStreamPayload = HeartbeatRunStreamItem extends infer Item
+  ? Item extends unknown
+    ? Omit<Item, 'runId' | 'sequence' | 'timestamp'>
+    : never
+  : never;
+
+/**
+ * Owns the process-local lifecycle for one explicitly requested heartbeat run.
+ *
+ * Scheduling and durable task settlement remain in the heartbeat scheduler;
+ * deployment-specific model, tool, and MCP composition remain with the host.
+ */
+export class HeartbeatRunService {
+  private readonly createRunId: () => string;
+  private readonly now: () => string;
+  private readonly runner: HeartbeatRunner;
+
+  constructor(options: HeartbeatRunServiceOptions = {}) {
+    this.createRunId = options.createRunId ?? (() => `heartbeat-run-${randomUUID()}`);
+    this.now = options.now ?? (() => dayjs().toISOString());
+    this.runner = options.runner ?? HeartbeatRunnerAgent.run.bind(HeartbeatRunnerAgent);
+  }
+
+  start(options: RunAgentHeartbeatOptions): HeartbeatRunHandle {
+    const runId = this.createRunId();
+    const controller = new AbortController();
+    const signal = options.abortSignal
+      ? AbortSignal.any([options.abortSignal, controller.signal])
+      : controller.signal;
+    const stream = new RuntimeSubscriptionStream<HeartbeatRunStreamItem>();
+    let sequence = 0;
+    let terminal = false;
+
+    const publish = (item: HeartbeatRunStreamPayload): void => {
+      if (terminal) {
+        return;
+      }
+
+      const isTerminal = item.kind !== 'activity';
+      terminal = isTerminal;
+      sequence += 1;
+      stream.sink.push({
+        ...item,
+        runId,
+        sequence,
+        timestamp: this.now(),
+      } as HeartbeatRunStreamItem);
+      if (isTerminal) {
+        stream.sink.close();
+      }
+    };
+
+    const result = Promise.resolve()
+      .then(async () => {
+        HeartbeatRunService.throwIfCancelled(signal);
+        const heartbeatResult = await this.runner({
+          ...options,
+          abortSignal: signal,
+          onEvent: (event) => {
+            publish({ kind: 'activity', activity: event });
+            options.onEvent?.(event);
+          },
+        });
+        HeartbeatRunService.throwIfCancelled(signal);
+        publish({ kind: 'result', result: heartbeatResult });
+        return heartbeatResult;
+      })
+      .catch((error: unknown) => {
+        publish(signal.aborted
+          ? { kind: 'cancelled', reason: HEARTBEAT_CANCELLED_MESSAGE }
+          : {
+            kind: 'error',
+            error: {
+              code: 'heartbeat_run_failed',
+              message: HEARTBEAT_FAILED_MESSAGE,
+            },
+          });
+        throw error;
+      });
+    result.catch(() => undefined);
+
+    return {
+      runId,
+      result,
+      events: () => stream,
+      cancel: () => {
+        if (terminal || signal.aborted) {
+          return false;
+        }
+        controller.abort(new Error(HEARTBEAT_CANCELLED_MESSAGE));
+        return true;
+      },
+    };
+  }
+
+  private static throwIfCancelled(signal: AbortSignal): void {
+    if (!signal.aborted) {
+      return;
+    }
+
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error(HEARTBEAT_CANCELLED_MESSAGE);
+  }
+}

--- a/src/core/heartbeat/runs/types.ts
+++ b/src/core/heartbeat/runs/types.ts
@@ -1,0 +1,51 @@
+import type {
+  AgentHeartbeatEvent,
+  AgentHeartbeatResult,
+  RunAgentHeartbeatOptions,
+} from '../agent/index.js';
+
+export type HeartbeatRunPublicError = {
+  code: 'heartbeat_run_failed';
+  message: string;
+};
+
+type HeartbeatRunStreamEnvelope = {
+  runId: string;
+  sequence: number;
+  timestamp: string;
+};
+
+export type HeartbeatRunStreamItem =
+  | (HeartbeatRunStreamEnvelope & {
+    kind: 'activity';
+    activity: AgentHeartbeatEvent;
+  })
+  | (HeartbeatRunStreamEnvelope & {
+    kind: 'result';
+    result: AgentHeartbeatResult;
+  })
+  | (HeartbeatRunStreamEnvelope & {
+    kind: 'cancelled';
+    reason: string;
+  })
+  | (HeartbeatRunStreamEnvelope & {
+    kind: 'error';
+    error: HeartbeatRunPublicError;
+  });
+
+export type HeartbeatRunHandle = {
+  runId: string;
+  result: Promise<AgentHeartbeatResult>;
+  events(): AsyncIterable<HeartbeatRunStreamItem>;
+  cancel(): boolean;
+};
+
+export type HeartbeatRunner = (
+  options: RunAgentHeartbeatOptions,
+) => Promise<AgentHeartbeatResult>;
+
+export type HeartbeatRunServiceOptions = {
+  createRunId?: () => string;
+  now?: () => string;
+  runner?: HeartbeatRunner;
+};


### PR DESCRIPTION
## Summary
- add a public HeartbeatRunService for explicit heartbeat executions
- own run identity, ordered activity, cancellation, and exactly one safe terminal in Heddle
- expose the service from @heddleagent/runtime/advanced and prepare runtime 6.3.0

## Boundary
- keeps scheduling, durable task authority, AgentCore, MCP preparation, tools, credentials, and workspace policy outside the service
- avoids a universal run-framework redesign

## Verification
- focused lifecycle tests: 3 passed
- yarn typecheck
- yarn lint
- yarn runtime:build