### PR TITLE
feat: grant bounded actions to code subagents

### DIFF
--- a/docs/guides/programmatic/quickstart.md
+++ b/docs/guides/programmatic/quickstart.md
@@ -47,13 +47,21 @@ Creation fields never overwrite an existing session with that ID. A hosted
 service must derive the ID and repository scope from trusted server-side
 identity; Heddle does not provide authentication or tenant mapping.
 
-### Read-only subagents
+### Subagents
 
-Conversation turns make bounded read-only subagents available by default. The
-root model decides when independent repository inspection or review is useful
-and may call `delegate_task`; callers do not need to enable it per prompt.
-Children receive no parent transcript, cannot mutate the workspace, and cannot
-delegate again. The turn result exposes completed in-memory evidence through
+Conversation turns make bounded subagents available by default. The root model
+decides when an independent task is useful and may call `delegate_task`; callers
+do not need to enable it per prompt. Ask and Review children are read-only. When
+an implementation task needs actions, the root must explicitly select
+`builtin:code`; omitting the profile still chooses read-only Ask. Code receives
+only the root's existing workspace read/write and shell tools from a small exact
+catalog, and every action follows the root session's existing permission mode
+and approval callback. There is no separate subagent permission setting.
+
+Children share the root workspace, receive no parent transcript, and cannot
+delegate again. Action-capable children run one at a time, while read-only
+children may run in parallel within the configured global limit. The turn
+result exposes completed in-memory evidence through
 `result.delegation`. Its ordered activity stream reports correlated
 `delegation.started`, `delegation.finished`, `delegation.cancelled`, and
 `delegation.rejected` records. Child loop progress is wrapped in
@@ -86,8 +94,9 @@ const agent = new ConversationAgentService({
 ```
 
 An engine-level `off` cannot be widened by a turn-level `auto`. Child evidence
-and correlated live activity are currently in-process only; durable child
-records and purpose-built UI rendering are separate lifecycle features.
+is also stored as settled metadata on the owning parent turn, within that
+conversation's recent-turn retention window. Raw child transcripts and traces
+are not persisted or exposed through the client projection.
 
 If the host already acquired an OpenAI account access token, it can keep the
 token request-scoped instead of writing it to Heddle's credential store:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,7 +51,7 @@ These flags show up across multiple commands:
 - `--model <name>`: choose the active model
 - `--max-steps <n>`: limit the agent loop length
 - `--prefer-api-key`: prefer an available provider API key over a stored OAuth credential for that run
-- `heddle ask --delegation <auto|off>`: keep automatic read-only subagents available, or remove delegation for this one turn
+- `heddle ask --delegation <auto|off>`: keep bounded subagents available, or remove delegation for this one turn
 
 ## Common Usage Examples
 
@@ -68,7 +68,10 @@ heddle ask "Summarize the test strategy in this repository"
 ```
 
 Delegation is available by default and the root agent decides when it is
-useful. Remove the capability for one request when needed:
+useful. Ask and Review children are read-only. The root must explicitly choose
+the Code child for a task that needs actions; those actions use the same
+permission mode and approval surface as root-agent actions. Remove the entire
+capability for one request when needed:
 
 ```bash
 heddle ask --delegation off "Summarize this repository directly"
@@ -127,9 +130,10 @@ selected reusable session is already running or queued, it fails admission so
 the supervisor never loses the exact run identity it must observe.
 
 Approval policy is unchanged. `run.activity` records can show an approval wait,
-but JSONL mode does not silently auto-approve it. Configure a suitable host
-permission policy before launching, or let another attached TUI/web/API client
-resolve the approval for that session.
+including when a Code child requests an action, but JSONL mode does not silently
+auto-approve it. Configure a suitable host permission policy before launching,
+or let another attached TUI/web/API client resolve the approval for that
+session.
 
 Choose the smallest integration surface that fits the host:
 
@@ -230,6 +234,9 @@ Inside `heddle` / `heddle chat`, the most-used local commands are:
 - `/browser channel <chromium|chrome|msedge>`: select the Playwright browser channel future browser runs and manual profile windows should use
 - `/browser open-profile [url]`: open the selected Heddle-owned browser profile in a visible window for manual login or session management
 - `/browser close-profile`: close the selected manual browser profile window and release its profile lock
+- `/subagents`: show whether subagents are available for upcoming messages
+- `/subagents on`: allow bounded subagents for upcoming messages
+- `/subagents off`: remove subagents from upcoming messages
 
 Prompt editing supports `Shift+Enter` for newlines, `Ctrl+Z`/`Ctrl+Y` for undo/redo, and `Up`/`Down` for submitted prompt history when the cursor is on the first or last logical line.
 

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -553,6 +553,109 @@ describe('conversation turn lifecycle', () => {
     ]));
   });
 
+  it('lets an explicitly granted code child edit the shared workspace through root approvals', async () => {
+    const storage = await createConversationTurnStorage();
+    const approvalRequests: ToolCall[] = [];
+    let rootRequest = 0;
+    let childRequest = 0;
+    let childToolNames: string[] = [];
+    const rootAdapter = testAdapter(async () => {
+      rootRequest += 1;
+      return rootRequest === 1
+        ? {
+            content: 'I will grant a code child the focused workspace action.',
+            toolCalls: [{
+              id: 'delegate-code-child',
+              tool: 'delegate_task',
+              input: {
+                task: 'Create child-action.txt containing ACTION_CHILD_OK.',
+                agentProfileId: 'builtin:code',
+              },
+            }],
+          }
+        : { content: 'The delegated action completed.' };
+    });
+    const childAdapter = testAdapter(async (_messages, tools) => {
+      childToolNames = (tools ?? []).map((tool) => tool.name);
+      childRequest += 1;
+      return childRequest === 1
+        ? {
+            content: 'I will create the requested file.',
+            toolCalls: [{
+              id: 'child-edit-file',
+              tool: 'edit_file',
+              input: {
+                path: 'child-action.txt',
+                content: 'ACTION_CHILD_OK\n',
+                createIfMissing: true,
+              },
+            }],
+          }
+        : { content: 'Created child-action.txt and verified the edit succeeded.' };
+    });
+    vi.spyOn(LlmAdapterService, 'create')
+      .mockReturnValueOnce(rootAdapter)
+      .mockReturnValueOnce(childAdapter);
+
+    const turnResult = await EngineConversationTurnService.run({
+      workspaceRoot: storage.workspaceRoot,
+      stateRoot: storage.stateRoot,
+      traceDir: join(storage.stateRoot, 'traces'),
+      sessionStoragePath: storage.sessionStoragePath,
+      sessionId: storage.sessionId,
+      prompt: 'Delegate this focused file creation to a code child.',
+      apiKey: 'explicit-key',
+      systemContext: 'BASE_SYSTEM_CONTEXT',
+      agentSnapshot: rootCodeAgentSnapshot(),
+      host: {
+        approveToolCall: async (call) => {
+          approvalRequests.push(structuredClone(call));
+          return { approved: true, reason: 'Approved by the root session test host' };
+        },
+      },
+      memoryMaintenanceMode: 'none',
+      artifactRoot: storage.artifactRoot,
+      artifactsEnabled: true,
+    });
+
+    expect(readFileSync(join(storage.workspaceRoot, 'child-action.txt'), 'utf8')).toBe(
+      'ACTION_CHILD_OK\n',
+    );
+    expect(approvalRequests).toEqual([
+      expect.objectContaining({ id: 'child-edit-file', tool: 'edit_file' }),
+    ]);
+    expect(childToolNames.sort()).toEqual([
+      'delete_file',
+      'edit_file',
+      'list_files',
+      'move_file',
+      'project_dashboard',
+      'read_file',
+      'run_shell_inspect',
+      'run_shell_mutate',
+      'search_files',
+    ]);
+    expect(turnResult.delegation?.records).toEqual([
+      expect.objectContaining({
+        task: 'Create child-action.txt containing ACTION_CHILD_OK.',
+        status: 'finished',
+        outcome: 'done',
+        summary: 'Created child-action.txt and verified the edit succeeded.',
+        agentSnapshot: expect.objectContaining({ agentProfileId: 'builtin:code' }),
+      }),
+    ]);
+    const persisted = await readStoredChatSession(
+      new FileChatSessionRepository({ sessionStoragePath: storage.sessionStoragePath }),
+      storage.sessionId,
+    );
+    expect(persisted?.turns.at(-1)?.delegations).toEqual([
+      expect.objectContaining({
+        agentSnapshot: expect.objectContaining({ agentProfileId: 'builtin:code' }),
+        outcome: 'done',
+      }),
+    ]);
+  });
+
   it('propagates parent cancellation into an active delegated child', async () => {
     const storage = await createConversationTurnStorage();
     const controller = new AbortController();
@@ -1071,6 +1174,22 @@ function rootAgentSnapshot(): CustomAgentExecutionSnapshot {
     },
     approvalProfile: { preset: 'read_only' },
     systemContextAppendix: 'ROOT_PROFILE_SENTINEL',
+  };
+}
+
+function rootCodeAgentSnapshot(): CustomAgentExecutionSnapshot {
+  return {
+    agentProfileId: 'project:root-coder',
+    agentName: 'Root coder',
+    source: 'project',
+    definitionHash: 'root-coder-definition',
+    runtime: { maxSteps: 6 },
+    toolProfile: {
+      preset: 'default',
+      memoryMode: 'none',
+    },
+    approvalProfile: { preset: 'interactive' },
+    systemContextAppendix: 'ROOT_CODE_PROFILE_SENTINEL',
   };
 }
 

--- a/src/__tests__/unit/cli-v2/tui-local-slash-command-service.test.ts
+++ b/src/__tests__/unit/cli-v2/tui-local-slash-command-service.test.ts
@@ -11,7 +11,7 @@ describe('TuiLocalSlashCommandService', () => {
       { command: '/c', description: 'toggle terminal command output' },
       { command: '/commands', description: 'toggle terminal command output' },
       { command: '/subagents', description: 'show the local subagent preference' },
-      { command: '/subagents on', description: 'allow read-only subagents for upcoming messages' },
+      { command: '/subagents on', description: 'allow bounded subagents for upcoming messages' },
       { command: '/subagents off', description: 'disable subagents for upcoming messages' },
     ]);
   });

--- a/src/__tests__/unit/client-shared/session-delegation-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-delegation-service.test.ts
@@ -6,6 +6,27 @@ import type { ClientSharedSessionActivity } from '@/client-shared/services/sessi
 import type { ControlPlaneSessionTurn } from '@/client-shared/api/types.js';
 
 describe('ClientSharedSessionDelegationService', () => {
+  it('uses the Code display name for live action-capable children', () => {
+    const state = ClientSharedSessionDelegationService.reduceActivity([], {
+      source: 'delegation',
+      type: 'delegation.started',
+      rootRunId: 'run-root',
+      parentRunId: 'run-root',
+      delegationId: 'delegation-code',
+      childRunId: 'run-code-child',
+      depth: 1,
+      task: 'Apply the focused change.',
+      agentProfileId: 'builtin:code',
+      timestamp: '2026-08-28T00:00:00.000Z',
+    });
+
+    expect(state[0]).toMatchObject({
+      agentProfileId: 'builtin:code',
+      agentName: 'Code',
+      status: 'running',
+    });
+  });
+
   it('reduces replayed child lifecycle events into one safe live row', () => {
     const started = delegationStarted();
     let state = ClientSharedSessionDelegationService.reduceActivity([], started);

--- a/src/__tests__/unit/core/delegation.test.ts
+++ b/src/__tests__/unit/core/delegation.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToolApprovalService } from '@/core/approvals/index.js';
+import type { ToolApprovalPolicy, ToolApprovalSurface } from '@/core/approvals/index.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import {
   DelegationService,
@@ -101,7 +102,7 @@ describe('delegation policy and scope', () => {
       { enabled: true, maxChildDurationMs: 999 },
       { enabled: true, maxChildDurationMs: 15 * 60_000 + 1 },
       { enabled: true, allowedAgentProfileIds: [] },
-      { enabled: true, allowedAgentProfileIds: ['builtin:code'] },
+      { enabled: true, allowedAgentProfileIds: ['builtin:unknown'] },
     ];
 
     invalidPolicies.forEach((policy) => {
@@ -150,7 +151,7 @@ describe('delegation policy and scope', () => {
     expect(tool.parameters).toMatchObject({
       properties: {
         agentProfileId: {
-          description: 'Read-only child profile. Omit to use builtin:review.',
+          description: 'Child authority profile. Omit for read-only builtin:review; select builtin:code only when the task requires actions.',
         },
       },
     });
@@ -418,6 +419,193 @@ describe('delegation policy and scope', () => {
     expect(output(result)).not.toHaveProperty('usage');
   });
 
+  it('grants an explicit code child only the bounded action catalog and inherited approvals', async () => {
+    const workspaceRoot = workspace();
+    const parentTools = RuntimeToolService.createDefaultAgentTools({
+      model: 'gpt-test',
+      workspaceRoot,
+    });
+    const inheritedPolicy: ToolApprovalPolicy = ({ tool }) => tool.name === 'edit_file'
+      ? { type: 'request', reason: 'Inherited root permission policy' }
+      : undefined;
+    const approveToolCall = vi.fn<ToolApprovalSurface>(async () => ({
+      approved: true,
+      reason: 'Approved through the root host',
+    }));
+    let captured: RunAgentLoopOptions | undefined;
+    vi.spyOn(AgentLoopRuntimeService, 'run').mockImplementation(async (options) => {
+      captured = options;
+      return completedResult(options, 'Action child result.');
+    });
+    const scope = new DelegationService({
+      policy: { enabled: true, allowedAgentProfileIds: ['builtin:code'] },
+    }).createRootScope({
+      rootRunId: 'run_action-root',
+      workspaceRoot,
+      runtime: {
+        model: 'gpt-test',
+        logger: silentLogger,
+        parentTools,
+        approvalPolicies: [inheritedPolicy],
+        approveToolCall,
+      },
+      agentSnapshotResolver: {
+        resolveExecutionSnapshot: () => codeSnapshot(),
+      },
+    });
+
+    const result = await scope.delegateTask({
+      task: 'Make the focused code change.',
+      agentProfileId: 'builtin:code',
+    });
+    const tools = captured?.tools ?? [];
+    const approvalService = new ToolApprovalService();
+    const editFile = tools.find((tool) => tool.name === 'edit_file');
+    const inheritedDecision = editFile
+      ? await approvalService.evaluate({
+          policies: captured?.approvalPolicies ?? [],
+          context: {
+            call: { id: 'call-edit-file', tool: editFile.name, input: { path: 'README.md' } },
+            tool: editFile,
+            workspaceRoot,
+          },
+        })
+      : undefined;
+    const forgedDelegation: ToolDefinition = {
+      name: 'delegate_task',
+      description: 'Forged recursive delegation tool.',
+      capabilities: ['agent.delegate'],
+      parameters: {},
+      execute: async () => ({ ok: true }),
+    };
+    const forgedDecision = await approvalService.evaluate({
+      policies: captured?.approvalPolicies ?? [],
+      context: {
+        call: { id: 'call-forged-delegation', tool: forgedDelegation.name, input: {} },
+        tool: forgedDelegation,
+        workspaceRoot,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(scope.createTool().parameters).toMatchObject({
+      properties: { agentProfileId: { enum: ['builtin:code'] } },
+    });
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      'delete_file',
+      'edit_file',
+      'list_files',
+      'move_file',
+      'project_dashboard',
+      'read_file',
+      'run_shell_inspect',
+      'run_shell_mutate',
+      'search_files',
+    ]);
+    expect(tools.map((tool) => tool.name)).not.toEqual(expect.arrayContaining([
+      'delegate_task',
+      'memory_search',
+      'read_artifact',
+      'read_agent_skill',
+      'mcp_call_tool',
+      'browser_action',
+    ]));
+    expect(inheritedDecision).toEqual({
+      type: 'request',
+      reason: 'Inherited root permission policy',
+    });
+    expect(forgedDecision).toEqual({
+      type: 'deny',
+      reason: 'delegate_task is outside the delegated action tool allowlist',
+    });
+    expect(captured?.approveToolCall).toBe(approveToolCall);
+    expect(captured?.systemContext).toContain('bounded action-capable child agent');
+    expect(captured?.systemContext).toContain('do not delegate further');
+    expect(scope.records()[0]?.agentSnapshot.agentProfileId).toBe('builtin:code');
+  });
+
+  it('does not advertise code delegation above the effective root tool ceiling', async () => {
+    const workspaceRoot = workspace();
+    const readOnlyParentTools = RuntimeToolService.createDefaultAgentTools({
+      model: 'gpt-test',
+      workspaceRoot,
+      toolProfile: { preset: 'inspect' },
+    });
+    const scope = new DelegationService({
+      policy: {
+        enabled: true,
+        allowedAgentProfileIds: ['builtin:ask', 'builtin:code'],
+      },
+    }).createRootScope({
+      workspaceRoot,
+      runtime: {
+        model: 'gpt-test',
+        logger: silentLogger,
+        parentTools: readOnlyParentTools,
+        createChildLlm: () => finalAdapter(async () => ({ content: 'Read-only result.' })),
+      },
+      agentSnapshotResolver: {
+        resolveExecutionSnapshot: (agentProfileId) => agentProfileId === 'builtin:code'
+          ? codeSnapshot()
+          : askSnapshot(),
+      },
+    });
+
+    expect(scope.createTool().parameters).toMatchObject({
+      properties: { agentProfileId: { enum: ['builtin:ask'] } },
+    });
+    await expect(scope.delegateTask({
+      task: 'Try to mutate.',
+      agentProfileId: 'builtin:code',
+    })).resolves.toMatchObject({
+      ok: false,
+      output: { error: { code: 'agent_not_allowed' } },
+    });
+  });
+
+  it('serializes action-capable children while preserving the global child limit', async () => {
+    const workspaceRoot = workspace();
+    let active = 0;
+    let peak = 0;
+    const scope = new DelegationService({
+      policy: {
+        enabled: true,
+        maxConcurrentChildren: 3,
+        allowedAgentProfileIds: ['builtin:code'],
+      },
+    }).createRootScope({
+      workspaceRoot,
+      runtime: {
+        model: 'gpt-test',
+        logger: silentLogger,
+        parentTools: RuntimeToolService.createDefaultAgentTools({
+          model: 'gpt-test',
+          workspaceRoot,
+        }),
+        createChildLlm: ({ task }) => finalAdapter(async () => {
+          active += 1;
+          peak = Math.max(peak, active);
+          await delay(20);
+          active -= 1;
+          return { content: `Completed ${task}.` };
+        }),
+      },
+      agentSnapshotResolver: {
+        resolveExecutionSnapshot: () => codeSnapshot(),
+      },
+    });
+
+    const results = await Promise.all([
+      scope.delegateTask({ task: 'action-one', agentProfileId: 'builtin:code' }),
+      scope.delegateTask({ task: 'action-two', agentProfileId: 'builtin:code' }),
+      scope.delegateTask({ task: 'action-three', agentProfileId: 'builtin:code' }),
+    ]);
+
+    expect(results.every((result) => result.ok)).toBe(true);
+    expect(peak).toBe(1);
+    expect(active).toBe(0);
+  });
+
   it('fails closed before root execution when an eligible snapshot is not read-only', () => {
     const unsafeSnapshot = askSnapshot({
       toolProfile: { preset: 'default' },
@@ -431,7 +619,7 @@ describe('delegation policy and scope', () => {
       agentSnapshotResolver: {
         resolveExecutionSnapshot: () => unsafeSnapshot,
       },
-    })).toThrow('not safely read-only');
+    })).toThrow('does not satisfy its delegated authority envelope');
   });
 
   it('cancels the active child and settles queued reservations without starting them', async () => {
@@ -621,6 +809,25 @@ function askSnapshot(
     },
     approvalProfile: { preset: 'read_only' },
     systemContextAppendix: 'You are running in ask mode. Inspect without changing project state.',
+    ...overrides,
+  };
+}
+
+function codeSnapshot(
+  overrides: Partial<CustomAgentExecutionSnapshot> = {},
+): CustomAgentExecutionSnapshot {
+  return {
+    agentProfileId: 'builtin:code',
+    agentName: 'Code',
+    modeAlias: 'code',
+    source: 'built-in',
+    definitionHash: 'fedcba9876543210',
+    runtime: { maxSteps: 60 },
+    toolProfile: {
+      preset: 'default',
+    },
+    approvalProfile: { preset: 'interactive' },
+    systemContextAppendix: 'You are running in code mode.',
     ...overrides,
   };
 }

--- a/src/cli-v2/services/slash-commands/tui-local-slash-command-service.ts
+++ b/src/cli-v2/services/slash-commands/tui-local-slash-command-service.ts
@@ -62,7 +62,7 @@ export class TuiLocalSlashCommandService {
     {
       action: 'subagentsOn',
       commands: ['/subagents on'],
-      description: 'allow read-only subagents for upcoming messages',
+      description: 'allow bounded subagents for upcoming messages',
     },
     {
       action: 'subagentsOff',

--- a/src/client-shared/services/session-delegations/session-delegation-service.ts
+++ b/src/client-shared/services/session-delegations/session-delegation-service.ts
@@ -34,6 +34,7 @@ export type ClientSharedDelegationView = {
 
 const BUILT_IN_AGENT_NAMES: Record<string, string> = {
   'builtin:ask': 'Ask',
+  'builtin:code': 'Code',
   'builtin:review': 'Review',
 };
 

--- a/src/core/chat/engine/delegation-policy.ts
+++ b/src/core/chat/engine/delegation-policy.ts
@@ -12,6 +12,12 @@ import type {
  * authority ceiling; a turn may remove delegation but never widen it.
  */
 export class ConversationDelegationPolicyService {
+  private static readonly DEFAULT_AGENT_PROFILE_IDS = [
+    'builtin:ask',
+    'builtin:review',
+    'builtin:code',
+  ] as const;
+
   static resolveEnginePolicy(
     config: ConversationDelegationConfig | undefined,
   ): DelegationPolicy {
@@ -20,6 +26,8 @@ export class ConversationDelegationPolicyService {
     return DelegationPolicyService.resolve({
       ...policyInput,
       enabled: mode === 'auto',
+      allowedAgentProfileIds: policyInput.allowedAgentProfileIds
+        ?? ConversationDelegationPolicyService.DEFAULT_AGENT_PROFILE_IDS,
     });
   }
 

--- a/src/core/chat/engine/turns/service.ts
+++ b/src/core/chat/engine/turns/service.ts
@@ -108,7 +108,21 @@ export class EngineConversationTurnService implements ConversationTurnService {
       agentSnapshot,
     } = context;
     const host = EngineConversationTurnService.turnHost(args);
-    const delegationScope = EngineConversationTurnService.createDelegationScope(args, context, host);
+    const approvalPolicies = ToolApprovalProfileService.compile({
+      profile: agentSnapshot?.approvalProfile,
+      autoProfile: agentSnapshot?.approvalProfile.preset === 'auto'
+        ? AutonomyPermissionModeService.buildAutoProfile({
+          trustedRoots: ProjectConfigService.read(args.workspaceRoot).autoTrustedRoots,
+        })
+        : undefined,
+      basePolicies: args.approvalPolicies,
+    });
+    const delegationScope = EngineConversationTurnService.createDelegationScope(
+      args,
+      context,
+      host,
+      approvalPolicies,
+    );
     const rootTools = delegationScope
       ? [...tools, delegationScope.createTool()]
       : tools;
@@ -170,15 +184,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
         shouldStop: () => leaseHeartbeat.signal.aborted || args.shouldStop?.() === true,
         onEvent: host.onEvent,
         approveToolCall: host.approveToolCall,
-        approvalPolicies: ToolApprovalProfileService.compile({
-          profile: agentSnapshot?.approvalProfile,
-          autoProfile: agentSnapshot?.approvalProfile.preset === 'auto'
-            ? AutonomyPermissionModeService.buildAutoProfile({
-              trustedRoots: ProjectConfigService.read(args.workspaceRoot).autoTrustedRoots,
-            })
-            : undefined,
-          basePolicies: args.approvalPolicies,
-        }),
+        approvalPolicies,
         recoverModelContext: async (input) => {
           leaseHeartbeat.throwIfFailed();
           const recovered = await ConversationTurnContextRecoveryService.recover({
@@ -319,6 +325,7 @@ export class EngineConversationTurnService implements ConversationTurnService {
     args: RunConversationTurnArgs,
     context: ConversationTurnContext,
     host: ChatTurnHostPort,
+    approvalPolicies: ReturnType<typeof ToolApprovalProfileService.compile>,
   ): DelegationRootScope | undefined {
     const policy = args.delegationPolicy
       ?? ConversationDelegationPolicyService.resolveEnginePolicy(undefined);
@@ -349,6 +356,9 @@ export class EngineConversationTurnService implements ConversationTurnService {
         searchIgnoreDirs: args.searchIgnoreDirs,
         baseSystemContext: context.baseSystemContext,
         createChildLlm: () => context.runtime.createLlm(),
+        parentTools: context.tools,
+        approvalPolicies,
+        approveToolCall: host.approveToolCall,
       },
     });
   }

--- a/src/core/delegation/README.md
+++ b/src/core/delegation/README.md
@@ -1,19 +1,25 @@
 # Delegation
 
 `src/core/delegation` owns bounded parent-to-child agent execution for one root
-run. It turns `delegate_task` calls into read-only child executions through the
-existing `AgentLoopRuntimeService`; it does not implement another model/tool
-loop.
+run. It turns `delegate_task` calls into child executions through the existing
+`AgentLoopRuntimeService`; it does not implement another model/tool loop. Ask
+and Review children are read-only. A main agent may explicitly select Code to
+grant a child a bounded action catalog within the main agent's existing tool
+and permission ceilings.
 
 ## Boundary
 
 This domain owns:
 
-- v1 policy validation and disabled-by-default activation;
+- policy validation and disabled-by-default low-level activation;
 - preallocated root, delegation, and child identities;
-- atomic total-child reservation and a per-root concurrency semaphore;
-- immutable `builtin:ask` / `builtin:review` snapshot selection;
-- the mandatory child read-only tool and approval envelopes;
+- atomic total-child reservation, a per-root concurrency semaphore, and
+  serialized action-child execution;
+- immutable `builtin:ask`, `builtin:review`, and `builtin:code` snapshot
+  selection;
+- exact read-only and action-capable child tool envelopes;
+- action-tool intersection with the effective root tool catalog;
+- reuse of the root approval policy chain and host approval surface;
 - fresh child context, adapter creation, cancellation, step clamping, and a
   validated per-child execution deadline;
 - correlated delegation lifecycle and wrapped child conversation activity;
@@ -27,10 +33,11 @@ split intact: graph state must not leak into the single-run runtime, and child
 authority must not be reconstructed by host callers.
 
 It does not own chat sessions, turn activation, durable storage, live UI
-rendering, provider-native delegation, child worktrees, write authority, or
-recursive delegation. Those concerns stay in their existing host/domain
-owners or later feature slices. The delegation scope only proves that its
-records are settled before the conversation domain persists a projection.
+rendering, provider-native delegation, child worktrees, root permission modes,
+or recursive delegation. Those concerns stay in their existing host/domain
+owners. The delegation scope only proves that its records are settled before
+the conversation domain persists a projection. Action children operate in the
+same workspace as the root; worktree isolation is not implied.
 
 ## Headless Composition
 
@@ -83,6 +90,43 @@ owns a five-minute default child deadline, configurable from one second through
 fifteen minutes. Root cancellation and child step limits remain independently
 active.
 
+### Granting bounded actions in a headless host
+
+The low-level service defaults to Ask and Review. A host must opt Code into its
+policy and pass the root's effective tools, approval policies, and approval
+surface to make action delegation available:
+
+```ts
+const rootTools = RuntimeToolService.createDefaultAgentTools({
+  model,
+  workspaceRoot,
+})
+const approvalPolicies = hostApprovalPolicies
+
+const scope = new DelegationService({
+  policy: {
+    enabled: true,
+    allowedAgentProfileIds: ['builtin:ask', 'builtin:review', 'builtin:code'],
+  },
+}).createRootScope({
+  workspaceRoot,
+  runtime: {
+    model,
+    parentTools: rootTools,
+    approvalPolicies,
+    approveToolCall: host.approveToolCall,
+  },
+})
+```
+
+`builtin:code` is omitted from the model-visible schema if the effective root
+catalog has no mutation tool. Selecting it in a `delegate_task` call is the
+main agent's explicit authority grant for that child. Omitting
+`agentProfileId` still chooses read-only Ask when available. Tool execution
+then follows the existing root permission behavior: an action may be allowed,
+denied, or sent to the same human approval surface. Delegation does not add a
+second permission mode.
+
 ## Conversation Engine Composition
 
 The lower-level `DelegationService` stays disabled by default so an ordinary
@@ -91,8 +135,11 @@ owns a different product-level default: it creates one enabled root scope per
 turn and exposes `delegate_task` unless the engine or turn selects `off`.
 
 The root model decides whether a task benefits from delegation; there is no
-per-turn enable gate. An engine-level `off` is an authority ceiling, so a turn
-cannot re-enable it. The conversation turn result includes a settled scope
+per-turn enable gate. It must explicitly select `builtin:code` when a child
+needs actions; ordinary Ask and Review children stay read-only. The Code option
+is visible only when the selected root agent itself has mutation tools. An
+engine-level `off` is an authority ceiling, so a turn cannot re-enable it. The
+conversation turn result includes a settled scope
 snapshot in memory and omits it when delegation is off. Completed child
 records are also projected into optional `TurnSummary.delegations` on the
 parent turn, so they follow the existing conversation repository and its
@@ -112,7 +159,7 @@ settled task/profile/status/summary records in both web-v2 and cli-v2. It does
 not expose raw child transcripts, traces, model/provider details, or child
 permission controls; those remain outside this slice.
 
-## V1 Safety Invariants
+## Safety Invariants
 
 - Depth is exactly one; child registries never contain `delegate_task`.
 - At most four children are reserved and at most three execute concurrently by
@@ -120,19 +167,22 @@ permission controls; those remain outside this slice.
 - A reservation remains consumed after completion, failure, or cancellation.
 - Child step budgets default to 24 and cannot exceed 32.
 - Child wall time defaults to five minutes and cannot exceed fifteen minutes.
-- Only built-in ask/review snapshots are eligible.
-- Snapshot tool selection is intersected with a mandatory capability envelope.
-- Children receive only `project_dashboard`, `list_files`, `read_file`, and
-  `search_files`. Shell execution is not available because model-authored shell
-  syntax cannot guarantee read-only host effects, and artifact tools stay out
-  of the first-slice repository-inspection catalog to keep tool selection
-  predictable.
+- Only built-in Ask, Review, and Code snapshots are eligible.
+- Ask and Review receive only `project_dashboard`, `list_files`, `read_file`,
+  and `search_files`.
+- Code receives only those four tools plus `edit_file`, `delete_file`,
+  `move_file`, `run_shell_inspect`, and `run_shell_mutate`. Each action tool
+  must also exist in the effective root catalog.
+- Action children execute one at a time within the existing global child
+  concurrency limit. Read-only children may still execute in parallel.
 - Agent-skill activation is unavailable to children so the inherited base
   context plus immutable child-profile appendix remain the complete child
   system context.
 - A delegation-owned approval policy independently enforces the same exact
-  tool-name and `workspace.read` capability allowlist, in addition to snapshot
-  approval policy.
+  tool-name and capability allowlist. Code children then reuse the root's
+  effective approval policy chain and human approval callback.
+- Children never receive memory, artifact, browser, MCP, skill, or delegation
+  tools.
 - Children share the normalized workspace but receive no root history or root
   profile appendix.
 - Raw child transcripts and traces never enter model-facing tool output.

--- a/src/core/delegation/child-runtime.ts
+++ b/src/core/delegation/child-runtime.ts
@@ -22,7 +22,6 @@ import type {
   ToolCapability,
 } from '@/core/runtime/tools/index.js';
 import type { ToolDefinition } from '@/core/types.js';
-import { DelegationPolicyService } from './policy.js';
 import type {
   DelegatedRunRecord,
   DelegationAgentProfileId,
@@ -30,7 +29,7 @@ import type {
   DelegationPolicy,
 } from './types.js';
 
-const MANDATORY_CHILD_TOOL_PROFILE: RuntimeToolSelectionProfile = {
+const READ_ONLY_CHILD_TOOL_PROFILE: RuntimeToolSelectionProfile = {
   preset: 'custom',
   allowedCapabilities: ['workspace.read'],
   deniedCapabilities: [
@@ -51,16 +50,66 @@ const MANDATORY_CHILD_TOOL_PROFILE: RuntimeToolSelectionProfile = {
   memoryMode: 'none',
 };
 
-const SAFE_CHILD_CAPABILITIES = new Set<ToolCapability>([
+const ACTION_CHILD_TOOL_PROFILE: RuntimeToolSelectionProfile = {
+  preset: 'custom',
+  allowedCapabilities: [
+    'workspace.read',
+    'workspace.write',
+    'shell.inspect',
+    'shell.mutate',
+  ],
+  deniedCapabilities: [
+    'agent.delegate',
+    'memory.read',
+    'memory.write',
+    'artifact.read',
+    'artifact.write',
+    'external.read',
+    'browser.read',
+    'browser.action',
+    'mcp.unknown',
+    'internal.state',
+  ],
+  memoryMode: 'none',
+};
+
+const READ_ONLY_CHILD_CAPABILITIES = new Set<ToolCapability>([
   'workspace.read',
 ]);
 
-const SAFE_CHILD_TOOL_NAMES = new Set([
+const ACTION_CHILD_CAPABILITIES = new Set<ToolCapability>([
+  'workspace.read',
+  'workspace.write',
+  'shell.inspect',
+  'shell.mutate',
+]);
+
+const READ_ONLY_CHILD_TOOL_NAMES = new Set([
   'project_dashboard',
   'list_files',
   'read_file',
   'search_files',
 ]);
+
+const ACTION_CHILD_TOOL_NAMES = new Set([
+  ...READ_ONLY_CHILD_TOOL_NAMES,
+  'edit_file',
+  'delete_file',
+  'move_file',
+  'run_shell_inspect',
+  'run_shell_mutate',
+]);
+
+const MUTATING_CHILD_CAPABILITIES = new Set<ToolCapability>([
+  'workspace.write',
+  'shell.mutate',
+]);
+
+const ACTION_CHILD_SYSTEM_CONTEXT = [
+  'You are a bounded action-capable child agent working for a main agent.',
+  'Complete only the delegated task in the shared workspace, use the granted tools when needed, and do not delegate further.',
+  'Keep changes focused, verify them proportionately, and return a concise summary of actions, files, and validation.',
+].join('\n');
 
 const CHILD_RUNTIME_OPTION_KEYS = [
   'model',
@@ -76,11 +125,14 @@ const CHILD_RUNTIME_OPTION_KEYS = [
   'baseSystemContext',
   'logger',
   'createChildLlm',
+  'parentTools',
+  'approvalPolicies',
+  'approveToolCall',
 ] as const satisfies readonly (keyof DelegationChildRuntimeOptions)[];
 
 /**
  * Builds and executes one child through the existing single-run runtime while
- * enforcing the non-widenable v1 context, tool, approval, and adapter rules.
+ * enforcing the non-widenable context, tool, approval, and adapter rules.
  */
 export class DelegationChildRuntimeService {
   private readonly runtime: Readonly<DelegationChildRuntimeOptions>;
@@ -104,6 +156,12 @@ export class DelegationChildRuntimeService {
       searchIgnoreDirs: runtime.searchIgnoreDirs
         ? Object.freeze([...runtime.searchIgnoreDirs]) as string[]
         : undefined,
+      parentTools: runtime.parentTools
+        ? Object.freeze([...runtime.parentTools]) as ToolDefinition[]
+        : undefined,
+      approvalPolicies: runtime.approvalPolicies
+        ? Object.freeze([...runtime.approvalPolicies]) as ToolApprovalPolicy[]
+        : undefined,
     });
     if (!this.runtime.model.trim() || this.runtime.model !== this.runtime.model.trim()) {
       throw new Error('Delegation child runtime model must be a non-empty trimmed string');
@@ -117,9 +175,11 @@ export class DelegationChildRuntimeService {
   preflightSnapshot(
     agentProfileId: DelegationAgentProfileId,
     snapshot: CustomAgentExecutionSnapshot,
-  ): void {
-    DelegationChildRuntimeService.assertReadOnlySnapshot(agentProfileId, snapshot);
-    this.buildChildTools(snapshot);
+  ): boolean {
+    DelegationChildRuntimeService.assertSupportedSnapshot(agentProfileId, snapshot);
+    const tools = this.buildChildTools(snapshot);
+    return !DelegationChildRuntimeService.isActionProfile(agentProfileId)
+      || tools.some((tool) => DelegationChildRuntimeService.isMutatingTool(tool));
   }
 
   async run(input: {
@@ -151,16 +211,24 @@ export class DelegationChildRuntimeService {
   }): Promise<AgentLoopResult> {
     input.signal.throwIfAborted();
     const tools = this.buildChildTools(input.snapshot);
-    const systemContext = CustomAgentRuntimeContextService.appendAgentInstructions({
+    const profileSystemContext = CustomAgentRuntimeContextService.appendAgentInstructions({
       systemContext: this.runtime.baseSystemContext,
       snapshot: input.snapshot,
     });
+    const systemContext = DelegationChildRuntimeService.isActionProfile(
+      input.snapshot.agentProfileId as DelegationAgentProfileId,
+    )
+      ? [profileSystemContext, ACTION_CHILD_SYSTEM_CONTEXT].filter(Boolean).join('\n\n')
+      : profileSystemContext;
     const llm = await this.createChildLlm(input);
     input.signal.throwIfAborted();
 
     const {
       baseSystemContext: _baseSystemContext,
       createChildLlm: _createChildLlm,
+      parentTools: _parentTools,
+      approvalPolicies: _approvalPolicies,
+      approveToolCall,
       ...runtime
     } = this.runtime;
     const effectiveMaxSteps = Math.min(
@@ -180,6 +248,7 @@ export class DelegationChildRuntimeService {
       systemContext,
       maxSteps: effectiveMaxSteps,
       approvalPolicies: this.createChildApprovalPolicies(input.snapshot),
+      approveToolCall,
       abortSignal: input.signal,
       onEvent: (event) => {
         if (
@@ -194,6 +263,15 @@ export class DelegationChildRuntimeService {
   }
 
   private buildChildTools(snapshot: CustomAgentExecutionSnapshot): ToolDefinition[] {
+    const agentProfileId = snapshot.agentProfileId as DelegationAgentProfileId;
+    const actionCapable = DelegationChildRuntimeService.isActionProfile(agentProfileId);
+    const toolProfile = actionCapable
+      ? ACTION_CHILD_TOOL_PROFILE
+      : READ_ONLY_CHILD_TOOL_PROFILE;
+    const allowedToolNames = actionCapable
+      ? ACTION_CHILD_TOOL_NAMES
+      : READ_ONLY_CHILD_TOOL_NAMES;
+    const parentToolNames = new Set(this.runtime.parentTools?.map((tool) => tool.name) ?? []);
     const snapshotTools = RuntimeToolService.createDefaultAgentTools({
       model: this.runtime.model,
       workspaceRoot: this.workspaceRoot,
@@ -206,13 +284,16 @@ export class DelegationChildRuntimeService {
     });
     const tools = RuntimeToolProfileService.apply({
       tools: snapshotTools,
-      profile: MANDATORY_CHILD_TOOL_PROFILE,
-    }).filter((tool) => SAFE_CHILD_TOOL_NAMES.has(tool.name));
+      profile: toolProfile,
+    }).filter((tool) => (
+      allowedToolNames.has(tool.name)
+      && (!actionCapable || parentToolNames.has(tool.name))
+    ));
 
     tools.forEach((tool) => {
-      if (!DelegationChildRuntimeService.isSafeChildTool(tool)) {
+      if (!DelegationChildRuntimeService.isAllowedChildTool(agentProfileId, tool)) {
         throw new Error(
-          `${DelegationPolicyService.message('agent_not_read_only')} Tool: ${tool.name}`,
+          `Delegated child tool is outside the ${actionCapable ? 'action' : 'read-only'} allowlist: ${tool.name}`,
         );
       }
     });
@@ -226,27 +307,42 @@ export class DelegationChildRuntimeService {
       profile: snapshot.approvalProfile,
     });
     return [
-      DelegationChildRuntimeService.enforceSafeChildToolAllowlist(),
+      DelegationChildRuntimeService.enforceChildToolAllowlist(
+        snapshot.agentProfileId as DelegationAgentProfileId,
+      ),
       ...snapshotPolicies,
+      ...(this.runtime.approvalPolicies ?? []),
     ];
   }
 
-  private static enforceSafeChildToolAllowlist(): ToolApprovalPolicy {
+  private static enforceChildToolAllowlist(
+    agentProfileId: DelegationAgentProfileId,
+  ): ToolApprovalPolicy {
     return ({ tool }) => {
-      return DelegationChildRuntimeService.isSafeChildTool(tool)
+      return DelegationChildRuntimeService.isAllowedChildTool(agentProfileId, tool)
         ? undefined
         : {
           type: 'deny',
-          reason: `${tool.name} is outside the delegated read-only tool allowlist`,
+          reason: `${tool.name} is outside the delegated ${DelegationChildRuntimeService.isActionProfile(agentProfileId) ? 'action' : 'read-only'} tool allowlist`,
         };
     };
   }
 
-  private static isSafeChildTool(tool: ToolDefinition): boolean {
+  private static isAllowedChildTool(
+    agentProfileId: DelegationAgentProfileId,
+    tool: ToolDefinition,
+  ): boolean {
+    const actionCapable = DelegationChildRuntimeService.isActionProfile(agentProfileId);
+    const allowedToolNames = actionCapable
+      ? ACTION_CHILD_TOOL_NAMES
+      : READ_ONLY_CHILD_TOOL_NAMES;
+    const allowedCapabilities = actionCapable
+      ? ACTION_CHILD_CAPABILITIES
+      : READ_ONLY_CHILD_CAPABILITIES;
     const capabilities = RuntimeToolProfileService.capabilitiesFor(tool);
-    return SAFE_CHILD_TOOL_NAMES.has(tool.name)
+    return allowedToolNames.has(tool.name)
       && capabilities.length > 0
-      && capabilities.every((capability) => SAFE_CHILD_CAPABILITIES.has(capability));
+      && capabilities.every((capability) => allowedCapabilities.has(capability));
   }
 
   private async createChildLlm(input: {
@@ -281,23 +377,35 @@ export class DelegationChildRuntimeService {
     return adapter;
   }
 
-  private static assertReadOnlySnapshot(
+  private static assertSupportedSnapshot(
     agentProfileId: DelegationAgentProfileId,
     snapshot: CustomAgentExecutionSnapshot,
   ): void {
     const maxSteps = snapshot.runtime.maxSteps;
     const validStepDefault = maxSteps === undefined
       || (Number.isInteger(maxSteps) && maxSteps > 0);
-    const safelyReadOnly = snapshot.agentProfileId === agentProfileId
+    const sharedInvariant = snapshot.agentProfileId === agentProfileId
       && snapshot.source === 'built-in'
-      && snapshot.toolProfile.preset === 'inspect'
-      && snapshot.toolProfile.memoryMode === 'none'
-      && snapshot.approvalProfile.preset === 'read_only'
       && validStepDefault;
-    if (!safelyReadOnly) {
+    const validProfile = DelegationChildRuntimeService.isActionProfile(agentProfileId)
+      ? snapshot.toolProfile.preset === 'default'
+        && snapshot.approvalProfile.preset === 'interactive'
+      : snapshot.toolProfile.preset === 'inspect'
+        && snapshot.toolProfile.memoryMode === 'none'
+        && snapshot.approvalProfile.preset === 'read_only';
+    if (!sharedInvariant || !validProfile) {
       throw new Error(
-        `${DelegationPolicyService.message('agent_not_read_only')} Profile: ${agentProfileId}`,
+        `The requested child agent profile does not satisfy its delegated authority envelope. Profile: ${agentProfileId}`,
       );
     }
+  }
+
+  static isActionProfile(agentProfileId: DelegationAgentProfileId): boolean {
+    return agentProfileId === 'builtin:code';
+  }
+
+  private static isMutatingTool(tool: ToolDefinition): boolean {
+    return RuntimeToolProfileService.capabilitiesFor(tool)
+      .some((capability) => MUTATING_CHILD_CAPABILITIES.has(capability));
   }
 }

--- a/src/core/delegation/policy.ts
+++ b/src/core/delegation/policy.ts
@@ -21,6 +21,7 @@ export const MAX_DELEGATED_SUMMARY_LENGTH = 8_000;
 const SUPPORTED_AGENT_PROFILE_IDS = new Set<DelegationAgentProfileId>([
   'builtin:ask',
   'builtin:review',
+  'builtin:code',
 ]);
 
 const DEFAULT_AGENT_PROFILE_IDS: DelegationAgentProfileId[] = [
@@ -95,7 +96,7 @@ export class DelegationPolicyService {
     );
     if (unsupportedProfile) {
       throw new Error(
-        `Delegation v1 only supports builtin:ask and builtin:review; received ${unsupportedProfile}`,
+        `Delegation only supports builtin:ask, builtin:review, and builtin:code; received ${unsupportedProfile}`,
       );
     }
 

--- a/src/core/delegation/service.ts
+++ b/src/core/delegation/service.ts
@@ -80,6 +80,7 @@ export class DelegationRootScope {
   private readonly childRuntime: DelegationChildRuntimeService;
   private readonly defaultAgentProfileId: DelegationAgentProfileId;
   private readonly onActivity: CreateDelegationRootScopeOptions['onActivity'];
+  private readonly actionSemaphore = new Semaphore(1);
   private readonly semaphore: Semaphore;
   private readonly scopeController = new AbortController();
 
@@ -92,9 +93,6 @@ export class DelegationRootScope {
     this.workspaceRoot = resolve(options.workspaceRoot);
     this.onActivity = options.onActivity;
     this.semaphore = new Semaphore(this.policy.maxConcurrentChildren);
-    this.defaultAgentProfileId = this.policy.allowedAgentProfileIds.includes('builtin:ask')
-      ? 'builtin:ask'
-      : this.policy.allowedAgentProfileIds[0]!;
     this.childRuntime = new DelegationChildRuntimeService({
       rootRunId: this.rootRunId,
       workspaceRoot: this.workspaceRoot,
@@ -110,17 +108,26 @@ export class DelegationRootScope {
     this.agentSnapshots = this.policy.enabled
       ? this.resolveAgentSnapshots(resolver)
       : new Map();
+    const availableAgentProfileIds = [...this.agentSnapshots.keys()];
+    if (this.policy.enabled && availableAgentProfileIds.length === 0) {
+      throw new Error('Delegation has no child agent profile within the root authority ceiling');
+    }
+    this.defaultAgentProfileId = this.agentSnapshots.has('builtin:ask')
+      ? 'builtin:ask'
+      : availableAgentProfileIds[0] ?? 'builtin:ask';
   }
 
   /**
    * Creates the only model-visible delegation entry point for this scope.
    */
   createTool(): ToolDefinition {
+    const availableAgentProfileIds = [...this.agentSnapshots.keys()];
     return {
       name: 'delegate_task',
       description: [
-        'Run one bounded, read-only child agent on an independent inspection task.',
-        'The child receives the same workspace but no parent transcript and cannot delegate or mutate state.',
+        'Run one bounded child agent on an independent task.',
+        'Ask and Review children are read-only. Explicitly selecting builtin:code grants the child a bounded coding catalog within the root agent tool and permission ceilings.',
+        'The child receives the same workspace but no parent transcript and cannot delegate further.',
         `task is required and limited to ${MAX_DELEGATED_TASK_LENGTH} characters.`,
         `agentProfileId may be omitted to use ${this.defaultAgentProfileId}.`,
       ].join(' '),
@@ -135,12 +142,12 @@ export class DelegationRootScope {
             type: 'string',
             minLength: 1,
             maxLength: MAX_DELEGATED_TASK_LENGTH,
-            description: 'Self-contained inspection or review task for the child agent.',
+            description: 'Self-contained task for the child agent.',
           },
           agentProfileId: {
             type: 'string',
-            enum: [...this.policy.allowedAgentProfileIds],
-            description: `Read-only child profile. Omit to use ${this.defaultAgentProfileId}.`,
+            enum: availableAgentProfileIds,
+            description: `Child authority profile. Omit for read-only ${this.defaultAgentProfileId}; select builtin:code only when the task requires actions.`,
           },
         },
         required: ['task'],
@@ -249,13 +256,14 @@ export class DelegationRootScope {
   private resolveAgentSnapshots(
     resolver: DelegationAgentSnapshotResolver,
   ): ReadonlyMap<DelegationAgentProfileId, CustomAgentExecutionSnapshot> {
-    return new Map(this.policy.allowedAgentProfileIds.map((agentProfileId) => {
+    return new Map(this.policy.allowedAgentProfileIds.flatMap((agentProfileId) => {
       const snapshot = resolver.resolveExecutionSnapshot(agentProfileId);
       if (!snapshot) {
         throw new Error(`Delegation agent profile could not be resolved: ${agentProfileId}`);
       }
-      this.childRuntime.preflightSnapshot(agentProfileId, snapshot);
-      return [agentProfileId, cloneDeep(snapshot)];
+      return this.childRuntime.preflightSnapshot(agentProfileId, snapshot)
+        ? [[agentProfileId, cloneDeep(snapshot)] as const]
+        : [];
     }));
   }
 
@@ -317,47 +325,59 @@ export class DelegationRootScope {
     ]);
 
     try {
-      return await this.semaphore.runExclusive(async () => {
-        if (ownershipSignal.aborted) {
-          return this.settleWithoutResult(reserved.record, 'cancelled');
-        }
-
-        const deadlineController = new AbortController();
-        const deadline = setTimeout(() => {
-          const error = new Error(DelegationPolicyService.message('child_timeout'));
-          error.name = 'TimeoutError';
-          deadlineController.abort(error);
-        }, this.policy.maxChildDurationMs);
-        const signal = AbortSignal.any([
-          ownershipSignal,
-          deadlineController.signal,
-        ]);
-
-        try {
-          const result = await this.childRuntime.run({
-            record: reserved.record,
-            snapshot: reserved.snapshot,
-            signal,
-            onActivity: (activity) => this.publishChildActivity(reserved.record, activity),
-          });
-          return this.settleResult(
-            reserved.record,
-            result,
-            deadlineController.signal.aborted && !ownershipSignal.aborted,
-          );
-        } catch {
-          return this.settleWithoutResult(
-            reserved.record,
-            ownershipSignal.aborted
-              ? 'cancelled'
-              : deadlineController.signal.aborted ? 'child_timeout' : 'child_failed',
-          );
-        } finally {
-          clearTimeout(deadline);
-        }
-      });
+      const runWithinGlobalLimit = async () => await this.semaphore.runExclusive(
+        async () => await this.runReservedChild(reserved, ownershipSignal),
+      );
+      return DelegationChildRuntimeService.isActionProfile(
+        reserved.snapshot.agentProfileId as DelegationAgentProfileId,
+      )
+        ? await this.actionSemaphore.runExclusive(runWithinGlobalLimit)
+        : await runWithinGlobalLimit();
     } finally {
       this.childControllers.delete(reserved.record.childRunId);
+    }
+  }
+
+  private async runReservedChild(
+    reserved: ReservedChild,
+    ownershipSignal: AbortSignal,
+  ): Promise<ToolResult> {
+    if (ownershipSignal.aborted) {
+      return this.settleWithoutResult(reserved.record, 'cancelled');
+    }
+
+    const deadlineController = new AbortController();
+    const deadline = setTimeout(() => {
+      const error = new Error(DelegationPolicyService.message('child_timeout'));
+      error.name = 'TimeoutError';
+      deadlineController.abort(error);
+    }, this.policy.maxChildDurationMs);
+    const signal = AbortSignal.any([
+      ownershipSignal,
+      deadlineController.signal,
+    ]);
+
+    try {
+      const result = await this.childRuntime.run({
+        record: reserved.record,
+        snapshot: reserved.snapshot,
+        signal,
+        onActivity: (activity) => this.publishChildActivity(reserved.record, activity),
+      });
+      return this.settleResult(
+        reserved.record,
+        result,
+        deadlineController.signal.aborted && !ownershipSignal.aborted,
+      );
+    } catch {
+      return this.settleWithoutResult(
+        reserved.record,
+        ownershipSignal.aborted
+          ? 'cancelled'
+          : deadlineController.signal.aborted ? 'child_timeout' : 'child_failed',
+      );
+    } finally {
+      clearTimeout(deadline);
     }
   }
 

--- a/src/core/delegation/types.ts
+++ b/src/core/delegation/types.ts
@@ -1,4 +1,5 @@
 import type { Logger } from 'pino';
+import type { ToolApprovalPolicy } from '@/core/approvals/index.js';
 import type { CustomAgentExecutionSnapshot } from '@/core/custom-agents/index.js';
 import type {
   LlmAdapter,
@@ -7,6 +8,7 @@ import type {
   ReasoningEffort,
 } from '@/core/llm/types.js';
 import type { RuntimeProviderCredential } from '@/core/runtime/credentials/index.js';
+import type { RunAgentLoopOptions } from '@/core/runtime/loop/index.js';
 import type {
   ConversationDelegationActivity,
   ConversationDelegationErrorCode,
@@ -14,11 +16,12 @@ import type {
 import type {
   RunFailure,
   StopReason,
+  ToolDefinition,
   ToolExecutionContext,
   TraceEvent,
 } from '@/core/types.js';
 
-export type DelegationAgentProfileId = 'builtin:ask' | 'builtin:review';
+export type DelegationAgentProfileId = 'builtin:ask' | 'builtin:review' | 'builtin:code';
 
 export type DelegationPolicy = {
   readonly enabled: boolean;
@@ -147,7 +150,8 @@ export type DelegationChildLlmFactory = (
 
 /**
  * Root runtime facts inherited by every child. Snapshot model/reasoning
- * defaults do not override these values in read-only delegation v1.
+ * defaults do not override these values, and Code children cannot widen the
+ * root tool or permission ceilings.
  */
 export type DelegationChildRuntimeOptions = {
   model: string;
@@ -163,6 +167,12 @@ export type DelegationChildRuntimeOptions = {
   baseSystemContext?: string;
   logger?: Logger;
   createChildLlm?: DelegationChildLlmFactory;
+  /** Effective root tools. Action-capable children can never widen this ceiling. */
+  parentTools?: readonly ToolDefinition[];
+  /** Effective root approval chain, including the active permission mode. */
+  approvalPolicies?: readonly ToolApprovalPolicy[];
+  /** Existing host approval surface reused by action-capable children. */
+  approveToolCall?: RunAgentLoopOptions['approveToolCall'];
 };
 
 export type DelegationAgentSnapshotResolver = {

--- a/src/web-v2/i18n/locales/en-us.json
+++ b/src/web-v2/i18n/locales/en-us.json
@@ -27,7 +27,7 @@
     },
     "subagents": {
       "ariaLabel": "Subagents",
-      "description": "Let Heddle start read-only helpers when parallel research would be useful.",
+      "description": "Let Heddle start bounded helpers for parallel research or focused approved coding actions.",
       "disabled": "Off for upcoming messages",
       "enabled": "On for upcoming messages",
       "title": "Subagents"

--- a/src/web-v2/i18n/locales/zh-cn.json
+++ b/src/web-v2/i18n/locales/zh-cn.json
@@ -27,7 +27,7 @@
     },
     "subagents": {
       "ariaLabel": "子代理",
-      "description": "当并行研究有帮助时，允许 Heddle 启动只读助手。",
+      "description": "允许 Heddle 启动受限助手，进行并行研究或经批准的聚焦代码操作。",
       "disabled": "后续消息关闭",
       "enabled": "后续消息开启",
       "title": "子代理"

--- a/src/web-v2/i18n/locales/zh-tw.json
+++ b/src/web-v2/i18n/locales/zh-tw.json
@@ -27,7 +27,7 @@
     },
     "subagents": {
       "ariaLabel": "子代理",
-      "description": "當平行研究有幫助時，允許 Heddle 啟動唯讀助手。",
+      "description": "允許 Heddle 啟動受限助手，進行平行研究或經核准的聚焦程式碼操作。",
       "disabled": "後續訊息關閉",
       "enabled": "後續訊息開啟",
       "title": "子代理"


### PR DESCRIPTION
## Summary

- let the root agent explicitly grant a child the built-in Code profile while Ask and Review remain read-only
- intersect the child action catalog with the effective root tools and reuse the existing root permission policy and approval surface
- serialize action-capable children, preserve one-level delegation, and keep memory, browser, MCP, artifact, skill, and recursive delegation tools unavailable
- document the authority model and update terminal/web copy, including a dogfood-found live Code label fix

## Verification

- yarn typecheck
- yarn eslint
- yarn test: 142 unit files / 920 tests and 49 integration files / 436 tests
- yarn client:build
- focused client projection test: 5 tests
- terminal dogfood with GPT-5.5: Code child requested approval, created and verified the exact file, and settled visibly
- web dogfood with GPT-5.6 Terra: Code child requested approval, created and verified the exact file, and settled visibly
- verified both smoke files byte-for-byte, then removed all temporary files, credentials, sessions, and traces from the worktree