### PR TITLE
feat(memory): report turn memory changes

### DIFF
--- a/docs/guides/programmatic/conversation-engine.md
+++ b/docs/guides/programmatic/conversation-engine.md
@@ -80,6 +80,12 @@ controls the memory tools visible to the model, while
 turn selects a custom agent, that agent's tool profile overrides the engine
 default for the turn.
 
+`background` runs maintenance after the primary turn is persisted, so streamed
+assistant output is not held back. The returned turn promise still waits for
+maintenance to reach a stable boundary before reporting memory changes to
+checkpointing hosts. `inline` includes maintenance events in the primary
+persisted turn result; `none` leaves recorded candidates pending.
+
 For host event adapters, import `HeddleEventType` instead of duplicating event
 name strings:
 

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -396,7 +396,7 @@ describe('conversation turn lifecycle', () => {
     expect(requestToolApproval).toHaveBeenCalledWith({ call, tool });
   });
 
-  it('returns persisted trace, session artifacts, and completed tool results to hosts', async () => {
+  it('returns persisted trace, session artifacts, completed tool results, and memory changes to hosts', async () => {
     const storage = await createConversationTurnStorage();
     const artifact = new ArtifactService({ artifactRoot: storage.artifactRoot }).saveText({
       sessionId: storage.sessionId,
@@ -420,6 +420,13 @@ describe('conversation turn lifecycle', () => {
           durationMs: 42,
           step: 1,
           timestamp: '2026-05-03T00:00:01.000Z',
+        },
+        {
+          type: 'memory.candidate_recorded',
+          candidateId: 'candidate-1',
+          path: '_maintenance/candidates.jsonl',
+          step: 1,
+          timestamp: '2026-05-03T00:00:01.500Z',
         },
         {
           type: 'run.finished',
@@ -463,6 +470,7 @@ describe('conversation turn lifecycle', () => {
         timestamp: '2026-05-03T00:00:01.000Z',
       },
     ]);
+    expect(turnResult.memory).toEqual({ changed: true });
   });
 
   it('returns the safe model failure category to programmatic hosts', async () => {
@@ -489,6 +497,7 @@ describe('conversation turn lifecycle', () => {
     });
 
     expect(turnResult.failure).toEqual({ source: 'model', code: 'authentication' });
+    expect(turnResult.memory).toEqual({ changed: false });
   });
 
   it('returns the safe quota failure category and actionable summary to programmatic hosts', async () => {

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ProviderCredentialRepository } from '@/core/auth/index.js';
 import { ArtifactService } from '@/core/artifacts/index.js';
 import { EngineConversationTurnService } from '@/core/chat/engine/turns/service.js';
+import { ConversationTurnMemoryMaintenance } from '@/core/chat/engine/turns/memory/index.js';
 import { FileConversationSessionService } from '@/core/chat/engine/sessions/service.js';
 import {
   ChatSessionLeases,
@@ -471,6 +472,53 @@ describe('conversation turn lifecycle', () => {
       },
     ]);
     expect(turnResult.memory).toEqual({ changed: true });
+  });
+
+  it('waits for background memory maintenance before reporting a memory change', async () => {
+    const storage = await createConversationTurnStorage();
+    vi.spyOn(agentLoopModule.AgentLoopRuntimeService, 'run').mockResolvedValue(createLoopResult({
+      workspaceRoot: storage.workspaceRoot,
+      prompt: 'Remember this.',
+      summary: 'Remembered.',
+      trace: [{
+        type: 'memory.candidate_recorded',
+        candidateId: 'candidate-1',
+        path: '_maintenance/candidates.jsonl',
+        step: 1,
+        timestamp: '2026-05-03T00:00:01.000Z',
+      }],
+    }) as never);
+
+    let completeMaintenance!: () => void;
+    const maintenanceBoundary = new Promise<void>((resolvePromise) => {
+      completeMaintenance = resolvePromise;
+    });
+    const maintenanceSpy = vi.spyOn(ConversationTurnMemoryMaintenance, 'runBackground')
+      .mockReturnValue(maintenanceBoundary);
+
+    let settled = false;
+    const turn = EngineConversationTurnService.run({
+      workspaceRoot: storage.workspaceRoot,
+      stateRoot: storage.stateRoot,
+      traceDir: join(storage.stateRoot, 'traces'),
+      sessionStoragePath: storage.sessionStoragePath,
+      sessionId: storage.sessionId,
+      prompt: 'Remember this.',
+      apiKey: 'explicit-key',
+      memoryMaintenanceMode: 'background',
+      artifactRoot: storage.artifactRoot,
+      artifactsEnabled: true,
+    }).finally(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => expect(maintenanceSpy).toHaveBeenCalledOnce());
+    expect(settled).toBe(false);
+
+    completeMaintenance();
+    await expect(turn).resolves.toEqual(expect.objectContaining({
+      memory: { changed: true },
+    }));
   });
 
   it('returns the safe model failure category to programmatic hosts', async () => {

--- a/src/__tests__/integration/sdk/hosted-agent-stack.test.ts
+++ b/src/__tests__/integration/sdk/hosted-agent-stack.test.ts
@@ -321,6 +321,7 @@ function createTurnResult(sessionId: string, prompt: string): ConversationTurnRe
     session: { id: sessionId } as ConversationTurnResultSummary['session'],
     artifacts: [],
     toolResults: [],
+    memory: { changed: false },
   };
 }
 

--- a/src/__tests__/unit/core/conversation-engine.test.ts
+++ b/src/__tests__/unit/core/conversation-engine.test.ts
@@ -40,6 +40,7 @@ describe('createConversationEngine', () => {
         session: stored?.session as ChatSession,
         artifacts: [],
         toolResults: [],
+        memory: { changed: false },
       };
     });
   });

--- a/src/__tests__/unit/core/conversation-run-service.test.ts
+++ b/src/__tests__/unit/core/conversation-run-service.test.ts
@@ -400,6 +400,7 @@ function turnResult(): ConversationTurnResultSummary {
     }),
     artifacts: [],
     toolResults: [],
+    memory: { changed: false },
   };
 }
 

--- a/src/__tests__/unit/core/conversation-text-host.test.ts
+++ b/src/__tests__/unit/core/conversation-text-host.test.ts
@@ -118,6 +118,7 @@ describe('createConversationTextHost', () => {
         step: 1,
         timestamp: '2026-07-02T00:00:01.000Z',
       }],
+      memory: { changed: false },
     };
 
     textHost.renderTurnResult(result);

--- a/src/__tests__/unit/sdk/conversation-agent.test.ts
+++ b/src/__tests__/unit/sdk/conversation-agent.test.ts
@@ -30,6 +30,7 @@ describe('ConversationAgentService', () => {
         session: session?.session,
         artifacts: [],
         toolResults: [],
+        memory: { changed: false },
       } as Awaited<ReturnType<typeof EngineConversationTurnService.run>>;
     });
   });

--- a/src/core/chat/engine/turn-result.ts
+++ b/src/core/chat/engine/turn-result.ts
@@ -18,4 +18,8 @@ export type ConversationTurnResultSummary = {
   traceFile?: string;
   artifacts: RuntimeArtifact[];
   toolResults: ConversationTurnToolResult[];
+  memory: {
+    /** Whether this turn changed Heddle's portable memory working copy. */
+    changed: boolean;
+  };
 };

--- a/src/core/chat/engine/turn-result.ts
+++ b/src/core/chat/engine/turn-result.ts
@@ -19,7 +19,11 @@ export type ConversationTurnResultSummary = {
   artifacts: RuntimeArtifact[];
   toolResults: ConversationTurnToolResult[];
   memory: {
-    /** Whether this turn changed Heddle's portable memory working copy. */
+    /**
+     * Whether this turn changed Heddle's portable memory working copy.
+     * The turn result resolves only after configured memory maintenance reaches
+     * a stable boundary, so checkpointing callers may act on this value.
+     */
     changed: boolean;
   };
 };

--- a/src/core/chat/engine/turns/README.md
+++ b/src/core/chat/engine/turns/README.md
@@ -21,8 +21,8 @@ the class that owns that phase.
   turn. Engine turns renew themselves; hosts must not duplicate that heartbeat.
 - `persistence/`: builds turn artifacts and writes completed turns back to
   session storage.
-- `memory/`: runs inline/background memory maintenance and records its trace
-  evidence.
+- `memory/`: runs inline or post-persistence memory maintenance, records its
+  trace evidence, and establishes the stable boundary before turn settlement.
 - `host/`: normalizes public host callbacks into turn-runtime ports.
 - `trace/`: writes persisted trace files.
 

--- a/src/core/chat/engine/turns/memory/index.ts
+++ b/src/core/chat/engine/turns/memory/index.ts
@@ -1,6 +1,6 @@
 export { ConversationTurnMemoryMaintenance } from './turn-memory-maintenance.js';
 export type {
+  RunBackgroundTurnMemoryMaintenanceArgs,
   RunInlineTurnMemoryMaintenanceArgs,
-  ScheduleBackgroundTurnMemoryMaintenanceArgs,
   TurnMemoryMaintenanceRuntimeInput,
 } from './types.js';

--- a/src/core/chat/engine/turns/memory/turn-memory-maintenance.ts
+++ b/src/core/chat/engine/turns/memory/turn-memory-maintenance.ts
@@ -5,9 +5,9 @@ import { MemoryMaintenanceIntegrationService } from '@/core/memory/maintenance-i
 import { TraceSummaryService } from '@/core/observability/index.js';
 import type {
   AppendTurnMemoryMaintenanceEventsArgs,
+  RunBackgroundTurnMemoryMaintenanceArgs,
   RunMemoryMaintenanceCoreArgs,
   RunInlineTurnMemoryMaintenanceArgs,
-  ScheduleBackgroundTurnMemoryMaintenanceArgs,
 } from './types.js';
 
 /**
@@ -38,21 +38,7 @@ export class ConversationTurnMemoryMaintenance {
     return ConversationTurnMemoryMaintenance.appendAgentLoopTrace(args.result, maintenance.events);
   }
 
-  static scheduleBackground(args: ScheduleBackgroundTurnMemoryMaintenanceArgs) {
-    void ConversationTurnMemoryMaintenance.runBackground(args).catch((error) => {
-      args.onEvent?.({
-        type: 'trace',
-        runId: args.runId,
-        event: ConversationTurnMemoryMaintenance.createFailureEvent({
-          error,
-          trace: args.trace,
-        }),
-        timestamp: new Date().toISOString(),
-      });
-    });
-  }
-
-  static async runBackground(args: ScheduleBackgroundTurnMemoryMaintenanceArgs) {
+  static async runBackground(args: RunBackgroundTurnMemoryMaintenanceArgs): Promise<void> {
     const maintenanceInput: RunMemoryMaintenanceCoreArgs = args;
     const maintenance = await new MemoryMaintenanceIntegrationService(maintenanceInput.memoryRoot).runForRecordedCandidates({
       llm: maintenanceInput.llm,
@@ -123,23 +109,5 @@ export class ConversationTurnMemoryMaintenance {
     } catch {
       return [];
     }
-  }
-
-  private static createFailureEvent(args: {
-    error: unknown;
-    trace: TraceEvent[];
-  }): Extract<TraceEvent, { type: 'memory.maintenance_failed' }> {
-    return {
-      type: 'memory.maintenance_failed',
-      runId: `memory-run-${Date.now()}`,
-      error: args.error instanceof Error ? args.error.message : String(args.error),
-      candidateIds: [],
-      step: ConversationTurnMemoryMaintenance.nextTraceStep(args.trace),
-      timestamp: new Date().toISOString(),
-    };
-  }
-
-  private static nextTraceStep(trace: TraceEvent[]): number {
-    return trace.reduce((max, event) => ('step' in event ? Math.max(max, event.step) : max), 0) + 1;
   }
 }

--- a/src/core/chat/engine/turns/memory/types.ts
+++ b/src/core/chat/engine/turns/memory/types.ts
@@ -11,7 +11,7 @@ export type RunInlineTurnMemoryMaintenanceArgs = {
   onEvent?: (event: AgentLoopEvent) => void;
 };
 
-export type ScheduleBackgroundTurnMemoryMaintenanceArgs = {
+export type RunBackgroundTurnMemoryMaintenanceArgs = {
   memoryRoot: string;
   llm: LlmAdapter;
   source: string;
@@ -36,7 +36,7 @@ export type TurnMemoryMaintenanceRuntimeInput = Pick<
 >;
 
 export type AppendTurnMemoryMaintenanceEventsArgs = Pick<
-  ScheduleBackgroundTurnMemoryMaintenanceArgs,
+  RunBackgroundTurnMemoryMaintenanceArgs,
   'traceFile' | 'sessionService' | 'sessionId'
 > & {
   events: AgentLoopResult['trace'];

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -211,7 +211,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
       leaseHeartbeat.throwIfFailed();
 
       if (maintenanceMode === 'background') {
-        ConversationTurnMemoryMaintenance.scheduleBackground({
+        await ConversationTurnMemoryMaintenance.runBackground({
           ...memoryRuntime,
           trace: result.trace,
           traceFile: persisted.traceFile,
@@ -235,6 +235,8 @@ export class EngineConversationTurnService implements ConversationTurnService {
         }),
         toolResults: EngineConversationTurnService.summarizeToolResults(resultForPersistence.trace),
         memory: {
+          // Background maintenance runs after the primary turn is persisted,
+          // but the result does not resolve until that working copy is stable.
           changed: resultForPersistence.trace.some(
             ({ type }) => type === HeddleEventType.memoryCandidateRecorded,
           ),

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -234,6 +234,11 @@ export class EngineConversationTurnService implements ConversationTurnService {
           sessionId: session.id,
         }),
         toolResults: EngineConversationTurnService.summarizeToolResults(resultForPersistence.trace),
+        memory: {
+          changed: resultForPersistence.trace.some(
+            ({ type }) => type === HeddleEventType.memoryCandidateRecorded,
+          ),
+        },
       };
     } finally {
       await leaseHeartbeat.stop();

--- a/src/core/memory/checkpoint/README.md
+++ b/src/core/memory/checkpoint/README.md
@@ -40,6 +40,10 @@ fail capture instead of being followed.
 5. A shutdown checkpoint may reduce recent loss, but must not be the only
    checkpoint trigger.
 
+Conversation turns report `result.memory.changed` from Heddle-owned memory
+events. Hosted callers should combine that fact with their own terminal-outcome
+policy instead of interpreting Heddle tool names or tool-result payloads.
+
 `restore()` never merges with or overwrites existing files. The caller must
 serialize bootstrap, restore, and first use for one working copy. It must also
 serialize `checkpoint()` with memory mutations so capture observes one stable

--- a/src/core/memory/checkpoint/README.md
+++ b/src/core/memory/checkpoint/README.md
@@ -42,7 +42,10 @@ fail capture instead of being followed.
 
 Conversation turns report `result.memory.changed` from Heddle-owned memory
 events. Hosted callers should combine that fact with their own terminal-outcome
-policy instead of interpreting Heddle tool names or tool-result payloads.
+policy instead of interpreting Heddle tool names or tool-result payloads. The
+turn's returned promise resolves only after configured post-turn maintenance
+reaches a stable boundary. In `background` mode, the assistant response may
+still stream first; only result settlement waits for maintenance.
 
 `restore()` never merges with or overwrites existing files. The caller must
 serialize bootstrap, restore, and first use for one working copy. It must also


### PR DESCRIPTION
## Summary

- expose Heddle-owned `result.memory.changed` on conversation turn results
- derive the fact from the existing `memory.candidate_recorded` domain event
- let hosted callers apply persistence policy without interpreting Heddle tool names or result payloads

## Ownership boundary

Heddle owns whether its portable memory working copy changed. Execution hosts continue to own verified scope binding, provider-session isolation, storage composition, restore timing, and terminal-outcome checkpoint policy.

## Verification

- `yarn typecheck`
- `yarn runtime:build`
- targeted contract suite: 58 tests
- full unit suite: 902 tests
- full integration suite: 430 tests
- `git diff --check`