### PR TITLE
Serialize heartbeat run events at the JSON boundary

### DIFF
--- a/src/__tests__/unit/core/heartbeat-run-service.test.ts
+++ b/src/__tests__/unit/core/heartbeat-run-service.test.ts
@@ -43,6 +43,32 @@ describe('HeartbeatRunService', () => {
     expect(run.cancel()).toBe(false);
   });
 
+  it('projects stream payloads onto a JSON-compatible boundary', async () => {
+    const activity = {
+      ...heartbeatActivity(),
+      optionalDetail: undefined,
+    } as AgentHeartbeatEvent;
+    const heartbeatResult = result();
+    heartbeatResult.state.usage = undefined;
+    const runner = vi.fn(async (options: RunAgentHeartbeatOptions) => {
+      options.onEvent?.(activity);
+      return heartbeatResult;
+    });
+    const service = new HeartbeatRunService({
+      createRunId: () => 'heartbeat-run-json',
+      now: () => '2026-08-18T12:00:00.000Z',
+      runner,
+    });
+
+    const run = service.start({ task: 'Review the workspace.' });
+    await run.result;
+    const events = await collect(run.events());
+
+    expect(events).toEqual(JSON.parse(JSON.stringify(events)));
+    expect(events[0]).not.toHaveProperty('activity.optionalDetail');
+    expect(events[1]).not.toHaveProperty('result.state.usage');
+  });
+
   it('aborts an active runner and publishes cancellation as the terminal', async () => {
     let markStarted: (() => void) | undefined;
     const started = new Promise<void>((resolve) => {

--- a/src/core/heartbeat/runs/README.md
+++ b/src/core/heartbeat/runs/README.md
@@ -5,8 +5,11 @@ requested `HeartbeatRunnerAgent` execution.
 
 It turns the runner's callback events and result promise into one cancellable
 handle with ordered activity and exactly one result, cancellation, or safe
-error terminal. Hosts can stream that handle without implementing their own
-buffer, sequence counter, cancellation controller, or terminal state machine.
+error terminal. Stream payloads are projected through JSON serialization so
+optional `undefined` fields cannot break a durable store or wire contract.
+Hosts can stream that handle without implementing their own buffer, sequence
+counter, cancellation controller, serialization shim, or terminal state
+machine.
 
 The service does not schedule tasks, persist checkpoints or task state, select
 models and tools, prepare MCP access, or know about AgentCore and HTTP. Those

--- a/src/core/heartbeat/runs/service.ts
+++ b/src/core/heartbeat/runs/service.ts
@@ -51,11 +51,12 @@ export class HeartbeatRunService {
         return;
       }
 
-      const isTerminal = item.kind !== 'activity';
+      const projected = toJsonCompatible(item);
+      const isTerminal = projected.kind !== 'activity';
       terminal = isTerminal;
       sequence += 1;
       stream.sink.push({
-        ...item,
+        ...projected,
         runId,
         sequence,
         timestamp: this.now(),
@@ -117,4 +118,14 @@ export class HeartbeatRunService {
       ? signal.reason
       : new Error(HEARTBEAT_CANCELLED_MESSAGE);
   }
+}
+
+/**
+ * Projects rich in-process events onto the same JSON value boundary used by
+ * durable heartbeat stores and Execution Host transports. This removes
+ * optional `undefined` properties without making every host rebuild the
+ * serialization step that Heddle's run service promises to own.
+ */
+function toJsonCompatible<Value>(value: Value): Value {
+  return JSON.parse(JSON.stringify(value)) as Value;
 }


### PR DESCRIPTION
Summary
- project heartbeat activity and terminal items through JSON serialization before publishing the run stream
- keep the wire/durable serialization rule inside Heddle rather than every Execution Host
- document the boundary and cover nested optional undefined fields with one focused test

Why
The real local Lucid coordinator vertical exposed that rich in-process events accepted by the Runtime could fail the strict Execution Host JSON schema. The prior private host had supplied this projection before heartbeat lifecycle moved into Heddle; the reusable run service now owns it.

Verification
- yarn vitest run src/__tests__/unit/core/heartbeat-run-service.test.ts
- 1 file, 4 tests passed
- real local foreground and heartbeat paths passed with this compiled service mounted into the Runtime; no AWS resources changed