### PR TITLE
Acquire request-scoped OAuth credentials

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -56,6 +56,12 @@ reimplementing callback buffering or terminal sequencing. Scheduling, task
 persistence, and deployment-specific model/tool/MCP preparation stay outside
 the service.
 
+`RuntimeCredentialService.acquireRequestScopedCredentialForModel` lets a Node
+host reuse its Heddle OpenAI account login safely across an isolation boundary.
+Heddle refreshes and persists the stored credential at the host boundary, then
+returns only an access token, expiry, and optional account identifier. The
+refresh token must never be passed to an Execution Host.
+
 ## Does not own
 
 - the finished `heddle` command, TUI, daemon lifecycle, or built browser UI;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/runtime",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "Embeddable TypeScript and Node.js agent runtime and SDK for Heddle-powered products",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/src/__tests__/unit/core/runtime-credentials.test.ts
+++ b/src/__tests__/unit/core/runtime-credentials.test.ts
@@ -9,6 +9,7 @@ import { LlmProviderRuntimeService } from '@/core/runtime/provider-runtime/index
 describe('RuntimeCredentialService', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.useRealTimers();
   });
 
   it('does not fall back to OpenAI keys for Anthropic models', () => {
@@ -270,6 +271,146 @@ describe('RuntimeCredentialService', () => {
         expiresAt: credential.expiresAt,
       },
     });
+  });
+
+  it('projects a fresh stored OAuth credential without exposing refresh material', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-28T08:00:00.000Z'));
+    const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-runtime-request-credential-'));
+    const storePath = ProviderCredentialRepository.resolveStorePath(stateRoot);
+    new ProviderCredentialRepository({ storePath }).set({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'stored-access-token',
+      refreshToken: 'stored-refresh-token',
+      expiresAt: Date.parse('2026-08-28T09:00:00.000Z'),
+      accountId: 'account-123',
+      createdAt: '2026-08-28T07:00:00.000Z',
+      updatedAt: '2026-08-28T07:00:00.000Z',
+    });
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    const credential = await RuntimeCredentialService
+      .acquireRequestScopedCredentialForModel('gpt-5.4', {
+        stateRoot,
+        fetchImpl,
+      });
+
+    expect(credential).toEqual({
+      type: 'oauth-access-token',
+      provider: 'openai',
+      accessToken: 'stored-access-token',
+      expiresAt: Date.parse('2026-08-28T09:00:00.000Z'),
+      accountId: 'account-123',
+    });
+    expect(Object.keys(credential ?? {}).sort()).toEqual([
+      'accessToken',
+      'accountId',
+      'expiresAt',
+      'provider',
+      'type',
+    ]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('refreshes and persists a near-expiry credential before projecting it', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-28T08:00:00.000Z'));
+    const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-runtime-refresh-credential-')), 'auth.json');
+    const repository = new ProviderCredentialRepository({ storePath });
+    repository.set({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'old-access-token',
+      refreshToken: 'old-refresh-token',
+      expiresAt: Date.parse('2026-08-28T08:00:30.000Z'),
+      accountId: 'account-123',
+      createdAt: '2026-08-27T08:00:00.000Z',
+      updatedAt: '2026-08-27T08:00:00.000Z',
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+      expires_in: 3_600,
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const credential = await RuntimeCredentialService
+      .acquireRequestScopedCredentialForModel('gpt-5.4', {
+        storePath,
+        fetchImpl,
+      });
+
+    expect(credential).toMatchObject({
+      type: 'oauth-access-token',
+      provider: 'openai',
+      accessToken: 'new-access-token',
+      expiresAt: Date.parse('2026-08-28T09:00:00.000Z'),
+      accountId: 'account-123',
+    });
+    expect(repository.get('openai')).toMatchObject({
+      type: 'oauth',
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      accountId: 'account-123',
+      createdAt: '2026-08-27T08:00:00.000Z',
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('coalesces concurrent refreshes for the same credential store', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-28T08:00:00.000Z'));
+    const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-runtime-concurrent-refresh-')), 'auth.json');
+    new ProviderCredentialRepository({ storePath }).set({
+      type: 'oauth',
+      provider: 'openai',
+      accessToken: 'old-access-token',
+      refreshToken: 'old-refresh-token',
+      expiresAt: Date.parse('2026-08-28T08:00:30.000Z'),
+      createdAt: '2026-08-27T08:00:00.000Z',
+      updatedAt: '2026-08-27T08:00:00.000Z',
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+      expires_in: 3_600,
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const credentials = await Promise.all([
+      RuntimeCredentialService.acquireRequestScopedCredentialForModel(
+        'gpt-5.4',
+        { storePath, fetchImpl },
+      ),
+      RuntimeCredentialService.acquireRequestScopedCredentialForModel(
+        'gpt-5.4',
+        { storePath, fetchImpl },
+      ),
+    ]);
+
+    expect(credentials).toEqual([
+      expect.objectContaining({ accessToken: 'new-access-token' }),
+      expect.objectContaining({ accessToken: 'new-access-token' }),
+    ]);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('returns no request-scoped credential when the model has no stored OAuth login', async () => {
+    const storePath = join(mkdtempSync(join(tmpdir(), 'heddle-runtime-missing-credential-')), 'auth.json');
+
+    await expect(RuntimeCredentialService.acquireRequestScopedCredentialForModel(
+      'gpt-5.4',
+      { storePath },
+    )).resolves.toBeUndefined();
+    await expect(RuntimeCredentialService.acquireRequestScopedCredentialForModel(
+      'claude-sonnet-4-6',
+      { storePath },
+    )).resolves.toBeUndefined();
   });
 
   it('rejects ambiguous or provider-mismatched runtime credentials', () => {

--- a/src/core/auth/openai-oauth.ts
+++ b/src/core/auth/openai-oauth.ts
@@ -88,11 +88,12 @@ export class OpenAiOAuthService {
 
   static async refreshCredential(
     credential: OpenAiOAuthCredential,
-    options: { fetchImpl?: typeof fetch } = {},
+    options: { fetchImpl?: typeof fetch; signal?: AbortSignal } = {},
   ): Promise<OpenAiOAuthCredential> {
     const tokens = await OpenAiOAuthService.refreshToken({
       refreshToken: credential.refreshToken,
       fetchImpl: options.fetchImpl,
+      signal: options.signal,
     });
     return {
       ...OpenAiOAuthService.createCredential(tokens),

--- a/src/core/runtime/credentials/README.md
+++ b/src/core/runtime/credentials/README.md
@@ -23,6 +23,15 @@ Hosts must acquire request-scoped tokens outside Heddle and send them only over
 an authenticated transport. They remain responsible for tenant authorization,
 redaction, and re-authentication after expiry or process/browser refresh.
 
+Node hosts that use Heddle's credential store should call
+`RuntimeCredentialService.acquireRequestScopedCredentialForModel`. The service
+refreshes a near-expiry stored OpenAI credential at the host boundary, persists
+the refreshed credential, and returns only the access-token runtime shape. A
+refresh token must never cross into an isolated Execution Host.
+Pass the Heddle `stateRoot` when the host should use that root's canonical
+`auth.json`; `storePath` remains available for custom credential repositories
+and tests, and the two options are mutually exclusive.
+
 Do not combine `apiKey` and `credential` for one runtime. The ambiguity is
 rejected during resolution instead of relying on an implicit precedence rule.
 

--- a/src/core/runtime/credentials/service.ts
+++ b/src/core/runtime/credentials/service.ts
@@ -1,4 +1,7 @@
+import dayjs from 'dayjs';
+import { Mutex } from 'async-mutex';
 import {
+  OpenAiOAuthService,
   ProviderCredentialRepository,
   type StoredProviderCredential,
 } from '@/core/auth/index.js';
@@ -22,6 +25,7 @@ import type {
 export class RuntimeCredentialService {
   static readonly DEFAULT_OLLAMA_OPENAI_BASE_URL = 'http://127.0.0.1:11434/v1';
   static readonly DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
+  private static readonly requestCredentialMutexes = new Map<string, Mutex>();
 
   static resolveProviderApiKey(provider: LlmProvider): string | undefined {
     const compatibleProfile = OpenAiCompatibleProviderProfileService.maybeGet(provider);
@@ -59,6 +63,93 @@ export class RuntimeCredentialService {
     const provider = LlmAdapterService.inferProvider(model);
     const credential = new ProviderCredentialRepository({ storePath: options.storePath }).get(provider);
     return credential?.type === 'oauth' ? credential : undefined;
+  }
+
+  /**
+   * Acquires an access-token-only credential for an isolated runtime request.
+   *
+   * The host-side credential store retains refresh material. When the stored
+   * OpenAI credential is near expiry, Heddle refreshes and persists it before
+   * returning the non-persistable runtime shape. Callers must send only the
+   * returned value across their authenticated execution boundary.
+   */
+  static async acquireRequestScopedCredentialForModel(
+    model: string,
+    options: {
+      stateRoot?: string;
+      storePath?: string;
+      fetchImpl?: typeof fetch;
+      refreshBeforeMs?: number;
+      signal?: AbortSignal;
+    } = {},
+  ): Promise<RuntimeProviderCredential | undefined> {
+    const provider = LlmAdapterService.inferProvider(model);
+    if (provider !== 'openai') {
+      return undefined;
+    }
+    if (options.stateRoot && options.storePath) {
+      throw new Error('Provide either stateRoot or storePath for runtime credential acquisition, not both.');
+    }
+
+    const refreshBeforeMs = options.refreshBeforeMs ?? 60_000;
+    if (!Number.isFinite(refreshBeforeMs) || refreshBeforeMs < 0) {
+      throw new Error('Runtime credential refresh window must be a non-negative finite number of milliseconds.');
+    }
+    const storePath = options.storePath ?? ProviderCredentialRepository.resolveStorePath(
+      options.stateRoot,
+    );
+    const mutex = RuntimeCredentialService.resolveRequestCredentialMutex(storePath);
+
+    try {
+      return await mutex.runExclusive(async () => {
+        options.signal?.throwIfAborted();
+        const repository = new ProviderCredentialRepository({ storePath });
+        const stored = repository.get(provider);
+        if (stored?.type !== 'oauth') {
+          return undefined;
+        }
+
+        const credential = dayjs(stored.expiresAt).isAfter(
+          dayjs().add(refreshBeforeMs, 'millisecond'),
+        )
+          ? stored
+          : await OpenAiOAuthService.refreshCredential(stored, {
+              fetchImpl: options.fetchImpl,
+              signal: options.signal,
+            });
+        if (credential !== stored) {
+          repository.set(credential);
+        }
+        options.signal?.throwIfAborted();
+
+        return {
+          type: 'oauth-access-token',
+          provider: 'openai',
+          accessToken: credential.accessToken,
+          expiresAt: credential.expiresAt,
+          ...(credential.accountId ? { accountId: credential.accountId } : {}),
+        };
+      });
+    } finally {
+      if (
+        !mutex.isLocked()
+        && RuntimeCredentialService.requestCredentialMutexes.get(storePath)
+          === mutex
+      ) {
+        RuntimeCredentialService.requestCredentialMutexes.delete(storePath);
+      }
+    }
+  }
+
+  private static resolveRequestCredentialMutex(storePath: string): Mutex {
+    const existing = RuntimeCredentialService.requestCredentialMutexes.get(storePath);
+    if (existing) {
+      return existing;
+    }
+
+    const mutex = new Mutex();
+    RuntimeCredentialService.requestCredentialMutexes.set(storePath, mutex);
+    return mutex;
   }
 
   static hasCredentialForModel(


### PR DESCRIPTION
## Summary

- add a Runtime credential service boundary that refreshes and persists a stored OpenAI login before isolated execution
- return only the access token, expiry, and optional account identifier; refresh material remains in the host process
- coalesce concurrent refreshes per credential store, propagate cancellation, document the boundary, and bump @heddleagent/runtime to 6.7.0

## Validation

- full Heddle unit and integration suite: 142 files, 925 tests passed
- focused runtime credential suite: 18 tests passed
- yarn typecheck
- yarn eslint
- runtime package build and pack