### PR TITLE
Prepare Runtime 6.7.0 release

### DIFF
--- a/docs/releases/runtime-v6.7.0.md
+++ b/docs/releases/runtime-v6.7.0.md
@@ -1,0 +1,38 @@
+# `@heddleagent/runtime` 6.7.0
+
+This release lets adopter backends reuse an existing Heddle OpenAI/Codex
+account login across an authenticated execution boundary without giving the
+isolated Runtime any OAuth refresh material.
+
+## What changed
+
+- add `RuntimeCredentialService.acquireRequestScopedCredentialForModel` for
+  OpenAI-backed models;
+- resolve the canonical credential store from a Heddle `stateRoot`, while
+  retaining an explicit `storePath` option for custom repositories and tests;
+- refresh near-expiry OAuth credentials at the host boundary, serialize
+  concurrent refreshes per credential store, and persist the refreshed account
+  credential before returning; and
+- return only the request-scoped access token, expiry, and optional account
+  identifier. Refresh tokens never enter the returned Runtime shape.
+
+The method accepts an abort signal and configurable refresh window so a host can
+acquire a credential that remains valid for its bounded invocation rather than
+discovering expiry after work has started.
+
+## Upgrade note
+
+Adopter backends that already use Heddle's credential store can replace custom
+OAuth-file parsing or refresh logic with the new service. Keep API-key and
+OAuth credential paths explicit: this API returns `undefined` for unsupported
+providers or a store without a compatible OpenAI account login.
+
+The host remains responsible for authenticating and authorizing the invocation,
+redacting credentials, and sending the returned access-token-only shape over a
+trusted transport.
+
+## Verification
+
+Credential tests cover valid reuse, refresh and persistence, concurrent
+acquisition, abort handling, invalid refresh windows, and missing or
+incompatible credentials.


### PR DESCRIPTION
## Summary

- document the Runtime 6.7.0 credential-service release
- record the host-owned OAuth refresh and persistence boundary
- make the access-token-only Runtime contract explicit

## Validation

- `yarn install --frozen-lockfile`
- `yarn build`
- `yarn test` (925 unit and 436 integration tests)
- `npm pack ./packages/runtime --dry-run`
- `git diff --check`

This PR prepares the release documentation only. It does not publish the npm package.
