### PR TITLE
feat: add prompt-free permission modes

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -56,8 +56,10 @@ Configuration is applied in this order:
 - `agentContextPaths`: optional project instruction files injected into the system prompt. When omitted, Heddle loads the first non-empty file found in this order: `HEDDLE.md`, `AGENTS.md`, `CLAUDE.md`. Only one default file is loaded to preserve context space. If configured, Heddle uses the listed paths exactly, so advanced projects can opt into custom names or multiple files.
 - `permissionMode`: user-facing approval mode for the workspace. `default`
   keeps normal approval behavior, `auto` enables the generated local coding
-  profile, and `custom` uses the hand-authored `autopilot` profile when one
-  exists with `mode: "autopilot"`. Switching modes preserves the `autopilot`
+  profile and asks at boundaries, `unattended` uses the same bounded authority
+  but denies boundary misses instead of ever opening an approval prompt, and
+  `custom` uses the hand-authored `autopilot` profile when one exists with
+  `mode: "autopilot"`. Switching modes preserves the `autopilot`
   field so a custom profile is not deleted when the user temporarily returns to
   Default or Auto. An `autopilot` block with `mode: "interactive"` documents
   normal approval behavior and does not make Custom selectable.
@@ -71,6 +73,11 @@ Configuration is applied in this order:
   envelope and the runtime-computed facts match the configured roots,
   capabilities, and environments. Hard-deny rules still block destructive
   actions before remembered approvals.
+
+`unattended` is prompt-free, not unrestricted. Network operations, production
+environments, unconfigured/manual-only roots, missing capabilities, and unclear
+policy envelopes are denied and traced. Shell commands still run with the host
+user's authority when allowed, so use OS isolation for untrusted workloads.
 
 `autopilot.roots[].path` should be a project/workspace boundary, usually a git
 repository root or a folder with config such as `package.json`,

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -57,8 +57,10 @@ Configuration is applied in this order:
 - `permissionMode`: user-facing approval mode for the workspace. `default`
   keeps normal approval behavior, `auto` enables the generated local coding
   profile and asks at boundaries, `unattended` uses the same bounded authority
-  but denies boundary misses instead of ever opening an approval prompt, and
-  `custom` uses the hand-authored `autopilot` profile when one exists with
+  but denies boundary misses instead of ever opening an approval prompt,
+  `unrestricted` skips Heddle approval prompts and checks for calls not blocked
+  by an explicit earlier deny policy, and `custom` uses the hand-authored
+  `autopilot` profile when one exists with
   `mode: "autopilot"`. Switching modes preserves the `autopilot`
   field so a custom profile is not deleted when the user temporarily returns to
   Default or Auto. An `autopilot` block with `mode: "interactive"` documents
@@ -78,6 +80,13 @@ Configuration is applied in this order:
 environments, unconfigured/manual-only roots, missing capabilities, and unclear
 policy envelopes are denied and traced. Shell commands still run with the host
 user's authority when allowed, so use OS isolation for untrusted workloads.
+
+`unrestricted` is also prompt-free, but it auto-approves tool calls that reach
+the permission fallback, including network, remote-service, and outside-root
+requests. Explicit deny policies placed before that fallback still win, and
+tool-owned schema, path-containment, and catastrophic shell-command guards still
+run during execution. This mode is not a sandbox: use it only in a disposable
+container or VM with least-privilege credentials and constrained network access.
 
 `autopilot.roots[].path` should be a project/workspace boundary, usually a git
 repository root or a folder with config such as `package.json`,
@@ -114,6 +123,8 @@ active workspace root, so a sibling notes repo can be stored as
 - you want unattended local/dev coding work inside specific project roots while
   keeping dangerous roots, production-like environments, and broad destructive
   actions approval-gated or denied
+- you want a fully prompt-free agent inside an isolated environment and accept
+  the host-level authority granted by `unrestricted`
 
 ## See Also
 

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -298,6 +298,50 @@ describe('control-plane session runtime integration', () => {
       reason: expect.stringContaining('root/home recursive deletion is blocked'),
     }));
   });
+
+  it('places the unrestricted fallback after explicit control-plane policies', async () => {
+    const engineArgs = createControlPlaneSessionEngineArgs();
+    const permissionGrant: AutonomyPermissionGrant = {
+      mode: 'unrestricted',
+      boundaryBehavior: 'allow',
+      authority: { kind: 'unrestricted' },
+    };
+    const explicitDeny: ToolApprovalPolicy = () => ({
+      type: 'deny',
+      reason: 'Blocked by explicit host policy',
+    });
+    const session = await controlPlaneChatSessionsController.createSession({
+      ...engineArgs,
+      suggestedName: 'Unrestricted policy order test',
+      model: 'gpt-5.4',
+      permissionGrant,
+      approvalPolicies: [explicitDeny],
+    });
+    const loopSpy = vi.spyOn(agentLoopModule.AgentLoopRuntimeService, 'run').mockResolvedValue(createLoopResult({
+      workspaceRoot: engineArgs.workspaceRoot,
+      prompt: 'Run without prompts.',
+      summary: 'Done.',
+    }) as never);
+
+    await controlPlaneChatSessionsController.submitPrompt({
+      ...engineArgs,
+      sessionId: session.id,
+      prompt: 'Run without prompts.',
+      permissionGrant,
+      approvalPolicies: [explicitDeny],
+      apiKey: 'test-openai-key',
+      leaseOwner: {
+        ownerKind: 'daemon',
+        hostId: 'test-host',
+        ownerId: 'daemon-test',
+        clientLabel: 'control plane',
+      },
+    });
+
+    const policies = loopSpy.mock.calls[0]?.[0].approvalPolicies ?? [];
+    expect(policies).toHaveLength(3);
+    expect(policies[0]).toBe(explicitDeny);
+  });
 });
 
 describe('conversation turn lifecycle', () => {

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -15,7 +15,7 @@ import { ChatSessionRecords } from '@/core/chat/engine/sessions/records/index.js
 import { FileChatSessionRepository } from '@/core/chat/engine/sessions/repository/index.js';
 import { readStoredChatSession } from '@/__tests__/helpers/chat-session-repository.js';
 import * as agentLoopModule from '@/core/runtime/loop/index.js';
-import type { AutopilotProfile } from '@/core/approvals/index.js';
+import type { AutonomyPermissionGrant, AutopilotProfile } from '@/core/approvals/index.js';
 import type { ToolApprovalPolicy } from '@/core/approvals/types.js';
 import type { RunResult, ToolCall, ToolDefinition } from '@/index.js';
 import { controlPlaneChatSessionsController } from '@/server/controllers/trpc/control-plane/chat-sessions-controller.js';
@@ -233,11 +233,16 @@ describe('control-plane session runtime integration', () => {
         requireApproval: ['staging', 'production', 'unknown'],
       },
     };
+    const permissionGrant: AutonomyPermissionGrant = {
+      mode: 'custom',
+      boundaryBehavior: 'request',
+      authority: { kind: 'autopilot', profile: autopilot },
+    };
     const session = await controlPlaneChatSessionsController.createSession({
       ...engineArgs,
       suggestedName: 'Autopilot policy order test',
       model: 'gpt-5.4',
-      autopilot,
+      permissionGrant,
     });
     const loopSpy = vi.spyOn(agentLoopModule.AgentLoopRuntimeService, 'run').mockResolvedValue(createLoopResult({
       workspaceRoot: engineArgs.workspaceRoot,
@@ -249,7 +254,7 @@ describe('control-plane session runtime integration', () => {
       ...engineArgs,
       sessionId: session.id,
       prompt: 'Run safely.',
-      autopilot,
+      permissionGrant,
       apiKey: 'test-openai-key',
       leaseOwner: {
         ownerKind: 'daemon',

--- a/src/__tests__/unit/control-plane/control-plane-workspace.test.ts
+++ b/src/__tests__/unit/control-plane/control-plane-workspace.test.ts
@@ -33,16 +33,23 @@ describe('resolveControlPlaneRequestWorkspace', () => {
 
     const resolved = resolveControlPlaneRequestWorkspace(createContext(workspace));
 
-    expect(resolved.sessionEngineArgs.autopilot).toEqual({
-      mode: 'autopilot',
-      roots: [{
-        path: '.',
-        access: 'autopilot',
-        allow: ['read', 'write', 'execute'],
-      }],
-      environments: {
-        allow: ['local', 'dev'],
-        requireApproval: ['staging', 'production', 'unknown'],
+    expect(resolved.sessionEngineArgs.permissionGrant).toEqual({
+      mode: 'custom',
+      boundaryBehavior: 'request',
+      authority: {
+        kind: 'autopilot',
+        profile: {
+          mode: 'autopilot',
+          roots: [{
+            path: '.',
+            access: 'autopilot',
+            allow: ['read', 'write', 'execute'],
+          }],
+          environments: {
+            allow: ['local', 'dev'],
+            requireApproval: ['staging', 'production', 'unknown'],
+          },
+        },
       },
     });
     expect(resolved.sessionEngineArgs.credentialStorePath).toBe(join(stateRoot, 'auth.json'));

--- a/src/__tests__/unit/core/approval-policy-chain.test.ts
+++ b/src/__tests__/unit/core/approval-policy-chain.test.ts
@@ -352,6 +352,58 @@ describe('approval policy chain', () => {
     expect(human).not.toHaveBeenCalled();
   });
 
+  it('allows unrestricted calls without invoking the human approval surface', async () => {
+    const service = new ToolApprovalService();
+    const human = vi.fn(async () => ({ approved: false, reason: 'should not request human approval' }));
+    const grant = AutonomyPermissionModeService.resolveGrant({
+      config: { permissionMode: 'unrestricted' },
+      workspaceRoot: '/workspace',
+    });
+
+    await expect(service.resolve({
+      policies: [
+        ...ToolApprovalPolicies.default(),
+        ...ToolApprovalPolicies.forPermissionGrant(grant),
+      ],
+      context: context({
+        call: {
+          id: 'call-gh',
+          tool: 'run_shell_mutate',
+          input: { command: 'gh run view 123 --log-failed' },
+        },
+      }),
+      requestHumanApproval: human,
+    })).resolves.toEqual({
+      approved: true,
+      reason: 'Allowed by unrestricted permission mode',
+    });
+    expect(human).not.toHaveBeenCalled();
+  });
+
+  it('keeps explicit denials authoritative before the unrestricted fallback', async () => {
+    const service = new ToolApprovalService();
+    const human = vi.fn(async () => ({ approved: true, reason: 'should not request human approval' }));
+    const grant = AutonomyPermissionModeService.resolveGrant({
+      config: { permissionMode: 'unrestricted' },
+      workspaceRoot: '/workspace',
+    });
+
+    await expect(service.resolve({
+      policies: [
+        ...ToolApprovalPolicies.default(),
+        ...ToolApprovalPolicies.forPermissionGrant(grant, [
+          () => ({ type: 'deny', reason: 'Blocked by explicit host policy' }),
+        ]),
+      ],
+      context: context(),
+      requestHumanApproval: human,
+    })).resolves.toEqual({
+      approved: false,
+      reason: 'Blocked by explicit host policy',
+    });
+    expect(human).not.toHaveBeenCalled();
+  });
+
   it('evaluates Auto access against a symlink target canonicalized outside the workspace', async () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-auto-symlink-root-'));
     const outsideRoot = mkdtempSync(join(tmpdir(), 'heddle-auto-symlink-outside-'));

--- a/src/__tests__/unit/core/approval-policy-chain.test.ts
+++ b/src/__tests__/unit/core/approval-policy-chain.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  AutonomyPermissionModeService,
   AutonomyPolicyService,
   ToolApprovalProfileService,
   ToolApprovalPolicies,
@@ -314,6 +315,38 @@ describe('approval policy chain', () => {
       reason: 'allowed by autopilot profile and declared policy envelope',
       autonomyEvaluation: expect.objectContaining({
         decision: expect.objectContaining({ type: 'allow' }),
+      }),
+    }));
+    expect(human).not.toHaveBeenCalled();
+  });
+
+  it('denies unattended boundary misses without invoking the human approval surface', async () => {
+    const service = new ToolApprovalService();
+    const human = vi.fn(async () => ({ approved: true, reason: 'should not request human approval' }));
+    const grant = AutonomyPermissionModeService.resolveGrant({
+      config: { permissionMode: 'unattended' },
+      workspaceRoot: '/workspace',
+    });
+
+    await expect(service.resolve({
+      policies: [
+        ...ToolApprovalPolicies.default(),
+        ...ToolApprovalPolicies.forPermissionGrant(grant),
+      ],
+      context: context({
+        call: {
+          id: 'call-gh',
+          tool: 'run_shell_mutate',
+          input: { command: 'gh run view 123 --log-failed' },
+        },
+      }),
+      requestHumanApproval: human,
+    })).resolves.toEqual(expect.objectContaining({
+      approved: false,
+      reason: 'unattended permission boundary denied: tool call needs a declared policy envelope',
+      autonomyEvaluation: expect.objectContaining({
+        boundaryBehavior: 'deny',
+        decision: expect.objectContaining({ type: 'deny' }),
       }),
     }));
     expect(human).not.toHaveBeenCalled();

--- a/src/__tests__/unit/core/autonomy-permission-mode-service.test.ts
+++ b/src/__tests__/unit/core/autonomy-permission-mode-service.test.ts
@@ -16,6 +16,14 @@ describe('AutonomyPermissionModeService', () => {
       config: {},
       workspaceRoot,
     })).toBeUndefined();
+    expect(AutonomyPermissionModeService.resolveGrant({
+      config: {},
+      workspaceRoot,
+    })).toEqual({
+      mode: 'default',
+      boundaryBehavior: 'request',
+      authority: { kind: 'default' },
+    });
   });
 
   it('maps auto mode to the generated local coding profile', () => {
@@ -29,6 +37,50 @@ describe('AutonomyPermissionModeService', () => {
       path: '.',
       access: 'autopilot',
     });
+    expect(AutonomyPermissionModeService.resolveGrant({
+      config: { permissionMode: 'auto' },
+      workspaceRoot,
+    })).toMatchObject({
+      mode: 'auto',
+      boundaryBehavior: 'request',
+      authority: {
+        kind: 'autopilot',
+        profile: { preset: 'auto' },
+      },
+    });
+  });
+
+  it('maps unattended mode to Auto authority with deny-on-boundary behavior', () => {
+    const grant = AutonomyPermissionModeService.resolveGrant({
+      config: {
+        permissionMode: 'unattended',
+        autoTrustedRoots: ['../trusted-repo'],
+      },
+      workspaceRoot,
+    });
+
+    expect(grant).toMatchObject({
+      mode: 'unattended',
+      boundaryBehavior: 'deny',
+      authority: {
+        kind: 'autopilot',
+        profile: {
+          mode: 'autopilot',
+          preset: 'auto',
+          roots: expect.arrayContaining([
+            expect.objectContaining({ path: '../trusted-repo', access: 'autopilot' }),
+          ]),
+        },
+      },
+    });
+    expect(AutonomyPermissionModeService.buildOptions({
+      config: { permissionMode: 'unattended' },
+      workspaceRoot,
+    })).toContainEqual(expect.objectContaining({
+      id: 'unattended',
+      label: 'Unattended',
+    }));
+    expect(AutonomyPermissionModeService.resolveAutoRootTrustProfile(grant)).toBeUndefined();
   });
 
   it('keeps auto mode when user-trusted repo roots extend the generated profile', () => {
@@ -61,6 +113,9 @@ describe('AutonomyPermissionModeService', () => {
         source: 'user-trusted-repo',
       }),
     ]));
+    expect(AutonomyPermissionModeService.resolveAutoRootTrustProfile(
+      AutonomyPermissionModeService.resolveGrant({ config, workspaceRoot }),
+    )).toBeDefined();
   });
 
   it('preserves custom profiles when switching away from custom mode', () => {

--- a/src/__tests__/unit/core/autonomy-permission-mode-service.test.ts
+++ b/src/__tests__/unit/core/autonomy-permission-mode-service.test.ts
@@ -83,6 +83,30 @@ describe('AutonomyPermissionModeService', () => {
     expect(AutonomyPermissionModeService.resolveAutoRootTrustProfile(grant)).toBeUndefined();
   });
 
+  it('maps unrestricted mode to prompt-free bypass authority without an Auto profile', () => {
+    const config = { permissionMode: 'unrestricted' as const };
+
+    expect(AutonomyPermissionModeService.resolveGrant({
+      config,
+      workspaceRoot,
+    })).toEqual({
+      mode: 'unrestricted',
+      boundaryBehavior: 'allow',
+      authority: { kind: 'unrestricted' },
+    });
+    expect(AutonomyPermissionModeService.resolveEffectiveProfile({
+      config,
+      workspaceRoot,
+    })).toBeUndefined();
+    expect(AutonomyPermissionModeService.buildOptions({
+      config,
+      workspaceRoot,
+    })).toContainEqual(expect.objectContaining({
+      id: 'unrestricted',
+      label: 'Unrestricted',
+    }));
+  });
+
   it('keeps auto mode when user-trusted repo roots extend the generated profile', () => {
     const config = AutonomyPermissionModeService.trustAutoRoot({
       config: { permissionMode: 'auto' },

--- a/src/__tests__/unit/core/autonomy-policy-service.test.ts
+++ b/src/__tests__/unit/core/autonomy-policy-service.test.ts
@@ -93,6 +93,26 @@ describe('AutonomyPolicyService', () => {
     }));
   });
 
+  it('denies instead of requesting when unattended mode reaches a policy boundary', () => {
+    const evaluation = AutonomyPolicyService.evaluate({
+      context: context({
+        call: {
+          id: 'call-unattended',
+          tool: 'run_shell_mutate',
+          input: { command: 'gh run view 123 --log-failed' },
+        },
+      }),
+      profile,
+      boundaryBehavior: 'deny',
+    });
+
+    expect(evaluation.boundaryBehavior).toBe('deny');
+    expect(evaluation.decision).toEqual(expect.objectContaining({
+      type: 'deny',
+      reason: 'unattended permission boundary denied: tool call needs a declared policy envelope',
+    }));
+  });
+
   it('requests approval for no-envelope reads outside configured Auto roots', () => {
     const evaluation = AutonomyPolicyService.evaluate({
       context: context({

--- a/src/__tests__/unit/core/autonomy-postflight-audit-service.test.ts
+++ b/src/__tests__/unit/core/autonomy-postflight-audit-service.test.ts
@@ -22,6 +22,7 @@ function evaluation(overrides: Partial<AutonomyEvaluation> = {}): AutonomyEvalua
       },
     },
     profileMode: 'autopilot',
+    boundaryBehavior: 'request',
     envelope: {
       operations: ['write'],
       intent: 'Update a source file.',

--- a/src/__tests__/unit/core/chat-turn-host-normalizer.test.ts
+++ b/src/__tests__/unit/core/chat-turn-host-normalizer.test.ts
@@ -21,11 +21,15 @@ describe('conversation engine host normalizer', () => {
       },
     };
 
-    await expect(host?.approveToolCall?.(call, tool)).resolves.toEqual({
+    await expect(host?.approveToolCall?.(call, tool, undefined, 'edit_file requires approval')).resolves.toEqual({
       approved: true,
       reason: 'approved by host',
     });
-    expect(requestToolApproval).toHaveBeenCalledWith({ call, tool });
+    expect(requestToolApproval).toHaveBeenCalledWith({
+      call,
+      tool,
+      reason: 'edit_file requires approval',
+    });
   });
 
   it('fans out compaction status by phase through the normalized turn host', () => {

--- a/src/__tests__/unit/core/project-config.test.ts
+++ b/src/__tests__/unit/core/project-config.test.ts
@@ -107,6 +107,20 @@ describe('ProjectConfigService', () => {
     });
   });
 
+  it('persists unattended permission mode as a supported project setting', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-project-config-'));
+
+    const updated = ProjectConfigService.update(workspaceRoot, (config) => ({
+      ...config,
+      permissionMode: 'unattended',
+    }));
+
+    expect(updated.permissionMode).toBe('unattended');
+    expect(JSON.parse(readFileSync(ProjectConfigService.resolvePath(workspaceRoot), 'utf8'))).toMatchObject({
+      permissionMode: 'unattended',
+    });
+  });
+
   it('reads legacy root config only when local config is absent', () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-project-config-'));
     // Legacy-only fixture: root-level config existed before config moved under

--- a/src/__tests__/unit/core/project-config.test.ts
+++ b/src/__tests__/unit/core/project-config.test.ts
@@ -107,17 +107,17 @@ describe('ProjectConfigService', () => {
     });
   });
 
-  it('persists unattended permission mode as a supported project setting', () => {
+  it.each(['unattended', 'unrestricted'] as const)('persists %s permission mode as a supported project setting', (permissionMode) => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-project-config-'));
 
     const updated = ProjectConfigService.update(workspaceRoot, (config) => ({
       ...config,
-      permissionMode: 'unattended',
+      permissionMode,
     }));
 
-    expect(updated.permissionMode).toBe('unattended');
+    expect(updated.permissionMode).toBe(permissionMode);
     expect(JSON.parse(readFileSync(ProjectConfigService.resolvePath(workspaceRoot), 'utf8'))).toMatchObject({
-      permissionMode: 'unattended',
+      permissionMode,
     });
   });
 

--- a/src/__tests__/unit/core/slash-command-modules.test.ts
+++ b/src/__tests__/unit/core/slash-command-modules.test.ts
@@ -98,7 +98,7 @@ function testHeartbeatRun(overrides: Partial<HeartbeatTaskRunRecordEntry> = {}):
 function createContext(overrides: Partial<SlashCommandExecutionContext> = {}): SlashCommandExecutionContext {
   let activeModel = 'gpt-5.4';
   let driftEnabled = false;
-  let permissionMode: 'default' | 'auto' | 'unattended' | 'custom' = 'default';
+  let permissionMode: 'default' | 'auto' | 'unattended' | 'unrestricted' | 'custom' = 'default';
   const sessions = [
     testSession({ id: 'session-a', name: 'Alpha' }),
     testSession({ id: 'session-b', name: 'Beta', updatedAt: '2024-01-02' }),
@@ -316,13 +316,17 @@ describe('core slash command modules', () => {
       kind: 'message',
       message: 'Set permission mode to unattended.',
     });
+    await expect(registry.run(context, '/permissions unrestricted')).resolves.toMatchObject({
+      kind: 'message',
+      message: 'Set permission mode to unrestricted.',
+    });
     await expect(registry.run(context, '/permissions set')).resolves.toMatchObject({
       kind: 'message',
       message: 'Use /permissions set <query> to filter permission modes, then use arrows and Enter to choose one.',
     });
     await expect(registry.run(context, '/permissions nope')).resolves.toMatchObject({
       kind: 'message',
-      message: 'Usage: /permissions set <query> or /permissions <default|auto|unattended|custom>',
+      message: 'Usage: /permissions set <query> or /permissions <default|auto|unattended|unrestricted|custom>',
     });
   });
 

--- a/src/__tests__/unit/core/slash-command-modules.test.ts
+++ b/src/__tests__/unit/core/slash-command-modules.test.ts
@@ -98,7 +98,7 @@ function testHeartbeatRun(overrides: Partial<HeartbeatTaskRunRecordEntry> = {}):
 function createContext(overrides: Partial<SlashCommandExecutionContext> = {}): SlashCommandExecutionContext {
   let activeModel = 'gpt-5.4';
   let driftEnabled = false;
-  let permissionMode: 'default' | 'auto' | 'custom' = 'default';
+  let permissionMode: 'default' | 'auto' | 'unattended' | 'custom' = 'default';
   const sessions = [
     testSession({ id: 'session-a', name: 'Alpha' }),
     testSession({ id: 'session-b', name: 'Beta', updatedAt: '2024-01-02' }),
@@ -312,13 +312,17 @@ describe('core slash command modules', () => {
       kind: 'message',
       message: 'Current permission mode: auto',
     });
+    await expect(registry.run(context, '/permissions unattended')).resolves.toMatchObject({
+      kind: 'message',
+      message: 'Set permission mode to unattended.',
+    });
     await expect(registry.run(context, '/permissions set')).resolves.toMatchObject({
       kind: 'message',
       message: 'Use /permissions set <query> to filter permission modes, then use arrows and Enter to choose one.',
     });
     await expect(registry.run(context, '/permissions nope')).resolves.toMatchObject({
       kind: 'message',
-      message: 'Usage: /permissions set <query> or /permissions <default|auto|custom>',
+      message: 'Usage: /permissions set <query> or /permissions <default|auto|unattended|custom>',
     });
   });
 

--- a/src/__tests__/unit/core/trace-format.test.ts
+++ b/src/__tests__/unit/core/trace-format.test.ts
@@ -103,6 +103,7 @@ describe('TraceConsoleFormatter', () => {
         evaluation: {
           call: { id: 'call-1', tool: 'edit_file', input: { path: 'src/generated.ts' } },
           profileMode: 'autopilot',
+          boundaryBehavior: 'request',
           envelope: {
             operations: ['write'],
             intent: 'Create a generated source file.',

--- a/src/__tests__/unit/core/trace-summarizers.test.ts
+++ b/src/__tests__/unit/core/trace-summarizers.test.ts
@@ -43,6 +43,7 @@ describe('trace summarizers', () => {
         evaluation: {
           call: { id: 'call-auto-1', tool: 'edit_file', input: { path: 'src/generated.ts' } },
           profileMode: 'autopilot',
+          boundaryBehavior: 'request',
           facts: {
             tool: 'edit_file',
             operations: ['write'],

--- a/src/core/agent/tools/tool-dispatcher.ts
+++ b/src/core/agent/tools/tool-dispatcher.ts
@@ -51,7 +51,7 @@ export class AgentToolDispatcher {
       // This await is the execution gate. Host implementations resolve
       // approveToolCall only after the user approves or denies the request, so
       // no approval-gated tool executes before the decision is returned.
-      requestHumanApproval: approveToolCall ? async (_context, _reason, autonomyEvaluation) => {
+      requestHumanApproval: approveToolCall ? async (_context, reason, autonomyEvaluation) => {
         live.traceActivity({
           trace: { type: HeddleEventType.toolApprovalRequested, call, step, timestamp: now() },
           activity: {
@@ -66,7 +66,7 @@ export class AgentToolDispatcher {
         });
         // Control-plane hosts keep this promise resolver in memory and expose
         // the pending request through an API until the browser resolves it.
-        const humanDecision = await approveToolCall(call, tool, autonomyEvaluation);
+        const humanDecision = await approveToolCall(call, tool, autonomyEvaluation, reason);
         live.traceActivity({
           trace: {
             type: HeddleEventType.toolApprovalResolved,

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -63,7 +63,12 @@ export type RunAgentOptions = {
   systemContext?: string;
   onEvent?: (event: AgentRunEvent) => void;
   approvalPolicies?: ToolApprovalPolicy[];
-  approveToolCall?: (call: ToolCall, tool: ToolDefinition, autonomyEvaluation?: AutonomyEvaluation) => Promise<ToolApprovalDecision>;
+  approveToolCall?: (
+    call: ToolCall,
+    tool: ToolDefinition,
+    autonomyEvaluation?: AutonomyEvaluation,
+    reason?: string,
+  ) => Promise<ToolApprovalDecision>;
   shouldStop?: () => boolean;
   abortSignal?: AbortSignal;
   /**

--- a/src/core/approvals/README.md
+++ b/src/core/approvals/README.md
@@ -43,9 +43,10 @@ Approval behavior currently exists in these places:
   agent-scoped policy to the ordinary ordered policy chain; it does not own
   host UI or tool execution.
 - `autonomy/`: autopilot profile normalization, tool policy evaluation,
-  computed policy facts, postflight audit objects, and autonomy trace event
-  construction. This subdomain owns approval decisions for long-running agent
-  mode, not tool execution or host presentation.
+  resolved permission grants, computed policy facts, postflight audit objects,
+  and autonomy trace event construction. This subdomain owns approval decisions
+  and prompt-vs-deny boundary behavior for long-running agent mode, not tool
+  execution or host presentation.
 - `remembered-rules/`: project approval rule service, repository, codec,
   schemas, and types. The repository is an internal storage boundary for
   `ToolApprovalService`; host/controller code must not import it directly.
@@ -63,6 +64,10 @@ AgentToolDispatcher
   -> ToolApprovalService.resolveUserDecision(...)
   -> tool execution continues or receives an approval-denied tool result
 ```
+
+Unattended mode follows the same dispatcher path but resolves a policy boundary
+to `deny`, never `request`. No pending promise or host approval surface is
+created for those calls.
 
 `ToolApprovalService` owns the host-neutral request shape. A request includes
 the tool name, call id, raw input, requested timestamp, compact summary, policy

--- a/src/core/approvals/README.md
+++ b/src/core/approvals/README.md
@@ -69,6 +69,13 @@ Unattended mode follows the same dispatcher path but resolves a policy boundary
 to `deny`, never `request`. No pending promise or host approval surface is
 created for those calls.
 
+Unrestricted mode appends a terminal `allow` fallback after explicit host deny
+policies. Earlier denies remain authoritative, requests fall through without a
+pending promise, and tool-owned validation still runs when the approved call is
+executed. Hosts composing `ToolApprovalPolicies.forPermissionGrant(...)`
+directly should pass non-bypassable policies as its second argument so the
+service preserves that ordering.
+
 `ToolApprovalService` owns the host-neutral request shape. A request includes
 the tool name, call id, raw input, requested timestamp, compact summary, policy
 reason, optional edit preview, and optional remembered project approval metadata.

--- a/src/core/approvals/autonomy/README.md
+++ b/src/core/approvals/autonomy/README.md
@@ -52,20 +52,25 @@ Autonomy evaluates that contract against configured roots and hard-deny facts.
 There is one resolved `AutonomyPermissionGrant` at the host boundary. It keeps
 two independent questions explicit:
 
-- `boundaryBehavior`: should a policy miss request a person or be denied?
-- `authority`: is the run using ordinary approval behavior or a bounded
-  `AutopilotProfile`?
+- `boundaryBehavior`: should a policy miss request a person, be denied, or be
+  allowed without prompting?
+- `authority`: is the run using ordinary approval behavior, a bounded
+  `AutopilotProfile`, or an explicit unrestricted bypass?
 
-The evaluator still receives one effective `AutopilotProfile`; the grant tells
-the approval policy whether a profile miss becomes `request` or `deny`.
+Bounded modes still send one effective `AutopilotProfile` to the evaluator; the
+grant tells the approval policy whether a profile miss becomes `request` or
+`deny`. Unrestricted authority skips that bounded evaluator and becomes a
+terminal `allow` fallback after explicit deny policies.
 
 User-facing mental model:
 
 ```text
 Auto = agent can do normal local coding work by itself in trusted repos.
 Unattended = same authority as Auto, but never pause for approval.
+Unrestricted = approve every call that is not blocked by an earlier explicit deny.
 Trusted repos = current repo + repos the user explicitly trusted.
 Dangerous or unclear actions request approval in Auto and are denied in Unattended.
+Tool-owned validation and catastrophic shell guards still run in Unrestricted.
 ```
 
 The approval UI should teach that model with `Approve once`, `Trust this repo`,
@@ -86,6 +91,11 @@ permissionMode: unattended
   -> generated Auto profile
   -> plus autoTrustedRoots
   -> permission grant { boundaryBehavior: "deny", authority: AutopilotProfile }
+
+permissionMode: unrestricted
+  -> no AutopilotProfile
+  -> permission grant { boundaryBehavior: "allow", authority: "unrestricted" }
+  -> terminal allow fallback after explicit host deny policies
 
 permissionMode: custom
   -> hand-authored config.autopilot
@@ -254,6 +264,12 @@ templates, choose boundary behavior, or reinterpret mode names.
   denied, traced, and returned to the model as a tool failure. This includes
   network operations, production-like environments, manual-only or
   unconfigured roots, missing capabilities, and unclear policy envelopes.
+- `unrestricted`: Heddle skips approval prompts and approval-policy checks for
+  every call that reaches the terminal unrestricted fallback. Explicit host or
+  agent deny policies placed before the fallback still win. Tool-owned schema,
+  path-containment, and catastrophic shell-command validation also still runs
+  during execution. Use this mode only inside an isolated container or VM with
+  least-privilege credentials and constrained network access.
 - `custom`: Heddle uses the workspace's hand-authored `autopilot` profile.
   This is selectable only when a hand-authored profile exists with
   `mode: "autopilot"` and differs from Heddle's generated Auto profile. An
@@ -261,8 +277,9 @@ templates, choose boundary behavior, or reinterpret mode names.
   not Custom. The full custom profile editor is a later UI/TUI slice.
 
 Project config stores `permissionMode` separately from the hand-authored
-`autopilot` profile. This lets a user switch Default/Auto/Unattended/Custom without
-deleting a custom profile. Auto-specific user expansions live in
+`autopilot` profile. This lets a user switch
+Default/Auto/Unattended/Unrestricted/Custom without deleting a custom profile.
+Auto-specific user expansions live in
 `autoTrustedRoots`, not in the custom `autopilot` object:
 
 ```json
@@ -275,6 +292,7 @@ deleting a custom profile. Auto-specific user expansions live in
 `AutonomyPermissionModeService.resolveGrant(...)` converts that config into one
 concrete permission grant. Auto and Unattended both carry an
 `AutopilotProfile` with `preset: "auto"`; only their boundary behavior differs.
+Unrestricted carries explicit unrestricted authority instead of a profile.
 Downstream approval policy does not read `autoTrustedRoots` directly.
 
 ## Approval-Driven Auto Expansion
@@ -407,6 +425,11 @@ Decision rules:
   capabilities match, environment is allowed when an envelope is present, and
   no hard-deny or approval reason is present.
 
+Unrestricted does not run this bounded evaluator. Its terminal approval policy
+allows the call after earlier explicit denies have had a chance to stop it.
+Normal tool execution and trace events still occur, including deterministic
+tool-owned validation failures.
+
 ## Trace Contract
 
 Autonomy trace exists so later sessions can understand why a long-running agent
@@ -455,7 +478,7 @@ This service is the core policy foundation. Workspace config may provide a
 project-config validates the persisted shape, and control-plane request context
 passes the resolved permission grant into this approval policy. Postflight
 audit now records observed structured effects after unattended autopilot
-execution. Unattended is deliberately not an unrestricted host-user bypass and
-is not a sandbox. Richer custom profile editing, explicit remote-service
-capabilities, OS isolation, and richer shell effect observation remain
-follow-up slices.
+execution. Unattended is deliberately not an unrestricted host-user bypass.
+Unrestricted is that explicit approval bypass, but it is still not a sandbox.
+Richer custom profile editing, explicit remote-service capabilities, OS
+isolation, and richer shell effect observation remain follow-up slices.

--- a/src/core/approvals/autonomy/README.md
+++ b/src/core/approvals/autonomy/README.md
@@ -49,15 +49,23 @@ Autonomy evaluates that contract against configured roots and hard-deny facts.
 
 ## How The Model Fits Together
 
-There is one policy object at decision time: the effective `AutopilotProfile`.
-Mode/config fields are only inputs for building that profile.
+There is one resolved `AutonomyPermissionGrant` at the host boundary. It keeps
+two independent questions explicit:
+
+- `boundaryBehavior`: should a policy miss request a person or be denied?
+- `authority`: is the run using ordinary approval behavior or a bounded
+  `AutopilotProfile`?
+
+The evaluator still receives one effective `AutopilotProfile`; the grant tells
+the approval policy whether a profile miss becomes `request` or `deny`.
 
 User-facing mental model:
 
 ```text
 Auto = agent can do normal local coding work by itself in trusted repos.
+Unattended = same authority as Auto, but never pause for approval.
 Trusted repos = current repo + repos the user explicitly trusted.
-Dangerous or unclear actions still stop.
+Dangerous or unclear actions request approval in Auto and are denied in Unattended.
 ```
 
 The approval UI should teach that model with `Approve once`, `Trust this repo`,
@@ -72,7 +80,12 @@ permissionMode: default
 permissionMode: auto
   -> generated Auto profile
   -> plus autoTrustedRoots
-  -> effective AutopilotProfile { preset: "auto" }
+  -> permission grant { boundaryBehavior: "request", authority: AutopilotProfile }
+
+permissionMode: unattended
+  -> generated Auto profile
+  -> plus autoTrustedRoots
+  -> permission grant { boundaryBehavior: "deny", authority: AutopilotProfile }
 
 permissionMode: custom
   -> hand-authored config.autopilot
@@ -89,8 +102,8 @@ expanding the generated Auto preset:
 }
 ```
 
-At runtime, `AutonomyPermissionModeService.resolveEffectiveProfile(...)`
-produces:
+At runtime, `AutonomyPermissionModeService.resolveGrant(...)` produces a grant
+whose Auto or Unattended authority contains:
 
 ```ts
 {
@@ -106,8 +119,9 @@ produces:
 }
 ```
 
-The evaluator only consumes that final profile. It does not separately inspect
-`permissionMode`, `autoTrustedRoots`, or UI approval choices.
+The evaluator consumes that final profile plus the resolved boundary behavior.
+It does not separately inspect `permissionMode`, `autoTrustedRoots`, or UI
+approval choices.
 
 For each tool call:
 
@@ -225,8 +239,8 @@ many-file deletion/edit scopes.
 ## Permission Modes
 
 `AutonomyPermissionModeService` owns the product mapping from user-facing
-permission modes to effective autonomy profiles. Hosts should not build their
-own profile templates or reinterpret mode names.
+permission modes to resolved grants. Hosts should not build their own profile
+templates, choose boundary behavior, or reinterpret mode names.
 
 - `default`: no autopilot profile is active. Heddle uses the normal approval
   flow.
@@ -235,6 +249,11 @@ own profile templates or reinterpret mode names.
   dependency, and git-stage capabilities under the current workspace root and
   any user-approved Auto roots while keeping the home directory manual-only and
   denying device/volume roots.
+- `unattended`: Heddle uses the same generated local coding authority as Auto,
+  but it never creates a pending approval. A call that Auto would ask about is
+  denied, traced, and returned to the model as a tool failure. This includes
+  network operations, production-like environments, manual-only or
+  unconfigured roots, missing capabilities, and unclear policy envelopes.
 - `custom`: Heddle uses the workspace's hand-authored `autopilot` profile.
   This is selectable only when a hand-authored profile exists with
   `mode: "autopilot"` and differs from Heddle's generated Auto profile. An
@@ -242,7 +261,7 @@ own profile templates or reinterpret mode names.
   not Custom. The full custom profile editor is a later UI/TUI slice.
 
 Project config stores `permissionMode` separately from the hand-authored
-`autopilot` profile. This lets a user switch Default/Auto/Custom without
+`autopilot` profile. This lets a user switch Default/Auto/Unattended/Custom without
 deleting a custom profile. Auto-specific user expansions live in
 `autoTrustedRoots`, not in the custom `autopilot` object:
 
@@ -253,9 +272,10 @@ deleting a custom profile. Auto-specific user expansions live in
 }
 ```
 
-`AutonomyPermissionModeService.resolveEffectiveProfile(...)` converts that
-config into one concrete `AutopilotProfile` with `preset: "auto"`. Downstream
-approval policy does not read `autoTrustedRoots` directly.
+`AutonomyPermissionModeService.resolveGrant(...)` converts that config into one
+concrete permission grant. Auto and Unattended both carry an
+`AutopilotProfile` with `preset: "auto"`; only their boundary behavior differs.
+Downstream approval policy does not read `autoTrustedRoots` directly.
 
 ## Approval-Driven Auto Expansion
 
@@ -379,7 +399,7 @@ Decision rules:
 - `deny`: hard-denied root, root/home recursive delete, workspace-wide
   recursive delete, wildcard recursive delete, privilege escalation, hard git
   reset, force push, disk formatting, device writes, or `terraform destroy`.
-- `request`: missing envelope for approval-gated mutating tools,
+- `request` in Auto/Custom, or `deny` in Unattended: missing envelope for approval-gated mutating tools,
   `unknown`/low-confidence intent, disallowed environment, manual-only root,
   unconfigured root, missing capability, or network operation. Root checks run
   even for read/list/search calls that do not require an envelope.
@@ -433,7 +453,9 @@ policy hints together.
 This service is the core policy foundation. Workspace config may provide a
 `permissionMode` and optional `autopilot` profile through `.heddle/config.json`;
 project-config validates the persisted shape, and control-plane request context
-passes the resolved effective profile into this approval policy. Postflight
+passes the resolved permission grant into this approval policy. Postflight
 audit now records observed structured effects after unattended autopilot
-execution. Richer custom profile editing and richer shell
-effect observation remain follow-up slices.
+execution. Unattended is deliberately not an unrestricted host-user bypass and
+is not a sandbox. Richer custom profile editing, explicit remote-service
+capabilities, OS isolation, and richer shell effect observation remain
+follow-up slices.

--- a/src/core/approvals/autonomy/index.ts
+++ b/src/core/approvals/autonomy/index.ts
@@ -14,9 +14,11 @@ export {
   AutopilotRootSourceSchema,
 } from './schemas.js';
 export type {
+  AutonomyBoundaryBehavior,
   AutonomyEvaluation,
   AutonomyPermissionMode,
   AutonomyPermissionModeConfig,
+  AutonomyPermissionGrant,
   AutonomyPermissionModeOption,
   AutonomyPolicyHint,
   AutonomyPostflightAudit,

--- a/src/core/approvals/autonomy/permission-mode-service.ts
+++ b/src/core/approvals/autonomy/permission-mode-service.ts
@@ -31,8 +31,9 @@ const AUTO_ROOT_POLICY = {
 /**
  * Owns the product-level permission mode mapping for autonomy.
  *
- * UI surfaces should select Default/Auto/Unattended/Custom only. This service
- * maps those modes to one permission grant so hosts do not duplicate policy.
+ * UI surfaces should select Default/Auto/Unattended/Unrestricted/Custom only.
+ * This service maps those modes to one permission grant so hosts do not
+ * duplicate policy.
  */
 export class AutonomyPermissionModeService {
   static buildAutoProfile(args: { trustedRoots?: string[] } = {}): AutopilotProfile {
@@ -144,6 +145,14 @@ export class AutonomyPermissionModeService {
       };
     }
 
+    if (mode === 'unrestricted') {
+      return {
+        mode,
+        boundaryBehavior: 'allow',
+        authority: { kind: 'unrestricted' },
+      };
+    }
+
     const customProfile = args.config.autopilot;
     if (!customProfile || customProfile.mode !== 'autopilot') {
       throw new Error('Resolved custom permission mode without a valid autopilot profile.');
@@ -180,6 +189,11 @@ export class AutonomyPermissionModeService {
         id: 'unattended',
         label: 'Unattended',
         description: 'Never prompt; deny actions outside the trusted local coding policy.',
+      },
+      {
+        id: 'unrestricted',
+        label: 'Unrestricted',
+        description: 'Skip approval prompts and checks. Use only in an isolated environment.',
       },
       {
         id: 'custom',

--- a/src/core/approvals/autonomy/permission-mode-service.ts
+++ b/src/core/approvals/autonomy/permission-mode-service.ts
@@ -5,6 +5,7 @@ import type {
   AutonomyPermissionMode,
   AutonomyPermissionModeConfig,
   AutonomyPermissionModeOption,
+  AutonomyPermissionGrant,
   AutopilotCapability,
   AutopilotProfile,
 } from './types.js';
@@ -30,8 +31,8 @@ const AUTO_ROOT_POLICY = {
 /**
  * Owns the product-level permission mode mapping for autonomy.
  *
- * UI surfaces should select Default/Auto/Custom only. This service maps those
- * modes to the effective autopilot profile so hosts do not duplicate policy.
+ * UI surfaces should select Default/Auto/Unattended/Custom only. This service
+ * maps those modes to one permission grant so hosts do not duplicate policy.
  */
 export class AutonomyPermissionModeService {
   static buildAutoProfile(args: { trustedRoots?: string[] } = {}): AutopilotProfile {
@@ -100,18 +101,62 @@ export class AutonomyPermissionModeService {
     config: AutonomyPermissionModeConfig;
     workspaceRoot: string;
   }): AutopilotProfile | undefined {
+    const grant = AutonomyPermissionModeService.resolveGrant(args);
+    return grant.authority.kind === 'autopilot' ? grant.authority.profile : undefined;
+  }
+
+  static resolveGrant(args: {
+    config: AutonomyPermissionModeConfig;
+    workspaceRoot: string;
+  }): AutonomyPermissionGrant {
     const mode = AutonomyPermissionModeService.resolveMode(args);
     if (mode === 'default') {
-      return undefined;
+      return {
+        mode,
+        boundaryBehavior: 'request',
+        authority: { kind: 'default' },
+      };
     }
 
     if (mode === 'auto') {
-      return AutonomyPermissionModeService.buildAutoProfile({
-        trustedRoots: args.config.autoTrustedRoots,
-      });
+      return {
+        mode,
+        boundaryBehavior: 'request',
+        authority: {
+          kind: 'autopilot',
+          profile: AutonomyPermissionModeService.buildAutoProfile({
+            trustedRoots: args.config.autoTrustedRoots,
+          }),
+        },
+      };
     }
 
-    return args.config.autopilot?.mode === 'autopilot' ? args.config.autopilot : undefined;
+    if (mode === 'unattended') {
+      return {
+        mode,
+        boundaryBehavior: 'deny',
+        authority: {
+          kind: 'autopilot',
+          profile: AutonomyPermissionModeService.buildAutoProfile({
+            trustedRoots: args.config.autoTrustedRoots,
+          }),
+        },
+      };
+    }
+
+    const customProfile = args.config.autopilot;
+    if (!customProfile || customProfile.mode !== 'autopilot') {
+      throw new Error('Resolved custom permission mode without a valid autopilot profile.');
+    }
+
+    return {
+      mode,
+      boundaryBehavior: 'request',
+      authority: {
+        kind: 'autopilot',
+        profile: customProfile,
+      },
+    };
   }
 
   static buildOptions(args: {
@@ -130,6 +175,11 @@ export class AutonomyPermissionModeService {
         id: 'auto',
         label: 'Auto',
         description: 'Run trusted local coding actions without routine approval.',
+      },
+      {
+        id: 'unattended',
+        label: 'Unattended',
+        description: 'Never prompt; deny actions outside the trusted local coding policy.',
       },
       {
         id: 'custom',
@@ -203,6 +253,14 @@ export class AutonomyPermissionModeService {
 
   static autoRootCapabilities(): AutopilotCapability[] {
     return [...AUTO_CAPABILITIES];
+  }
+
+  static resolveAutoRootTrustProfile(grant: AutonomyPermissionGrant | undefined): AutopilotProfile | undefined {
+    return grant?.mode === 'auto'
+      && grant.authority.kind === 'autopilot'
+      && grant.authority.profile.preset === 'auto'
+      ? grant.authority.profile
+      : undefined;
   }
 
   private static isGeneratedAutoProfile(args: {

--- a/src/core/approvals/autonomy/policy-service.ts
+++ b/src/core/approvals/autonomy/policy-service.ts
@@ -9,6 +9,7 @@ import {
   type ToolPolicyReconciliation,
 } from '@/core/tools/index.js';
 import type {
+  AutonomyBoundaryBehavior,
   AutonomyEvaluation,
   AutonomyPolicyHint,
   AutopilotCapability,
@@ -29,6 +30,7 @@ export class AutonomyPolicyService {
   static evaluate(args: {
     context: ToolApprovalPolicyContext;
     profile: AutopilotProfile;
+    boundaryBehavior?: AutonomyBoundaryBehavior;
   }): AutonomyEvaluation {
     const workspaceRoot = resolve(args.context.workspaceRoot ?? process.cwd());
     const profile = AutopilotProfileService.normalize({
@@ -55,12 +57,14 @@ export class AutonomyPolicyService {
       envelope,
       facts,
       profile,
+      boundaryBehavior: args.boundaryBehavior ?? 'request',
     });
 
     return {
       call: args.context.call,
       profileMode: profile.mode,
       profilePreset: profile.preset,
+      boundaryBehavior: args.boundaryBehavior ?? 'request',
       policy: resolution.reconciliation,
       envelope,
       facts,
@@ -86,11 +90,16 @@ export class AutonomyPolicyService {
     envelope?: ToolPolicyEnvelope;
     facts: ToolPolicyFacts;
     profile: NormalizedAutopilotProfile;
+    boundaryBehavior: AutonomyBoundaryBehavior;
   }): AutopilotDecision {
     const { context, envelope, facts, profile } = args;
 
     if (profile.mode !== 'autopilot') {
-      return { type: 'request', reason: 'interactive approval mode', facts };
+      return AutonomyPolicyService.boundaryDecision({
+        behavior: args.boundaryBehavior,
+        reason: 'interactive approval mode',
+        facts,
+      });
     }
 
     if (facts.hardDenyReasons.length > 0) {
@@ -98,20 +107,36 @@ export class AutonomyPolicyService {
     }
 
     if (AutonomyPolicyService.requiresPolicyEnvelope(context) && !envelope) {
-      return { type: 'request', reason: 'tool call needs a declared policy envelope', facts };
+      return AutonomyPolicyService.boundaryDecision({
+        behavior: args.boundaryBehavior,
+        reason: 'tool call needs a declared policy envelope',
+        facts,
+      });
     }
 
     if (facts.approvalReasons.length > 0) {
-      return { type: 'request', reason: facts.approvalReasons.join('; '), facts };
+      return AutonomyPolicyService.boundaryDecision({
+        behavior: args.boundaryBehavior,
+        reason: facts.approvalReasons.join('; '),
+        facts,
+      });
     }
 
     if (envelope && (envelope.confidence === 'low' || envelope.operations.includes('unknown'))) {
-      return { type: 'request', reason: 'policy envelope is not specific enough for autopilot', facts };
+      return AutonomyPolicyService.boundaryDecision({
+        behavior: args.boundaryBehavior,
+        reason: 'policy envelope is not specific enough for autopilot',
+        facts,
+      });
     }
 
     const hasEnvironmentClaim = envelope !== undefined || facts.environment !== 'unknown';
     if (hasEnvironmentClaim && !profile.environments.allow.includes(facts.environment as 'local' | 'dev')) {
-      return { type: 'request', reason: 'environment is not allowed for unattended execution', facts };
+      return AutonomyPolicyService.boundaryDecision({
+        behavior: args.boundaryBehavior,
+        reason: 'environment is not allowed for unattended execution',
+        facts,
+      });
     }
 
     if (!envelope) {
@@ -119,6 +144,20 @@ export class AutonomyPolicyService {
     }
 
     return { type: 'allow', reason: 'allowed by autopilot profile and declared policy envelope', facts };
+  }
+
+  private static boundaryDecision(args: {
+    behavior: AutonomyBoundaryBehavior;
+    reason: string;
+    facts: ToolPolicyFacts;
+  }): AutopilotDecision {
+    return args.behavior === 'deny'
+      ? {
+          type: 'deny',
+          reason: `unattended permission boundary denied: ${args.reason}`,
+          facts: args.facts,
+        }
+      : { type: 'request', reason: args.reason, facts: args.facts };
   }
 
   private static computeFacts(args: {

--- a/src/core/approvals/autonomy/types.ts
+++ b/src/core/approvals/autonomy/types.ts
@@ -45,7 +45,7 @@ export type AutopilotProfile = {
   };
 };
 
-export const AUTONOMY_PERMISSION_MODES = ['default', 'auto', 'unattended', 'custom'] as const;
+export const AUTONOMY_PERMISSION_MODES = ['default', 'auto', 'unattended', 'unrestricted', 'custom'] as const;
 
 export type AutonomyPermissionMode = typeof AUTONOMY_PERMISSION_MODES[number];
 
@@ -77,8 +77,8 @@ export type AutonomyPermissionModeOption = {
  * One resolved permission contract for a run.
  *
  * `boundaryBehavior` controls interactivity; `authority` controls what may run.
- * Keeping those dimensions separate prevents prompt-free execution from
- * silently becoming an unrestricted host-user capability grant.
+ * Keeping those dimensions separate prevents bounded prompt-free execution
+ * from silently becoming an unrestricted host-user capability grant.
  */
 export type AutonomyPermissionGrant =
   | {
@@ -95,6 +95,11 @@ export type AutonomyPermissionGrant =
       mode: 'unattended';
       boundaryBehavior: 'deny';
       authority: { kind: 'autopilot'; profile: AutopilotProfile };
+    }
+  | {
+      mode: 'unrestricted';
+      boundaryBehavior: 'allow';
+      authority: { kind: 'unrestricted' };
     };
 
 export type NormalizedAutopilotRootPolicy = AutopilotRootPolicy & {

--- a/src/core/approvals/autonomy/types.ts
+++ b/src/core/approvals/autonomy/types.ts
@@ -45,9 +45,11 @@ export type AutopilotProfile = {
   };
 };
 
-export const AUTONOMY_PERMISSION_MODES = ['default', 'auto', 'custom'] as const;
+export const AUTONOMY_PERMISSION_MODES = ['default', 'auto', 'unattended', 'custom'] as const;
 
 export type AutonomyPermissionMode = typeof AUTONOMY_PERMISSION_MODES[number];
+
+export type AutonomyBoundaryBehavior = 'request' | 'deny';
 
 export type AutonomyPermissionModeConfig = {
   permissionMode?: AutonomyPermissionMode;
@@ -70,6 +72,30 @@ export type AutonomyPermissionModeOption = {
   disabled?: boolean;
   disabledReason?: string;
 };
+
+/**
+ * One resolved permission contract for a run.
+ *
+ * `boundaryBehavior` controls interactivity; `authority` controls what may run.
+ * Keeping those dimensions separate prevents prompt-free execution from
+ * silently becoming an unrestricted host-user capability grant.
+ */
+export type AutonomyPermissionGrant =
+  | {
+      mode: 'default';
+      boundaryBehavior: 'request';
+      authority: { kind: 'default' };
+    }
+  | {
+      mode: 'auto' | 'custom';
+      boundaryBehavior: 'request';
+      authority: { kind: 'autopilot'; profile: AutopilotProfile };
+    }
+  | {
+      mode: 'unattended';
+      boundaryBehavior: 'deny';
+      authority: { kind: 'autopilot'; profile: AutopilotProfile };
+    };
 
 export type NormalizedAutopilotRootPolicy = AutopilotRootPolicy & {
   path: string;
@@ -117,6 +143,7 @@ export type AutonomyEvaluation = {
   call: ToolCall;
   profileMode: AutopilotProfile['mode'];
   profilePreset?: AutopilotProfilePreset;
+  boundaryBehavior: AutonomyBoundaryBehavior;
   /** Proposed, host-owned, and effective fields retained for policy audit. */
   policy: ToolPolicyReconciliation;
   /** Effective envelope retained for compatibility with existing consumers. */

--- a/src/core/approvals/index.ts
+++ b/src/core/approvals/index.ts
@@ -14,9 +14,11 @@ export {
 export type { ToolApprovalServiceOptions } from './service.js';
 export type { ToolApprovalProfile } from './profiles/index.js';
 export type {
+  AutonomyBoundaryBehavior,
   AutonomyEvaluation,
   AutonomyPermissionMode,
   AutonomyPermissionModeConfig,
+  AutonomyPermissionGrant,
   AutonomyPermissionModeOption,
   AutonomyPolicyHint,
   AutonomyPostflightAudit,

--- a/src/core/approvals/policies.ts
+++ b/src/core/approvals/policies.ts
@@ -9,7 +9,12 @@ import {
   WorkspacePathPolicy,
 } from '@/core/tools/toolkits/coding-files/workspace-path-policy.js';
 import type { ToolApprovalPolicy, ToolApprovalPolicyContext, ToolApprovalSurface } from './types.js';
-import { AutonomyPolicyService, type AutopilotProfile } from './autonomy/index.js';
+import {
+  AutonomyPolicyService,
+  type AutonomyBoundaryBehavior,
+  type AutonomyPermissionGrant,
+  type AutopilotProfile,
+} from './autonomy/index.js';
 
 /**
  * Owns reusable approval policy constructors and the default policy chain.
@@ -92,7 +97,19 @@ export class ToolApprovalPolicies {
     };
   }
 
-  static autopilot(args: { profile: AutopilotProfile }): ToolApprovalPolicy {
+  static forPermissionGrant(grant: AutonomyPermissionGrant): ToolApprovalPolicy[] {
+    return grant.authority.kind === 'autopilot'
+      ? [ToolApprovalPolicies.autopilot({
+          profile: grant.authority.profile,
+          boundaryBehavior: grant.boundaryBehavior,
+        })]
+      : [];
+  }
+
+  static autopilot(args: {
+    profile: AutopilotProfile;
+    boundaryBehavior?: AutonomyBoundaryBehavior;
+  }): ToolApprovalPolicy {
     return async (context) => {
       let canonicalTargetPaths: string[] | undefined;
       try {
@@ -112,6 +129,7 @@ export class ToolApprovalPolicies {
         AutonomyPolicyService.evaluate({
           context: canonicalTargetPaths ? { ...context, canonicalTargetPaths } : context,
           profile: args.profile,
+          boundaryBehavior: args.boundaryBehavior,
         }),
       );
     };

--- a/src/core/approvals/policies.ts
+++ b/src/core/approvals/policies.ts
@@ -97,13 +97,34 @@ export class ToolApprovalPolicies {
     };
   }
 
-  static forPermissionGrant(grant: AutonomyPermissionGrant): ToolApprovalPolicy[] {
-    return grant.authority.kind === 'autopilot'
-      ? [ToolApprovalPolicies.autopilot({
-          profile: grant.authority.profile,
-          boundaryBehavior: grant.boundaryBehavior,
-        })]
-      : [];
+  static unrestricted(): ToolApprovalPolicy {
+    return () => ({
+      type: 'allow',
+      reason: 'Allowed by unrestricted permission mode',
+    });
+  }
+
+  /** Composes bounded gates before host policies and Unrestricted after them. */
+  static forPermissionGrant(
+    grant: AutonomyPermissionGrant | undefined,
+    policies: ToolApprovalPolicy[] = [],
+  ): ToolApprovalPolicy[] {
+    if (!grant) {
+      return policies;
+    }
+
+    if (grant.mode === 'unrestricted') {
+      return [...policies, ToolApprovalPolicies.unrestricted()];
+    }
+
+    if (grant.authority.kind !== 'autopilot') {
+      return policies;
+    }
+
+    return [ToolApprovalPolicies.autopilot({
+      profile: grant.authority.profile,
+      boundaryBehavior: grant.boundaryBehavior,
+    }), ...policies];
   }
 
   static autopilot(args: {

--- a/src/core/approvals/types.ts
+++ b/src/core/approvals/types.ts
@@ -29,7 +29,10 @@ export type ToolApprovalPolicy = (
 ) => ToolApprovalPolicyDecision | undefined | Promise<ToolApprovalPolicyDecision | undefined>;
 
 export type ToolApprovalSurface = (
-  context: ToolApprovalPolicyContext & { autonomyEvaluation?: AutonomyEvaluation },
+  context: ToolApprovalPolicyContext & {
+    reason?: string;
+    autonomyEvaluation?: AutonomyEvaluation;
+  },
 ) => Promise<ToolApprovalDecision>;
 
 export type EvaluateToolApprovalPoliciesArgs = {

--- a/src/core/chat/engine/turns/host/host-normalizer.ts
+++ b/src/core/chat/engine/turns/host/host-normalizer.ts
@@ -22,9 +22,10 @@ export class ConversationEngineHostNormalizer {
         }
       },
       approveToolCall: requestToolApproval
-        ? ((call, tool, autonomyEvaluation) => requestToolApproval({
+        ? ((call, tool, autonomyEvaluation, reason) => requestToolApproval({
           call,
           tool,
+          ...(reason ? { reason } : {}),
           ...(autonomyEvaluation ? { autonomyEvaluation } : {}),
         }))
         : undefined,

--- a/src/core/commands/slash/modules/permissions/permission-commands.ts
+++ b/src/core/commands/slash/modules/permissions/permission-commands.ts
@@ -14,7 +14,7 @@ export function createPermissionsSlashCommandModule(): SlashCommandModule<SlashC
     hints: [
       { command: '/permissions', description: 'show the active permission mode' },
       { command: '/permissions set [query]', description: 'pick permission mode with filtering' },
-      { command: '/permissions <default|auto|unattended|custom>', description: 'set the workspace permission mode' },
+      { command: '/permissions <default|auto|unattended|unrestricted|custom>', description: 'set the workspace permission mode' },
     ],
     commands: [
       {
@@ -33,7 +33,7 @@ export function createPermissionsSlashCommandModule(): SlashCommandModule<SlashC
       },
       {
         id: 'permissions.set',
-        syntax: '/permissions <default|auto|unattended|custom>',
+        syntax: '/permissions <default|auto|unattended|unrestricted|custom>',
         description: 'set the workspace permission mode',
         match: SlashCommandParser.matchesPrefix('/permissions'),
         run: (context, input) => setPermissionMode(context, argumentAfterPrefix(input, '/permissions')),
@@ -53,7 +53,7 @@ function setPermissionMode(
 
   const selected = normalized.startsWith('set ') ? normalized.slice('set '.length).trim() : normalized;
   if (!isPermissionMode(selected)) {
-    return slashMessageResult('Usage: /permissions set <query> or /permissions <default|auto|unattended|custom>');
+    return slashMessageResult('Usage: /permissions set <query> or /permissions <default|auto|unattended|unrestricted|custom>');
   }
 
   const next = context.permissions.set(selected);

--- a/src/core/commands/slash/modules/permissions/permission-commands.ts
+++ b/src/core/commands/slash/modules/permissions/permission-commands.ts
@@ -14,7 +14,7 @@ export function createPermissionsSlashCommandModule(): SlashCommandModule<SlashC
     hints: [
       { command: '/permissions', description: 'show the active permission mode' },
       { command: '/permissions set [query]', description: 'pick permission mode with filtering' },
-      { command: '/permissions <default|auto|custom>', description: 'set the workspace permission mode' },
+      { command: '/permissions <default|auto|unattended|custom>', description: 'set the workspace permission mode' },
     ],
     commands: [
       {
@@ -33,7 +33,7 @@ export function createPermissionsSlashCommandModule(): SlashCommandModule<SlashC
       },
       {
         id: 'permissions.set',
-        syntax: '/permissions <default|auto|custom>',
+        syntax: '/permissions <default|auto|unattended|custom>',
         description: 'set the workspace permission mode',
         match: SlashCommandParser.matchesPrefix('/permissions'),
         run: (context, input) => setPermissionMode(context, argumentAfterPrefix(input, '/permissions')),
@@ -53,7 +53,7 @@ function setPermissionMode(
 
   const selected = normalized.startsWith('set ') ? normalized.slice('set '.length).trim() : normalized;
   if (!isPermissionMode(selected)) {
-    return slashMessageResult('Usage: /permissions set <query> or /permissions <default|auto|custom>');
+    return slashMessageResult('Usage: /permissions set <query> or /permissions <default|auto|unattended|custom>');
   }
 
   const next = context.permissions.set(selected);

--- a/src/core/project-config/README.md
+++ b/src/core/project-config/README.md
@@ -13,8 +13,9 @@ The public adapter methods are intentionally small:
 - `ProjectConfigService.update(workspaceRoot, updater)` persists supported
   config fields through the same schema used for reads.
 - The optional `permissionMode` field stores the selected user-facing
-  Default/Auto/Custom mode. Approval autonomy owns the mapping from that mode to
-  an effective profile.
+  Default/Auto/Unattended/Custom mode. Approval autonomy owns the mapping from
+  that mode to one permission grant. Unattended uses Auto's bounded authority
+  but converts approval boundaries into deterministic denials.
 - The optional `autopilot` field uses the approval autonomy profile schema from
   `src/core/approvals/autonomy/`. Project config validates the persisted shape,
   but approval semantics and policy decisions stay in the approvals domain.

--- a/src/core/project-config/README.md
+++ b/src/core/project-config/README.md
@@ -13,9 +13,10 @@ The public adapter methods are intentionally small:
 - `ProjectConfigService.update(workspaceRoot, updater)` persists supported
   config fields through the same schema used for reads.
 - The optional `permissionMode` field stores the selected user-facing
-  Default/Auto/Unattended/Custom mode. Approval autonomy owns the mapping from
-  that mode to one permission grant. Unattended uses Auto's bounded authority
-  but converts approval boundaries into deterministic denials.
+  Default/Auto/Unattended/Unrestricted/Custom mode. Approval autonomy owns the
+  mapping from that mode to one permission grant. Unattended uses Auto's bounded
+  authority but converts approval boundaries into deterministic denials;
+  Unrestricted is an explicit prompt-free approval bypass for isolated hosts.
 - The optional `autopilot` field uses the approval autonomy profile schema from
   `src/core/approvals/autonomy/`. Project config validates the persisted shape,
   but approval semantics and policy decisions stay in the approvals domain.

--- a/src/core/runtime/loop/types.ts
+++ b/src/core/runtime/loop/types.ts
@@ -107,7 +107,12 @@ export type RunAgentLoopOptions = {
   onEvent?: (event: AgentLoopEvent) => void;
   onTraceEvent?: (event: TraceEvent) => void;
   approvalPolicies?: ToolApprovalPolicy[];
-  approveToolCall?: (call: ToolCall, tool: ToolDefinition, autonomyEvaluation?: AutonomyEvaluation) => Promise<ToolApprovalDecision>;
+  approveToolCall?: (
+    call: ToolCall,
+    tool: ToolDefinition,
+    autonomyEvaluation?: AutonomyEvaluation,
+    reason?: string,
+  ) => Promise<ToolApprovalDecision>;
   shouldStop?: () => boolean;
   abortSignal?: AbortSignal;
   recoverModelContext?: AgentModelContextRecovery;

--- a/src/core/tools/toolkits/shell-process/README.md
+++ b/src/core/tools/toolkits/shell-process/README.md
@@ -46,6 +46,12 @@ technical containment mechanism. Unattended permission mode removes the human
 wait, not this requirement: policy misses are denied, while allowed shell calls
 still inherit the host process authority described above.
 
+Unrestricted permission mode bypasses the approval gate for
+`run_shell_mutate`, so arbitrary commands can use that full host authority
+without prompting. The tool-owned catastrophic home/root/disk guard still runs
+at execution time. Use Unrestricted only inside an isolated container or VM
+with least-privilege credentials and constrained network access.
+
 ## Two Tools, Two Gates
 
 | Tool | Policy | Approval | Control operators |

--- a/src/core/tools/toolkits/shell-process/README.md
+++ b/src/core/tools/toolkits/shell-process/README.md
@@ -42,7 +42,9 @@ the other. See `../coding-files/README.md`.
 Hosts running untrusted or model-directed workloads should place the whole
 Heddle process inside mature OS isolation (a container, a VM, or a
 least-privilege user account). Approval is a human-judgment gate, not a
-technical containment mechanism.
+technical containment mechanism. Unattended permission mode removes the human
+wait, not this requirement: policy misses are denied, while allowed shell calls
+still inherit the host process authority described above.
 
 ## Two Tools, Two Gates
 

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -15,6 +15,7 @@
 import { EventEmitter } from 'node:events';
 import { watch } from 'node:fs';
 import { join } from 'node:path';
+import omit from 'lodash/omit.js';
 import type { Logger } from 'pino';
 import {
   AutonomyPermissionModeService,
@@ -596,7 +597,8 @@ export class ControlPlaneChatSessionsController {
           })
           : await this.runEngineTurn(args, run, async ({ engine, host, abortSignal, shouldStop }) => {
             return await engine.turns.submit({
-              ...args,
+              // Engine config already owns the composed permission chain.
+              ...omit(args, ['approvalPolicies', 'permissionGrant']),
               agentProfileId: args.agentProfileId,
               agentSnapshot: args.agentSnapshot,
               host,
@@ -856,15 +858,13 @@ export class ControlPlaneChatSessionsController {
     permissionGrant?: AutonomyPermissionGrant;
     approvalService: ToolApprovalService;
   }): ToolApprovalPolicy[] {
-    return [
-      ...(args.permissionGrant ? ToolApprovalPolicies.forPermissionGrant(args.permissionGrant) : []),
+    return ToolApprovalPolicies.forPermissionGrant(args.permissionGrant, [
       ...(args.approvalPolicies ?? []),
       ToolApprovalPolicies.rememberedProjectRule({
         isApproved: (context) => args.approvalService.isApprovedByRememberedProjectRule(context),
       }),
-    ];
+    ]);
   }
-
   private createEngineHost(args: ControlPlaneSessionReadArgs & ControlPlaneSessionAddress, publisher: ControlPlaneTurnPublisher): ConversationEngineHost {
     const approvalService = this.createApprovalService(args);
 

--- a/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
+++ b/src/server/controllers/trpc/control-plane/chat-sessions-controller.ts
@@ -20,7 +20,7 @@ import {
   AutonomyPermissionModeService,
   ToolApprovalPolicies,
   ToolApprovalService,
-  type AutopilotProfile,
+  type AutonomyPermissionGrant,
   type ToolApprovalRequest,
   type ToolApprovalPolicy,
   type ToolApprovalUserDecision,
@@ -72,7 +72,7 @@ type ControlPlaneSessionReadArgs = Omit<ConversationEngineConfig, 'model' | 'wor
   model?: string;
   sessionStoragePath: string;
   workspaceId: string;
-  autopilot?: AutopilotProfile;
+  permissionGrant?: AutonomyPermissionGrant;
 };
 
 type CreateControlPlaneChatSessionArgs = ControlPlaneSessionReadArgs & {
@@ -838,14 +838,14 @@ export class ControlPlaneChatSessionsController {
   }
 
   private createEngine(args: ControlPlaneSessionReadArgs): ConversationEngine {
-    const { autopilot, ...engineArgs } = args;
+    const { permissionGrant, ...engineArgs } = args;
     const approvalService = this.createApprovalService(args);
     return createConversationEngine({
       ...engineArgs,
       model: args.model ?? DEFAULT_OPENAI_MODEL,
       approvalPolicies: this.createApprovalPolicies({
         approvalPolicies: args.approvalPolicies,
-        autopilot,
+        permissionGrant,
         approvalService,
       }),
     });
@@ -853,11 +853,11 @@ export class ControlPlaneChatSessionsController {
 
   private createApprovalPolicies(args: {
     approvalPolicies?: ToolApprovalPolicy[];
-    autopilot?: AutopilotProfile;
+    permissionGrant?: AutonomyPermissionGrant;
     approvalService: ToolApprovalService;
   }): ToolApprovalPolicy[] {
     return [
-      ...(args.autopilot ? [ToolApprovalPolicies.autopilot({ profile: args.autopilot })] : []),
+      ...(args.permissionGrant ? ToolApprovalPolicies.forPermissionGrant(args.permissionGrant) : []),
       ...(args.approvalPolicies ?? []),
       ToolApprovalPolicies.rememberedProjectRule({
         isApproved: (context) => args.approvalService.isApprovedByRememberedProjectRule(context),
@@ -873,11 +873,12 @@ export class ControlPlaneChatSessionsController {
         onActivity: publisher.publishActivity,
       },
       approvals: {
-        requestToolApproval: async ({ call, tool, autonomyEvaluation }) => {
+        requestToolApproval: async ({ call, tool, reason, autonomyEvaluation }) => {
           const decision = await approvalService.requestHumanApproval({
             call,
             tool,
             workspaceRoot: args.workspaceRoot,
+            reason,
             autonomyEvaluation,
             storePending: ({ request, resolve }) => {
               // Keep the resolver in memory while the browser renders the
@@ -916,9 +917,9 @@ export class ControlPlaneChatSessionsController {
     if (input.decision.type !== 'approve_and_trust_autopilot_root') {
       return input.decision;
     }
-
     const rootApproval = input.request.autopilotRootApproval;
-    if (!rootApproval || input.engineArgs.autopilot?.preset !== 'auto') {
+    const profile = AutonomyPermissionModeService.resolveAutoRootTrustProfile(input.engineArgs.permissionGrant);
+    if (!rootApproval || !profile) {
       return {
         type: 'deny',
         reason: 'No Auto repo root is available for this approval.',
@@ -934,7 +935,7 @@ export class ControlPlaneChatSessionsController {
         })
       ));
       AutonomyPermissionModeService.addTrustedRootToProfile({
-        profile: input.engineArgs.autopilot,
+        profile,
         workspaceRoot: input.engineArgs.workspaceRoot,
         root: rootApproval.root,
       });

--- a/src/server/routes/trpc/control-plane-workspace.ts
+++ b/src/server/routes/trpc/control-plane-workspace.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import { TRPCError } from '@trpc/server';
 import type { Logger } from 'pino';
-import { AutonomyPermissionModeService, type AutopilotProfile } from '@/core/approvals/index.js';
+import { AutonomyPermissionModeService, type AutonomyPermissionGrant } from '@/core/approvals/index.js';
 import { ProjectConfigService } from '@/core/project-config/index.js';
 import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import { FileDaemonRegistryRepository, RuntimeDaemonRegistryService } from '@/core/runtime/daemon/index.js';
@@ -30,7 +30,7 @@ export type ControlPlaneRequestWorkspace = {
     credentialStorePath: string;
     preferApiKey: boolean;
     workspaceId: string;
-    autopilot?: AutopilotProfile;
+    permissionGrant: AutonomyPermissionGrant;
   };
 };
 
@@ -112,7 +112,7 @@ export function resolveControlPlaneRequestWorkspace(
 ): ControlPlaneRequestWorkspace {
   const workspace = resolveWorkspaceDescriptor(ctx, input?.workspaceId);
   const projectConfig = ProjectConfigService.read(workspace.workspaceRoot);
-  const autopilot = AutonomyPermissionModeService.resolveEffectiveProfile({
+  const permissionGrant = AutonomyPermissionModeService.resolveGrant({
     config: projectConfig,
     workspaceRoot: workspace.workspaceRoot,
   });
@@ -127,7 +127,7 @@ export function resolveControlPlaneRequestWorkspace(
       credentialStorePath: ProviderCredentialRepository.resolveStorePath(workspace.stateRoot),
       preferApiKey: ctx.preferApiKey,
       workspaceId: workspace.id,
-      autopilot,
+      permissionGrant,
     },
   };
 }

--- a/src/web-v2/components/conversation/ComposerContextMenu.tsx
+++ b/src/web-v2/components/conversation/ComposerContextMenu.tsx
@@ -54,12 +54,14 @@ const driftLevelMessageKeys = {
 const permissionModeLabelKeys = {
   default: 'composer.permissionMode.default.label',
   auto: 'composer.permissionMode.auto.label',
+  unattended: 'composer.permissionMode.unattended.label',
   custom: 'composer.permissionMode.custom.label',
 } as const satisfies Record<ControlPlanePermissionMode, I18nMessageKey>;
 
 const permissionModeDescriptionKeys = {
   default: 'composer.permissionMode.default.description',
   auto: 'composer.permissionMode.auto.description',
+  unattended: 'composer.permissionMode.unattended.description',
   custom: 'composer.permissionMode.custom.description',
 } as const satisfies Record<ControlPlanePermissionMode, I18nMessageKey>;
 

--- a/src/web-v2/components/conversation/ComposerContextMenu.tsx
+++ b/src/web-v2/components/conversation/ComposerContextMenu.tsx
@@ -55,6 +55,7 @@ const permissionModeLabelKeys = {
   default: 'composer.permissionMode.default.label',
   auto: 'composer.permissionMode.auto.label',
   unattended: 'composer.permissionMode.unattended.label',
+  unrestricted: 'composer.permissionMode.unrestricted.label',
   custom: 'composer.permissionMode.custom.label',
 } as const satisfies Record<ControlPlanePermissionMode, I18nMessageKey>;
 
@@ -62,6 +63,7 @@ const permissionModeDescriptionKeys = {
   default: 'composer.permissionMode.default.description',
   auto: 'composer.permissionMode.auto.description',
   unattended: 'composer.permissionMode.unattended.description',
+  unrestricted: 'composer.permissionMode.unrestricted.description',
   custom: 'composer.permissionMode.custom.description',
 } as const satisfies Record<ControlPlanePermissionMode, I18nMessageKey>;
 

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -113,7 +113,7 @@
     },
     "permissionMode": {
       "auto": {
-        "description": "Approve trusted local coding actions.",
+        "description": "Run trusted local coding actions without routine approval.",
         "label": "Auto"
       },
       "custom": {
@@ -123,6 +123,10 @@
       "default": {
         "description": "Use the default permission behavior.",
         "label": "Default"
+      },
+      "unattended": {
+        "description": "Never prompt; deny actions outside trusted local coding policy.",
+        "label": "Unattended"
       },
       "statusPrefix": "Mode",
       "title": "Permission mode"

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -128,6 +128,10 @@
         "description": "Never prompt; deny actions outside trusted local coding policy.",
         "label": "Unattended"
       },
+      "unrestricted": {
+        "description": "Skip approval prompts and checks. Use only in an isolated environment.",
+        "label": "Unrestricted"
+      },
       "statusPrefix": "Mode",
       "title": "Permission mode"
     },

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -128,6 +128,10 @@
         "description": "不显示批准提示；拒绝超出受信任本地编码策略的操作。",
         "label": "无人值守"
       },
+      "unrestricted": {
+        "description": "跳过批准提示和检查。仅在隔离环境中使用。",
+        "label": "不受限"
+      },
       "statusPrefix": "模式",
       "title": "权限模式"
     },

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -113,7 +113,7 @@
     },
     "permissionMode": {
       "auto": {
-        "description": "自动批准可信的本地 coding 操作。",
+        "description": "无需常规批准即可执行受信任的本地编码操作。",
         "label": "Auto"
       },
       "custom": {
@@ -123,6 +123,10 @@
       "default": {
         "description": "使用默认权限行为。",
         "label": "Default"
+      },
+      "unattended": {
+        "description": "不显示批准提示；拒绝超出受信任本地编码策略的操作。",
+        "label": "无人值守"
       },
       "statusPrefix": "模式",
       "title": "权限模式"

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -113,7 +113,7 @@
     },
     "permissionMode": {
       "auto": {
-        "description": "自動核准可信任的本機 coding 動作。",
+        "description": "在無需例行核准的情況下執行受信任的本機程式設計動作。",
         "label": "Auto"
       },
       "custom": {
@@ -123,6 +123,10 @@
       "default": {
         "description": "使用預設權限行為。",
         "label": "Default"
+      },
+      "unattended": {
+        "description": "不顯示核准提示；拒絕超出受信任本機程式設計政策的動作。",
+        "label": "無人值守"
       },
       "statusPrefix": "模式",
       "title": "權限模式"

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -128,6 +128,10 @@
         "description": "不顯示核准提示；拒絕超出受信任本機程式設計政策的動作。",
         "label": "無人值守"
       },
+      "unrestricted": {
+        "description": "略過核准提示與檢查。僅在隔離環境中使用。",
+        "label": "不受限制"
+      },
       "statusPrefix": "模式",
       "title": "權限模式"
     },


### PR DESCRIPTION
## Summary
- add Unattended mode: reuse the bounded Auto authority but deny boundary misses instead of opening approval prompts
- add Unrestricted mode: evaluate explicit deny policies first, then auto-allow requests without prompting
- keep deterministic tool validation active, including workspace containment and the catastrophic shell-command guard
- prevent raw turn policies from replacing the control-plane composed permission chain
- expose both modes through project config, slash commands, CLI/browser selectors, localized copy, and maintainer documentation

## Permission semantics
- Auto: bounded local coding authority; asks at policy boundaries
- Unattended: the same bounded authority; denies at policy boundaries and never asks
- Unrestricted: skips routine approval checks and never asks; explicit earlier denies and tool-owned validation still apply

Unrestricted is not a sandbox. It should be used only inside an isolated container or VM with least-privilege credentials and constrained network access.

## Verification
- yarn test
- yarn build
- yarn lint
- git diff --check