### PR TITLE
Expose a public Drizzle schema path

### DIFF
--- a/docs/releases/postgres-v6.1.1.md
+++ b/docs/releases/postgres-v6.1.1.md
@@ -1,0 +1,14 @@
+# `@heddleagent/postgres` 6.1.1
+
+This patch makes the public heartbeat schema entrypoint resolvable by tools
+such as Drizzle Kit without exposing the package's internal build layout.
+
+## Changed
+
+- `require.resolve('@heddleagent/postgres/heartbeat/schema')` now resolves the
+  supported schema entrypoint.
+- Drizzle consumers no longer need to locate `package.json` and append a
+  `dist/heartbeat/schema.js` implementation path.
+
+The heartbeat tables, task authority, SQL migrations, and runtime behavior are
+unchanged.

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,7 +4,7 @@ Status: **five stable packages**
 
 This directory records the v6 package identities and responsibility boundaries.
 `@heddleagent/execution-host-client@6.2.0` contains its canonical
-implementation as a stable package. `@heddleagent/postgres@6.1.0` ships the
+implementation as a stable package. `@heddleagent/postgres@6.1.1` ships the
 Execution Host lifecycle and heartbeat adapters. `@heddleagent/run-client@6.0.0`
 ships the existing browser-safe run client under its final coordinate.
 `@heddleagent/runtime@6.3.0` ships the existing embeddable SDK, the bridge
@@ -23,7 +23,7 @@ keep running; new integrations should use the `@heddleagent/*` packages.
 | `@heddleagent/cli` | Installable Heddle coding-agent product and `heddle` executable | Existing CLI, TUI, daemon, and browser control plane activated at stable `6.0.0` |
 | `@heddleagent/run-client` | Browser-safe JavaScript run protocol consumer | Existing implementation activated at stable `6.0.0` |
 | `@heddleagent/execution-host-client` | Backend contracts and direct/AgentCore clients for invoking a separate compatible Execution Host | Stable `6.2.0`; explicit conversation and heartbeat workflows with hosted heartbeat composition at `/heartbeat` |
-| `@heddleagent/postgres` | Official PostgreSQL implementations for supported Heddle-owned durable ports | Stable `6.1.0`; Execution Host conversation lifecycle and heartbeat task authority are explicit subpaths |
+| `@heddleagent/postgres` | Official PostgreSQL implementations for supported Heddle-owned durable ports | Stable `6.1.1`; Execution Host conversation lifecycle and heartbeat task authority are explicit subpaths |
 
 The in-process run service is exposed from
 `@heddleagent/runtime/runs`; it is not a sixth package. Its conventional Node

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -1,7 +1,7 @@
 # `@heddleagent/postgres`
 
 Official PostgreSQL implementations for selected, public Heddle-owned durable
-ports. Version `6.1.0` ships two independent adapter families:
+ports. Version `6.1.1` ships two independent adapter families:
 
 | Entrypoint | Domain contract | Status |
 | --- | --- | --- |
@@ -150,6 +150,29 @@ required because the application—not a library running at startup—owns schem
 review, rollout order, rollback policy, and production database credentials.
 When upgrading `@heddleagent/postgres`, compare the exported ordered list with
 the migrations already adopted and copy only newly published files.
+
+### Generate a Drizzle migration from the heartbeat schema
+
+Drizzle Kit expects a filesystem path rather than a package import. Resolve the
+public schema subpath in `drizzle.config.ts`; do not inspect the package's
+internal `dist/` layout:
+
+```ts
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { defineConfig } from 'drizzle-kit';
+
+const require = createRequire(join(process.cwd(), 'package.json'));
+
+export default defineConfig({
+  dialect: 'postgresql',
+  schema: require.resolve('@heddleagent/postgres/heartbeat/schema'),
+  out: './drizzle',
+});
+```
+
+The package's public export owns the resolved file location. This workflow
+requires `@heddleagent/postgres@6.1.1` or newer.
 
 ## Correctness promise
 

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/postgres",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Official PostgreSQL adapters for selected Heddle-owned domain persistence ports",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",
@@ -30,7 +30,8 @@
     },
     "./heartbeat/schema": {
       "types": "./dist/heartbeat/schema.d.ts",
-      "import": "./dist/heartbeat/schema.js"
+      "import": "./dist/heartbeat/schema.js",
+      "default": "./dist/heartbeat/schema.js"
     },
     "./execution-host/conversations": {
       "types": "./dist/execution-host/conversations/index.d.ts",


### PR DESCRIPTION
## Summary
- make the published heartbeat schema resolvable through its public package subpath
- document the Drizzle Kit configuration without leaking the package dist layout
- prepare @heddleagent/postgres 6.1.1 release notes

## Verification
- yarn postgres:build
- packed @heddleagent/postgres@6.1.1 into a temporary consumer
- createRequire(...).resolve("@heddleagent/postgres/heartbeat/schema") resolved the packed schema
- Drizzle Kit loaded the resolved public path and reported no schema changes