### PR TITLE
Add hosted coordinator integration client

### DIFF
--- a/docs/guides/programmatic/component-model.md
+++ b/docs/guides/programmatic/component-model.md
@@ -105,7 +105,7 @@ adopter database credential.
 | `@heddleagent/runtime/runs` | That same Node process needs addressable runs, replay, cancel, or reconnect | This is an in-process run service, not the separate Execution Host |
 | `@heddleagent/run-client` | A browser or JavaScript client consumes hosted-run envelopes | It consumes execution; it does not run an agent |
 | `@heddleagent/postgres/heartbeat` | Heddle heartbeat tasks need PostgreSQL leases, checkpoints, and history | It is one explicit adapter subpath, not a general product DB or conversation-history adapter |
-| `@heddleagent/execution-host-client` | A product or Heddle coordinator invokes a separate compatible Execution Host | Authority, conversation and heartbeat transports, turn orchestration, durable conversation lifecycle semantics, Node helpers, and cross-language conformance |
+| `@heddleagent/execution-host-client` | A product or Heddle coordinator invokes a separate compatible Execution Host | Authority, conversation and heartbeat transports, coordinator task/delegation clients, desired-state reconciliation, turn orchestration, durable conversation lifecycle semantics, Node helpers, and cross-language conformance |
 | `@heddleagent/postgres/execution-host/conversations` | That product stores the generic lifecycle in PostgreSQL | Official atomic store and ordered migrations; no product history/query policy or pool ownership |
 | v1 OpenAPI, JSON Schema, and fixtures | The adopter backend is Python, Go, Java, or another stack | Implement the network and optional durable-lifecycle profiles; never port Heddle's agent loop |
 
@@ -122,7 +122,7 @@ SDK and not a promise to mirror every TypeScript convenience.
 | --- | --- | --- |
 | `@heddleagent/runtime` and `/runs` | Public | TypeScript/Node SDK and runtime surfaces for adopter-owned processes |
 | `@heddleagent/run-client` | Public | Browser-safe run protocol and optional HTTP/SSE client |
-| `@heddleagent/execution-host-client` | Public | The canonical backend integration kit, including conversation and heartbeat workflows, durable conversation lifecycle semantics, store conformance, and shared TypeScript/Python fixtures |
+| `@heddleagent/execution-host-client` | Public | The canonical backend integration kit, including conversation and heartbeat workflows, coordinator integration, durable conversation lifecycle semantics, store conformance, and shared TypeScript/Python fixtures |
 | `@heddleagent/postgres/execution-host/conversations` | Public | Official PostgreSQL lifecycle adapter over an adopter-managed database and migration process |
 | Compatible Heddle Execution Host | Private research | A proving ground for isolated hosted execution and deployment evidence; it is not distributed or offered as a service |
 | AWS AgentCore deployment | Private research target | One way to test managed session isolation and lifecycle behavior, not a requirement of the public contract |

--- a/docs/guides/programmatic/execution-host-adopters.md
+++ b/docs/guides/programmatic/execution-host-adopters.md
@@ -10,7 +10,7 @@ The package is currently an experimental public contract and local proving
 surface. Heddle does not distribute the compatible Execution Host or offer a
 hosted service today.
 
-The stable coordinate is `@heddleagent/execution-host-client@6.2.0`. The
+The stable coordinate is `@heddleagent/execution-host-client@6.3.0`. The
 former `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 installable only for existing consumers. It does not include the durable
 lifecycle described below.
@@ -78,6 +78,11 @@ Its subpaths separate responsibility:
 - `/heartbeat` connects Heddle's provider-neutral heartbeat scheduler to one
   remotely executed agent cycle while keeping durable task authority in the
   coordinator;
+- `/coordinator` owns the authenticated task client, pause-first desired-state
+  reconciliation, product delegation contract, Runtime-session derivation,
+  and delegated heartbeat execution;
+- `/coordinator/node` exposes the standard authenticated Node HTTP edge for a
+  product's task authorization decision;
 - `/mcp` independently verifies product-MCP capabilities against a fixed
   deployment and supported-tool set;
 - `/mcp/node` owns a stateless official-SDK Streamable HTTP lifecycle around
@@ -169,11 +174,17 @@ Runtime deployment.
 The `heartbeat-task` workflow is intentionally narrower than a general control
 plane. One long-running coordinator owns the heartbeat PostgreSQL store,
 scheduler, claims, fencing, checkpoints, settlement, recovery, and shutdown.
-It supplies `HostedHeartbeatAgentExecutionTransport` to the runtime scheduler.
-The transport resolves an already-authorized product scope, Runtime session,
-and deadline, then `HostedHeartbeatTaskService` owns assertion issuance, model
-credentials, optional product MCP, AgentCore/direct invocation, ordered
-activity, cancellation, and terminal classification.
+The product uses `HostedHeartbeatCoordinatorClient` and
+`HostedHeartbeatTaskReconciler` to publish its desired task catalog. It exposes
+`HostedHeartbeatDelegationService` through the optional Node HTTP service; its
+callback returns only the authorized product scope and exact MCP tool set.
+
+The coordinator uses `HostedHeartbeatDelegationClient` and
+`HostedHeartbeatDelegatedExecutionTransport` to obtain that one-run authority
+and execute the claimed task. Heddle owns request validation, Runtime-session
+derivation, deadline and authority construction, scope/tool binding, model
+credentials, AgentCore/direct invocation, ordered activity, cancellation, and
+terminal classification. Neither side recreates the shared wire shape.
 
 Only the nested agent cycle runs in the Execution Host. The Runtime receives
 neither the Heddle database credential nor product database access. Omitting

--- a/packages/execution-host-client/README.md
+++ b/packages/execution-host-client/README.md
@@ -5,7 +5,7 @@ products that invoke a separately deployed Heddle Execution Host. It lets an
 adopter keep its own language stack, authentication, database, product policy,
 MCP tools, and UI while reusing the security-sensitive v1 contract machinery.
 
-> **Current availability:** stable version `6.2.0`. The former
+> **Current availability:** stable version `6.3.0`. The former
 > `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 > installable only for existing consumers. Heddle does not currently distribute
 > the compatible Execution Host implementation or offer a hosted service. The
@@ -31,6 +31,8 @@ modular AWS SDK for its AgentCore transport and the official MCP SDK, plus
 | `@heddleagent/execution-host-client/authority` | ES256 execution assertion and optional MCP capability issuance plus public JWKS projection |
 | `@heddleagent/execution-host-client/conversation` | Turn orchestration across authority, model credentials, optional MCP policy, an `ExecutionHost`, and an optional adopter-implemented durable lifecycle store |
 | `@heddleagent/execution-host-client/heartbeat` | Remote heartbeat orchestration that keeps durable task authority in a coordinator while a compatible Execution Host runs the agent cycle |
+| `@heddleagent/execution-host-client/coordinator` | Authenticated task publication, pause-first desired-state reconciliation, product delegation, and delegated heartbeat execution |
+| `@heddleagent/execution-host-client/coordinator/node` | Standard authenticated Node HTTP edge for product-owned heartbeat authorization |
 | `@heddleagent/execution-host-client/mcp` | Independent capability verification at the adopter's MCP edge |
 | `@heddleagent/execution-host-client/mcp/node` | Stateless official-SDK Streamable HTTP lifecycle around adopter-defined toolsets |
 | `@heddleagent/execution-host-client/http-sse` | Transport-neutral conversation and heartbeat ports plus the strict direct-development HTTP/SSE client |
@@ -279,30 +281,81 @@ The client refuses redirects, bounds parser and error bodies, validates ordered
 SSE identity, streams accepted/activity events incrementally, and withholds the
 terminal event until clean EOF. It never retries an ambiguous invocation.
 
-## Delegate heartbeat agent cycles
+## Connect a product to the heartbeat coordinator
+
+The product publishes only its desired task state and authorizes individual
+runs. Heddle owns the coordinator protocol, safe reconciliation order, Runtime
+session derivation, short-lived authority bundle, and execution composition.
+
+```ts
+import {
+  HostedHeartbeatCoordinatorClient,
+  HostedHeartbeatDelegationService,
+  HostedHeartbeatTaskReconciler,
+} from '@heddleagent/execution-host-client/coordinator'
+import {
+  NodeHostedHeartbeatDelegationHttpService,
+} from '@heddleagent/execution-host-client/coordinator/node'
+
+const coordinator = new HostedHeartbeatCoordinatorClient({
+  baseUrl: coordinatorUrl,
+  apiToken: coordinatorApiToken,
+})
+await new HostedHeartbeatTaskReconciler({ coordinator }).reconcile({
+  desiredTasks: await projectDesiredHeartbeatTasks(),
+  resume: backgroundChecksEnabled,
+})
+
+const delegations = new HostedHeartbeatDelegationService({
+  authority,
+  runtimeSessionNamespace: 'example-product',
+  maxExecutionMs: 300_000,
+  authorizer: {
+    authorize: ({ taskId, signal }) =>
+      authorizeProductHeartbeat({ taskId, signal }),
+  },
+})
+const delegationHttp = new NodeHostedHeartbeatDelegationHttpService({
+  delegations,
+  apiToken: coordinatorDelegationToken,
+})
+```
+
+`projectDesiredHeartbeatTasks` remains product-owned because it translates
+product records into desired Heddle tasks. `authorizeProductHeartbeat` remains
+product-owned because it decides whether the task may run and returns only the
+authorized tenant/subject/product-session scope and exact MCP tool set. Product
+code does not construct coordinator requests, Runtime-session IDs, deadlines,
+JWTs, or delegation response objects.
+
+The Node handler can be mounted before an existing router through
+`delegationHttp.handle(request, response)`. See the
+[coordinator boundary](src/coordinator/README.md) for the corresponding
+coordinator-side client and execution transport.
+
+## Compose the coordinator execution transport
 
 For autonomous work, keep the durable task store and scheduler in one
 long-running coordinator. Inject the hosted transport only at the point where
-the scheduler would otherwise run the local heartbeat agent:
+the scheduler would otherwise run the local heartbeat agent. The coordinator
+uses the product delegation endpoint rather than receiving product signing
+keys or reimplementing its authority shape:
 
 ```ts
 import { HeartbeatSchedulerService } from '@heddleagent/runtime/advanced'
 import {
-  HostedHeartbeatAgentExecutionTransport,
-  HostedHeartbeatTaskService,
-} from '@heddleagent/execution-host-client/heartbeat'
+  HostedHeartbeatDelegatedExecutionTransport,
+  HostedHeartbeatDelegationClient,
+} from '@heddleagent/execution-host-client/coordinator'
 
-const hostedHeartbeat = new HostedHeartbeatTaskService({
-  authority,
+const delegations = new HostedHeartbeatDelegationClient({
+  baseUrl: productBackendUrl,
+  apiToken: productDelegationToken,
+})
+const agentExecutionTransport = new HostedHeartbeatDelegatedExecutionTransport({
+  delegations,
   executionHost: agentCoreExecutionHost,
   modelCredentials,
-  mcp: { allowedTools: ['read_workspace_snapshot'] },
-})
-const agentExecutionTransport = new HostedHeartbeatAgentExecutionTransport({
-  runner: hostedHeartbeat,
-  resolveInvocationContext: ({ taskId, executionId, signal }) => (
-    resolveAuthorizedHeartbeatInvocation({ taskId, executionId, signal })
-  ),
 })
 
 const scheduler = HeartbeatSchedulerService.start({
@@ -311,11 +364,13 @@ const scheduler = HeartbeatSchedulerService.start({
 })
 ```
 
-The coordinator still owns task lookup, claims, checkpoint loading, cancellation,
-claim-fenced settlement, history, and recovery. The Runtime receives a bounded
-task/checkpoint request plus invocation-scoped authority and model credentials;
-it receives no Heddle database credential. Omitting `agentExecutionTransport`
-preserves the existing in-process runner.
+The coordinator still owns task lookup, claims, checkpoint loading,
+cancellation, claim-fenced settlement, history, and recovery. The Runtime
+receives a bounded task/checkpoint request plus invocation-scoped authority and
+model credentials; it receives no Heddle database credential. Omitting
+`agentExecutionTransport` preserves the existing in-process runner. The lower
+level `/heartbeat` composition remains available for deployments whose
+coordinator and product authority live in the same process.
 
 ## Verify an adopter integration locally
 

--- a/packages/execution-host-client/package.json
+++ b/packages/execution-host-client/package.json
@@ -46,6 +46,14 @@
       "types": "./dist/heartbeat/index.d.ts",
       "import": "./dist/heartbeat/index.js"
     },
+    "./coordinator": {
+      "types": "./dist/coordinator/index.d.ts",
+      "import": "./dist/coordinator/index.js"
+    },
+    "./coordinator/node": {
+      "types": "./dist/coordinator/node/index.d.ts",
+      "import": "./dist/coordinator/node/index.js"
+    },
     "./mcp": {
       "types": "./dist/mcp/index.d.ts",
       "import": "./dist/mcp/index.js"

--- a/packages/execution-host-client/src/README.md
+++ b/packages/execution-host-client/src/README.md
@@ -11,6 +11,13 @@ independent so an adopter can use only the machinery it needs:
   capability issuance plus public JWKS projection;
 - `conversation`: provider-neutral authority, credential, tool-policy, and
   Execution Host turn orchestration;
+- `heartbeat`: one remotely executed heartbeat cycle behind Heddle's existing
+  scheduler transport;
+- `coordinator`: authenticated task publication, desired-state reconciliation,
+  product delegation, and delegated heartbeat execution shared by products and
+  the Heddle coordinator;
+- `coordinator/node`: the standard authenticated Node HTTP edge for a
+  product-owned heartbeat authorization decision;
 - `mcp`: independent product-edge capability verification against a fixed
   deployment and supported-tool set;
 - `mcp/node`: optional official-SDK Streamable HTTP lifecycle around an
@@ -22,11 +29,12 @@ independent so an adopter can use only the machinery it needs:
 - `node`: optional Node HTTP edge and safe local signing-key conveniences. It
   owns generic mechanics, never product identity or tool policy.
 
-The package must never import the Heddle runtime, Execution Host internals, AWS
-SDK, a database adapter, or product domain code. The explicit `mcp/node`
-surface may import the official MCP SDK, but owns no model-visible tools. New reusable
-machinery belongs here only when it is required by more than one adopter and
-can preserve that dependency boundary.
+The package must never import the Heddle runtime, Execution Host internals, a
+database adapter, or product domain code. The explicit `agentcore` surface may
+import the modular AWS SDK, and `mcp/node` may import the official MCP SDK, but
+neither owns product deployment or model-visible tools. New reusable machinery
+belongs here only when it is required by more than one adopter and can preserve
+that dependency boundary.
 
 The repository includes one clean-room Python consumer to prove the versioned
 contract is implementable outside TypeScript. It is a bounded conformance

--- a/packages/execution-host-client/src/__tests__/coordinator.test.ts
+++ b/packages/execution-host-client/src/__tests__/coordinator.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ExecutionAuthorityIssueInput,
+  IssuedExecutionAuthority,
+} from '../authority/index.js';
+import {
+  HostedHeartbeatCoordinatorClient,
+  HostedHeartbeatCoordinatorRequestError,
+  HostedHeartbeatDelegationService,
+  HostedHeartbeatTaskReconciler,
+} from '../coordinator/index.js';
+
+const API_TOKEN = 'coordinator-api-token-at-least-32-characters';
+
+describe('HostedHeartbeatCoordinatorClient', () => {
+  it('owns authenticated task API requests and validates the response', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (request, init) => {
+      expect(String(request)).toBe('http://127.0.0.1:18082/v1/heartbeat/tasks');
+      expect(new Headers(init?.headers).get('authorization')).toBe(
+        `Bearer ${API_TOKEN}`,
+      );
+      return new Response(JSON.stringify({
+        tasks: [{ id: 'task-1', workspaceId: 'workspace-1', state: {} }],
+      }), { status: 200 });
+    });
+    const client = new HostedHeartbeatCoordinatorClient({
+      baseUrl: new URL('http://127.0.0.1:18082'),
+      apiToken: API_TOKEN,
+      fetch,
+    });
+
+    await expect(client.listTasks()).resolves.toEqual([
+      { id: 'task-1', workspaceId: 'workspace-1', state: {} },
+    ]);
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('reports a safe method, path, and status for rejected requests', async () => {
+    const client = new HostedHeartbeatCoordinatorClient({
+      baseUrl: new URL('http://127.0.0.1:18082'),
+      apiToken: API_TOKEN,
+      fetch: async () => new Response('secret details', { status: 403 }),
+    });
+
+    await expect(client.pause()).rejects.toEqual(
+      new HostedHeartbeatCoordinatorRequestError(
+        'POST',
+        '/v1/control/pause',
+        403,
+      ),
+    );
+  });
+});
+
+describe('HostedHeartbeatTaskReconciler', () => {
+  it('keeps admission paused until stale tasks are deleted and desired tasks persist', async () => {
+    const events: string[] = [];
+    const reconciler = new HostedHeartbeatTaskReconciler({
+      coordinator: {
+        pause: async () => { events.push('pause'); },
+        listTasks: async () => {
+          events.push('list');
+          return [
+            { id: 'retired-task', workspaceId: 'workspace-1' },
+            { id: 'active-task', workspaceId: 'workspace-old' },
+          ];
+        },
+        deleteTask: async (taskId) => { events.push(`delete:${taskId}`); },
+        upsertTask: async (taskId) => { events.push(`upsert:${taskId}`); },
+        resume: async () => { events.push('resume'); },
+      },
+    });
+
+    await expect(reconciler.reconcile({
+      desiredTasks: [{
+        taskId: 'active-task',
+        input: { workspaceId: 'workspace-new', task: 'Check for updates.' },
+      }],
+      resume: true,
+    })).resolves.toEqual({ deleted: 2, upserted: 1, resumed: true });
+    expect(events).toEqual([
+      'pause',
+      'list',
+      'delete:retired-task',
+      'delete:active-task',
+      'upsert:active-task',
+      'resume',
+    ]);
+  });
+
+  it('does not resume after desired-state persistence fails', async () => {
+    const resume = vi.fn(async () => undefined);
+    const reconciler = new HostedHeartbeatTaskReconciler({
+      coordinator: {
+        pause: async () => undefined,
+        listTasks: async () => [],
+        deleteTask: async () => undefined,
+        upsertTask: async () => { throw new Error('database unavailable'); },
+        resume,
+      },
+    });
+
+    await expect(reconciler.reconcile({
+      desiredTasks: [{ taskId: 'task-1', input: { task: 'Check.' } }],
+      resume: true,
+    })).rejects.toThrow('database unavailable');
+    expect(resume).not.toHaveBeenCalled();
+  });
+});
+
+describe('HostedHeartbeatDelegationService', () => {
+  it('constructs the authority wire bundle from product authorization only', async () => {
+    const authorityInput: ExecutionAuthorityIssueInput[] = [];
+    const service = new HostedHeartbeatDelegationService({
+      authority: {
+        issue: async (input) => {
+          authorityInput.push(input);
+          return issuedAuthority(input);
+        },
+      },
+      authorizer: {
+        authorize: async () => ({
+          scope: {
+            tenantId: 'tenant-1',
+            subjectId: 'user-1',
+            productSessionId: 'workspace-1',
+          },
+          allowedTools: ['read_workspace_snapshot'],
+        }),
+      },
+      runtimeSessionNamespace: 'lucid',
+      maxExecutionMs: 60_000,
+      now: () => new Date('2026-08-25T00:00:00.000Z'),
+    });
+
+    const delegation = await service.issue({
+      schemaVersion: 1,
+      taskId: 'task-1',
+      executionId: 'execution-1',
+    });
+
+    expect(delegation.deadlineAt).toBe('2026-08-25T00:01:00.000Z');
+    expect(delegation.runtimeSessionId).toMatch(
+      /^lucid-runtime-session-[a-f0-9]{64}$/,
+    );
+    expect(delegation.authority.executionAssertion).toBe('execution-token');
+    expect(authorityInput).toEqual([{
+      scope: delegation.scope,
+      runtimeSessionId: delegation.runtimeSessionId,
+      invocationId: 'execution-1',
+      workflow: 'heartbeat-task',
+      mcp: { allowedTools: ['read_workspace_snapshot'] },
+    }]);
+  });
+});
+
+function issuedAuthority(
+  input: ExecutionAuthorityIssueInput,
+): IssuedExecutionAuthority {
+  const metadata = {
+    scope: { adopterId: 'lucid', ...input.scope },
+    runtimeSessionId: input.runtimeSessionId,
+    invocationId: input.invocationId,
+    workflow: input.workflow,
+    issuedAt: '2026-08-25T00:00:00.000Z',
+    executionExpiresAt: '2026-08-25T00:01:00.000Z',
+    mcp: {
+      capabilityId: 'capability-1',
+      serverId: 'lucid_product',
+      allowedTools: [...(input.mcp?.allowedTools ?? [])],
+      expiresAt: '2026-08-25T00:01:00.000Z',
+    },
+  };
+  return {
+    metadata,
+    executionAssertion: () => 'execution-token',
+    mcpCapability: () => 'mcp-token',
+    toJSON: () => metadata,
+  };
+}

--- a/packages/execution-host-client/src/__tests__/node-coordinator.test.ts
+++ b/packages/execution-host-client/src/__tests__/node-coordinator.test.ts
@@ -1,0 +1,154 @@
+import { createServer, type Server } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createHostedRuntimeSessionId,
+  type HostedHeartbeatDelegation,
+} from '../coordinator/index.js';
+import {
+  NodeHostedHeartbeatDelegationHttpService,
+} from '../coordinator/node/index.js';
+
+const API_TOKEN = 'delegation-api-token-at-least-32-characters';
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>(
+    (resolve, reject) => server.close((error) => error ? reject(error) : resolve()),
+  )));
+});
+
+describe('NodeHostedHeartbeatDelegationHttpService', () => {
+  it('owns authenticated request parsing and the delegation response edge', async () => {
+    const service = new NodeHostedHeartbeatDelegationHttpService({
+      apiToken: API_TOKEN,
+      delegations: {
+        issue: async (input) => delegation(input.taskId, input.executionId),
+      },
+    });
+    const baseUrl = await listen(service);
+
+    const unauthorized = await fetch(new URL(
+      '/hosted-execution/internal/heartbeat-delegations',
+      baseUrl,
+    ), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        schemaVersion: 1,
+        taskId: 'task-1',
+        executionId: 'execution-1',
+      }),
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const response = await fetch(new URL(
+      '/hosted-execution/internal/heartbeat-delegations',
+      baseUrl,
+    ), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${API_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        schemaVersion: 1,
+        taskId: 'task-1',
+        executionId: 'execution-1',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(await response.json()).toMatchObject({
+      taskId: 'task-1',
+      executionId: 'execution-1',
+      authority: { executionAssertion: 'execution-token' },
+    });
+    await service.close();
+  });
+});
+
+describe('createHostedRuntimeSessionId', () => {
+  it('is deterministic, namespaced, and bound to product scope', () => {
+    const input = {
+      namespace: 'lucid',
+      scope: {
+        tenantId: 'tenant-1',
+        subjectId: 'user-1',
+        productSessionId: 'workspace-1',
+      },
+    };
+    const first = createHostedRuntimeSessionId(input);
+
+    expect(createHostedRuntimeSessionId(input)).toBe(first);
+    expect(createHostedRuntimeSessionId({
+      ...input,
+      scope: { ...input.scope, subjectId: 'user-2' },
+    })).not.toBe(first);
+    expect(first).toMatch(/^lucid-runtime-session-[a-f0-9]{64}$/);
+  });
+});
+
+async function listen(
+  service: NodeHostedHeartbeatDelegationHttpService,
+): Promise<URL> {
+  const server = createServer((request, response) => {
+    if (!service.handle(request, response)) {
+      response.writeHead(404).end();
+    }
+  });
+  servers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected a TCP test server address.');
+  }
+  return new URL(`http://127.0.0.1:${address.port}`);
+}
+
+function delegation(
+  taskId: string,
+  executionId: string,
+): HostedHeartbeatDelegation {
+  const scope = {
+    tenantId: 'tenant-1',
+    subjectId: 'user-1',
+    productSessionId: 'workspace-1',
+  };
+  const runtimeSessionId = createHostedRuntimeSessionId({
+    namespace: 'lucid',
+    scope,
+  });
+  return {
+    schemaVersion: 1,
+    taskId,
+    executionId,
+    scope,
+    runtimeSessionId,
+    deadlineAt: '2026-08-25T00:01:00.000Z',
+    authority: {
+      metadata: {
+        scope: { adopterId: 'lucid', ...scope },
+        runtimeSessionId,
+        invocationId: executionId,
+        workflow: 'heartbeat-task',
+        issuedAt: '2026-08-25T00:00:00.000Z',
+        executionExpiresAt: '2026-08-25T00:01:00.000Z',
+        mcp: {
+          capabilityId: 'capability-1',
+          serverId: 'lucid_product',
+          allowedTools: ['read_workspace_snapshot'],
+          expiresAt: '2026-08-25T00:01:00.000Z',
+        },
+      },
+      executionAssertion: 'execution-token',
+      mcpCapability: 'mcp-token',
+    },
+  };
+}

--- a/packages/execution-host-client/src/coordinator/README.md
+++ b/packages/execution-host-client/src/coordinator/README.md
@@ -1,0 +1,95 @@
+# Hosted heartbeat coordinator integration
+
+This module is the shared boundary between a product backend and a long-running
+Heddle heartbeat coordinator. It keeps coordinator protocol, reconciliation,
+delegated authority, and remote-execution composition out of every adopter.
+
+## Owns
+
+- the authenticated coordinator task API client;
+- pause-first desired-task reconciliation;
+- the coordinator-to-product delegation request and response contracts;
+- stable Runtime-session derivation from authorized product scope;
+- construction and validation of one short-lived heartbeat authority bundle;
+  and
+- execution of a claimed heartbeat with that delegated bundle.
+
+## Does not own
+
+- product authentication, user or agent authorization, or desired-task
+  projection;
+- product MCP tools, product data, or the set of tools allowed for a task;
+- the coordinator's database, scheduler, claims, recovery, HTTP router, or
+  deployment; or
+- foreground conversation relay or a general hosted control plane.
+
+The intended division is:
+
+```text
+PRODUCT BACKEND
+  project state -> desired tasks
+  task/user authorization -> scope + allowed tools
+        |                              ^
+        | coordinator client           | delegation client
+        v                              |
+HEDDLE COORDINATOR --------------------+
+  task store + scheduler + claims + recovery
+        |
+        v
+HEDDLE EXECUTION HOST
+```
+
+## Publish desired task state
+
+Product code projects its own records into Heddle task input. The shared
+reconciler pauses admission, removes obsolete tasks, publishes the desired
+catalog, and resumes only after every write succeeds.
+
+```ts
+import {
+  HostedHeartbeatCoordinatorClient,
+  HostedHeartbeatTaskReconciler,
+} from '@heddleagent/execution-host-client/coordinator'
+
+const coordinator = new HostedHeartbeatCoordinatorClient({
+  baseUrl: new URL(process.env.HEDDLE_COORDINATOR_URL!),
+  apiToken: process.env.HEDDLE_COORDINATOR_API_TOKEN!,
+})
+
+await new HostedHeartbeatTaskReconciler({ coordinator }).reconcile({
+  desiredTasks: await projectDesiredHeartbeatTasks(),
+  resume: backgroundChecksEnabled,
+})
+```
+
+If reconciliation fails after pausing, the coordinator remains paused. This is
+intentional: partial desired state must not start new runs.
+
+## Authorize one coordinator run
+
+The product callback makes only the product-owned decision. Heddle derives the
+Runtime session, deadline, execution assertion, and MCP capability and binds
+them to the coordinator's task and execution IDs.
+
+```ts
+import {
+  HostedHeartbeatDelegationService,
+} from '@heddleagent/execution-host-client/coordinator'
+
+const delegations = new HostedHeartbeatDelegationService({
+  authority,
+  runtimeSessionNamespace: 'example-product',
+  maxExecutionMs: 300_000,
+  authorizer: {
+    authorize: ({ taskId, signal }) =>
+      authorizeProductHeartbeat({ taskId, signal }),
+    // Returns { scope: { tenantId, subjectId, productSessionId }, allowedTools }
+  },
+})
+```
+
+Use the [`coordinator/node`](node/README.md) HTTP service to expose this issuer
+from a Node backend. A coordinator consumes it through
+`HostedHeartbeatDelegationClient` and
+`HostedHeartbeatDelegatedExecutionTransport`; product code does not construct
+or reinterpret the authority wire shape.

--- a/packages/execution-host-client/src/coordinator/contracts.ts
+++ b/packages/execution-host-client/src/coordinator/contracts.ts
@@ -1,0 +1,158 @@
+import { z } from 'zod';
+import {
+  ExecutionScopeSchema,
+  HEARTBEAT_TASK_WORKFLOW,
+  McpAllowedToolsSchema,
+  McpServerIdSchema,
+  OpaqueIdSchema,
+  RuntimeSessionIdSchema,
+  TimestampSchema,
+} from '../contracts/index.js';
+
+const ProductExecutionScopeSchema = ExecutionScopeSchema.omit({
+  adopterId: true,
+});
+
+export const HOSTED_HEARTBEAT_COORDINATOR_PATHS = Object.freeze({
+  tasks: '/v1/heartbeat/tasks',
+  pause: '/v1/control/pause',
+  resume: '/v1/control/resume',
+});
+
+export const HOSTED_HEARTBEAT_DELEGATIONS_PATH =
+  '/hosted-execution/internal/heartbeat-delegations';
+
+export const HostedHeartbeatCoordinatorTaskInputSchema = z.object({
+  workspaceId: OpaqueIdSchema.optional(),
+  name: z.string().trim().min(1).max(200).optional(),
+  task: z.string().trim().min(1).max(200_000),
+  enabled: z.boolean().optional(),
+  continuationMode: z.enum(['operator', 'agent']).optional(),
+  intervalMs: z.number().int().min(1_000).max(Number.MAX_SAFE_INTEGER)
+    .optional(),
+  defer: z.boolean().optional(),
+  model: z.string().trim().min(1).max(512).optional(),
+  maxSteps: z.number().int().positive().max(10_000).optional(),
+  searchIgnoreDirs: z.array(z.string().min(1).max(1_024)).max(1_000)
+    .optional(),
+  systemContext: z.string().max(200_000).optional(),
+}).strict();
+
+export const HostedHeartbeatCoordinatorTaskSummarySchema = z.object({
+  id: OpaqueIdSchema,
+  workspaceId: OpaqueIdSchema.optional(),
+}).passthrough();
+
+export const HostedHeartbeatCoordinatorTaskListSchema = z.object({
+  tasks: z.array(HostedHeartbeatCoordinatorTaskSummarySchema),
+}).strict();
+
+export const HostedHeartbeatDesiredTaskSchema = z.object({
+  taskId: OpaqueIdSchema,
+  input: HostedHeartbeatCoordinatorTaskInputSchema,
+}).strict();
+
+export const HostedHeartbeatDesiredTaskCatalogSchema = z.object({
+  tasks: z.array(HostedHeartbeatDesiredTaskSchema).max(10_000),
+  resume: z.boolean(),
+}).strict().superRefine(({ tasks }, context) => {
+  const seen = new Set<string>();
+  tasks.forEach(({ taskId }, index) => {
+    if (seen.has(taskId)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['tasks', index, 'taskId'],
+        message: 'must be unique within the desired task catalog',
+      });
+    }
+    seen.add(taskId);
+  });
+});
+
+export const HostedHeartbeatDelegationRequestSchema = z.object({
+  schemaVersion: z.literal(1),
+  taskId: OpaqueIdSchema,
+  executionId: OpaqueIdSchema,
+}).strict();
+
+const DelegatedAuthorityMetadataSchema = z.object({
+  scope: ExecutionScopeSchema,
+  runtimeSessionId: RuntimeSessionIdSchema,
+  invocationId: OpaqueIdSchema,
+  workflow: z.literal(HEARTBEAT_TASK_WORKFLOW),
+  issuedAt: TimestampSchema,
+  executionExpiresAt: TimestampSchema,
+  mcp: z.object({
+    capabilityId: OpaqueIdSchema,
+    serverId: McpServerIdSchema,
+    allowedTools: McpAllowedToolsSchema,
+    expiresAt: TimestampSchema,
+  }).strict(),
+}).strict();
+
+export const HostedHeartbeatDelegationSchema = z.object({
+  schemaVersion: z.literal(1),
+  taskId: OpaqueIdSchema,
+  executionId: OpaqueIdSchema,
+  scope: ProductExecutionScopeSchema,
+  runtimeSessionId: RuntimeSessionIdSchema,
+  deadlineAt: TimestampSchema,
+  authority: z.object({
+    metadata: DelegatedAuthorityMetadataSchema,
+    executionAssertion: z.string().min(1).max(16_384),
+    mcpCapability: z.string().min(1).max(16_384),
+  }).strict(),
+}).strict().superRefine((delegation, context) => {
+  const metadata = delegation.authority.metadata;
+  const mismatches: Array<[path: string, mismatched: boolean]> = [
+    ['executionId', metadata.invocationId !== delegation.executionId],
+    [
+      'runtimeSessionId',
+      metadata.runtimeSessionId !== delegation.runtimeSessionId,
+    ],
+    ['scope', !sameProductScope(metadata.scope, delegation.scope)],
+  ];
+  mismatches
+    .filter(([, mismatched]) => mismatched)
+    .forEach(([path]) => context.addIssue({
+      code: 'custom',
+      path: [path],
+      message: 'must match the delegated execution authority metadata',
+    }));
+});
+
+export const HostedHeartbeatDelegationAuthorizationSchema = z.object({
+  scope: ProductExecutionScopeSchema,
+  allowedTools: McpAllowedToolsSchema,
+}).strict();
+
+export type HostedHeartbeatCoordinatorTaskInput = z.infer<
+  typeof HostedHeartbeatCoordinatorTaskInputSchema
+>;
+export type HostedHeartbeatCoordinatorTaskSummary = z.infer<
+  typeof HostedHeartbeatCoordinatorTaskSummarySchema
+>;
+export type HostedHeartbeatDesiredTask = z.infer<
+  typeof HostedHeartbeatDesiredTaskSchema
+>;
+export type HostedHeartbeatDesiredTaskCatalog = z.infer<
+  typeof HostedHeartbeatDesiredTaskCatalogSchema
+>;
+export type HostedHeartbeatDelegationRequest = z.infer<
+  typeof HostedHeartbeatDelegationRequestSchema
+>;
+export type HostedHeartbeatDelegation = z.infer<
+  typeof HostedHeartbeatDelegationSchema
+>;
+export type HostedHeartbeatDelegationAuthorization = z.infer<
+  typeof HostedHeartbeatDelegationAuthorizationSchema
+>;
+
+function sameProductScope(
+  left: z.infer<typeof ExecutionScopeSchema>,
+  right: z.infer<typeof ProductExecutionScopeSchema>,
+): boolean {
+  return left.tenantId === right.tenantId
+    && left.subjectId === right.subjectId
+    && left.productSessionId === right.productSessionId;
+}

--- a/packages/execution-host-client/src/coordinator/hosted-heartbeat-coordinator-client.ts
+++ b/packages/execution-host-client/src/coordinator/hosted-heartbeat-coordinator-client.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import {
+  OpaqueIdSchema,
+  isSafeWebUrl,
+} from '../contracts/index.js';
+import {
+  HOSTED_HEARTBEAT_COORDINATOR_PATHS,
+  HostedHeartbeatCoordinatorTaskInputSchema,
+  HostedHeartbeatCoordinatorTaskListSchema,
+  type HostedHeartbeatCoordinatorTaskInput,
+  type HostedHeartbeatCoordinatorTaskSummary,
+} from './contracts.js';
+import { HostedHeartbeatServiceTokenSchema } from './service-token.js';
+import type {
+  HostedHeartbeatCoordinatorClientConfig,
+  HostedHeartbeatCoordinatorTaskApi,
+} from './types.js';
+
+const SafeBaseUrlSchema = z.custom<URL>(
+  (value) => value instanceof URL && isSafeWebUrl(value),
+  'baseUrl must be a safe HTTPS or loopback HTTP URL',
+);
+
+export class HostedHeartbeatCoordinatorRequestError extends Error {
+  readonly name = 'HostedHeartbeatCoordinatorRequestError';
+
+  constructor(
+    readonly method: string,
+    readonly path: string,
+    readonly status: number,
+  ) {
+    super(`Heddle Coordinator ${method} ${path} failed with status ${status}.`);
+  }
+}
+
+/** Authenticated desired-task and admission client for a Heddle Coordinator. */
+export class HostedHeartbeatCoordinatorClient
+implements HostedHeartbeatCoordinatorTaskApi {
+  readonly #baseUrl: URL;
+  readonly #authorization: string;
+  readonly #fetch: typeof globalThis.fetch;
+
+  constructor(config: HostedHeartbeatCoordinatorClientConfig) {
+    this.#baseUrl = new URL(SafeBaseUrlSchema.parse(config.baseUrl));
+    this.#authorization = `Bearer ${
+      HostedHeartbeatServiceTokenSchema.parse(config.apiToken)
+    }`;
+    this.#fetch = config.fetch ?? globalThis.fetch;
+  }
+
+  async listTasks(
+    signal?: AbortSignal,
+  ): Promise<HostedHeartbeatCoordinatorTaskSummary[]> {
+    const response = await this.#request(
+      HOSTED_HEARTBEAT_COORDINATOR_PATHS.tasks,
+      { method: 'GET', signal },
+    );
+    return HostedHeartbeatCoordinatorTaskListSchema.parse(
+      await response.json(),
+    ).tasks;
+  }
+
+  async upsertTask(
+    rawTaskId: string,
+    rawTask: HostedHeartbeatCoordinatorTaskInput,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const taskId = OpaqueIdSchema.parse(rawTaskId);
+    const task = HostedHeartbeatCoordinatorTaskInputSchema.parse(rawTask);
+    await this.#request(this.#taskPath(taskId), {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(task),
+      signal,
+    });
+  }
+
+  async deleteTask(rawTaskId: string, signal?: AbortSignal): Promise<void> {
+    await this.#request(this.#taskPath(OpaqueIdSchema.parse(rawTaskId)), {
+      method: 'DELETE',
+      signal,
+    });
+  }
+
+  async pause(signal?: AbortSignal): Promise<void> {
+    await this.#request(HOSTED_HEARTBEAT_COORDINATOR_PATHS.pause, {
+      method: 'POST',
+      signal,
+    });
+  }
+
+  async resume(signal?: AbortSignal): Promise<void> {
+    await this.#request(HOSTED_HEARTBEAT_COORDINATOR_PATHS.resume, {
+      method: 'POST',
+      signal,
+    });
+  }
+
+  #taskPath(taskId: string): string {
+    return `${HOSTED_HEARTBEAT_COORDINATOR_PATHS.tasks}/${
+      encodeURIComponent(taskId)
+    }`;
+  }
+
+  async #request(path: string, init: RequestInit): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.set('authorization', this.#authorization);
+    const response = await this.#fetch(new URL(path, this.#baseUrl), {
+      ...init,
+      headers,
+      redirect: 'error',
+    });
+    if (!response.ok) {
+      throw new HostedHeartbeatCoordinatorRequestError(
+        init.method ?? 'GET',
+        path,
+        response.status,
+      );
+    }
+    return response;
+  }
+}

--- a/packages/execution-host-client/src/coordinator/hosted-heartbeat-delegation-client.ts
+++ b/packages/execution-host-client/src/coordinator/hosted-heartbeat-delegation-client.ts
@@ -1,0 +1,188 @@
+import { z } from 'zod';
+import type {
+  ExecutionAuthorityIssueInput,
+  ExecutionAuthorityIssuer,
+  IssuedExecutionAuthority,
+  IssuedExecutionAuthorityMetadata,
+} from '../authority/index.js';
+import {
+  HEARTBEAT_TASK_WORKFLOW,
+  isSafeWebUrl,
+} from '../contracts/index.js';
+import {
+  HostedHeartbeatAgentExecutionTransport,
+  HostedHeartbeatTaskService,
+  type HostedHeartbeatAgentExecutionTransportInput,
+} from '../heartbeat/index.js';
+import {
+  HOSTED_HEARTBEAT_DELEGATIONS_PATH,
+  HostedHeartbeatDelegationRequestSchema,
+  HostedHeartbeatDelegationSchema,
+  type HostedHeartbeatDelegation,
+  type HostedHeartbeatDelegationRequest,
+} from './contracts.js';
+import { HostedHeartbeatServiceTokenSchema } from './service-token.js';
+import type {
+  HostedHeartbeatDelegatedExecutionTransportConfig,
+  HostedHeartbeatDelegatedExecutionTransportPort,
+  HostedHeartbeatDelegationClientConfig,
+  HostedHeartbeatDelegationIssuer,
+} from './types.js';
+
+const SafeBaseUrlSchema = z.custom<URL>(
+  (value) => value instanceof URL && isSafeWebUrl(value),
+  'baseUrl must be a safe HTTPS or loopback HTTP URL',
+);
+const AbsolutePathSchema = z.string().min(1).max(256).regex(
+  /^\/(?:[^?#\s]*)$/,
+  'must be an absolute path without query, fragment, or whitespace',
+);
+
+export class HostedHeartbeatDelegationRequestError extends Error {
+  readonly name = 'HostedHeartbeatDelegationRequestError';
+
+  constructor(readonly status: number) {
+    super(`Heartbeat delegation failed with status ${status}.`);
+  }
+}
+
+/** Authenticated coordinator client for one product-issued authority bundle. */
+export class HostedHeartbeatDelegationClient
+implements HostedHeartbeatDelegationIssuer {
+  readonly #endpoint: URL;
+  readonly #authorization: string;
+  readonly #fetch: typeof globalThis.fetch;
+
+  constructor(config: HostedHeartbeatDelegationClientConfig) {
+    const baseUrl = SafeBaseUrlSchema.parse(config.baseUrl);
+    this.#endpoint = new URL(
+      AbsolutePathSchema.parse(
+        config.path ?? HOSTED_HEARTBEAT_DELEGATIONS_PATH,
+      ),
+      baseUrl,
+    );
+    this.#authorization = `Bearer ${
+      HostedHeartbeatServiceTokenSchema.parse(config.apiToken)
+    }`;
+    this.#fetch = config.fetch ?? globalThis.fetch;
+  }
+
+  async issue(
+    rawInput: HostedHeartbeatDelegationRequest,
+    signal?: AbortSignal,
+  ): Promise<HostedHeartbeatDelegation> {
+    const input = HostedHeartbeatDelegationRequestSchema.parse(rawInput);
+    const response = await this.#fetch(this.#endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: this.#authorization,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(input),
+      redirect: 'error',
+      signal,
+    });
+    if (!response.ok) {
+      throw new HostedHeartbeatDelegationRequestError(response.status);
+    }
+    const delegation = HostedHeartbeatDelegationSchema.parse(
+      await response.json(),
+    );
+    if (
+      delegation.taskId !== input.taskId
+      || delegation.executionId !== input.executionId
+    ) {
+      throw new Error(
+        'Product backend returned a mismatched heartbeat delegation.',
+      );
+    }
+    return delegation;
+  }
+}
+
+/** Executes a claimed task with the exact product-issued authority bundle. */
+export class HostedHeartbeatDelegatedExecutionTransport
+implements HostedHeartbeatDelegatedExecutionTransportPort {
+  readonly #config: HostedHeartbeatDelegatedExecutionTransportConfig;
+
+  constructor(config: HostedHeartbeatDelegatedExecutionTransportConfig) {
+    this.#config = config;
+  }
+
+  async execute(
+    input: HostedHeartbeatAgentExecutionTransportInput,
+  ): Promise<unknown> {
+    const delegation = await this.#config.delegations.issue({
+      schemaVersion: 1,
+      taskId: input.request.taskId,
+      executionId: input.request.executionId,
+    }, input.signal);
+    const service = new HostedHeartbeatTaskService({
+      authority: new DelegatedExecutionAuthorityIssuer(delegation),
+      executionHost: this.#config.executionHost,
+      modelCredentials: this.#config.modelCredentials,
+      mcp: {
+        allowedTools: delegation.authority.metadata.mcp.allowedTools,
+      },
+    });
+    const transport = new HostedHeartbeatAgentExecutionTransport({
+      runner: service,
+      resolveInvocationContext: () => ({
+        scope: delegation.scope,
+        runtimeSessionId: delegation.runtimeSessionId,
+        deadlineAt: delegation.deadlineAt,
+      }),
+    });
+    return await transport.execute(input);
+  }
+}
+
+/** Ensures downstream execution cannot widen a delegated authority bundle. */
+class DelegatedExecutionAuthorityIssuer implements ExecutionAuthorityIssuer {
+  constructor(private readonly delegation: HostedHeartbeatDelegation) {}
+
+  async issue(
+    input: ExecutionAuthorityIssueInput,
+  ): Promise<IssuedExecutionAuthority> {
+    const metadata = this.delegation.authority.metadata;
+    if (
+      input.workflow !== HEARTBEAT_TASK_WORKFLOW
+      || input.workflow !== metadata.workflow
+      || input.invocationId !== metadata.invocationId
+      || input.runtimeSessionId !== metadata.runtimeSessionId
+      || !sameScope(input.scope, this.delegation.scope)
+      || !sameScope(input.scope, metadata.scope)
+      || !sameTools(input.mcp?.allowedTools, metadata.mcp.allowedTools)
+    ) {
+      throw new Error('Heartbeat delegation does not match Heddle execution.');
+    }
+    const authority = this.delegation.authority;
+    return Object.freeze({
+      metadata: metadata as IssuedExecutionAuthorityMetadata,
+      executionAssertion: () => authority.executionAssertion,
+      mcpCapability: () => authority.mcpCapability,
+      toJSON: () => metadata as IssuedExecutionAuthorityMetadata,
+    });
+  }
+}
+
+function sameScope(
+  left: ExecutionAuthorityIssueInput['scope'],
+  right: HostedHeartbeatDelegation['scope']
+    | HostedHeartbeatDelegation['authority']['metadata']['scope'],
+): boolean {
+  return left.tenantId === right.tenantId
+    && left.subjectId === right.subjectId
+    && left.productSessionId === right.productSessionId;
+}
+
+function sameTools(
+  left: readonly string[] | undefined,
+  right: readonly string[],
+): boolean {
+  return Boolean(
+    left
+    && left.length === right.length
+    && left.every((tool, index) => tool === right[index]),
+  );
+}

--- a/packages/execution-host-client/src/coordinator/hosted-heartbeat-delegation-service.ts
+++ b/packages/execution-host-client/src/coordinator/hosted-heartbeat-delegation-service.ts
@@ -1,0 +1,106 @@
+import dayjs from 'dayjs';
+import { z } from 'zod';
+import { HEARTBEAT_TASK_WORKFLOW, OpaqueIdSchema } from '../contracts/index.js';
+import {
+  HostedHeartbeatDelegationAuthorizationSchema,
+  HostedHeartbeatDelegationRequestSchema,
+  HostedHeartbeatDelegationSchema,
+  type HostedHeartbeatDelegation,
+  type HostedHeartbeatDelegationRequest,
+} from './contracts.js';
+import { createHostedRuntimeSessionId } from './runtime-session.js';
+import type {
+  HostedHeartbeatDelegationIssuer,
+  HostedHeartbeatDelegationServiceConfig,
+} from './types.js';
+
+const DelegationServiceConfigSchema = z.object({
+  runtimeSessionNamespace: OpaqueIdSchema,
+  maxExecutionMs: z.number().int().min(1_000).max(Number.MAX_SAFE_INTEGER),
+}).strict();
+
+export class HostedHeartbeatDelegationRejectedError extends Error {
+  readonly name = 'HostedHeartbeatDelegationRejectedError';
+}
+
+/**
+ * Converts one product authorization decision into a fully bound Heddle
+ * authority bundle. Product code never constructs the delegation wire shape.
+ */
+export class HostedHeartbeatDelegationService
+implements HostedHeartbeatDelegationIssuer {
+  readonly #authority: HostedHeartbeatDelegationServiceConfig['authority'];
+  readonly #authorizer: HostedHeartbeatDelegationServiceConfig['authorizer'];
+  readonly #runtimeSessionNamespace: string;
+  readonly #maxExecutionMs: number;
+  readonly #now: () => Date;
+
+  constructor(config: HostedHeartbeatDelegationServiceConfig) {
+    const parsed = DelegationServiceConfigSchema.parse({
+      runtimeSessionNamespace: config.runtimeSessionNamespace,
+      maxExecutionMs: config.maxExecutionMs,
+    });
+    this.#authority = config.authority;
+    this.#authorizer = config.authorizer;
+    this.#runtimeSessionNamespace = parsed.runtimeSessionNamespace;
+    this.#maxExecutionMs = parsed.maxExecutionMs;
+    this.#now = config.now ?? (() => new Date());
+  }
+
+  async issue(
+    rawInput: HostedHeartbeatDelegationRequest,
+    rawSignal?: AbortSignal,
+  ): Promise<HostedHeartbeatDelegation> {
+    const input = HostedHeartbeatDelegationRequestSchema.parse(rawInput);
+    const signal = rawSignal ?? new AbortController().signal;
+    signal.throwIfAborted();
+    const rawAuthorization = await this.#authorizer.authorize({
+      taskId: input.taskId,
+      executionId: input.executionId,
+      signal,
+    });
+    if (!rawAuthorization) {
+      throw new HostedHeartbeatDelegationRejectedError(
+        'The product rejected this heartbeat execution.',
+      );
+    }
+    const authorization = HostedHeartbeatDelegationAuthorizationSchema.parse(
+      rawAuthorization,
+    );
+    const runtimeSessionId = createHostedRuntimeSessionId({
+      namespace: this.#runtimeSessionNamespace,
+      scope: authorization.scope,
+    });
+    const deadlineAt = dayjs(this.#now())
+      .add(this.#maxExecutionMs, 'millisecond')
+      .toISOString();
+    const issued = await this.#authority.issue({
+      scope: authorization.scope,
+      runtimeSessionId,
+      invocationId: input.executionId,
+      workflow: HEARTBEAT_TASK_WORKFLOW,
+      mcp: { allowedTools: authorization.allowedTools },
+    });
+    signal.throwIfAborted();
+    const mcpCapability = issued.mcpCapability();
+    if (!mcpCapability || !issued.metadata.mcp) {
+      throw new Error(
+        'Hosted heartbeat delegation requires an MCP-capable execution authority.',
+      );
+    }
+
+    return HostedHeartbeatDelegationSchema.parse({
+      schemaVersion: 1,
+      taskId: input.taskId,
+      executionId: input.executionId,
+      scope: authorization.scope,
+      runtimeSessionId,
+      deadlineAt,
+      authority: {
+        metadata: issued.metadata,
+        executionAssertion: issued.executionAssertion(),
+        mcpCapability,
+      },
+    });
+  }
+}

--- a/packages/execution-host-client/src/coordinator/hosted-heartbeat-task-reconciler.ts
+++ b/packages/execution-host-client/src/coordinator/hosted-heartbeat-task-reconciler.ts
@@ -1,0 +1,57 @@
+import {
+  HostedHeartbeatDesiredTaskCatalogSchema,
+} from './contracts.js';
+import type {
+  HostedHeartbeatTaskReconcilerConfig,
+  HostedHeartbeatTaskReconciliation,
+  HostedHeartbeatTaskReconciliationInput,
+} from './types.js';
+
+/**
+ * Publishes one product's desired catalog while keeping admission paused until
+ * every deletion and upsert has succeeded.
+ */
+export class HostedHeartbeatTaskReconciler {
+  readonly #coordinator: HostedHeartbeatTaskReconcilerConfig['coordinator'];
+
+  constructor(config: HostedHeartbeatTaskReconcilerConfig) {
+    this.#coordinator = config.coordinator;
+  }
+
+  async reconcile(
+    rawInput: HostedHeartbeatTaskReconciliationInput,
+  ): Promise<HostedHeartbeatTaskReconciliation> {
+    const input = HostedHeartbeatDesiredTaskCatalogSchema.parse({
+      tasks: rawInput.desiredTasks,
+      resume: rawInput.resume,
+    });
+    rawInput.signal?.throwIfAborted();
+    await this.#coordinator.pause(rawInput.signal);
+    const existingTasks = await this.#coordinator.listTasks(rawInput.signal);
+    const desiredByTaskId = new Map(
+      input.tasks.map((task) => [task.taskId, task]),
+    );
+    const deletedTaskIds = existingTasks
+      .filter(({ id, workspaceId }) => {
+        const desired = desiredByTaskId.get(id);
+        return !desired || workspaceId !== desired.input.workspaceId;
+      })
+      .map(({ id }) => id);
+
+    await Promise.all(deletedTaskIds.map((taskId) => (
+      this.#coordinator.deleteTask(taskId, rawInput.signal)
+    )));
+    await Promise.all(input.tasks.map(({ taskId, input: task }) => (
+      this.#coordinator.upsertTask(taskId, task, rawInput.signal)
+    )));
+    if (input.resume) {
+      await this.#coordinator.resume(rawInput.signal);
+    }
+
+    return {
+      deleted: deletedTaskIds.length,
+      upserted: input.tasks.length,
+      resumed: input.resume,
+    };
+  }
+}

--- a/packages/execution-host-client/src/coordinator/index.ts
+++ b/packages/execution-host-client/src/coordinator/index.ts
@@ -1,0 +1,50 @@
+export {
+  HOSTED_HEARTBEAT_COORDINATOR_PATHS,
+  HOSTED_HEARTBEAT_DELEGATIONS_PATH,
+  HostedHeartbeatCoordinatorTaskInputSchema,
+  HostedHeartbeatCoordinatorTaskListSchema,
+  HostedHeartbeatCoordinatorTaskSummarySchema,
+  HostedHeartbeatDelegationAuthorizationSchema,
+  HostedHeartbeatDelegationRequestSchema,
+  HostedHeartbeatDelegationSchema,
+  HostedHeartbeatDesiredTaskCatalogSchema,
+  HostedHeartbeatDesiredTaskSchema,
+} from './contracts.js';
+export type {
+  HostedHeartbeatCoordinatorTaskInput,
+  HostedHeartbeatCoordinatorTaskSummary,
+  HostedHeartbeatDelegation,
+  HostedHeartbeatDelegationAuthorization,
+  HostedHeartbeatDelegationRequest,
+  HostedHeartbeatDesiredTask,
+  HostedHeartbeatDesiredTaskCatalog,
+} from './contracts.js';
+export {
+  HostedHeartbeatCoordinatorClient,
+  HostedHeartbeatCoordinatorRequestError,
+} from './hosted-heartbeat-coordinator-client.js';
+export {
+  HostedHeartbeatDelegatedExecutionTransport,
+  HostedHeartbeatDelegationClient,
+  HostedHeartbeatDelegationRequestError,
+} from './hosted-heartbeat-delegation-client.js';
+export {
+  HostedHeartbeatDelegationRejectedError,
+  HostedHeartbeatDelegationService,
+} from './hosted-heartbeat-delegation-service.js';
+export { HostedHeartbeatTaskReconciler } from './hosted-heartbeat-task-reconciler.js';
+export { createHostedRuntimeSessionId } from './runtime-session.js';
+export type {
+  HostedHeartbeatCoordinatorClientConfig,
+  HostedHeartbeatCoordinatorTaskApi,
+  HostedHeartbeatDelegatedExecutionTransportConfig,
+  HostedHeartbeatDelegatedExecutionTransportPort,
+  HostedHeartbeatDelegationAuthorizationInput,
+  HostedHeartbeatDelegationAuthorizer,
+  HostedHeartbeatDelegationClientConfig,
+  HostedHeartbeatDelegationIssuer,
+  HostedHeartbeatDelegationServiceConfig,
+  HostedHeartbeatTaskReconcilerConfig,
+  HostedHeartbeatTaskReconciliation,
+  HostedHeartbeatTaskReconciliationInput,
+} from './types.js';

--- a/packages/execution-host-client/src/coordinator/node/README.md
+++ b/packages/execution-host-client/src/coordinator/node/README.md
@@ -1,0 +1,37 @@
+# Node coordinator integration
+
+This subpath provides the standard Node HTTP edge for product-issued heartbeat
+delegations. It owns bounded JSON parsing, timing-safe bearer authentication,
+authorization-header removal, safe failures, disconnect cancellation, and
+graceful shutdown.
+
+It does not own product routing, task authorization, signing keys, tenant
+lookup, MCP policy, or coordinator credentials. Mount it before the product's
+fallback router:
+
+```ts
+import {
+  NodeHostedHeartbeatDelegationHttpService,
+  takeHostedHeartbeatServiceToken,
+} from '@heddleagent/execution-host-client/coordinator/node'
+
+const apiToken = takeHostedHeartbeatServiceToken(
+  process.env,
+  'HEDDLE_COORDINATOR_DELEGATION_TOKEN',
+)
+if (!apiToken) throw new Error('Coordinator delegation token is required.')
+
+const delegationApi = new NodeHostedHeartbeatDelegationHttpService({
+  delegations,
+  apiToken,
+})
+
+if (delegationApi.handle(request, response)) return
+
+// During graceful shutdown:
+await delegationApi.close()
+```
+
+`takeHostedHeartbeatServiceToken` validates the secret and removes it from the
+mutable environment object so later application code cannot accidentally
+enumerate it. Production secret delivery and rotation remain deployment-owned.

--- a/packages/execution-host-client/src/coordinator/node/delegation-http-service.ts
+++ b/packages/execution-host-client/src/coordinator/node/delegation-http-service.ts
@@ -1,0 +1,206 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { z, ZodError } from 'zod';
+import {
+  HOSTED_HEARTBEAT_DELEGATIONS_PATH,
+  HostedHeartbeatDelegationRequestSchema,
+} from '../contracts.js';
+import {
+  HostedHeartbeatDelegationRejectedError,
+} from '../hosted-heartbeat-delegation-service.js';
+import { HostedHeartbeatServiceTokenSchema } from '../service-token.js';
+import {
+  NodeHttpPathSchema,
+  NodeHttpRequestError,
+  errorType,
+  readJsonBody,
+  readPathname,
+  takeAuthorization,
+  writeJson,
+  writeJsonError,
+} from '../../node/http-utils.js';
+import type {
+  NodeHostedHeartbeatDelegationFailure,
+  NodeHostedHeartbeatDelegationHttpHandler,
+  NodeHostedHeartbeatDelegationHttpServiceConfig,
+} from './types.js';
+
+const DEFAULT_MAX_BODY_BYTES = 16 * 1_024;
+
+type ActiveDelegation = {
+  abortController: AbortController;
+  request: IncomingMessage;
+  response: ServerResponse;
+  pending: Promise<void>;
+};
+
+/** Standard authenticated Node HTTP edge for product-owned run authority. */
+export class NodeHostedHeartbeatDelegationHttpService
+implements NodeHostedHeartbeatDelegationHttpHandler {
+  readonly #delegations: NodeHostedHeartbeatDelegationHttpServiceConfig[
+    'delegations'
+  ];
+  readonly #tokenDigest: Buffer;
+  readonly #path: string;
+  readonly #maxBodyBytes: number;
+  readonly #reportFailure: NodeHostedHeartbeatDelegationHttpServiceConfig[
+    'reportFailure'
+  ];
+  readonly #active = new Set<ActiveDelegation>();
+  #closed = false;
+  #closePromise: Promise<void> | undefined;
+
+  constructor(config: NodeHostedHeartbeatDelegationHttpServiceConfig) {
+    this.#delegations = config.delegations;
+    this.#tokenDigest = digest(
+      HostedHeartbeatServiceTokenSchema.parse(config.apiToken),
+    );
+    this.#path = NodeHttpPathSchema.parse(
+      config.path ?? HOSTED_HEARTBEAT_DELEGATIONS_PATH,
+    );
+    this.#maxBodyBytes = z.number().int().min(1).max(1_048_576).parse(
+      config.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+    );
+    this.#reportFailure = config.reportFailure;
+  }
+
+  handle(request: IncomingMessage, response: ServerResponse): boolean {
+    if (readPathname(request.url) !== this.#path) {
+      return false;
+    }
+    this.handleDelegation(request, response);
+    return true;
+  }
+
+  handleDelegation(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): void {
+    if (this.#closed) {
+      request.resume();
+      writeJsonError(response, 503, 'Hosted execution is unavailable.');
+      return;
+    }
+
+    let authorization: string | undefined;
+    try {
+      authorization = takeAuthorization(request);
+      if (request.method !== 'POST') {
+        request.resume();
+        writeJsonError(response, 405, 'Method not allowed.', {
+          Allow: 'POST',
+        });
+        return;
+      }
+    } catch (error) {
+      request.resume();
+      writeJsonError(
+        response,
+        error instanceof NodeHttpRequestError ? error.statusCode : 400,
+        'Invalid heartbeat delegation request.',
+      );
+      return;
+    }
+    if (!this.#authenticates(authorization)) {
+      request.resume();
+      writeJsonError(response, 401, 'Authentication is required.', {
+        'WWW-Authenticate': 'Bearer',
+      });
+      return;
+    }
+
+    const abortController = new AbortController();
+    const abort = () => abortController.abort(
+      new Error('The heartbeat delegation request closed.'),
+    );
+    request.once('aborted', abort);
+    response.once('close', abort);
+    const active: ActiveDelegation = {
+      abortController,
+      request,
+      response,
+      pending: Promise.resolve(),
+    };
+    active.pending = this.#serve(
+      request,
+      response,
+      abortController.signal,
+    ).finally(() => {
+      request.removeListener('aborted', abort);
+      response.removeListener('close', abort);
+      this.#active.delete(active);
+    });
+    this.#active.add(active);
+  }
+
+  close(): Promise<void> {
+    if (!this.#closePromise) {
+      this.#closed = true;
+      const active = [...this.#active];
+      active.forEach(({ abortController, request, response }) => {
+        abortController.abort(
+          new Error('The heartbeat delegation service is stopping.'),
+        );
+        request.destroy();
+        response.destroy();
+      });
+      this.#closePromise = Promise.allSettled(
+        active.map(({ pending }) => pending),
+      ).then(() => undefined);
+    }
+    return this.#closePromise;
+  }
+
+  async #serve(
+    request: IncomingMessage,
+    response: ServerResponse,
+    signal: AbortSignal,
+  ): Promise<void> {
+    try {
+      const input = HostedHeartbeatDelegationRequestSchema.parse(
+        await readJsonBody(request, this.#maxBodyBytes, signal),
+      );
+      const delegation = await this.#delegations.issue(input, signal);
+      writeJson(response, 200, delegation);
+    } catch (error) {
+      if (signal.aborted) {
+        return;
+      }
+      if (error instanceof HostedHeartbeatDelegationRejectedError) {
+        writeJsonError(response, 403, error.message);
+        return;
+      }
+      if (error instanceof NodeHttpRequestError || error instanceof ZodError) {
+        writeJsonError(
+          response,
+          error instanceof NodeHttpRequestError ? error.statusCode : 400,
+          'Invalid heartbeat delegation request.',
+        );
+        return;
+      }
+      this.#report({ phase: 'delegation', errorType: errorType(error) });
+      writeJsonError(response, 500, 'Heartbeat delegation failed.');
+    }
+  }
+
+  #authenticates(authorization: string | undefined): boolean {
+    const token = /^Bearer ([^\s]+)$/i.exec(
+      authorization?.trim() ?? '',
+    )?.[1];
+    return token
+      ? timingSafeEqual(digest(token), this.#tokenDigest)
+      : false;
+  }
+
+  #report(failure: NodeHostedHeartbeatDelegationFailure): void {
+    try {
+      this.#reportFailure?.(Object.freeze({ ...failure }));
+    } catch {
+      // Observability must not change request settlement.
+    }
+  }
+}
+
+function digest(value: string): Buffer {
+  return createHash('sha256').update(value, 'utf8').digest();
+}

--- a/packages/execution-host-client/src/coordinator/node/environment.ts
+++ b/packages/execution-host-client/src/coordinator/node/environment.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import { HostedHeartbeatServiceTokenSchema } from '../service-token.js';
+
+const EnvironmentNameSchema = z.string().min(1).max(128).regex(
+  /^[A-Za-z_][A-Za-z0-9_]*$/,
+  'must be an environment variable name',
+);
+
+/** Removes one optional coordinator secret from the supplied environment. */
+export function takeHostedHeartbeatServiceToken(
+  environment: NodeJS.ProcessEnv,
+  rawName: string,
+): string | undefined {
+  const name = EnvironmentNameSchema.parse(rawName);
+  const token = environment[name];
+  delete environment[name];
+  return token?.trim()
+    ? HostedHeartbeatServiceTokenSchema.parse(token)
+    : undefined;
+}

--- a/packages/execution-host-client/src/coordinator/node/index.ts
+++ b/packages/execution-host-client/src/coordinator/node/index.ts
@@ -1,0 +1,7 @@
+export { NodeHostedHeartbeatDelegationHttpService } from './delegation-http-service.js';
+export { takeHostedHeartbeatServiceToken } from './environment.js';
+export type {
+  NodeHostedHeartbeatDelegationFailure,
+  NodeHostedHeartbeatDelegationHttpHandler,
+  NodeHostedHeartbeatDelegationHttpServiceConfig,
+} from './types.js';

--- a/packages/execution-host-client/src/coordinator/node/types.ts
+++ b/packages/execution-host-client/src/coordinator/node/types.ts
@@ -1,0 +1,25 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { HostedHeartbeatDelegationIssuer } from '../types.js';
+
+export type NodeHostedHeartbeatDelegationFailure = {
+  phase: 'delegation';
+  errorType: string;
+};
+
+export type NodeHostedHeartbeatDelegationHttpServiceConfig = {
+  delegations: HostedHeartbeatDelegationIssuer;
+  apiToken: string;
+  path?: string;
+  maxBodyBytes?: number;
+  /** Receives credential-free operational metadata, never the raw error. */
+  reportFailure?: (failure: NodeHostedHeartbeatDelegationFailure) => void;
+};
+
+export interface NodeHostedHeartbeatDelegationHttpHandler {
+  handle(request: IncomingMessage, response: ServerResponse): boolean;
+  handleDelegation(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): void;
+  close(): Promise<void>;
+}

--- a/packages/execution-host-client/src/coordinator/runtime-session.ts
+++ b/packages/execution-host-client/src/coordinator/runtime-session.ts
@@ -1,0 +1,34 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+import {
+  ExecutionScopeSchema,
+  OpaqueIdSchema,
+  RuntimeSessionIdSchema,
+} from '../contracts/index.js';
+
+const ProductExecutionScopeSchema = ExecutionScopeSchema.omit({
+  adopterId: true,
+});
+
+const HostedRuntimeSessionInputSchema = z.object({
+  namespace: OpaqueIdSchema,
+  scope: ProductExecutionScopeSchema,
+}).strict();
+
+/** Stable Runtime session identity derived only from product-owned scope. */
+export function createHostedRuntimeSessionId(rawInput: {
+  namespace: string;
+  scope: z.infer<typeof ProductExecutionScopeSchema>;
+}): string {
+  const input = HostedRuntimeSessionInputSchema.parse(rawInput);
+  const digest = createHash('sha256')
+    .update(JSON.stringify([
+      input.scope.tenantId,
+      input.scope.subjectId,
+      input.scope.productSessionId,
+    ]))
+    .digest('hex');
+  return RuntimeSessionIdSchema.parse(
+    `${input.namespace}-runtime-session-${digest}`,
+  );
+}

--- a/packages/execution-host-client/src/coordinator/service-token.ts
+++ b/packages/execution-host-client/src/coordinator/service-token.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const HostedHeartbeatServiceTokenSchema = z
+  .string()
+  .trim()
+  .min(32)
+  .max(4_096);

--- a/packages/execution-host-client/src/coordinator/types.ts
+++ b/packages/execution-host-client/src/coordinator/types.ts
@@ -1,0 +1,102 @@
+import type {
+  ExecutionAuthorityIssuer,
+} from '../authority/index.js';
+import type {
+  HostedModelCredentialProvider,
+} from '../conversation/index.js';
+import type {
+  HostedHeartbeatAgentExecutionTransportInput,
+} from '../heartbeat/index.js';
+import type { HeartbeatExecutionHost } from '../http-sse/index.js';
+import type {
+  HostedHeartbeatCoordinatorTaskInput,
+  HostedHeartbeatCoordinatorTaskSummary,
+  HostedHeartbeatDelegation,
+  HostedHeartbeatDelegationAuthorization,
+  HostedHeartbeatDelegationRequest,
+  HostedHeartbeatDesiredTask,
+} from './contracts.js';
+
+export type HostedHeartbeatCoordinatorClientConfig = {
+  baseUrl: URL;
+  apiToken: string;
+  fetch?: typeof globalThis.fetch;
+};
+
+export interface HostedHeartbeatCoordinatorTaskApi {
+  listTasks(signal?: AbortSignal): Promise<
+    HostedHeartbeatCoordinatorTaskSummary[]
+  >;
+  upsertTask(
+    taskId: string,
+    task: HostedHeartbeatCoordinatorTaskInput,
+    signal?: AbortSignal,
+  ): Promise<void>;
+  deleteTask(taskId: string, signal?: AbortSignal): Promise<void>;
+  pause(signal?: AbortSignal): Promise<void>;
+  resume(signal?: AbortSignal): Promise<void>;
+}
+
+export type HostedHeartbeatTaskReconciliationInput = {
+  desiredTasks: readonly HostedHeartbeatDesiredTask[];
+  resume: boolean;
+  signal?: AbortSignal;
+};
+
+export type HostedHeartbeatTaskReconciliation = {
+  deleted: number;
+  upserted: number;
+  resumed: boolean;
+};
+
+export type HostedHeartbeatTaskReconcilerConfig = {
+  coordinator: HostedHeartbeatCoordinatorTaskApi;
+};
+
+export type HostedHeartbeatDelegationAuthorizationInput = {
+  taskId: string;
+  executionId: string;
+  signal: AbortSignal;
+};
+
+export interface HostedHeartbeatDelegationAuthorizer {
+  authorize(
+    input: HostedHeartbeatDelegationAuthorizationInput,
+  ): HostedHeartbeatDelegationAuthorization
+    | undefined
+    | Promise<HostedHeartbeatDelegationAuthorization | undefined>;
+}
+
+export type HostedHeartbeatDelegationServiceConfig = {
+  authority: ExecutionAuthorityIssuer;
+  authorizer: HostedHeartbeatDelegationAuthorizer;
+  runtimeSessionNamespace: string;
+  maxExecutionMs: number;
+  now?: () => Date;
+};
+
+export interface HostedHeartbeatDelegationIssuer {
+  issue(
+    input: HostedHeartbeatDelegationRequest,
+    signal?: AbortSignal,
+  ): Promise<HostedHeartbeatDelegation>;
+}
+
+export type HostedHeartbeatDelegationClientConfig = {
+  baseUrl: URL;
+  apiToken: string;
+  fetch?: typeof globalThis.fetch;
+  path?: string;
+};
+
+export type HostedHeartbeatDelegatedExecutionTransportConfig = {
+  delegations: HostedHeartbeatDelegationIssuer;
+  executionHost: HeartbeatExecutionHost;
+  modelCredentials: HostedModelCredentialProvider;
+};
+
+export interface HostedHeartbeatDelegatedExecutionTransportPort {
+  execute(
+    input: HostedHeartbeatAgentExecutionTransportInput,
+  ): Promise<unknown>;
+}

--- a/packages/execution-host-client/src/heartbeat/README.md
+++ b/packages/execution-host-client/src/heartbeat/README.md
@@ -27,11 +27,15 @@ task authority while an isolated Runtime performs only the agent cycle.
 
 The coordinator supplies `HostedHeartbeatAgentExecutionTransport` to
 `HeartbeatSchedulerService`. The scheduler's existing local runner remains the
-default when no transport is configured. The transport's
-`resolveInvocationContext` callback is deliberately small: it selects only the
-already-authorized product scope, Runtime session, and deadline for the claimed
-task. `HostedHeartbeatTaskService` owns the reusable authority, credential,
-MCP, transport, and stream behavior after that selection.
+default when no transport is configured. This low-level transport is suitable
+when product authority and the coordinator live in the same process.
+
+For a separately deployed product backend, use the higher-level
+[`coordinator`](../coordinator/README.md) surface. It owns the authenticated
+task/delegation clients, desired-state reconciliation, Runtime-session and
+authority construction, and delegated execution composition. Product code then
+returns only its authorized scope and allowed tools rather than implementing
+`resolveInvocationContext` or the delegation wire shape.
 
 The returned value crosses an untrusted network boundary. The runtime scheduler
 validates it as an `AgentHeartbeatResult` before any checkpoint or successful

--- a/packages/execution-host-client/src/index.ts
+++ b/packages/execution-host-client/src/index.ts
@@ -2,5 +2,6 @@ export * from './contracts/index.js';
 export * from './authority/index.js';
 export * from './conversation/index.js';
 export * from './heartbeat/index.js';
+export * from './coordinator/index.js';
 export * from './mcp/index.js';
 export * from './http-sse/index.js';

--- a/packages/execution-host-client/src/node/http-service.ts
+++ b/packages/execution-host-client/src/node/http-service.ts
@@ -6,6 +6,16 @@ import type {
 import { z } from 'zod';
 import { ExecutionHostStreamEventSchema } from '../contracts/index.js';
 import { ExecutionHostInvocationCancelledError } from '../http-sse/index.js';
+import {
+  NodeHttpPathSchema,
+  NodeHttpRequestError,
+  errorType,
+  readJsonBody,
+  readPathname,
+  takeAuthorization,
+  writeJson,
+  writeJsonError,
+} from './http-utils.js';
 import type {
   NodeExecutionAdopterFailure,
   NodeExecutionAdopterHttpHandler,
@@ -20,12 +30,6 @@ export const DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH =
 
 const DEFAULT_MAX_BODY_BYTES = 64 * 1_024;
 const DEFAULT_MAX_PROMPT_CHARACTERS = 20_000;
-const REDACTED_HEADER_VALUE = '[REDACTED]';
-const MAX_AUTHORIZATION_CHARACTERS = 8_192;
-const PathSchema = z.string().min(1).max(256).regex(
-  /^\/(?:[^?#\s]*)$/,
-  'must be an absolute path without query, fragment, or whitespace',
-);
 const PublicErrorSchema = z.object({
   statusCode: z.number().int().min(400).max(599),
   message: z.string().min(1).max(1_600),
@@ -37,12 +41,6 @@ type ActiveConversation = {
   response: ServerResponse;
   pending: Promise<void>;
 };
-
-class AdopterHttpRequestError extends Error {
-  constructor(readonly statusCode: 400 | 413 | 415) {
-    super('Invalid adopter HTTP request.');
-  }
-}
 
 /**
  * Standard Node HTTP edge for adopter-side JWKS and hosted conversations.
@@ -212,7 +210,7 @@ implements NodeExecutionAdopterHttpHandler {
       request.resume();
       writeJsonError(
         response,
-        error instanceof AdopterHttpRequestError ? error.statusCode : 400,
+        error instanceof NodeHttpRequestError ? error.statusCode : 400,
         'Invalid conversation request.',
       );
       return;
@@ -250,7 +248,7 @@ implements NodeExecutionAdopterHttpHandler {
         prompt: z.string().trim().min(1).max(this.#maxPromptCharacters),
       }).strict().parse(body).prompt;
     } catch (error) {
-      const statusCode = error instanceof AdopterHttpRequestError
+      const statusCode = error instanceof NodeHttpRequestError
         ? error.statusCode
         : 400;
       writeJsonError(response, statusCode, 'Invalid conversation request.');
@@ -330,8 +328,8 @@ function parsePaths(
   paths: Partial<NodeExecutionAdopterHttpPaths> | undefined,
 ): Readonly<NodeExecutionAdopterHttpPaths> {
   const parsed = {
-    jwks: PathSchema.parse(paths?.jwks ?? DEFAULT_ADOPTER_JWKS_PATH),
-    conversationTurns: PathSchema.parse(
+    jwks: NodeHttpPathSchema.parse(paths?.jwks ?? DEFAULT_ADOPTER_JWKS_PATH),
+    conversationTurns: NodeHttpPathSchema.parse(
       paths?.conversationTurns ?? DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH,
     ),
   };
@@ -339,88 +337,6 @@ function parsePaths(
     throw new Error('Adopter HTTP paths must be distinct.');
   }
   return Object.freeze(parsed);
-}
-
-function readPathname(rawUrl: string | undefined): string | undefined {
-  try {
-    return new URL(rawUrl ?? '/', 'http://localhost').pathname;
-  } catch {
-    return undefined;
-  }
-}
-
-function takeAuthorization(request: IncomingMessage): string | undefined {
-  const occurrences = request.rawHeaders.reduce(
-    (count, headerName, index) => count
-      + (index % 2 === 0 && headerName.toLowerCase() === 'authorization' ? 1 : 0),
-    0,
-  );
-  const raw = request.headers.authorization;
-  request.headers.authorization = raw === undefined
-    ? undefined
-    : REDACTED_HEADER_VALUE;
-  for (let index = 0; index < request.rawHeaders.length; index += 2) {
-    if (request.rawHeaders[index]?.toLowerCase() === 'authorization') {
-      request.rawHeaders[index + 1] = REDACTED_HEADER_VALUE;
-    }
-  }
-  if (occurrences > 1 || Array.isArray(raw)) {
-    throw new AdopterHttpRequestError(400);
-  }
-  if (raw && raw.length > MAX_AUTHORIZATION_CHARACTERS) {
-    throw new AdopterHttpRequestError(400);
-  }
-  return raw;
-}
-
-async function readJsonBody(
-  request: IncomingMessage,
-  maxBodyBytes: number,
-  signal: AbortSignal,
-): Promise<unknown> {
-  const contentType = request.headers['content-type']
-    ?.split(';', 1)[0]
-    ?.trim()
-    .toLowerCase();
-  if (contentType !== 'application/json') {
-    request.resume();
-    throw new AdopterHttpRequestError(415);
-  }
-  const contentLength = request.headers['content-length'];
-  if (contentLength !== undefined) {
-    const declaredLength = Number(contentLength);
-    if (!Number.isSafeInteger(declaredLength) || declaredLength < 0) {
-      request.resume();
-      throw new AdopterHttpRequestError(400);
-    }
-    if (declaredLength > maxBodyBytes) {
-      request.resume();
-      throw new AdopterHttpRequestError(413);
-    }
-  }
-
-  const chunks: Buffer[] = [];
-  let receivedBytes = 0;
-  for await (const chunk of request) {
-    signal.throwIfAborted();
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    receivedBytes += buffer.byteLength;
-    if (receivedBytes > maxBodyBytes) {
-      request.resume();
-      throw new AdopterHttpRequestError(413);
-    }
-    chunks.push(buffer);
-  }
-  if (!request.complete || receivedBytes === 0) {
-    throw new AdopterHttpRequestError(400);
-  }
-  try {
-    return JSON.parse(
-      Buffer.concat(chunks, receivedBytes).toString('utf8'),
-    ) as unknown;
-  } catch {
-    throw new AdopterHttpRequestError(400);
-  }
 }
 
 function writeEventStreamHeaders(response: ServerResponse): void {
@@ -448,40 +364,4 @@ async function writeSseEvent(
   if (!response.write(frame)) {
     await once(response, 'drain', { signal });
   }
-}
-
-function writeJsonError(
-  response: ServerResponse,
-  statusCode: number,
-  message: string,
-  headers: Record<string, string> = {},
-): void {
-  writeJson(response, statusCode, { error: { message } }, {
-    'Cache-Control': 'no-store',
-    ...headers,
-  });
-}
-
-function writeJson(
-  response: ServerResponse,
-  statusCode: number,
-  value: unknown,
-  headers: Record<string, string> = {},
-): void {
-  if (response.headersSent || response.destroyed) {
-    return;
-  }
-  const body = JSON.stringify(value);
-  response.writeHead(statusCode, {
-    'Cache-Control': 'no-store',
-    'Content-Length': Buffer.byteLength(body),
-    'Content-Type': 'application/json; charset=utf-8',
-    'X-Content-Type-Options': 'nosniff',
-    ...headers,
-  });
-  response.end(body);
-}
-
-function errorType(error: unknown): string {
-  return error instanceof Error ? error.name : 'unknown';
 }

--- a/packages/execution-host-client/src/node/http-utils.ts
+++ b/packages/execution-host-client/src/node/http-utils.ts
@@ -1,0 +1,140 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { z } from 'zod';
+
+const REDACTED_HEADER_VALUE = '[REDACTED]';
+const MAX_AUTHORIZATION_CHARACTERS = 8_192;
+
+export const NodeHttpPathSchema = z.string().min(1).max(256).regex(
+  /^\/(?:[^?#\s]*)$/,
+  'must be an absolute path without query, fragment, or whitespace',
+);
+
+export class NodeHttpRequestError extends Error {
+  readonly name = 'NodeHttpRequestError';
+
+  constructor(readonly statusCode: 400 | 413 | 415) {
+    super('Invalid Node HTTP request.');
+  }
+}
+
+export function readPathname(rawUrl: string | undefined): string | undefined {
+  try {
+    return new URL(rawUrl ?? '/', 'http://localhost').pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+export function takeAuthorization(
+  request: IncomingMessage,
+): string | undefined {
+  const occurrences = request.rawHeaders.reduce(
+    (count, headerName, index) => count
+      + (index % 2 === 0 && headerName.toLowerCase() === 'authorization'
+        ? 1
+        : 0),
+    0,
+  );
+  const raw = request.headers.authorization;
+  request.headers.authorization = raw === undefined
+    ? undefined
+    : REDACTED_HEADER_VALUE;
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index]?.toLowerCase() === 'authorization') {
+      request.rawHeaders[index + 1] = REDACTED_HEADER_VALUE;
+    }
+  }
+  if (occurrences > 1 || Array.isArray(raw)) {
+    throw new NodeHttpRequestError(400);
+  }
+  if (raw && raw.length > MAX_AUTHORIZATION_CHARACTERS) {
+    throw new NodeHttpRequestError(400);
+  }
+  return raw;
+}
+
+export async function readJsonBody(
+  request: IncomingMessage,
+  maxBodyBytes: number,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const contentType = request.headers['content-type']
+    ?.split(';', 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== 'application/json') {
+    request.resume();
+    throw new NodeHttpRequestError(415);
+  }
+  const contentLength = request.headers['content-length'];
+  if (contentLength !== undefined) {
+    const declaredLength = Number(contentLength);
+    if (!Number.isSafeInteger(declaredLength) || declaredLength < 0) {
+      request.resume();
+      throw new NodeHttpRequestError(400);
+    }
+    if (declaredLength > maxBodyBytes) {
+      request.resume();
+      throw new NodeHttpRequestError(413);
+    }
+  }
+
+  const chunks: Buffer[] = [];
+  let receivedBytes = 0;
+  for await (const chunk of request) {
+    signal.throwIfAborted();
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    receivedBytes += buffer.byteLength;
+    if (receivedBytes > maxBodyBytes) {
+      request.resume();
+      throw new NodeHttpRequestError(413);
+    }
+    chunks.push(buffer);
+  }
+  if (!request.complete || receivedBytes === 0) {
+    throw new NodeHttpRequestError(400);
+  }
+  try {
+    return JSON.parse(
+      Buffer.concat(chunks, receivedBytes).toString('utf8'),
+    ) as unknown;
+  } catch {
+    throw new NodeHttpRequestError(400);
+  }
+}
+
+export function writeJsonError(
+  response: ServerResponse,
+  statusCode: number,
+  message: string,
+  headers: Record<string, string> = {},
+): void {
+  writeJson(response, statusCode, { error: { message } }, {
+    'Cache-Control': 'no-store',
+    ...headers,
+  });
+}
+
+export function writeJson(
+  response: ServerResponse,
+  statusCode: number,
+  value: unknown,
+  headers: Record<string, string> = {},
+): void {
+  if (response.headersSent || response.destroyed) {
+    return;
+  }
+  const body = JSON.stringify(value);
+  response.writeHead(statusCode, {
+    'Cache-Control': 'no-store',
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': 'application/json; charset=utf-8',
+    'X-Content-Type-Options': 'nosniff',
+    ...headers,
+  });
+  response.end(body);
+}
+
+export function errorType(error: unknown): string {
+  return error instanceof Error ? error.name : 'unknown';
+}


### PR DESCRIPTION
## Summary

- add public coordinator task/delegation contracts, an authenticated API client, and pause-first desired-state reconciliation
- add product-side delegation authority plus coordinator-side delegated heartbeat execution so adopters do not rebuild Heddle protocol logic
- add the optional Node delegation HTTP/auth edge and reuse the existing safe Node HTTP primitives
- document the product/coordinator/Execution Host ownership boundary

## Boundary

Products still own desired-task projection, authenticated scope, allowed MCP tools, and product data. Heddle now owns coordinator requests, Runtime-session derivation, deadlines, authority bundles, and delegated execution composition. This PR does not add persistence, deployment, or Lucid policy.

## Verification

- `yarn execution-host-client:compile`
- `yarn execution-host-client:test` (126 tests)
- `yarn tsc -p packages/execution-host-client/tsconfig.test.json --noEmit`
- `yarn eslint ...` (repository lint passed)