### PR TITLE
feat: show subagent activity in web and TUI

### DIFF
--- a/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
+++ b/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
@@ -76,6 +76,29 @@ test('opens side panels as mobile overlays', async ({ page }) => {
   await expect(page.getByTestId('web-v2-surface-sessions')).toBeVisible();
 });
 
+test('keeps the upcoming-turn subagent switch keyboard-accessible on narrow screens', async ({ page }) => {
+  const state = await trpc.controlPlane.state.query();
+  const session = await trpc.controlPlane.sessionCreate.mutate({
+    name: `Subagent control smoke ${Date.now()}`,
+  });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(`/workspaces/${state.activeWorkspaceId}/sessions/${session.id}`);
+
+  await expect.poll(async () => page.evaluate(() => document.documentElement.scrollWidth)).toBe(390);
+  await page.getByRole('button', { name: /Add context/ }).click();
+
+  const subagents = page.getByRole('switch', { name: /Subagents/ });
+  await expect(subagents).toHaveAttribute('data-state', 'checked');
+  await expect(page.getByText('Permission mode', { exact: true })).toBeVisible();
+
+  await subagents.press('Space');
+  await expect(subagents).toHaveAttribute('data-state', 'unchecked');
+  await expect(page.getByText('Off for upcoming messages', { exact: true })).toBeVisible();
+
+  await subagents.press('Space');
+  await expect(subagents).toHaveAttribute('data-state', 'checked');
+});
+
 test('navigates primary and settings routes without hash routing', async ({ page }) => {
   await page.goto('/sessions');
 

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -81,6 +81,51 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('reduces live subagent lifecycle events into the shared terminal snapshot', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    fixture.emitRunActivity({
+      source: 'delegation',
+      type: 'delegation.started',
+      rootRunId: 'run-root-1',
+      parentRunId: 'run-root-1',
+      delegationId: 'delegation-1',
+      childRunId: 'run-child-1',
+      depth: 1,
+      task: 'Inspect the shared client.',
+      agentProfileId: 'builtin:ask',
+      timestamp: '2026-08-27T08:00:00.000Z',
+    });
+
+    expect(store.getSnapshot().liveDelegations).toEqual([expect.objectContaining({
+      delegationId: 'delegation-1',
+      status: 'running',
+    })]);
+
+    fixture.emitRunActivity({
+      source: 'delegation',
+      type: 'delegation.finished',
+      rootRunId: 'run-root-1',
+      parentRunId: 'run-root-1',
+      delegationId: 'delegation-1',
+      childRunId: 'run-child-1',
+      depth: 1,
+      task: 'Inspect the shared client.',
+      agentProfileId: 'builtin:ask',
+      outcome: 'done',
+      summary: 'Found the projection.',
+      timestamp: '2026-08-27T08:00:03.000Z',
+    });
+
+    expect(store.getSnapshot().liveDelegations).toEqual([expect.objectContaining({
+      status: 'finished',
+      summary: 'Found the projection.',
+    })]);
+    store.dispose();
+  });
+
   it('recovers and subscribes to an active run when loading a session', async () => {
     const fixture = createClientFixture();
     fixture.calls.sessionRunStateQuery.mockResolvedValueOnce({
@@ -190,6 +235,7 @@ describe('ControlPlaneSessionStore', () => {
       workspaceId: 'workspace-1',
       sessionId: 'session-1',
       prompt: 'Build the next slice',
+      delegation: 'auto',
       maxSteps: 12,
       searchIgnoreDirs: ['node_modules'],
       apiKey: undefined,
@@ -202,6 +248,23 @@ describe('ControlPlaneSessionStore', () => {
       text: 'Build the next slice',
       isPending: true,
     });
+    store.dispose();
+  });
+
+  it('submits the TUI-local off preference without changing permission mode', async () => {
+    const fixture = createClientFixture();
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+    await store.start();
+
+    store.setDelegationMode('off');
+    await store.submitPrompt('Work without helpers');
+
+    expect(fixture.calls.sessionSendPromptAsyncMutate).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: 'Work without helpers',
+      delegation: 'off',
+    }));
+    expect(fixture.calls.workspacePermissionModeUpdateMutate).not.toHaveBeenCalled();
+    expect(store.getSnapshot().delegationMode).toBe('off');
     store.dispose();
   });
 
@@ -718,6 +781,19 @@ describe('ControlPlaneSessionStore', () => {
     const store = new ControlPlaneSessionStore({ client: fixture.client });
     await store.start();
 
+    fixture.emitRunActivity({
+      source: 'delegation',
+      type: 'delegation.started',
+      rootRunId: 'run-root-1',
+      parentRunId: 'run-root-1',
+      delegationId: 'delegation-1',
+      childRunId: 'run-child-1',
+      depth: 1,
+      task: 'Keep inspecting the current turn.',
+      agentProfileId: 'builtin:ask',
+      timestamp: '2026-08-27T08:00:00.000Z',
+    });
+
     await store.submitPrompt('Next prompt');
 
     expect(fixture.calls.sessionSendPromptAsyncMutate).toHaveBeenCalledWith(expect.objectContaining({
@@ -727,6 +803,7 @@ describe('ControlPlaneSessionStore', () => {
     }));
     expect(store.getSnapshot()).toMatchObject({
       running: true,
+      liveDelegations: [expect.objectContaining({ delegationId: 'delegation-1' })],
       latestUpdate: {
         label: 'Prompt queued',
         detail: 'position 1',
@@ -1358,12 +1435,13 @@ function createClientFixture(options: {
   };
 
   const emitRunActivity = (activity: ControlPlaneRunActivity) => {
-    if (activeRunId !== activity.runId || !runEvents) {
-      announceRun(activity.runId);
+    const runId = 'runId' in activity ? activity.runId : activity.rootRunId;
+    if (activeRunId !== runId || !runEvents) {
+      announceRun(runId);
     }
     runEvents?.onData?.({
       kind: 'activity',
-      runId: activity.runId,
+      runId,
       sequence: ++runSequence,
       timestamp: activity.timestamp,
       activity,

--- a/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
+++ b/src/__tests__/unit/cli-v2/conversation-panel.test.tsx
@@ -177,6 +177,36 @@ describe('cli-v2 ConversationPanel', () => {
     expect(view.container.textContent).toContain('docs/index.md');
     expect(view.container.textContent).toContain('+new');
   });
+
+  it('renders compact durable subagent results without a child transcript', () => {
+    const view = render(
+      <ConversationPanel
+        session={createSessionDetail({
+          messages: [
+            { id: 'message-1', role: 'user', text: 'Inspect the runtime' },
+            { id: 'message-2', role: 'assistant', text: 'Done.' },
+          ],
+          turns: [{
+            id: 'turn-1',
+            prompt: 'Inspect the runtime',
+            outcome: 'done',
+            summary: 'Done.',
+            steps: 2,
+            traceFile: '/tmp/trace.json',
+            events: [],
+            delegations: [createSettledDelegation()],
+          }],
+        })}
+        runtimeContext={createRuntimeContext()}
+      />,
+    );
+
+    expect(view.container.textContent).toContain('Subagent results');
+    expect(view.container.textContent).toContain('Ask · done · 3s');
+    expect(view.container.textContent).toContain('Inspect the client boundary.');
+    expect(view.container.textContent).toContain('Found the shared seam.');
+    expect(view.container.textContent).not.toContain('child transcript');
+  });
 });
 
 function createSessionDetail(
@@ -233,5 +263,33 @@ function createRuntimeContext(
       carriesTranscriptAcrossTurns: true,
     },
     ...overrides,
+  };
+}
+
+function createSettledDelegation(): NonNullable<NonNullable<ControlPlaneSessionDetail>['turns'][number]['delegations']>[number] {
+  return {
+    schemaVersion: 1,
+    delegationId: 'delegation-1',
+    rootRunId: 'run-root-1',
+    parentRunId: 'run-root-1',
+    childRunId: 'run-child-1',
+    depth: 1,
+    task: 'Inspect the client boundary.',
+    agentSnapshot: {
+      agentProfileId: 'builtin:ask',
+      agentName: 'Ask',
+      modeAlias: 'ask',
+      source: 'built-in',
+      definitionHash: 'ask-definition',
+      runtime: { maxSteps: 24 },
+      toolProfile: { preset: 'inspect', memoryMode: 'none' },
+      approvalProfile: { preset: 'read_only' },
+      systemContextAppendix: 'Read only.',
+    },
+    status: 'finished',
+    outcome: 'done',
+    summary: 'Found the shared seam.',
+    startedAt: '2026-08-27T08:00:00.000Z',
+    finishedAt: '2026-08-27T08:00:03.000Z',
   };
 }

--- a/src/__tests__/unit/cli-v2/daemon-command.test.ts
+++ b/src/__tests__/unit/cli-v2/daemon-command.test.ts
@@ -126,6 +126,57 @@ describe('daemon CLI helpers', () => {
     }]);
   });
 
+  it('projects settled delegation evidence into session detail without raw child runtime fields', () => {
+    const detail = ControlPlaneChatSessionPresenter.projectDetail({
+      id: 'session-1',
+      name: 'Subagent work',
+      pinned: false,
+      messages: [{ id: 'message-1', role: 'user', text: 'Inspect the runtime' }],
+      turns: [{
+        id: 'turn-1',
+        prompt: 'Inspect the runtime',
+        outcome: 'done',
+        summary: 'Done.',
+        steps: 2,
+        traceFile: '/tmp/root-trace.json',
+        events: [],
+        delegations: [{
+          schemaVersion: 1,
+          delegationId: 'delegation-1',
+          rootRunId: 'run-root-1',
+          parentRunId: 'run-root-1',
+          childRunId: 'run-child-1',
+          depth: 1,
+          task: 'Inspect the shared client.',
+          agentSnapshot: {
+            agentProfileId: 'builtin:ask',
+            agentName: 'Ask',
+            modeAlias: 'ask',
+            source: 'built-in',
+            definitionHash: 'ask-definition',
+            runtime: { maxSteps: 24 },
+            toolProfile: { preset: 'inspect', memoryMode: 'none' },
+            approvalProfile: { preset: 'read_only' },
+            systemContextAppendix: 'Read only.',
+          },
+          status: 'finished',
+          outcome: 'done',
+          summary: 'Found the projection.',
+          startedAt: '2026-08-27T08:00:00.000Z',
+          finishedAt: '2026-08-27T08:00:03.000Z',
+        }],
+      }],
+    })[0];
+
+    expect(detail?.turns[0]?.delegations).toEqual([expect.objectContaining({
+      delegationId: 'delegation-1',
+      summary: 'Found the projection.',
+    })]);
+    expect(detail?.turns[0]?.delegations?.[0]).not.toHaveProperty('trace');
+    expect(detail?.turns[0]?.delegations?.[0]).not.toHaveProperty('model');
+    expect(detail?.turns[0]?.delegations?.[0]).not.toHaveProperty('provider');
+  });
+
   it('ignores invalid chat session records', () => {
     expect(ControlPlaneChatSessionPresenter.projectView({ id: 'missing-name' })).toEqual([]);
     expect(ControlPlaneChatSessionPresenter.projectView(null)).toEqual([]);

--- a/src/__tests__/unit/cli-v2/runtime-status.test.ts
+++ b/src/__tests__/unit/cli-v2/runtime-status.test.ts
@@ -5,7 +5,7 @@ import type { ControlPlaneSessionStoreSnapshot } from '../../../cli-v2/state/con
 describe('RuntimeStatusService', () => {
   it('formats runtime context for the cli-v2 status bar', () => {
     expect(RuntimeStatusService.build(createSnapshot())).toBe(
-      'model=gpt-5.4 • reasoning=medium • permissions=default • auth=openai-oauth • context window ~400,000 tokens • drift=off • session=session-1 (Session 1)',
+      'model=gpt-5.4 • reasoning=medium • permissions=default • subagents=on • auth=openai-oauth • context window ~400,000 tokens • drift=off • session=session-1 (Session 1)',
     );
   });
 
@@ -20,7 +20,7 @@ describe('RuntimeStatusService', () => {
         running: true,
       },
     }))).toBe(
-      'model=gpt-5.4 • reasoning=medium • permissions=default • auth=openai-oauth • estimated input 20,000 / 400,000 tokens (5%) • drift=low • session=session-1 (Session 1) • status=running',
+      'model=gpt-5.4 • reasoning=medium • permissions=default • subagents=on • auth=openai-oauth • estimated input 20,000 / 400,000 tokens (5%) • drift=low • session=session-1 (Session 1) • status=running',
     );
   });
 });
@@ -70,6 +70,8 @@ function createSnapshot(overrides: Partial<ControlPlaneSessionStoreSnapshot> = {
     running: false,
     cancelling: false,
     streamConnected: false,
+    liveDelegations: [],
+    delegationMode: 'auto',
     commandResults: [],
     ...overrides,
   };

--- a/src/__tests__/unit/cli-v2/tui-local-slash-command-service.test.ts
+++ b/src/__tests__/unit/cli-v2/tui-local-slash-command-service.test.ts
@@ -10,6 +10,9 @@ describe('TuiLocalSlashCommandService', () => {
       { command: '/diff', description: 'open terminal diff review' },
       { command: '/c', description: 'toggle terminal command output' },
       { command: '/commands', description: 'toggle terminal command output' },
+      { command: '/subagents', description: 'show the local subagent preference' },
+      { command: '/subagents on', description: 'allow read-only subagents for upcoming messages' },
+      { command: '/subagents off', description: 'disable subagents for upcoming messages' },
     ]);
   });
 
@@ -17,16 +20,22 @@ describe('TuiLocalSlashCommandService', () => {
     const activity = vi.fn();
     const diff = vi.fn();
     const commandResults = vi.fn();
+    const subagentsStatus = vi.fn();
+    const subagentsOn = vi.fn();
+    const subagentsOff = vi.fn();
+    const handlers = { activity, diff, commandResults, subagentsStatus, subagentsOn, subagentsOff };
 
-    expect(TuiLocalSlashCommandService.execute('/a', { activity, diff, commandResults })).toBe(true);
-    expect(TuiLocalSlashCommandService.execute('/DIFF', { activity, diff, commandResults })).toBe(true);
-    expect(TuiLocalSlashCommandService.execute(' /commands ', { activity, diff, commandResults })).toBe(true);
-    expect(TuiLocalSlashCommandService.execute('/model', { activity, diff, commandResults })).toBe(false);
-    expect(TuiLocalSlashCommandService.execute('/permissions set', { activity, diff, commandResults })).toBe(false);
-    expect(TuiLocalSlashCommandService.execute('/permissions auto', { activity, diff, commandResults })).toBe(false);
+    expect(TuiLocalSlashCommandService.execute('/a', handlers)).toBe(true);
+    expect(TuiLocalSlashCommandService.execute('/DIFF', handlers)).toBe(true);
+    expect(TuiLocalSlashCommandService.execute(' /commands ', handlers)).toBe(true);
+    expect(TuiLocalSlashCommandService.execute('/SUBAGENTS OFF', handlers)).toBe(true);
+    expect(TuiLocalSlashCommandService.execute('/model', handlers)).toBe(false);
+    expect(TuiLocalSlashCommandService.execute('/permissions set', handlers)).toBe(false);
+    expect(TuiLocalSlashCommandService.execute('/permissions auto', handlers)).toBe(false);
 
     expect(activity).toHaveBeenCalledTimes(1);
     expect(diff).toHaveBeenCalledTimes(1);
     expect(commandResults).toHaveBeenCalledTimes(1);
+    expect(subagentsOff).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/unit/client-shared/session-delegation-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-delegation-service.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ClientSharedSessionDelegationService,
+} from '@/client-shared/services/session-delegations/index.js';
+import type { ClientSharedSessionActivity } from '@/client-shared/services/session-activities/index.js';
+import type { ControlPlaneSessionTurn } from '@/client-shared/api/types.js';
+
+describe('ClientSharedSessionDelegationService', () => {
+  it('reduces replayed child lifecycle events into one safe live row', () => {
+    const started = delegationStarted();
+    let state = ClientSharedSessionDelegationService.reduceActivity([], started);
+    state = ClientSharedSessionDelegationService.reduceActivity(state, started);
+
+    expect(state).toEqual([expect.objectContaining({
+      delegationId: 'delegation-1',
+      agentName: 'Ask',
+      task: 'Inspect the durable boundary.',
+      status: 'running',
+      latestActivity: { label: 'Starting' },
+    })]);
+
+    state = ClientSharedSessionDelegationService.reduceActivity(state, {
+      ...delegationBase(),
+      type: 'delegation.child.activity',
+      activity: {
+        source: 'agent-loop',
+        type: 'reasoning.summary',
+        runId: 'run-child-1',
+        step: 1,
+        text: 'Private provider progress must not be projected.',
+        done: false,
+        timestamp: '2026-08-27T08:00:01.000Z',
+      },
+    } as ClientSharedSessionActivity);
+
+    expect(state[0]?.latestActivity).toEqual({ label: 'Thinking' });
+    expect(JSON.stringify(state)).not.toContain('Private provider progress');
+
+    state = ClientSharedSessionDelegationService.reduceActivity(state, {
+      ...delegationBase(),
+      type: 'delegation.finished',
+      outcome: 'done',
+      summary: 'Found the shared client seam.\nIt is replay safe.',
+      timestamp: '2026-08-27T08:00:03.000Z',
+    } as ClientSharedSessionActivity);
+
+    expect(state).toEqual([expect.objectContaining({
+      status: 'finished',
+      outcome: 'done',
+      summary: 'Found the shared client seam. It is replay safe.',
+      startedAt: '2026-08-27T08:00:00.000Z',
+      finishedAt: '2026-08-27T08:00:03.000Z',
+      latestActivity: undefined,
+    })]);
+  });
+
+  it('recovers a terminal row without a previously observed start and clears it for a new root run', () => {
+    const recovered = ClientSharedSessionDelegationService.reduceActivity([], {
+      ...delegationBase(),
+      type: 'delegation.cancelled',
+      outcome: 'interrupted',
+      error: { code: 'child_timeout', message: 'Child exceeded its time limit.' },
+      timestamp: '2026-08-27T08:00:05.000Z',
+    } as ClientSharedSessionActivity);
+
+    expect(recovered).toEqual([expect.objectContaining({
+      status: 'cancelled',
+      error: 'Child exceeded its time limit.',
+    })]);
+
+    expect(ClientSharedSessionDelegationService.reduceActivity(recovered, {
+      source: 'agent-loop',
+      type: 'loop.started',
+      runId: 'run-root-2',
+      goal: 'Start another turn.',
+      model: 'gpt-5.6-terra',
+      provider: 'openai',
+      workspaceRoot: '/tmp/workspace',
+      timestamp: '2026-08-27T08:01:00.000Z',
+    } as ClientSharedSessionActivity)).toEqual([]);
+  });
+
+  it('projects settled records without trace, provider, or transcript fields', () => {
+    const delegations: NonNullable<ControlPlaneSessionTurn['delegations']> = [settledDelegation()];
+
+    expect(ClientSharedSessionDelegationService.projectSettled(delegations)).toEqual([{
+      delegationId: 'delegation-1',
+      rootRunId: 'run-root-1',
+      childRunId: 'run-child-1',
+      agentProfileId: 'builtin:ask',
+      agentName: 'Ask',
+      task: 'Inspect the durable boundary.',
+      status: 'finished',
+      outcome: 'done',
+      summary: 'Found the shared client seam.',
+      startedAt: '2026-08-27T08:00:00.000Z',
+      finishedAt: '2026-08-27T08:00:03.000Z',
+    }]);
+  });
+
+  it('formats stable compact durations', () => {
+    expect(ClientSharedSessionDelegationService.formatDuration(
+      '2026-08-27T08:00:00.000Z',
+      '2026-08-27T08:01:05.000Z',
+    )).toBe('1m 5s');
+    expect(ClientSharedSessionDelegationService.formatDuration('invalid')).toBe('—');
+  });
+});
+
+function delegationBase() {
+  return {
+    source: 'delegation' as const,
+    rootRunId: 'run-root-1',
+    parentRunId: 'run-root-1',
+    delegationId: 'delegation-1',
+    childRunId: 'run-child-1',
+    depth: 1 as const,
+    task: 'Inspect the durable boundary.',
+    agentProfileId: 'builtin:ask',
+  };
+}
+
+function delegationStarted(): ClientSharedSessionActivity {
+  return {
+    ...delegationBase(),
+    type: 'delegation.started',
+    timestamp: '2026-08-27T08:00:00.000Z',
+  };
+}
+
+function settledDelegation(): NonNullable<ControlPlaneSessionTurn['delegations']>[number] {
+  return {
+    schemaVersion: 1,
+    delegationId: 'delegation-1',
+    rootRunId: 'run-root-1',
+    parentRunId: 'run-root-1',
+    childRunId: 'run-child-1',
+    depth: 1,
+    task: 'Inspect the durable boundary.',
+    agentSnapshot: {
+      agentProfileId: 'builtin:ask',
+      agentName: 'Ask',
+      modeAlias: 'ask',
+      source: 'built-in',
+      definitionHash: 'ask-definition',
+      runtime: { maxSteps: 24 },
+      toolProfile: { preset: 'inspect', memoryMode: 'none' },
+      approvalProfile: { preset: 'read_only' },
+      systemContextAppendix: 'Read only.',
+    },
+    status: 'finished',
+    outcome: 'done',
+    summary: 'Found the shared client seam.',
+    startedAt: '2026-08-27T08:00:00.000Z',
+    finishedAt: '2026-08-27T08:00:03.000Z',
+  };
+}

--- a/src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-turn-presentation-service.test.ts
@@ -117,6 +117,34 @@ describe('ClientSharedSessionTurnPresentationService', () => {
       'turn-1:activity-group',
     ]);
   });
+
+  it('projects durable subagent results immediately after the owning prompt', () => {
+    const session = createSessionDetail({
+      messages: [
+        { id: 'message-1', role: 'user', text: 'Inspect the runtime' },
+        { id: 'message-2', role: 'assistant', text: 'Done.' },
+      ],
+      turns: [createTurn({
+        id: 'turn-1',
+        prompt: 'Inspect the runtime',
+        delegations: [createSettledDelegation()],
+      })],
+    });
+
+    const timeline = ClientSharedSessionTurnPresentationService.projectConversationTimeline(session);
+    expect(timeline.map((item) => item.id)).toEqual([
+      'message-1',
+      'turn-1:delegation-group',
+      'message-2',
+    ]);
+    expect(timeline.find((item) => item.type === 'turn_delegation_group')).toEqual(expect.objectContaining({
+      delegations: [expect.objectContaining({
+        agentName: 'Ask',
+        status: 'finished',
+        summary: 'Found the client boundary.',
+      })],
+    }));
+  });
 });
 
 function createSessionDetail(
@@ -148,5 +176,33 @@ function createTurn(
     traceFile: '/tmp/trace.json',
     events: [],
     ...overrides,
+  };
+}
+
+function createSettledDelegation(): NonNullable<NonNullable<ControlPlaneSessionDetail>['turns'][number]['delegations']>[number] {
+  return {
+    schemaVersion: 1,
+    delegationId: 'delegation-1',
+    rootRunId: 'run-root-1',
+    parentRunId: 'run-root-1',
+    childRunId: 'run-child-1',
+    depth: 1,
+    task: 'Inspect the client boundary.',
+    agentSnapshot: {
+      agentProfileId: 'builtin:ask',
+      agentName: 'Ask',
+      modeAlias: 'ask',
+      source: 'built-in',
+      definitionHash: 'ask-definition',
+      runtime: { maxSteps: 24 },
+      toolProfile: { preset: 'inspect', memoryMode: 'none' },
+      approvalProfile: { preset: 'read_only' },
+      systemContextAppendix: 'Read only.',
+    },
+    status: 'finished',
+    outcome: 'done',
+    summary: 'Found the client boundary.',
+    startedAt: '2026-08-27T08:00:00.000Z',
+    finishedAt: '2026-08-27T08:00:03.000Z',
   };
 }

--- a/src/__tests__/unit/web-v2/conversation-composer-subagents.test.tsx
+++ b/src/__tests__/unit/web-v2/conversation-composer-subagents.test.tsx
@@ -1,0 +1,55 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import type { AppRouter } from '@heddleagent/runtime/cli';
+import { ConversationComposer } from '@/web-v2/components/conversation/ConversationComposer.js';
+import { I18nProvider } from '@/web-v2/i18n/I18nProvider.js';
+import { trpcReact } from '@/web-v2/api/client.js';
+
+describe('web-v2 ConversationComposer subagent preference', () => {
+  afterEach(cleanup);
+
+  it('defaults on and submits an explicit off override after the user flips the switch', async () => {
+    const onSubmitPrompt = vi.fn().mockResolvedValue(undefined);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const trpcClient = createTRPCProxyClient<AppRouter>({
+      links: [httpLink({ url: 'http://127.0.0.1:1/trpc' })],
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <trpcReact.Provider client={trpcClient} queryClient={queryClient}>
+          <MemoryRouter>
+            <I18nProvider>
+              <ConversationComposer
+                sessionId="session-1"
+                workspaceId="workspace-1"
+                onSubmitPrompt={onSubmitPrompt}
+              />
+            </I18nProvider>
+          </MemoryRouter>
+        </trpcReact.Provider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Add context/i }));
+    const subagentSwitch = screen.getByRole('switch', { name: /Subagents/i });
+    expect(subagentSwitch.getAttribute('data-state')).toBe('checked');
+    fireEvent.click(subagentSwitch);
+    expect(subagentSwitch.getAttribute('data-state')).toBe('unchecked');
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Message' }), {
+      target: { value: 'Inspect this feature' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => {
+      expect(onSubmitPrompt).toHaveBeenCalledWith('Inspect this feature', expect.objectContaining({
+        delegation: 'off',
+      }));
+    });
+  });
+});

--- a/src/__tests__/unit/web-v2/subagent-activity-panel.test.tsx
+++ b/src/__tests__/unit/web-v2/subagent-activity-panel.test.tsx
@@ -1,0 +1,37 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SubagentActivityPanel } from '@/web-v2/components/conversation/SubagentActivityPanel.js';
+import { I18nProvider } from '@/web-v2/i18n/I18nProvider.js';
+
+describe('web-v2 SubagentActivityPanel', () => {
+  afterEach(cleanup);
+
+  it('shows compact correlated child facts without raw child details', () => {
+    render(
+      <I18nProvider>
+        <SubagentActivityPanel delegations={[{
+          delegationId: 'delegation-1',
+          rootRunId: 'run-root-1',
+          childRunId: 'run-child-1',
+          agentProfileId: 'builtin:ask',
+          agentName: 'Ask',
+          task: 'Inspect the durable boundary.',
+          status: 'finished',
+          outcome: 'done',
+          summary: 'Found the shared client seam.',
+          startedAt: '2026-08-27T08:00:00.000Z',
+          finishedAt: '2026-08-27T08:00:03.000Z',
+        }]} />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByLabelText('Live subagent activity')).toBeTruthy();
+    expect(screen.getByText('Ask')).toBeTruthy();
+    expect(screen.getByText('Done')).toBeTruthy();
+    expect(screen.getByText('3s')).toBeTruthy();
+    expect(screen.getByText('Found the shared client seam.')).toBeTruthy();
+    expect(document.body.textContent).not.toContain('run-child-1');
+  });
+});

--- a/src/cli-v2/App.tsx
+++ b/src/cli-v2/App.tsx
@@ -15,6 +15,7 @@ import { QueuedPromptPanel } from './components/QueuedPromptPanel.js';
 import { RecentEditDiffPanel } from './components/RecentEditDiffPanel.js';
 import { RunControls } from './components/RunControls.js';
 import { RuntimeStatusBar } from './components/RuntimeStatusBar.js';
+import { SubagentActivityPanel } from './components/SubagentActivityPanel.js';
 import { useControlPlaneSessionStore } from './hooks/useControlPlaneSessionStore.js';
 import { useRecentEditDiffReview } from './hooks/useRecentEditDiffReview.js';
 import { PromptActivityService } from './services/activities/prompt-activity-service.js';
@@ -95,7 +96,22 @@ export function App({
 
       recentEditDiffReview.open();
     },
-  }), [hasCommandResults, hasConversationActivityGroups, recentEditDiffReview, store]);
+    subagentsStatus: () => {
+      store.showLocalCommandMessage(
+        snapshot.delegationMode === 'auto'
+          ? 'Subagents are on for upcoming messages.'
+          : 'Subagents are off for upcoming messages.',
+      );
+    },
+    subagentsOn: () => {
+      store.setDelegationMode('auto');
+      store.showLocalCommandMessage('Subagents are on for upcoming messages.');
+    },
+    subagentsOff: () => {
+      store.setDelegationMode('off');
+      store.showLocalCommandMessage('Subagents are off for upcoming messages.');
+    },
+  }), [hasCommandResults, hasConversationActivityGroups, recentEditDiffReview, snapshot.delegationMode, store]);
   const localSlashCommandHints = useMemo(
     () => TuiLocalSlashCommandService.hints(),
     [],
@@ -150,6 +166,7 @@ export function App({
         onCancel={cancelRun}
       />
       <AgentPlanPanel plan={snapshot.activePlan} />
+      {snapshot.running ? <SubagentActivityPanel delegations={snapshot.liveDelegations} /> : null}
       <ChangedFilesPanel files={snapshot.workspaceChanges} />
       <PromptStatusPanel
         currentActivity={snapshot.currentActivity}

--- a/src/cli-v2/components/ConversationPanel.tsx
+++ b/src/cli-v2/components/ConversationPanel.tsx
@@ -5,6 +5,7 @@ import { ClientSharedSessionTurnPresentationService } from '@/client-shared/serv
 import type { ClientSharedConversationTimelineItem } from '@/client-shared/services/session-turn-presentation/index.js';
 import { AssistantMarkdown } from './AssistantMarkdown.js';
 import { ConversationTurnActivityBlock } from './ConversationTurnActivityBlock.js';
+import { ConversationTurnDelegationBlock } from './ConversationTurnDelegationBlock.js';
 
 type ConversationMessage = NonNullable<ControlPlaneSessionDetail>['messages'][number];
 const MAX_VISIBLE_TIMELINE_ITEMS = 14;
@@ -49,6 +50,18 @@ function ConversationTimelineItemView({
   item: ClientSharedConversationTimelineItem;
   last: boolean;
 }) {
+  if (item.type === 'turn_delegation_group') {
+    return (
+      <Box flexDirection="column" marginBottom={1}>
+        <Text dimColor>┌ Subagents</Text>
+        <Box paddingLeft={2} flexDirection="column">
+          <ConversationTurnDelegationBlock item={item} />
+        </Box>
+        <TimelineFooter last={last} />
+      </Box>
+    );
+  }
+
   if (item.type === 'turn_activity_group') {
     return (
       <Box flexDirection="column" marginBottom={1}>

--- a/src/cli-v2/components/ConversationTurnDelegationBlock.tsx
+++ b/src/cli-v2/components/ConversationTurnDelegationBlock.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { ClientSharedConversationTimelineDelegationGroupItem } from '@/client-shared/services/session-turn-presentation/index.js';
+import { SubagentRow } from './SubagentActivityPanel.js';
+
+export function ConversationTurnDelegationBlock({
+  item,
+}: {
+  item: ClientSharedConversationTimelineDelegationGroupItem;
+}) {
+  return (
+    <Box flexDirection="column">
+      <Text color="cyan">Subagent results <Text dimColor>· {item.delegations.length}</Text></Text>
+      <Box flexDirection="column" marginTop={1} paddingLeft={2}>
+        {item.delegations.map((delegation) => (
+          <SubagentRow delegation={delegation} key={delegation.delegationId} />
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/cli-v2/components/SubagentActivityPanel.tsx
+++ b/src/cli-v2/components/SubagentActivityPanel.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import {
+  ClientSharedSessionDelegationService,
+  type ClientSharedDelegationView,
+} from '@/client-shared/services/session-delegations/index.js';
+
+export function SubagentActivityPanel({ delegations }: { delegations: ClientSharedDelegationView[] }) {
+  const [now, setNow] = useState(() => new Date());
+  const hasRunningDelegation = delegations.some((delegation) => delegation.status === 'running');
+
+  useEffect(() => {
+    if (!hasRunningDelegation) {
+      return undefined;
+    }
+
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, [hasRunningDelegation]);
+
+  if (delegations.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text bold>Subagents <Text dimColor>· {delegations.length}</Text></Text>
+      <Box flexDirection="column" paddingLeft={2}>
+        {delegations.map((delegation) => (
+          <SubagentRow delegation={delegation} key={delegation.delegationId} now={now} />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+export function SubagentRow({
+  delegation,
+  now = new Date(),
+}: {
+  delegation: ClientSharedDelegationView;
+  now?: Date;
+}) {
+  const status = resolveStatus(delegation);
+  const duration = ClientSharedSessionDelegationService.formatDuration(
+    delegation.startedAt,
+    delegation.finishedAt ?? now,
+  );
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text>
+        <Text color="cyan">{delegation.agentName}</Text>
+        <Text dimColor> · </Text>
+        <Text color={status.color}>{status.label}</Text>
+        <Text dimColor> · {duration}</Text>
+      </Text>
+      <Text>{delegation.task}</Text>
+      {delegation.latestActivity ? (
+        <Text dimColor>
+          {delegation.latestActivity.label}
+          {delegation.latestActivity.detail ? ` · ${delegation.latestActivity.detail}` : ''}
+        </Text>
+      ) : null}
+      {delegation.summary ? <Text dimColor>{delegation.summary}</Text> : null}
+      {delegation.error && !delegation.summary ? <Text color="red">{delegation.error}</Text> : null}
+    </Box>
+  );
+}
+
+function resolveStatus(delegation: ClientSharedDelegationView): { label: string; color: string } {
+  if (delegation.status === 'running') {
+    return { label: 'working', color: 'cyan' };
+  }
+
+  if (delegation.status === 'cancelled' || delegation.outcome === 'interrupted') {
+    return { label: 'cancelled', color: 'yellow' };
+  }
+
+  if (delegation.outcome === 'error') {
+    return { label: 'failed', color: 'red' };
+  }
+
+  if (delegation.outcome === 'max_steps') {
+    return { label: 'step limit', color: 'yellow' };
+  }
+
+  return { label: delegation.outcome === 'done' ? 'done' : 'finished', color: 'green' };
+}

--- a/src/cli-v2/services/slash-commands/tui-local-slash-command-service.ts
+++ b/src/cli-v2/services/slash-commands/tui-local-slash-command-service.ts
@@ -1,6 +1,12 @@
 import type { ControlPlaneSlashCommandHint } from '@/client-shared/api/types.js';
 
-export type TuiLocalSlashCommandAction = 'activity' | 'diff' | 'commandResults';
+export type TuiLocalSlashCommandAction =
+  | 'activity'
+  | 'diff'
+  | 'commandResults'
+  | 'subagentsStatus'
+  | 'subagentsOn'
+  | 'subagentsOff';
 
 export type TuiLocalSlashCommandHandlers = Record<TuiLocalSlashCommandAction, () => void>;
 
@@ -26,6 +32,10 @@ type TuiLocalSlashCommandDefinition = {
  * If a future command needs both shared effects and TUI presentation changes,
  * keep the shared operation in core/control-plane and let cli-v2 react to the
  * returned state instead of moving core policy into this service.
+ *
+ * `/subagents on|off` is the one submission-preference exception: it changes
+ * only the TUI-local value sent in the existing per-turn `delegation` field.
+ * It does not mutate runtime policy or durable session settings.
  */
 export class TuiLocalSlashCommandService {
   private static readonly definitions: TuiLocalSlashCommandDefinition[] = [
@@ -43,6 +53,21 @@ export class TuiLocalSlashCommandService {
       action: 'commandResults',
       commands: ['/c', '/commands'],
       description: 'toggle terminal command output',
+    },
+    {
+      action: 'subagentsStatus',
+      commands: ['/subagents'],
+      description: 'show the local subagent preference',
+    },
+    {
+      action: 'subagentsOn',
+      commands: ['/subagents on'],
+      description: 'allow read-only subagents for upcoming messages',
+    },
+    {
+      action: 'subagentsOff',
+      commands: ['/subagents off'],
+      description: 'disable subagents for upcoming messages',
     },
   ];
 

--- a/src/cli-v2/services/status/runtime-status-service.ts
+++ b/src/cli-v2/services/status/runtime-status-service.ts
@@ -12,6 +12,7 @@ export class RuntimeStatusService {
       `model=${context.model}`,
       `reasoning=${RuntimeStatusService.formatReasoning(context)}`,
       `permissions=${context.permissionMode}`,
+      `subagents=${snapshot.delegationMode === 'off' ? 'off' : 'on'}`,
       RuntimeStatusService.formatAuth(context),
       RuntimeStatusService.formatContextWindow(context),
       `drift=${context.driftEnabled ? context.driftLevel ?? 'unknown' : 'off'}`,

--- a/src/cli-v2/state/README.md
+++ b/src/cli-v2/state/README.md
@@ -32,7 +32,7 @@ snapshot and call user-intent methods.
   replayable run stream remains the source of truth.
 - `control-plane-live-event-reducer.ts` owns reduction of control-plane live
   events into the TUI snapshot. Shared activity semantics stay in
-  `client-shared`.
+  `client-shared`, including replay-safe subagent lifecycle rows.
 - `control-plane-workspace-changes-controller.ts` owns coalesced refresh of the
   control-plane's canonical Git workspace-change projection after shared
   workspace-change activity triggers. It does not infer changes from terminal
@@ -55,3 +55,6 @@ snapshot and call user-intent methods.
 - Do not duplicate domain policy in this folder. If a rule belongs to slash
   commands, shell policy, model capabilities, approvals, or activity semantics,
   move it to the owning core/control-plane/client-shared module instead.
+- `delegationMode` is a TUI-local, default-on next-turn preference. It resets
+  when a session is opened and is sent through the existing per-turn API field;
+  it is not a durable permission or runtime-policy setting.

--- a/src/cli-v2/state/control-plane-live-event-reducer.ts
+++ b/src/cli-v2/state/control-plane-live-event-reducer.ts
@@ -1,6 +1,7 @@
 import { ClientSharedSessionActivityService } from '@/client-shared/services/session-activities/index.js';
 import { ClientSharedNotificationIntentService } from '@/client-shared/services/notifications/index.js';
 import { ClientSharedSessionMessageService } from '@/client-shared/services/session-messages/index.js';
+import { ClientSharedSessionDelegationService } from '@/client-shared/services/session-delegations/index.js';
 import type {
   ControlPlaneSessionEventEnvelope,
   ControlPlaneSessionRunEventEnvelope,
@@ -77,6 +78,13 @@ export class ControlPlaneLiveEventReducer {
     }
 
     const activity = event.activity;
+    this.options.state.patch((current) => {
+      const liveDelegations = ClientSharedSessionDelegationService.reduceActivity(
+        current.liveDelegations,
+        activity,
+      );
+      return liveDelegations === current.liveDelegations ? {} : { liveDelegations };
+    });
     this.options.notificationService?.deliver(ClientSharedNotificationIntentService.projectSessionActivity({
       workspaceId,
       sessionId,

--- a/src/cli-v2/state/control-plane-prompt-controller.ts
+++ b/src/cli-v2/state/control-plane-prompt-controller.ts
@@ -62,6 +62,7 @@ export class ControlPlanePromptController {
       commandResultExpanded: false,
       error: undefined,
       activePlan: undefined,
+      liveDelegations: current.running ? current.liveDelegations : [],
       currentActivity: ClientSharedSessionActivityService.createThinkingStatus(),
       liveStatus: current.streamConnected
         ? 'Heddle is working...'
@@ -78,6 +79,7 @@ export class ControlPlanePromptController {
         workspaceId,
         sessionId,
         prompt,
+        delegation: this.options.state.getSnapshot().delegationMode,
       });
       if ('queued' in result) {
         this.options.state.patch({

--- a/src/cli-v2/state/control-plane-session-loader.ts
+++ b/src/cli-v2/state/control-plane-session-loader.ts
@@ -56,6 +56,8 @@ export class ControlPlaneSessionLoader {
       liveStatus: undefined,
       currentActivity: undefined,
       activePlan: undefined,
+      liveDelegations: [],
+      delegationMode: 'auto',
       recentEditDiffs: [],
       latestUpdate: undefined,
       activeRun: undefined,

--- a/src/cli-v2/state/control-plane-session-state.ts
+++ b/src/cli-v2/state/control-plane-session-state.ts
@@ -3,9 +3,11 @@ import type {
   ClientSharedRecentEditDiff,
   ClientSharedSessionPlan,
 } from '@/client-shared/services/session-activities/index.js';
+import type { ClientSharedDelegationView } from '@/client-shared/services/session-delegations/index.js';
 import type { ControlPlaneProxyClient } from '@/client-shared/api/proxy.js';
 import type {
   ControlPlaneApprovalDecision,
+  ControlPlaneConversationDelegationMode,
   ControlPlaneModelOptions,
   ControlPlanePendingApproval,
   ControlPlaneSessionDirectShellPreflight,
@@ -55,6 +57,9 @@ export type ControlPlaneSessionStoreSnapshot = {
   liveStatus?: string;
   currentActivity?: ClientSharedAgentActivityStatus;
   activePlan?: ClientSharedSessionPlan;
+  liveDelegations: ClientSharedDelegationView[];
+  /** TUI-local next-turn preference. It is not a durable session policy. */
+  delegationMode: ControlPlaneConversationDelegationMode;
   recentEditDiffs: ClientSharedRecentEditDiff[];
   workspaceChanges: ControlPlaneWorkspaceChangedFile[];
   latestUpdate?: ControlPlaneSessionLatestUpdate;
@@ -82,6 +87,8 @@ export const INITIAL_CONTROL_PLANE_SESSION_SNAPSHOT: ControlPlaneSessionStoreSna
   activeRun: undefined,
   cancelling: false,
   streamConnected: false,
+  liveDelegations: [],
+  delegationMode: 'auto',
   recentEditDiffs: [],
   workspaceChanges: [],
   commandResults: [],

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -18,6 +18,7 @@ import {
 } from './control-plane-session-state.js';
 import type {
   ControlPlaneApprovalDecision,
+  ControlPlaneConversationDelegationMode,
   ControlPlanePermissionMode,
   ControlPlaneSessionView,
   ControlPlaneSlashCommandHint,
@@ -257,6 +258,10 @@ export class ControlPlaneSessionStore {
 
   async selectPermissionModeFromPicker(mode: ControlPlanePermissionMode): Promise<void> {
     await this.slashCommands.execute(`/permissions ${mode}`);
+  }
+
+  setDelegationMode(mode: ControlPlaneConversationDelegationMode): void {
+    this.state.patch({ delegationMode: mode });
   }
 
   async cancelRun(): Promise<void> {

--- a/src/client-shared/README.md
+++ b/src/client-shared/README.md
@@ -21,7 +21,8 @@ the `ControlPlane*` types exported from `api/types.ts`.
   frontends. These classes may consume tRPC-derived types, but must not import
   core services, server controllers, or UI renderers. Shared services own
   API-derived behavior such as transient session messages, session activity
-  effect dispatch, and approval input display metadata.
+  effect dispatch, replay-safe subagent lifecycle projection, and approval
+  input display metadata.
 - `hooks/`: React hooks. Files in this folder use `useXxx` naming and return
   hook-shaped values.
 
@@ -34,6 +35,8 @@ the `ControlPlane*` types exported from `api/types.ts`.
 - shared API-consumer services such as transient conversation message
   shaping, session activity effect dispatch, and approval payload display
   shaping;
+- shared live and settled subagent rows derived from correlated lifecycle
+  events and durable turn records, excluding raw child transcripts and traces;
 - shared conversation-run cursor, duplicate suppression, terminal detection,
   and bounded reconnect policy;
 - `trpcReact` for React Query tRPC usage in React interfaces;

--- a/src/client-shared/api/types.ts
+++ b/src/client-shared/api/types.ts
@@ -24,6 +24,10 @@ export type ControlPlaneSessionTurn = NonNullable<ControlPlaneSessionDetail>['tu
 export type ControlPlaneApprovalDecision = RouterInputs['controlPlane']['sessionResolveApproval']['decision'];
 export type ControlPlaneSessionSendPromptResult = RouterOutputs['controlPlane']['sessionSendPrompt'];
 export type ControlPlaneSessionSendPromptAsyncResult = RouterOutputs['controlPlane']['sessionSendPromptAsync'];
+export type ControlPlaneConversationDelegationMode = Exclude<
+  RouterInputs['controlPlane']['sessionSendPromptAsync']['delegation'],
+  undefined
+>;
 export type ControlPlaneSessionDirectShellPreflight = RouterOutputs['controlPlane']['sessionDirectShellPreflight'];
 export type ControlPlaneSessionDirectShellAsyncResult = RouterOutputs['controlPlane']['sessionDirectShellAsync'];
 export type ControlPlaneSessionRunState = RouterOutputs['controlPlane']['sessionRunState'];

--- a/src/client-shared/services/session-delegations/README.md
+++ b/src/client-shared/services/session-delegations/README.md
@@ -1,0 +1,17 @@
+# Session delegation projection
+
+This client-shared service owns the frontend-neutral projection of subagent
+lifecycle events and settled per-turn delegation records.
+
+## Boundary
+
+- Core and the control plane own delegation policy, event ordering, correlation
+  identifiers, cancellation, and durable records.
+- This service owns replay-safe live rows, compact settled rows, safe child
+  activity labels, and duration/text formatting shared by web-v2 and cli-v2.
+- Web-v2 and cli-v2 own layout, colors, accessibility, keyboard interaction,
+  and their local default-on composer preference.
+
+The projection deliberately excludes raw child transcripts, traces, model and
+provider details, tool inputs, and permission controls. Extending those facts
+requires a separate durability and disclosure design.

--- a/src/client-shared/services/session-delegations/index.ts
+++ b/src/client-shared/services/session-delegations/index.ts
@@ -1,0 +1,5 @@
+export {
+  ClientSharedSessionDelegationService,
+  type ClientSharedDelegationActivity,
+  type ClientSharedDelegationView,
+} from './session-delegation-service.js';

--- a/src/client-shared/services/session-delegations/session-delegation-service.ts
+++ b/src/client-shared/services/session-delegations/session-delegation-service.ts
@@ -1,0 +1,226 @@
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration.js';
+import type {
+  ControlPlaneSessionRunEventEnvelope,
+  ControlPlaneSessionTurn,
+} from '../../api/types.js';
+import { ClientSharedSessionActivityService } from '../session-activities/index.js';
+
+dayjs.extend(duration);
+
+type SessionActivity = Extract<ControlPlaneSessionRunEventEnvelope, { kind: 'activity' }>['activity'];
+type SettledDelegation = NonNullable<ControlPlaneSessionTurn['delegations']>[number];
+
+export type ClientSharedDelegationActivity = {
+  label: string;
+  detail?: string;
+};
+
+export type ClientSharedDelegationView = {
+  delegationId: string;
+  rootRunId: string;
+  childRunId: string;
+  agentProfileId: string;
+  agentName: string;
+  task: string;
+  status: 'running' | 'finished' | 'cancelled';
+  outcome?: string;
+  summary?: string;
+  error?: string;
+  startedAt: string;
+  finishedAt?: string;
+  latestActivity?: ClientSharedDelegationActivity;
+};
+
+const BUILT_IN_AGENT_NAMES: Record<string, string> = {
+  'builtin:ask': 'Ask',
+  'builtin:review': 'Review',
+};
+
+const COMPACT_TEXT_LIMIT = 360;
+
+/**
+ * Owns the frontend-neutral view of live and settled subagent lifecycles.
+ *
+ * The control plane remains authoritative for event order and durable child
+ * records. This service makes replay idempotent for both clients and keeps raw
+ * child transcript/model details out of the UI projection.
+ */
+export class ClientSharedSessionDelegationService {
+  static reduceActivity(
+    current: ClientSharedDelegationView[],
+    activity: SessionActivity,
+  ): ClientSharedDelegationView[] {
+    if (activity.type === 'loop.started' || activity.type === 'direct_shell.started') {
+      return current.length > 0 ? [] : current;
+    }
+
+    if (activity.type === 'delegation.started') {
+      if (current.some((candidate) => candidate.delegationId === activity.delegationId)) {
+        return current;
+      }
+
+      return ClientSharedSessionDelegationService.upsert(current, {
+        delegationId: activity.delegationId,
+        rootRunId: activity.rootRunId,
+        childRunId: activity.childRunId,
+        agentProfileId: activity.agentProfileId,
+        agentName: ClientSharedSessionDelegationService.formatAgentName(activity.agentProfileId),
+        task: activity.task,
+        status: 'running',
+        startedAt: activity.timestamp,
+        latestActivity: { label: 'Starting' },
+      });
+    }
+
+    if (activity.type === 'delegation.child.activity') {
+      const existing = current.find((candidate) => candidate.delegationId === activity.delegationId);
+      if (existing && existing.status !== 'running') {
+        return current;
+      }
+
+      return ClientSharedSessionDelegationService.upsert(current, {
+        ...(existing ?? ClientSharedSessionDelegationService.createRunningView(activity)),
+        latestActivity: ClientSharedSessionDelegationService.projectChildActivity(activity.activity),
+      });
+    }
+
+    if (activity.type === 'delegation.finished') {
+      const existing = current.find((candidate) => candidate.delegationId === activity.delegationId);
+      return ClientSharedSessionDelegationService.upsert(current, {
+        ...(existing ?? ClientSharedSessionDelegationService.createRunningView(activity)),
+        status: 'finished',
+        outcome: activity.outcome,
+        ...(activity.summary
+          ? { summary: ClientSharedSessionDelegationService.formatCompactText(activity.summary) }
+          : {}),
+        finishedAt: activity.timestamp,
+        latestActivity: undefined,
+      });
+    }
+
+    if (activity.type === 'delegation.cancelled') {
+      const existing = current.find((candidate) => candidate.delegationId === activity.delegationId);
+      return ClientSharedSessionDelegationService.upsert(current, {
+        ...(existing ?? ClientSharedSessionDelegationService.createRunningView(activity)),
+        status: 'cancelled',
+        outcome: activity.outcome,
+        ...(activity.summary
+          ? { summary: ClientSharedSessionDelegationService.formatCompactText(activity.summary) }
+          : {}),
+        error: activity.error.message,
+        finishedAt: activity.timestamp,
+        latestActivity: undefined,
+      });
+    }
+
+    return current;
+  }
+
+  static projectSettled(delegations: readonly SettledDelegation[]): ClientSharedDelegationView[] {
+    return delegations.map((delegation) => ({
+      delegationId: delegation.delegationId,
+      rootRunId: delegation.rootRunId,
+      childRunId: delegation.childRunId,
+      agentProfileId: delegation.agentSnapshot.agentProfileId,
+      agentName: delegation.agentSnapshot.agentName,
+      task: delegation.task,
+      status: delegation.status,
+      outcome: delegation.outcome,
+      summary: ClientSharedSessionDelegationService.formatCompactText(delegation.summary),
+      ...(delegation.failure
+        ? { error: `${delegation.failure.source}:${delegation.failure.code}` }
+        : {}),
+      startedAt: delegation.startedAt,
+      finishedAt: delegation.finishedAt,
+    }));
+  }
+
+  static formatDuration(startedAt: string, finishedAt: string | Date = new Date()): string {
+    const start = dayjs(startedAt);
+    const finish = dayjs(finishedAt);
+    if (!start.isValid() || !finish.isValid()) {
+      return '—';
+    }
+
+    const elapsedMs = Math.max(0, finish.diff(start));
+    const elapsed = dayjs.duration(elapsedMs);
+    const hours = Math.floor(elapsed.asHours());
+    const minutes = elapsed.minutes();
+    const seconds = elapsed.seconds();
+
+    if (hours > 0) {
+      return `${hours}h ${minutes}m`;
+    }
+
+    if (minutes > 0) {
+      return `${minutes}m ${seconds}s`;
+    }
+
+    return `${Math.max(1, seconds)}s`;
+  }
+
+  static formatCompactText(value: string): string {
+    const compact = value.replace(/\s+/g, ' ').trim();
+    return compact.length > COMPACT_TEXT_LIMIT
+      ? `${compact.slice(0, COMPACT_TEXT_LIMIT - 1).trimEnd()}…`
+      : compact;
+  }
+
+  private static createRunningView(activity: Extract<
+    SessionActivity,
+    { type: 'delegation.child.activity' | 'delegation.finished' | 'delegation.cancelled' }
+  >): ClientSharedDelegationView {
+    return {
+      delegationId: activity.delegationId,
+      rootRunId: activity.rootRunId,
+      childRunId: activity.childRunId,
+      agentProfileId: activity.agentProfileId,
+      agentName: ClientSharedSessionDelegationService.formatAgentName(activity.agentProfileId),
+      task: activity.task,
+      status: 'running',
+      startedAt: activity.timestamp,
+    };
+  }
+
+  private static formatAgentName(agentProfileId: string): string {
+    return BUILT_IN_AGENT_NAMES[agentProfileId] ?? agentProfileId;
+  }
+
+  private static projectChildActivity(
+    activity: Extract<SessionActivity, { type: 'delegation.child.activity' }>['activity'],
+  ): ClientSharedDelegationActivity {
+    if (activity.type === 'assistant.commentary') {
+      return { label: 'Working' };
+    }
+
+    if (activity.type === 'reasoning.summary') {
+      return { label: 'Thinking' };
+    }
+
+    if (activity.type === 'assistant.stream') {
+      return { label: activity.done ? 'Answer ready' : 'Writing answer' };
+    }
+
+    if (activity.type === 'loop.started') {
+      return { label: 'Started' };
+    }
+
+    const latest = ClientSharedSessionActivityService.resolveLatestUpdate(activity);
+    return latest
+      ? { label: latest.label, ...(latest.detail ? { detail: latest.detail } : {}) }
+      : { label: 'Working' };
+  }
+
+  private static upsert(
+    current: ClientSharedDelegationView[],
+    next: ClientSharedDelegationView,
+  ): ClientSharedDelegationView[] {
+    const existingIndex = current.findIndex((candidate) => candidate.delegationId === next.delegationId);
+    if (existingIndex < 0) {
+      return [...current, next];
+    }
+
+    return current.map((candidate, index) => index === existingIndex ? next : candidate);
+  }
+}

--- a/src/client-shared/services/session-turn-presentation/index.ts
+++ b/src/client-shared/services/session-turn-presentation/index.ts
@@ -1,6 +1,7 @@
 export {
   ClientSharedSessionTurnPresentationService,
   type ClientSharedConversationTimelineActivityGroupItem,
+  type ClientSharedConversationTimelineDelegationGroupItem,
   type ClientSharedConversationTimelineItem,
   type ClientSharedConversationTimelineMessageItem,
   type ClientSharedSessionTurnPresentationItem,

--- a/src/client-shared/services/session-turn-presentation/session-turn-presentation-service.ts
+++ b/src/client-shared/services/session-turn-presentation/session-turn-presentation-service.ts
@@ -4,6 +4,10 @@ import type {
   ControlPlaneSessionTurn,
 } from '../../api/types.js';
 import type { ConversationTurnPresentationTimelineItem } from '@heddleagent/runtime/cli';
+import {
+  ClientSharedSessionDelegationService,
+  type ClientSharedDelegationView,
+} from '../session-delegations/index.js';
 
 export type ClientSharedSessionTurnPresentationItem = {
   id: string;
@@ -27,8 +31,17 @@ export type ClientSharedConversationTimelineActivityGroupItem = {
   activities: ConversationTurnPresentationTimelineItem[];
 };
 
+export type ClientSharedConversationTimelineDelegationGroupItem = {
+  type: 'turn_delegation_group';
+  id: string;
+  turnId: string;
+  turnPrompt: string;
+  delegations: ClientSharedDelegationView[];
+};
+
 export type ClientSharedConversationTimelineItem =
   | ClientSharedConversationTimelineMessageItem
+  | ClientSharedConversationTimelineDelegationGroupItem
   | ClientSharedConversationTimelineActivityGroupItem;
 
 /**
@@ -75,7 +88,7 @@ export class ClientSharedSessionTurnPresentationService {
       placedTurnIds.add(turn.id);
       return [
         messageItem,
-        ...ClientSharedSessionTurnPresentationService.projectConversationActivityGroup(turn),
+        ...ClientSharedSessionTurnPresentationService.projectConversationTurnGroups(turn),
       ];
     });
 
@@ -83,7 +96,7 @@ export class ClientSharedSessionTurnPresentationService {
       ...timeline,
       ...session.turns
         .filter((turn) => !placedTurnIds.has(turn.id))
-        .flatMap((turn) => ClientSharedSessionTurnPresentationService.projectConversationActivityGroup(turn)),
+        .flatMap((turn) => ClientSharedSessionTurnPresentationService.projectConversationTurnGroups(turn)),
     ];
   }
 
@@ -117,6 +130,28 @@ export class ClientSharedSessionTurnPresentationService {
       turnPrompt: turn.prompt,
       activities,
     }];
+  }
+
+  private static projectConversationDelegationGroup(turn: ControlPlaneSessionTurn): ClientSharedConversationTimelineDelegationGroupItem[] {
+    const delegations = ClientSharedSessionDelegationService.projectSettled(turn.delegations ?? []);
+    if (delegations.length === 0) {
+      return [];
+    }
+
+    return [{
+      type: 'turn_delegation_group',
+      id: `${turn.id}:delegation-group`,
+      turnId: turn.id,
+      turnPrompt: turn.prompt,
+      delegations,
+    }];
+  }
+
+  private static projectConversationTurnGroups(turn: ControlPlaneSessionTurn): ClientSharedConversationTimelineItem[] {
+    return [
+      ...ClientSharedSessionTurnPresentationService.projectConversationDelegationGroup(turn),
+      ...ClientSharedSessionTurnPresentationService.projectConversationActivityGroup(turn),
+    ];
   }
 
   private static findUnplacedTurnForPrompt({

--- a/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
+++ b/src/core/chat/engine/sessions/repository/chat-session-schemas.ts
@@ -125,7 +125,7 @@ const ConversationTurnDelegationRecordSchema = z.object({
   finishedAt: z.string().describe('Timestamp when the child reached a terminal record.'),
 }).strict();
 
-const ConversationTurnDelegationsReadSchema = z.array(z.unknown())
+export const ConversationTurnDelegationsReadSchema = z.array(z.unknown())
   .transform((records) => records.flatMap((record) => {
     const parsed = ConversationTurnDelegationRecordSchema.safeParse(record);
     return parsed.success ? [parsed.data] : [];

--- a/src/core/delegation/README.md
+++ b/src/core/delegation/README.md
@@ -107,7 +107,10 @@ activity would let existing clients mistake child settlement for root-turn
 settlement. Redundant child `assistant.stream` draft snapshots are omitted;
 `delegation.finished.summary` carries the completed child answer while tool,
 reasoning, warning, cancellation, and loop progress remain visible.
-Purpose-built UI rendering remains a later slice.
+The first purpose-built client projection shows correlated live child rows and
+settled task/profile/status/summary records in both web-v2 and cli-v2. It does
+not expose raw child transcripts, traces, model/provider details, or child
+permission controls; those remain outside this slice.
 
 ## V1 Safety Invariants
 

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -15,6 +15,7 @@ import type { ConversationRunStreamItem } from '@/core/chat/runs/index.js';
 import type {
   ChatSessionRetention,
   ConversationDirectShellLineResult,
+  ConversationTurnDelegationRecord,
   ConversationTurnPresentation,
   QueuedConversationPrompt,
 } from '@/core/chat/types.js';
@@ -96,6 +97,7 @@ export type ChatTurnView = {
   events: string[];
   presentation?: ConversationTurnPresentation;
   agent?: ChatTurnAgentView;
+  delegations?: ConversationTurnDelegationRecord[];
 };
 
 export type CommandEvidenceView = {

--- a/src/server/controllers/trpc/control-plane/chat-session-presenter.ts
+++ b/src/server/controllers/trpc/control-plane/chat-session-presenter.ts
@@ -3,6 +3,7 @@ import { LlmUsageSchema } from '@/core/llm/usage/index.js';
 import { REASONING_EFFORTS, type ReasoningEffort } from '@/core/llm/types.js';
 import { ConversationDirectShellLineResultSchema } from '@/core/chat/engine/direct-shell/result-schema.js';
 import { ConversationTurnPresentationService } from '@/core/chat/engine/turns/presentation/index.js';
+import { ConversationTurnDelegationsReadSchema } from '@/core/chat/engine/sessions/repository/chat-session-schemas.js';
 import type {
   ChatSessionDetail,
   ChatSessionMessage,
@@ -237,7 +238,13 @@ export class ControlPlaneChatSessionPresenter {
       events,
       presentation: ConversationTurnPresentationService.read(candidate.presentation),
       agent: ControlPlaneChatSessionPresenter.projectTurnAgent(candidate.agent),
+      delegations: ControlPlaneChatSessionPresenter.projectTurnDelegations(candidate.delegations),
     }];
+  }
+
+  private static projectTurnDelegations(raw: unknown): ChatTurnView['delegations'] | undefined {
+    const parsed = ConversationTurnDelegationsReadSchema.safeParse(raw);
+    return parsed.success && parsed.data.length > 0 ? parsed.data : undefined;
   }
 
   private static projectTurnAgent(raw: unknown): ChatTurnView['agent'] | undefined {

--- a/src/web-v2/README.md
+++ b/src/web-v2/README.md
@@ -69,3 +69,10 @@ Run cursor, duplicate, sequence-gap, and reconnect rules belong to
 `ConversationRunConsumerService` from the public remote-run SDK layer, shared
 with cli-v2 through `client-shared`. React hooks own only tRPC binding, cache
 refresh, and browser presentation state.
+
+Subagent visibility follows the same boundary. Web-v2 keeps one local,
+default-on composer switch and sends the existing per-turn `delegation` field.
+`client-shared` reduces correlated lifecycle events into live rows, while the
+session detail API supplies settled per-turn records after reload. The web UI
+does not expose child permissions, transcripts, raw traces, model, or provider
+details.

--- a/src/web-v2/components/conversation/ComposerContextMenu.tsx
+++ b/src/web-v2/components/conversation/ComposerContextMenu.tsx
@@ -16,6 +16,7 @@ import {
   SessionDriftStatusGlyph,
   type SessionDriftLevel,
 } from './SessionDriftControl';
+import { ComposerSubagentControl } from './ComposerSubagentControl';
 
 type ComposerContextMenuProps = {
   agents?: ControlPlaneCustomAgents;
@@ -23,6 +24,7 @@ type ComposerContextMenuProps = {
   driftEnabled: boolean;
   driftLevel: SessionDriftLevel;
   browserIntentEnabled?: boolean;
+  subagentsEnabled: boolean;
   permissionMode?: ControlPlanePermissionMode;
   permissionModeOptions?: ControlPlaneSessionRuntimeContext['permissionModeOptions'];
   selectedAgentProfileId: string;
@@ -30,6 +32,7 @@ type ComposerContextMenuProps = {
   uploadDisabled?: boolean;
   onSelectAgentProfileId: (agentProfileId: string) => void;
   onToggleBrowserIntent?: () => void;
+  onSubagentsEnabledChange: (enabled: boolean) => void;
   onUploadImagesClick?: () => void;
   onUpdateDriftEnabled?: (enabled: boolean) => Promise<void>;
   onUpdatePermissionMode?: (mode: ControlPlanePermissionMode) => Promise<void>;
@@ -99,6 +102,7 @@ export function ComposerContextMenu({
   driftEnabled,
   driftLevel,
   browserIntentEnabled,
+  subagentsEnabled,
   permissionMode,
   permissionModeOptions,
   selectedAgentProfileId,
@@ -106,6 +110,7 @@ export function ComposerContextMenu({
   uploadDisabled,
   onSelectAgentProfileId,
   onToggleBrowserIntent,
+  onSubagentsEnabledChange,
   onUploadImagesClick,
   onUpdateDriftEnabled,
   onUpdatePermissionMode,
@@ -211,6 +216,11 @@ export function ComposerContextMenu({
             </Button>
           </div>
         ) : null}
+        <ComposerSubagentControl
+          disabled={disabled}
+          enabled={subagentsEnabled}
+          onEnabledChange={onSubagentsEnabledChange}
+        />
         {onUpdatePermissionMode && permissionModeOptions?.length ? (
           <div className="v2-permission-mode-menu-section">
             <div className="v2-permission-mode-menu-header">

--- a/src/web-v2/components/conversation/ComposerSubagentControl.tsx
+++ b/src/web-v2/components/conversation/ComposerSubagentControl.tsx
@@ -1,0 +1,41 @@
+import { useId } from 'react';
+import { Network } from 'lucide-react';
+import { Switch } from '@web/components/ui/switch';
+import { useI18n } from '@web/i18n';
+
+type ComposerSubagentControlProps = {
+  enabled: boolean;
+  disabled?: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+};
+
+/** Local next-turn preference; delegation policy remains owned by the runtime. */
+export function ComposerSubagentControl({
+  enabled,
+  disabled,
+  onEnabledChange,
+}: ComposerSubagentControlProps) {
+  const { t } = useI18n();
+  const switchId = useId();
+  const status = t(enabled ? 'composer.subagents.enabled' : 'composer.subagents.disabled');
+
+  return (
+    <div className="v2-subagents-menu-section">
+      <div className="v2-drift-menu-row">
+        <Network aria-hidden="true" data-icon="inline-start" className="v2-drift-menu-icon" />
+        <label htmlFor={switchId} className="v2-drift-menu-copy">
+          <span className="v2-drift-menu-title">{t('composer.subagents.title')}</span>
+          <span className="v2-drift-menu-status">{status}</span>
+        </label>
+        <Switch
+          id={switchId}
+          checked={enabled}
+          disabled={disabled}
+          aria-label={`${t('composer.subagents.ariaLabel')}: ${status}`}
+          onCheckedChange={onEnabledChange}
+        />
+      </div>
+      <p className="v2-drift-menu-note text-pretty">{t('composer.subagents.description')}</p>
+    </div>
+  );
+}

--- a/src/web-v2/components/conversation/ConversationComposer.tsx
+++ b/src/web-v2/components/conversation/ConversationComposer.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowUp, Globe2, X } from 'lucide-react';
-import type { ControlPlaneCustomAgents, ControlPlaneModelOptions, ControlPlanePermissionMode, ControlPlaneSessionRuntimeContext } from '@web/api/client';
+import type {
+  ControlPlaneConversationDelegationMode,
+  ControlPlaneCustomAgents,
+  ControlPlaneModelOptions,
+  ControlPlanePermissionMode,
+  ControlPlaneSessionRuntimeContext,
+} from '@web/api/client';
 import { Button } from '@web/components/ui/button';
 import { Textarea } from '@web/components/ui/textarea';
 import type { ControlPlaneReasoningEffortSelection } from '@web/hooks/sessions/useControlPlaneSessionDetail';
@@ -70,7 +76,11 @@ export function ConversationComposer({
   submitting?: boolean;
   running?: boolean;
   cancelling?: boolean;
-  onSubmitPrompt: (prompt: string, options?: { agentProfileId?: string; browserIntent?: 'preferred' }) => Promise<void>;
+  onSubmitPrompt: (prompt: string, options?: {
+    agentProfileId?: string;
+    browserIntent?: 'preferred';
+    delegation?: ControlPlaneConversationDelegationMode;
+  }) => Promise<void>;
   onCancelRun?: () => Promise<void>;
   onUpdateDriftEnabled?: (enabled: boolean) => Promise<void>;
   onUpdatePermissionMode?: (mode: ControlPlanePermissionMode) => Promise<void>;
@@ -83,6 +93,7 @@ export function ConversationComposer({
   const [draft, setDraft] = useState('');
   const [selectedAgentProfileId, setSelectedAgentProfileId] = useState<string>(BUILT_IN_COMPOSER_AGENT_IDS.code);
   const [browserIntentEnabled, setBrowserIntentEnabled] = useState(false);
+  const [subagentsEnabled, setSubagentsEnabled] = useState(true);
   const {
     attachments: imageUploadAttachments,
     clearUploadedAttachments,
@@ -141,12 +152,13 @@ export function ConversationComposer({
     await onSubmitPrompt(prompt, {
       agentProfileId: selectedAgentProfileId,
       browserIntent: browserIntentEnabled ? 'preferred' : undefined,
+      delegation: subagentsEnabled ? 'auto' : 'off',
     });
     recordPrompt(prompt);
     setDraft('');
     setBrowserIntentEnabled(false);
     clearUploadedAttachments();
-  }, [browserIntentEnabled, clearUploadedAttachments, draft, onSubmitPrompt, recordPrompt, selectedAgentProfileId, sendDisabled, uploadedImagePaths]);
+  }, [browserIntentEnabled, clearUploadedAttachments, draft, onSubmitPrompt, recordPrompt, selectedAgentProfileId, sendDisabled, subagentsEnabled, uploadedImagePaths]);
   const fileMentions = useFileMentionAutocomplete({
     workspaceId,
     value: draft,
@@ -234,11 +246,13 @@ export function ConversationComposer({
           permissionMode={permissionMode}
           permissionModeOptions={permissionModeOptions}
           browserIntentEnabled={browserIntentEnabled}
+          subagentsEnabled={subagentsEnabled}
           selectedAgentProfileId={selectedAgentProfileId}
           settingsUpdating={settingsUpdating}
           uploadDisabled={imageUploadDisabled}
           onSelectAgentProfileId={setSelectedAgentProfileId}
           onToggleBrowserIntent={() => setBrowserIntentEnabled((current) => !current)}
+          onSubagentsEnabledChange={setSubagentsEnabled}
           onUploadImagesClick={() => imageUploadControlsRef.current?.openFilePicker()}
           onUpdateDriftEnabled={onUpdateDriftEnabled}
           onUpdatePermissionMode={onUpdatePermissionMode}

--- a/src/web-v2/components/conversation/ConversationThread.tsx
+++ b/src/web-v2/components/conversation/ConversationThread.tsx
@@ -13,6 +13,7 @@ import type {
 } from '@web/hooks/sessions/useControlPlaneSessionDetail';
 import { useConversationAutoScroll } from '@web/hooks/conversation/useConversationAutoScroll';
 import type { ClientSharedSessionPlan } from '@/client-shared/services/session-activities';
+import type { ClientSharedDelegationView } from '@/client-shared/services/session-delegations';
 import type {
   ClientSharedAgentActivityStatus,
   ClientSharedSessionLatestUpdate,
@@ -24,6 +25,8 @@ import { ApprovalPanel } from './ApprovalPanel';
 import { ConversationComposer } from './ConversationComposer';
 import { ConversationMessage } from './ConversationMessage';
 import { ConversationTurnActivityGroup } from './ConversationTurnActivity';
+import { ConversationTurnDelegationGroup } from './ConversationTurnDelegation';
+import { SubagentActivityPanel } from './SubagentActivityPanel';
 import { ConversationWelcomePanel } from './ConversationWelcomePanel';
 import { DirectShellConfirmDialog } from './DirectShellConfirmDialog';
 import { QueuedPromptStrip } from './QueuedPromptStrip';
@@ -40,6 +43,7 @@ interface ConversationThreadProps {
   currentActivity?: ClientSharedAgentActivityStatus;
   latestUpdate?: ClientSharedSessionLatestUpdate;
   activePlan?: ClientSharedSessionPlan;
+  liveDelegations: ClientSharedDelegationView[];
   runtimeContext?: ControlPlaneSessionRuntimeContext;
   agents?: ControlPlaneCustomAgents;
   pendingApproval: ControlPlanePendingApproval;
@@ -51,7 +55,11 @@ interface ConversationThreadProps {
   queueUpdating: boolean;
   directShellConfirmation?: ControlPlaneSessionDirectShellPreflight;
   emptyTitle: string;
-  onSubmitPrompt: (prompt: string, options?: { agentProfileId?: string }) => Promise<void>;
+  onSubmitPrompt: (prompt: string, options?: {
+    agentProfileId?: string;
+    browserIntent?: 'preferred';
+    delegation?: 'auto' | 'off';
+  }) => Promise<void>;
   onConfirmDirectShell: () => Promise<void>;
   onCancelDirectShellConfirmation: () => void;
   onUpdateQueuedPrompt: (queueItemId: string, prompt: string) => Promise<void>;
@@ -76,6 +84,7 @@ export function ConversationThread({
   currentActivity,
   latestUpdate,
   activePlan,
+  liveDelegations,
   runtimeContext,
   agents,
   pendingApproval,
@@ -158,6 +167,8 @@ export function ConversationThread({
           {conversationTimeline.map((item) => (
             item.type === 'message' ? (
               <ConversationMessage key={item.id} message={item.message} turnAgent={item.turnAgent} />
+            ) : item.type === 'turn_delegation_group' ? (
+              <ConversationTurnDelegationGroup key={item.id} item={item} />
             ) : (
               <ConversationTurnActivityGroup key={item.id} item={item} />
             )
@@ -177,6 +188,11 @@ export function ConversationThread({
       {activePlan ? (
         <div className="v2-agent-plan-region">
           <AgentPlanPanel plan={activePlan} />
+        </div>
+      ) : null}
+      {running && liveDelegations.length > 0 ? (
+        <div className="v2-subagent-activity-region">
+          <SubagentActivityPanel delegations={liveDelegations} />
         </div>
       ) : null}
       {currentActivity || latestUpdate ? (

--- a/src/web-v2/components/conversation/ConversationTurnDelegation.tsx
+++ b/src/web-v2/components/conversation/ConversationTurnDelegation.tsx
@@ -1,0 +1,26 @@
+import { memo } from 'react';
+import { Network } from 'lucide-react';
+import type { ClientSharedConversationTimelineDelegationGroupItem } from '@/client-shared/services/session-turn-presentation';
+import { useI18n } from '@web/i18n';
+import { SubagentActivityList } from './SubagentActivityList';
+
+export const ConversationTurnDelegationGroup = memo(function ConversationTurnDelegationGroup({
+  item,
+}: {
+  item: ClientSharedConversationTimelineDelegationGroupItem;
+}) {
+  const { t } = useI18n();
+
+  return (
+    <article className="v2-message-row v2-message-row-assistant" data-message-role="assistant">
+      <section className="v2-subagent-activity-panel v2-subagent-activity-panel-settled" aria-label={t('subagents.historyLabel')}>
+        <header className="v2-subagent-activity-title-row">
+          <Network aria-hidden="true" />
+          <span>{t('subagents.title')}</span>
+          <span className="v2-subagent-activity-count tabular-nums">{item.delegations.length}</span>
+        </header>
+        <SubagentActivityList delegations={item.delegations} />
+      </section>
+    </article>
+  );
+});

--- a/src/web-v2/components/conversation/SubagentActivityList.tsx
+++ b/src/web-v2/components/conversation/SubagentActivityList.tsx
@@ -1,0 +1,83 @@
+import type { ClientSharedDelegationView } from '@/client-shared/services/session-delegations';
+import { ClientSharedSessionDelegationService } from '@/client-shared/services/session-delegations';
+import type { I18nMessageKey } from '@web/i18n';
+import { useI18n } from '@web/i18n';
+
+type SubagentActivityListProps = {
+  delegations: ClientSharedDelegationView[];
+  now?: Date;
+};
+
+type SubagentStatus = 'running' | 'done' | 'finished' | 'stepLimit' | 'failed' | 'cancelled';
+
+const statusMessageKeys = {
+  running: 'subagents.status.running',
+  done: 'subagents.status.done',
+  finished: 'subagents.status.finished',
+  stepLimit: 'subagents.status.stepLimit',
+  failed: 'subagents.status.failed',
+  cancelled: 'subagents.status.cancelled',
+} as const satisfies Record<SubagentStatus, I18nMessageKey>;
+
+export function SubagentActivityList({ delegations, now = new Date() }: SubagentActivityListProps) {
+  const { t } = useI18n();
+
+  return (
+    <ul className="v2-subagent-activity-list">
+      {delegations.map((delegation) => {
+        const status = resolveStatus(delegation);
+        return (
+          <li
+            className="v2-subagent-activity-item"
+            data-status={status}
+            key={delegation.delegationId}
+          >
+            <div className="v2-subagent-activity-header">
+              <span className="v2-subagent-activity-agent">{delegation.agentName}</span>
+              <span className="v2-subagent-activity-status">{t(statusMessageKeys[status])}</span>
+              <span className="v2-subagent-activity-duration tabular-nums">
+                {ClientSharedSessionDelegationService.formatDuration(
+                  delegation.startedAt,
+                  delegation.finishedAt ?? now,
+                )}
+              </span>
+            </div>
+            <p className="v2-subagent-activity-task text-pretty">{delegation.task}</p>
+            {delegation.latestActivity ? (
+              <p className="v2-subagent-activity-detail text-pretty">
+                {delegation.latestActivity.label}
+                {delegation.latestActivity.detail ? ` · ${delegation.latestActivity.detail}` : ''}
+              </p>
+            ) : null}
+            {delegation.summary ? (
+              <p className="v2-subagent-activity-summary text-pretty">{delegation.summary}</p>
+            ) : null}
+            {delegation.error && !delegation.summary ? (
+              <p className="v2-subagent-activity-error text-pretty">{delegation.error}</p>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function resolveStatus(delegation: ClientSharedDelegationView): SubagentStatus {
+  if (delegation.status === 'running') {
+    return 'running';
+  }
+
+  if (delegation.status === 'cancelled' || delegation.outcome === 'interrupted') {
+    return 'cancelled';
+  }
+
+  if (delegation.outcome === 'error') {
+    return 'failed';
+  }
+
+  if (delegation.outcome === 'max_steps') {
+    return 'stepLimit';
+  }
+
+  return delegation.outcome === 'done' ? 'done' : 'finished';
+}

--- a/src/web-v2/components/conversation/SubagentActivityPanel.tsx
+++ b/src/web-v2/components/conversation/SubagentActivityPanel.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { Network } from 'lucide-react';
+import type { ClientSharedDelegationView } from '@/client-shared/services/session-delegations';
+import { useI18n } from '@web/i18n';
+import { SubagentActivityList } from './SubagentActivityList';
+
+export function SubagentActivityPanel({ delegations }: { delegations: ClientSharedDelegationView[] }) {
+  const { t } = useI18n();
+  const [now, setNow] = useState(() => new Date());
+  const hasRunningDelegation = delegations.some((delegation) => delegation.status === 'running');
+
+  useEffect(() => {
+    if (!hasRunningDelegation) {
+      return undefined;
+    }
+
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, [hasRunningDelegation]);
+
+  return (
+    <section className="v2-subagent-activity-panel" aria-label={t('subagents.liveLabel')} aria-live="polite">
+      <header className="v2-subagent-activity-title-row">
+        <Network aria-hidden="true" />
+        <span>{t('subagents.title')}</span>
+        <span className="v2-subagent-activity-count tabular-nums">{delegations.length}</span>
+      </header>
+      <SubagentActivityList delegations={delegations} now={now} />
+    </section>
+  );
+}

--- a/src/web-v2/components/conversation/index.ts
+++ b/src/web-v2/components/conversation/index.ts
@@ -4,9 +4,11 @@ export { AgentActivityStatus } from './AgentActivityStatus';
 export { ApprovalPanel } from './ApprovalPanel';
 export { ConversationComposer } from './ConversationComposer';
 export { ConversationMessage } from './ConversationMessage';
+export { ConversationTurnDelegationGroup } from './ConversationTurnDelegation';
 export { ConversationThread } from './ConversationThread';
 export { ConversationWelcomePanel } from './ConversationWelcomePanel';
 export { FileMentionMenu } from './FileMentionMenu';
+export { SubagentActivityPanel } from './SubagentActivityPanel';
 export {
   SessionDriftMenuSection,
   SessionDriftStatusGlyph,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionDetail.ts
@@ -10,6 +10,7 @@ import {
   type ClientSharedSessionPlan,
 } from '@/client-shared/services/session-activities';
 import type { ClientSharedNotificationIntent } from '@/client-shared/services/notifications';
+import type { ClientSharedDelegationView } from '@/client-shared/services/session-delegations';
 import { useControlPlaneSessionEvents } from './useControlPlaneSessionEvents';
 import { useControlPlaneSessionLoader } from './useControlPlaneSessionLoader';
 import { useControlPlanePendingApproval } from './useControlPlanePendingApproval';
@@ -38,6 +39,7 @@ type ControlPlaneSessionDetailState = {
   currentActivity?: ClientSharedAgentActivityStatus;
   latestUpdate?: ClientSharedSessionLatestUpdate;
   activePlan?: ClientSharedSessionPlan;
+  liveDelegations: ClientSharedDelegationView[];
   runtimeContext?: ControlPlaneSessionRuntimeContext;
   cancelError?: string;
   pendingApproval: ReturnType<typeof useControlPlanePendingApproval>['pendingApproval'];
@@ -78,6 +80,7 @@ export function useControlPlaneSessionDetail({
   const [currentActivity, setCurrentActivity] = useState<ClientSharedAgentActivityStatus | undefined>();
   const [latestUpdate, setLatestUpdate] = useState<ClientSharedSessionLatestUpdate | undefined>();
   const [activePlan, setActivePlan] = useState<ClientSharedSessionPlan | undefined>();
+  const [liveDelegations, setLiveDelegations] = useState<ClientSharedDelegationView[]>([]);
   const loader = useControlPlaneSessionLoader({ workspaceId, sessionId });
   const runControl = useControlPlaneSessionRunControl({
     workspaceId,
@@ -110,6 +113,7 @@ export function useControlPlaneSessionDetail({
     setActivePlan,
     setCurrentActivity,
     setLatestUpdate,
+    setLiveDelegations,
     onNotificationIntent,
   });
   const promptSubmit = useControlPlaneSessionPromptSubmit({
@@ -121,6 +125,7 @@ export function useControlPlaneSessionDetail({
     setError: loader.setError,
     setLiveStatus,
     setCurrentActivity,
+    setLiveDelegations,
     onRunAccepted: runControl.trackAcceptedRun,
   });
   const settings = useControlPlaneSessionSettings({
@@ -153,6 +158,7 @@ export function useControlPlaneSessionDetail({
     currentActivity,
     latestUpdate,
     activePlan,
+    liveDelegations,
     runtimeContext: runtimeContext.runtimeContext,
     cancelError: runControl.cancelError,
     pendingApproval: approval.pendingApproval,
@@ -183,6 +189,7 @@ export function useControlPlaneSessionDetail({
     currentActivity,
     latestUpdate,
     liveStatus,
+    liveDelegations,
     loader.error,
     loader.loading,
     loader.session,

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionEvents.ts
@@ -20,6 +20,10 @@ import type {
   ClientSharedSessionPlan,
 } from '@/client-shared/services/session-activities';
 import { ClientSharedSessionMessageService } from '@/client-shared/services/session-messages';
+import {
+  ClientSharedSessionDelegationService,
+  type ClientSharedDelegationView,
+} from '@/client-shared/services/session-delegations';
 import type { RefreshControlPlaneSession } from './useControlPlaneSessionLoader';
 
 type SessionRunUpdate = Extract<ControlPlaneSessionEventEnvelope, { type: 'session.run.updated' }>;
@@ -42,6 +46,7 @@ type UseControlPlaneSessionEventsArgs = {
   setActivePlan: Dispatch<SetStateAction<ClientSharedSessionPlan | undefined>>;
   setCurrentActivity: Dispatch<SetStateAction<ClientSharedAgentActivityStatus | undefined>>;
   setLatestUpdate: Dispatch<SetStateAction<ClientSharedSessionLatestUpdate | undefined>>;
+  setLiveDelegations: Dispatch<SetStateAction<ClientSharedDelegationView[]>>;
   onNotificationIntent?: (intent: ClientSharedNotificationIntent | undefined) => void;
 };
 
@@ -65,6 +70,7 @@ export function useControlPlaneSessionEvents({
   setActivePlan,
   setCurrentActivity,
   setLatestUpdate,
+  setLiveDelegations,
   onNotificationIntent,
 }: UseControlPlaneSessionEventsArgs): ControlPlaneSessionEventsState {
   const utils = trpcReact.useUtils();
@@ -183,13 +189,14 @@ export function useControlPlaneSessionEvents({
         setActivePlan,
         setCurrentActivity,
         setLatestUpdate,
+        setLiveDelegations,
         notify: onNotificationIntent,
         workspaceId: activeWorkspaceId,
       });
     } catch (error) {
       scheduleReconnect(asError(error));
     }
-  }, [finishRun, invalidateWorkspaceDiff, onNotificationIntent, refresh, refreshPendingApproval, scheduleReconnect, setActivePlan, setCurrentActivity, setLatestUpdate, setLiveStatus, setSession, utils.controlPlane.session]);
+  }, [finishRun, invalidateWorkspaceDiff, onNotificationIntent, refresh, refreshPendingApproval, scheduleReconnect, setActivePlan, setCurrentActivity, setLatestUpdate, setLiveDelegations, setLiveStatus, setSession, utils.controlPlane.session]);
 
   trpcReact.controlPlane.sessionEvents.useSubscription(
     sessionId && workspaceId ? { sessionId, workspaceId } : skipToken,
@@ -228,6 +235,7 @@ export function useControlPlaneSessionEvents({
       setActivePlan(undefined);
       setCurrentActivity(undefined);
       setLatestUpdate(undefined);
+      setLiveDelegations([]);
       return;
     }
 
@@ -235,7 +243,8 @@ export function useControlPlaneSessionEvents({
     setActivePlan(undefined);
     setCurrentActivity(undefined);
     setLatestUpdate(undefined);
-  }, [sessionId, setActivePlan, setCurrentActivity, setLatestUpdate, setLiveStatus, workspaceId]);
+    setLiveDelegations([]);
+  }, [sessionId, setActivePlan, setCurrentActivity, setLatestUpdate, setLiveDelegations, setLiveStatus, workspaceId]);
 
   useEffect(() => {
     if (activeRun) {
@@ -284,6 +293,7 @@ type SessionActivityContext = {
   setActivePlan: Dispatch<SetStateAction<ClientSharedSessionPlan | undefined>>;
   setCurrentActivity: Dispatch<SetStateAction<ClientSharedAgentActivityStatus | undefined>>;
   setLatestUpdate: Dispatch<SetStateAction<ClientSharedSessionLatestUpdate | undefined>>;
+  setLiveDelegations: Dispatch<SetStateAction<ClientSharedDelegationView[]>>;
   notify?: (intent: ClientSharedNotificationIntent | undefined) => void;
 };
 
@@ -295,6 +305,10 @@ function applySessionActivity(activity: ControlPlaneSessionActivity, context: Se
     sessionId: context.sessionId,
     activity,
   }));
+
+  context.setLiveDelegations((current) => (
+    ClientSharedSessionDelegationService.reduceActivity(current, activity)
+  ));
 
   const latestUpdate = ClientSharedSessionActivityService.resolveLatestUpdate(activity);
   if (latestUpdate) {

--- a/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
+++ b/src/web-v2/hooks/sessions/useControlPlaneSessionPromptSubmit.ts
@@ -7,9 +7,11 @@ import {
 } from '@/client-shared/services/session-activities';
 import { ClientSharedPromptInputService } from '@/client-shared/services/prompt-input';
 import type {
+  ControlPlaneConversationDelegationMode,
   ControlPlaneSessionDirectShellPreflight,
   ControlPlaneSessionRunReference,
 } from '@/client-shared/api/types';
+import type { ClientSharedDelegationView } from '@/client-shared/services/session-delegations';
 
 type UseControlPlaneSessionPromptSubmitArgs = {
   workspaceId?: string;
@@ -20,12 +22,17 @@ type UseControlPlaneSessionPromptSubmitArgs = {
   setError: Dispatch<SetStateAction<string | undefined>>;
   setLiveStatus: Dispatch<SetStateAction<string | undefined>>;
   setCurrentActivity: Dispatch<SetStateAction<ClientSharedAgentActivityStatus | undefined>>;
+  setLiveDelegations: Dispatch<SetStateAction<ClientSharedDelegationView[]>>;
   onRunAccepted: (run: ControlPlaneSessionRunReference) => void;
 };
 
 export type ControlPlaneSessionPromptSubmitState = {
   submitting: boolean;
-  submitPrompt: (prompt: string, options?: { agentProfileId?: string; browserIntent?: 'preferred' }) => Promise<void>;
+  submitPrompt: (prompt: string, options?: {
+    agentProfileId?: string;
+    browserIntent?: 'preferred';
+    delegation?: ControlPlaneConversationDelegationMode;
+  }) => Promise<void>;
   directShellConfirmation?: ControlPlaneSessionDirectShellPreflight;
   confirmDirectShell: () => Promise<void>;
   cancelDirectShellConfirmation: () => void;
@@ -47,6 +54,7 @@ export function useControlPlaneSessionPromptSubmit({
   setError,
   setLiveStatus,
   setCurrentActivity,
+  setLiveDelegations,
   onRunAccepted,
 }: UseControlPlaneSessionPromptSubmitArgs): ControlPlaneSessionPromptSubmitState {
   const { t } = useI18n();
@@ -68,6 +76,7 @@ export function useControlPlaneSessionPromptSubmit({
     prompt: string;
     agentProfileId?: string;
     browserIntent?: 'preferred';
+    delegation?: ControlPlaneConversationDelegationMode;
     directShell?: { command: string; riskAccepted?: boolean };
   }) => {
     if (!workspaceId || !sessionId || submitting) {
@@ -96,6 +105,7 @@ export function useControlPlaneSessionPromptSubmit({
     setRunning(true);
     setError(undefined);
     if (!running) {
+      setLiveDelegations([]);
       setLiveStatus(streamConnected ? 'Heddle is working...' : 'Heddle is working... reconnecting live stream if needed.');
       setCurrentActivity(ClientSharedSessionActivityService.createThinkingStatus());
     }
@@ -114,6 +124,7 @@ export function useControlPlaneSessionPromptSubmit({
           prompt: input.prompt,
           agentProfileId: input.agentProfileId,
           browserIntent: input.browserIntent,
+          delegation: input.delegation,
         });
       if ('queued' in result) {
         if (isCurrentSubmission()) {
@@ -153,6 +164,7 @@ export function useControlPlaneSessionPromptSubmit({
     setError,
     setLiveStatus,
     setCurrentActivity,
+    setLiveDelegations,
     setRunning,
     running,
     onRunAccepted,
@@ -168,7 +180,11 @@ export function useControlPlaneSessionPromptSubmit({
     workspaceId,
   ]);
 
-  const submitPrompt = useCallback(async (prompt: string, options?: { agentProfileId?: string; browserIntent?: 'preferred' }) => {
+  const submitPrompt = useCallback(async (prompt: string, options?: {
+    agentProfileId?: string;
+    browserIntent?: 'preferred';
+    delegation?: ControlPlaneConversationDelegationMode;
+  }) => {
     const trimmed = prompt.trim();
     if (!workspaceId || !sessionId || !trimmed || submitting) {
       return;
@@ -208,6 +224,7 @@ export function useControlPlaneSessionPromptSubmit({
       prompt: trimmed,
       agentProfileId: options?.agentProfileId,
       browserIntent: options?.browserIntent,
+      delegation: options?.delegation,
     });
   }, [
     running,

--- a/src/web-v2/hooks/useControlPlaneAppState.ts
+++ b/src/web-v2/hooks/useControlPlaneAppState.ts
@@ -417,6 +417,7 @@ export function useControlPlaneAppState() {
         currentActivity: selectedSession.currentActivity,
         latestUpdate: selectedSession.latestUpdate,
         activePlan: selectedSession.activePlan,
+        liveDelegations: selectedSession.liveDelegations,
         runtimeContext: selectedSession.runtimeContext,
         agents: customAgentsQuery.data,
         pendingApproval: selectedSession.pendingApproval,

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -25,6 +25,13 @@
       "useAction": "Use browser",
       "useDescription": "Nudge the agent to inspect or operate the relevant page for this task."
     },
+    "subagents": {
+      "ariaLabel": "Subagents",
+      "description": "Let Heddle start read-only helpers when parallel research would be useful.",
+      "disabled": "Off for upcoming messages",
+      "enabled": "On for upcoming messages",
+      "title": "Subagents"
+    },
     "drift": {
       "ariaLabel": "Semantic drift",
       "disabled": "Drift off",
@@ -157,6 +164,19 @@
     "searchModels": "Search models",
     "send": "Send",
     "stop": "Stop"
+  },
+  "subagents": {
+    "historyLabel": "Subagent results",
+    "liveLabel": "Live subagent activity",
+    "status": {
+      "cancelled": "Cancelled",
+      "done": "Done",
+      "failed": "Failed",
+      "finished": "Finished",
+      "running": "Working",
+      "stepLimit": "Step limit"
+    },
+    "title": "Subagents"
   },
   "diffPreview": {
     "binary": "binary",

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -25,6 +25,13 @@
       "useAction": "使用浏览器",
       "useDescription": "提示代理为这个任务检查或操作相关页面。"
     },
+    "subagents": {
+      "ariaLabel": "子代理",
+      "description": "当并行研究有帮助时，允许 Heddle 启动只读助手。",
+      "disabled": "后续消息关闭",
+      "enabled": "后续消息开启",
+      "title": "子代理"
+    },
     "drift": {
       "ariaLabel": "语义漂移",
       "disabled": "漂移关闭",
@@ -157,6 +164,19 @@
     "searchModels": "搜索模型",
     "send": "发送",
     "stop": "停止"
+  },
+  "subagents": {
+    "historyLabel": "子代理结果",
+    "liveLabel": "实时子代理活动",
+    "status": {
+      "cancelled": "已取消",
+      "done": "完成",
+      "failed": "失败",
+      "finished": "已结束",
+      "running": "处理中",
+      "stepLimit": "已达步数上限"
+    },
+    "title": "子代理"
   },
   "diffPreview": {
     "binary": "二进制",

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -25,6 +25,13 @@
       "useAction": "使用瀏覽器",
       "useDescription": "提示代理為這個任務檢查或操作相關頁面。"
     },
+    "subagents": {
+      "ariaLabel": "子代理",
+      "description": "當平行研究有幫助時，允許 Heddle 啟動唯讀助手。",
+      "disabled": "後續訊息關閉",
+      "enabled": "後續訊息開啟",
+      "title": "子代理"
+    },
     "drift": {
       "ariaLabel": "語意漂移",
       "disabled": "漂移關閉",
@@ -157,6 +164,19 @@
     "searchModels": "搜尋模型",
     "send": "送出",
     "stop": "停止"
+  },
+  "subagents": {
+    "historyLabel": "子代理結果",
+    "liveLabel": "即時子代理活動",
+    "status": {
+      "cancelled": "已取消",
+      "done": "完成",
+      "failed": "失敗",
+      "finished": "已結束",
+      "running": "處理中",
+      "stepLimit": "已達步數上限"
+    },
+    "title": "子代理"
   },
   "diffPreview": {
     "binary": "二進位",

--- a/src/web-v2/styles/composer.css
+++ b/src/web-v2/styles/composer.css
@@ -615,6 +615,13 @@
     flex-direction: column;
   }
 
+  .v2-subagents-menu-section {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
   .v2-permission-mode-menu-section {
     display: flex;
     min-width: 0;
@@ -625,12 +632,14 @@
   .v2-composer-context-menu > :is(
     .v2-upload-menu-section,
     .v2-browser-intent-menu-section,
+    .v2-subagents-menu-section,
     .v2-permission-mode-menu-section,
     .v2-agent-menu-section,
     .v2-drift-menu-section
   ) + :is(
     .v2-upload-menu-section,
     .v2-browser-intent-menu-section,
+    .v2-subagents-menu-section,
     .v2-permission-mode-menu-section,
     .v2-agent-menu-section,
     .v2-drift-menu-section

--- a/src/web-v2/styles/conversation.css
+++ b/src/web-v2/styles/conversation.css
@@ -357,6 +357,119 @@
     padding: 0 1.5rem 0.45rem;
   }
 
+  .v2-subagent-activity-region {
+    padding: 0 1.5rem 0.5rem;
+  }
+
+  .v2-subagent-activity-panel {
+    margin-inline: auto;
+    width: min(100%, 48rem);
+    min-width: 0;
+    border-radius: var(--radius-lg);
+    border: 1px solid color-mix(in oklab, var(--color-border) 70%, transparent);
+    background: color-mix(in oklab, var(--color-background) 90%, var(--color-muted));
+    padding: 0.625rem 0.75rem;
+  }
+
+  .v2-subagent-activity-panel-settled {
+    margin-inline: 0;
+    width: min(100%, 46rem);
+  }
+
+  .v2-subagent-activity-title-row,
+  .v2-subagent-activity-header {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .v2-subagent-activity-title-row {
+    color: var(--color-foreground);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.25rem;
+  }
+
+  .v2-subagent-activity-title-row svg {
+    height: 0.875rem;
+    width: 0.875rem;
+    color: var(--color-muted-foreground);
+  }
+
+  .v2-subagent-activity-count {
+    color: var(--color-muted-foreground);
+    font-size: 0.75rem;
+    font-weight: 400;
+  }
+
+  .v2-subagent-activity-list {
+    display: grid;
+    gap: 0.5rem;
+    margin: 0.55rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .v2-subagent-activity-item {
+    min-width: 0;
+    border-left: 2px solid color-mix(in oklab, var(--color-border) 82%, transparent);
+    padding-left: 0.625rem;
+  }
+
+  .v2-subagent-activity-item[data-status="running"] {
+    border-left-color: color-mix(in oklab, var(--color-primary) 60%, var(--color-border));
+  }
+
+  .v2-subagent-activity-item[data-status="failed"],
+  .v2-subagent-activity-item[data-status="cancelled"] {
+    border-left-color: color-mix(in oklab, var(--color-destructive) 58%, var(--color-border));
+  }
+
+  .v2-subagent-activity-agent {
+    color: var(--color-foreground);
+    font-size: 0.8125rem;
+    font-weight: 500;
+  }
+
+  .v2-subagent-activity-status,
+  .v2-subagent-activity-duration,
+  .v2-subagent-activity-detail {
+    color: var(--color-muted-foreground);
+    font-size: 0.75rem;
+    line-height: 1.35;
+  }
+
+  .v2-subagent-activity-duration {
+    margin-left: auto;
+  }
+
+  .v2-subagent-activity-task,
+  .v2-subagent-activity-summary,
+  .v2-subagent-activity-error,
+  .v2-subagent-activity-detail {
+    margin: 0.15rem 0 0;
+  }
+
+  .v2-subagent-activity-task,
+  .v2-subagent-activity-summary,
+  .v2-subagent-activity-error {
+    font-size: 0.8125rem;
+    line-height: 1.45;
+  }
+
+  .v2-subagent-activity-task {
+    color: color-mix(in oklab, var(--color-foreground) 88%, var(--color-muted-foreground));
+  }
+
+  .v2-subagent-activity-summary {
+    color: var(--color-muted-foreground);
+  }
+
+  .v2-subagent-activity-error {
+    color: var(--color-destructive);
+  }
+
   .v2-agent-activity-stack {
     margin-inline: auto;
     display: flex;


### PR DESCRIPTION
## Summary

- add one default-on, host-local Subagents switch in web and `/subagents on|off` in the TUI, both using the existing per-turn `auto | off` input
- add a client-shared replay-safe projection for correlated live child events and sanitized settled records
- expose existing M3-A turn delegation records through session detail without a new store or durability owner
- render compact live and completed child rows in web and TUI, including profile, task, status, elapsed time, coarse activity, and bounded summary
- keep Permission Mode, child authority, raw transcripts/traces, model/provider fields, and per-child controls unchanged

## Behavior

The main agent still decides when delegation is useful. Subagents are available by default and the user can turn them off for upcoming messages. Children remain bounded by the existing fixed read-only safety envelope.

Live rows are driven by the shared delegation event vocabulary. Completed rows come from the persisted parent turn and survive reload. Queuing another TUI prompt now preserves the current live child rows until the queued turn actually starts.

## Verification

- `yarn lint`
- `yarn typecheck`
- `yarn test`: 917 unit and 435 integration tests passed
- `yarn test:browser-integration`: 8 tests passed, including keyboard activation at a 390 by 844 viewport
- `yarn build`

## Live dogfood

Ran this branch through an isolated Heddle control plane with stored OpenAI OAuth and `gpt-5.6-luna`:

- web: Luna issued two concurrent child delegations; both appeared live, settled, and reappeared after reload
- web off path: no child events or rows; the root completed the request itself
- TUI: reloaded the same durable child results, `/subagents off|on` updated status, and a TUI-started one-child run rendered live and settled state

The live review exposed the queued-prompt visibility edge case fixed in this PR.
