### PR TITLE
Narrow hosted execution authority issuer boundary

### DIFF
--- a/packages/execution-host-client/src/__tests__/conversation.test.ts
+++ b/packages/execution-host-client/src/__tests__/conversation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type {
-  ExecutionAuthority,
+  ExecutionAuthorityIssuer,
   ExecutionAuthorityIssueInput,
   IssuedExecutionAuthority,
 } from '../authority/index.js';
@@ -113,7 +113,7 @@ describe('hosted conversation turn service', () => {
     const controller = new AbortController();
     controller.abort();
     const service = new HostedConversationTurnService({
-      authority: { issue, publicJwks: () => ({ keys: [] }) },
+      authority: { issue },
       executionHost: {
         streamConversationTurn: async function* () {
           yield accepted();
@@ -136,10 +136,9 @@ function authority(
   issue: (
     input: ExecutionAuthorityIssueInput,
   ) => IssuedExecutionAuthority,
-): ExecutionAuthority {
+): ExecutionAuthorityIssuer {
   return {
     issue: async (input) => issue(input),
-    publicJwks: () => ({ keys: [] }),
   };
 }
 

--- a/packages/execution-host-client/src/__tests__/heartbeat.test.ts
+++ b/packages/execution-host-client/src/__tests__/heartbeat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ExecutionAuthority } from '../authority/index.js';
+import type { ExecutionAuthorityIssuer } from '../authority/index.js';
 import {
   EXECUTION_CONTRACT_VERSION,
   HEARTBEAT_TASK_WORKFLOW,
@@ -20,7 +20,7 @@ const RUNTIME_SESSION_ID = `runtime-session-${'a'.repeat(40)}`;
 
 describe('hosted heartbeat execution', () => {
   it('binds authority and credentials while returning activity and the terminal result', async () => {
-    const issue = vi.fn<ExecutionAuthority['issue']>(async (authority) => {
+    const issue = vi.fn<ExecutionAuthorityIssuer['issue']>(async (authority) => {
       const metadata = {
         scope: { adopterId: 'adopter-a', ...authority.scope },
         runtimeSessionId: authority.runtimeSessionId,
@@ -48,7 +48,7 @@ describe('hosted heartbeat execution', () => {
       },
     };
     const service = new HostedHeartbeatTaskService({
-      authority: { issue, publicJwks: () => ({ keys: [] }) },
+      authority: { issue },
       executionHost,
       modelCredentials: {
         resolveModelApiKey: async () => 'model-api-key-value',

--- a/packages/execution-host-client/src/authority/index.ts
+++ b/packages/execution-host-client/src/authority/index.ts
@@ -2,6 +2,7 @@ export { JoseExecutionAuthority } from './jose-execution-authority.js';
 export type {
   ExecutionAuthority,
   ExecutionAuthorityConfig,
+  ExecutionAuthorityIssuer,
   ExecutionAuthorityIssueInput,
   ExecutionAuthorityKeyPair,
   ExecutionAuthorityMcpConfig,

--- a/packages/execution-host-client/src/authority/types.ts
+++ b/packages/execution-host-client/src/authority/types.ts
@@ -58,8 +58,11 @@ export interface IssuedExecutionAuthority {
   toJSON(): IssuedExecutionAuthorityMetadata;
 }
 
-export interface ExecutionAuthority {
+export interface ExecutionAuthorityIssuer {
   issue(input: ExecutionAuthorityIssueInput): Promise<IssuedExecutionAuthority>;
+}
+
+export interface ExecutionAuthority extends ExecutionAuthorityIssuer {
   publicJwks(): JSONWebKeySet;
 }
 

--- a/packages/execution-host-client/src/conversation/types.ts
+++ b/packages/execution-host-client/src/conversation/types.ts
@@ -5,7 +5,7 @@ import {
   RuntimeSessionIdSchema,
   type ExecutionHostStreamEvent,
 } from '../contracts/index.js';
-import type { ExecutionAuthority } from '../authority/index.js';
+import type { ExecutionAuthorityIssuer } from '../authority/index.js';
 import type { ExecutionHost } from '../http-sse/index.js';
 
 export const HostedConversationTurnInputSchema = z.object({
@@ -47,7 +47,7 @@ export interface HostedConversationTurnRunner {
 }
 
 export type HostedConversationTurnServiceConfig = {
-  authority: ExecutionAuthority;
+  authority: ExecutionAuthorityIssuer;
   executionHost: ExecutionHost;
   modelCredentials: HostedModelCredentialProvider;
   /** Omit this policy when the hosted workflow needs no product MCP tools. */

--- a/packages/execution-host-client/src/heartbeat/types.ts
+++ b/packages/execution-host-client/src/heartbeat/types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { ExecutionAuthority } from '../authority/index.js';
+import type { ExecutionAuthorityIssuer } from '../authority/index.js';
 import {
   ExecutionHostHeartbeatTaskRequestSchema,
   ExecutionScopeSchema,
@@ -34,7 +34,7 @@ export interface HostedHeartbeatTaskRunner {
 }
 
 export type HostedHeartbeatTaskServiceConfig = {
-  authority: ExecutionAuthority;
+  authority: ExecutionAuthorityIssuer;
   executionHost: HeartbeatExecutionHost;
   modelCredentials: HostedModelCredentialProvider;
   /** Omit this policy when the heartbeat workflow needs no product MCP tools. */


### PR DESCRIPTION
## What changed

- add the focused `ExecutionAuthorityIssuer` contract for components that only mint short-lived execution credentials
- let hosted conversation and heartbeat services depend on that issuer instead of the full authority/JWKS surface
- keep `ExecutionAuthority` as the issuer plus public JWKS for HTTP verification edges

## Why

The hosted coordinator obtains just-in-time credentials from the product authority. It should not need product signing keys or pretend to serve the product JWKS. Narrowing the public contract keeps that integration explicit and reusable.

## Validation

- `yarn execution-host-client:test` (14 files, 119 tests)
- `yarn execution-host-client:compile`
- `git diff --check`
