### PR TITLE
feat(memory): define stable hosted scope

### DIFF
--- a/docs/architecture/durable-state.md
+++ b/docs/architecture/durable-state.md
@@ -170,6 +170,16 @@ define single-writer/CAS behavior, conflict handling, deletion, and secret
 exclusion. It must not reuse the conversation repository or blindly snapshot
 the entire state root.
 
+Long-lived memory is addressed by the memory domain's versioned opaque scope,
+not by a Runtime session, product conversation, filesystem path, or raw object
+store key. The host derives that scope from already verified adopter, tenant,
+and subject identity plus one stable agent or workspace owner. That keeps two
+subjects isolated while letting the same subject and owner restore memory in a
+new conversation or Runtime session. Scope derivation does not grant access;
+the future repository or checkpoint adapter must enforce the verified
+authority independently. These ids must be stable and non-recycled; mutable
+names, slugs, and workspace-version ids are not valid durable identities.
+
 ### Package boundary
 
 Domain contracts use purpose names and remain with the package that owns their
@@ -291,6 +301,12 @@ universal storage provider shared by unrelated domains.
 knowledge under `.heddle/memory`, including catalog files, notes, append-only
 candidate/run records, and a maintenance lock. This is workspace knowledge, not
 a transcript or application database.
+
+For hosted recovery, `deriveMemoryScopeId()` gives this domain one stable
+address. Its v1 inputs are verified adopter, tenant, and subject ids plus a
+stable agent or workspace owner. Product conversation and Runtime session ids
+are deliberately not part of the address. The derivation is deterministic and
+opaque but is neither authentication nor a storage authorization decision.
 
 Maintenance combines an in-process queue with an exclusive lock file. Invalid
 JSONL entries are skipped during tolerant reads, and a process failure may leave

--- a/docs/guides/programmatic/durability-support.md
+++ b/docs/guides/programmatic/durability-support.md
@@ -72,6 +72,13 @@ version, checksums, generation fencing, conflict policy, secret exclusion,
 retention, and deletion. Uploading at shutdown may reduce loss but cannot be the
 only checkpoint.
 
+The stable address for that future repository is available from
+`deriveMemoryScopeId()` in `@heddleagent/runtime/advanced`. Supply verified
+adopter, tenant, and subject ids plus the stable agent or workspace that owns
+the memory. Do not use a product conversation id, Runtime session id, local
+path, bucket name, or object key. Scope derivation is deterministic addressing;
+the host and storage adapter still own authorization.
+
 ## Minimum Hosted Conversation Promise
 
 To promise that a user can return to a completed conversation and continue it

--- a/src/__tests__/unit/core/memory-scope.test.ts
+++ b/src/__tests__/unit/core/memory-scope.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MemoryScopeIdentitySchema,
+  deriveMemoryScopeId,
+} from '@/core/memory/scope.js';
+
+const identity = {
+  adopterId: 'lucid',
+  tenantId: 'tenant-a',
+  subjectId: 'user-a',
+  owner: { kind: 'agent', id: 'agent-a' },
+} as const;
+
+describe('deriveMemoryScopeId', () => {
+  it('derives one stable opaque v1 id from verified identity and owner', () => {
+    const scopeId = deriveMemoryScopeId(identity);
+
+    expect(scopeId).toBe(
+      'memory-v1-f6c317c8362c7f6a261782e0c296239075d478fdbf9e861bc6a7a5c3ffc50a97',
+    );
+    expect(scopeId).not.toContain(identity.tenantId);
+    expect(scopeId).not.toContain(identity.subjectId);
+    expect(scopeId).not.toContain(identity.owner.id);
+  });
+
+  it('isolates adopters, tenants, subjects, and agent or workspace owners', () => {
+    const scopeIds = [
+      identity,
+      { ...identity, adopterId: 'another-adopter' },
+      { ...identity, tenantId: 'tenant-b' },
+      { ...identity, subjectId: 'user-b' },
+      { ...identity, owner: { kind: 'agent', id: 'agent-b' } as const },
+      { ...identity, owner: { kind: 'workspace', id: 'agent-a' } as const },
+    ].map(deriveMemoryScopeId);
+
+    expect(new Set(scopeIds)).toHaveLength(scopeIds.length);
+  });
+
+  it('rejects session identifiers and malformed identity instead of folding them into memory scope', () => {
+    expect(() => MemoryScopeIdentitySchema.parse({
+      ...identity,
+      productSessionId: 'conversation-a',
+      runtimeSessionId: 'runtime-a',
+    })).toThrow();
+    expect(() => deriveMemoryScopeId({
+      ...identity,
+      subjectId: ' user-a ',
+    })).toThrow('must not contain outer whitespace');
+  });
+});

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -165,6 +165,16 @@ export { MemoryMaintenanceRepository } from './core/memory/maintenance-repositor
 export { MemoryMaintenanceService } from './core/memory/maintainer.js';
 export { MemoryMaintenanceIntegrationService } from './core/memory/maintenance-integration.js';
 export { MemoryNoteService } from './core/memory/note-service.js';
+export {
+  MEMORY_SCOPE_VERSION,
+  MemoryScopeIdentitySchema,
+  MemoryScopeIdSchema,
+  deriveMemoryScopeId,
+} from './core/memory/scope.js';
+export type {
+  MemoryScopeIdentity,
+  MemoryScopeId,
+} from './core/memory/scope.js';
 export { MemoryValidationService } from './core/memory/validation.js';
 export { MemoryVisibilityService } from './core/memory/visibility.js';
 export type {

--- a/src/core/memory/README.md
+++ b/src/core/memory/README.md
@@ -13,6 +13,8 @@ guidance.
 - Memory maintenance integration after chat turns.
 - Memory note templates and slug generation.
 - Host-facing memory visibility helpers.
+- Stable, opaque memory scope derivation from verified subject and agent or
+  workspace identity.
 
 ## Does Not Own
 
@@ -21,12 +23,19 @@ guidance.
 - UI rendering for memory status or notes.
 - General file tools outside memory-specific note access.
 - Provider credential resolution.
+- Authentication, tenant lookup, or authorization of the identity supplied to
+  memory scope derivation.
+- Runtime-session, conversation-session, or storage-key selection.
 
 ## Public Entry Points
 
 - `types.ts`: memory-domain contracts for catalogs, candidates, runs, visibility,
   validation, and note operations.
 - `schemas.ts`: zod validation for persisted memory JSONL records and locks.
+- `scope.ts`: versioned, deterministic memory scope derivation. The host passes
+  already verified adopter, tenant, and subject ids plus one stable agent or
+  workspace owner. Runtime-session and conversation-session ids are excluded
+  so the same subject and owner resolve the same memory after a fresh session.
 - `catalog.ts`: `MemoryCatalogService` owns catalog bootstrap, root catalog
   loading, startup system-context assembly, and required catalog shape.
 - `domain-prompt.ts`: memory-specific system context.
@@ -85,6 +94,39 @@ or maintainer semantics.
   once it exists.
 - Add persisted memory records by updating `types.ts`, `schemas.ts`, and the
   owning repository together.
+- Change memory identity only by introducing a new scope version. Changing the
+  v1 canonical fields or hash would orphan existing hosted memory.
+
+## Hosted Memory Scope
+
+`deriveMemoryScopeId()` creates the durable address for one subject's memory.
+It does not authenticate a request and it does not accept a caller-selected S3
+key. A hosted authority must first verify the adopter, tenant, and subject, then
+select the stable Heddle agent or workspace that owns the memory:
+
+```ts
+import { deriveMemoryScopeId } from '@heddleagent/runtime/advanced';
+
+const memoryScopeId = deriveMemoryScopeId({
+  adopterId: verifiedExecution.scope.adopterId,
+  tenantId: verifiedExecution.scope.tenantId,
+  subjectId: verifiedExecution.scope.subjectId,
+  owner: { kind: 'agent', id: authenticatedAgent.id },
+});
+```
+
+Every input id must be stable and non-recycled within its authority domain.
+Display names, mutable slugs, and version ids are not durable identities.
+
+The resulting `memory-v1-...` value is deterministic and opaque. Different
+adopters, tenants, subjects, owner kinds, or owner ids cannot resolve the same
+scope through this contract. Product conversation ids and Runtime session ids
+must not be substituted for the stable owner id: they would either fragment
+memory on every conversation or incorrectly tie it to an expiring Runtime.
+
+The scope id is an address, not a secret or bearer credential. A future memory
+repository or checkpoint adapter must authorize the verified identity before
+reading, writing, retaining, or deleting that address.
 
 ## Common Changes
 

--- a/src/core/memory/index.ts
+++ b/src/core/memory/index.ts
@@ -14,6 +14,13 @@ export { MemoryMaintenanceIntegrationService } from './maintenance-integration.j
 export { createMemoryMaintainerTools } from './maintainer-tools.js';
 export { MemoryNoteService } from './note-service.js';
 export { MemorySchemas } from './schemas.js';
+export {
+  MEMORY_SCOPE_VERSION,
+  MemoryScopeIdentitySchema,
+  MemoryScopeIdSchema,
+  deriveMemoryScopeId,
+} from './scope.js';
+export type { MemoryScopeIdentity, MemoryScopeId } from './scope.js';
 export { createMemoryNoteTemplate, slugifyMemoryTitle } from './templates.js';
 export { MemoryValidationService } from './validation.js';
 export { MemoryVisibilityService } from './visibility.js';

--- a/src/core/memory/scope.ts
+++ b/src/core/memory/scope.ts
@@ -1,0 +1,63 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+
+export const MEMORY_SCOPE_VERSION = 1 as const;
+
+const MemoryScopeIdentityPartSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .refine((value) => value === value.trim(), 'must not contain outer whitespace');
+
+const MemoryScopeOwnerSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('agent'),
+    id: MemoryScopeIdentityPartSchema,
+  }).strict(),
+  z.object({
+    kind: z.literal('workspace'),
+    id: MemoryScopeIdentityPartSchema,
+  }).strict(),
+]);
+
+export const MemoryScopeIdentitySchema = z.object({
+  adopterId: MemoryScopeIdentityPartSchema,
+  tenantId: MemoryScopeIdentityPartSchema,
+  subjectId: MemoryScopeIdentityPartSchema,
+  owner: MemoryScopeOwnerSchema,
+}).strict();
+
+export const MemoryScopeIdSchema = z
+  .string()
+  .regex(/^memory-v1-[a-f0-9]{64}$/)
+  .brand('MemoryScopeId');
+
+export type MemoryScopeIdentity = z.input<typeof MemoryScopeIdentitySchema>;
+export type MemoryScopeId = z.infer<typeof MemoryScopeIdSchema>;
+
+/**
+ * Derives the stable, opaque address for one subject's Heddle memory.
+ *
+ * The authority boundary must supply adopter, tenant, and subject identifiers
+ * from already verified identity. `owner` names the stable agent or workspace
+ * whose memory is being addressed. Conversation and Runtime session ids are
+ * intentionally absent so a fresh session resolves the same memory.
+ *
+ * This id is an address, not an authorization credential or a storage key
+ * chosen by the caller. Storage adapters must still enforce tenant authority.
+ */
+export function deriveMemoryScopeId(identity: MemoryScopeIdentity): MemoryScopeId {
+  const parsed = MemoryScopeIdentitySchema.parse(identity);
+  const canonicalIdentity = JSON.stringify([
+    'heddle-memory-scope',
+    MEMORY_SCOPE_VERSION,
+    parsed.adopterId,
+    parsed.tenantId,
+    parsed.subjectId,
+    parsed.owner.kind,
+    parsed.owner.id,
+  ]);
+  const digest = createHash('sha256').update(canonicalIdentity).digest('hex');
+
+  return MemoryScopeIdSchema.parse(`memory-v${MEMORY_SCOPE_VERSION}-${digest}`);
+}


### PR DESCRIPTION
## Summary

- derive one versioned opaque memory scope from verified adopter, tenant, and subject identity plus a stable agent or workspace owner
- exclude product-conversation and Runtime-session identifiers from durable memory identity
- expose the contract from `@heddleagent/runtime/advanced` and document the authorization boundary

## Scope boundary

This PR does not add a checkpoint codec, S3 adapter, Runtime integration, managed session storage, or deployment work.

## Verification

- `yarn vitest run src/__tests__/unit/core/memory-scope.test.ts`
- `yarn typecheck`
- `yarn eslint src/core/memory/scope.ts src/__tests__/unit/core/memory-scope.test.ts src/advanced.ts`
- `yarn runtime:build`