### PR TITLE
Centralize Execution Host adopter boundaries

### DIFF
--- a/packages/execution-host-client/README.md
+++ b/packages/execution-host-client/README.md
@@ -1,12 +1,12 @@
 # `@heddleagent/execution-host-client`
 
-`@heddleagent/execution-host-client` is the backend-side SDK for
-products that invoke a separately deployed Heddle Execution Host. It lets an
+`@heddleagent/execution-host-client` is the integration SDK for products that
+invoke a separately deployed Heddle Execution Host. It lets an
 adopter keep its own language stack, authentication, database, product policy,
 MCP tools, and UI while reusing the security-sensitive v1 contract machinery.
 
-> **Current availability:** `6.5.0` is the next manual release from this
-> repository; `6.4.0` remains the latest published version until then. The former
+> **Current availability:** `6.5.0` is the latest published version as of
+> 2026-08-25; repository source may be ahead of that release. The former
 > `@roackb2/heddle-adopter@5.13.0` coordinate is deprecated and remains
 > installable only for existing consumers. Heddle does not currently distribute
 > the compatible Execution Host implementation or offer a hosted service. The
@@ -28,6 +28,7 @@ modular AWS SDK for its AgentCore transport and the official MCP SDK, plus
 
 | Import | Reusable responsibility |
 | --- | --- |
+| `@heddleagent/execution-host-client/adopter` | Browser-safe authenticated hosted-conversation client, canonical adopter paths, bounded public errors, and strict ordered SSE settlement |
 | `@heddleagent/execution-host-client/contracts` | Runtime-validated v1 request, stream, identity, capability, and header contracts |
 | `@heddleagent/execution-host-client/authority` | ES256 execution assertion and optional MCP capability issuance plus public JWKS projection |
 | `@heddleagent/execution-host-client/conversation` | Turn orchestration across authority, model credentials, optional MCP policy, an `ExecutionHost`, and an optional adopter-implemented durable lifecycle store |
@@ -37,7 +38,7 @@ modular AWS SDK for its AgentCore transport and the official MCP SDK, plus
 | `@heddleagent/execution-host-client/mcp` | Independent capability verification at the adopter's MCP edge |
 | `@heddleagent/execution-host-client/mcp/node` | Stateless official-SDK Streamable HTTP lifecycle around adopter-defined toolsets |
 | `@heddleagent/execution-host-client/http-sse` | Transport-neutral conversation and heartbeat ports plus the strict direct-development HTTP/SSE client |
-| `@heddleagent/execution-host-client/agentcore` | Official AWS AgentCore/SigV4 implementation of the same conversation and heartbeat ports |
+| `@heddleagent/execution-host-client/agentcore` | Canonical AgentCore deployment-target validation plus the official AWS AgentCore/SigV4 implementation of the conversation and heartbeat ports |
 | `@heddleagent/execution-host-client/host` | Invocation-bound execution-identity and MCP-capability verification shared by compatible Execution Host implementations |
 | `@heddleagent/execution-host-client/testing` | Node-only loopback v1 fixture plus durable-turn store conformance for real adapters |
 | `@heddleagent/execution-host-client/node` | Optional Node JWKS/conversation HTTP edge plus safe local signing-key helpers |

--- a/packages/execution-host-client/README.md
+++ b/packages/execution-host-client/README.md
@@ -39,7 +39,7 @@ modular AWS SDK for its AgentCore transport and the official MCP SDK, plus
 | `@heddleagent/execution-host-client/mcp/node` | Stateless official-SDK Streamable HTTP lifecycle around adopter-defined toolsets |
 | `@heddleagent/execution-host-client/http-sse` | Transport-neutral conversation and heartbeat ports plus the strict direct-development HTTP/SSE client |
 | `@heddleagent/execution-host-client/agentcore` | Canonical AgentCore deployment-target validation plus the official AWS AgentCore/SigV4 implementation of the conversation and heartbeat ports |
-| `@heddleagent/execution-host-client/host` | Invocation-bound execution-identity and MCP-capability verification shared by compatible Execution Host implementations |
+| `@heddleagent/execution-host-client/host` | Invocation-bound authority verification plus provider-neutral Runtime-session scope binding, admission, deadlines, cancellation, status, and workflow dispatch shared by compatible Execution Host implementations |
 | `@heddleagent/execution-host-client/testing` | Node-only loopback v1 fixture plus durable-turn store conformance for real adapters |
 | `@heddleagent/execution-host-client/node` | Optional Node JWKS/conversation HTTP edge plus safe local signing-key helpers |
 

--- a/packages/execution-host-client/package.json
+++ b/packages/execution-host-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@heddleagent/execution-host-client",
   "version": "6.5.0",
-  "description": "Backend contracts, execution authority, lifecycle services, and clients for compatible Heddle Execution Hosts",
+  "description": "Contracts, execution authority, lifecycle services, and adopter clients for compatible Heddle Execution Hosts",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",
   "type": "module",
@@ -37,6 +37,10 @@
     "./authority": {
       "types": "./dist/authority/index.d.ts",
       "import": "./dist/authority/index.js"
+    },
+    "./adopter": {
+      "types": "./dist/adopter/index.d.ts",
+      "import": "./dist/adopter/index.js"
     },
     "./conversation": {
       "types": "./dist/conversation/index.d.ts",

--- a/packages/execution-host-client/src/__tests__/coordinator.test.ts
+++ b/packages/execution-host-client/src/__tests__/coordinator.test.ts
@@ -8,6 +8,7 @@ import {
   HostedHeartbeatCoordinatorRequestError,
   HostedHeartbeatDelegationService,
   HostedHeartbeatTaskReconciler,
+  type HostedHeartbeatCoordinatorTaskView,
 } from '../coordinator/index.js';
 
 const API_TOKEN = 'coordinator-api-token-at-least-32-characters';
@@ -20,7 +21,7 @@ describe('HostedHeartbeatCoordinatorClient', () => {
         `Bearer ${API_TOKEN}`,
       );
       return new Response(JSON.stringify({
-        tasks: [{ id: 'task-1', workspaceId: 'workspace-1', state: {} }],
+        tasks: [coordinatorTask()],
       }), { status: 200 });
     });
     const client = new HostedHeartbeatCoordinatorClient({
@@ -30,9 +31,48 @@ describe('HostedHeartbeatCoordinatorClient', () => {
     });
 
     await expect(client.listTasks()).resolves.toEqual([
-      { id: 'task-1', workspaceId: 'workspace-1', state: {} },
+      coordinatorTask(),
     ]);
     expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('owns task inspection, triggering, and coordinator admission requests', async () => {
+    const requests: string[] = [];
+    const fetch = vi.fn<typeof globalThis.fetch>(async (request, init) => {
+      const path = new URL(String(request)).pathname;
+      requests.push(`${init?.method ?? 'GET'} ${path}`);
+      if (path === '/v1/coordinator') {
+        return Response.json({ state: 'running' });
+      }
+      if (path.endsWith('/trigger')) {
+        return Response.json(coordinatorTask());
+      }
+      if (path.endsWith('/task-1')) {
+        return Response.json({ task: coordinatorTask(), runs: [] });
+      }
+      return Response.json({ state: 'drained' });
+    });
+    const client = new HostedHeartbeatCoordinatorClient({
+      baseUrl: new URL('http://127.0.0.1:18082'),
+      apiToken: API_TOKEN,
+      fetch,
+    });
+
+    await expect(client.readState()).resolves.toBe('running');
+    await expect(client.readTask('task-1')).resolves.toEqual({
+      task: coordinatorTask(),
+      runs: [],
+    });
+    await expect(client.triggerTask('task-1')).resolves.toEqual(
+      coordinatorTask(),
+    );
+    await expect(client.drain()).resolves.toBeUndefined();
+    expect(requests).toEqual([
+      'GET /v1/coordinator',
+      'GET /v1/heartbeat/tasks/task-1',
+      'POST /v1/heartbeat/tasks/task-1/trigger',
+      'POST /v1/control/drain',
+    ]);
   });
 
   it('reports a safe method, path, and status for rejected requests', async () => {
@@ -61,8 +101,15 @@ describe('HostedHeartbeatTaskReconciler', () => {
         listTasks: async () => {
           events.push('list');
           return [
-            { id: 'retired-task', workspaceId: 'workspace-1' },
-            { id: 'active-task', workspaceId: 'workspace-old' },
+            coordinatorTask({
+              id: 'retired-task',
+              taskId: 'retired-task',
+            }),
+            coordinatorTask({
+              id: 'active-task',
+              taskId: 'active-task',
+              workspaceId: 'workspace-old',
+            }),
           ];
         },
         deleteTask: async (taskId) => { events.push(`delete:${taskId}`); },
@@ -153,6 +200,23 @@ describe('HostedHeartbeatDelegationService', () => {
     }]);
   });
 });
+
+function coordinatorTask(
+  overrides: Partial<HostedHeartbeatCoordinatorTaskView> = {},
+): HostedHeartbeatCoordinatorTaskView {
+  return {
+    id: 'task-1',
+    taskId: 'task-1',
+    workspaceId: 'workspace-1',
+    name: 'Task one',
+    task: 'Check for relevant changes.',
+    enabled: true,
+    continuationMode: 'operator',
+    schedule: { intervalMs: 60_000 },
+    state: { status: 'idle' },
+    ...overrides,
+  };
+}
 
 function issuedAuthority(
   input: ExecutionAuthorityIssueInput,

--- a/packages/execution-host-client/src/__tests__/runtime-session.test.ts
+++ b/packages/execution-host-client/src/__tests__/runtime-session.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ExecutionHostConversationTurnRequest,
+  ExecutionHostHeartbeatTaskRequest,
+  RuntimePublicResult,
+} from '../contracts/index.js';
+import {
+  RuntimeBusyError,
+  RuntimeDuplicateInvocationError,
+  RuntimeScopeMismatchError,
+  RuntimeSessionService,
+  type RuntimeExecutionHandle,
+  type RuntimeExecutionInput,
+  type RuntimeWorkflowExecutor,
+} from '../host/index.js';
+import type { VerifiedExecutionIdentity } from '../host/types.js';
+
+const NOW = new Date('2026-08-25T12:00:00.000Z');
+
+describe('RuntimeSessionService', () => {
+  it('binds one scope and delegates an invocation to the matching workflow', async () => {
+    const executor = new TestConversationExecutor();
+    const service = createService(executor);
+    const handle = await service.start(startInput());
+
+    expect(service.readStatus().state).toBe('executing');
+    expect(executor.input).toMatchObject({
+      executionSessionId: expect.stringMatching(/^runtime-[a-f0-9]{64}$/),
+      request: { kind: 'conversation-turn', prompt: 'Inspect the workspace.' },
+      modelApiKey: 'model-api-key',
+    });
+
+    executor.resolve({ outcome: 'done' });
+    await expect(handle.result).resolves.toEqual({ outcome: 'done' });
+    expect(service.readStatus().state).toBe('idle');
+  });
+
+  it('rejects concurrent, cross-scope, and recently completed invocations', async () => {
+    const executor = new TestConversationExecutor();
+    const service = createService(executor);
+    const first = await service.start(startInput());
+
+    await expect(service.start(startInput('invocation-b'))).rejects
+      .toBeInstanceOf(RuntimeBusyError);
+    await expect(service.start({
+      ...startInput('invocation-c'),
+      identity: {
+        ...identity('invocation-c'),
+        scope: { ...identity('invocation-c').scope, tenantId: 'tenant-b' },
+      },
+    })).rejects.toBeInstanceOf(RuntimeScopeMismatchError);
+
+    executor.resolve({ outcome: 'done' });
+    await first.result;
+    await expect(service.start(startInput())).rejects
+      .toBeInstanceOf(RuntimeDuplicateInvocationError);
+  });
+
+  it('propagates caller cancellation to the active workflow', async () => {
+    const executor = new TestConversationExecutor();
+    const service = createService(executor);
+    const caller = new AbortController();
+    const handle = await service.start({
+      ...startInput(),
+      callerSignal: caller.signal,
+    });
+
+    caller.abort(new Error('Caller disconnected.'));
+    expect(executor.cancel).toHaveBeenCalledOnce();
+
+    executor.reject(new Error('Cancelled.'));
+    await expect(handle.result).rejects.toThrow('Cancelled.');
+    expect(service.readStatus().state).toBe('idle');
+  });
+});
+
+class TestConversationExecutor implements RuntimeWorkflowExecutor<
+  ExecutionHostConversationTurnRequest,
+  RuntimePublicResult
+> {
+  input?: RuntimeExecutionInput<ExecutionHostConversationTurnRequest>;
+  readonly cancel = vi.fn(() => true);
+  private readonly result = deferred<RuntimePublicResult>();
+
+  start(
+    input: RuntimeExecutionInput<ExecutionHostConversationTurnRequest>,
+  ): Promise<RuntimeExecutionHandle<RuntimePublicResult>> {
+    this.input = input;
+    return Promise.resolve({
+      runId: 'run-a',
+      result: this.result.promise,
+      events: async function* () {},
+      cancel: this.cancel,
+    });
+  }
+
+  resolve(result: RuntimePublicResult): void {
+    this.result.resolve(result);
+  }
+
+  reject(error: Error): void {
+    this.result.reject(error);
+  }
+}
+
+function createService(conversationTurn: TestConversationExecutor) {
+  const heartbeatTask: RuntimeWorkflowExecutor<
+    ExecutionHostHeartbeatTaskRequest,
+    unknown
+  > = {
+    start: () => Promise.reject(new Error('Unexpected heartbeat invocation.')),
+  };
+  return new RuntimeSessionService({
+    config: { maxInvocationMs: 15 * 60_000 },
+    executors: { conversationTurn, heartbeatTask },
+    now: () => NOW,
+  });
+}
+
+function startInput(invocationId = 'invocation-a') {
+  return {
+    identity: identity(invocationId),
+    invocation: {
+      schemaVersion: 1 as const,
+      kind: 'conversation-turn' as const,
+      invocationId,
+      prompt: 'Inspect the workspace.',
+    },
+    modelApiKey: 'model-api-key',
+    callerSignal: new AbortController().signal,
+  };
+}
+
+function identity(invocationId: string): VerifiedExecutionIdentity {
+  return {
+    scope: {
+      adopterId: 'lucid',
+      tenantId: 'tenant-a',
+      subjectId: 'subject-a',
+      productSessionId: 'conversation-a',
+    },
+    runtimeSessionId: 's'.repeat(33),
+    invocationId,
+    workflow: 'conversation-turn',
+    issuedAt: '2026-08-25T11:59:00.000Z',
+    expiresAt: '2026-08-25T12:05:00.000Z',
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/packages/execution-host-client/src/adopter/README.md
+++ b/packages/execution-host-client/src/adopter/README.md
@@ -1,0 +1,27 @@
+# Adopter hosted-conversation client
+
+This browser-safe module is the public client for the authenticated
+hosted-conversation route served by Heddle's Node adopter HTTP service. Product
+code supplies its own user access token and presents canonical stream events;
+the package owns request validation, redirect refusal, bounded public errors,
+ordered SSE parsing, identity binding, terminal settlement, cancellation, and
+ambiguous interruption behavior.
+
+It does not acquire product authentication tokens, persist UI state, decide how
+events are presented, or expose Execution Host credentials to the browser.
+
+```ts
+import {
+  HostedConversationClient,
+} from '@heddleagent/execution-host-client/adopter'
+
+const conversations = new HostedConversationClient()
+
+for await (const event of conversations.streamTurn({
+  prompt: 'Summarize my workspace.',
+  accessToken: productSessionToken,
+  signal,
+})) {
+  present(event)
+}
+```

--- a/packages/execution-host-client/src/adopter/contracts.ts
+++ b/packages/execution-host-client/src/adopter/contracts.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import { ExecutionHostConversationTurnRequestSchema } from '../contracts/index.js';
+
+export const DEFAULT_ADOPTER_JWKS_PATH = '/.well-known/jwks.json';
+export const DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH =
+  '/hosted-execution/conversation-turns';
+
+export const HostedConversationRequestSchema = z.object({
+  prompt: ExecutionHostConversationTurnRequestSchema.shape.prompt,
+}).strict();
+
+export const HostedConversationPublicErrorSchema = z.object({
+  error: z.object({
+    message: z.string().min(1).max(1_600),
+  }).strict(),
+}).strict();
+
+export type HostedConversationRequest = z.infer<
+  typeof HostedConversationRequestSchema
+>;

--- a/packages/execution-host-client/src/adopter/hosted-conversation-client.test.ts
+++ b/packages/execution-host-client/src/adopter/hosted-conversation-client.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import type { ExecutionHostStreamEvent } from '../contracts/index.js';
+import {
+  ExecutionHostInvocationCancelledError,
+  ExecutionHostProtocolError,
+  ExecutionHostStreamInterruptedError,
+} from '../http-sse/index.js';
+import {
+  HostedConversationClient,
+  HostedConversationClientError,
+} from './hosted-conversation-client.js';
+
+const NOW = '2026-08-25T00:00:00.000Z';
+
+describe('HostedConversationClient', () => {
+  it('authenticates and validates one ordered terminal stream', async () => {
+    const events = [
+      event(0, { kind: 'accepted' }),
+      event(1, { kind: 'activity', activity: { type: 'tool.calling' } }),
+      event(2, {
+        kind: 'result',
+        result: { outcome: 'done', summary: 'Workspace summary.' },
+      }),
+    ] satisfies ExecutionHostStreamEvent[];
+    let observedInit: RequestInit | undefined;
+    const client = new HostedConversationClient({
+      fetch: async (_input, init) => {
+        observedInit = init;
+        return sseResponse(events);
+      },
+    });
+
+    expect(await collect(client.streamTurn({
+      accessToken: 'user-token-value',
+      prompt: '  summarize my workspace  ',
+    }))).toEqual(events);
+    expect(new Headers(observedInit?.headers).get('authorization'))
+      .toBe('Bearer user-token-value');
+    expect(observedInit?.body).toBe(JSON.stringify({
+      prompt: 'summarize my workspace',
+    }));
+  });
+
+  it('keeps an incomplete stream distinct from invalid protocol', async () => {
+    const incomplete = new HostedConversationClient({
+      fetch: async () => sseResponse([event(0, { kind: 'accepted' })]),
+    });
+    const invalid = new HostedConversationClient({
+      fetch: async () => sseResponse([
+        event(0, { kind: 'accepted' }),
+        event(2, {
+          kind: 'result',
+          result: { outcome: 'done', summary: 'Invalid sequence.' },
+        }),
+      ]),
+    });
+
+    await expect(collect(incomplete.streamTurn(turn())))
+      .rejects.toBeInstanceOf(ExecutionHostStreamInterruptedError);
+    await expect(collect(invalid.streamTurn(turn())))
+      .rejects.toBeInstanceOf(ExecutionHostProtocolError);
+  });
+
+  it('projects only the server public rejection message', async () => {
+    const client = new HostedConversationClient({
+      fetch: async () => new Response(JSON.stringify({
+        error: { message: 'Hosted execution is currently unavailable.' },
+      }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    });
+
+    await expect(collect(client.streamTurn(turn())))
+      .rejects.toMatchObject({
+        name: 'HostedConversationClientError',
+        status: 503,
+        message: 'Hosted execution is currently unavailable.',
+      });
+  });
+
+  it('uses a safe fallback for oversized rejection bodies', async () => {
+    const client = new HostedConversationClient({
+      fetch: async () => new Response('x'.repeat(16_385), { status: 502 }),
+    });
+
+    await expect(collect(client.streamTurn(turn())))
+      .rejects.toEqual(new HostedConversationClientError(
+        'Hosted conversation could not be started.',
+        502,
+      ));
+  });
+
+  it('normalizes caller cancellation to the Execution Host vocabulary', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const client = new HostedConversationClient();
+
+    await expect(collect(client.streamTurn(turn({
+      signal: controller.signal,
+    })))).rejects.toBeInstanceOf(ExecutionHostInvocationCancelledError);
+  });
+});
+
+function turn(
+  overrides: Partial<Parameters<HostedConversationClient['streamTurn']>[0]> = {},
+): Parameters<HostedConversationClient['streamTurn']>[0] {
+  return {
+    accessToken: 'user-token-value',
+    prompt: 'summarize',
+    ...overrides,
+  };
+}
+
+type EventBody =
+  | { kind: 'accepted' }
+  | { kind: 'activity'; activity: unknown }
+  | { kind: 'result'; result: { outcome: 'done'; summary: string } };
+
+function event(sequence: number, body: EventBody): ExecutionHostStreamEvent {
+  return {
+    schemaVersion: 1,
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sequence,
+    timestamp: NOW,
+    ...body,
+  } as ExecutionHostStreamEvent;
+}
+
+function sseResponse(events: ExecutionHostStreamEvent[]): Response {
+  return new Response(events.map((item) => [
+    `event: ${item.kind}`,
+    `id: ${item.sequence}`,
+    `data: ${JSON.stringify(item)}`,
+    '',
+    '',
+  ].join('\n')).join(''), {
+    headers: { 'Content-Type': 'text/event-stream; charset=utf-8' },
+  });
+}
+
+async function collect(
+  stream: AsyncIterable<ExecutionHostStreamEvent>,
+): Promise<ExecutionHostStreamEvent[]> {
+  const events: ExecutionHostStreamEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}

--- a/packages/execution-host-client/src/adopter/hosted-conversation-client.ts
+++ b/packages/execution-host-client/src/adopter/hosted-conversation-client.ts
@@ -1,0 +1,158 @@
+import { z } from 'zod';
+import {
+  ExecutionHostStreamEventSchema,
+  isExecutionHostTerminalEvent,
+  isSafeWebUrl,
+  type ExecutionHostStreamEvent,
+} from '../contracts/index.js';
+import {
+  readExecutionHostEventStream,
+  toExecutionHostTransportError,
+} from '../internal/execution-host-event-stream.js';
+import { readBoundedJsonResponse } from '../internal/http-response.js';
+import {
+  DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH,
+  HostedConversationPublicErrorSchema,
+  HostedConversationRequestSchema,
+} from './contracts.js';
+import type {
+  HostedConversationClientConfig,
+  HostedConversationClientTurnInput,
+  HostedConversationStreamClient,
+} from './types.js';
+
+const MAX_ERROR_BODY_BYTES = 16_384;
+const AccessTokenSchema = z.string().trim().min(1).max(4_096).regex(
+  /^\S+$/,
+  'accessToken must not contain whitespace',
+);
+
+export class HostedConversationClientError extends Error {
+  readonly name = 'HostedConversationClientError';
+
+  constructor(
+    message: string,
+    readonly status?: number,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+  }
+}
+
+/**
+ * Browser-safe client for an adopter's authenticated hosted-conversation edge.
+ *
+ * Product code supplies its user token. Heddle owns the request shape,
+ * redirect refusal, bounded public errors, ordered SSE validation, truthful
+ * terminal settlement, cancellation, and ambiguous-interruption semantics.
+ */
+export class HostedConversationClient
+implements HostedConversationStreamClient {
+  readonly #endpoint: string | URL;
+  readonly #fetch: typeof globalThis.fetch;
+
+  constructor(config: HostedConversationClientConfig = {}) {
+    this.#endpoint = parseEndpoint(
+      config.endpoint ?? DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH,
+    );
+    this.#fetch = config.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  async *streamTurn(
+    rawInput: HostedConversationClientTurnInput,
+  ): AsyncIterable<ExecutionHostStreamEvent> {
+    const request = HostedConversationRequestSchema.parse({
+      prompt: rawInput.prompt,
+    });
+    const accessToken = AccessTokenSchema.parse(rawInput.accessToken);
+    if (rawInput.signal?.aborted) {
+      throw toExecutionHostTransportError(
+        rawInput.signal.reason,
+        rawInput.signal,
+      );
+    }
+
+    let response: Response;
+    try {
+      response = await this.#fetch(this.#endpoint, {
+        method: 'POST',
+        redirect: 'error',
+        signal: rawInput.signal,
+        headers: {
+          Accept: 'text/event-stream',
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request),
+      });
+    } catch (error) {
+      if (rawInput.signal?.aborted) {
+        throw toExecutionHostTransportError(error, rawInput.signal);
+      }
+      throw new HostedConversationClientError(
+        'Hosted conversation endpoint could not be reached.',
+        undefined,
+        { cause: error },
+      );
+    }
+
+    if (!response.ok) {
+      throw new HostedConversationClientError(
+        await readPublicError(response),
+        response.status,
+      );
+    }
+    yield* readExecutionHostEventStream({
+      response,
+      schema: ExecutionHostStreamEventSchema,
+      isTerminal: isExecutionHostTerminalEvent,
+      signal: rawInput.signal,
+    });
+  }
+}
+
+async function readPublicError(response: Response): Promise<string> {
+  const parsed = HostedConversationPublicErrorSchema.safeParse(
+    await readBoundedJsonResponse(response, MAX_ERROR_BODY_BYTES),
+  );
+  return parsed.success
+    ? parsed.data.error.message
+    : fallbackError(response.status);
+}
+
+function fallbackError(status: number): string {
+  return status === 401
+    ? 'Hosted conversation authorization was not accepted.'
+    : 'Hosted conversation could not be started.';
+}
+
+function parseEndpoint(value: string | URL): string | URL {
+  if (value instanceof URL) {
+    return parseAbsoluteEndpoint(new URL(value));
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new HostedConversationClientError(
+      'Hosted conversation endpoint cannot be empty.',
+    );
+  }
+  if (normalized.startsWith('/')) {
+    const relative = new URL(normalized, 'https://adopter.invalid');
+    if (relative.search || relative.hash || relative.pathname !== normalized) {
+      throw new HostedConversationClientError(
+        'Hosted conversation endpoint must be a path without query or fragment.',
+      );
+    }
+    return relative.pathname;
+  }
+  return parseAbsoluteEndpoint(new URL(normalized));
+}
+
+function parseAbsoluteEndpoint(url: URL): URL {
+  if (!isSafeWebUrl(url)) {
+    throw new HostedConversationClientError(
+      'Hosted conversation endpoint must use HTTPS or loopback HTTP without credentials, query, or fragment.',
+    );
+  }
+  return url;
+}

--- a/packages/execution-host-client/src/adopter/index.ts
+++ b/packages/execution-host-client/src/adopter/index.ts
@@ -1,0 +1,16 @@
+export {
+  DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH,
+  DEFAULT_ADOPTER_JWKS_PATH,
+  HostedConversationPublicErrorSchema,
+  HostedConversationRequestSchema,
+} from './contracts.js';
+export {
+  HostedConversationClient,
+  HostedConversationClientError,
+} from './hosted-conversation-client.js';
+export type {
+  HostedConversationClientConfig,
+  HostedConversationClientTurnInput,
+  HostedConversationStreamClient,
+} from './types.js';
+export type { HostedConversationRequest } from './contracts.js';

--- a/packages/execution-host-client/src/adopter/types.ts
+++ b/packages/execution-host-client/src/adopter/types.ts
@@ -1,0 +1,18 @@
+import type { ExecutionHostStreamEvent } from '../contracts/index.js';
+
+export type HostedConversationClientConfig = {
+  endpoint?: string | URL;
+  fetch?: typeof globalThis.fetch;
+};
+
+export type HostedConversationClientTurnInput = {
+  prompt: string;
+  accessToken: string;
+  signal?: AbortSignal;
+};
+
+export interface HostedConversationStreamClient {
+  streamTurn(
+    input: HostedConversationClientTurnInput,
+  ): AsyncIterable<ExecutionHostStreamEvent>;
+}

--- a/packages/execution-host-client/src/agentcore/README.md
+++ b/packages/execution-host-client/src/agentcore/README.md
@@ -7,6 +7,7 @@ delegates strict request/SSE validation to the shared Execution Host client.
 
 It owns:
 
+- canonical Runtime region, ARN, qualifier, and composed-target validation;
 - AgentCore Runtime session-ID validation;
 - AWS SDK client construction through the default credential chain;
 - one-attempt invocation semantics because a disconnected streaming request
@@ -19,6 +20,11 @@ It does not own AWS account configuration, Runtime provisioning, product
 authentication, authority issuance, model credentials, MCP tools, persistence,
 result application, or UI. Adopters provide their region, Runtime ARN, optional
 qualifier, and normal AWS credential environment at composition.
+
+The same `AgentCoreRegionSchema`, `AgentCoreRuntimeArnSchema`,
+`AgentCoreQualifierSchema`, and `AgentCoreExecutionTargetSchema` are public for
+deployment configuration loaders. Consumers should use these contracts
+directly instead of copying the rules or renaming their inferred types.
 
 Both conversation turns and heartbeat tasks use the same AgentCore client,
 Runtime-session validation, signed custom headers, one-attempt policy, and SSE

--- a/packages/execution-host-client/src/agentcore/agentcore-execution-host.test.ts
+++ b/packages/execution-host-client/src/agentcore/agentcore-execution-host.test.ts
@@ -37,6 +37,20 @@ afterEach(async () => {
 });
 
 describe('AgentCoreExecutionHost', () => {
+  it.each([
+    ['region', { region: 'US East 2' }],
+    ['Runtime ARN', { runtimeArn: 'arn:aws:lambda:us-east-2:123:function:x' }],
+    ['qualifier', { qualifier: 'invalid qualifier' }],
+  ])('rejects an invalid %s at composition', (_label, override) => {
+    expect(() => new AgentCoreExecutionHost({
+      region: 'us-east-2',
+      runtimeArn: RUNTIME_ARN,
+      qualifier: 'pilot',
+      client: { send: vi.fn<AgentCoreRuntimeClient['send']>() },
+      ...override,
+    })).toThrow();
+  });
+
   it('signs and streams the portable Execution Host contract through the AWS SDK', async () => {
     const observed = {
       headers: {} as IncomingMessage['headers'],

--- a/packages/execution-host-client/src/agentcore/agentcore-execution-host.ts
+++ b/packages/execution-host-client/src/agentcore/agentcore-execution-host.ts
@@ -24,6 +24,7 @@ import type {
   AgentCoreExecutionHostConfig,
   AgentCoreRuntimeClient,
 } from './types.js';
+import { AgentCoreExecutionTargetSchema } from './schemas.js';
 
 const CONTENT_TYPE = 'application/json';
 const ACCEPT = 'text/event-stream';
@@ -55,10 +56,12 @@ implements ExecutionHost, HeartbeatExecutionHost {
   readonly #wire: DirectHttpExecutionHost;
 
   constructor(config: AgentCoreExecutionHostConfig) {
-    this.#runtimeArn = config.runtimeArn;
-    this.#qualifier = config.qualifier;
-    this.#client = config.client ?? new BedrockAgentCoreClient({
-      region: config.region,
+    const { client, ...rawTarget } = config;
+    const target = AgentCoreExecutionTargetSchema.parse(rawTarget);
+    this.#runtimeArn = target.runtimeArn;
+    this.#qualifier = target.qualifier;
+    this.#client = client ?? new BedrockAgentCoreClient({
+      region: target.region,
       // Invocation settlement is ambiguous after a transport interruption.
       // Product policy, not the AWS client, decides whether a turn may retry.
       maxAttempts: 1,

--- a/packages/execution-host-client/src/agentcore/index.ts
+++ b/packages/execution-host-client/src/agentcore/index.ts
@@ -3,6 +3,13 @@ export {
   AGENTCORE_FORWARDED_HEADER_NAMES,
   AgentCoreExecutionHost,
 } from './agentcore-execution-host.js';
+export {
+  AgentCoreExecutionTargetSchema,
+  AgentCoreQualifierSchema,
+  AgentCoreRegionSchema,
+  AgentCoreRuntimeArnSchema,
+} from './schemas.js';
+export type { AgentCoreExecutionTarget } from './schemas.js';
 export type {
   AgentCoreExecutionHostConfig,
   AgentCoreRuntimeClient,

--- a/packages/execution-host-client/src/agentcore/schemas.ts
+++ b/packages/execution-host-client/src/agentcore/schemas.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const AgentCoreRegionSchema = z.string().trim().min(1).max(64).regex(
+  /^[a-z]{2}(?:-[a-z0-9]+)+-\d+$/,
+  'must be an AWS region identifier',
+);
+
+export const AgentCoreRuntimeArnSchema = z.string().trim().min(20).max(2_048)
+  .regex(
+    /^arn:[a-z0-9-]+:bedrock-agentcore:[a-z0-9-]+:\d{12}:runtime\/[A-Za-z0-9_-]+$/,
+    'must be an AgentCore Runtime ARN',
+  );
+
+export const AgentCoreQualifierSchema = z.string().trim().min(1).max(64)
+  .regex(
+    /^[A-Za-z0-9][A-Za-z0-9_-]*$/,
+    'must be an AgentCore endpoint qualifier',
+  );
+
+export const AgentCoreExecutionTargetSchema = z.object({
+  region: AgentCoreRegionSchema,
+  runtimeArn: AgentCoreRuntimeArnSchema,
+  qualifier: AgentCoreQualifierSchema.optional(),
+}).strict();
+
+export type AgentCoreExecutionTarget = z.infer<
+  typeof AgentCoreExecutionTargetSchema
+>;

--- a/packages/execution-host-client/src/agentcore/types.ts
+++ b/packages/execution-host-client/src/agentcore/types.ts
@@ -2,6 +2,7 @@ import type {
   InvokeAgentRuntimeCommand,
   InvokeAgentRuntimeCommandOutput,
 } from '@aws-sdk/client-bedrock-agentcore';
+import type { AgentCoreExecutionTarget } from './schemas.js';
 
 export interface AgentCoreRuntimeClient {
   send(
@@ -11,9 +12,6 @@ export interface AgentCoreRuntimeClient {
   destroy?(): void;
 }
 
-export type AgentCoreExecutionHostConfig = {
-  region: string;
-  runtimeArn: string;
-  qualifier?: string;
+export type AgentCoreExecutionHostConfig = AgentCoreExecutionTarget & {
   client?: AgentCoreRuntimeClient;
 };

--- a/packages/execution-host-client/src/coordinator/README.md
+++ b/packages/execution-host-client/src/coordinator/README.md
@@ -6,7 +6,8 @@ delegated authority, and remote-execution composition out of every adopter.
 
 ## Owns
 
-- the authenticated coordinator task API client;
+- the authenticated coordinator state, task inspection, mutation, trigger,
+  pause, resume, and drain client;
 - pause-first desired-task reconciliation;
 - the coordinator-to-product delegation request and response contracts;
 - stable Runtime-session derivation from authorized product scope;
@@ -64,6 +65,20 @@ await new HostedHeartbeatTaskReconciler({ coordinator }).reconcile({
 
 If reconciliation fails after pausing, the coordinator remains paused. This is
 intentional: partial desired state must not start new runs.
+
+The same client is the canonical product/operator API for current status and
+explicit control. It validates Heddle's task-view vocabulary rather than
+requiring each product to redefine the response or construct HTTP requests.
+
+```ts
+const tasks = await coordinator.listTasks()
+const detail = await coordinator.readTask(tasks[0].taskId)
+await coordinator.triggerTask(detail.task.taskId)
+```
+
+`readState()`, `pause()`, `resume()`, and `drain()` expose the coordinator
+lifecycle directly. Product code still decides who may perform those actions
+and how a task view appears in its UI.
 
 ## Authorize one coordinator run
 

--- a/packages/execution-host-client/src/coordinator/contracts.ts
+++ b/packages/execution-host-client/src/coordinator/contracts.ts
@@ -14,9 +14,11 @@ const ProductExecutionScopeSchema = ExecutionScopeSchema.omit({
 });
 
 export const HOSTED_HEARTBEAT_COORDINATOR_PATHS = Object.freeze({
+  state: '/v1/coordinator',
   tasks: '/v1/heartbeat/tasks',
   pause: '/v1/control/pause',
   resume: '/v1/control/resume',
+  drain: '/v1/control/drain',
 });
 
 export const HOSTED_HEARTBEAT_DELEGATIONS_PATH =
@@ -38,13 +40,87 @@ export const HostedHeartbeatCoordinatorTaskInputSchema = z.object({
   systemContext: z.string().max(200_000).optional(),
 }).strict();
 
-export const HostedHeartbeatCoordinatorTaskSummarySchema = z.object({
+export const HostedHeartbeatCoordinatorStateSchema = z.enum([
+  'running',
+  'paused',
+  'drained',
+  'stopped',
+]);
+
+export const HostedHeartbeatCoordinatorStateResponseSchema = z.object({
+  state: HostedHeartbeatCoordinatorStateSchema,
+}).strict();
+
+export const HostedHeartbeatCoordinatorTaskStatusSchema = z.enum([
+  'idle',
+  'running',
+  'waiting',
+  'blocked',
+  'complete',
+  'failed',
+]);
+
+export const HostedHeartbeatCoordinatorTaskResultSchema = z.object({
+  kind: z.enum([
+    'agent',
+    'skipped',
+    'cancelled',
+    'retry',
+    'blocked',
+    'failed',
+  ]),
+  decision: z.enum(['continue', 'pause', 'complete', 'escalate']).optional(),
+  summary: z.string(),
+  outcome: z.string(),
+  agentRunId: OpaqueIdSchema.optional(),
+  usage: z.unknown().optional(),
+}).passthrough();
+
+/** Stable product/operator projection returned by the Coordinator API. */
+export const HostedHeartbeatCoordinatorTaskViewSchema = z.object({
   id: OpaqueIdSchema,
+  taskId: OpaqueIdSchema,
   workspaceId: OpaqueIdSchema.optional(),
+  name: z.string().optional(),
+  task: z.string(),
+  enabled: z.boolean(),
+  continuationMode: z.enum(['operator', 'agent']).optional(),
+  schedule: z.object({
+    intervalMs: z.number().int().positive(),
+    nextRunAt: TimestampSchema.optional(),
+  }).passthrough(),
+  state: z.object({
+    status: HostedHeartbeatCoordinatorTaskStatusSchema,
+    progress: z.string().optional(),
+    runId: OpaqueIdSchema.optional(),
+    runAt: TimestampSchema.optional(),
+    loadedCheckpoint: z.boolean().optional(),
+    resumable: z.boolean().optional(),
+    result: HostedHeartbeatCoordinatorTaskResultSchema.optional(),
+    error: z.string().optional(),
+    updatedAt: TimestampSchema.optional(),
+  }).passthrough(),
 }).passthrough();
 
 export const HostedHeartbeatCoordinatorTaskListSchema = z.object({
-  tasks: z.array(HostedHeartbeatCoordinatorTaskSummarySchema),
+  tasks: z.array(HostedHeartbeatCoordinatorTaskViewSchema),
+}).strict();
+
+export const HostedHeartbeatCoordinatorRunViewSchema = z.object({
+  id: OpaqueIdSchema,
+  taskId: OpaqueIdSchema,
+  workspaceId: OpaqueIdSchema.optional(),
+  executionId: OpaqueIdSchema,
+  runId: OpaqueIdSchema.optional(),
+  createdAt: TimestampSchema,
+  task: HostedHeartbeatCoordinatorTaskViewSchema,
+  result: HostedHeartbeatCoordinatorTaskResultSchema,
+  loadedCheckpoint: z.boolean().optional(),
+}).passthrough();
+
+export const HostedHeartbeatCoordinatorTaskDetailSchema = z.object({
+  task: HostedHeartbeatCoordinatorTaskViewSchema,
+  runs: z.array(HostedHeartbeatCoordinatorRunViewSchema),
 }).strict();
 
 export const HostedHeartbeatDesiredTaskSchema = z.object({
@@ -129,8 +205,17 @@ export const HostedHeartbeatDelegationAuthorizationSchema = z.object({
 export type HostedHeartbeatCoordinatorTaskInput = z.infer<
   typeof HostedHeartbeatCoordinatorTaskInputSchema
 >;
-export type HostedHeartbeatCoordinatorTaskSummary = z.infer<
-  typeof HostedHeartbeatCoordinatorTaskSummarySchema
+export type HostedHeartbeatCoordinatorState = z.infer<
+  typeof HostedHeartbeatCoordinatorStateSchema
+>;
+export type HostedHeartbeatCoordinatorTaskView = z.infer<
+  typeof HostedHeartbeatCoordinatorTaskViewSchema
+>;
+export type HostedHeartbeatCoordinatorRunView = z.infer<
+  typeof HostedHeartbeatCoordinatorRunViewSchema
+>;
+export type HostedHeartbeatCoordinatorTaskDetail = z.infer<
+  typeof HostedHeartbeatCoordinatorTaskDetailSchema
 >;
 export type HostedHeartbeatDesiredTask = z.infer<
   typeof HostedHeartbeatDesiredTaskSchema

--- a/packages/execution-host-client/src/coordinator/hosted-heartbeat-coordinator-client.ts
+++ b/packages/execution-host-client/src/coordinator/hosted-heartbeat-coordinator-client.ts
@@ -5,10 +5,15 @@ import {
 } from '../contracts/index.js';
 import {
   HOSTED_HEARTBEAT_COORDINATOR_PATHS,
+  HostedHeartbeatCoordinatorStateResponseSchema,
+  HostedHeartbeatCoordinatorTaskDetailSchema,
   HostedHeartbeatCoordinatorTaskInputSchema,
   HostedHeartbeatCoordinatorTaskListSchema,
+  HostedHeartbeatCoordinatorTaskViewSchema,
   type HostedHeartbeatCoordinatorTaskInput,
-  type HostedHeartbeatCoordinatorTaskSummary,
+  type HostedHeartbeatCoordinatorState,
+  type HostedHeartbeatCoordinatorTaskDetail,
+  type HostedHeartbeatCoordinatorTaskView,
 } from './contracts.js';
 import { HostedHeartbeatServiceTokenSchema } from './service-token.js';
 import type {
@@ -48,9 +53,21 @@ implements HostedHeartbeatCoordinatorTaskApi {
     this.#fetch = config.fetch ?? globalThis.fetch;
   }
 
+  async readState(
+    signal?: AbortSignal,
+  ): Promise<HostedHeartbeatCoordinatorState> {
+    const response = await this.#request(
+      HOSTED_HEARTBEAT_COORDINATOR_PATHS.state,
+      { method: 'GET', signal },
+    );
+    return HostedHeartbeatCoordinatorStateResponseSchema.parse(
+      await response.json(),
+    ).state;
+  }
+
   async listTasks(
     signal?: AbortSignal,
-  ): Promise<HostedHeartbeatCoordinatorTaskSummary[]> {
+  ): Promise<HostedHeartbeatCoordinatorTaskView[]> {
     const response = await this.#request(
       HOSTED_HEARTBEAT_COORDINATOR_PATHS.tasks,
       { method: 'GET', signal },
@@ -58,6 +75,19 @@ implements HostedHeartbeatCoordinatorTaskApi {
     return HostedHeartbeatCoordinatorTaskListSchema.parse(
       await response.json(),
     ).tasks;
+  }
+
+  async readTask(
+    rawTaskId: string,
+    signal?: AbortSignal,
+  ): Promise<HostedHeartbeatCoordinatorTaskDetail> {
+    const response = await this.#request(
+      this.#taskPath(OpaqueIdSchema.parse(rawTaskId)),
+      { method: 'GET', signal },
+    );
+    return HostedHeartbeatCoordinatorTaskDetailSchema.parse(
+      await response.json(),
+    );
   }
 
   async upsertTask(
@@ -82,6 +112,18 @@ implements HostedHeartbeatCoordinatorTaskApi {
     });
   }
 
+  async triggerTask(
+    rawTaskId: string,
+    signal?: AbortSignal,
+  ): Promise<HostedHeartbeatCoordinatorTaskView> {
+    const taskId = OpaqueIdSchema.parse(rawTaskId);
+    const path = `${this.#taskPath(taskId)}/trigger`;
+    const response = await this.#request(path, { method: 'POST', signal });
+    return HostedHeartbeatCoordinatorTaskViewSchema.parse(
+      await response.json(),
+    );
+  }
+
   async pause(signal?: AbortSignal): Promise<void> {
     await this.#request(HOSTED_HEARTBEAT_COORDINATOR_PATHS.pause, {
       method: 'POST',
@@ -91,6 +133,13 @@ implements HostedHeartbeatCoordinatorTaskApi {
 
   async resume(signal?: AbortSignal): Promise<void> {
     await this.#request(HOSTED_HEARTBEAT_COORDINATOR_PATHS.resume, {
+      method: 'POST',
+      signal,
+    });
+  }
+
+  async drain(signal?: AbortSignal): Promise<void> {
+    await this.#request(HOSTED_HEARTBEAT_COORDINATOR_PATHS.drain, {
       method: 'POST',
       signal,
     });

--- a/packages/execution-host-client/src/coordinator/index.ts
+++ b/packages/execution-host-client/src/coordinator/index.ts
@@ -1,9 +1,15 @@
 export {
   HOSTED_HEARTBEAT_COORDINATOR_PATHS,
   HOSTED_HEARTBEAT_DELEGATIONS_PATH,
+  HostedHeartbeatCoordinatorRunViewSchema,
+  HostedHeartbeatCoordinatorStateResponseSchema,
+  HostedHeartbeatCoordinatorStateSchema,
+  HostedHeartbeatCoordinatorTaskDetailSchema,
   HostedHeartbeatCoordinatorTaskInputSchema,
   HostedHeartbeatCoordinatorTaskListSchema,
-  HostedHeartbeatCoordinatorTaskSummarySchema,
+  HostedHeartbeatCoordinatorTaskResultSchema,
+  HostedHeartbeatCoordinatorTaskStatusSchema,
+  HostedHeartbeatCoordinatorTaskViewSchema,
   HostedHeartbeatDelegationAuthorizationSchema,
   HostedHeartbeatDelegationRequestSchema,
   HostedHeartbeatDelegationSchema,
@@ -12,7 +18,10 @@ export {
 } from './contracts.js';
 export type {
   HostedHeartbeatCoordinatorTaskInput,
-  HostedHeartbeatCoordinatorTaskSummary,
+  HostedHeartbeatCoordinatorRunView,
+  HostedHeartbeatCoordinatorState,
+  HostedHeartbeatCoordinatorTaskDetail,
+  HostedHeartbeatCoordinatorTaskView,
   HostedHeartbeatDelegation,
   HostedHeartbeatDelegationAuthorization,
   HostedHeartbeatDelegationRequest,

--- a/packages/execution-host-client/src/coordinator/types.ts
+++ b/packages/execution-host-client/src/coordinator/types.ts
@@ -10,7 +10,9 @@ import type {
 import type { HeartbeatExecutionHost } from '../http-sse/index.js';
 import type {
   HostedHeartbeatCoordinatorTaskInput,
-  HostedHeartbeatCoordinatorTaskSummary,
+  HostedHeartbeatCoordinatorState,
+  HostedHeartbeatCoordinatorTaskDetail,
+  HostedHeartbeatCoordinatorTaskView,
   HostedHeartbeatDelegation,
   HostedHeartbeatDelegationAuthorization,
   HostedHeartbeatDelegationRequest,
@@ -24,17 +26,27 @@ export type HostedHeartbeatCoordinatorClientConfig = {
 };
 
 export interface HostedHeartbeatCoordinatorTaskApi {
-  listTasks(signal?: AbortSignal): Promise<
-    HostedHeartbeatCoordinatorTaskSummary[]
-  >;
+  readState(signal?: AbortSignal): Promise<HostedHeartbeatCoordinatorState>;
+  listTasks(
+    signal?: AbortSignal,
+  ): Promise<HostedHeartbeatCoordinatorTaskView[]>;
+  readTask(
+    taskId: string,
+    signal?: AbortSignal,
+  ): Promise<HostedHeartbeatCoordinatorTaskDetail>;
   upsertTask(
     taskId: string,
     task: HostedHeartbeatCoordinatorTaskInput,
     signal?: AbortSignal,
   ): Promise<void>;
+  triggerTask(
+    taskId: string,
+    signal?: AbortSignal,
+  ): Promise<HostedHeartbeatCoordinatorTaskView>;
   deleteTask(taskId: string, signal?: AbortSignal): Promise<void>;
   pause(signal?: AbortSignal): Promise<void>;
   resume(signal?: AbortSignal): Promise<void>;
+  drain(signal?: AbortSignal): Promise<void>;
 }
 
 export type HostedHeartbeatTaskReconciliationInput = {
@@ -50,7 +62,10 @@ export type HostedHeartbeatTaskReconciliation = {
 };
 
 export type HostedHeartbeatTaskReconcilerConfig = {
-  coordinator: HostedHeartbeatCoordinatorTaskApi;
+  coordinator: Pick<
+    HostedHeartbeatCoordinatorTaskApi,
+    'listTasks' | 'upsertTask' | 'deleteTask' | 'pause' | 'resume'
+  >;
 };
 
 export type HostedHeartbeatDelegationAuthorizationInput = {

--- a/packages/execution-host-client/src/host/README.md
+++ b/packages/execution-host-client/src/host/README.md
@@ -13,3 +13,9 @@ authorization, and capability issuance.
 The product MCP edge uses `../mcp` instead. Its verifier derives scope from a
 capability for product data access; this module independently cross-checks that
 same capability against the host's verified execution identity.
+
+The provider-neutral Runtime session service under `runtime-session/` owns
+immutable scope binding, one-active-invocation admission, workflow dispatch,
+deadlines, cancellation, bounded duplicate suppression, status, and shutdown.
+Provider ingress, process isolation, health projection, engine composition, and
+deployment bootstrap remain responsibilities of the deployable host.

--- a/packages/execution-host-client/src/host/index.ts
+++ b/packages/execution-host-client/src/host/index.ts
@@ -27,3 +27,4 @@ export type {
   VerifiedExecutionHostMcpCapability,
   VerifiedExecutionIdentity,
 } from './types.js';
+export * from './runtime-session/index.js';

--- a/packages/execution-host-client/src/host/runtime-session/README.md
+++ b/packages/execution-host-client/src/host/runtime-session/README.md
@@ -1,0 +1,17 @@
+# Execution Host Runtime session
+
+This is the provider-neutral application-service boundary for one
+process-bound compatible Execution Host session. It coordinates immutable
+scope binding, one-active-invocation admission, workflow dispatch, deadlines,
+caller cancellation, bounded duplicate suppression, status, and shutdown.
+
+It accepts only already verified execution identity and MCP capability values.
+It does not parse HTTP, know AgentCore or another host provider, construct a
+Heddle engine, schedule heartbeat tasks, persist product data, or provide
+durable idempotency. A deployable host supplies the conversation and heartbeat
+workflow executors and projects the resulting events onto its provider ingress.
+
+Host implementations should import these types and services directly. Do not
+rename their vocabulary or maintain a local copy. Provider bootstrap,
+isolation, health-shape projection, HTTP/SSE framing, and process signals remain
+the deployable host's responsibility.

--- a/packages/execution-host-client/src/host/runtime-session/errors.ts
+++ b/packages/execution-host-client/src/host/runtime-session/errors.ts
@@ -1,0 +1,32 @@
+export class RuntimeExecutionPreparationError extends Error {
+  readonly name = 'RuntimeExecutionPreparationError';
+
+  constructor(
+    readonly category: RuntimeExecutionPreparationCategory,
+    options: { cause?: unknown } = {},
+  ) {
+    super('The agent execution dependency could not be prepared.', options);
+  }
+}
+
+export type RuntimeExecutionPreparationCategory =
+  | 'authority'
+  | 'configuration'
+  | 'contract'
+  | 'dependency';
+
+export class RuntimeBusyError extends Error {
+  readonly name = 'RuntimeBusyError';
+}
+
+export class RuntimeDuplicateInvocationError extends Error {
+  readonly name = 'RuntimeDuplicateInvocationError';
+}
+
+export class RuntimeDeadlineError extends Error {
+  readonly name = 'RuntimeDeadlineError';
+}
+
+export class RuntimeScopeMismatchError extends Error {
+  readonly name = 'RuntimeScopeMismatchError';
+}

--- a/packages/execution-host-client/src/host/runtime-session/index.ts
+++ b/packages/execution-host-client/src/host/runtime-session/index.ts
@@ -1,0 +1,30 @@
+export {
+  RuntimeBusyError,
+  RuntimeDeadlineError,
+  RuntimeDuplicateInvocationError,
+  RuntimeExecutionPreparationError,
+  RuntimeScopeMismatchError,
+} from './errors.js';
+export type {
+  RuntimeExecutionPreparationCategory,
+} from './errors.js';
+export {
+  RuntimeScopeBindingService,
+} from './scope-binding.js';
+export type {
+  BoundRuntimeScope,
+  RuntimeScopeBinding,
+} from './scope-binding.js';
+export { RuntimeSessionService } from './service.js';
+export { RuntimeSessionStatusService } from './status.js';
+export type { RuntimeSessionStatusSnapshot } from './status.js';
+export type {
+  RuntimeExecutionHandle,
+  RuntimeExecutionInput,
+  RuntimeExecutionStreamItem,
+  RuntimeInvocationHandle,
+  RuntimeInvocationRequest,
+  RuntimeSessionConfig,
+  RuntimeWorkflowExecutor,
+  RuntimeWorkflowExecutors,
+} from './types.js';

--- a/packages/execution-host-client/src/host/runtime-session/scope-binding.ts
+++ b/packages/execution-host-client/src/host/runtime-session/scope-binding.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto';
+import type { ExecutionScope } from '../../contracts/index.js';
+import { RuntimeScopeMismatchError } from './errors.js';
+
+export type RuntimeScopeBinding = ExecutionScope & {
+  runtimeSessionId: string;
+};
+
+export type BoundRuntimeScope = {
+  binding: RuntimeScopeBinding;
+  scopeKey: string;
+  executionSessionId: string;
+};
+
+/** Defense in depth if a host process is reused across execution scopes. */
+export class RuntimeScopeBindingService {
+  private bound?: BoundRuntimeScope;
+
+  bind(input: RuntimeScopeBinding): BoundRuntimeScope {
+    const candidate = RuntimeScopeBindingService.toBoundScope(input);
+    if (!this.bound) {
+      this.bound = candidate;
+      return candidate;
+    }
+
+    if (this.bound.scopeKey !== candidate.scopeKey) {
+      throw new RuntimeScopeMismatchError(
+        'This runtime process is already bound to a different execution scope.',
+      );
+    }
+
+    return this.bound;
+  }
+
+  current(): BoundRuntimeScope | undefined {
+    return this.bound;
+  }
+
+  private static toBoundScope(binding: RuntimeScopeBinding): BoundRuntimeScope {
+    const scopeKey = createHash('sha256')
+      .update(JSON.stringify([
+        binding.runtimeSessionId,
+        binding.adopterId,
+        binding.tenantId,
+        binding.subjectId,
+        binding.productSessionId,
+      ]))
+      .digest('hex');
+
+    return {
+      binding: { ...binding },
+      scopeKey,
+      executionSessionId: `runtime-${scopeKey}`,
+    };
+  }
+}

--- a/packages/execution-host-client/src/host/runtime-session/service.ts
+++ b/packages/execution-host-client/src/host/runtime-session/service.ts
@@ -1,0 +1,260 @@
+import type {
+  VerifiedExecutionHostMcpCapability,
+  VerifiedExecutionIdentity,
+} from '../types.js';
+import {
+  RuntimeBusyError,
+  RuntimeDeadlineError,
+  RuntimeDuplicateInvocationError,
+} from './errors.js';
+import {
+  RuntimeScopeBindingService,
+  type BoundRuntimeScope,
+} from './scope-binding.js';
+import {
+  RuntimeSessionStatusService,
+  type RuntimeSessionStatusSnapshot,
+} from './status.js';
+import type {
+  RuntimeExecutionHandle,
+  RuntimeExecutionInput,
+  RuntimeInvocationHandle,
+  RuntimeInvocationRequest,
+  RuntimeSessionConfig,
+  RuntimeWorkflowExecutors,
+} from './types.js';
+
+const RECENT_INVOCATION_LIMIT = 128;
+
+type ActiveInvocation = {
+  invocationId: string;
+  run: RuntimeExecutionHandle;
+  controller: AbortController;
+  deadlineTimer: ReturnType<typeof setTimeout>;
+  removeCallerAbortListener: () => void;
+};
+
+type StartingInvocation = {
+  controller: AbortController;
+  promise: Promise<RuntimeExecutionHandle>;
+};
+
+/** Coordinates one process-bound Runtime session without owning product data. */
+export class RuntimeSessionService {
+  private active?: ActiveInvocation;
+  private starting?: StartingInvocation;
+  private readonly recentCompletedInvocationIds = new Set<string>();
+  private readonly recentCompletedInvocationOrder: string[] = [];
+  private readonly config: RuntimeSessionConfig;
+  private readonly executors: RuntimeWorkflowExecutors;
+  private readonly binding: RuntimeScopeBindingService;
+  private readonly status: RuntimeSessionStatusService;
+  private readonly now: () => Date;
+
+  constructor(options: {
+    config: RuntimeSessionConfig;
+    executors: RuntimeWorkflowExecutors;
+    binding?: RuntimeScopeBindingService;
+    status?: RuntimeSessionStatusService;
+    now?: () => Date;
+  }) {
+    if (
+      !Number.isSafeInteger(options.config.maxInvocationMs)
+      || options.config.maxInvocationMs <= 0
+    ) {
+      throw new Error('maxInvocationMs must be a positive safe integer.');
+    }
+    this.config = options.config;
+    this.executors = options.executors;
+    this.binding = options.binding ?? new RuntimeScopeBindingService();
+    this.now = options.now ?? (() => new Date());
+    this.status = options.status ?? new RuntimeSessionStatusService(this.now);
+  }
+
+  readStatus(): RuntimeSessionStatusSnapshot {
+    return this.status.read();
+  }
+
+  async start(input: {
+    identity: VerifiedExecutionIdentity;
+    invocation: RuntimeInvocationRequest;
+    modelApiKey: string;
+    mcpCapability?: VerifiedExecutionHostMcpCapability;
+    callerSignal: AbortSignal;
+  }): Promise<RuntimeInvocationHandle> {
+    const deadline = this.resolveDeadline(input.invocation.deadlineAt);
+    const binding = this.binding.bind({
+      runtimeSessionId: input.identity.runtimeSessionId,
+      ...input.identity.scope,
+    });
+
+    if (this.active || this.starting) {
+      throw new RuntimeBusyError(
+        'This runtime session already has an active invocation.',
+      );
+    }
+    if (this.recentCompletedInvocationIds.has(input.identity.invocationId)) {
+      throw new RuntimeDuplicateInvocationError(
+        'This recent invocation identifier already completed in the current runtime process.',
+      );
+    }
+
+    const controller = new AbortController();
+    const abortFromCaller = () => controller.abort(input.callerSignal.reason);
+    input.callerSignal.addEventListener('abort', abortFromCaller, { once: true });
+    if (input.callerSignal.aborted) {
+      abortFromCaller();
+    }
+
+    const deadlineTimer = setTimeout(
+      () => controller.abort(
+        new RuntimeDeadlineError('The runtime invocation deadline elapsed.'),
+      ),
+      deadline.getTime() - this.now().getTime(),
+    );
+    deadlineTimer.unref();
+
+    this.status.markExecuting();
+    const executionInput = {
+      scopeKey: binding.scopeKey,
+      executionSessionId: binding.executionSessionId,
+      request: input.invocation,
+      modelApiKey: input.modelApiKey,
+      mcpCapability: input.mcpCapability,
+      abortSignal: controller.signal,
+    } satisfies RuntimeExecutionInput;
+    const startPromise = Promise.resolve().then(
+      () => this.startExecution(executionInput),
+    );
+    const starting: StartingInvocation = {
+      controller,
+      promise: startPromise,
+    };
+    this.starting = starting;
+
+    let run: RuntimeExecutionHandle;
+    try {
+      run = await startPromise;
+    } catch (error) {
+      clearTimeout(deadlineTimer);
+      input.callerSignal.removeEventListener('abort', abortFromCaller);
+      this.status.markIdle();
+      throw error;
+    } finally {
+      if (this.starting === starting) {
+        this.starting = undefined;
+      }
+    }
+
+    const active: ActiveInvocation = {
+      invocationId: input.identity.invocationId,
+      run,
+      controller,
+      deadlineTimer,
+      removeCallerAbortListener: () =>
+        input.callerSignal.removeEventListener('abort', abortFromCaller),
+    };
+    this.active = active;
+    controller.signal.addEventListener('abort', () => run.cancel(), {
+      once: true,
+    });
+    if (controller.signal.aborted) {
+      run.cancel();
+    }
+
+    const result = run.result.finally(() => this.settle(active));
+    result.catch(() => undefined);
+
+    return {
+      runId: run.runId,
+      acceptedAt: this.now().toISOString(),
+      // The execution signal cancels the agent, but the event subscription
+      // remains open for the executor's truthful cancelled terminal.
+      events: () => run.events(),
+      cancel: () => {
+        const wasActive = !controller.signal.aborted;
+        controller.abort();
+        return wasActive;
+      },
+      result,
+    };
+  }
+
+  async shutdown(): Promise<void> {
+    const starting = this.starting;
+    if (starting) {
+      starting.controller.abort(new Error('Runtime is shutting down.'));
+      const run = await starting.promise.catch(() => undefined);
+      if (run) {
+        run.cancel();
+        await run.result.catch(() => undefined);
+      }
+    }
+
+    const active = this.active;
+    if (!active) {
+      return;
+    }
+    active.controller.abort(new Error('Runtime is shutting down.'));
+    active.run.cancel();
+    await active.run.result.catch(() => undefined);
+  }
+
+  boundScope(): BoundRuntimeScope | undefined {
+    return this.binding.current();
+  }
+
+  private resolveDeadline(deadlineAt?: string): Date {
+    const now = this.now();
+    const maximum = new Date(now.getTime() + this.config.maxInvocationMs);
+    if (!deadlineAt) {
+      return maximum;
+    }
+
+    const requested = new Date(deadlineAt);
+    if (requested.getTime() <= now.getTime()) {
+      throw new RuntimeDeadlineError(
+        'The runtime invocation deadline has already elapsed.',
+      );
+    }
+    return requested.getTime() < maximum.getTime() ? requested : maximum;
+  }
+
+  private settle(active: ActiveInvocation): void {
+    if (this.active !== active) {
+      return;
+    }
+    clearTimeout(active.deadlineTimer);
+    active.removeCallerAbortListener();
+    this.active = undefined;
+    this.rememberCompletedInvocation(active.invocationId);
+    this.status.markIdle();
+  }
+
+  private rememberCompletedInvocation(invocationId: string): void {
+    this.recentCompletedInvocationIds.add(invocationId);
+    this.recentCompletedInvocationOrder.push(invocationId);
+    if (this.recentCompletedInvocationOrder.length <= RECENT_INVOCATION_LIMIT) {
+      return;
+    }
+    const oldest = this.recentCompletedInvocationOrder.shift();
+    if (oldest) {
+      this.recentCompletedInvocationIds.delete(oldest);
+    }
+  }
+
+  private startExecution(
+    input: RuntimeExecutionInput,
+  ): Promise<RuntimeExecutionHandle> {
+    if (input.request.kind === 'conversation-turn') {
+      return this.executors.conversationTurn.start({
+        ...input,
+        request: input.request,
+      });
+    }
+    return this.executors.heartbeatTask.start({
+      ...input,
+      request: input.request,
+    });
+  }
+}

--- a/packages/execution-host-client/src/host/runtime-session/status.ts
+++ b/packages/execution-host-client/src/host/runtime-session/status.ts
@@ -1,0 +1,41 @@
+export type RuntimeSessionStatusSnapshot = {
+  state: 'idle' | 'executing';
+  changedAtUnixSeconds: number;
+};
+
+/** Tracks process-local execution status without provider-specific vocabulary. */
+export class RuntimeSessionStatusService {
+  private state: RuntimeSessionStatusSnapshot['state'] = 'idle';
+  private changedAtUnixSeconds: number;
+
+  constructor(private readonly now: () => Date = () => new Date()) {
+    this.changedAtUnixSeconds = this.currentUnixSeconds();
+  }
+
+  markExecuting(): void {
+    this.transition('executing');
+  }
+
+  markIdle(): void {
+    this.transition('idle');
+  }
+
+  read(): RuntimeSessionStatusSnapshot {
+    return {
+      state: this.state,
+      changedAtUnixSeconds: this.changedAtUnixSeconds,
+    };
+  }
+
+  private transition(next: RuntimeSessionStatusSnapshot['state']): void {
+    if (this.state === next) {
+      return;
+    }
+    this.state = next;
+    this.changedAtUnixSeconds = this.currentUnixSeconds();
+  }
+
+  private currentUnixSeconds(): number {
+    return Math.floor(this.now().getTime() / 1_000);
+  }
+}

--- a/packages/execution-host-client/src/host/runtime-session/types.ts
+++ b/packages/execution-host-client/src/host/runtime-session/types.ts
@@ -1,0 +1,88 @@
+import type {
+  ExecutionHostConversationTurnRequest,
+  ExecutionHostHeartbeatTaskRequest,
+  RuntimePublicResult,
+} from '../../contracts/index.js';
+import type { VerifiedExecutionHostMcpCapability } from '../types.js';
+
+type RuntimeExecutionStreamEnvelope = {
+  runId: string;
+  sequence: number;
+  timestamp: string;
+};
+
+/** Ordered execution events exposed by any workflow executor. */
+export type RuntimeExecutionStreamItem<Result = unknown> =
+  | (RuntimeExecutionStreamEnvelope & {
+    kind: 'activity';
+    activity: unknown;
+  })
+  | (RuntimeExecutionStreamEnvelope & {
+    kind: 'result';
+    result: Result;
+  })
+  | (RuntimeExecutionStreamEnvelope & {
+    kind: 'cancelled';
+    reason: string;
+  })
+  | (RuntimeExecutionStreamEnvelope & {
+    kind: 'error';
+    error: { code: string; message: string };
+  });
+
+export type RuntimeInvocationRequest =
+  | ExecutionHostConversationTurnRequest
+  | ExecutionHostHeartbeatTaskRequest;
+
+export type RuntimeExecutionInput<
+  Request extends RuntimeInvocationRequest = RuntimeInvocationRequest,
+> = {
+  scopeKey: string;
+  executionSessionId: string;
+  request: Request;
+  modelApiKey: string;
+  mcpCapability?: VerifiedExecutionHostMcpCapability;
+  abortSignal: AbortSignal;
+};
+
+export type RuntimeExecutionHandle<Result = unknown> = {
+  runId: string;
+  result: Promise<Result>;
+  events(options?: {
+    signal?: AbortSignal;
+  }): AsyncIterable<RuntimeExecutionStreamItem<Result>>;
+  cancel(): boolean;
+};
+
+/** Outbound execution port for one provider-neutral workflow. */
+export type RuntimeWorkflowExecutor<
+  Request extends RuntimeInvocationRequest,
+  Result,
+> = {
+  start(
+    input: RuntimeExecutionInput<Request>,
+  ): Promise<RuntimeExecutionHandle<Result>>;
+};
+
+export type RuntimeWorkflowExecutors<HeartbeatResult = unknown> = {
+  conversationTurn: RuntimeWorkflowExecutor<
+    ExecutionHostConversationTurnRequest,
+    RuntimePublicResult
+  >;
+  heartbeatTask: RuntimeWorkflowExecutor<
+    ExecutionHostHeartbeatTaskRequest,
+    HeartbeatResult
+  >;
+};
+
+export type RuntimeInvocationHandle<Result = unknown> = {
+  runId: string;
+  acceptedAt: string;
+  events(): AsyncIterable<RuntimeExecutionStreamItem<Result>>;
+  cancel(): boolean;
+  result: Promise<Result>;
+};
+
+export type RuntimeSessionConfig = {
+  maxInvocationMs: number;
+};

--- a/packages/execution-host-client/src/http-sse/direct-http-execution-host.ts
+++ b/packages/execution-host-client/src/http-sse/direct-http-execution-host.ts
@@ -1,4 +1,3 @@
-import { createParser, type EventSourceMessage } from 'eventsource-parser';
 import { z } from 'zod';
 import {
   AGENTCORE_RUNTIME_SESSION_HEADER,
@@ -24,9 +23,7 @@ import {
 } from '../contracts/index.js';
 import {
   ExecutionHostInvocationCancelledError,
-  ExecutionHostProtocolError,
   ExecutionHostRejectedError,
-  ExecutionHostStreamInterruptedError,
 } from './errors.js';
 import type {
   DirectHttpExecutionHostConfig,
@@ -35,9 +32,12 @@ import type {
   ExecutionHostHeartbeatTask,
   HeartbeatExecutionHost,
 } from './types.js';
+import {
+  readExecutionHostEventStream,
+  toExecutionHostTransportError,
+} from '../internal/execution-host-event-stream.js';
+import { readBoundedJsonResponse } from '../internal/http-response.js';
 
-const MAX_SSE_BUFFER_CHARACTERS = 1_048_576;
-const MAX_PENDING_SSE_FRAMES = 1_024;
 const MAX_ERROR_BODY_BYTES = 16_384;
 const SecretSchema = z.string().min(8).max(4_096);
 const InvocationAuthoritySchema = z.object({
@@ -154,98 +154,13 @@ implements ExecutionHost, HeartbeatExecutionHost {
         await readSafeErrorCode(response),
       );
     }
-    if (!isEventStream(response.headers.get('content-type'))) {
-      await cancelBody(response);
-      throw new ExecutionHostProtocolError(
-        'Execution Host did not return an SSE stream.',
-      );
-    }
-    if (!response.body) {
-      throw new ExecutionHostProtocolError(
-        'Execution Host returned an empty SSE response body.',
-      );
-    }
-
-    const state: StreamValidationState = {
+    yield* readExecutionHostEventStream({
+      response,
+      schema,
+      isTerminal,
       invocationId: input.invocationId,
-      nextSequence: 0,
-      terminal: false,
-    };
-    const decoder = new TextDecoder();
-    const pending: EventSourceMessage[] = [];
-    let terminalEvent: TEvent | undefined;
-    let parserError = false;
-    const parser = createParser({
-      maxBufferSize: MAX_SSE_BUFFER_CHARACTERS,
-      onEvent: (event) => {
-        if (pending.length >= MAX_PENDING_SSE_FRAMES) {
-          parserError = true;
-          return;
-        }
-        pending.push(event);
-      },
-      onError: () => {
-        parserError = true;
-      },
+      signal: input.signal,
     });
-
-    try {
-      for await (const chunk of response.body) {
-        input.signal?.throwIfAborted();
-        parser.feed(decoder.decode(chunk, { stream: true }));
-        if (parserError) {
-          throw new ExecutionHostProtocolError();
-        }
-        while (pending.length > 0) {
-          const event = validateEvent(
-            pending.shift()!,
-            state,
-            schema,
-            isTerminal,
-          );
-          if (isTerminal(event)) {
-            terminalEvent = event;
-          } else {
-            yield event;
-          }
-        }
-      }
-      parser.feed(decoder.decode());
-      parser.reset({ consume: true });
-      if (parserError) {
-        throw new ExecutionHostProtocolError();
-      }
-      while (pending.length > 0) {
-        const event = validateEvent(
-          pending.shift()!,
-          state,
-          schema,
-          isTerminal,
-        );
-        if (isTerminal(event)) {
-          terminalEvent = event;
-        } else {
-          yield event;
-        }
-      }
-    } catch (error) {
-      if (error instanceof ExecutionHostProtocolError) {
-        throw error;
-      }
-      throw toTransportError(error, input.signal);
-    }
-
-    if (!state.accepted) {
-      throw new ExecutionHostProtocolError(
-        'Execution Host stream omitted the accepted event.',
-      );
-    }
-    if (!state.terminal || !terminalEvent) {
-      throw new ExecutionHostStreamInterruptedError();
-    }
-    // Terminal is released only after clean EOF, so a trailing malformed or
-    // post-terminal frame cannot be projected as success.
-    yield terminalEvent;
   }
 
   async #invoke(input: InvocationInput, body: unknown): Promise<Response> {
@@ -258,18 +173,10 @@ implements ExecutionHost, HeartbeatExecutionHost {
         body: JSON.stringify(body),
       });
     } catch (error) {
-      throw toTransportError(error, input.signal);
+      throw toExecutionHostTransportError(error, input.signal);
     }
   }
 }
-
-type StreamValidationState = {
-  invocationId: string;
-  runId?: string;
-  nextSequence: number;
-  accepted?: true;
-  terminal: boolean;
-};
 
 type InvocationInput = {
   invocationId: string;
@@ -287,46 +194,6 @@ type ValidatedStreamEvent = {
   sequence: number;
   timestamp: string;
 };
-
-function validateEvent<TEvent extends ValidatedStreamEvent>(
-  frame: EventSourceMessage,
-  state: StreamValidationState,
-  schema: z.ZodType<TEvent>,
-  isTerminal: (event: TEvent) => boolean,
-): TEvent {
-  let decoded: unknown;
-  try {
-    decoded = JSON.parse(frame.data);
-  } catch {
-    throw new ExecutionHostProtocolError();
-  }
-  const parsed = schema.safeParse(decoded);
-  if (!parsed.success) {
-    throw new ExecutionHostProtocolError();
-  }
-  const event = parsed.data;
-  const correctFrameMetadata = frame.event === event.kind
-    && frame.id === String(event.sequence);
-  const correctEnvelope = event.invocationId === state.invocationId
-    && event.sequence === state.nextSequence;
-  if (!correctFrameMetadata || !correctEnvelope || state.terminal) {
-    throw new ExecutionHostProtocolError();
-  }
-
-  if (!state.accepted) {
-    if (event.kind !== 'accepted') {
-      throw new ExecutionHostProtocolError();
-    }
-    state.accepted = true;
-    state.runId = event.runId;
-  } else if (event.kind === 'accepted' || event.runId !== state.runId) {
-    throw new ExecutionHostProtocolError();
-  }
-
-  state.nextSequence += 1;
-  state.terminal = isTerminal(event);
-  return event;
-}
 
 function createSensitiveHeaders(
   input: InvocationInput,
@@ -346,86 +213,16 @@ function createSensitiveHeaders(
   return headers;
 }
 
-function isEventStream(contentType: string | null): boolean {
-  return contentType?.split(';', 1)[0]?.trim().toLowerCase()
-    === 'text/event-stream';
-}
-
 async function readSafeErrorCode(response: Response): Promise<string> {
   try {
-    const declaredLength = Number(response.headers.get('content-length'));
-    if (
-      Number.isFinite(declaredLength)
-      && declaredLength > MAX_ERROR_BODY_BYTES
-    ) {
-      await cancelBody(response);
-      return 'unknown';
-    }
-    const bytes = await readBoundedBody(response, MAX_ERROR_BODY_BYTES);
-    if (!bytes) {
-      return 'unknown';
-    }
-    const parsed = ApiErrorSchema.safeParse(
-      JSON.parse(new TextDecoder().decode(bytes)),
-    );
+    const parsed = ApiErrorSchema.safeParse(await readBoundedJsonResponse(
+      response,
+      MAX_ERROR_BODY_BYTES,
+    ));
     return parsed.success ? parsed.data.error.code : 'unknown';
   } catch {
     return 'unknown';
   }
-}
-
-async function readBoundedBody(
-  response: Response,
-  maxBytes: number,
-): Promise<Uint8Array | undefined> {
-  if (!response.body) {
-    return new Uint8Array();
-  }
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let totalBytes = 0;
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-      totalBytes += value.byteLength;
-      if (totalBytes > maxBytes) {
-        await reader.cancel();
-        return undefined;
-      }
-      chunks.push(value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  const bytes = new Uint8Array(totalBytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return bytes;
-}
-
-async function cancelBody(response: Response): Promise<void> {
-  try {
-    await response.body?.cancel();
-  } catch {
-    // Response cleanup is best effort and must not replace the protocol error.
-  }
-}
-
-function toTransportError(error: unknown, signal?: AbortSignal): Error {
-  if (signal?.aborted || isAbortError(error)) {
-    return new ExecutionHostInvocationCancelledError();
-  }
-  return new ExecutionHostStreamInterruptedError();
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError';
 }
 
 function assertSafeBaseUrl(url: URL): void {

--- a/packages/execution-host-client/src/index.ts
+++ b/packages/execution-host-client/src/index.ts
@@ -1,4 +1,5 @@
 export * from './contracts/index.js';
+export * from './adopter/index.js';
 export * from './authority/index.js';
 export * from './conversation/index.js';
 export * from './heartbeat/index.js';

--- a/packages/execution-host-client/src/internal/execution-host-event-stream.ts
+++ b/packages/execution-host-client/src/internal/execution-host-event-stream.ts
@@ -1,0 +1,198 @@
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
+import type { z } from 'zod';
+import {
+  ExecutionHostInvocationCancelledError,
+  ExecutionHostProtocolError,
+  ExecutionHostStreamInterruptedError,
+} from '../http-sse/errors.js';
+import {
+  cancelResponseBody,
+  isEventStreamResponse,
+} from './http-response.js';
+
+const MAX_SSE_BUFFER_CHARACTERS = 1_048_576;
+const MAX_PENDING_SSE_FRAMES = 1_024;
+
+type ExecutionHostEvent = {
+  kind: string;
+  invocationId: string;
+  runId: string;
+  sequence: number;
+  timestamp: string;
+};
+
+type StreamValidationState = {
+  invocationId?: string;
+  runId?: string;
+  nextSequence: number;
+  accepted?: true;
+  terminal: boolean;
+};
+
+export async function* readExecutionHostEventStream<
+  Event extends ExecutionHostEvent,
+>(input: {
+  response: Response;
+  schema: z.ZodType<Event>;
+  isTerminal: (event: Event) => boolean;
+  invocationId?: string;
+  signal?: AbortSignal;
+}): AsyncIterable<Event> {
+  if (!isEventStreamResponse(input.response)) {
+    await cancelResponseBody(input.response);
+    throw new ExecutionHostProtocolError(
+      'Execution Host did not return an SSE stream.',
+    );
+  }
+  if (!input.response.body) {
+    throw new ExecutionHostProtocolError(
+      'Execution Host returned an empty SSE response body.',
+    );
+  }
+
+  const state: StreamValidationState = {
+    invocationId: input.invocationId,
+    nextSequence: 0,
+    terminal: false,
+  };
+  const decoder = new TextDecoder();
+  const pending: EventSourceMessage[] = [];
+  let terminalEvent: Event | undefined;
+  let parserFailed = false;
+  const parser = createParser({
+    maxBufferSize: MAX_SSE_BUFFER_CHARACTERS,
+    onEvent: (event) => {
+      if (pending.length >= MAX_PENDING_SSE_FRAMES) {
+        parserFailed = true;
+        return;
+      }
+      pending.push(event);
+    },
+    onError: () => {
+      parserFailed = true;
+    },
+  });
+  const reader = input.response.body.getReader();
+
+  try {
+    while (true) {
+      input.signal?.throwIfAborted();
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      parser.feed(decoder.decode(value, { stream: true }));
+      assertParserHealthy(parserFailed);
+      for (const event of drainEvents(pending, state, input.schema, input.isTerminal)) {
+        if (input.isTerminal(event)) {
+          terminalEvent = event;
+        } else {
+          yield event;
+        }
+      }
+    }
+
+    parser.feed(decoder.decode());
+    parser.reset({ consume: true });
+    assertParserHealthy(parserFailed);
+    for (const event of drainEvents(pending, state, input.schema, input.isTerminal)) {
+      if (input.isTerminal(event)) {
+        terminalEvent = event;
+      } else {
+        yield event;
+      }
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    if (error instanceof ExecutionHostProtocolError) {
+      throw error;
+    }
+    throw toExecutionHostTransportError(error, input.signal);
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (!state.accepted) {
+    throw new ExecutionHostProtocolError(
+      'Execution Host stream omitted the accepted event.',
+    );
+  }
+  if (!state.terminal || !terminalEvent) {
+    throw new ExecutionHostStreamInterruptedError();
+  }
+  // A terminal event is observable only after clean EOF. This keeps success
+  // truthful if the transport appends malformed or post-terminal data.
+  yield terminalEvent;
+}
+
+export function toExecutionHostTransportError(
+  error: unknown,
+  signal?: AbortSignal,
+): Error {
+  if (signal?.aborted || isAbortError(error)) {
+    return new ExecutionHostInvocationCancelledError();
+  }
+  return new ExecutionHostStreamInterruptedError();
+}
+
+function* drainEvents<Event extends ExecutionHostEvent>(
+  pending: EventSourceMessage[],
+  state: StreamValidationState,
+  schema: z.ZodType<Event>,
+  isTerminal: (event: Event) => boolean,
+): Generator<Event> {
+  while (pending.length > 0) {
+    yield validateEvent(pending.shift()!, state, schema, isTerminal);
+  }
+}
+
+function validateEvent<Event extends ExecutionHostEvent>(
+  frame: EventSourceMessage,
+  state: StreamValidationState,
+  schema: z.ZodType<Event>,
+  isTerminal: (event: Event) => boolean,
+): Event {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(frame.data) as unknown;
+  } catch {
+    throw new ExecutionHostProtocolError();
+  }
+  const parsed = schema.safeParse(decoded);
+  if (!parsed.success) {
+    throw new ExecutionHostProtocolError();
+  }
+  const event = parsed.data;
+  const correctFrameMetadata = frame.event === event.kind
+    && frame.id === String(event.sequence);
+  const correctEnvelope = event.sequence === state.nextSequence
+    && (!state.invocationId || event.invocationId === state.invocationId);
+  if (!correctFrameMetadata || !correctEnvelope || state.terminal) {
+    throw new ExecutionHostProtocolError();
+  }
+
+  if (!state.accepted) {
+    if (event.kind !== 'accepted') {
+      throw new ExecutionHostProtocolError();
+    }
+    state.accepted = true;
+    state.invocationId = event.invocationId;
+    state.runId = event.runId;
+  } else if (event.kind === 'accepted' || event.runId !== state.runId) {
+    throw new ExecutionHostProtocolError();
+  }
+
+  state.nextSequence += 1;
+  state.terminal = isTerminal(event);
+  return event;
+}
+
+function assertParserHealthy(failed: boolean): void {
+  if (failed) {
+    throw new ExecutionHostProtocolError();
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}

--- a/packages/execution-host-client/src/internal/http-response.ts
+++ b/packages/execution-host-client/src/internal/http-response.ts
@@ -1,0 +1,60 @@
+export async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Response cleanup is best effort and must not replace the owning error.
+  }
+}
+
+export function isEventStreamResponse(response: Response): boolean {
+  return response.headers.get('content-type')
+    ?.split(';', 1)[0]
+    ?.trim()
+    .toLowerCase() === 'text/event-stream';
+}
+
+export async function readBoundedJsonResponse(
+  response: Response,
+  maxBytes: number,
+): Promise<unknown | undefined> {
+  const declaredLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    await cancelResponseBody(response);
+    return undefined;
+  }
+  if (!response.body) {
+    return undefined;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel();
+        return undefined;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/execution-host-client/src/node/http-service.ts
+++ b/packages/execution-host-client/src/node/http-service.ts
@@ -4,6 +4,10 @@ import type {
   ServerResponse,
 } from 'node:http';
 import { z } from 'zod';
+import {
+  DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH,
+  DEFAULT_ADOPTER_JWKS_PATH,
+} from '../adopter/index.js';
 import { ExecutionHostStreamEventSchema } from '../contracts/index.js';
 import { ExecutionHostInvocationCancelledError } from '../http-sse/index.js';
 import {
@@ -23,10 +27,6 @@ import type {
   NodeExecutionAdopterHttpServiceConfig,
   NodeExecutionAdopterPublicError,
 } from './types.js';
-
-export const DEFAULT_ADOPTER_JWKS_PATH = '/.well-known/jwks.json';
-export const DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH =
-  '/hosted-execution/conversation-turns';
 
 const DEFAULT_MAX_BODY_BYTES = 64 * 1_024;
 const DEFAULT_MAX_PROMPT_CHARACTERS = 20_000;

--- a/packages/execution-host-client/src/node/index.ts
+++ b/packages/execution-host-client/src/node/index.ts
@@ -11,6 +11,8 @@ export type {
 export {
   DEFAULT_ADOPTER_CONVERSATION_TURNS_PATH,
   DEFAULT_ADOPTER_JWKS_PATH,
+} from '../adopter/index.js';
+export {
   NodeExecutionAdopterHttpService,
 } from './http-service.js';
 export type {


### PR DESCRIPTION
## Summary
- add the browser-safe hosted-conversation client and share ordered SSE/error handling with the direct transport
- make AgentCore target validation canonical in the public package
- complete the authenticated coordinator state, task inspection, trigger, and admission client

## Boundary result
Lucid can delete its browser SSE implementation, local path aliases, AgentCore regex copies, and product-side coordinator request construction. The private host can consume the same AgentCore target schemas.

## Verification
- yarn execution-host-client:test (18 files, 138 tests)
- yarn tsc -p packages/execution-host-client/tsconfig.test.json --noEmit
- yarn execution-host-client:build
- git diff --check