### PR TITLE
Add portable Heddle memory checkpoints

### DIFF
--- a/docs/architecture/durable-state.md
+++ b/docs/architecture/durable-state.md
@@ -311,19 +311,22 @@ opaque but is neither authentication nor a storage authorization decision.
 Maintenance combines an in-process queue with an exclusive lock file. Invalid
 JSONL entries are skipped during tolerant reads, and a process failure may leave
 pending candidates or a lock until stale-lock recovery. Memory explicitly must
-not contain credentials or secrets. The selected portable-memory design must be
-a separate domain boundary with conflict and authority rules; it must not be
-inferred from the conversation repository contract.
+not contain credentials or secrets. The memory domain now exposes a separate
+portable checkpoint boundary with its own scope, integrity, restore, and
+manifest compare-and-swap rules; it is not inferred from the conversation
+repository contract.
 
 For an ephemeral Execution Host, provider-managed session storage can preserve
 the working memory directory across ordinary stop/resume, but it remains a
 continuity layer if the provider can expire it or reset it on a runtime update.
-Longer-lived recovery should use a memory-specific repository or checkpoint:
-write an immutable, scoped revision; atomically advance a generation manifest;
-and restore only after validating its schema, scope, checksums, and runtime
-compatibility. Checkpoint after selected memory maintenance boundaries and
-periodically for long sessions. A shutdown checkpoint may reduce loss, but must
-not be the sole commit path.
+Longer-lived recovery uses the memory-specific checkpoint contract in
+[`src/core/memory/checkpoint`](../../src/core/memory/checkpoint/README.md): write
+an immutable, scoped generation; atomically advance a generation manifest; and
+restore only after validating its schema, scope, checksums, and file allowlist.
+Checkpoint after selected memory-changing interactions or maintenance
+boundaries. A shutdown checkpoint may reduce loss, but must not be the sole
+commit path. An official object-store adapter, periodic long-session trigger,
+and Execution Host recovery integration are not implemented yet.
 
 ### Approval policy and project configuration
 

--- a/src/__tests__/unit/core/memory-checkpoint.test.ts
+++ b/src/__tests__/unit/core/memory-checkpoint.test.ts
@@ -1,0 +1,152 @@
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  MemoryCheckpointConflictError,
+  MemoryCheckpointCorruptionError,
+  MemoryCheckpointGenerationIdSchema,
+  MemoryCheckpointGenerationSchema,
+  MemoryCheckpointRestoreTargetError,
+  MemoryCheckpointService,
+  type CommitMemoryCheckpointInput,
+  type DeleteMemoryCheckpointInput,
+  type LoadMemoryCheckpointGenerationInput,
+  type MemoryCheckpointGeneration,
+  type MemoryCheckpointManifest,
+  type MemoryCheckpointStore,
+} from '@/core/memory/checkpoint/index.js';
+import { deriveMemoryScopeId } from '@/core/memory/scope.js';
+
+const scopeId = deriveMemoryScopeId({
+  adopterId: 'lucid',
+  tenantId: 'tenant-a',
+  subjectId: 'user-a',
+  owner: { kind: 'agent', id: 'agent-a' },
+});
+
+class InMemoryCheckpointStore implements MemoryCheckpointStore {
+  manifest: MemoryCheckpointManifest | undefined;
+  readonly generations = new Map<string, MemoryCheckpointGeneration>();
+
+  async loadManifest(): Promise<unknown | undefined> {
+    return this.manifest ? structuredClone(this.manifest) : undefined;
+  }
+
+  async loadGeneration(input: LoadMemoryCheckpointGenerationInput): Promise<unknown | undefined> {
+    const generation = this.generations.get(input.generationId);
+    return generation ? structuredClone(generation) : undefined;
+  }
+
+  async commit(input: CommitMemoryCheckpointInput): Promise<void> {
+    const actualGenerationId = this.manifest?.generationId ?? null;
+    if (actualGenerationId !== input.expectedGenerationId) {
+      throw new MemoryCheckpointConflictError(
+        input.manifest.scopeId,
+        input.expectedGenerationId,
+        actualGenerationId,
+      );
+    }
+
+    this.generations.set(input.generation.generationId, structuredClone(input.generation));
+    this.manifest = structuredClone(input.manifest);
+  }
+
+  async delete(input: DeleteMemoryCheckpointInput): Promise<void> {
+    const actualGenerationId = this.manifest?.generationId ?? null;
+    if (actualGenerationId !== input.expectedGenerationId) {
+      throw new MemoryCheckpointConflictError(
+        input.scopeId,
+        input.expectedGenerationId,
+        actualGenerationId,
+      );
+    }
+    this.manifest = undefined;
+  }
+}
+
+describe('MemoryCheckpointService', () => {
+  const temporaryRoots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(temporaryRoots.splice(0).map(path => rm(path, { recursive: true, force: true })));
+  });
+
+  it('round-trips only allowlisted memory files through a committed generation', async () => {
+    const fixture = await createFixture();
+    const store = new InMemoryCheckpointStore();
+    const service = createService(fixture.memoryRoot, store);
+
+    const manifest = await service.checkpoint(scopeId);
+    const generation = MemoryCheckpointGenerationSchema.parse(
+      await store.loadGeneration({ scopeId, generationId: manifest.generationId }),
+    );
+
+    expect(generation.files.map(file => file.path)).toEqual([
+      'README.md',
+      '_maintenance/candidates.jsonl',
+      '_maintenance/runs.jsonl',
+      'preferences/music.md',
+    ]);
+
+    await rm(fixture.memoryRoot, { recursive: true });
+    await expect(service.restore(scopeId)).resolves.toMatchObject({
+      status: 'restored',
+      manifest: { generationId: manifest.generationId },
+    });
+    await expect(readFile(join(fixture.memoryRoot, 'preferences/music.md'), 'utf8'))
+      .resolves.toBe('# Music\nAmbient and post-rock.\n');
+    await expect(stat(join(fixture.memoryRoot, '_maintenance/maintenance.lock'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(stat(join(fixture.memoryRoot, 'credentials.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rejects corrupt durable content before creating a local working copy', async () => {
+    const fixture = await createFixture();
+    const store = new InMemoryCheckpointStore();
+    const service = createService(fixture.memoryRoot, store);
+    const manifest = await service.checkpoint(scopeId);
+    const generation = store.generations.get(manifest.generationId);
+    if (!generation) {
+      throw new Error('Expected test checkpoint generation.');
+    }
+    generation.files[0] = { ...generation.files[0], contentBase64: 'Y29ycnVwdA==' };
+
+    await rm(fixture.memoryRoot, { recursive: true });
+    await expect(service.restore(scopeId)).rejects.toBeInstanceOf(MemoryCheckpointCorruptionError);
+    await expect(stat(fixture.memoryRoot)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('does not merge into an existing working copy and deletes by committed generation', async () => {
+    const fixture = await createFixture();
+    const store = new InMemoryCheckpointStore();
+    const service = createService(fixture.memoryRoot, store);
+    await service.checkpoint(scopeId);
+
+    await expect(service.restore(scopeId)).rejects.toBeInstanceOf(MemoryCheckpointRestoreTargetError);
+    await expect(readFile(join(fixture.memoryRoot, 'README.md'), 'utf8')).resolves.toBe('# Memory\n');
+    await expect(service.delete(scopeId)).resolves.toBe(true);
+    await expect(service.delete(scopeId)).resolves.toBe(false);
+  });
+
+  async function createFixture(): Promise<{ memoryRoot: string }> {
+    const root = await mkdtemp(join(tmpdir(), 'heddle-memory-checkpoint-'));
+    temporaryRoots.push(root);
+    const memoryRoot = join(root, 'memory');
+    await mkdir(join(memoryRoot, 'preferences'), { recursive: true });
+    await mkdir(join(memoryRoot, '_maintenance'), { recursive: true });
+    await writeFile(join(memoryRoot, 'README.md'), '# Memory\n');
+    await writeFile(join(memoryRoot, 'preferences/music.md'), '# Music\nAmbient and post-rock.\n');
+    await writeFile(join(memoryRoot, '_maintenance/candidates.jsonl'), '{"id":"candidate-a"}\n');
+    await writeFile(join(memoryRoot, '_maintenance/runs.jsonl'), '{"id":"run-a"}\n');
+    await writeFile(join(memoryRoot, '_maintenance/maintenance.lock'), '{"pid":1}\n');
+    await writeFile(join(memoryRoot, 'credentials.json'), '{"token":"secret"}\n');
+    return { memoryRoot };
+  }
+
+  function createService(memoryRoot: string, store: MemoryCheckpointStore): MemoryCheckpointService {
+    return new MemoryCheckpointService(memoryRoot, store, {
+      now: () => new Date('2026-08-26T00:00:00.000Z'),
+      createGenerationId: () => MemoryCheckpointGenerationIdSchema.parse('generation-1'),
+    });
+  }
+});

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -154,6 +154,32 @@ export { buildSystemPrompt } from './core/prompts/system-prompt.js';
 // --- Building blocks: memory & knowledge -----------------------------------
 export { buildMemoryDomainSystemContext } from './core/memory/domain-prompt.js';
 export {
+  MEMORY_CHECKPOINT_SCHEMA_VERSION,
+  MemoryCheckpointCaptureError,
+  MemoryCheckpointCodec,
+  MemoryCheckpointConflictError,
+  MemoryCheckpointCorruptionError,
+  MemoryCheckpointFileSchema,
+  MemoryCheckpointGenerationIdSchema,
+  MemoryCheckpointGenerationSchema,
+  MemoryCheckpointManifestSchema,
+  MemoryCheckpointRestoreTargetError,
+  MemoryCheckpointService,
+} from './core/memory/checkpoint/index.js';
+export type {
+  CommitMemoryCheckpointInput,
+  DeleteMemoryCheckpointInput,
+  LoadMemoryCheckpointGenerationInput,
+  MemoryCheckpointBundle,
+  MemoryCheckpointFile,
+  MemoryCheckpointGeneration,
+  MemoryCheckpointGenerationId,
+  MemoryCheckpointManifest,
+  MemoryCheckpointServiceOptions,
+  MemoryCheckpointStore,
+  RestoreMemoryCheckpointResult,
+} from './core/memory/checkpoint/index.js';
+export {
   DEFAULT_MEMORY_CATEGORIES,
   DEFAULT_MEMORY_FOLDER_CATALOG_MAX_BYTES,
   DEFAULT_MEMORY_FOLDER_CATALOG_TARGET_BYTES,

--- a/src/core/memory/README.md
+++ b/src/core/memory/README.md
@@ -15,6 +15,7 @@ guidance.
 - Host-facing memory visibility helpers.
 - Stable, opaque memory scope derivation from verified subject and agent or
   workspace identity.
+- Portable, versioned checkpoints for a memory-only working copy.
 
 ## Does Not Own
 
@@ -26,6 +27,7 @@ guidance.
 - Authentication, tenant lookup, or authorization of the identity supplied to
   memory scope derivation.
 - Runtime-session, conversation-session, or storage-key selection.
+- Provider SDKs, checkpoint scheduling, or execution-host lifecycle hooks.
 
 ## Public Entry Points
 
@@ -36,6 +38,10 @@ guidance.
   already verified adopter, tenant, and subject ids plus one stable agent or
   workspace owner. Runtime-session and conversation-session ids are excluded
   so the same subject and owner resolve the same memory after a fresh session.
+- `checkpoint/`: provider-neutral checkpoint schemas, deterministic memory-file
+  capture, integrity validation, restore-before-use, and a manifest-last store
+  contract. The host supplies the durable store and invokes checkpoints at
+  stable memory boundaries; see its [`README`](checkpoint/README.md).
 - `catalog.ts`: `MemoryCatalogService` owns catalog bootstrap, root catalog
   loading, startup system-context assembly, and required catalog shape.
 - `domain-prompt.ts`: memory-specific system context.
@@ -124,9 +130,11 @@ scope through this contract. Product conversation ids and Runtime session ids
 must not be substituted for the stable owner id: they would either fragment
 memory on every conversation or incorrectly tie it to an expiring Runtime.
 
-The scope id is an address, not a secret or bearer credential. A future memory
-repository or checkpoint adapter must authorize the verified identity before
-reading, writing, retaining, or deleting that address.
+The scope id is an address, not a secret or bearer credential. A checkpoint
+adapter must authorize the verified identity before reading, writing,
+retaining, or deleting that address. Heddle now defines the portable checkpoint
+contract; an official object-store adapter and Execution Host lifecycle
+integration remain separate work.
 
 ## Common Changes
 

--- a/src/core/memory/checkpoint/README.md
+++ b/src/core/memory/checkpoint/README.md
@@ -1,0 +1,67 @@
+# Memory Checkpoints
+
+This module owns the portable, memory-only recovery boundary for a Heddle
+memory working copy. A host may persist the checkpoint through S3, another
+object store, or a purpose-built implementation of `MemoryCheckpointStore`.
+The provider does not redefine Heddle's file selection, encoding, validation,
+or restore semantics.
+
+## Owns
+
+- A versioned generation and committed-manifest schema.
+- Deterministic capture of portable memory files.
+- Per-file and whole-generation integrity checks.
+- Restore-before-use into an absent or empty memory root.
+- Manifest compare-and-swap expectations for concurrent writers.
+- Explicit deletion of the authoritative manifest.
+
+## Portable Files
+
+A checkpoint contains:
+
+- Markdown catalogs and notes outside `_maintenance/`;
+- `_maintenance/candidates.jsonl`;
+- `_maintenance/runs.jsonl`.
+
+It deliberately excludes maintenance locks, credentials, project
+configuration, approval policy, MCP configuration, browser profiles, trace
+output, and every other non-memory file. Symbolic links inside the memory root
+fail capture instead of being followed.
+
+## Lifecycle
+
+1. Derive and authorize a stable `MemoryScopeId` from verified product
+   identity.
+2. Before bootstrapping or reading a fresh local working copy, call
+   `restore(scopeId)`.
+3. Let the memory domain use the restored local files normally.
+4. After a memory-changing interaction or maintenance transaction reaches a
+   stable boundary, call `checkpoint(scopeId)`.
+5. A shutdown checkpoint may reduce recent loss, but must not be the only
+   checkpoint trigger.
+
+`restore()` never merges with or overwrites existing files. The caller must
+serialize bootstrap, restore, and first use for one working copy. It must also
+serialize `checkpoint()` with memory mutations so capture observes one stable
+domain state rather than an in-progress file transaction.
+
+## Store Contract
+
+`MemoryCheckpointStore.commit()` makes the immutable generation durable first,
+then atomically advances the scope's authoritative manifest only when it still
+points at `expectedGenerationId`. A competing change raises
+`MemoryCheckpointConflictError`. This compare-and-swap boundary prevents an
+older host from silently replacing newer memory.
+
+The store may retain unreferenced immutable generations for recovery or delete
+them according to its documented retention policy. `delete()` must atomically
+remove the manifest only when it still names the expected generation; orphan
+cleanup remains an adapter concern.
+
+## Does Not Own
+
+- An S3 client or any other provider SDK.
+- Periodic scheduling or process shutdown hooks.
+- Runtime-session lifecycle and AgentCore integration.
+- General workspace backup or synchronization.
+- Configuration, approval, MCP, telemetry, artifact, or conversation storage.

--- a/src/core/memory/checkpoint/codec.ts
+++ b/src/core/memory/checkpoint/codec.ts
@@ -1,0 +1,231 @@
+import { createHash } from 'node:crypto';
+import { posix } from 'node:path';
+import type { MemoryScopeId } from '../scope.js';
+import { MemoryCheckpointCorruptionError } from './errors.js';
+import {
+  MemoryCheckpointFileSchema,
+  MemoryCheckpointGenerationSchema,
+  MemoryCheckpointManifestSchema,
+  type MemoryCheckpointFile,
+  type MemoryCheckpointGeneration,
+  type MemoryCheckpointGenerationId,
+  type MemoryCheckpointManifest,
+} from './schemas.js';
+
+const PORTABLE_MAINTENANCE_FILES = new Set([
+  '_maintenance/candidates.jsonl',
+  '_maintenance/runs.jsonl',
+]);
+
+type CreateMemoryCheckpointGenerationInput = {
+  scopeId: MemoryScopeId;
+  generationId: MemoryCheckpointGenerationId;
+  createdAt: string;
+  files: MemoryCheckpointFile[];
+};
+
+type CreateMemoryCheckpointManifestInput = {
+  generation: MemoryCheckpointGeneration;
+  committedAt: string;
+};
+
+/**
+ * Owns the provider-neutral, versioned encoding and integrity rules for one
+ * allowlisted Heddle memory generation.
+ */
+export class MemoryCheckpointCodec {
+  static isPortablePath(path: string): boolean {
+    if (!MemoryCheckpointCodec.isCanonicalRelativePath(path)) {
+      return false;
+    }
+
+    if (PORTABLE_MAINTENANCE_FILES.has(path)) {
+      return true;
+    }
+
+    return !path.startsWith('_maintenance/') && path.endsWith('.md');
+  }
+
+  static createFile(path: string, content: Buffer): MemoryCheckpointFile {
+    return MemoryCheckpointFileSchema.parse({
+      path,
+      contentBase64: content.toString('base64'),
+      byteLength: content.byteLength,
+      sha256: MemoryCheckpointCodec.sha256(content),
+    });
+  }
+
+  static createGeneration(input: CreateMemoryCheckpointGenerationInput): MemoryCheckpointGeneration {
+    const generation = MemoryCheckpointGenerationSchema.parse({
+      kind: 'heddle-memory-checkpoint-generation',
+      schemaVersion: 1,
+      ...input,
+      files: [...input.files].sort((left, right) => MemoryCheckpointCodec.comparePaths(left.path, right.path)),
+    });
+
+    MemoryCheckpointCodec.validateFiles(generation.scopeId, generation.files);
+    return generation;
+  }
+
+  static createManifest(input: CreateMemoryCheckpointManifestInput): MemoryCheckpointManifest {
+    return MemoryCheckpointManifestSchema.parse({
+      kind: 'heddle-memory-checkpoint-manifest',
+      schemaVersion: 1,
+      scopeId: input.generation.scopeId,
+      generationId: input.generation.generationId,
+      generationSha256: MemoryCheckpointCodec.generationSha256(input.generation),
+      fileCount: input.generation.files.length,
+      totalBytes: input.generation.files.reduce((total, file) => total + file.byteLength, 0),
+      committedAt: input.committedAt,
+    });
+  }
+
+  static parseManifest(value: unknown, expectedScopeId: MemoryScopeId): MemoryCheckpointManifest {
+    const manifest = MemoryCheckpointCodec.parsePersisted(
+      expectedScopeId,
+      'manifest',
+      () => MemoryCheckpointManifestSchema.parse(value),
+    );
+    if (manifest.scopeId !== expectedScopeId) {
+      throw new MemoryCheckpointCorruptionError(
+        expectedScopeId,
+        `manifest scope mismatch: found ${manifest.scopeId}`,
+      );
+    }
+    return manifest;
+  }
+
+  static parseGeneration(
+    value: unknown,
+    expectedScopeId: MemoryScopeId,
+    expectedGenerationId: MemoryCheckpointGenerationId,
+  ): MemoryCheckpointGeneration {
+    const generation = MemoryCheckpointCodec.parsePersisted(
+      expectedScopeId,
+      'generation',
+      () => MemoryCheckpointGenerationSchema.parse(value),
+    );
+    if (generation.scopeId !== expectedScopeId) {
+      throw new MemoryCheckpointCorruptionError(
+        expectedScopeId,
+        `generation scope mismatch: found ${generation.scopeId}`,
+      );
+    }
+    if (generation.generationId !== expectedGenerationId) {
+      throw new MemoryCheckpointCorruptionError(
+        expectedScopeId,
+        `generation id mismatch: expected ${expectedGenerationId}, found ${generation.generationId}`,
+      );
+    }
+
+    MemoryCheckpointCodec.validateFiles(expectedScopeId, generation.files);
+    return generation;
+  }
+
+  static validateCommitted(
+    manifest: MemoryCheckpointManifest,
+    generation: MemoryCheckpointGeneration,
+  ): void {
+    const failures = [
+      manifest.scopeId !== generation.scopeId ? 'manifest and generation scopes differ' : undefined,
+      manifest.generationId !== generation.generationId ? 'manifest and generation ids differ' : undefined,
+      manifest.fileCount !== generation.files.length ? 'manifest file count does not match generation' : undefined,
+      manifest.totalBytes !== generation.files.reduce((total, file) => total + file.byteLength, 0) ?
+        'manifest byte count does not match generation'
+      : undefined,
+      manifest.generationSha256 !== MemoryCheckpointCodec.generationSha256(generation) ?
+        'manifest checksum does not match generation'
+      : undefined,
+    ].filter((failure): failure is string => Boolean(failure));
+
+    if (failures[0]) {
+      throw new MemoryCheckpointCorruptionError(manifest.scopeId, failures[0]);
+    }
+  }
+
+  static serializeGeneration(generation: MemoryCheckpointGeneration): string {
+    const parsed = MemoryCheckpointGenerationSchema.parse(generation);
+    MemoryCheckpointCodec.validateFiles(parsed.scopeId, parsed.files);
+    return `${JSON.stringify(parsed, null, 2)}\n`;
+  }
+
+  static serializeManifest(manifest: MemoryCheckpointManifest): string {
+    return `${JSON.stringify(MemoryCheckpointManifestSchema.parse(manifest), null, 2)}\n`;
+  }
+
+  static decodeFile(scopeId: MemoryScopeId, file: MemoryCheckpointFile): Buffer {
+    if (!MemoryCheckpointCodec.isPortablePath(file.path)) {
+      throw new MemoryCheckpointCorruptionError(scopeId, `path is not portable memory state: ${file.path}`);
+    }
+
+    const content = Buffer.from(file.contentBase64, 'base64');
+    if (content.toString('base64') !== file.contentBase64) {
+      throw new MemoryCheckpointCorruptionError(scopeId, `file has invalid base64 content: ${file.path}`);
+    }
+    if (content.byteLength !== file.byteLength) {
+      throw new MemoryCheckpointCorruptionError(scopeId, `file byte length does not match content: ${file.path}`);
+    }
+    if (MemoryCheckpointCodec.sha256(content) !== file.sha256) {
+      throw new MemoryCheckpointCorruptionError(scopeId, `file checksum does not match content: ${file.path}`);
+    }
+    return content;
+  }
+
+  private static validateFiles(scopeId: MemoryScopeId, files: MemoryCheckpointFile[]): void {
+    const paths = new Set<string>();
+    let priorPath: string | undefined;
+
+    for (const file of files) {
+      MemoryCheckpointCodec.decodeFile(scopeId, file);
+      if (paths.has(file.path)) {
+        throw new MemoryCheckpointCorruptionError(scopeId, `duplicate file path: ${file.path}`);
+      }
+      if (priorPath && MemoryCheckpointCodec.comparePaths(priorPath, file.path) >= 0) {
+        throw new MemoryCheckpointCorruptionError(scopeId, 'generation files are not in canonical path order');
+      }
+      paths.add(file.path);
+      priorPath = file.path;
+    }
+  }
+
+  private static isCanonicalRelativePath(path: string): boolean {
+    return Boolean(path)
+      && !path.includes('\\')
+      && !path.includes('\0')
+      && !posix.isAbsolute(path)
+      && posix.normalize(path) === path
+      && path !== '.'
+      && !path.startsWith('../');
+  }
+
+  private static comparePaths(left: string, right: string): number {
+    return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'));
+  }
+
+  private static generationSha256(generation: MemoryCheckpointGeneration): string {
+    return MemoryCheckpointCodec.sha256(Buffer.from(MemoryCheckpointCodec.serializeGeneration(generation), 'utf8'));
+  }
+
+  private static sha256(content: Buffer): string {
+    return createHash('sha256').update(content).digest('hex');
+  }
+
+  private static parsePersisted<T>(
+    scopeId: MemoryScopeId,
+    kind: string,
+    parse: () => T,
+  ): T {
+    try {
+      return parse();
+    } catch (error) {
+      if (error instanceof MemoryCheckpointCorruptionError) {
+        throw error;
+      }
+      throw new MemoryCheckpointCorruptionError(
+        scopeId,
+        `${kind} does not match the supported schema`,
+        { cause: error },
+      );
+    }
+  }
+}

--- a/src/core/memory/checkpoint/errors.ts
+++ b/src/core/memory/checkpoint/errors.ts
@@ -1,0 +1,52 @@
+import type { MemoryScopeId } from '../scope.js';
+import type { MemoryCheckpointGenerationId } from './schemas.js';
+
+/** Raised when persisted checkpoint data cannot be trusted or restored. */
+export class MemoryCheckpointCorruptionError extends Error {
+  readonly code = 'MEMORY_CHECKPOINT_CORRUPTION';
+
+  constructor(
+    readonly scopeId: MemoryScopeId,
+    detail: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Invalid memory checkpoint for ${scopeId}: ${detail}`, options);
+    this.name = 'MemoryCheckpointCorruptionError';
+  }
+}
+
+/** Raised by stores when another writer advances the committed generation. */
+export class MemoryCheckpointConflictError extends Error {
+  readonly code = 'MEMORY_CHECKPOINT_CONFLICT';
+
+  constructor(
+    readonly scopeId: MemoryScopeId,
+    readonly expectedGenerationId: MemoryCheckpointGenerationId | null,
+    readonly actualGenerationId: MemoryCheckpointGenerationId | null,
+  ) {
+    super(
+      `Memory checkpoint conflict for ${scopeId}: expected ${expectedGenerationId ?? 'no generation'}, found ${actualGenerationId ?? 'no generation'}.`,
+    );
+    this.name = 'MemoryCheckpointConflictError';
+  }
+}
+
+/** Raised when restore would merge with or overwrite an existing working copy. */
+export class MemoryCheckpointRestoreTargetError extends Error {
+  readonly code = 'MEMORY_CHECKPOINT_RESTORE_TARGET_NOT_EMPTY';
+
+  constructor(readonly memoryRoot: string) {
+    super(`Memory checkpoint restore requires an absent or empty memory root: ${memoryRoot}`);
+    this.name = 'MemoryCheckpointRestoreTargetError';
+  }
+}
+
+/** Raised when the local working copy cannot be captured safely. */
+export class MemoryCheckpointCaptureError extends Error {
+  readonly code = 'MEMORY_CHECKPOINT_CAPTURE_ERROR';
+
+  constructor(readonly memoryRoot: string, detail: string, options?: ErrorOptions) {
+    super(`Failed to capture memory checkpoint from ${memoryRoot}: ${detail}`, options);
+    this.name = 'MemoryCheckpointCaptureError';
+  }
+}

--- a/src/core/memory/checkpoint/index.ts
+++ b/src/core/memory/checkpoint/index.ts
@@ -1,0 +1,30 @@
+export { MemoryCheckpointCodec } from './codec.js';
+export {
+  MemoryCheckpointCaptureError,
+  MemoryCheckpointConflictError,
+  MemoryCheckpointCorruptionError,
+  MemoryCheckpointRestoreTargetError,
+} from './errors.js';
+export {
+  MEMORY_CHECKPOINT_SCHEMA_VERSION,
+  MemoryCheckpointFileSchema,
+  MemoryCheckpointGenerationIdSchema,
+  MemoryCheckpointGenerationSchema,
+  MemoryCheckpointManifestSchema,
+} from './schemas.js';
+export { MemoryCheckpointService } from './service.js';
+export type {
+  MemoryCheckpointFile,
+  MemoryCheckpointGeneration,
+  MemoryCheckpointGenerationId,
+  MemoryCheckpointManifest,
+} from './schemas.js';
+export type {
+  CommitMemoryCheckpointInput,
+  DeleteMemoryCheckpointInput,
+  LoadMemoryCheckpointGenerationInput,
+  MemoryCheckpointBundle,
+  MemoryCheckpointServiceOptions,
+  MemoryCheckpointStore,
+  RestoreMemoryCheckpointResult,
+} from './types.js';

--- a/src/core/memory/checkpoint/schemas.ts
+++ b/src/core/memory/checkpoint/schemas.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { MemoryScopeIdSchema } from '../scope.js';
+
+export const MEMORY_CHECKPOINT_SCHEMA_VERSION = 1 as const;
+
+export const MemoryCheckpointGenerationIdSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/u)
+  .brand('MemoryCheckpointGenerationId');
+
+export const MemoryCheckpointFileSchema = z.object({
+  path: z.string().min(1),
+  contentBase64: z.string(),
+  byteLength: z.number().int().nonnegative(),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/u),
+}).strict();
+
+export const MemoryCheckpointGenerationSchema = z.object({
+  kind: z.literal('heddle-memory-checkpoint-generation'),
+  schemaVersion: z.literal(MEMORY_CHECKPOINT_SCHEMA_VERSION),
+  scopeId: MemoryScopeIdSchema,
+  generationId: MemoryCheckpointGenerationIdSchema,
+  createdAt: z.iso.datetime(),
+  files: z.array(MemoryCheckpointFileSchema),
+}).strict();
+
+export const MemoryCheckpointManifestSchema = z.object({
+  kind: z.literal('heddle-memory-checkpoint-manifest'),
+  schemaVersion: z.literal(MEMORY_CHECKPOINT_SCHEMA_VERSION),
+  scopeId: MemoryScopeIdSchema,
+  generationId: MemoryCheckpointGenerationIdSchema,
+  generationSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+  fileCount: z.number().int().nonnegative(),
+  totalBytes: z.number().int().nonnegative(),
+  committedAt: z.iso.datetime(),
+}).strict();
+
+export type MemoryCheckpointGenerationId = z.infer<typeof MemoryCheckpointGenerationIdSchema>;
+export type MemoryCheckpointFile = z.infer<typeof MemoryCheckpointFileSchema>;
+export type MemoryCheckpointGeneration = z.infer<typeof MemoryCheckpointGenerationSchema>;
+export type MemoryCheckpointManifest = z.infer<typeof MemoryCheckpointManifestSchema>;

--- a/src/core/memory/checkpoint/service.ts
+++ b/src/core/memory/checkpoint/service.ts
@@ -1,0 +1,240 @@
+import { randomUUID } from 'node:crypto';
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  rmdir,
+  writeFile,
+} from 'node:fs/promises';
+import { basename, dirname, join, relative, resolve, sep } from 'node:path';
+import type { MemoryScopeId } from '../scope.js';
+import { MemoryCheckpointCodec } from './codec.js';
+import {
+  MemoryCheckpointCaptureError,
+  MemoryCheckpointCorruptionError,
+  MemoryCheckpointRestoreTargetError,
+} from './errors.js';
+import {
+  MemoryCheckpointGenerationIdSchema,
+  type MemoryCheckpointFile,
+  type MemoryCheckpointManifest,
+} from './schemas.js';
+import type {
+  MemoryCheckpointBundle,
+  MemoryCheckpointServiceOptions,
+  MemoryCheckpointStore,
+  RestoreMemoryCheckpointResult,
+} from './types.js';
+
+/**
+ * Owns explicit checkpoint, restore-before-use, and deletion operations for
+ * one local Heddle memory working copy over a host-supplied durable store.
+ */
+export class MemoryCheckpointService {
+  private readonly now: () => Date;
+  private readonly createGenerationId: NonNullable<MemoryCheckpointServiceOptions['createGenerationId']>;
+
+  constructor(
+    private readonly memoryRoot: string,
+    private readonly store: MemoryCheckpointStore,
+    options: MemoryCheckpointServiceOptions = {},
+  ) {
+    this.now = options.now ?? (() => new Date());
+    this.createGenerationId = options.createGenerationId
+      ?? (() => MemoryCheckpointGenerationIdSchema.parse(`memory-generation-v1-${randomUUID()}`));
+  }
+
+  /**
+   * Captures the current working copy and commits it as one immutable
+   * generation. Callers invoke this only after a memory-changing interaction
+   * or maintenance transaction reaches its stable boundary.
+   */
+  async checkpoint(scopeId: MemoryScopeId): Promise<MemoryCheckpointManifest> {
+    const prior = await this.loadManifest(scopeId);
+    const timestamp = this.now().toISOString();
+    const generation = MemoryCheckpointCodec.createGeneration({
+      scopeId,
+      generationId: this.createGenerationId(),
+      createdAt: timestamp,
+      files: await this.captureFiles(),
+    });
+    const manifest = MemoryCheckpointCodec.createManifest({
+      generation,
+      committedAt: timestamp,
+    });
+
+    await this.store.commit({
+      expectedGenerationId: prior?.generationId ?? null,
+      generation,
+      manifest,
+    });
+    return manifest;
+  }
+
+  /** Loads and validates the complete generation named by the committed manifest. */
+  async load(scopeId: MemoryScopeId): Promise<MemoryCheckpointBundle | undefined> {
+    const persistedManifest = await this.store.loadManifest(scopeId);
+    if (persistedManifest === undefined) {
+      return undefined;
+    }
+
+    const manifest = MemoryCheckpointCodec.parseManifest(persistedManifest, scopeId);
+    const persistedGeneration = await this.store.loadGeneration({
+      scopeId,
+      generationId: manifest.generationId,
+    });
+    if (persistedGeneration === undefined) {
+      throw new MemoryCheckpointCorruptionError(
+        scopeId,
+        `committed generation is missing: ${manifest.generationId}`,
+      );
+    }
+
+    const generation = MemoryCheckpointCodec.parseGeneration(
+      persistedGeneration,
+      scopeId,
+      manifest.generationId,
+    );
+    MemoryCheckpointCodec.validateCommitted(manifest, generation);
+    return { manifest, generation };
+  }
+
+  /**
+   * Restores a committed checkpoint before the memory workspace is
+   * bootstrapped or accessed. Existing memory is never merged or overwritten.
+   */
+  async restore(scopeId: MemoryScopeId): Promise<RestoreMemoryCheckpointResult> {
+    const checkpoint = await this.load(scopeId);
+    if (!checkpoint) {
+      return { status: 'absent' };
+    }
+
+    const memoryRoot = resolve(this.memoryRoot);
+    await this.prepareRestoreTarget(memoryRoot);
+    await this.restoreGeneration(memoryRoot, checkpoint);
+    return {
+      status: 'restored',
+      memoryRoot,
+      manifest: checkpoint.manifest,
+    };
+  }
+
+  /** Removes the authoritative checkpoint without inventing file-merge semantics. */
+  async delete(scopeId: MemoryScopeId): Promise<boolean> {
+    const manifest = await this.loadManifest(scopeId);
+    if (!manifest) {
+      return false;
+    }
+
+    await this.store.delete({
+      scopeId,
+      expectedGenerationId: manifest.generationId,
+    });
+    return true;
+  }
+
+  private async loadManifest(scopeId: MemoryScopeId): Promise<MemoryCheckpointManifest | undefined> {
+    const persistedManifest = await this.store.loadManifest(scopeId);
+    return persistedManifest === undefined
+      ? undefined
+      : MemoryCheckpointCodec.parseManifest(persistedManifest, scopeId);
+  }
+
+  private async captureFiles(): Promise<MemoryCheckpointFile[]> {
+    const configuredRoot = resolve(this.memoryRoot);
+    let memoryRoot: string;
+    try {
+      memoryRoot = await realpath(configuredRoot);
+    } catch (error) {
+      throw new MemoryCheckpointCaptureError(configuredRoot, 'memory root does not exist', { cause: error });
+    }
+
+    const files: MemoryCheckpointFile[] = [];
+    await this.walkMemoryFiles(memoryRoot, memoryRoot, files);
+    return files;
+  }
+
+  private async walkMemoryFiles(
+    memoryRoot: string,
+    directory: string,
+    files: MemoryCheckpointFile[],
+  ): Promise<void> {
+    const entries = (await readdir(directory, { withFileTypes: true }))
+      .sort((left, right) => Buffer.compare(Buffer.from(left.name), Buffer.from(right.name)));
+
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      const portablePath = relative(memoryRoot, path).split(sep).join('/');
+
+      if (entry.isSymbolicLink()) {
+        throw new MemoryCheckpointCaptureError(
+          memoryRoot,
+          `symbolic links are not portable memory state: ${portablePath}`,
+        );
+      }
+      if (entry.isDirectory()) {
+        await this.walkMemoryFiles(memoryRoot, path, files);
+        continue;
+      }
+      if (!MemoryCheckpointCodec.isPortablePath(portablePath)) {
+        continue;
+      }
+      if (!entry.isFile()) {
+        throw new MemoryCheckpointCaptureError(
+          memoryRoot,
+          `portable memory path is not a regular file: ${portablePath}`,
+        );
+      }
+
+      files.push(MemoryCheckpointCodec.createFile(portablePath, await readFile(path)));
+    }
+  }
+
+  private async prepareRestoreTarget(memoryRoot: string): Promise<void> {
+    try {
+      const target = await lstat(memoryRoot);
+      if (!target.isDirectory() || target.isSymbolicLink()) {
+        throw new MemoryCheckpointRestoreTargetError(memoryRoot);
+      }
+      if ((await readdir(memoryRoot)).length > 0) {
+        throw new MemoryCheckpointRestoreTargetError(memoryRoot);
+      }
+      await rmdir(memoryRoot);
+    } catch (error) {
+      if (MemoryCheckpointService.isErrorWithCode(error, 'ENOENT')) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private async restoreGeneration(memoryRoot: string, checkpoint: MemoryCheckpointBundle): Promise<void> {
+    const parent = dirname(memoryRoot);
+    await mkdir(parent, { recursive: true });
+    const stagingRoot = await mkdtemp(join(parent, `.${basename(memoryRoot)}.restore-`));
+
+    try {
+      for (const file of checkpoint.generation.files) {
+        const targetPath = resolve(stagingRoot, ...file.path.split('/'));
+        await mkdir(dirname(targetPath), { recursive: true });
+        await writeFile(
+          targetPath,
+          MemoryCheckpointCodec.decodeFile(checkpoint.manifest.scopeId, file),
+          { flag: 'wx', mode: 0o600 },
+        );
+      }
+      await rename(stagingRoot, memoryRoot);
+    } finally {
+      await rm(stagingRoot, { recursive: true, force: true });
+    }
+  }
+
+  private static isErrorWithCode(error: unknown, code: string): error is Error & { code: string } {
+    return error instanceof Error && 'code' in error && error.code === code;
+  }
+}

--- a/src/core/memory/checkpoint/types.ts
+++ b/src/core/memory/checkpoint/types.ts
@@ -1,0 +1,60 @@
+import type { MemoryScopeId } from '../scope.js';
+import type {
+  MemoryCheckpointGeneration,
+  MemoryCheckpointGenerationId,
+  MemoryCheckpointManifest,
+} from './schemas.js';
+
+export type LoadMemoryCheckpointGenerationInput = {
+  scopeId: MemoryScopeId;
+  generationId: MemoryCheckpointGenerationId;
+};
+
+export type CommitMemoryCheckpointInput = {
+  expectedGenerationId: MemoryCheckpointGenerationId | null;
+  generation: MemoryCheckpointGeneration;
+  manifest: MemoryCheckpointManifest;
+};
+
+export type DeleteMemoryCheckpointInput = {
+  scopeId: MemoryScopeId;
+  expectedGenerationId: MemoryCheckpointGenerationId;
+};
+
+/**
+ * Provider-neutral durable storage for one subject-scoped Heddle memory.
+ *
+ * A commit must make the immutable generation durable before atomically
+ * advancing the authoritative manifest from `expectedGenerationId`. Competing
+ * manifest changes must raise `MemoryCheckpointConflictError`. Exact retries
+ * of an already committed generation may succeed idempotently.
+ */
+export type MemoryCheckpointStore = {
+  loadManifest(scopeId: MemoryScopeId): Promise<unknown | undefined>;
+  loadGeneration(input: LoadMemoryCheckpointGenerationInput): Promise<unknown | undefined>;
+  commit(input: CommitMemoryCheckpointInput): Promise<void>;
+  /**
+   * Atomically removes the authoritative manifest when it still points at the
+   * expected generation. Immutable generation cleanup may follow the adapter's
+   * documented retention policy.
+   */
+  delete(input: DeleteMemoryCheckpointInput): Promise<void>;
+};
+
+export type MemoryCheckpointServiceOptions = {
+  now?: () => Date;
+  createGenerationId?: () => MemoryCheckpointGenerationId;
+};
+
+export type MemoryCheckpointBundle = {
+  manifest: MemoryCheckpointManifest;
+  generation: MemoryCheckpointGeneration;
+};
+
+export type RestoreMemoryCheckpointResult =
+  | { status: 'absent' }
+  | {
+    status: 'restored';
+    memoryRoot: string;
+    manifest: MemoryCheckpointManifest;
+  };

--- a/src/core/memory/index.ts
+++ b/src/core/memory/index.ts
@@ -7,6 +7,7 @@ export {
   MemoryCatalogService,
 } from './catalog.js';
 export { buildMemoryDomainSystemContext } from './domain-prompt.js';
+export * from './checkpoint/index.js';
 export { MemoryMaintenanceRepository } from './maintenance-repository.js';
 export { MemoryMaintainerPrompt } from './maintainer-prompt.js';
 export { MemoryMaintenanceService } from './maintainer.js';


### PR DESCRIPTION
## Summary

- add a versioned, provider-neutral checkpoint contract for Heddle memory only
- capture an explicit allowlist into immutable generations with per-file and generation integrity checks
- require manifest compare-and-swap, restore-before-use, and non-overwriting recovery semantics
- expose the boundary from `@heddleagent/runtime/advanced` and document what remains outside it

## Boundary

This PR does not add S3, checkpoint scheduling, Execution Host integration, general workspace backup, or portability for configuration/approvals/MCP/telemetry. Those remain separate slices.

## Verification

- focused memory checkpoint and scope tests: 6 passing
- TypeScript typecheck
- ESLint
- runtime package build