### PR TITLE
feat(runtime): add headless read-only delegation

### DIFF
--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -117,6 +117,56 @@ describe('AgentLoopRuntimeService.run', () => {
     });
   });
 
+  it('uses a validated host-preallocated run id in state and every runtime event', async () => {
+    const events: AgentLoopEvent[] = [];
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: false,
+          parallelToolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        return { content: 'Done with the supplied identity.' };
+      },
+    };
+
+    const result = await AgentLoopRuntimeService.run({
+      runId: 'run_preallocated-test:1',
+      goal: 'Use the supplied run id.',
+      llm: fakeLlm,
+      tools: [],
+      includeDefaultTools: false,
+      logger: silentLogger,
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(result.state.runId).toBe('run_preallocated-test:1');
+    expect(events).not.toHaveLength(0);
+    expect(events.every((event) => event.runId === 'run_preallocated-test:1')).toBe(true);
+  });
+
+  it('rejects invalid host-preallocated run ids before execution starts', async () => {
+    const fakeLlm: LlmAdapter = {
+      async chat(): Promise<LlmResponse> {
+        return { content: 'This should not run.' };
+      },
+    };
+
+    await expect(AgentLoopRuntimeService.run({
+      runId: ' invalid/run ',
+      goal: 'Reject the invalid run id.',
+      llm: fakeLlm,
+      tools: [],
+      includeDefaultTools: false,
+      logger: silentLogger,
+    })).rejects.toThrow('runId must start with an alphanumeric character');
+  });
+
   it('propagates safe model failures through loop state and terminal activity', async () => {
     const events: AgentLoopEvent[] = [];
     const fakeLlm: LlmAdapter = {

--- a/src/__tests__/integration/core/delegation.test.ts
+++ b/src/__tests__/integration/core/delegation.test.ts
@@ -1,0 +1,262 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  AgentLoopRuntimeService,
+  DelegationService,
+  type ChatMessage,
+  type DelegateTaskOutput,
+  type DelegatedRunRecord,
+  type LlmAdapter,
+  type LlmResponse,
+  type ToolDefinition,
+} from '../../../advanced.js';
+import { createLogger } from '../../../core/utils/logger.js';
+import { RuntimeToolProfileService } from '../../../core/runtime/tools/index.js';
+
+const silentLogger = createLogger({ level: 'silent', console: false });
+
+describe('headless read-only delegation', () => {
+  it('runs two parallel children through the existing runtime and lets the root synthesize', async () => {
+    const fixture = await runFixture(true);
+
+    expect(fixture.rootResult).toMatchObject({
+      outcome: 'done',
+      summary: 'Synthesized module and test findings.',
+      state: { runId: 'run_root-two-child-fixture' },
+    });
+    expect(fixture.peakActiveChildren).toBe(2);
+    expect(fixture.childAdapters.size).toBe(2);
+    expect(fixture.childFactoryInputs).toHaveLength(2);
+    expect(fixture.rootToolOutputs.map((output) => output.summary)).toEqual([
+      'Module inspection found the runtime boundary.',
+      'Test review found complete negative coverage.',
+    ]);
+    expect(fixture.rootToolOutputs.every((output) => (
+      !('trace' in output) && !('transcript' in output) && !('usage' in output)
+    ))).toBe(true);
+    expect(fixture.records).toHaveLength(2);
+    expect(fixture.records.every((record) => (
+      record.rootRunId === fixture.rootResult.state.runId
+      && record.parentRunId === fixture.rootResult.state.runId
+      && record.depth === 1
+      && record.status === 'finished'
+      && record.outcome === 'done'
+      && record.model === 'gpt-test'
+      && record.provider === 'openai'
+      && record.trace.length > 0
+      && record.usage?.requests === 1
+    ))).toBe(true);
+    expect(fixture.childMessages.every((messages) => {
+      const serialized = JSON.stringify(messages);
+      return serialized.includes('BASE_PROJECT_CONTEXT')
+        && serialized.includes('Selected Agent Profile')
+        && !serialized.includes('ROOT_PROFILE_SENTINEL')
+        && !serialized.includes('PARENT_HISTORY_SENTINEL');
+    })).toBe(true);
+    expect(fixture.childTools.every((tools) => (
+      !tools.some((tool) => tool.name === 'delegate_task')
+      && tools.every((tool) => RuntimeToolProfileService.capabilitiesFor(tool).every(
+        (capability) => ['workspace.read', 'shell.inspect', 'artifact.read'].includes(capability),
+      ))
+    ))).toBe(true);
+  });
+
+  it('preserves result order and executes serially when the root adapter lacks parallel-tool support', async () => {
+    const fixture = await runFixture(false);
+
+    expect(fixture.rootResult.outcome).toBe('done');
+    expect(fixture.peakActiveChildren).toBe(1);
+    expect(fixture.rootToolOutputs.map((output) => output.summary)).toEqual([
+      'Module inspection found the runtime boundary.',
+      'Test review found complete negative coverage.',
+    ]);
+    expect(fixture.records.map((record) => record.task)).toEqual([
+      'Inspect the module boundary.',
+      'Review the test coverage.',
+    ]);
+  });
+});
+
+async function runFixture(rootSupportsParallel: boolean): Promise<{
+  rootResult: Awaited<ReturnType<typeof AgentLoopRuntimeService.run>>;
+  records: DelegatedRunRecord[];
+  rootToolOutputs: DelegateTaskOutput[];
+  childMessages: ChatMessage[][];
+  childTools: ToolDefinition[][];
+  childFactoryInputs: Array<{ childRunId: string; delegationId: string; task: string }>;
+  childAdapters: Set<LlmAdapter>;
+  peakActiveChildren: number;
+}> {
+  const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-delegation-integration-'));
+  const childMessages: ChatMessage[][] = [];
+  const childTools: ToolDefinition[][] = [];
+  const childFactoryInputs: Array<{ childRunId: string; delegationId: string; task: string }> = [];
+  const childAdapters = new Set<LlmAdapter>();
+  const rootToolOutputs: DelegateTaskOutput[] = [];
+  let activeChildren = 0;
+  let peakActiveChildren = 0;
+  let rootRequest = 0;
+
+  const delegation = new DelegationService({
+    policy: {
+      enabled: true,
+      maxChildren: 4,
+      maxConcurrentChildren: 3,
+      maxStepsPerChild: 24,
+    },
+  });
+  const scope = delegation.createRootScope({
+    rootRunId: 'run_root-two-child-fixture',
+    workspaceRoot,
+    runtime: {
+      model: 'gpt-test',
+      baseSystemContext: 'BASE_PROJECT_CONTEXT',
+      logger: silentLogger,
+      createChildLlm: (input) => {
+        childFactoryInputs.push({
+          childRunId: input.childRunId,
+          delegationId: input.delegationId,
+          task: input.task,
+        });
+        const adapter = childAdapter({
+          task: input.task,
+          onStart: () => {
+            activeChildren += 1;
+            peakActiveChildren = Math.max(peakActiveChildren, activeChildren);
+          },
+          onFinish: () => {
+            activeChildren -= 1;
+          },
+          onRequest: (messages, tools) => {
+            childMessages.push(messages);
+            childTools.push(tools);
+          },
+        });
+        childAdapters.add(adapter);
+        return adapter;
+      },
+    },
+  });
+  const rootAdapter: LlmAdapter = {
+    info: {
+      provider: 'openai',
+      model: 'gpt-test',
+      capabilities: {
+        toolCalls: true,
+        systemMessages: true,
+        reasoningSummaries: false,
+        parallelToolCalls: rootSupportsParallel,
+      },
+    },
+    async chat(messages): Promise<LlmResponse> {
+      rootRequest += 1;
+      if (rootRequest === 1) {
+        return {
+          content: 'I will delegate two independent inspections.',
+          toolCalls: [
+            {
+              id: 'delegate-module',
+              tool: 'delegate_task',
+              input: {
+                task: 'Inspect the module boundary.',
+                agentProfileId: 'builtin:ask',
+              },
+            },
+            {
+              id: 'delegate-tests',
+              tool: 'delegate_task',
+              input: {
+                task: 'Review the test coverage.',
+                agentProfileId: 'builtin:review',
+              },
+            },
+          ],
+        };
+      }
+
+      const toolMessages = messages.filter(
+        (message): message is Extract<ChatMessage, { role: 'tool' }> => message.role === 'tool',
+      );
+      rootToolOutputs.push(...toolMessages.map((message) => {
+        const result = JSON.parse(message.content) as { output: DelegateTaskOutput };
+        return result.output;
+      }));
+      return { content: 'Synthesized module and test findings.' };
+    },
+  };
+
+  const rootResult = await AgentLoopRuntimeService.run({
+    runId: scope.rootRunId,
+    goal: 'Inspect the runtime and its tests using independent children.',
+    model: 'gpt-test',
+    llm: rootAdapter,
+    tools: [scope.createTool()],
+    includeDefaultTools: false,
+    maxSteps: 3,
+    maxToolConcurrency: 3,
+    workspaceRoot,
+    logger: silentLogger,
+    systemContext: 'ROOT_PROFILE_SENTINEL',
+    history: [
+      { role: 'user', content: 'PARENT_HISTORY_SENTINEL' },
+      { role: 'assistant', content: 'Prior root-only response.' },
+    ],
+  });
+
+  return {
+    rootResult,
+    records: scope.records(),
+    rootToolOutputs,
+    childMessages,
+    childTools,
+    childFactoryInputs,
+    childAdapters,
+    peakActiveChildren,
+  };
+}
+
+function childAdapter(input: {
+  task: string;
+  onStart: () => void;
+  onFinish: () => void;
+  onRequest: (messages: ChatMessage[], tools: ToolDefinition[]) => void;
+}): LlmAdapter {
+  return {
+    info: {
+      provider: 'openai',
+      model: 'gpt-test',
+      capabilities: {
+        toolCalls: true,
+        systemMessages: true,
+        reasoningSummaries: false,
+        parallelToolCalls: true,
+      },
+    },
+    async chat(messages, tools): Promise<LlmResponse> {
+      input.onRequest(messages, tools);
+      input.onStart();
+      try {
+        await delay(input.task.startsWith('Inspect') ? 20 : 5);
+        return {
+          content: input.task.startsWith('Inspect')
+            ? 'Module inspection found the runtime boundary.'
+            : 'Test review found complete negative coverage.',
+          usage: {
+            inputTokens: 20,
+            outputTokens: 8,
+            totalTokens: 28,
+            requests: 1,
+          },
+        };
+      } finally {
+        input.onFinish();
+      }
+    },
+  };
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}

--- a/src/__tests__/integration/core/delegation.test.ts
+++ b/src/__tests__/integration/core/delegation.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   AgentLoopRuntimeService,
   DelegationService,
@@ -57,8 +57,10 @@ describe('headless read-only delegation', () => {
     })).toBe(true);
     expect(fixture.childTools.every((tools) => (
       !tools.some((tool) => tool.name === 'delegate_task')
+      && !tools.some((tool) => tool.name === 'run_shell_inspect')
+      && !tools.some((tool) => tool.name === 'read_agent_skill')
       && tools.every((tool) => RuntimeToolProfileService.capabilitiesFor(tool).every(
-        (capability) => ['workspace.read', 'shell.inspect', 'artifact.read'].includes(capability),
+        (capability) => capability === 'workspace.read',
       ))
     ))).toBe(true);
   });
@@ -76,6 +78,93 @@ describe('headless read-only delegation', () => {
       'Inspect the module boundary.',
       'Review the test coverage.',
     ]);
+  });
+
+  it('lets a delegated child exceed the generic 30-second tool timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const workspaceRoot = mkdtempSync(join(tmpdir(), 'heddle-long-delegation-integration-'));
+      let markChildStarted!: () => void;
+      const childStarted = new Promise<void>((resolveStarted) => {
+        markChildStarted = resolveStarted;
+      });
+      const scope = new DelegationService({
+        policy: {
+          enabled: true,
+          maxChildren: 1,
+          maxConcurrentChildren: 1,
+          maxStepsPerChild: 2,
+          allowedAgentProfileIds: ['builtin:ask'],
+        },
+      }).createRootScope({
+        rootRunId: 'run_long-child-fixture',
+        workspaceRoot,
+        runtime: {
+          model: 'gpt-test',
+          logger: silentLogger,
+          createChildLlm: () => childAdapter({
+            task: 'Inspect slow-child',
+            onStart: markChildStarted,
+            onFinish: () => undefined,
+            onRequest: () => undefined,
+            delayMs: 30_001,
+          }),
+        },
+      });
+      let rootRequest = 0;
+      const rootAdapter: LlmAdapter = {
+        info: {
+          provider: 'openai',
+          model: 'gpt-test',
+          capabilities: {
+            toolCalls: true,
+            systemMessages: true,
+            reasoningSummaries: false,
+            parallelToolCalls: false,
+          },
+        },
+        async chat(): Promise<LlmResponse> {
+          rootRequest += 1;
+          return rootRequest === 1
+            ? {
+              toolCalls: [{
+                id: 'delegate-slow-child',
+                tool: 'delegate_task',
+                input: { task: 'Inspect slow-child', agentProfileId: 'builtin:ask' },
+              }],
+            }
+            : { content: 'Synthesized slow child result.' };
+        },
+      };
+
+      const running = AgentLoopRuntimeService.run({
+        runId: scope.rootRunId,
+        goal: 'Delegate one deliberately slow inspection.',
+        model: 'gpt-test',
+        llm: rootAdapter,
+        tools: [scope.createTool()],
+        includeDefaultTools: false,
+        maxSteps: 3,
+        workspaceRoot,
+        logger: silentLogger,
+      });
+
+      await childStarted;
+      await vi.advanceTimersByTimeAsync(30_001);
+      const result = await running;
+
+      expect(result).toMatchObject({
+        outcome: 'done',
+        summary: 'Synthesized slow child result.',
+      });
+      expect(scope.records()).toMatchObject([{
+        status: 'finished',
+        outcome: 'done',
+        summary: 'Module inspection found the runtime boundary.',
+      }]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -222,6 +311,7 @@ function childAdapter(input: {
   onStart: () => void;
   onFinish: () => void;
   onRequest: (messages: ChatMessage[], tools: ToolDefinition[]) => void;
+  delayMs?: number;
 }): LlmAdapter {
   return {
     info: {
@@ -238,7 +328,7 @@ function childAdapter(input: {
       input.onRequest(messages, tools);
       input.onStart();
       try {
-        await delay(input.task.startsWith('Inspect') ? 20 : 5);
+        await delay(input.delayMs ?? (input.task.startsWith('Inspect') ? 20 : 5));
         return {
           content: input.task.startsWith('Inspect')
             ? 'Module inspection found the runtime boundary.'

--- a/src/__tests__/unit/core/delegation.test.ts
+++ b/src/__tests__/unit/core/delegation.test.ts
@@ -1,0 +1,492 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ToolApprovalService } from '@/core/approvals/index.js';
+import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
+import {
+  DelegationService,
+  type DelegateTaskOutput,
+  type DelegationChildLlmFactory,
+  type DelegationChildRuntimeOptions,
+  type DelegationPolicyInput,
+} from '@/core/delegation/index.js';
+import type { LlmAdapter, LlmResponse } from '@/core/llm/types.js';
+import {
+  AgentLoopRuntimeService,
+  type AgentLoopResult,
+  type RunAgentLoopOptions,
+} from '@/core/runtime/loop/index.js';
+import {
+  RuntimeToolProfileService,
+  RuntimeToolService,
+} from '@/core/runtime/tools/index.js';
+import type { ToolDefinition, ToolResult } from '@/core/types.js';
+import { createLogger } from '@/core/utils/logger.js';
+
+const silentLogger = createLogger({ level: 'silent', console: false });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('delegation policy and scope', () => {
+  it('is disabled by default and does not add delegation to the default runtime tools', async () => {
+    const workspaceRoot = workspace();
+    const service = new DelegationService();
+    const scope = service.createRootScope({
+      workspaceRoot,
+      runtime: { model: 'gpt-test', logger: silentLogger },
+    });
+
+    const result = await scope.createTool().execute({ task: 'Inspect the repository.' });
+    const defaultTools = RuntimeToolService.createDefaultAgentTools({
+      model: 'gpt-test',
+      workspaceRoot,
+    });
+
+    expect(service.enabled).toBe(false);
+    expect(output(result).error?.code).toBe('delegation_disabled');
+    expect(scope.records()).toEqual([]);
+    expect(defaultTools.map((tool) => tool.name)).not.toContain('delegate_task');
+  });
+
+  it('creates one explicit parallel-safe agent.delegate tool with a closed schema', () => {
+    const { scope, workspaceRoot } = activeScope();
+    const tool = scope.createTool();
+
+    expect(tool).toMatchObject({
+      name: 'delegate_task',
+      capabilities: ['agent.delegate'],
+      concurrency: 'parallel-safe',
+      parameters: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['task'],
+      },
+    });
+    expect(RuntimeToolProfileService.apply({
+      tools: [tool],
+      profile: { preset: 'custom', allowedCapabilities: ['agent.delegate'] },
+    }).map((candidate) => candidate.name)).toEqual(['delegate_task']);
+    expect(RuntimeToolProfileService.apply({
+      tools: [tool],
+      profile: { preset: 'inspect' },
+    })).toEqual([]);
+    expect(() => RuntimeToolService.createDefaultAgentTools({
+      model: 'gpt-test',
+      workspaceRoot,
+      tools: [tool, scope.createTool()],
+    })).toThrow('Duplicate runtime tool name: delegate_task');
+  });
+
+  it('validates every v1 host limit before a root scope can start', () => {
+    const invalidPolicies: DelegationPolicyInput[] = [
+      { enabled: true, maxDepth: 2 },
+      { enabled: true, maxChildren: 5 },
+      { enabled: true, maxConcurrentChildren: 4 },
+      { enabled: true, maxChildren: 2, maxConcurrentChildren: 3 },
+      { enabled: true, maxStepsPerChild: 33 },
+      { enabled: true, allowedAgentProfileIds: [] },
+      { enabled: true, allowedAgentProfileIds: ['builtin:code'] },
+    ];
+
+    invalidPolicies.forEach((policy) => {
+      expect(() => new DelegationService({ policy })).toThrow();
+    });
+
+    const validService = new DelegationService({ policy: { enabled: true } });
+    expect(Object.isFrozen(validService.policy)).toBe(true);
+    expect(Object.isFrozen(validService.policy.allowedAgentProfileIds)).toBe(true);
+    expect(() => Object.assign(validService.policy, { maxChildren: 99 })).toThrow(TypeError);
+  });
+
+  it('returns stable safe rejections for invalid tasks, disallowed agents, and depth two', async () => {
+    const { scope } = activeScope({
+      policy: { allowedAgentProfileIds: ['builtin:ask'] },
+    });
+
+    const invalidTask = await scope.delegateTask({ task: '   ' });
+    const unknownField = await scope.delegateTask({ task: 'Inspect.', depth: 1 });
+    const disallowedAgent = await scope.delegateTask({
+      task: 'Review the repository.',
+      agentProfileId: 'builtin:review',
+    });
+    const depthTwo = await scope.delegateTask(
+      { task: 'Try nested delegation.' },
+      { parentDepth: 1 },
+    );
+
+    expect(output(invalidTask).error?.code).toBe('invalid_task');
+    expect(output(unknownField).error?.code).toBe('invalid_task');
+    expect(output(disallowedAgent).error?.code).toBe('agent_not_allowed');
+    expect(output(depthTwo).error?.code).toBe('depth_limit');
+    expect(scope.records()).toEqual([]);
+  });
+
+  it('consumes the total slot after success, provider failure, and cancellation', async () => {
+    let cancelStarted!: () => void;
+    const started = new Promise<void>((resolveStarted) => {
+      cancelStarted = resolveStarted;
+    });
+    const { scope } = activeScope({
+      createChildLlm: ({ task }) => taskAdapter(task, cancelStarted),
+    });
+
+    const success = await scope.delegateTask({ task: 'success-one' });
+    const failure = await scope.delegateTask({ task: 'provider-failure' });
+    const controller = new AbortController();
+    const cancellationPromise = scope.delegateTask(
+      { task: 'cancel-me' },
+      { signal: controller.signal },
+    );
+    await started;
+    controller.abort();
+    const cancellation = await cancellationPromise;
+    const finalSuccess = await scope.delegateTask({ task: 'success-two' });
+    const fifth = await scope.delegateTask({ task: 'over-limit' });
+
+    expect(success.ok).toBe(true);
+    expect(output(failure)).toMatchObject({
+      outcome: 'error',
+      error: { code: 'child_failed' },
+    });
+    expect(output(cancellation)).toMatchObject({
+      outcome: 'interrupted',
+      error: { code: 'cancelled' },
+    });
+    expect(finalSuccess.ok).toBe(true);
+    expect(output(fifth).error?.code).toBe('child_limit');
+    expect(JSON.stringify([failure, cancellation])).not.toContain('raw-provider-secret');
+    expect(scope.records().map((record) => record.outcome)).toEqual([
+      'done',
+      'error',
+      'interrupted',
+      'done',
+    ]);
+  });
+
+  it('never executes more than three reserved children concurrently', async () => {
+    let active = 0;
+    let peak = 0;
+    const { scope } = activeScope({
+      createChildLlm: ({ task }) => finalAdapter(async () => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await delay(20);
+        active -= 1;
+        return { content: `Completed ${task}.` };
+      }),
+    });
+
+    const results = await Promise.all([
+      scope.delegateTask({ task: 'one' }),
+      scope.delegateTask({ task: 'two' }),
+      scope.delegateTask({ task: 'three' }),
+      scope.delegateTask({ task: 'four' }),
+    ]);
+
+    expect(results.every((result) => result.ok)).toBe(true);
+    expect(peak).toBe(3);
+    expect(active).toBe(0);
+  });
+
+  it('rejects a child adapter instance reused by a custom host factory', async () => {
+    const sharedAdapter = finalAdapter(async () => ({ content: 'Shared result.' }));
+    const { scope } = activeScope({
+      createChildLlm: () => sharedAdapter,
+    });
+
+    const first = await scope.delegateTask({ task: 'first' });
+    const second = await scope.delegateTask({ task: 'second' });
+
+    expect(first.ok).toBe(true);
+    expect(output(second).error?.code).toBe('child_failed');
+    expect(JSON.stringify(second)).not.toContain('fresh adapter');
+    expect(scope.records().at(1)).toMatchObject({
+      status: 'finished',
+      outcome: 'error',
+    });
+  });
+
+  it('intersects snapshot tools with the mandatory envelope and passes a separate read-only approval policy', async () => {
+    const workspaceRoot = workspace();
+    const snapshot = askSnapshot({
+      toolProfile: {
+        preset: 'inspect',
+        includeTools: ['read_file', 'edit_file', 'delegate_task'],
+        memoryMode: 'none',
+      },
+    });
+    const mutationTool: ToolDefinition = {
+      name: 'forged_mutation',
+      description: 'A forged mutation used to test defense in depth.',
+      capabilities: ['workspace.write'],
+      parameters: {},
+      execute: async () => ({ ok: true }),
+    };
+    let captured: RunAgentLoopOptions | undefined;
+    vi.spyOn(AgentLoopRuntimeService, 'run').mockImplementation(async (options) => {
+      captured = options;
+      return completedResult(options, 'Read-only child result.');
+    });
+    const scope = new DelegationService({
+      policy: { enabled: true, allowedAgentProfileIds: ['builtin:ask'] },
+    }).createRootScope({
+      rootRunId: 'run_read-only-root',
+      workspaceRoot,
+      runtime: {
+        model: 'gpt-test',
+        baseSystemContext: 'BASE_PROJECT_CONTEXT',
+        logger: silentLogger,
+        extraTools: [mutationTool],
+        llm: finalAdapter(async () => ({ content: 'Unsafe shared adapter.' })),
+      } as unknown as DelegationChildRuntimeOptions,
+      agentSnapshotResolver: {
+        resolveExecutionSnapshot: () => snapshot,
+      },
+    });
+
+    const result = await scope.delegateTask({ task: 'Inspect safely.' });
+    const tools = captured?.tools ?? [];
+    const approval = await new ToolApprovalService().evaluate({
+      policies: captured?.approvalPolicies ?? [],
+      context: {
+        call: { id: 'forged-call', tool: mutationTool.name, input: {} },
+        tool: mutationTool,
+        workspaceRoot,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(tools.map((tool) => tool.name)).toContain('read_file');
+    expect(tools.map((tool) => tool.name)).not.toEqual(expect.arrayContaining([
+      'edit_file',
+      'delegate_task',
+      'run_shell_mutate',
+      'mcp_call_tool',
+    ]));
+    expect(tools.every((tool) => RuntimeToolProfileService.capabilitiesFor(tool).every(
+      (capability) => ['workspace.read', 'shell.inspect', 'artifact.read'].includes(capability),
+    ))).toBe(true);
+    expect(approval).toEqual({
+      type: 'deny',
+      reason: 'forged_mutation is not available to read-only agents',
+    });
+    expect(captured).toMatchObject({
+      runId: expect.stringMatching(/^run_/),
+      goal: 'Inspect safely.',
+      workspaceRoot,
+      includeDefaultTools: false,
+      history: [],
+      maxSteps: 24,
+    });
+    expect(captured?.extraTools).toBeUndefined();
+    expect(captured?.llm).toBeUndefined();
+    expect(captured?.systemContext).toContain('BASE_PROJECT_CONTEXT');
+    expect(captured?.systemContext).toContain('You are running in ask mode.');
+    expect(captured?.systemContext).not.toContain('ROOT_PROFILE_CONTEXT');
+    expect(scope.records()[0]?.agentSnapshot.definitionHash).toBe(snapshot.definitionHash);
+    expect(output(result)).not.toHaveProperty('trace');
+    expect(output(result)).not.toHaveProperty('usage');
+  });
+
+  it('fails closed before root execution when an eligible snapshot is not read-only', () => {
+    const unsafeSnapshot = askSnapshot({
+      toolProfile: { preset: 'default' },
+    });
+
+    expect(() => new DelegationService({
+      policy: { enabled: true, allowedAgentProfileIds: ['builtin:ask'] },
+    }).createRootScope({
+      workspaceRoot: workspace(),
+      runtime: { model: 'gpt-test', logger: silentLogger },
+      agentSnapshotResolver: {
+        resolveExecutionSnapshot: () => unsafeSnapshot,
+      },
+    })).toThrow('not safely read-only');
+  });
+
+  it('cancels the active child and settles queued reservations without starting them', async () => {
+    let adaptersCreated = 0;
+    let active = 0;
+    let firstStarted!: () => void;
+    const started = new Promise<void>((resolveStarted) => {
+      firstStarted = resolveStarted;
+    });
+    const { scope } = activeScope({
+      policy: { maxConcurrentChildren: 1 },
+      createChildLlm: () => {
+        adaptersCreated += 1;
+        return finalAdapter(async (_messages, _tools, signal) => {
+          active += 1;
+          firstStarted();
+          try {
+            return await rejectWhenAborted(signal);
+          } finally {
+            active -= 1;
+          }
+        });
+      },
+    });
+
+    const pending = [
+      scope.delegateTask({ task: 'active' }),
+      scope.delegateTask({ task: 'queued-one' }),
+      scope.delegateTask({ task: 'queued-two' }),
+    ];
+    await started;
+    scope.cancel('root cancelled');
+    const results = await Promise.all(pending);
+
+    expect(results.map((result) => output(result).error?.code)).toEqual([
+      'cancelled',
+      'cancelled',
+      'cancelled',
+    ]);
+    expect(adaptersCreated).toBe(1);
+    expect(active).toBe(0);
+    expect(scope.records().every((record) => record.status === 'cancelled')).toBe(true);
+  });
+});
+
+function activeScope(options: {
+  policy?: DelegationPolicyInput;
+  createChildLlm?: DelegationChildLlmFactory;
+} = {}) {
+  const workspaceRoot = workspace();
+  const service = new DelegationService({
+    policy: {
+      enabled: true,
+      ...options.policy,
+    },
+  });
+  const scope = service.createRootScope({
+    rootRunId: 'run_delegation-unit-root',
+    workspaceRoot,
+    runtime: {
+      model: 'gpt-test',
+      logger: silentLogger,
+      createChildLlm: options.createChildLlm
+        ?? (() => finalAdapter(async () => ({ content: 'Child completed.' }))),
+    },
+  });
+  return { scope, service, workspaceRoot };
+}
+
+function workspace(): string {
+  return mkdtempSync(join(tmpdir(), 'heddle-delegation-'));
+}
+
+function output(result: ToolResult): DelegateTaskOutput {
+  return result.output as DelegateTaskOutput;
+}
+
+function finalAdapter(
+  chat: LlmAdapter['chat'],
+): LlmAdapter {
+  return {
+    info: {
+      provider: 'openai',
+      model: 'gpt-test',
+      capabilities: {
+        toolCalls: true,
+        systemMessages: true,
+        reasoningSummaries: false,
+        parallelToolCalls: true,
+      },
+    },
+    chat,
+  };
+}
+
+function taskAdapter(task: string, cancelStarted: () => void): LlmAdapter {
+  if (task === 'provider-failure') {
+    return finalAdapter(async () => {
+      throw Object.assign(new Error('raw-provider-secret'), { status: 401 });
+    });
+  }
+  if (task === 'cancel-me') {
+    return finalAdapter(async (_messages, _tools, signal) => {
+      cancelStarted();
+      return await rejectWhenAborted(signal);
+    });
+  }
+  return finalAdapter(async () => ({ content: `Completed ${task}.` }));
+}
+
+async function rejectWhenAborted(signal: AbortSignal | undefined): Promise<LlmResponse> {
+  if (!signal) {
+    throw new Error('Expected an abort signal');
+  }
+  if (signal.aborted) {
+    throw abortError();
+  }
+
+  return await new Promise<LlmResponse>((_resolve, reject) => {
+    signal.addEventListener('abort', () => reject(abortError()), { once: true });
+  });
+}
+
+function abortError(): Error {
+  return Object.assign(new Error('raw cancellation detail'), { name: 'AbortError' });
+}
+
+function askSnapshot(
+  overrides: Partial<CustomAgentExecutionSnapshot> = {},
+): CustomAgentExecutionSnapshot {
+  return {
+    agentProfileId: 'builtin:ask',
+    agentName: 'Ask',
+    modeAlias: 'ask',
+    source: 'built-in',
+    definitionHash: '0123456789abcdef',
+    runtime: { maxSteps: 60 },
+    toolProfile: {
+      preset: 'inspect',
+      includeTools: ['read_file'],
+      memoryMode: 'none',
+    },
+    approvalProfile: { preset: 'read_only' },
+    systemContextAppendix: 'You are running in ask mode. Inspect without changing project state.',
+    ...overrides,
+  };
+}
+
+function completedResult(
+  options: RunAgentLoopOptions,
+  summary: string,
+): AgentLoopResult {
+  const runId = options.runId ?? 'run-test';
+  const model = options.model ?? 'gpt-test';
+  const workspaceRoot = options.workspaceRoot ?? process.cwd();
+  const startedAt = '2026-08-25T00:00:00.000Z';
+  const finishedAt = '2026-08-25T00:00:01.000Z';
+  return {
+    outcome: 'done',
+    summary,
+    trace: [],
+    transcript: [],
+    model,
+    provider: 'openai',
+    workspaceRoot,
+    state: {
+      status: 'finished',
+      runId,
+      goal: options.goal,
+      model,
+      provider: 'openai',
+      workspaceRoot,
+      startedAt,
+      finishedAt,
+      outcome: 'done',
+      summary,
+      transcript: [],
+      trace: [],
+    },
+  };
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}

--- a/src/__tests__/unit/core/delegation.test.ts
+++ b/src/__tests__/unit/core/delegation.test.ts
@@ -59,6 +59,7 @@ describe('delegation policy and scope', () => {
       name: 'delegate_task',
       capabilities: ['agent.delegate'],
       concurrency: 'parallel-safe',
+      timeoutMs: null,
       parameters: {
         type: 'object',
         additionalProperties: false,
@@ -122,6 +123,26 @@ describe('delegation policy and scope', () => {
     expect(output(disallowedAgent).error?.code).toBe('agent_not_allowed');
     expect(output(depthTwo).error?.code).toBe('depth_limit');
     expect(scope.records()).toEqual([]);
+  });
+
+  it('defaults an omitted profile to the host-allowed review worker when ask is unavailable', async () => {
+    const { scope } = activeScope({
+      policy: { allowedAgentProfileIds: ['builtin:review'] },
+    });
+
+    const result = await scope.delegateTask({ task: 'Review safely.' });
+    const tool = scope.createTool();
+
+    expect(result.ok).toBe(true);
+    expect(tool.description).toContain('omitted to use builtin:review');
+    expect(tool.parameters).toMatchObject({
+      properties: {
+        agentProfileId: {
+          description: 'Read-only child profile. Omit to use builtin:review.',
+        },
+      },
+    });
+    expect(scope.records()[0]?.agentSnapshot.agentProfileId).toBe('builtin:review');
   });
 
   it('consumes the total slot after success, provider failure, and cancellation', async () => {
@@ -209,22 +230,36 @@ describe('delegation policy and scope', () => {
     });
   });
 
-  it('intersects snapshot tools with the mandatory envelope and passes a separate read-only approval policy', async () => {
+  it('intersects snapshot tools with the exact delegated read-only allowlist', async () => {
     const workspaceRoot = workspace();
     const snapshot = askSnapshot({
       toolProfile: {
         preset: 'inspect',
-        includeTools: ['read_file', 'edit_file', 'delegate_task'],
+        includeTools: [
+          'read_file',
+          'edit_file',
+          'run_shell_inspect',
+          'read_agent_skill',
+          'delegate_task',
+        ],
         memoryMode: 'none',
       },
     });
-    const mutationTool: ToolDefinition = {
-      name: 'forged_mutation',
-      description: 'A forged mutation used to test defense in depth.',
-      capabilities: ['workspace.write'],
+    const unsafeTools: ToolDefinition[] = ([
+      ['forged_mutation', 'workspace.write'],
+      ['forged_shell', 'shell.inspect'],
+      ['forged_external_read', 'external.read'],
+      ['forged_memory_read', 'memory.read'],
+      ['forged_artifact_read', 'artifact.read'],
+      ['read_agent_skill', 'workspace.read'],
+      ['forged_future_read', 'workspace.read'],
+    ] as const).map(([name, capability]) => ({
+      name,
+      description: `A forged ${capability} tool used to test defense in depth.`,
+      capabilities: [capability],
       parameters: {},
       execute: async () => ({ ok: true }),
-    };
+    }));
     let captured: RunAgentLoopOptions | undefined;
     vi.spyOn(AgentLoopRuntimeService, 'run').mockImplementation(async (options) => {
       captured = options;
@@ -239,7 +274,7 @@ describe('delegation policy and scope', () => {
         model: 'gpt-test',
         baseSystemContext: 'BASE_PROJECT_CONTEXT',
         logger: silentLogger,
-        extraTools: [mutationTool],
+        extraTools: unsafeTools,
         llm: finalAdapter(async () => ({ content: 'Unsafe shared adapter.' })),
       } as unknown as DelegationChildRuntimeOptions,
       agentSnapshotResolver: {
@@ -249,30 +284,53 @@ describe('delegation policy and scope', () => {
 
     const result = await scope.delegateTask({ task: 'Inspect safely.' });
     const tools = captured?.tools ?? [];
-    const approval = await new ToolApprovalService().evaluate({
-      policies: captured?.approvalPolicies ?? [],
-      context: {
-        call: { id: 'forged-call', tool: mutationTool.name, input: {} },
-        tool: mutationTool,
-        workspaceRoot,
-      },
-    });
+    const approvalService = new ToolApprovalService();
+    const approvals = await Promise.all(unsafeTools.map(async (tool) => (
+      await approvalService.evaluate({
+        policies: captured?.approvalPolicies ?? [],
+        context: {
+          call: { id: `call-${tool.name}`, tool: tool.name, input: {} },
+          tool,
+          workspaceRoot,
+        },
+      })
+    )));
+    const readFileTool = tools.find((tool) => tool.name === 'read_file');
+    const safeApproval = readFileTool
+      ? await approvalService.evaluate({
+        policies: captured?.approvalPolicies ?? [],
+        context: {
+          call: { id: 'call-read-file', tool: readFileTool.name, input: {} },
+          tool: readFileTool,
+          workspaceRoot,
+        },
+      })
+      : undefined;
 
     expect(result.ok).toBe(true);
-    expect(tools.map((tool) => tool.name)).toContain('read_file');
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      'list_files',
+      'project_dashboard',
+      'read_file',
+      'search_files',
+    ]);
     expect(tools.map((tool) => tool.name)).not.toEqual(expect.arrayContaining([
       'edit_file',
       'delegate_task',
+      'run_shell_inspect',
       'run_shell_mutate',
+      'read_artifact',
+      'read_agent_skill',
       'mcp_call_tool',
     ]));
     expect(tools.every((tool) => RuntimeToolProfileService.capabilitiesFor(tool).every(
-      (capability) => ['workspace.read', 'shell.inspect', 'artifact.read'].includes(capability),
+      (capability) => capability === 'workspace.read',
     ))).toBe(true);
-    expect(approval).toEqual({
+    expect(approvals).toEqual(unsafeTools.map((tool) => ({
       type: 'deny',
-      reason: 'forged_mutation is not available to read-only agents',
-    });
+      reason: `${tool.name} is outside the delegated read-only tool allowlist`,
+    })));
+    expect(safeApproval).toBeUndefined();
     expect(captured).toMatchObject({
       runId: expect.stringMatching(/^run_/),
       goal: 'Inspect safely.',

--- a/src/__tests__/unit/tools/tool-execution-lifecycle.test.ts
+++ b/src/__tests__/unit/tools/tool-execution-lifecycle.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { ToolExecutionService, ToolRegistry } from '@/core/tools/index.js';
 import type { ToolDefinition } from '@/core/types.js';
 
-function registry(execute: ToolDefinition['execute']): ToolRegistry {
+function registry(
+  execute: ToolDefinition['execute'],
+  timeoutMs?: number | null,
+): ToolRegistry {
   return new ToolRegistry([{
     name: 'lifecycle_tool',
     description: 'Exercise tool lifecycle behavior.',
+    timeoutMs,
     parameters: { type: 'object', properties: {} },
     execute,
   }]);
@@ -87,4 +91,157 @@ describe('tool execution lifecycle', () => {
       vi.useRealTimers();
     }
   });
+
+  it('uses the 30-second default when neither the tool nor caller specifies a timeout', async () => {
+    vi.useFakeTimers();
+    let toolSignal: AbortSignal | undefined;
+
+    try {
+      const execution = ToolExecutionService.execute(
+        registry(async (_input, context) => {
+          toolSignal = context?.signal;
+          await new Promise<void>((resolve) => {
+            context?.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return { ok: false, error: 'tool observed timeout' };
+        }),
+        { id: 'call-1', tool: 'lifecycle_tool', input: {} },
+      );
+
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(toolSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expect(execution).resolves.toEqual({
+        ok: false,
+        error: 'Tool "lifecycle_tool" timed out after 30000ms',
+      });
+      expect(toolSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses a tool-owned timeout when the caller does not override it', async () => {
+    vi.useFakeTimers();
+    let toolSignal: AbortSignal | undefined;
+
+    try {
+      const execution = ToolExecutionService.execute(
+        registry(async (_input, context) => {
+          toolSignal = context?.signal;
+          await new Promise<void>((resolve) => {
+            context?.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return { ok: false, error: 'tool observed timeout' };
+        }, 125),
+        { id: 'call-1', tool: 'lifecycle_tool', input: {} },
+      );
+
+      await vi.advanceTimersByTimeAsync(125);
+
+      await expect(execution).resolves.toEqual({
+        ok: false,
+        error: 'Tool "lifecycle_tool" timed out after 125ms',
+      });
+      expect(toolSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('lets an explicit execution timeout override the tool-owned timeout', async () => {
+    vi.useFakeTimers();
+    let toolSignal: AbortSignal | undefined;
+
+    try {
+      const execution = ToolExecutionService.execute(
+        registry(async (_input, context) => {
+          toolSignal = context?.signal;
+          await new Promise<void>((resolve) => {
+            context?.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return { ok: false, error: 'tool observed timeout' };
+        }, 25),
+        { id: 'call-1', tool: 'lifecycle_tool', input: {} },
+        { timeoutMs: 100 },
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(toolSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(75);
+
+      await expect(execution).resolves.toEqual({
+        ok: false,
+        error: 'Tool "lifecycle_tool" timed out after 100ms',
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('disables only the wrapper timer while preserving host cancellation', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    let toolSignal: AbortSignal | undefined;
+
+    try {
+      const execution = ToolExecutionService.execute(
+        registry(async (_input, context) => {
+          toolSignal = context?.signal;
+          await new Promise<void>((resolve) => {
+            context?.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return { ok: false, error: 'tool observed abort' };
+        }, null),
+        { id: 'call-1', tool: 'lifecycle_tool', input: {} },
+        { signal: controller.signal },
+      );
+
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(toolSignal?.aborted).toBe(false);
+
+      controller.abort(new Error('host cancelled long-running tool'));
+
+      await expect(execution).resolves.toEqual({
+        ok: false,
+        error: 'host cancelled long-running tool',
+      });
+      expect(toolSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid tool-owned timeout %s',
+    async (timeoutMs) => {
+      await expect(ToolExecutionService.execute(
+        registry(async () => ({ ok: true }), timeoutMs),
+        { id: 'call-1', tool: 'lifecycle_tool', input: {} },
+      )).resolves.toEqual({
+        ok: false,
+        error: 'Tool "lifecycle_tool" timeoutMs must be null or a positive finite number',
+      });
+    },
+  );
+
+  it.each([0, Number.POSITIVE_INFINITY])(
+    'rejects invalid caller timeout override %s',
+    async (timeoutMs) => {
+      await expect(ToolExecutionService.execute(
+        registry(async () => ({ ok: true }), 125),
+        { id: 'call-1', tool: 'lifecycle_tool', input: {} },
+        { timeoutMs },
+      )).resolves.toEqual({
+        ok: false,
+        error: 'Tool "lifecycle_tool" timeoutMs must be null or a positive finite number',
+      });
+    },
+  );
 });

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -241,6 +241,40 @@ export type {
 export { AgentLoopCheckpointService, AgentLoopRuntimeService } from './core/runtime/loop/index.js';
 export type { AgentLoopCheckpoint, AgentLoopEvent, AgentLoopResult, AgentLoopState, AgentLoopStatus, RunAgentLoopOptions } from './core/runtime/loop/index.js';
 
+// --- Specialized runtimes: read-only delegation ---------------------------
+export {
+  DEFAULT_DELEGATION_MAX_CHILDREN,
+  DEFAULT_DELEGATION_MAX_CONCURRENT_CHILDREN,
+  DEFAULT_DELEGATION_MAX_STEPS_PER_CHILD,
+  MAX_DELEGATED_SUMMARY_LENGTH,
+  MAX_DELEGATED_TASK_LENGTH,
+  MAX_DELEGATION_CHILDREN,
+  MAX_DELEGATION_CONCURRENT_CHILDREN,
+  MAX_DELEGATION_STEPS_PER_CHILD,
+  DelegationPolicyService,
+  DelegationRootScope,
+  DelegationService,
+} from './core/delegation/index.js';
+export type {
+  CreateDelegationRootScopeOptions,
+  DelegateTaskError,
+  DelegateTaskExecutionContext,
+  DelegateTaskInput,
+  DelegateTaskOutput,
+  DelegatedRunRecord,
+  DelegatedRunStatus,
+  DelegationAgentProfileId,
+  DelegationAgentSnapshotResolver,
+  DelegationChildLlmFactory,
+  DelegationChildLlmFactoryInput,
+  DelegationChildRuntimeOptions,
+  DelegationPolicy,
+  DelegationPolicyInput,
+  DelegationRejectionCode,
+  DelegationRootScopeSnapshot,
+  DelegationServiceOptions,
+} from './core/delegation/index.js';
+
 // --- Specialized runtimes: heartbeat ---------------------------------------
 export { HeartbeatRunnerAgent } from './core/heartbeat/agent/index.js';
 export type {

--- a/src/core/delegation/README.md
+++ b/src/core/delegation/README.md
@@ -1,0 +1,90 @@
+# Delegation
+
+`src/core/delegation` owns bounded parent-to-child agent execution for one root
+run. It turns `delegate_task` calls into read-only child executions through the
+existing `AgentLoopRuntimeService`; it does not implement another model/tool
+loop.
+
+## Boundary
+
+This domain owns:
+
+- v1 policy validation and disabled-by-default activation;
+- preallocated root, delegation, and child identities;
+- atomic total-child reservation and a per-root concurrency semaphore;
+- immutable `builtin:ask` / `builtin:review` snapshot selection;
+- the mandatory child read-only tool and approval envelopes;
+- fresh child context, adapter creation, cancellation, and step clamping;
+- bounded model-facing results and richer in-memory host records.
+
+`DelegationRootScope` owns the mutable per-root graph, reservation semaphore,
+and cancellation lifecycle. `DelegationChildRuntimeService` owns concrete
+child prompt/tool/approval composition and fresh adapter execution. Keep that
+split intact: graph state must not leak into the single-run runtime, and child
+authority must not be reconstructed by host callers.
+
+It does not own chat sessions, turn activation, durable records, live UI
+projection, provider-native delegation, child worktrees, write authority, or
+recursive delegation. Those concerns must stay in their existing host/domain
+owners or later feature slices.
+
+## Headless Composition
+
+Delegation is opt-in. Construct a service with an enabled host policy, create
+one scope before composing root tools, and pass the same `rootRunId` to the
+root runtime:
+
+```ts
+const delegation = new DelegationService({
+  policy: { enabled: true },
+});
+const scope = delegation.createRootScope({
+  workspaceRoot,
+  runtime: {
+    model,
+    apiKey,
+    baseSystemContext,
+  },
+});
+
+const root = await AgentLoopRuntimeService.run({
+  runId: scope.rootRunId,
+  goal,
+  model,
+  apiKey,
+  workspaceRoot,
+  extraTools: [scope.createTool()],
+  abortSignal,
+});
+
+const childRuns = scope.records();
+```
+
+If a host supplies custom adapters, it must provide `createChildLlm`; the
+factory is called once per child and must return a fresh adapter. The service
+rejects adapter reuse because concurrent safety is not part of `LlmAdapter`'s
+contract.
+
+Ordinary `AgentLoopRuntimeService` callers do not receive `delegate_task`, and
+omitting `runId` preserves generated run IDs. Calling `scope.cancel()` aborts
+active and queued children. A root runtime's abort signal also reaches every
+delegate tool call through the existing tool execution context.
+
+## V1 Safety Invariants
+
+- Depth is exactly one; child registries never contain `delegate_task`.
+- At most four children are reserved and at most three execute concurrently by
+  default.
+- A reservation remains consumed after completion, failure, or cancellation.
+- Child step budgets default to 24 and cannot exceed 32.
+- Only built-in ask/review snapshots are eligible.
+- Snapshot tool selection is intersected with a mandatory capability envelope.
+- A separate read-only approval policy remains active as defense in depth.
+- Children share the normalized workspace but receive no root history or root
+  profile appendix.
+- Raw child transcripts and traces never enter model-facing tool output.
+- No child is retried automatically or detached from the owning root scope.
+
+`records()` returns defensive copies of the current in-memory records,
+including trace and usage. Durable trace sidecars and conversation-turn
+summaries are intentionally deferred; do not add persistence to this domain.

--- a/src/core/delegation/README.md
+++ b/src/core/delegation/README.md
@@ -70,6 +70,11 @@ omitting `runId` preserves generated run IDs. Calling `scope.cancel()` aborts
 active and queued children. A root runtime's abort signal also reaches every
 delegate tool call through the existing tool execution context.
 
+`delegate_task` disables the tools domain's generic 30-second wrapper timeout
+because one call owns a complete child loop. Root cancellation and child step
+limits remain active. Until delegation owns a validated wall-time policy, hosts
+that need a wall-clock bound should provide an abort signal for the root run.
+
 ## V1 Safety Invariants
 
 - Depth is exactly one; child registries never contain `delegate_task`.
@@ -79,7 +84,17 @@ delegate tool call through the existing tool execution context.
 - Child step budgets default to 24 and cannot exceed 32.
 - Only built-in ask/review snapshots are eligible.
 - Snapshot tool selection is intersected with a mandatory capability envelope.
-- A separate read-only approval policy remains active as defense in depth.
+- Children receive only `project_dashboard`, `list_files`, `read_file`, and
+  `search_files`. Shell execution is not available because model-authored shell
+  syntax cannot guarantee read-only host effects, and artifact tools stay out
+  of the first-slice repository-inspection catalog to keep tool selection
+  predictable.
+- Agent-skill activation is unavailable to children so the inherited base
+  context plus immutable child-profile appendix remain the complete child
+  system context.
+- A delegation-owned approval policy independently enforces the same exact
+  tool-name and `workspace.read` capability allowlist, in addition to snapshot
+  approval policy.
 - Children share the normalized workspace but receive no root history or root
   profile appendix.
 - Raw child transcripts and traces never enter model-facing tool output.

--- a/src/core/delegation/child-runtime.ts
+++ b/src/core/delegation/child-runtime.ts
@@ -30,13 +30,15 @@ import type {
 
 const MANDATORY_CHILD_TOOL_PROFILE: RuntimeToolSelectionProfile = {
   preset: 'custom',
-  allowedCapabilities: ['workspace.read', 'shell.inspect', 'artifact.read'],
+  allowedCapabilities: ['workspace.read'],
   deniedCapabilities: [
     'agent.delegate',
     'workspace.write',
+    'shell.inspect',
     'shell.mutate',
     'memory.read',
     'memory.write',
+    'artifact.read',
     'artifact.write',
     'external.read',
     'browser.read',
@@ -49,8 +51,13 @@ const MANDATORY_CHILD_TOOL_PROFILE: RuntimeToolSelectionProfile = {
 
 const SAFE_CHILD_CAPABILITIES = new Set<ToolCapability>([
   'workspace.read',
-  'shell.inspect',
-  'artifact.read',
+]);
+
+const SAFE_CHILD_TOOL_NAMES = new Set([
+  'project_dashboard',
+  'list_files',
+  'read_file',
+  'search_files',
 ]);
 
 const CHILD_RUNTIME_OPTION_KEYS = [
@@ -188,14 +195,10 @@ export class DelegationChildRuntimeService {
     const tools = RuntimeToolProfileService.apply({
       tools: snapshotTools,
       profile: MANDATORY_CHILD_TOOL_PROFILE,
-    });
+    }).filter((tool) => SAFE_CHILD_TOOL_NAMES.has(tool.name));
 
     tools.forEach((tool) => {
-      const capabilities = RuntimeToolProfileService.capabilitiesFor(tool);
-      const isSafe = tool.name !== 'delegate_task'
-        && capabilities.length > 0
-        && capabilities.every((capability) => SAFE_CHILD_CAPABILITIES.has(capability));
-      if (!isSafe) {
+      if (!DelegationChildRuntimeService.isSafeChildTool(tool)) {
         throw new Error(
           `${DelegationPolicyService.message('agent_not_read_only')} Tool: ${tool.name}`,
         );
@@ -210,10 +213,28 @@ export class DelegationChildRuntimeService {
     const snapshotPolicies = ToolApprovalProfileService.compile({
       profile: snapshot.approvalProfile,
     });
-    return ToolApprovalProfileService.compile({
-      profile: { preset: 'read_only' },
-      basePolicies: snapshotPolicies,
-    });
+    return [
+      DelegationChildRuntimeService.enforceSafeChildToolAllowlist(),
+      ...snapshotPolicies,
+    ];
+  }
+
+  private static enforceSafeChildToolAllowlist(): ToolApprovalPolicy {
+    return ({ tool }) => {
+      return DelegationChildRuntimeService.isSafeChildTool(tool)
+        ? undefined
+        : {
+          type: 'deny',
+          reason: `${tool.name} is outside the delegated read-only tool allowlist`,
+        };
+    };
+  }
+
+  private static isSafeChildTool(tool: ToolDefinition): boolean {
+    const capabilities = RuntimeToolProfileService.capabilitiesFor(tool);
+    return SAFE_CHILD_TOOL_NAMES.has(tool.name)
+      && capabilities.length > 0
+      && capabilities.every((capability) => SAFE_CHILD_CAPABILITIES.has(capability));
   }
 
   private async createChildLlm(input: {

--- a/src/core/delegation/child-runtime.ts
+++ b/src/core/delegation/child-runtime.ts
@@ -1,0 +1,270 @@
+import cloneDeep from 'lodash/cloneDeep.js';
+import pick from 'lodash/pick.js';
+import { ToolApprovalProfileService } from '@/core/approvals/index.js';
+import type { ToolApprovalPolicy } from '@/core/approvals/index.js';
+import {
+  CustomAgentRuntimeContextService,
+} from '@/core/custom-agents/index.js';
+import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
+import type { LlmAdapter } from '@/core/llm/types.js';
+import {
+  AgentLoopRuntimeService,
+} from '@/core/runtime/loop/index.js';
+import type { AgentLoopResult } from '@/core/runtime/loop/index.js';
+import {
+  RuntimeToolProfileService,
+  RuntimeToolService,
+} from '@/core/runtime/tools/index.js';
+import type {
+  RuntimeToolSelectionProfile,
+  ToolCapability,
+} from '@/core/runtime/tools/index.js';
+import type { ToolDefinition } from '@/core/types.js';
+import { DelegationPolicyService } from './policy.js';
+import type {
+  DelegatedRunRecord,
+  DelegationAgentProfileId,
+  DelegationChildRuntimeOptions,
+  DelegationPolicy,
+} from './types.js';
+
+const MANDATORY_CHILD_TOOL_PROFILE: RuntimeToolSelectionProfile = {
+  preset: 'custom',
+  allowedCapabilities: ['workspace.read', 'shell.inspect', 'artifact.read'],
+  deniedCapabilities: [
+    'agent.delegate',
+    'workspace.write',
+    'shell.mutate',
+    'memory.read',
+    'memory.write',
+    'artifact.write',
+    'external.read',
+    'browser.read',
+    'browser.action',
+    'mcp.unknown',
+    'internal.state',
+  ],
+  memoryMode: 'none',
+};
+
+const SAFE_CHILD_CAPABILITIES = new Set<ToolCapability>([
+  'workspace.read',
+  'shell.inspect',
+  'artifact.read',
+]);
+
+const CHILD_RUNTIME_OPTION_KEYS = [
+  'model',
+  'reasoningEffort',
+  'apiKey',
+  'apiKeyProvider',
+  'credential',
+  'preferApiKey',
+  'maxToolConcurrency',
+  'stateDir',
+  'memoryDir',
+  'searchIgnoreDirs',
+  'baseSystemContext',
+  'logger',
+  'createChildLlm',
+] as const satisfies readonly (keyof DelegationChildRuntimeOptions)[];
+
+/**
+ * Builds and executes one child through the existing single-run runtime while
+ * enforcing the non-widenable v1 context, tool, approval, and adapter rules.
+ */
+export class DelegationChildRuntimeService {
+  private readonly runtime: Readonly<DelegationChildRuntimeOptions>;
+  private readonly childAdapters = new WeakSet<object>();
+  private readonly policy: DelegationPolicy;
+  private readonly rootRunId: string;
+  private readonly workspaceRoot: string;
+
+  constructor(options: {
+    rootRunId: string;
+    workspaceRoot: string;
+    policy: DelegationPolicy;
+    runtime: DelegationChildRuntimeOptions;
+  }) {
+    this.rootRunId = options.rootRunId;
+    this.workspaceRoot = options.workspaceRoot;
+    this.policy = options.policy;
+    const runtime = pick(options.runtime, CHILD_RUNTIME_OPTION_KEYS);
+    this.runtime = Object.freeze({
+      ...runtime,
+      searchIgnoreDirs: runtime.searchIgnoreDirs
+        ? Object.freeze([...runtime.searchIgnoreDirs]) as string[]
+        : undefined,
+    });
+    if (!this.runtime.model.trim() || this.runtime.model !== this.runtime.model.trim()) {
+      throw new Error('Delegation child runtime model must be a non-empty trimmed string');
+    }
+  }
+
+  /**
+   * Fails before root execution if a configured profile or the current tool
+   * catalog cannot satisfy the mandatory child envelope.
+   */
+  preflightSnapshot(
+    agentProfileId: DelegationAgentProfileId,
+    snapshot: CustomAgentExecutionSnapshot,
+  ): void {
+    DelegationChildRuntimeService.assertReadOnlySnapshot(agentProfileId, snapshot);
+    this.buildChildTools(snapshot);
+  }
+
+  async run(input: {
+    record: DelegatedRunRecord;
+    snapshot: CustomAgentExecutionSnapshot;
+    signal: AbortSignal;
+  }): Promise<AgentLoopResult> {
+    try {
+      return await this.execute(input);
+    } catch (error: unknown) {
+      if (!input.signal.aborted) {
+        this.runtime.logger?.warn({
+          rootRunId: this.rootRunId,
+          delegationId: input.record.delegationId,
+          childRunId: input.record.childRunId,
+          errorType: error instanceof Error ? error.name : typeof error,
+        }, 'Delegated child execution failed');
+      }
+      throw error;
+    }
+  }
+
+  private async execute(input: {
+    record: DelegatedRunRecord;
+    snapshot: CustomAgentExecutionSnapshot;
+    signal: AbortSignal;
+  }): Promise<AgentLoopResult> {
+    input.signal.throwIfAborted();
+    const tools = this.buildChildTools(input.snapshot);
+    const systemContext = CustomAgentRuntimeContextService.appendAgentInstructions({
+      systemContext: this.runtime.baseSystemContext,
+      snapshot: input.snapshot,
+    });
+    const llm = await this.createChildLlm(input);
+    input.signal.throwIfAborted();
+
+    const {
+      baseSystemContext: _baseSystemContext,
+      createChildLlm: _createChildLlm,
+      ...runtime
+    } = this.runtime;
+    const effectiveMaxSteps = Math.min(
+      input.snapshot.runtime.maxSteps ?? this.policy.maxStepsPerChild,
+      this.policy.maxStepsPerChild,
+    );
+
+    return await AgentLoopRuntimeService.run({
+      ...runtime,
+      runId: input.record.childRunId,
+      goal: input.record.task,
+      workspaceRoot: this.workspaceRoot,
+      tools,
+      includeDefaultTools: false,
+      includePlanTool: false,
+      history: [],
+      systemContext,
+      maxSteps: effectiveMaxSteps,
+      approvalPolicies: this.createChildApprovalPolicies(input.snapshot),
+      abortSignal: input.signal,
+      ...(llm ? { llm } : {}),
+    });
+  }
+
+  private buildChildTools(snapshot: CustomAgentExecutionSnapshot): ToolDefinition[] {
+    const snapshotTools = RuntimeToolService.createDefaultAgentTools({
+      model: this.runtime.model,
+      workspaceRoot: this.workspaceRoot,
+      stateDir: this.runtime.stateDir,
+      memoryDir: this.runtime.memoryDir,
+      memoryMode: snapshot.toolProfile.memoryMode ?? 'none',
+      searchIgnoreDirs: this.runtime.searchIgnoreDirs,
+      includePlanTool: false,
+      toolProfile: snapshot.toolProfile,
+    });
+    const tools = RuntimeToolProfileService.apply({
+      tools: snapshotTools,
+      profile: MANDATORY_CHILD_TOOL_PROFILE,
+    });
+
+    tools.forEach((tool) => {
+      const capabilities = RuntimeToolProfileService.capabilitiesFor(tool);
+      const isSafe = tool.name !== 'delegate_task'
+        && capabilities.length > 0
+        && capabilities.every((capability) => SAFE_CHILD_CAPABILITIES.has(capability));
+      if (!isSafe) {
+        throw new Error(
+          `${DelegationPolicyService.message('agent_not_read_only')} Tool: ${tool.name}`,
+        );
+      }
+    });
+    return tools;
+  }
+
+  private createChildApprovalPolicies(
+    snapshot: CustomAgentExecutionSnapshot,
+  ): ToolApprovalPolicy[] {
+    const snapshotPolicies = ToolApprovalProfileService.compile({
+      profile: snapshot.approvalProfile,
+    });
+    return ToolApprovalProfileService.compile({
+      profile: { preset: 'read_only' },
+      basePolicies: snapshotPolicies,
+    });
+  }
+
+  private async createChildLlm(input: {
+    record: DelegatedRunRecord;
+    snapshot: CustomAgentExecutionSnapshot;
+    signal: AbortSignal;
+  }): Promise<LlmAdapter | undefined> {
+    if (!this.runtime.createChildLlm) {
+      return undefined;
+    }
+
+    const adapter = await this.runtime.createChildLlm({
+      rootRunId: this.rootRunId,
+      parentRunId: this.rootRunId,
+      childRunId: input.record.childRunId,
+      delegationId: input.record.delegationId,
+      depth: 1,
+      task: input.record.task,
+      agentSnapshot: cloneDeep(input.snapshot),
+      model: this.runtime.model,
+      reasoningEffort: this.runtime.reasoningEffort,
+      signal: input.signal,
+    });
+    if (!adapter || typeof adapter !== 'object' || typeof adapter.chat !== 'function') {
+      throw new TypeError('Delegation child LLM factory must return an LlmAdapter');
+    }
+    if (this.childAdapters.has(adapter)) {
+      throw new Error('Delegation child LLM factory must return a fresh adapter for every child');
+    }
+
+    this.childAdapters.add(adapter);
+    return adapter;
+  }
+
+  private static assertReadOnlySnapshot(
+    agentProfileId: DelegationAgentProfileId,
+    snapshot: CustomAgentExecutionSnapshot,
+  ): void {
+    const maxSteps = snapshot.runtime.maxSteps;
+    const validStepDefault = maxSteps === undefined
+      || (Number.isInteger(maxSteps) && maxSteps > 0);
+    const safelyReadOnly = snapshot.agentProfileId === agentProfileId
+      && snapshot.source === 'built-in'
+      && snapshot.toolProfile.preset === 'inspect'
+      && snapshot.toolProfile.memoryMode === 'none'
+      && snapshot.approvalProfile.preset === 'read_only'
+      && validStepDefault;
+    if (!safelyReadOnly) {
+      throw new Error(
+        `${DelegationPolicyService.message('agent_not_read_only')} Profile: ${agentProfileId}`,
+      );
+    }
+  }
+}

--- a/src/core/delegation/index.ts
+++ b/src/core/delegation/index.ts
@@ -1,0 +1,34 @@
+export {
+  DelegationRootScope,
+  DelegationService,
+} from './service.js';
+export {
+  DEFAULT_DELEGATION_MAX_CHILDREN,
+  DEFAULT_DELEGATION_MAX_CONCURRENT_CHILDREN,
+  DEFAULT_DELEGATION_MAX_STEPS_PER_CHILD,
+  MAX_DELEGATED_SUMMARY_LENGTH,
+  MAX_DELEGATED_TASK_LENGTH,
+  MAX_DELEGATION_CHILDREN,
+  MAX_DELEGATION_CONCURRENT_CHILDREN,
+  MAX_DELEGATION_STEPS_PER_CHILD,
+  DelegationPolicyService,
+} from './policy.js';
+export type {
+  CreateDelegationRootScopeOptions,
+  DelegateTaskError,
+  DelegateTaskExecutionContext,
+  DelegateTaskInput,
+  DelegateTaskOutput,
+  DelegatedRunRecord,
+  DelegatedRunStatus,
+  DelegationAgentProfileId,
+  DelegationAgentSnapshotResolver,
+  DelegationChildLlmFactory,
+  DelegationChildLlmFactoryInput,
+  DelegationChildRuntimeOptions,
+  DelegationPolicy,
+  DelegationPolicyInput,
+  DelegationRejectionCode,
+  DelegationRootScopeSnapshot,
+  DelegationServiceOptions,
+} from './types.js';

--- a/src/core/delegation/policy.ts
+++ b/src/core/delegation/policy.ts
@@ -1,0 +1,190 @@
+import type {
+  DelegateTaskInput,
+  DelegationAgentProfileId,
+  DelegationPolicy,
+  DelegationPolicyInput,
+  DelegationRejectionCode,
+} from './types.js';
+
+export const DEFAULT_DELEGATION_MAX_CHILDREN = 4;
+export const DEFAULT_DELEGATION_MAX_CONCURRENT_CHILDREN = 3;
+export const DEFAULT_DELEGATION_MAX_STEPS_PER_CHILD = 24;
+export const MAX_DELEGATION_CHILDREN = 4;
+export const MAX_DELEGATION_CONCURRENT_CHILDREN = 3;
+export const MAX_DELEGATION_STEPS_PER_CHILD = 32;
+export const MAX_DELEGATED_TASK_LENGTH = 8_000;
+export const MAX_DELEGATED_SUMMARY_LENGTH = 8_000;
+
+const SUPPORTED_AGENT_PROFILE_IDS = new Set<DelegationAgentProfileId>([
+  'builtin:ask',
+  'builtin:review',
+]);
+
+const DEFAULT_AGENT_PROFILE_IDS: DelegationAgentProfileId[] = [
+  'builtin:ask',
+  'builtin:review',
+];
+
+type DelegationRequestResolution =
+  | { ok: true; input: DelegateTaskInput }
+  | { ok: false; code: DelegationRejectionCode };
+
+/**
+ * Owns v1 delegation-envelope validation and request authorization.
+ */
+export class DelegationPolicyService {
+  static resolve(input: DelegationPolicyInput = {}): DelegationPolicy {
+    const allowedAgentProfileIds = [
+      ...new Set(input.allowedAgentProfileIds ?? DEFAULT_AGENT_PROFILE_IDS),
+    ];
+    const policy = {
+      enabled: input.enabled ?? false,
+      maxDepth: input.maxDepth ?? 1,
+      maxChildren: input.maxChildren ?? DEFAULT_DELEGATION_MAX_CHILDREN,
+      maxConcurrentChildren:
+        input.maxConcurrentChildren ?? DEFAULT_DELEGATION_MAX_CONCURRENT_CHILDREN,
+      maxStepsPerChild:
+        input.maxStepsPerChild ?? DEFAULT_DELEGATION_MAX_STEPS_PER_CHILD,
+      allowedAgentProfileIds,
+    };
+
+    if (typeof policy.enabled !== 'boolean') {
+      throw new TypeError('delegation enabled must be a boolean');
+    }
+    if (policy.maxDepth !== 1) {
+      throw new RangeError('delegation maxDepth must be exactly 1 in v1');
+    }
+    DelegationPolicyService.assertIntegerRange(
+      'maxChildren',
+      policy.maxChildren,
+      1,
+      MAX_DELEGATION_CHILDREN,
+    );
+    DelegationPolicyService.assertIntegerRange(
+      'maxConcurrentChildren',
+      policy.maxConcurrentChildren,
+      1,
+      MAX_DELEGATION_CONCURRENT_CHILDREN,
+    );
+    if (policy.maxConcurrentChildren > policy.maxChildren) {
+      throw new RangeError('delegation maxConcurrentChildren cannot exceed maxChildren');
+    }
+    DelegationPolicyService.assertIntegerRange(
+      'maxStepsPerChild',
+      policy.maxStepsPerChild,
+      1,
+      MAX_DELEGATION_STEPS_PER_CHILD,
+    );
+    if (allowedAgentProfileIds.length === 0) {
+      throw new RangeError('delegation allowedAgentProfileIds must not be empty');
+    }
+
+    const unsupportedProfile = allowedAgentProfileIds.find(
+      (profileId) => !SUPPORTED_AGENT_PROFILE_IDS.has(profileId as DelegationAgentProfileId),
+    );
+    if (unsupportedProfile) {
+      throw new Error(
+        `Delegation v1 only supports builtin:ask and builtin:review; received ${unsupportedProfile}`,
+      );
+    }
+
+    return Object.freeze({
+      ...policy,
+      maxDepth: 1,
+      allowedAgentProfileIds: Object.freeze(
+        allowedAgentProfileIds as DelegationAgentProfileId[],
+      ),
+    });
+  }
+
+  static resolveRequest(input: {
+    raw: unknown;
+    policy: DelegationPolicy;
+    parentDepth: number;
+    reservedChildren: number;
+    cancelled: boolean;
+  }): DelegationRequestResolution {
+    if (!input.policy.enabled) {
+      return { ok: false, code: 'delegation_disabled' };
+    }
+    if (!Number.isInteger(input.parentDepth) || input.parentDepth < 0 || input.parentDepth >= input.policy.maxDepth) {
+      return { ok: false, code: 'depth_limit' };
+    }
+    if (input.cancelled) {
+      return { ok: false, code: 'cancelled' };
+    }
+
+    const parsed = DelegationPolicyService.parseTaskInput(input.raw);
+    if (!parsed.ok) {
+      return parsed;
+    }
+    if (!input.policy.allowedAgentProfileIds.includes(parsed.input.agentProfileId ?? 'builtin:ask')) {
+      return { ok: false, code: 'agent_not_allowed' };
+    }
+    if (input.reservedChildren >= input.policy.maxChildren) {
+      return { ok: false, code: 'child_limit' };
+    }
+
+    return { ok: true, input: parsed.input };
+  }
+
+  static message(code: DelegationRejectionCode): string {
+    const messages: Record<DelegationRejectionCode, string> = {
+      delegation_disabled: 'Delegation is disabled for this root run.',
+      depth_limit: 'Delegation is limited to one child level.',
+      child_limit: 'The root run has reached its total delegated-child limit.',
+      agent_not_allowed: 'The requested child agent profile is not allowed.',
+      agent_not_read_only: 'The requested child agent profile is not safely read-only.',
+      invalid_task: `delegate_task requires a non-empty task up to ${MAX_DELEGATED_TASK_LENGTH} characters and an optional supported agentProfileId.`,
+      cancelled: 'Delegated work was cancelled by the host.',
+      child_failed: 'The delegated child did not complete successfully.',
+    };
+    return messages[code];
+  }
+
+  private static parseTaskInput(raw: unknown): DelegationRequestResolution {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return { ok: false, code: 'invalid_task' };
+    }
+
+    const input = raw as Record<string, unknown>;
+    const allowedKeys = new Set(['task', 'agentProfileId']);
+    if (Object.keys(input).some((key) => !allowedKeys.has(key))) {
+      return { ok: false, code: 'invalid_task' };
+    }
+    if (
+      typeof input.task !== 'string'
+      || !input.task.trim()
+      || input.task.length > MAX_DELEGATED_TASK_LENGTH
+    ) {
+      return { ok: false, code: 'invalid_task' };
+    }
+    if (
+      input.agentProfileId !== undefined
+      && typeof input.agentProfileId !== 'string'
+    ) {
+      return { ok: false, code: 'agent_not_allowed' };
+    }
+
+    return {
+      ok: true,
+      input: {
+        task: input.task.trim(),
+        agentProfileId: input.agentProfileId as DelegationAgentProfileId | undefined,
+      },
+    };
+  }
+
+  private static assertIntegerRange(
+    field: string,
+    value: number,
+    minimum: number,
+    maximum: number,
+  ): void {
+    if (!Number.isInteger(value) || value < minimum || value > maximum) {
+      throw new RangeError(
+        `delegation ${field} must be an integer between ${minimum} and ${maximum}`,
+      );
+    }
+  }
+}

--- a/src/core/delegation/policy.ts
+++ b/src/core/delegation/policy.ts
@@ -118,7 +118,10 @@ export class DelegationPolicyService {
     if (!parsed.ok) {
       return parsed;
     }
-    if (!input.policy.allowedAgentProfileIds.includes(parsed.input.agentProfileId ?? 'builtin:ask')) {
+    if (
+      parsed.input.agentProfileId
+      && !input.policy.allowedAgentProfileIds.includes(parsed.input.agentProfileId)
+    ) {
       return { ok: false, code: 'agent_not_allowed' };
     }
     if (input.reservedChildren >= input.policy.maxChildren) {

--- a/src/core/delegation/service.ts
+++ b/src/core/delegation/service.ts
@@ -1,0 +1,362 @@
+import { randomUUID } from 'node:crypto';
+import { resolve } from 'node:path';
+import { Semaphore } from 'async-mutex';
+import cloneDeep from 'lodash/cloneDeep.js';
+import truncate from 'lodash/truncate.js';
+import {
+  CustomAgentService,
+} from '@/core/custom-agents/index.js';
+import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
+import {
+  AgentLoopCheckpointService,
+} from '@/core/runtime/loop/index.js';
+import type { AgentLoopResult } from '@/core/runtime/loop/index.js';
+import type { ToolDefinition, ToolResult } from '@/core/types.js';
+import {
+  DelegationPolicyService,
+  MAX_DELEGATED_SUMMARY_LENGTH,
+  MAX_DELEGATED_TASK_LENGTH,
+} from './policy.js';
+import type {
+  CreateDelegationRootScopeOptions,
+  DelegateTaskExecutionContext,
+  DelegateTaskOutput,
+  DelegatedRunRecord,
+  DelegationAgentProfileId,
+  DelegationAgentSnapshotResolver,
+  DelegationPolicy,
+  DelegationRejectionCode,
+  DelegationRootScopeSnapshot,
+  DelegationServiceOptions,
+} from './types.js';
+import { DelegationChildRuntimeService } from './child-runtime.js';
+
+type ReservedChild = {
+  record: DelegatedRunRecord;
+  controller: AbortController;
+  snapshot: CustomAgentExecutionSnapshot;
+};
+
+/**
+ * Host-owned delegation configuration. Create one root scope per root run;
+ * the service itself keeps no cross-run mutable execution state.
+ */
+export class DelegationService {
+  readonly policy: DelegationPolicy;
+
+  constructor(options: DelegationServiceOptions = {}) {
+    this.policy = DelegationPolicyService.resolve(options.policy);
+  }
+
+  get enabled(): boolean {
+    return this.policy.enabled;
+  }
+
+  createRootScope(options: CreateDelegationRootScopeOptions): DelegationRootScope {
+    return new DelegationRootScope(this.policy, options);
+  }
+}
+
+/**
+ * Owns one root run's child reservations, scheduling, cancellation, and
+ * host-visible records. It never creates chat sessions or a second agent loop.
+ */
+export class DelegationRootScope {
+  readonly rootRunId: string;
+  readonly workspaceRoot: string;
+  readonly policy: DelegationPolicy;
+
+  private readonly agentSnapshots: ReadonlyMap<DelegationAgentProfileId, CustomAgentExecutionSnapshot>;
+  private readonly childRecords: DelegatedRunRecord[] = [];
+  private readonly childControllers = new Map<string, AbortController>();
+  private readonly childRuntime: DelegationChildRuntimeService;
+  private readonly semaphore: Semaphore;
+  private readonly scopeController = new AbortController();
+
+  constructor(
+    policy: DelegationPolicy,
+    options: CreateDelegationRootScopeOptions,
+  ) {
+    this.policy = DelegationPolicyService.resolve(policy);
+    this.rootRunId = AgentLoopCheckpointService.resolveRunId(options.rootRunId);
+    this.workspaceRoot = resolve(options.workspaceRoot);
+    this.semaphore = new Semaphore(this.policy.maxConcurrentChildren);
+    this.childRuntime = new DelegationChildRuntimeService({
+      rootRunId: this.rootRunId,
+      workspaceRoot: this.workspaceRoot,
+      policy: this.policy,
+      runtime: options.runtime,
+    });
+
+    const resolver = options.agentSnapshotResolver
+      ?? new CustomAgentService({
+        workspaceRoot: this.workspaceRoot,
+        homeDir: options.homeDir,
+      });
+    this.agentSnapshots = this.policy.enabled
+      ? this.resolveAgentSnapshots(resolver)
+      : new Map();
+  }
+
+  /**
+   * Creates the only model-visible delegation entry point for this scope.
+   */
+  createTool(): ToolDefinition {
+    return {
+      name: 'delegate_task',
+      description: [
+        'Run one bounded, read-only child agent on an independent inspection task.',
+        'The child receives the same workspace but no parent transcript and cannot delegate or mutate state.',
+        `task is required and limited to ${MAX_DELEGATED_TASK_LENGTH} characters.`,
+        'agentProfileId may be builtin:ask (default) or builtin:review when allowed by the host.',
+      ].join(' '),
+      capabilities: ['agent.delegate'],
+      concurrency: 'parallel-safe',
+      parameters: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          task: {
+            type: 'string',
+            minLength: 1,
+            maxLength: MAX_DELEGATED_TASK_LENGTH,
+            description: 'Self-contained inspection or review task for the child agent.',
+          },
+          agentProfileId: {
+            type: 'string',
+            enum: [...this.policy.allowedAgentProfileIds],
+            description: 'Read-only child profile. Omit to use builtin:ask.',
+          },
+        },
+        required: ['task'],
+      },
+      execute: async (raw, context) => await this.delegateTask(raw, {
+        signal: context?.signal,
+        parentDepth: 0,
+      }),
+    };
+  }
+
+  /**
+   * Executes the same policy path used by the model-visible tool. A reservation
+   * is registered synchronously before the first awaited operation.
+   */
+  async delegateTask(
+    raw: unknown,
+    context: DelegateTaskExecutionContext = {},
+  ): Promise<ToolResult> {
+    const request = DelegationPolicyService.resolveRequest({
+      raw,
+      policy: this.policy,
+      parentDepth: context.parentDepth ?? 0,
+      reservedChildren: this.childRecords.length,
+      cancelled: this.scopeController.signal.aborted || context.signal?.aborted === true,
+    });
+    if (!request.ok) {
+      return this.rejection(request.code);
+    }
+
+    const agentProfileId = request.input.agentProfileId ?? 'builtin:ask';
+    const snapshot = this.agentSnapshots.get(agentProfileId);
+    if (!snapshot) {
+      return this.rejection('agent_not_allowed');
+    }
+
+    const reserved = this.reserveChild({
+      task: request.input.task,
+      agentProfileId,
+      snapshot,
+    });
+    return await this.executeReservedChild(reserved, context.signal);
+  }
+
+  records(): DelegatedRunRecord[] {
+    return cloneDeep(this.childRecords);
+  }
+
+  snapshot(): DelegationRootScopeSnapshot {
+    return {
+      schemaVersion: 1,
+      rootRunId: this.rootRunId,
+      policy: cloneDeep(this.policy),
+      records: this.records(),
+    };
+  }
+
+  cancel(reason?: unknown): void {
+    if (!this.scopeController.signal.aborted) {
+      this.scopeController.abort(reason);
+    }
+    this.childControllers.forEach((controller) => {
+      if (!controller.signal.aborted) {
+        controller.abort(reason);
+      }
+    });
+  }
+
+  private resolveAgentSnapshots(
+    resolver: DelegationAgentSnapshotResolver,
+  ): ReadonlyMap<DelegationAgentProfileId, CustomAgentExecutionSnapshot> {
+    return new Map(this.policy.allowedAgentProfileIds.map((agentProfileId) => {
+      const snapshot = resolver.resolveExecutionSnapshot(agentProfileId);
+      if (!snapshot) {
+        throw new Error(`Delegation agent profile could not be resolved: ${agentProfileId}`);
+      }
+      this.childRuntime.preflightSnapshot(agentProfileId, snapshot);
+      return [agentProfileId, cloneDeep(snapshot)];
+    }));
+  }
+
+  private reserveChild(input: {
+    task: string;
+    agentProfileId: DelegationAgentProfileId;
+    snapshot: CustomAgentExecutionSnapshot;
+  }): ReservedChild {
+    const delegationId = `delegation_${randomUUID()}`;
+    const childRunId = this.nextChildRunId();
+    const controller = new AbortController();
+    const record: DelegatedRunRecord = {
+      schemaVersion: 1,
+      delegationId,
+      rootRunId: this.rootRunId,
+      parentRunId: this.rootRunId,
+      childRunId,
+      depth: 1,
+      task: input.task,
+      agentSnapshot: cloneDeep(input.snapshot),
+      status: 'running',
+      startedAt: new Date().toISOString(),
+      trace: [],
+    };
+
+    this.childRecords.push(record);
+    this.childControllers.set(childRunId, controller);
+    return { record, controller, snapshot: cloneDeep(input.snapshot) };
+  }
+
+  private nextChildRunId(): string {
+    const usedRunIds = new Set([
+      this.rootRunId,
+      ...this.childRecords.map((record) => record.childRunId),
+    ]);
+    let runId = AgentLoopCheckpointService.generateRunId();
+    while (usedRunIds.has(runId)) {
+      runId = AgentLoopCheckpointService.generateRunId();
+    }
+    return runId;
+  }
+
+  private async executeReservedChild(
+    reserved: ReservedChild,
+    parentSignal: AbortSignal | undefined,
+  ): Promise<ToolResult> {
+    const signal = AbortSignal.any([
+      this.scopeController.signal,
+      reserved.controller.signal,
+      ...(parentSignal ? [parentSignal] : []),
+    ]);
+
+    try {
+      return await this.semaphore.runExclusive(async () => {
+        if (signal.aborted) {
+          return this.settleWithoutResult(reserved.record, 'cancelled');
+        }
+
+        try {
+          const result = await this.childRuntime.run({
+            record: reserved.record,
+            snapshot: reserved.snapshot,
+            signal,
+          });
+          return this.settleResult(reserved.record, result);
+        } catch {
+          return this.settleWithoutResult(
+            reserved.record,
+            signal.aborted ? 'cancelled' : 'child_failed',
+          );
+        }
+      });
+    } finally {
+      this.childControllers.delete(reserved.record.childRunId);
+    }
+  }
+
+  private settleResult(
+    record: DelegatedRunRecord,
+    result: AgentLoopResult,
+  ): ToolResult {
+    const cancelled = result.outcome === 'interrupted';
+    Object.assign(record, {
+      status: cancelled ? 'cancelled' : 'finished',
+      outcome: result.outcome,
+      summary: result.summary,
+      ...(result.failure ? { failure: result.failure } : {}),
+      model: result.model,
+      provider: result.provider,
+      ...(result.usage ? { usage: result.usage } : {}),
+      trace: cloneDeep(result.trace),
+      finishedAt: new Date().toISOString(),
+    });
+
+    return this.resultForRecord(
+      record,
+      result.outcome === 'done'
+        ? undefined
+        : cancelled ? 'cancelled' : 'child_failed',
+    );
+  }
+
+  private settleWithoutResult(
+    record: DelegatedRunRecord,
+    code: 'cancelled' | 'child_failed',
+  ): ToolResult {
+    Object.assign(record, {
+      status: code === 'cancelled' ? 'cancelled' : 'finished',
+      outcome: code === 'cancelled' ? 'interrupted' : 'error',
+      summary: DelegationPolicyService.message(code),
+      finishedAt: new Date().toISOString(),
+    });
+    return this.resultForRecord(record, code);
+  }
+
+  private resultForRecord(
+    record: DelegatedRunRecord,
+    code: 'cancelled' | 'child_failed' | undefined,
+  ): ToolResult {
+    const output: DelegateTaskOutput = {
+      schemaVersion: 1,
+      status: code === 'cancelled' ? 'cancelled' : 'finished',
+      delegationId: record.delegationId,
+      childRunId: record.childRunId,
+      agentProfileId: record.agentSnapshot.agentProfileId as DelegationAgentProfileId,
+      outcome: record.outcome,
+      summary: record.summary
+        ? truncate(record.summary, {
+          length: MAX_DELEGATED_SUMMARY_LENGTH,
+          omission: '...',
+        })
+        : undefined,
+      failure: record.failure,
+      ...(code ? {
+        error: {
+          code,
+          message: DelegationPolicyService.message(code),
+        },
+      } : {}),
+    };
+
+    return code
+      ? { ok: false, error: output.error?.message, output }
+      : { ok: true, output };
+  }
+
+  private rejection(code: DelegationRejectionCode): ToolResult {
+    const message = DelegationPolicyService.message(code);
+    const output: DelegateTaskOutput = {
+      schemaVersion: 1,
+      status: code === 'cancelled' ? 'cancelled' : 'rejected',
+      error: { code, message },
+    };
+    return { ok: false, error: message, output };
+  }
+}

--- a/src/core/delegation/service.ts
+++ b/src/core/delegation/service.ts
@@ -70,6 +70,7 @@ export class DelegationRootScope {
   private readonly childRecords: DelegatedRunRecord[] = [];
   private readonly childControllers = new Map<string, AbortController>();
   private readonly childRuntime: DelegationChildRuntimeService;
+  private readonly defaultAgentProfileId: DelegationAgentProfileId;
   private readonly semaphore: Semaphore;
   private readonly scopeController = new AbortController();
 
@@ -81,6 +82,9 @@ export class DelegationRootScope {
     this.rootRunId = AgentLoopCheckpointService.resolveRunId(options.rootRunId);
     this.workspaceRoot = resolve(options.workspaceRoot);
     this.semaphore = new Semaphore(this.policy.maxConcurrentChildren);
+    this.defaultAgentProfileId = this.policy.allowedAgentProfileIds.includes('builtin:ask')
+      ? 'builtin:ask'
+      : this.policy.allowedAgentProfileIds[0]!;
     this.childRuntime = new DelegationChildRuntimeService({
       rootRunId: this.rootRunId,
       workspaceRoot: this.workspaceRoot,
@@ -108,10 +112,11 @@ export class DelegationRootScope {
         'Run one bounded, read-only child agent on an independent inspection task.',
         'The child receives the same workspace but no parent transcript and cannot delegate or mutate state.',
         `task is required and limited to ${MAX_DELEGATED_TASK_LENGTH} characters.`,
-        'agentProfileId may be builtin:ask (default) or builtin:review when allowed by the host.',
+        `agentProfileId may be omitted to use ${this.defaultAgentProfileId}.`,
       ].join(' '),
       capabilities: ['agent.delegate'],
       concurrency: 'parallel-safe',
+      timeoutMs: null,
       parameters: {
         type: 'object',
         additionalProperties: false,
@@ -125,7 +130,7 @@ export class DelegationRootScope {
           agentProfileId: {
             type: 'string',
             enum: [...this.policy.allowedAgentProfileIds],
-            description: 'Read-only child profile. Omit to use builtin:ask.',
+            description: `Read-only child profile. Omit to use ${this.defaultAgentProfileId}.`,
           },
         },
         required: ['task'],
@@ -156,7 +161,7 @@ export class DelegationRootScope {
       return this.rejection(request.code);
     }
 
-    const agentProfileId = request.input.agentProfileId ?? 'builtin:ask';
+    const agentProfileId = request.input.agentProfileId ?? this.defaultAgentProfileId;
     const snapshot = this.agentSnapshots.get(agentProfileId);
     if (!snapshot) {
       return this.rejection('agent_not_allowed');

--- a/src/core/delegation/types.ts
+++ b/src/core/delegation/types.ts
@@ -1,0 +1,162 @@
+import type { Logger } from 'pino';
+import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
+import type {
+  LlmAdapter,
+  LlmProvider,
+  LlmUsage,
+  ReasoningEffort,
+} from '@/core/llm/types.js';
+import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
+import type {
+  RunFailure,
+  StopReason,
+  ToolExecutionContext,
+  TraceEvent,
+} from '@/core/types.js';
+
+export type DelegationAgentProfileId = 'builtin:ask' | 'builtin:review';
+
+export type DelegationPolicy = {
+  readonly enabled: boolean;
+  readonly maxDepth: 1;
+  readonly maxChildren: number;
+  readonly maxConcurrentChildren: number;
+  readonly maxStepsPerChild: number;
+  readonly allowedAgentProfileIds: readonly DelegationAgentProfileId[];
+};
+
+export type DelegationPolicyInput = {
+  enabled?: boolean;
+  maxDepth?: number;
+  maxChildren?: number;
+  maxConcurrentChildren?: number;
+  maxStepsPerChild?: number;
+  allowedAgentProfileIds?: readonly string[];
+};
+
+export type DelegationServiceOptions = {
+  policy?: DelegationPolicyInput;
+};
+
+export type DelegateTaskInput = {
+  task: string;
+  agentProfileId?: DelegationAgentProfileId;
+};
+
+export type DelegateTaskExecutionContext = ToolExecutionContext & {
+  /**
+   * Host-owned depth of the caller. The model-facing tool always supplies 0;
+   * this seam lets direct programmatic callers receive the same depth guard.
+   */
+  parentDepth?: number;
+};
+
+export type DelegationRejectionCode =
+  | 'delegation_disabled'
+  | 'depth_limit'
+  | 'child_limit'
+  | 'agent_not_allowed'
+  | 'agent_not_read_only'
+  | 'invalid_task'
+  | 'cancelled'
+  | 'child_failed';
+
+export type DelegateTaskError = {
+  code: DelegationRejectionCode;
+  message: string;
+};
+
+export type DelegateTaskOutput = {
+  schemaVersion: 1;
+  status: 'finished' | 'cancelled' | 'rejected';
+  delegationId?: string;
+  childRunId?: string;
+  agentProfileId?: DelegationAgentProfileId;
+  outcome?: StopReason;
+  summary?: string;
+  failure?: RunFailure;
+  error?: DelegateTaskError;
+};
+
+export type DelegatedRunStatus = 'running' | 'finished' | 'cancelled';
+
+/**
+ * Host-facing in-memory record. Child transcripts are deliberately omitted;
+ * model-facing tool output is a smaller projection of this record.
+ */
+export type DelegatedRunRecord = {
+  schemaVersion: 1;
+  delegationId: string;
+  rootRunId: string;
+  parentRunId: string;
+  childRunId: string;
+  depth: 1;
+  task: string;
+  agentSnapshot: CustomAgentExecutionSnapshot;
+  status: DelegatedRunStatus;
+  outcome?: StopReason;
+  summary?: string;
+  failure?: RunFailure;
+  model?: string;
+  provider?: LlmProvider;
+  usage?: LlmUsage;
+  startedAt: string;
+  finishedAt?: string;
+  trace: TraceEvent[];
+};
+
+export type DelegationRootScopeSnapshot = {
+  schemaVersion: 1;
+  rootRunId: string;
+  policy: DelegationPolicy;
+  records: DelegatedRunRecord[];
+};
+
+export type DelegationChildLlmFactoryInput = {
+  rootRunId: string;
+  parentRunId: string;
+  childRunId: string;
+  delegationId: string;
+  depth: 1;
+  task: string;
+  agentSnapshot: CustomAgentExecutionSnapshot;
+  model: string;
+  reasoningEffort?: ReasoningEffort;
+  signal: AbortSignal;
+};
+
+export type DelegationChildLlmFactory = (
+  input: DelegationChildLlmFactoryInput,
+) => LlmAdapter | Promise<LlmAdapter>;
+
+/**
+ * Root runtime facts inherited by every child. Snapshot model/reasoning
+ * defaults do not override these values in read-only delegation v1.
+ */
+export type DelegationChildRuntimeOptions = {
+  model: string;
+  reasoningEffort?: ReasoningEffort;
+  apiKey?: string;
+  apiKeyProvider?: LlmProvider | 'explicit';
+  credential?: RuntimeProviderCredential;
+  preferApiKey?: boolean;
+  maxToolConcurrency?: number;
+  stateDir?: string;
+  memoryDir?: string;
+  searchIgnoreDirs?: string[];
+  baseSystemContext?: string;
+  logger?: Logger;
+  createChildLlm?: DelegationChildLlmFactory;
+};
+
+export type DelegationAgentSnapshotResolver = {
+  resolveExecutionSnapshot(agentProfileId: string): CustomAgentExecutionSnapshot | undefined;
+};
+
+export type CreateDelegationRootScopeOptions = {
+  rootRunId?: string;
+  workspaceRoot: string;
+  runtime: DelegationChildRuntimeOptions;
+  homeDir?: string;
+  agentSnapshotResolver?: DelegationAgentSnapshotResolver;
+};

--- a/src/core/runtime/loop/checkpoint.ts
+++ b/src/core/runtime/loop/checkpoint.ts
@@ -6,6 +6,8 @@ import type { AgentLoopCheckpoint, AgentLoopState } from './types.js';
  * Owns agent-loop state snapshots and checkpoint conversion.
  */
 export class AgentLoopCheckpointService {
+  static readonly MAX_RUN_ID_LENGTH = 128;
+
   static createFinishedState(args: {
     runId: string;
     goal: string;
@@ -50,6 +52,25 @@ export class AgentLoopCheckpointService {
     const timestamp = Date.now().toString(36);
     const random = Math.random().toString(36).slice(2, 6);
     return `run_${timestamp}_${random}`;
+  }
+
+  static resolveRunId(runId: string | undefined): string {
+    if (runId === undefined) {
+      return this.generateRunId();
+    }
+
+    if (
+      !runId.trim()
+      || runId !== runId.trim()
+      || runId.length > this.MAX_RUN_ID_LENGTH
+      || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(runId)
+    ) {
+      throw new Error(
+        `runId must start with an alphanumeric character, contain only letters, numbers, ., _, :, or -, and be at most ${this.MAX_RUN_ID_LENGTH} characters`,
+      );
+    }
+
+    return runId;
   }
 
   static historyFromState(state: AgentLoopState): ChatMessage[] {

--- a/src/core/runtime/loop/service.ts
+++ b/src/core/runtime/loop/service.ts
@@ -23,7 +23,7 @@ import type { AgentLoopResult, RunAgentLoopOptions } from './types.js';
  */
 export class AgentLoopRuntimeService {
   static async run(options: RunAgentLoopOptions): Promise<AgentLoopResult> {
-    const runId = AgentLoopCheckpointService.generateRunId();
+    const runId = AgentLoopCheckpointService.resolveRunId(options.runId);
     const model = options.model ?? options.llm?.info?.model ?? process.env.OPENAI_MODEL ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_OPENAI_MODEL;
     const workspaceRoot = resolve(options.workspaceRoot ?? process.cwd());
     const credentialStorePath = this.resolveCredentialStorePath({ workspaceRoot, stateDir: options.stateDir });

--- a/src/core/runtime/loop/types.ts
+++ b/src/core/runtime/loop/types.ts
@@ -82,6 +82,11 @@ export type AgentLoopEvent =
     };
 
 export type RunAgentLoopOptions = {
+  /**
+   * Optional host-preallocated identity for this run. Omit it to preserve the
+   * runtime's generated-ID behavior.
+   */
+  runId?: string;
   goal: string;
   model?: string;
   reasoningEffort?: ReasoningEffort;

--- a/src/core/runtime/tools/profiles/types.ts
+++ b/src/core/runtime/tools/profiles/types.ts
@@ -1,4 +1,5 @@
 export type ToolCapability =
+  | 'agent.delegate'
   | 'workspace.read'
   | 'workspace.write'
   | 'shell.inspect'

--- a/src/core/tools/README.md
+++ b/src/core/tools/README.md
@@ -56,7 +56,11 @@ workspace.
 - `ToolExecutionService`: executes one tool call against a registry with
   timeout/error normalization. It removes the shared policy envelope before
   calling the tool implementation and forwards an optional `AbortSignal`
-  through `ToolExecutionContext`.
+  through `ToolExecutionContext`. The wrapper defaults to 30 seconds; a
+  host-owned `ToolDefinition.timeoutMs` can override that duration or use
+  `null` when a cancellable long-running tool owns its lifecycle. Numeric
+  values must be positive and finite; invalid definitions or call overrides
+  fail before tool execution.
 - `ToolBundleComposer`: toolkit composition API used by runtime default-tool
   assembly.
 - `policy-envelope/*`: the cross-tool declaration shape used by approval
@@ -85,6 +89,9 @@ workspace.
   concurrency safety.
 - Long-running tools should observe `ToolExecutionContext.signal` so host
   cancellation can stop in-flight work promptly.
+- Use `ToolDefinition.timeoutMs: null` only when the tool owns a bounded or
+  host-cancellable lifecycle that must not race the generic wrapper timeout.
+  This field is host-only and is never projected into model-visible schemas.
 - Extend the shared `ToolPolicyEnvelope` only when all tool families can use
   the field consistently. Tool-specific arguments stay in each tool schema.
 

--- a/src/core/tools/execute-tool.ts
+++ b/src/core/tools/execute-tool.ts
@@ -1,4 +1,4 @@
-import type { ToolCall, ToolResult } from '@/core/types.js';
+import type { ToolCall, ToolDefinition, ToolResult } from '@/core/types.js';
 import type { ToolRegistry } from './registry.js';
 import { ToolPolicyResolutionService } from './policy-envelope/index.js';
 
@@ -6,7 +6,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 
 export type ToolExecutionOptions = {
   signal?: AbortSignal;
-  timeoutMs?: number;
+  timeoutMs?: number | null;
 };
 
 /**
@@ -28,7 +28,7 @@ export class ToolExecutionService {
 
     try {
       const resolvedOptions = typeof options === 'number' ? { timeoutMs: options } : options;
-      const timeoutMs = resolvedOptions.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const timeoutMs = ToolExecutionService.resolveTimeoutMs(tool, resolvedOptions);
       const timeoutController = new AbortController();
       const signal = resolvedOptions.signal
         ? AbortSignal.any([resolvedOptions.signal, timeoutController.signal])
@@ -46,7 +46,9 @@ export class ToolExecutionService {
         };
       }
 
-      const timeoutError = new Error(`Tool "${call.tool}" timed out after ${timeoutMs}ms`);
+      const timeoutError = timeoutMs === null
+        ? undefined
+        : new Error(`Tool "${call.tool}" timed out after ${timeoutMs}ms`);
       let rejectOnAbort: (() => void) | undefined;
       const cancellation = new Promise<never>((_, reject) => {
         rejectOnAbort = () => reject(
@@ -56,7 +58,9 @@ export class ToolExecutionService {
         );
         signal.addEventListener('abort', rejectOnAbort, { once: true });
       });
-      const timer = setTimeout(() => timeoutController.abort(timeoutError), timeoutMs);
+      const timer = timeoutMs === null
+        ? undefined
+        : setTimeout(() => timeoutController.abort(timeoutError), timeoutMs);
 
       try {
         return await Promise.race([
@@ -64,7 +68,9 @@ export class ToolExecutionService {
           cancellation,
         ]);
       } finally {
-        clearTimeout(timer);
+        if (timer !== undefined) {
+          clearTimeout(timer);
+        }
         if (rejectOnAbort) {
           signal.removeEventListener('abort', rejectOnAbort);
         }
@@ -75,6 +81,21 @@ export class ToolExecutionService {
         error: err instanceof Error ? err.message : String(err),
       };
     }
+  }
+
+  private static resolveTimeoutMs(
+    tool: ToolDefinition,
+    options: ToolExecutionOptions,
+  ): number | null {
+    const timeoutMs = options.timeoutMs !== undefined
+      ? options.timeoutMs
+      : tool.timeoutMs !== undefined ? tool.timeoutMs : DEFAULT_TIMEOUT_MS;
+    if (timeoutMs !== null && (!Number.isFinite(timeoutMs) || timeoutMs <= 0)) {
+      throw new RangeError(
+        `Tool "${tool.name}" timeoutMs must be null or a positive finite number`,
+      );
+    }
+    return timeoutMs;
   }
 
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -36,6 +36,12 @@ export type ToolDefinition = {
   requiresApproval?: boolean;
   capabilities?: string[];
   /**
+   * Host-only wrapper timeout. Omit for the tools-domain 30-second default,
+   * provide a positive duration to override it, or use null when the tool owns
+   * a cancellable long-running lifecycle that must not race the generic timer.
+   */
+  timeoutMs?: number | null;
+  /**
    * Defaults to `serial`. `parallel-safe` is an explicit guarantee from the
    * tool owner that separate calls may overlap without conflicting effects or
    * shared mutable state.


### PR DESCRIPTION
## Summary

- add an opt-in delegation domain that exposes one `delegate_task` tool per root scope
- execute builtin ask/review children through the existing `AgentLoopRuntimeService`
- enforce depth 1, total 4, concurrency 3, default 24 child steps, and a ceiling of 32
- restrict child visibility and approval to the exact structured-read allowlist: `project_dashboard`, `list_files`, `read_file`, and `search_files`
- isolate child history/context, require fresh custom adapters, cascade cancellation, and retain defensive host-only records
- let `delegate_task` own its long-running lifecycle instead of racing the tools domain's generic 30-second timeout; root abort remains authoritative
- add validated caller-supplied runtime run IDs and the `agent.delegate` capability
- export the headless API from the advanced runtime entry point

## Capability change

Advanced programmatic hosts can preallocate a root scope, add `delegate_task` to that root, let the root issue multiple independent child inspections, and inspect settled child snapshot/model/provider/usage/trace records after root synthesis.

Ordinary runtime and CLI calls remain unchanged. Delegation stays disabled and absent unless a host explicitly composes it.

## Live dogfood

Ran the advanced runtime path against local Ollama from a disposable workspace. A real root model issued two `delegate_task` calls, Heddle created two unique child runs with the expected parent linkage, both children used only structured workspace reads, and the root synthesized their results correctly.

Dogfooding exposed and this revision fixes:

- the generic 30-second tool wrapper cancelled healthy child loops and caused root retries/child-limit exhaustion
- the original inspect envelope exposed shell and artifact tools that were too broad or ambiguous for the first read-only slice
- capability-only approval could admit a future or forged `workspace.read` tool outside the intended catalog
- an omitted profile failed when the host allowed only `builtin:review`

The final concise local smoke completed root plus two children in about 128 seconds. A broader repository task also showed that small local-model contexts can saturate after tool results; child context budgeting/task retention remains follow-up work rather than being hidden in this slice.

## Verification

- focused delegation/tool-lifecycle regressions: 3 files, 27 tests passed
- `yarn lint`
- `yarn typecheck`
- `yarn test`
  - unit: 137 files, 896 tests passed
  - integration: 49 files, 430 tests passed
  - execution-host-client: 16 files, 126 tests passed
  - postgres: 8 passed, 16 intentionally skipped
- `yarn build`
- live local-model smoke through the public advanced runtime composition path

Verified at `4a626371`.

## Out of scope

- conversation-engine/CLI activation and live delegation events
- a delegation-owned validated wall-clock deadline; hosts can bound the root with an abort signal
- small-context child prompt/task-retention policy
- durable child summaries or trace sidecars
- TUI/web projection
- write-capable or worktree-isolated children
- provider-native, recursive, detached, or distributed delegation
