### PR TITLE
feat(execution-host): centralize authority verification

### DIFF
--- a/docs/releases/execution-host-client-v6.5.0.md
+++ b/docs/releases/execution-host-client-v6.5.0.md
@@ -1,0 +1,31 @@
+# Execution Host Client v6.5.0
+
+`@heddleagent/execution-host-client@6.5.0` moves reusable Execution Host-side
+authority verification into the public package. Compatible host
+implementations no longer need private copies of the JOSE verification and
+invocation-binding rules.
+
+## What changed
+
+- add `@heddleagent/execution-host-client/host` with execution-identity and
+  MCP-capability verifier ports, schemas, errors, and JOSE implementations;
+- bind each execution assertion to the exact Runtime session, invocation, and
+  workflow admitted by the host;
+- bind each MCP capability to the independently verified product scope and
+  invocation before forwarding it to the product MCP edge; and
+- share remote-JWKS cache and unavailable-error classification across both
+  host-side and product MCP-edge verification.
+
+## Ownership boundary
+
+The package owns portable credential verification and signed-scope binding.
+The deployable Execution Host still owns HTTP ingress, Runtime-session
+isolation, model credentials, Heddle composition, streaming, provider
+bootstrap, configuration, and deployment. Products still own signing keys,
+identity and authorization decisions, capability issuance, product data, and
+the independently verified MCP edge.
+
+## Publication
+
+Publish manually from the tagged release commit. This repository does not
+automatically publish packages from `main`.

--- a/packages/execution-host-client/README.md
+++ b/packages/execution-host-client/README.md
@@ -5,7 +5,8 @@ products that invoke a separately deployed Heddle Execution Host. It lets an
 adopter keep its own language stack, authentication, database, product policy,
 MCP tools, and UI while reusing the security-sensitive v1 contract machinery.
 
-> **Current availability:** stable version `6.4.0`. The former
+> **Current availability:** `6.5.0` is the next manual release from this
+> repository; `6.4.0` remains the latest published version until then. The former
 > `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 > installable only for existing consumers. Heddle does not currently distribute
 > the compatible Execution Host implementation or offer a hosted service. The
@@ -37,6 +38,7 @@ modular AWS SDK for its AgentCore transport and the official MCP SDK, plus
 | `@heddleagent/execution-host-client/mcp/node` | Stateless official-SDK Streamable HTTP lifecycle around adopter-defined toolsets |
 | `@heddleagent/execution-host-client/http-sse` | Transport-neutral conversation and heartbeat ports plus the strict direct-development HTTP/SSE client |
 | `@heddleagent/execution-host-client/agentcore` | Official AWS AgentCore/SigV4 implementation of the same conversation and heartbeat ports |
+| `@heddleagent/execution-host-client/host` | Invocation-bound execution-identity and MCP-capability verification shared by compatible Execution Host implementations |
 | `@heddleagent/execution-host-client/testing` | Node-only loopback v1 fixture plus durable-turn store conformance for real adapters |
 | `@heddleagent/execution-host-client/node` | Optional Node JWKS/conversation HTTP edge plus safe local signing-key helpers |
 
@@ -229,6 +231,50 @@ const productMcp = new NodeStreamableHttpMcpService({
 
 Use the lower-level `NodeMcpToolset` interface only when a tool needs custom MCP
 content or lifecycle semantics.
+
+## Verify authority inside a compatible Execution Host
+
+The host must independently verify the adopter's execution assertion before it
+trusts product scope, then bind any optional MCP capability to that same
+verified invocation. Compatible host implementations can reuse that generic
+security boundary instead of maintaining their own JOSE logic:
+
+```ts
+import {
+  JwtExecutionHostMcpCapabilityVerifier,
+  JwtExecutionIdentityVerifier,
+} from '@heddleagent/execution-host-client/host'
+
+const identity = await new JwtExecutionIdentityVerifier({
+  executionIssuer: 'https://api.example.com',
+  executionAudience: 'heddle-execution-host',
+  executionJwksUrl: new URL('https://api.example.com/.well-known/jwks.json'),
+  executionJwtAlgorithms: ['ES256'],
+  trustedAdopterId: 'example-product',
+  maxAssertionAgeSeconds: 300,
+  assertionClockToleranceSeconds: 5,
+}).verify({
+  assertion: executionAssertion,
+  runtimeSessionId,
+  invocationId,
+  workflow: 'conversation-turn',
+})
+
+const capability = await new JwtExecutionHostMcpCapabilityVerifier({
+  issuer: 'https://api.example.com',
+  audience: 'example-product-mcp',
+  jwksUrl: new URL('https://api.example.com/.well-known/jwks.json'),
+  jwtAlgorithms: ['ES256'],
+  trustedAdopterId: 'example-product',
+  serverId: 'product_capabilities',
+  maxCapabilityAgeSeconds: 900,
+  clockToleranceSeconds: 5,
+}).verify({ assertion: mcpCapability, identity })
+```
+
+This surface owns credential verification and exact scope binding. It does not
+own HTTP ingress, Runtime-session isolation, model credentials, streaming,
+provider bootstrap, or deployment.
 
 ## Invoke an Execution Host
 

--- a/packages/execution-host-client/package.json
+++ b/packages/execution-host-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/execution-host-client",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "Backend contracts, execution authority, lifecycle services, and clients for compatible Heddle Execution Hosts",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",
@@ -69,6 +69,10 @@
     "./agentcore": {
       "types": "./dist/agentcore/index.d.ts",
       "import": "./dist/agentcore/index.js"
+    },
+    "./host": {
+      "types": "./dist/host/index.d.ts",
+      "import": "./dist/host/index.js"
     },
     "./testing": {
       "types": "./dist/testing/index.d.ts",

--- a/packages/execution-host-client/src/README.md
+++ b/packages/execution-host-client/src/README.md
@@ -24,17 +24,19 @@ independent so an adopter can use only the machinery it needs:
   adopter-owned product toolset;
 - `http-sse`: a strict direct-development client behind a transport-neutral
   `ExecutionHost` port;
+- `host`: invocation-bound execution-identity and MCP-capability verification
+  shared by compatible Execution Host implementations;
 - `testing`: a Node-only loopback v1 contract fixture for adopter integration
   tests. It is intentionally available only through its explicit subpath.
 - `node`: optional Node HTTP edge and safe local signing-key conveniences. It
   owns generic mechanics, never product identity or tool policy.
 
-The package must never import the Heddle runtime, Execution Host internals, a
-database adapter, or product domain code. The explicit `agentcore` surface may
+The package must never import the Heddle runtime, deployable Execution Host
+internals, a database adapter, or product domain code. The explicit `agentcore` surface may
 import the modular AWS SDK, and `mcp/node` may import the official MCP SDK, but
 neither owns product deployment or model-visible tools. New reusable machinery
-belongs here only when it is required by more than one adopter and can preserve
-that dependency boundary.
+belongs here only when it is required across adopters or compatible host
+implementations and can preserve that dependency boundary.
 
 The repository includes one clean-room Python consumer to prove the versioned
 contract is implementable outside TypeScript. It is a bounded conformance

--- a/packages/execution-host-client/src/__tests__/host-verification.test.ts
+++ b/packages/execution-host-client/src/__tests__/host-verification.test.ts
@@ -1,0 +1,183 @@
+import { createLocalJWKSet, generateKeyPair, type CryptoKey } from 'jose';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { JoseExecutionAuthority } from '../authority/index.js';
+import {
+  ExecutionHostMcpCapabilityVerificationError,
+  ExecutionIdentityUnavailableError,
+  ExecutionIdentityVerificationError,
+  JwtExecutionHostMcpCapabilityVerifier,
+  JwtExecutionIdentityVerifier,
+} from '../host/index.js';
+
+const NOW = new Date('2026-08-25T12:00:00.000Z');
+const RUNTIME_SESSION_ID = 'runtime-session-'.padEnd(33, 's');
+
+let privateKey: CryptoKey;
+let publicKey: CryptoKey;
+
+beforeAll(async () => {
+  const pair = await generateKeyPair('ES256');
+  privateKey = pair.privateKey;
+  publicKey = pair.publicKey;
+});
+
+describe('Execution Host authority verification', () => {
+  it('binds execution and MCP authority to one verified invocation', async () => {
+    const { authority, execution, mcp } = await createVerificationFixture();
+    const issued = await authority.issue({
+      scope: {
+        tenantId: 'tenant-a',
+        subjectId: 'user-a',
+        productSessionId: 'conversation-a',
+      },
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      invocationId: 'invocation-a',
+      workflow: 'conversation-turn',
+      mcp: { allowedTools: ['read_snapshot'] },
+    });
+
+    const identity = await execution.verify({
+      assertion: issued.executionAssertion(),
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      invocationId: 'invocation-a',
+      workflow: 'conversation-turn',
+    });
+    const capability = await mcp.verify({
+      assertion: issued.mcpCapability()!,
+      identity,
+    });
+
+    expect(identity).toMatchObject({
+      scope: {
+        adopterId: 'example-adopter',
+        tenantId: 'tenant-a',
+        subjectId: 'user-a',
+        productSessionId: 'conversation-a',
+      },
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      invocationId: 'invocation-a',
+      workflow: 'conversation-turn',
+    });
+    expect(capability).toMatchObject({
+      serverId: 'product_capabilities',
+      allowedTools: ['read_snapshot'],
+    });
+    expect(capability.assertion).toBe(issued.mcpCapability());
+  });
+
+  it('rejects request and capability scope mismatches', async () => {
+    const { authority, execution, mcp } = await createVerificationFixture();
+    const issued = await authority.issue({
+      scope: {
+        tenantId: 'tenant-a',
+        subjectId: 'user-a',
+        productSessionId: 'conversation-a',
+      },
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      invocationId: 'invocation-a',
+      workflow: 'conversation-turn',
+      mcp: { allowedTools: ['read_snapshot'] },
+    });
+
+    await expect(execution.verify({
+      assertion: issued.executionAssertion(),
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      invocationId: 'invocation-b',
+      workflow: 'conversation-turn',
+    })).rejects.toBeInstanceOf(ExecutionIdentityVerificationError);
+
+    const identity = await execution.verify({
+      assertion: issued.executionAssertion(),
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      invocationId: 'invocation-a',
+      workflow: 'conversation-turn',
+    });
+    await expect(mcp.verify({
+      assertion: issued.mcpCapability()!,
+      identity: {
+        ...identity,
+        scope: { ...identity.scope, tenantId: 'tenant-b' },
+      },
+    })).rejects.toBeInstanceOf(
+      ExecutionHostMcpCapabilityVerificationError,
+    );
+  });
+
+  it('classifies unavailable key resolution without exposing its cause', async () => {
+    const { authority } = await createVerificationFixture();
+    const issued = await authority.issue({
+      scope: {
+        tenantId: 'tenant-a',
+        subjectId: 'user-a',
+        productSessionId: 'conversation-a',
+      },
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      invocationId: 'invocation-a',
+      workflow: 'conversation-turn',
+    });
+    const verifier = new JwtExecutionIdentityVerifier(executionConfig(), {
+      keyResolver: () => Promise.reject(new TypeError('private network detail')),
+      now: () => NOW,
+    });
+
+    await expect(verifier.verify({
+      assertion: issued.executionAssertion(),
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      invocationId: 'invocation-a',
+      workflow: 'conversation-turn',
+    })).rejects.toMatchObject({
+      name: 'ExecutionIdentityUnavailableError',
+      category: 'network',
+      message: 'Execution identity verification is temporarily unavailable.',
+    } satisfies Partial<ExecutionIdentityUnavailableError>);
+  });
+});
+
+async function createVerificationFixture() {
+  const authority = await JoseExecutionAuthority.create({
+    issuer: 'https://api.example.test',
+    adopterId: 'example-adopter',
+    executionAudience: 'urn:heddle-execution-host:example',
+    keyId: 'authority-key',
+    executionTtlSeconds: 300,
+    mcp: {
+      audience: 'urn:example:mcp',
+      serverId: 'product_capabilities',
+      ttlSeconds: 600,
+    },
+  }, { privateKey, publicKey }, {
+    now: () => NOW,
+    createCapabilityId: () => 'capability-a',
+  });
+  const options = {
+    keyResolver: createLocalJWKSet(authority.publicJwks()),
+    now: () => NOW,
+  };
+
+  return {
+    authority,
+    execution: new JwtExecutionIdentityVerifier(executionConfig(), options),
+    mcp: new JwtExecutionHostMcpCapabilityVerifier({
+      issuer: 'https://api.example.test',
+      audience: 'urn:example:mcp',
+      jwksUrl: new URL('https://api.example.test/.well-known/jwks.json'),
+      jwtAlgorithms: ['ES256'],
+      trustedAdopterId: 'example-adopter',
+      serverId: 'product_capabilities',
+      maxCapabilityAgeSeconds: 900,
+      clockToleranceSeconds: 2,
+    }, options),
+  };
+}
+
+function executionConfig() {
+  return {
+    executionIssuer: 'https://api.example.test',
+    executionAudience: 'urn:heddle-execution-host:example',
+    executionJwksUrl: new URL('https://api.example.test/.well-known/jwks.json'),
+    executionJwtAlgorithms: ['ES256'] as const,
+    trustedAdopterId: 'example-adopter',
+    maxAssertionAgeSeconds: 300,
+    assertionClockToleranceSeconds: 2,
+  };
+}

--- a/packages/execution-host-client/src/host/README.md
+++ b/packages/execution-host-client/src/host/README.md
@@ -1,0 +1,15 @@
+# Execution Host authority verification
+
+This subpath owns the reusable verification half of Heddle's signed Execution
+Host boundary. It verifies adopter-issued execution assertions and optional MCP
+capabilities, then binds both credentials to the exact Runtime session,
+invocation, workflow, and product scope admitted by the host.
+
+The deployable Execution Host still owns HTTP ingress, local authentication,
+Runtime-session isolation, model credentials, Heddle composition, streaming,
+and provider bootstrap. Adopters still own signing keys, identity selection,
+authorization, and capability issuance.
+
+The product MCP edge uses `../mcp` instead. Its verifier derives scope from a
+capability for product data access; this module independently cross-checks that
+same capability against the host's verified execution identity.

--- a/packages/execution-host-client/src/host/errors.ts
+++ b/packages/execution-host-client/src/host/errors.ts
@@ -1,0 +1,43 @@
+import type { JwtVerificationUnavailableCategory } from '../internal/jwt-verification.js';
+
+export class ExecutionIdentityVerificationError extends Error {
+  readonly name = 'ExecutionIdentityVerificationError';
+
+  constructor(options?: ErrorOptions) {
+    super('Execution identity verification failed.', options);
+  }
+}
+
+export class ExecutionIdentityUnavailableError extends Error {
+  readonly name = 'ExecutionIdentityUnavailableError';
+
+  constructor(
+    readonly category: JwtVerificationUnavailableCategory,
+    options?: ErrorOptions,
+  ) {
+    super('Execution identity verification is temporarily unavailable.', options);
+  }
+}
+
+export class ExecutionHostMcpCapabilityVerificationError extends Error {
+  readonly name = 'ExecutionHostMcpCapabilityVerificationError';
+
+  constructor(options?: ErrorOptions) {
+    super('MCP capability verification failed.', options);
+  }
+}
+
+export class ExecutionHostMcpCapabilityUnavailableError extends Error {
+  readonly name = 'ExecutionHostMcpCapabilityUnavailableError';
+
+  constructor(
+    readonly category: JwtVerificationUnavailableCategory,
+    options?: ErrorOptions,
+  ) {
+    super('MCP capability verification is temporarily unavailable.', options);
+  }
+}
+
+export class UnexpectedExecutionHostMcpCapabilityError extends Error {
+  readonly name = 'UnexpectedExecutionHostMcpCapabilityError';
+}

--- a/packages/execution-host-client/src/host/index.ts
+++ b/packages/execution-host-client/src/host/index.ts
@@ -1,0 +1,29 @@
+export {
+  ExecutionHostMcpCapabilityUnavailableError,
+  ExecutionHostMcpCapabilityVerificationError,
+  ExecutionIdentityUnavailableError,
+  ExecutionIdentityVerificationError,
+  UnexpectedExecutionHostMcpCapabilityError,
+} from './errors.js';
+export { JwtExecutionIdentityVerifier } from './jwt-execution-identity-verifier.js';
+export { JwtExecutionHostMcpCapabilityVerifier } from './jwt-execution-host-mcp-capability-verifier.js';
+export {
+  ExecutionHostJwtAlgorithmsSchema,
+  JwtExecutionHostMcpCapabilityVerifierConfigSchema,
+  JwtExecutionIdentityVerifierConfigSchema,
+} from './schemas.js';
+export {
+  EXECUTION_HOST_SUPPORTED_JWT_ALGORITHMS,
+} from './types.js';
+export type {
+  ExecutionHostJwtAlgorithm,
+  ExecutionHostJwtVerifierOptions,
+  ExecutionHostMcpCapabilityVerificationRequest,
+  ExecutionHostMcpCapabilityVerifier,
+  ExecutionIdentityVerificationRequest,
+  ExecutionIdentityVerifier,
+  JwtExecutionHostMcpCapabilityVerifierConfig,
+  JwtExecutionIdentityVerifierConfig,
+  VerifiedExecutionHostMcpCapability,
+  VerifiedExecutionIdentity,
+} from './types.js';

--- a/packages/execution-host-client/src/host/jwt-execution-host-mcp-capability-verifier.ts
+++ b/packages/execution-host-client/src/host/jwt-execution-host-mcp-capability-verifier.ts
@@ -1,0 +1,136 @@
+import { jwtVerify } from 'jose';
+import { z } from 'zod';
+import {
+  MCP_CAPABILITY_TYPE,
+  McpCapabilityClaimsSchema,
+} from '../contracts/index.js';
+import {
+  createJwtKeyResolver,
+  resolveJwtVerificationUnavailableCategory,
+} from '../internal/jwt-verification.js';
+import {
+  ExecutionHostMcpCapabilityUnavailableError,
+  ExecutionHostMcpCapabilityVerificationError,
+} from './errors.js';
+import { JwtExecutionHostMcpCapabilityVerifierConfigSchema } from './schemas.js';
+import type {
+  ExecutionHostJwtVerifierOptions,
+  ExecutionHostMcpCapabilityVerificationRequest,
+  ExecutionHostMcpCapabilityVerifier,
+  JwtExecutionHostMcpCapabilityVerifierConfig,
+  VerifiedExecutionHostMcpCapability,
+} from './types.js';
+
+const AssertionSchema = z.string().trim().min(32).max(4_096);
+type ParsedConfig = z.infer<
+  typeof JwtExecutionHostMcpCapabilityVerifierConfigSchema
+>;
+
+/** Verifies MCP authority against an independently verified host invocation. */
+export class JwtExecutionHostMcpCapabilityVerifier
+implements ExecutionHostMcpCapabilityVerifier {
+  readonly #config: Readonly<ParsedConfig>;
+  readonly #keyResolver: NonNullable<ExecutionHostJwtVerifierOptions['keyResolver']>;
+  readonly #now: () => Date;
+
+  constructor(
+    config: JwtExecutionHostMcpCapabilityVerifierConfig,
+    options: ExecutionHostJwtVerifierOptions = {},
+  ) {
+    const parsed = JwtExecutionHostMcpCapabilityVerifierConfigSchema.parse(
+      config,
+    );
+    this.#config = Object.freeze({
+      ...parsed,
+      jwksUrl: new URL(parsed.jwksUrl),
+    });
+    this.#keyResolver = options.keyResolver
+      ?? createJwtKeyResolver(this.#config.jwksUrl);
+    this.#now = options.now ?? (() => new Date());
+  }
+
+  async verify(
+    rawRequest: ExecutionHostMcpCapabilityVerificationRequest,
+  ): Promise<VerifiedExecutionHostMcpCapability> {
+    try {
+      const request = Object.freeze({
+        ...rawRequest,
+        assertion: AssertionSchema.parse(rawRequest.assertion),
+      });
+      const { payload } = await jwtVerify(
+        request.assertion,
+        this.#keyResolver,
+        {
+          algorithms: [...this.#config.jwtAlgorithms],
+          audience: this.#config.audience,
+          clockTolerance: this.#config.clockToleranceSeconds,
+          currentDate: this.#now(),
+          issuer: this.#config.issuer,
+          maxTokenAge: this.#config.maxCapabilityAgeSeconds,
+          requiredClaims: ['exp', 'iat', 'jti', 'sub'],
+          typ: MCP_CAPABILITY_TYPE,
+        },
+      );
+      const claims = McpCapabilityClaimsSchema.parse(payload);
+      this.#assertInvocationBinding(claims, request);
+      this.#assertBoundedLifetime(claims);
+
+      return Object.freeze({
+        assertion: request.assertion,
+        capabilityId: claims.jti,
+        serverId: claims.serverId,
+        allowedTools: Object.freeze([...claims.allowedTools]),
+        issuedAt: new Date(claims.iat * 1_000).toISOString(),
+        expiresAt: new Date(claims.exp * 1_000).toISOString(),
+      });
+    } catch (error) {
+      if (
+        error instanceof ExecutionHostMcpCapabilityVerificationError
+        || error instanceof ExecutionHostMcpCapabilityUnavailableError
+      ) {
+        throw error;
+      }
+      const category = resolveJwtVerificationUnavailableCategory(error);
+      if (category) {
+        throw new ExecutionHostMcpCapabilityUnavailableError(
+          category,
+          { cause: error },
+        );
+      }
+      throw new ExecutionHostMcpCapabilityVerificationError({ cause: error });
+    }
+  }
+
+  #assertInvocationBinding(
+    claims: z.infer<typeof McpCapabilityClaimsSchema>,
+    request: ExecutionHostMcpCapabilityVerificationRequest,
+  ): void {
+    const { identity } = request;
+    if (
+      claims.adopterId !== this.#config.trustedAdopterId
+      || claims.adopterId !== identity.scope.adopterId
+      || claims.tenantId !== identity.scope.tenantId
+      || claims.sub !== identity.scope.subjectId
+      || claims.productSessionId !== identity.scope.productSessionId
+      || claims.runtimeSessionId !== identity.runtimeSessionId
+      || claims.invocationId !== identity.invocationId
+      || claims.workflow !== identity.workflow
+      || claims.serverId !== this.#config.serverId
+      || claims.jti === identity.invocationId
+    ) {
+      throw new ExecutionHostMcpCapabilityVerificationError();
+    }
+  }
+
+  #assertBoundedLifetime(
+    claims: z.infer<typeof McpCapabilityClaimsSchema>,
+  ): void {
+    const lifetimeSeconds = claims.exp - claims.iat;
+    if (
+      lifetimeSeconds <= 0
+      || lifetimeSeconds > this.#config.maxCapabilityAgeSeconds
+    ) {
+      throw new ExecutionHostMcpCapabilityVerificationError();
+    }
+  }
+}

--- a/packages/execution-host-client/src/host/jwt-execution-identity-verifier.ts
+++ b/packages/execution-host-client/src/host/jwt-execution-identity-verifier.ts
@@ -1,0 +1,113 @@
+import { jwtVerify } from 'jose';
+import { z } from 'zod';
+import {
+  EXECUTION_ASSERTION_TYPE,
+  ExecutionAssertionClaimsSchema,
+} from '../contracts/index.js';
+import {
+  createJwtKeyResolver,
+  resolveJwtVerificationUnavailableCategory,
+} from '../internal/jwt-verification.js';
+import {
+  ExecutionIdentityUnavailableError,
+  ExecutionIdentityVerificationError,
+} from './errors.js';
+import { JwtExecutionIdentityVerifierConfigSchema } from './schemas.js';
+import type {
+  ExecutionIdentityVerificationRequest,
+  ExecutionIdentityVerifier,
+  ExecutionHostJwtVerifierOptions,
+  JwtExecutionIdentityVerifierConfig,
+  VerifiedExecutionIdentity,
+} from './types.js';
+
+const AssertionSchema = z.string().trim().min(32).max(4_096);
+type ParsedConfig = z.infer<typeof JwtExecutionIdentityVerifierConfigSchema>;
+
+/** Verifies adopter authority and binds it to one exact host invocation. */
+export class JwtExecutionIdentityVerifier implements ExecutionIdentityVerifier {
+  readonly #config: Readonly<ParsedConfig>;
+  readonly #keyResolver: NonNullable<ExecutionHostJwtVerifierOptions['keyResolver']>;
+  readonly #now: () => Date;
+
+  constructor(
+    config: JwtExecutionIdentityVerifierConfig,
+    options: ExecutionHostJwtVerifierOptions = {},
+  ) {
+    const parsed = JwtExecutionIdentityVerifierConfigSchema.parse(config);
+    this.#config = Object.freeze({
+      ...parsed,
+      executionJwksUrl: new URL(parsed.executionJwksUrl),
+    });
+    this.#keyResolver = options.keyResolver
+      ?? createJwtKeyResolver(this.#config.executionJwksUrl);
+    this.#now = options.now ?? (() => new Date());
+  }
+
+  async verify(
+    rawRequest: ExecutionIdentityVerificationRequest,
+  ): Promise<VerifiedExecutionIdentity> {
+    try {
+      const request = Object.freeze({
+        ...rawRequest,
+        assertion: AssertionSchema.parse(rawRequest.assertion),
+      });
+      const { payload } = await jwtVerify(
+        request.assertion,
+        this.#keyResolver,
+        {
+          algorithms: [...this.#config.executionJwtAlgorithms],
+          audience: this.#config.executionAudience,
+          clockTolerance: this.#config.assertionClockToleranceSeconds,
+          currentDate: this.#now(),
+          issuer: this.#config.executionIssuer,
+          maxTokenAge: this.#config.maxAssertionAgeSeconds,
+          requiredClaims: ['exp', 'iat', 'jti', 'sub'],
+          typ: EXECUTION_ASSERTION_TYPE,
+        },
+      );
+      const claims = ExecutionAssertionClaimsSchema.parse(payload);
+      this.#assertRequestBinding(claims, request);
+
+      return Object.freeze({
+        scope: Object.freeze({
+          adopterId: claims.adopterId,
+          tenantId: claims.tenantId,
+          subjectId: claims.sub,
+          productSessionId: claims.productSessionId,
+        }),
+        runtimeSessionId: claims.runtimeSessionId,
+        invocationId: claims.jti,
+        workflow: claims.workflow,
+        issuedAt: new Date(claims.iat * 1_000).toISOString(),
+        expiresAt: new Date(claims.exp * 1_000).toISOString(),
+      });
+    } catch (error) {
+      if (
+        error instanceof ExecutionIdentityVerificationError
+        || error instanceof ExecutionIdentityUnavailableError
+      ) {
+        throw error;
+      }
+      const category = resolveJwtVerificationUnavailableCategory(error);
+      if (category) {
+        throw new ExecutionIdentityUnavailableError(category, { cause: error });
+      }
+      throw new ExecutionIdentityVerificationError({ cause: error });
+    }
+  }
+
+  #assertRequestBinding(
+    claims: z.infer<typeof ExecutionAssertionClaimsSchema>,
+    request: ExecutionIdentityVerificationRequest,
+  ): void {
+    if (
+      claims.adopterId !== this.#config.trustedAdopterId
+      || claims.runtimeSessionId !== request.runtimeSessionId
+      || claims.jti !== request.invocationId
+      || claims.workflow !== request.workflow
+    ) {
+      throw new ExecutionIdentityVerificationError();
+    }
+  }
+}

--- a/packages/execution-host-client/src/host/schemas.ts
+++ b/packages/execution-host-client/src/host/schemas.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import {
+  JwtAudienceSchema,
+  JwtIssuerSchema,
+  McpServerIdSchema,
+  OpaqueIdSchema,
+  isSafeWebUrl,
+} from '../contracts/index.js';
+import { EXECUTION_HOST_SUPPORTED_JWT_ALGORITHMS } from './types.js';
+
+export const ExecutionHostJwtAlgorithmsSchema = z.array(
+  z.enum(EXECUTION_HOST_SUPPORTED_JWT_ALGORITHMS),
+).min(1).max(EXECUTION_HOST_SUPPORTED_JWT_ALGORITHMS.length).transform(
+  (algorithms) => Object.freeze([...new Set(algorithms)]),
+);
+
+export const JwtExecutionIdentityVerifierConfigSchema = z.object({
+  executionIssuer: JwtIssuerSchema,
+  executionAudience: JwtAudienceSchema,
+  executionJwksUrl: z.instanceof(URL).refine(
+    isSafeWebUrl,
+    'must use HTTPS or loopback HTTP and contain no credentials, query, or fragment',
+  ),
+  executionJwtAlgorithms: ExecutionHostJwtAlgorithmsSchema,
+  trustedAdopterId: OpaqueIdSchema,
+  maxAssertionAgeSeconds: z.number().int().min(1).max(15 * 60),
+  assertionClockToleranceSeconds: z.number().int().min(0).max(60),
+}).strict();
+
+export const JwtExecutionHostMcpCapabilityVerifierConfigSchema = z.object({
+  issuer: JwtIssuerSchema,
+  audience: JwtAudienceSchema,
+  jwksUrl: z.instanceof(URL).refine(
+    isSafeWebUrl,
+    'must use HTTPS or loopback HTTP and contain no credentials, query, or fragment',
+  ),
+  jwtAlgorithms: ExecutionHostJwtAlgorithmsSchema,
+  trustedAdopterId: OpaqueIdSchema,
+  serverId: McpServerIdSchema,
+  maxCapabilityAgeSeconds: z.number().int().min(1).max(15 * 60),
+  clockToleranceSeconds: z.number().int().min(0).max(60),
+}).strict();

--- a/packages/execution-host-client/src/host/types.ts
+++ b/packages/execution-host-client/src/host/types.ts
@@ -1,0 +1,85 @@
+import type { JWTVerifyGetKey } from 'jose';
+import type {
+  ExecutionScope,
+  HostedExecutionWorkflow,
+} from '../contracts/index.js';
+
+export const EXECUTION_HOST_SUPPORTED_JWT_ALGORITHMS = [
+  'RS256',
+  'PS256',
+  'ES256',
+  'EdDSA',
+] as const;
+
+export type ExecutionHostJwtAlgorithm =
+  typeof EXECUTION_HOST_SUPPORTED_JWT_ALGORITHMS[number];
+
+/** Authority established from one signed assertion and its request binding. */
+export type VerifiedExecutionIdentity = Readonly<{
+  scope: Readonly<ExecutionScope>;
+  runtimeSessionId: string;
+  invocationId: string;
+  workflow: HostedExecutionWorkflow;
+  issuedAt: string;
+  expiresAt: string;
+}>;
+
+export type ExecutionIdentityVerificationRequest = Readonly<{
+  assertion: string;
+  runtimeSessionId: string;
+  invocationId: string;
+  workflow: HostedExecutionWorkflow;
+}>;
+
+export interface ExecutionIdentityVerifier {
+  verify(
+    request: ExecutionIdentityVerificationRequest,
+  ): Promise<VerifiedExecutionIdentity>;
+}
+
+export type JwtExecutionIdentityVerifierConfig = Readonly<{
+  executionIssuer: string;
+  executionAudience: string;
+  executionJwksUrl: URL;
+  executionJwtAlgorithms: readonly ExecutionHostJwtAlgorithm[];
+  trustedAdopterId: string;
+  maxAssertionAgeSeconds: number;
+  assertionClockToleranceSeconds: number;
+}>;
+
+/** Opaque MCP bearer whose claims match the independently verified execution. */
+export type VerifiedExecutionHostMcpCapability = Readonly<{
+  assertion: string;
+  capabilityId: string;
+  serverId: string;
+  allowedTools: readonly string[];
+  issuedAt: string;
+  expiresAt: string;
+}>;
+
+export type ExecutionHostMcpCapabilityVerificationRequest = Readonly<{
+  assertion: string;
+  identity: VerifiedExecutionIdentity;
+}>;
+
+export interface ExecutionHostMcpCapabilityVerifier {
+  verify(
+    request: ExecutionHostMcpCapabilityVerificationRequest,
+  ): Promise<VerifiedExecutionHostMcpCapability>;
+}
+
+export type JwtExecutionHostMcpCapabilityVerifierConfig = Readonly<{
+  issuer: string;
+  audience: string;
+  jwksUrl: URL;
+  jwtAlgorithms: readonly ExecutionHostJwtAlgorithm[];
+  trustedAdopterId: string;
+  serverId: string;
+  maxCapabilityAgeSeconds: number;
+  clockToleranceSeconds: number;
+}>;
+
+export type ExecutionHostJwtVerifierOptions = Readonly<{
+  keyResolver?: JWTVerifyGetKey;
+  now?: () => Date;
+}>;

--- a/packages/execution-host-client/src/internal/jwt-verification.ts
+++ b/packages/execution-host-client/src/internal/jwt-verification.ts
@@ -1,0 +1,39 @@
+import {
+  createRemoteJWKSet,
+  errors,
+  type JWTVerifyGetKey,
+} from 'jose';
+
+const REMOTE_JWKS_OPTIONS = Object.freeze({
+  cacheMaxAge: 10 * 60_000,
+  cooldownDuration: 30_000,
+  timeoutDuration: 3_000,
+});
+
+const UNAVAILABLE_JOSE_CATEGORIES = new Map<string, JwtVerificationUnavailableCategory>([
+  ['ERR_JOSE_GENERIC', 'jwks_response'],
+  ['ERR_JWK_INVALID', 'jwks_response'],
+  ['ERR_JWKS_INVALID', 'jwks_response'],
+  ['ERR_JWKS_MULTIPLE_MATCHING_KEYS', 'jwks_response'],
+  ['ERR_JWKS_TIMEOUT', 'jwks_timeout'],
+]);
+
+export type JwtVerificationUnavailableCategory =
+  | 'network'
+  | 'jwks_response'
+  | 'jwks_timeout';
+
+export function createJwtKeyResolver(jwksUrl: URL): JWTVerifyGetKey {
+  return createRemoteJWKSet(jwksUrl, REMOTE_JWKS_OPTIONS);
+}
+
+export function resolveJwtVerificationUnavailableCategory(
+  error: unknown,
+): JwtVerificationUnavailableCategory | undefined {
+  if (error instanceof TypeError) {
+    return 'network';
+  }
+  return error instanceof errors.JOSEError
+    ? UNAVAILABLE_JOSE_CATEGORIES.get(error.code)
+    : undefined;
+}

--- a/packages/execution-host-client/src/mcp/jwt-capability-verifier.ts
+++ b/packages/execution-host-client/src/mcp/jwt-capability-verifier.ts
@@ -1,8 +1,4 @@
-import {
-  createRemoteJWKSet,
-  errors,
-  jwtVerify,
-} from 'jose';
+import { jwtVerify } from 'jose';
 import { z } from 'zod';
 import {
   JwtAudienceSchema,
@@ -18,6 +14,10 @@ import {
   McpCapabilityUnavailableError,
   McpCapabilityVerificationError,
 } from './errors.js';
+import {
+  createJwtKeyResolver,
+  resolveJwtVerificationUnavailableCategory,
+} from '../internal/jwt-verification.js';
 import type {
   JwtMcpCapabilityVerifierConfig,
   JwtMcpCapabilityVerifierOptions,
@@ -66,14 +66,8 @@ implements McpCapabilityVerifier<TToolName> {
       supportedTools: Object.freeze([...parsed.supportedTools]),
     });
     this.#supportedTools = new Set(this.#config.supportedTools);
-    this.#keyResolver = options.keyResolver ?? createRemoteJWKSet(
-      this.#config.jwksUrl,
-      {
-        cacheMaxAge: 10 * 60_000,
-        cooldownDuration: 30_000,
-        timeoutDuration: 3_000,
-      },
-    );
+    this.#keyResolver = options.keyResolver
+      ?? createJwtKeyResolver(this.#config.jwksUrl);
     this.#now = options.now ?? (() => new Date());
   }
 
@@ -118,9 +112,13 @@ implements McpCapabilityVerifier<TToolName> {
       ) {
         throw error;
       }
-      const unavailableCategory = resolveUnavailableCategory(error);
+      const unavailableCategory = resolveJwtVerificationUnavailableCategory(
+        error,
+      );
       if (unavailableCategory) {
-        throw new McpCapabilityUnavailableError(unavailableCategory);
+        throw new McpCapabilityUnavailableError(
+          unavailableCategory === 'network' ? 'network' : 'jwks',
+        );
       }
       throw new McpCapabilityVerificationError();
     }
@@ -175,27 +173,4 @@ function freezeVerifiedCapability<TToolName extends string>(
     allowedTools: Object.freeze([...capability.allowedTools]),
     scope: Object.freeze({ ...capability.scope }),
   });
-}
-
-const UNAVAILABLE_JOSE_CODES = new Set([
-  'ERR_JOSE_GENERIC',
-  'ERR_JWK_INVALID',
-  'ERR_JWKS_INVALID',
-  'ERR_JWKS_MULTIPLE_MATCHING_KEYS',
-  'ERR_JWKS_TIMEOUT',
-]);
-
-function resolveUnavailableCategory(
-  error: unknown,
-): 'network' | 'jwks' | undefined {
-  if (error instanceof TypeError) {
-    return 'network';
-  }
-  if (
-    error instanceof errors.JOSEError
-    && UNAVAILABLE_JOSE_CODES.has(error.code)
-  ) {
-    return 'jwks';
-  }
-  return undefined;
 }


### PR DESCRIPTION
## Summary

- add the public @heddleagent/execution-host-client/host boundary for execution identity and invocation-bound MCP capability verification
- share remote JWKS mechanics with the existing product MCP verifier
- document the ownership stop line and prepare the manual 6.5.0 release

## Why

Compatible Execution Hosts currently duplicate security-sensitive JOSE and signed-scope binding logic. This makes those semantics easy to drift and obscures that the public client package owns the portable host contract while private deployments own composition and infrastructure.

## Boundary

This does not add HTTP ingress, Runtime-session isolation, model credentials, provider bootstrap, or deployment to the package. Those remain deployable Execution Host responsibilities.

## Verification

- yarn execution-host-client:test (129 tests)
- yarn execution-host-client:conformance:python-v1
- yarn execution-host-client:build