### PR TITLE
Release Execution Host client 6.3.0

### DIFF
--- a/docs/releases/execution-host-client-v6.3.0.md
+++ b/docs/releases/execution-host-client-v6.3.0.md
@@ -1,0 +1,24 @@
+# Execution Host Client v6.3.0
+
+`@heddleagent/execution-host-client@6.3.0` separates execution-authority
+issuance from public-key publication so a product can grant one coordinator
+run without exposing or reimplementing the broader authority service.
+
+## What changed
+
+- add the narrow `ExecutionAuthorityIssuer` interface with the existing
+  `issue(...)` operation;
+- keep `ExecutionAuthority` as the full issuer plus public-JWKS authority;
+- let conversation and heartbeat delegation depend only on issuance when that
+  is the capability they need; and
+- preserve the existing JWT claims, workflow contracts, and wire behavior.
+
+This release does not add a coordinator service, persistence implementation,
+deployment workflow, or new authority format. Products still own authenticated
+scope and authorization; the coordinator receives one short-lived delegated
+authority rather than a signing key.
+
+## Publication
+
+Publish manually from the reviewed release commit. This repository does not
+automatically publish packages from `main`.

--- a/packages/execution-host-client/package.json
+++ b/packages/execution-host-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/execution-host-client",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Backend contracts, execution authority, lifecycle services, and clients for compatible Heddle Execution Hosts",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- publish the merged `ExecutionAuthorityIssuer` boundary as `@heddleagent/execution-host-client@6.3.0`
- add the curated package release note
- keep authority claims and wire behavior unchanged

## Checks

- 14 package test files / 119 tests passed
- Python clean-room conformance: 36 tests passed
- package build passed
- `npm pack --dry-run` reports `6.3.0`

## Scope

This release does not add the coordinator, deployment automation, persistence, or a new authority format.