### PR TITLE
fix: surface model quota failures

### DIFF
--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -1123,6 +1123,33 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('keeps the safe failure summary visible after loop completion', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    fixture.emitRunActivity({
+      source: 'agent-loop',
+      type: 'loop.finished',
+      runId: 'run-1',
+      outcome: 'error',
+      summary: 'LLM error: Model provider quota or billing limit reached',
+      failure: { source: 'model', code: 'quota' },
+      timestamp: new Date().toISOString(),
+    });
+    fixture.emitRunResult({
+      outcome: 'error',
+      summary: 'LLM error: Model provider quota or billing limit reached\n\nCheck the provider account or switch credentials.',
+    });
+
+    expect(store.getSnapshot().latestUpdate).toEqual({
+      label: 'Run failed',
+      detail: 'LLM error: Model provider quota or billing limit reached\n\nCheck the provider account or switch credentials.',
+      tone: 'error',
+    });
+    store.dispose();
+  });
+
   it('delivers terminal notifications from session live events when configured', async () => {
     const fixture = createClientFixture();
     const notificationService = { deliver: vi.fn() };

--- a/src/__tests__/unit/client-shared/session-activity-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-activity-service.test.ts
@@ -59,6 +59,24 @@ describe('ClientSharedSessionActivityService', () => {
     expect(effects).toEqual(['finished:Run finished: done', 'workspace changed']);
   });
 
+  it('projects the safe run summary for failed lifecycle activities', () => {
+    const latestUpdate = ClientSharedSessionActivityService.resolveLatestUpdate({
+      type: 'loop.finished',
+      outcome: 'error',
+      runId: 'run-1',
+      source: 'agent-loop',
+      summary: 'LLM error: Model provider quota or billing limit reached',
+      failure: { source: 'model', code: 'quota' },
+      timestamp: new Date().toISOString(),
+    } as ControlPlaneSessionActivity);
+
+    expect(latestUpdate).toEqual({
+      label: 'Run failed',
+      detail: 'LLM error: Model provider quota or billing limit reached',
+      tone: 'error',
+    });
+  });
+
   it('applies run effects for direct shell activities', () => {
     const effects: string[] = [];
 

--- a/src/__tests__/unit/core/agent-model-turn-retry-service.test.ts
+++ b/src/__tests__/unit/core/agent-model-turn-retry-service.test.ts
@@ -34,13 +34,18 @@ describe('AgentModelTurnRetryService', () => {
     expect(JSON.stringify(decision.failure)).not.toContain('secret-value');
   });
 
-  it.each([undefined, 429])(
-    'classifies structured insufficient_quota as non-retryable before status %s',
-    (status) => {
+  it.each([
+    ['insufficient_quota', undefined],
+    ['insufficient_quota', 429],
+    ['credit_balance_exhausted', undefined],
+    ['credit_balance_exhausted', 429],
+  ] as const)(
+    'classifies structured quota code %s as non-retryable before status %s',
+    (code, status) => {
       const decision = AgentModelTurnRetryService.resolve({
         kind: 'error',
         error: Object.assign(new Error('provider message'), {
-          code: 'insufficient_quota',
+          code,
           ...(status === undefined ? {} : { status }),
         }),
       });

--- a/src/cli-v2/state/control-plane-run-controller.ts
+++ b/src/cli-v2/state/control-plane-run-controller.ts
@@ -278,13 +278,15 @@ function terminalPresentation(event: Exclude<ControlPlaneSessionRunEventEnvelope
       latestUpdate: { label: 'Run cancelled', detail: event.reason, tone: 'warning' as const },
     };
   }
+  const outcome = event.result.outcome;
+  const failed = outcome === 'error';
   return {
     liveStatus: undefined,
     latestUpdate: {
-      label: 'Run finished',
-      detail: event.result.outcome ?? event.result.summary,
-      tone: event.result.outcome
-        ? SessionActivityService.resolveRunOutcomeTone(event.result.outcome)
+      label: failed ? 'Run failed' : 'Run finished',
+      detail: failed ? event.result.summary ?? outcome : outcome ?? event.result.summary,
+      tone: outcome
+        ? SessionActivityService.resolveRunOutcomeTone(outcome)
         : 'success' as const,
     },
   };

--- a/src/client-shared/services/session-activities/README.md
+++ b/src/client-shared/services/session-activities/README.md
@@ -11,6 +11,8 @@ after they receive API-provided live events.
 - Shared derived labels for tool-related activities.
 - Shared effects for final-answer, commentary, and reasoning-summary streams;
   each remains a distinct activity so clients can present them independently.
+- Safe latest-status projection for failed runs, preserving the core-provided
+  failure summary instead of reducing it to a generic error outcome.
 - Active plan lifetime at the client edge: `plan.updated` sets the visible plan,
   the first non-empty `assistant.stream` chunk clears it as the final answer
   becomes visible, and `loop.started` or `loop.finished` clear it as lifecycle

--- a/src/client-shared/services/session-activities/session-activity-service.ts
+++ b/src/client-shared/services/session-activities/session-activity-service.ts
@@ -229,8 +229,8 @@ export class ClientSharedSessionActivityService {
       tone: 'warning',
     }),
     'loop.finished': (activity) => ({
-      label: 'Run finished',
-      detail: activity.outcome,
+      label: activity.outcome === 'error' ? 'Run failed' : 'Run finished',
+      detail: activity.outcome === 'error' ? activity.summary : activity.outcome,
       tone: ClientSharedSessionActivityService.resolveRunOutcomeTone(activity.outcome),
     }),
     'compaction.running': (activity) => ({

--- a/src/core/agent/model/README.md
+++ b/src/core/agent/model/README.md
@@ -32,11 +32,12 @@ structured adapter errors. Product-specific copy and HTTP/API error mapping
 belong in the consuming host.
 
 Structured provider error codes take precedence over HTTP status when they
-carry more precise recovery semantics. For example, OpenAI's
-`insufficient_quota` is exposed as `{ source: 'model', code: 'quota' }` and is
-non-retryable, even if the provider also reports HTTP 429. An ordinary HTTP 429
-remains the retryable `rate_limit` category. Add future provider codes to this
-single classifier; never infer quota state from provider message text.
+carry more precise recovery semantics. For example, OpenAI quota failures can
+surface as `insufficient_quota` or `credit_balance_exhausted`; both are exposed
+as `{ source: 'model', code: 'quota' }` and are non-retryable, even if the
+provider also reports HTTP 429. An ordinary HTTP 429 remains the retryable
+`rate_limit` category. Add future provider codes to this single classifier;
+never infer quota state from provider message text.
 
 ## Adjacent Owners
 

--- a/src/core/agent/model/model-turn-retry-service.ts
+++ b/src/core/agent/model/model-turn-retry-service.ts
@@ -28,6 +28,7 @@ const RETRYABLE_STATUS_CODES = new Set([408, 409, 425, 429, 500, 502, 503, 504])
 const NON_RETRYABLE_STATUS_CODES = new Set([400, 401, 403, 404, 422]);
 const MODEL_FAILURE_BY_PROVIDER_CODE = new Map<string, ModelRunFailureCode>([
   ['insufficient_quota', 'quota'],
+  ['credit_balance_exhausted', 'quota'],
   ['context_length_exceeded', 'context_window'],
   ['context_window_exceeded', 'context_window'],
   ['max_context_length_exceeded', 'context_window'],


### PR DESCRIPTION
## Summary

- classify OpenAI credit_balance_exhausted stream errors as non-retryable quota failures
- preserve normalized failed-run summaries in shared clients and the CLI completion status
- document the error boundary and add focused regression coverage

## Root cause

OpenAI returned an HTTP 200 streaming response whose error event used type insufficient_quota and code credit_balance_exhausted. Heddle did not recognize that provider code, and the final UI projection then replaced the normalized failure summary with the generic outcome error.

## Verification

- yarn vitest run src/__tests__/unit/core/agent-model-turn-retry-service.test.ts src/__tests__/unit/client-shared/session-activity-service.test.ts src/__tests__/unit/cli-v2/control-plane-session-store.test.ts (71 tests passed)
- yarn lint
- yarn build (passed during yarn install --frozen-lockfile)