### PR TITLE
feat(heartbeat): add scoped durable admission

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -100,7 +100,8 @@ Custom stores implement this protocol through `HeartbeatTaskStore`:
 - `subscribeToRunRequests` optionally wakes a scheduler in the same process; polling remains the cross-process fallback
 - `claimTaskExecution` atomically rechecks task eligibility plus durable
   namespace/optional-group admission and establishes the current `executionId`
-  fencing token
+  fencing token; exact recovery mode also matches and consumes its durable
+  interrupted-execution marker
 - `completeTaskExecution`, `failTaskExecution`, and `recordTaskExecutionOutcome` project from the latest stored task and reject a stale token with `claim-lost`
 - `recoverInterruptedTasks` records the interrupted execution and makes only eligible tasks retryable
 
@@ -251,9 +252,10 @@ The method deliberately does **not** start a polling loop, subscribe to
 run-request notifications, perform a global task scan, or run interrupted-task
 recovery. Its final `due` claim rechecks durable enabled/running/schedule state,
 so a stale queue delivery cannot bypass an operator change between lookup and
-claim. That claim also rechecks durable namespace and optional group admission;
-a dispatcher precheck cannot replace it. A duplicate at-least-once delivery is arbitrated by that same claim, but
-hosts must still make their own domain side effects idempotent.
+claim. That fresh claim also rechecks durable namespace and optional group
+admission; a dispatcher precheck cannot replace it. A duplicate at-least-once
+delivery is arbitrated by that same claim, but hosts must still make their own
+domain side effects idempotent.
 
 For a long-lived single-host scheduler, `runLoop()` performs one startup
 recovery pass because it owns that process lifecycle. An ephemeral worker must
@@ -303,7 +305,9 @@ The optional `isAdmissionEnabled` callback is a fail-closed process-local
 precheck that can reduce unnecessary polling or invocation. It is not the
 admission authority because it can race with a claim. The store's final atomic
 claim is authoritative. `host.pause()` also has different semantics: it cancels
-locally active work, while closing durable admission prevents new claims only.
+locally active work, while closing durable admission blocks fresh logical work.
+An exact recovery continuation may still run through closed admission; use
+pause/drain/cancel when no execution may proceed.
 
 This host is intentionally for low-volume single-process admission. It is not a
 distributed queue, leader election service, or cross-replica concurrency limit.
@@ -342,11 +346,15 @@ for (const scenario of HeartbeatTaskStoreConformance.createScenarios(harness)) {
 }
 ```
 
-The required scenarios verify direct lookup, shared-backend round trips,
+The baseline scenarios verify direct lookup, shared-backend round trips,
 idempotent writes, request coalescing, atomic due claims, competing workers,
-claim-fenced success/failure/skip/cancellation, explicit recovery,
-close-vs-claim linearization, fail-closed assigned groups, and unrelated-group
-progress. The
+claim-fenced success/failure/skip/cancellation, and explicit recovery.
+`createAdmissionControl` is optional so an existing namespace-only harness
+remains source-compatible, but supplying it additionally verifies
+close-vs-claim linearization, active-claim survival, fail-closed assigned
+groups, exact crash recovery through closed scopes, stale-ID rejection,
+newer-request preservation, and unrelated-group progress. A harness that omits
+the port is not scoped-admission proof. The
 `makeExecutionRecoverable` hook is test-fixture authority: lease-backed stores
 expire a fixture lease there; it does not add recovery authority to production
 workers. Run-request subscriptions and history readback are checked only when
@@ -427,19 +435,33 @@ await admission.setAdmissionDecision(
 );
 ```
 
-The final claim requires the task to be enabled and eligible, namespace
-admission to be `ready`, and the assigned group (when present) to be `ready`.
+Fresh `due` and explicit `any` claims require the task to be enabled and
+eligible, namespace admission to be `ready`, and the assigned group (when
+present) to be `ready`.
 An absent namespace decision defaults to `ready`, preserving existing
 namespace-only tasks. An absent assigned-group decision defaults to `closed`,
 so a partially reconciled grouped task cannot run. Ungrouped tasks never infer
 membership from their ID or product data.
 
-Closing a target affects new claims only. It does not disable a task, change
-its due time, consume a run request, modify its checkpoint, cancel an active
-execution, or drain a worker. Those are separate explicit operations. Heddle
-does not model hosted desired state, preparing/blocked phases, transition IDs,
-retry timing, restart orchestration, or product cursor preparation; a hosted
-adapter owns that lifecycle and projects only `ready | closed` into this port.
+Group IDs are opaque, non-empty identity strings. Heddle does not canonicalize
+them: task fields, admission targets, and durable admission-map keys reject
+leading or trailing whitespace so visually similar identities cannot diverge.
+
+Closing a target affects fresh logical claims only. It does not disable a task,
+change its due time, consume a run request, modify its checkpoint, cancel an
+active execution, or drain a worker. An exact `claimMode: 'recovery'`
+continuation may bypass both closed scopes only when
+`recoveryOfExecutionId` matches the current durable pending marker. The atomic
+replacement consumes that marker once, preserves the interrupted run-request
+correlation, and leaves any newer request pending. Stale IDs, already-consumed
+markers, and recovery records from older versions without an explicit pending
+marker do not authorize bypass. Scheduler and targeted-worker paths select
+this mode only from the durable task marker created by
+`recoverInterruptedTasks`; explicit run-now never does. Use host pause, drain,
+or cancellation when no execution may proceed. Heddle does not model hosted
+desired state, preparing/blocked phases, transition IDs, retry timing, restart
+orchestration, or product cursor preparation; a hosted adapter owns that
+lifecycle and projects only `ready | closed` into this port.
 
 ### Durable event-driven run requests
 

--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -98,7 +98,9 @@ Custom stores implement this protocol through `HeartbeatTaskStore`:
 
 - `requestTaskRun` persists a monotonically distinguishable, level-triggered run request
 - `subscribeToRunRequests` optionally wakes a scheduler in the same process; polling remains the cross-process fallback
-- `claimTaskExecution` atomically establishes the current `executionId` fencing token
+- `claimTaskExecution` atomically rechecks task eligibility plus durable
+  namespace/optional-group admission and establishes the current `executionId`
+  fencing token
 - `completeTaskExecution`, `failTaskExecution`, and `recordTaskExecutionOutcome` project from the latest stored task and reject a stale token with `claim-lost`
 - `recoverInterruptedTasks` records the interrupted execution and makes only eligible tasks retryable
 
@@ -139,7 +141,7 @@ heartbeat store. Passing a remote task store moves only Heddle heartbeat task,
 checkpoint, and run persistence. It does not move or replace the host's product
 or domain database.
 
-A production remote adapter must make claims and fenced writes atomic, recover
+A production remote adapter must make claims, admission changes, and fenced writes atomic, recover
 only executions whose lease or owner is no longer live, and route run-request
 notifications to the scheduler process that can act on them.
 `subscribeToRunRequests` is an optional low-latency hint: if an adapter cannot
@@ -239,6 +241,8 @@ The result is typed so the dispatcher can make an explicit decision:
 - `retry`: a custom handler rejected its completed nested agent result and durably scheduled the bounded retry it requested.
 - `failed`: the task ran and entered the normal heartbeat failure/retry state.
 - `not-found`, `disabled`, or `not-due`: this delivery has no currently eligible work.
+- `admission-closed`: the namespace or assigned group currently rejects new
+  claims; the result includes that blocking target.
 - `busy`: another execution currently owns the task.
 - `claim-lost`: the worker lost ownership before final persistence; do not treat it as success.
 - `cancelled`: the worker was aborted before or during its attempt; a post-claim cancellation may include its durable record.
@@ -247,7 +251,8 @@ The method deliberately does **not** start a polling loop, subscribe to
 run-request notifications, perform a global task scan, or run interrupted-task
 recovery. Its final `due` claim rechecks durable enabled/running/schedule state,
 so a stale queue delivery cannot bypass an operator change between lookup and
-claim. A duplicate at-least-once delivery is arbitrated by that same claim, but
+claim. That claim also rechecks durable namespace and optional group admission;
+a dispatcher precheck cannot replace it. A duplicate at-least-once delivery is arbitrated by that same claim, but
 hosts must still make their own domain side effects idempotent.
 
 For a long-lived single-host scheduler, `runLoop()` performs one startup
@@ -281,7 +286,7 @@ const host = new HeartbeatTargetedTaskHost({
   recoveryIntervalMs: 30_000,
   invocationTimeoutMs: 15 * 60_000,
   maxConcurrentInvocations: 1,
-  isAdmissionEnabled: readDurableProductGate,
+  isAdmissionEnabled: readBestEffortDispatchPrecheck,
 });
 
 host.start({ handler, admissionEnabled: true });
@@ -291,7 +296,14 @@ The store must already be scoped to the task or tenant namespace this process
 may execute. An optional `taskIdPrefix` is defense in depth, not authorization.
 Notifications are latency hints; polling durable state is the correctness path.
 Only `busy` and `claim-lost` receive short delivery retries. Normal Heddle retry,
-failure, not-due, and cancellation results wait for their persisted schedule.
+failure, not-due, admission-closed, and cancellation results wait for their
+persisted schedule.
+
+The optional `isAdmissionEnabled` callback is a fail-closed process-local
+precheck that can reduce unnecessary polling or invocation. It is not the
+admission authority because it can race with a claim. The store's final atomic
+claim is authoritative. `host.pause()` also has different semantics: it cancels
+locally active work, while closing durable admission prevents new claims only.
 
 This host is intentionally for low-volume single-process admission. It is not a
 distributed queue, leader election service, or cross-replica concurrency limit.
@@ -313,6 +325,7 @@ import {
 
 const harness: HeartbeatTaskStoreConformanceHarness = {
   createStore: async (namespace) => createRemoteHeartbeatStore({ namespace }),
+  createAdmissionControl: async (namespace) => createRemoteHeartbeatAdmissionControl({ namespace }),
   cleanupNamespace: async (namespace) => deleteRemoteHeartbeatFixture(namespace),
   now: () => new Date('2026-08-08T00:00:00.000Z'),
   makeExecutionRecoverable: async ({ namespace, execution, recoverAt }) => {
@@ -331,7 +344,9 @@ for (const scenario of HeartbeatTaskStoreConformance.createScenarios(harness)) {
 
 The required scenarios verify direct lookup, shared-backend round trips,
 idempotent writes, request coalescing, atomic due claims, competing workers,
-claim-fenced success/failure/skip/cancellation, and explicit recovery. The
+claim-fenced success/failure/skip/cancellation, explicit recovery,
+close-vs-claim linearization, fail-closed assigned groups, and unrelated-group
+progress. The
 `makeExecutionRecoverable` hook is test-fixture authority: lease-backed stores
 expire a fixture lease there; it does not add recovery authority to production
 workers. Run-request subscriptions and history readback are checked only when
@@ -377,6 +392,54 @@ The administration contract is separate from `HeartbeatTargetedTaskStore` so
 execution adapters do not accidentally promise a control plane. One concrete
 class may implement both when it can uphold both atomicity contracts, as the
 built-in file service does for one Node.js process.
+
+### Scoped durable admission
+
+Use `HeartbeatTaskAdmissionControl` as the provider-neutral control boundary
+for new-claim admission. It exposes one namespace-wide emergency circuit
+breaker and one optional opaque `admissionGroupId` per task:
+
+```ts
+import type {
+  HeartbeatTaskAdministrationService,
+  HeartbeatTaskAdmissionControl,
+} from '@heddleagent/runtime/advanced';
+
+declare const tasks: HeartbeatTaskAdministrationService;
+declare const admission: HeartbeatTaskAdmissionControl;
+
+await admission.setAdmissionDecision(
+  { kind: 'group', groupId: 'publisher-a' },
+  'closed',
+);
+
+await tasks.createTask({
+  id: 'publisher-a-digest',
+  admissionGroupId: 'publisher-a',
+  task: 'Process the configured publisher work.',
+  intervalMs: 60_000,
+});
+
+// After any product-owned resume preparation commits successfully:
+await admission.setAdmissionDecision(
+  { kind: 'group', groupId: 'publisher-a' },
+  'ready',
+);
+```
+
+The final claim requires the task to be enabled and eligible, namespace
+admission to be `ready`, and the assigned group (when present) to be `ready`.
+An absent namespace decision defaults to `ready`, preserving existing
+namespace-only tasks. An absent assigned-group decision defaults to `closed`,
+so a partially reconciled grouped task cannot run. Ungrouped tasks never infer
+membership from their ID or product data.
+
+Closing a target affects new claims only. It does not disable a task, change
+its due time, consume a run request, modify its checkpoint, cancel an active
+execution, or drain a worker. Those are separate explicit operations. Heddle
+does not model hosted desired state, preparing/blocked phases, transition IDs,
+retry timing, restart orchestration, or product cursor preparation; a hosted
+adapter owns that lifecycle and projects only `ready | closed` into this port.
 
 ### Durable event-driven run requests
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,1 +1,29 @@
 # Unreleased
+
+## Planned `@heddleagent/runtime` 7.0.0
+
+- Add final atomic heartbeat claim admission for the store namespace plus one
+  optional opaque `HeartbeatTask.admissionGroupId`.
+- Add the separate `HeartbeatTaskAdmissionControl` binary `ready | closed`
+  port and return `admission-closed` with the blocking target from claim and
+  targeted-run results.
+- Preserve namespace-only tasks, while missing state for an explicitly assigned
+  group fails closed.
+- Add exact `recovery` claim mode for the current durable interrupted-execution
+  marker. It bypasses closed admission only as a single-use continuation of
+  already-admitted logical work, fences the interrupted execution, and leaves
+  newer run requests pending. Stale IDs and legacy diagnostic recovery records
+  cannot authorize the bypass.
+
+### Upgrade note
+
+This is planned as a Runtime major because `HeartbeatTaskClaimResult`,
+`HeartbeatTaskExecutionResult`, and `RunHeartbeatTaskResult` gain the public
+`admission-closed` discriminant. Exhaustive TypeScript consumers must handle
+that status. Existing task records need no migration when they do not set
+`admissionGroupId`.
+
+The adapter conformance harness keeps `createAdmissionControl` optional for
+source compatibility. Supplying it is required to run and claim
+scoped-admission conformance; omitting it certifies only the legacy
+namespace-only store contract.

--- a/src/__tests__/integration/core/heartbeat-scheduler.test.ts
+++ b/src/__tests__/integration/core/heartbeat-scheduler.test.ts
@@ -470,6 +470,7 @@ describe('heartbeat scheduler', () => {
     const checkpoint = createHeartbeatResult('pause').checkpoint;
     const task: HeartbeatTask = {
       id: 'retry-me',
+      admissionGroupId: 'recovery-group',
       task: 'Retry after restart.',
       enabled: true,
       schedule: { intervalMs: 60_000 },
@@ -485,6 +486,8 @@ describe('heartbeat scheduler', () => {
     };
     await store.saveTask(task);
     await store.saveCheckpoint(task, checkpoint);
+    await store.setAdmissionDecision({ kind: 'group', groupId: 'recovery-group' }, 'closed');
+    await store.setAdmissionDecision({ kind: 'namespace' }, 'closed');
     const controller = new AbortController();
     const events: HeartbeatSchedulerEvent[] = [];
     let runnerCalls = 0;
@@ -519,6 +522,14 @@ describe('heartbeat scheduler', () => {
       type: 'heartbeat.task.recovered',
       interruptedExecutionId: 'interrupted-execution',
       interruptedOwnerId: 'interrupted-worker',
+    });
+    await expect(store.loadTask(task.id)).resolves.toMatchObject({
+      state: {
+        recovery: {
+          interruptedExecutionId: 'interrupted-execution',
+          replacementExecutionId: expect.any(String),
+        },
+      },
     });
     await expect(store.listRunRecords()).resolves.toHaveLength(1);
   });
@@ -594,8 +605,21 @@ describe('heartbeat scheduler', () => {
       execution: replacementExecution,
       loadedCheckpoint: false,
       claimedAt: NOW,
+      claimMode: 'recovery',
+      recoveryOfExecutionId: originalExecution.executionId,
     });
     expect(replacementClaim.status).toBe('claimed');
+    expect(replacementClaim).toMatchObject({
+      status: 'claimed',
+      task: {
+        state: {
+          recovery: {
+            replacementStatus: 'claimed',
+            replacementExecutionId: replacementExecution.executionId,
+          },
+        },
+      },
+    });
 
     const lateResult = createHeartbeatResult('continue');
     await expect(store.completeTaskExecution({

--- a/src/__tests__/integration/core/heartbeat-targeted-dispatcher.test.ts
+++ b/src/__tests__/integration/core/heartbeat-targeted-dispatcher.test.ts
@@ -157,7 +157,7 @@ describe('targeted heartbeat task dispatcher', () => {
     expect(outcomes).toEqual(['busy', 'not-found']);
     expect(resolveHeartbeatTargetedTaskDispatchDecision('claim-lost', 25))
       .toEqual({ kind: 'retry-transiently', delayMs: 25 });
-    for (const status of ['retry', 'failed', 'not-due', 'cancelled'] as const) {
+    for (const status of ['retry', 'failed', 'not-due', 'admission-closed', 'cancelled'] as const) {
       expect(resolveHeartbeatTargetedTaskDispatchDecision(status, 25))
         .toEqual({ kind: 'wait-for-durable-schedule' });
     }

--- a/src/__tests__/integration/core/heartbeat-targeted-execution.test.ts
+++ b/src/__tests__/integration/core/heartbeat-targeted-execution.test.ts
@@ -172,6 +172,42 @@ describe('targeted heartbeat execution', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('returns the durable blocking admission target without invoking the handler', async () => {
+    const store = createStore('admission-closed');
+    const task = { ...createTask('grouped-task'), admissionGroupId: 'publisher-a' };
+    await store.saveTask(task);
+    const handler = vi.fn(async (context) => context.skip({ summary: 'Unexpected handler invocation.' }));
+
+    await expect(HeartbeatSchedulerService.runTask({
+      store,
+      taskId: task.id,
+      executionOwnerId: 'missing-group',
+      now: () => NOW,
+      handler,
+    })).resolves.toEqual({
+      status: 'admission-closed',
+      taskId: task.id,
+      target: { kind: 'group', groupId: 'publisher-a' },
+      failed: false,
+    });
+
+    await store.setAdmissionDecision({ kind: 'group', groupId: 'publisher-a' }, 'ready');
+    await store.setAdmissionDecision({ kind: 'namespace' }, 'closed');
+    await expect(HeartbeatSchedulerService.runTask({
+      store,
+      taskId: task.id,
+      executionOwnerId: 'closed-namespace',
+      now: () => NOW,
+      handler,
+    })).resolves.toEqual({
+      status: 'admission-closed',
+      taskId: task.id,
+      target: { kind: 'namespace' },
+      failed: false,
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it('returns normal failures and claim loss as distinct targeted outcomes', async () => {
     const failureStore = createStore('failure');
     const failureTask = createTask('failure-task');

--- a/src/__tests__/integration/core/heartbeat-task-store-conformance.test.ts
+++ b/src/__tests__/integration/core/heartbeat-task-store-conformance.test.ts
@@ -26,6 +26,7 @@ describe('HeartbeatTaskStoreConformance', () => {
 
   const harness: HeartbeatTaskStoreConformanceHarness = {
     createStore: (namespace) => new FileHeartbeatTaskService({ dir: join(root, namespace) }),
+    createAdmissionControl: (namespace) => new FileHeartbeatTaskService({ dir: join(root, namespace) }),
     cleanupNamespace: async (namespace) => await rm(join(root, namespace), { recursive: true, force: true }),
     now: () => new Date('2026-08-08T00:00:00.000Z'),
     makeExecutionRecoverable: async ({ store, task, execution }) => {
@@ -39,9 +40,9 @@ describe('HeartbeatTaskStoreConformance', () => {
 
   const scenarios = HeartbeatTaskStoreConformance.createScenarios(harness);
 
-  it('publishes seven uniquely named scenarios', () => {
-    expect(scenarios).toHaveLength(7);
-    expect(new Set(scenarios.map((scenario) => scenario.name)).size).toBe(7);
+  it('publishes eight uniquely named scenarios', () => {
+    expect(scenarios).toHaveLength(8);
+    expect(new Set(scenarios.map((scenario) => scenario.name)).size).toBe(8);
   });
 
   it.each(scenarios)('$name', async ({ run }) => {
@@ -50,10 +51,8 @@ describe('HeartbeatTaskStoreConformance', () => {
 
   it('rejects an adapter that ignores atomic due-claim eligibility', async () => {
     const brokenHarness: HeartbeatTaskStoreConformanceHarness = {
+      ...harness,
       createStore: async (namespace) => ignoreDueClaimMode(await harness.createStore(namespace)),
-      cleanupNamespace: harness.cleanupNamespace,
-      now: harness.now,
-      makeExecutionRecoverable: harness.makeExecutionRecoverable,
     };
     const targetedScenario = HeartbeatTaskStoreConformance.createScenarios(brokenHarness)
       .find((scenario) => scenario.name.includes('due claims'));
@@ -64,10 +63,8 @@ describe('HeartbeatTaskStoreConformance', () => {
 
   it('rejects an adapter that accepts stale settlement writes', async () => {
     const brokenHarness: HeartbeatTaskStoreConformanceHarness = {
+      ...harness,
       createStore: async (namespace) => ignoreExecutionFencing(await harness.createStore(namespace)),
-      cleanupNamespace: harness.cleanupNamespace,
-      now: harness.now,
-      makeExecutionRecoverable: harness.makeExecutionRecoverable,
     };
     const recoveryScenario = HeartbeatTaskStoreConformance.createScenarios(brokenHarness)
       .find((scenario) => scenario.name.includes('stale settlement'));
@@ -78,16 +75,26 @@ describe('HeartbeatTaskStoreConformance', () => {
 
   it('rejects an adapter that reports success without atomically persisting settlement', async () => {
     const brokenHarness: HeartbeatTaskStoreConformanceHarness = {
+      ...harness,
       createStore: async (namespace) => discardSuccessfulSettlement(await harness.createStore(namespace)),
-      cleanupNamespace: harness.cleanupNamespace,
-      now: harness.now,
-      makeExecutionRecoverable: harness.makeExecutionRecoverable,
     };
     const settlementScenario = HeartbeatTaskStoreConformance.createScenarios(brokenHarness)
       .find((scenario) => scenario.name.includes('settle atomically'));
 
     expect(settlementScenario).toBeDefined();
     await expect(settlementScenario?.run()).rejects.toBeInstanceOf(HeartbeatTaskStoreConformanceError);
+  });
+
+  it('rejects an adapter that ignores assigned admission groups', async () => {
+    const brokenHarness: HeartbeatTaskStoreConformanceHarness = {
+      ...harness,
+      createStore: async (namespace) => discardAdmissionGroup(await harness.createStore(namespace)),
+    };
+    const admissionScenario = HeartbeatTaskStoreConformance.createScenarios(brokenHarness)
+      .find((scenario) => scenario.name.includes('admission changes linearize'));
+
+    expect(admissionScenario).toBeDefined();
+    await expect(admissionScenario?.run()).rejects.toBeInstanceOf(HeartbeatTaskStoreConformanceError);
   });
 });
 
@@ -141,6 +148,22 @@ function discardSuccessfulSettlement(store: HeartbeatTargetedTaskStore): Heartbe
               loadedCheckpoint: input.loadedCheckpoint,
             },
           } as const;
+        };
+      }
+      const value = Reflect.get(target, property, target) as unknown;
+      return typeof value === 'function' ? value.bind(target) as unknown : value;
+    },
+  });
+}
+
+function discardAdmissionGroup(store: HeartbeatTargetedTaskStore): HeartbeatTargetedTaskStore {
+  return new Proxy(store, {
+    get(target, property) {
+      if (property === 'saveTask') {
+        return async (task: Parameters<HeartbeatTargetedTaskStore['saveTask']>[0]) => {
+          const ungrouped = { ...task };
+          delete ungrouped.admissionGroupId;
+          await target.saveTask(ungrouped);
         };
       }
       const value = Reflect.get(target, property, target) as unknown;

--- a/src/__tests__/integration/core/heartbeat-task-store-conformance.test.ts
+++ b/src/__tests__/integration/core/heartbeat-task-store-conformance.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -43,6 +43,20 @@ describe('HeartbeatTaskStoreConformance', () => {
   it('publishes eight uniquely named scenarios', () => {
     expect(scenarios).toHaveLength(8);
     expect(new Set(scenarios.map((scenario) => scenario.name)).size).toBe(8);
+  });
+
+  it('keeps the harness source-compatible for legacy namespace-only adapters', () => {
+    const legacyHarness: HeartbeatTaskStoreConformanceHarness = {
+      createStore: harness.createStore,
+      cleanupNamespace: harness.cleanupNamespace,
+      now: harness.now,
+      makeExecutionRecoverable: harness.makeExecutionRecoverable,
+      capabilities: harness.capabilities,
+    };
+    const legacyScenarios = HeartbeatTaskStoreConformance.createScenarios(legacyHarness);
+
+    expect(legacyScenarios).toHaveLength(7);
+    expect(legacyScenarios.some((scenario) => scenario.name.includes('admission changes linearize'))).toBe(false);
   });
 
   it.each(scenarios)('$name', async ({ run }) => {
@@ -95,6 +109,32 @@ describe('HeartbeatTaskStoreConformance', () => {
 
     expect(admissionScenario).toBeDefined();
     await expect(admissionScenario?.run()).rejects.toBeInstanceOf(HeartbeatTaskStoreConformanceError);
+  });
+
+  it('rejects non-canonical group targets and durable admission keys', async () => {
+    const namespace = 'non-canonical-admission-group';
+    const store = await harness.createStore(namespace);
+    await store.saveTask({
+      id: 'identity-fixture',
+      task: 'Validate admission identity.',
+      enabled: true,
+      schedule: { intervalMs: 60_000 },
+    });
+    const admission = await harness.createAdmissionControl?.(namespace);
+    if (!admission) {
+      throw new Error('Expected the file conformance harness to expose admission control.');
+    }
+    await expect(admission.setAdmissionDecision(
+      { kind: 'group', groupId: ' publisher-a ' },
+      'ready',
+    )).rejects.toThrow(/leading or trailing whitespace/i);
+
+    await writeFile(
+      join(root, namespace, 'admission.json'),
+      JSON.stringify({ version: 1, groups: { ' publisher-a ': 'ready' } }),
+    );
+    await expect(admission.readAdmissionDecision({ kind: 'group', groupId: 'publisher-a' }))
+      .rejects.toThrow();
   });
 });
 

--- a/src/__tests__/unit/core/heartbeat-task-control-policy.test.ts
+++ b/src/__tests__/unit/core/heartbeat-task-control-policy.test.ts
@@ -49,6 +49,11 @@ describe('HeartbeatTaskControlPolicy', () => {
       existingTasks: [],
       now: NOW,
     })).toThrow(/group id cannot be blank/i);
+    expect(() => HeartbeatTaskControlPolicy.createTask({
+      input: { task: 'Non-canonical group.', admissionGroupId: ' publisher-a ' },
+      existingTasks: [],
+      now: NOW,
+    })).toThrow(/leading or trailing whitespace/i);
   });
 
   it('updates the latest running task without erasing its claim or pending request', () => {

--- a/src/__tests__/unit/core/heartbeat-task-control-policy.test.ts
+++ b/src/__tests__/unit/core/heartbeat-task-control-policy.test.ts
@@ -3,6 +3,7 @@ import {
   FileHeartbeatTaskService,
   HeartbeatTaskControlPolicy,
   type HeartbeatTask,
+  type HeartbeatTaskAdmissionControl,
   type HeartbeatTaskAdministrationService,
 } from '../../../advanced.js';
 
@@ -13,6 +14,7 @@ describe('HeartbeatTaskControlPolicy', () => {
     const task = HeartbeatTaskControlPolicy.createTask({
       input: {
         name: 'Weekly Digest',
+        admissionGroupId: 'publisher-a',
         task: '  Summarize the week.  ',
         intervalMs: 60_000,
         defer: false,
@@ -24,6 +26,7 @@ describe('HeartbeatTaskControlPolicy', () => {
     expect(task).toMatchObject({
       id: 'weekly-digest-2',
       name: 'Weekly Digest',
+      admissionGroupId: 'publisher-a',
       task: 'Summarize the week.',
       enabled: true,
       continuationMode: 'operator',
@@ -41,6 +44,11 @@ describe('HeartbeatTaskControlPolicy', () => {
       existingTasks: [createTask({ id: 'weekly-digest' })],
       now: NOW,
     })).toThrow(/already exists/i);
+    expect(() => HeartbeatTaskControlPolicy.createTask({
+      input: { task: 'Invalid group.', admissionGroupId: '   ' },
+      existingTasks: [],
+      now: NOW,
+    })).toThrow(/group id cannot be blank/i);
   });
 
   it('updates the latest running task without erasing its claim or pending request', () => {
@@ -89,6 +97,18 @@ describe('HeartbeatTaskControlPolicy', () => {
     expect(disabled.schedule.nextRunAt).toBeUndefined();
     expect(disabled.state?.execution?.executionId).toBe('execution-live');
     expect(disabled.state?.runRequest).toMatchObject({ generation: 2, claimedGeneration: 2 });
+
+    const grouped = HeartbeatTaskControlPolicy.updateTask({
+      task: updated,
+      input: { admissionGroupId: 'publisher-b' },
+      now: NOW,
+    });
+    expect(grouped.admissionGroupId).toBe('publisher-b');
+    expect(HeartbeatTaskControlPolicy.updateTask({
+      task: grouped,
+      input: { admissionGroupId: null },
+      now: NOW,
+    }).admissionGroupId).toBeUndefined();
   });
 
   it('projects pause and resume semantics including blocked-task protection', () => {
@@ -192,7 +212,11 @@ describe('HeartbeatTaskControlPolicy', () => {
     const service: HeartbeatTaskAdministrationService = new FileHeartbeatTaskService({
       dir: '/tmp/heddle-heartbeat-administration-contract',
     });
+    const admission: HeartbeatTaskAdmissionControl = new FileHeartbeatTaskService({
+      dir: '/tmp/heddle-heartbeat-admission-contract',
+    });
     expect(service).toBeInstanceOf(FileHeartbeatTaskService);
+    expect(admission).toBeInstanceOf(FileHeartbeatTaskService);
   });
 });
 

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -355,7 +355,10 @@ export {
 export type {
   CreateHeartbeatTaskInput,
   FileHeartbeatTaskServiceOptions,
+  HeartbeatAdmissionDecision,
+  HeartbeatAdmissionTarget,
   HeartbeatTaskAdministrationService,
+  HeartbeatTaskAdmissionControl,
   HeartbeatTaskDetail,
   ListHeartbeatRunViewsOptions,
   ReadHeartbeatTaskOptions,

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -92,18 +92,25 @@ operator-facing heartbeat views.
 - Execution settlement must read and project from the latest stored task inside
   the same atomic store transition. Saving a projection derived from the
   pre-run snapshot can erase newer run requests or operator control changes.
-- A final claim is eligible only when the task is enabled, its claim mode is
-  due (unless an explicit `any` run-now claim is used), namespace admission is
-  `ready`, and its optional assigned group is `ready`. Missing namespace state
-  defaults to `ready` for legacy ungrouped tasks; a missing assigned-group state
-  defaults to `closed`. Namespace admission is the global emergency circuit
-  breaker. Group admission is one flat opaque scope, not a hierarchy, quota, or
-  fairness mechanism.
+- A fresh final claim is eligible only when the task is enabled, its `due`
+  schedule is eligible (unless explicit `any` run-now mode is used), namespace
+  admission is `ready`, and its optional assigned group is `ready`. Missing
+  namespace state defaults to `ready` for legacy ungrouped tasks; a missing
+  assigned-group state defaults to `closed`. Namespace admission is the global
+  fresh-work circuit breaker. It is not a zero-execution stop because exact
+  recovery can continue already admitted work. Group admission is one flat
+  opaque scope, not a hierarchy, quota, or fairness mechanism.
 - `HeartbeatTaskAdmissionControl.setAdmissionDecision()` must serialize with
-  `claimTaskExecution()`. Closing admission prevents only new claims. It does
-  not disable tasks, change due timestamps, consume run requests, alter
-  checkpoints, cancel active executions, or drain a worker; those remain
-  explicit lifecycle operations.
+  `claimTaskExecution()`. Closing admission prevents only fresh logical work.
+  `claimMode: 'recovery'` may bypass both closed scopes only when
+  `recoveryOfExecutionId` atomically matches the current unconsumed durable
+  recovery marker. The replacement consumes that marker once, inherits the
+  interrupted run-request correlation, and does not consume a newer request.
+  Caller-supplied, stale, legacy diagnostic, or already-consumed recovery IDs
+  cannot bypass admission. Closing admission otherwise does not disable tasks,
+  change due timestamps, consume run requests, alter
+  checkpoints, cancel active executions, or drain a worker. Use explicit host
+  pause, drain, or cancellation when no execution may proceed.
 - Custom adapters should use the public `HeartbeatTaskStateProjector` exported
   from `@heddleagent/runtime/advanced` for normalization, request, claim,
   settlement, and recovery transitions. The adapter still owns the backend
@@ -155,8 +162,10 @@ operator-facing heartbeat views.
   serialize admission changes with atomic claim, fencing, and recovery through
   database compare-and-swap, leases, or transactions.
 - Recovery preserves the latest checkpoint and run history, records the
-  interrupted execution identity under `task.state.recovery`, and makes an
-  enabled task immediately due. It does not record success or roll back host
+  interrupted execution identity plus a pending single-use replacement marker
+  under `task.state.recovery`, and makes an enabled task immediately due. A
+  missing marker on a legacy recovery record is diagnostic only and authorizes
+  no bypass. Recovery does not record success or roll back host
   domain side effects; host tools remain responsible for idempotent mutations.
 - Recovery is a lifecycle policy, not a consequence of receiving a different
   `ownerId`. The built-in file adapter can recover an execution only when its
@@ -166,11 +175,16 @@ operator-facing heartbeat views.
   final writes remain fenced after an explicit recovery.
 - Custom remote adapters should run the executable contract scenarios from
   `@heddleagent/runtime/heartbeat/testing` against two fresh store instances sharing
-  one backend namespace. Required scenarios cover exact lookup, atomic due
-  claims, coalesced requests, settlement, recovery, stale-write fencing,
-  close-vs-claim linearization, and unrelated-group progress;
-  history and subscription checks are capability-gated. The harness owns a
-  fixture-only hook for expiring a lease or simulating a dead prior process.
+  one backend namespace. Baseline scenarios cover exact lookup, atomic due
+  claims, coalesced requests, settlement, recovery, and stale-write fencing.
+  Supplying the optional `createAdmissionControl` harness port additionally
+  certifies fail-closed group state, close-vs-claim linearization, active-claim
+  survival, exact crash replacement through closed admission, stale recovery
+  rejection, newer-request preservation, and unrelated-group progress. This
+  keeps existing namespace-only harnesses source-compatible without treating
+  them as scoped-admission proof; history and subscription checks are
+  capability-gated. The harness owns a fixture-only hook for expiring a lease
+  or simulating a dead prior process.
   Passing the suite does not certify host queue delivery or exactly-once domain
   effects.
 - Heartbeat may depend on runtime's public `AgentLoopRuntimeService.run` and checkpoint types.

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -29,7 +29,11 @@ operator-facing heartbeat views.
   `FileHeartbeatTaskRepository`. It also owns process-local execution claims,
   recovery of interrupted single-host executions, fencing of late completion/
   failure/outcome writes, durable run-request generations, and the file
-  adapter's process-local scheduler wake signal. `HeartbeatTaskStateProjector`
+  adapter's process-local scheduler wake signal. The separate
+  `HeartbeatTaskAdmissionControl` port exposes only the durable binary
+  `ready | closed` projection for the namespace and one optional opaque task
+  group. The final claim checks that projection under the same mutation
+  boundary. `HeartbeatTaskStateProjector`
   owns task state transitions after agent success, no-work skip, cancellation,
   failure, request, claim, or recovery.
 - `scheduler/`: `HeartbeatSchedulerService` owns due-task selection and the
@@ -66,6 +70,10 @@ operator-facing heartbeat views.
   persistence. Those stay in `src/core/chat`.
 - CLI, server, web, or TUI presentation. Those surfaces should call this domain
   through typed heartbeat entry points.
+- Hosted admission orchestration such as desired state, preparing/blocked
+  phases, transition IDs, retries, restart reconciliation, or product-owned
+  resume preparation. A hosted adapter projects that richer lifecycle into
+  Heddle's binary claim decision.
 
 ## Boundary Notes
 
@@ -84,6 +92,18 @@ operator-facing heartbeat views.
 - Execution settlement must read and project from the latest stored task inside
   the same atomic store transition. Saving a projection derived from the
   pre-run snapshot can erase newer run requests or operator control changes.
+- A final claim is eligible only when the task is enabled, its claim mode is
+  due (unless an explicit `any` run-now claim is used), namespace admission is
+  `ready`, and its optional assigned group is `ready`. Missing namespace state
+  defaults to `ready` for legacy ungrouped tasks; a missing assigned-group state
+  defaults to `closed`. Namespace admission is the global emergency circuit
+  breaker. Group admission is one flat opaque scope, not a hierarchy, quota, or
+  fairness mechanism.
+- `HeartbeatTaskAdmissionControl.setAdmissionDecision()` must serialize with
+  `claimTaskExecution()`. Closing admission prevents only new claims. It does
+  not disable tasks, change due timestamps, consume run requests, alter
+  checkpoints, cancel active executions, or drain a worker; those remain
+  explicit lifecycle operations.
 - Custom adapters should use the public `HeartbeatTaskStateProjector` exported
   from `@heddleagent/runtime/advanced` for normalization, request, claim,
   settlement, and recovery transitions. The adapter still owns the backend
@@ -107,7 +127,8 @@ operator-facing heartbeat views.
   `loadTask(taskId)` resolves that task directly rather than scanning a global
   catalog. The method reads durable eligibility and makes the final due claim
   through the store; its typed result distinguishes settlement, normal failure,
-  missing/disabled/not-due/busy work, a lost claim, and cancellation.
+  missing/disabled/not-due/busy work, `admission-closed` with the blocking
+  target, a lost claim, and cancellation.
 - The one-shot `runTask()` method does not scan unrelated tasks, poll, subscribe,
   or recover interrupted executions. `HeartbeatTargetedTaskHost` is the
   low-volume in-process default around that primitive: it owns notification
@@ -117,7 +138,7 @@ operator-facing heartbeat views.
   host-domain idempotency remain host responsibilities. The store's atomic
   claim fences duplicate at-least-once worker deliveries; it does not make host
   tool side effects exactly once.
-- The file service serializes task/checkpoint/run mutations with a shared
+- The file service serializes task/checkpoint/run/admission mutations with a shared
   in-process mutex for one resolved heartbeat root. Task, checkpoint, and run
   JSON files are replaced atomically, so readers see a complete previous or next
   document rather than a partial write. Concurrent
@@ -130,7 +151,8 @@ operator-facing heartbeat views.
   latency; polling remains the restart fallback. This is reliable for one Node.js
   process owning a state root; it is not a distributed lease. Multiple processes
   or replicas must provide a remote
-  `HeartbeatTaskStore` that implements atomic claim, fencing, and recovery with
+  `HeartbeatTaskStore` plus `HeartbeatTaskAdmissionControl` implementations that
+  serialize admission changes with atomic claim, fencing, and recovery through
   database compare-and-swap, leases, or transactions.
 - Recovery preserves the latest checkpoint and run history, records the
   interrupted execution identity under `task.state.recovery`, and makes an
@@ -145,7 +167,8 @@ operator-facing heartbeat views.
 - Custom remote adapters should run the executable contract scenarios from
   `@heddleagent/runtime/heartbeat/testing` against two fresh store instances sharing
   one backend namespace. Required scenarios cover exact lookup, atomic due
-  claims, coalesced requests, settlement, recovery, and stale-write fencing;
+  claims, coalesced requests, settlement, recovery, stale-write fencing,
+  close-vs-claim linearization, and unrelated-group progress;
   history and subscription checks are capability-gated. The harness owns a
   fixture-only hook for expiring a lease or simulating a dead prior process.
   Passing the suite does not certify host queue delivery or exactly-once domain

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -48,7 +48,10 @@ export { MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH } from './tasks/index.js';
 export type {
   CreateHeartbeatTaskInput,
   FileHeartbeatTaskServiceOptions,
+  HeartbeatAdmissionDecision,
+  HeartbeatAdmissionTarget,
   HeartbeatTaskAdministrationService,
+  HeartbeatTaskAdmissionControl,
   HeartbeatTaskDetail,
   ListHeartbeatRunViewsOptions,
   ReadHeartbeatTaskOptions,

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -614,6 +614,14 @@ export class HeartbeatTaskRunnerService {
         failed: false,
       };
     }
+    if (claim.status === 'admission-closed') {
+      return {
+        status: 'admission-closed',
+        taskId,
+        target: claim.target,
+        failed: false,
+      };
+    }
     return { status: claim.status, taskId, failed: false };
   }
 

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -70,6 +70,8 @@ export class HeartbeatTaskRunnerService {
       runAt: Date;
       /** `due` requires the durable store to re-check eligibility while claiming. */
       claimMode?: HeartbeatTaskClaimMode;
+      /** Exact interrupted execution consumed only by `claimMode: 'recovery'`. */
+      recoveryOfExecutionId?: string;
     },
   ): Promise<HeartbeatTaskExecutionResult> {
     HeartbeatTaskRunnerService.assertHandlerConfiguration(options);
@@ -96,6 +98,7 @@ export class HeartbeatTaskRunnerService {
       loadedCheckpoint,
       claimedAt: runAt,
       claimMode: options.claimMode,
+      recoveryOfExecutionId: options.recoveryOfExecutionId,
     });
     if (claim.status !== 'claimed') {
       return HeartbeatTaskRunnerService.claimResult(task.id, claim);

--- a/src/core/heartbeat/scheduler/service.ts
+++ b/src/core/heartbeat/scheduler/service.ts
@@ -12,6 +12,7 @@ import pLimit from 'p-limit';
 import {
   FileHeartbeatTaskService,
   HeartbeatTaskExecutionEligibilityPolicy,
+  HeartbeatTaskStateProjector,
   type HeartbeatTask,
   type HeartbeatTaskRunRecord,
   type HeartbeatTaskRunRequestSignal,
@@ -176,7 +177,7 @@ export class HeartbeatSchedulerService {
       ...options,
       task,
       runAt: now,
-      claimMode: 'due',
+      ...HeartbeatSchedulerService.resolveDurableClaim(task),
     });
   }
 
@@ -214,7 +215,7 @@ export class HeartbeatSchedulerService {
             executionOwnerId,
             task,
             runAt: now,
-            claimMode: 'due',
+            ...HeartbeatSchedulerService.resolveDurableClaim(task),
             signal: HeartbeatSchedulerService.composeExecutionSignal(options.signal, taskSignal),
           });
         };
@@ -350,6 +351,17 @@ export class HeartbeatSchedulerService {
     }
 
     return dayjs(task.schedule.nextRunAt).valueOf();
+  }
+
+  private static resolveDurableClaim(task: HeartbeatTask): {
+    claimMode: 'due' | 'recovery';
+    recoveryOfExecutionId?: string;
+  } {
+    const recoveryOfExecutionId = HeartbeatTaskStateProjector.pendingRecoveryExecutionId(task);
+    return recoveryOfExecutionId ? {
+      claimMode: 'recovery',
+      recoveryOfExecutionId,
+    } : { claimMode: 'due' };
   }
 
   private static resolveMaxConcurrentTasks(value: number | undefined): number {

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -12,6 +12,7 @@ export {
   MAX_HEARTBEAT_HANDLER_RETRY_MS,
 } from '../tasks/types.js';
 import type {
+  HeartbeatAdmissionTarget,
   HeartbeatTask,
   HeartbeatTaskAgentRunRecord,
   HeartbeatTaskNonAgentRunRecord,
@@ -315,6 +316,7 @@ export type HeartbeatTaskExecutionResult = {
     }
   | { status: 'failed'; executionId: string; error: string; task: HeartbeatTask; failed: true }
   | { status: 'not-found' | 'disabled' | 'busy'; failed: false }
+  | { status: 'admission-closed'; target: HeartbeatAdmissionTarget; failed: false }
   | { status: 'not-due'; nextRunAt?: string; failed: false }
   | { status: 'claim-lost'; executionId: string; failed: false }
   | { status: 'cancelled'; executionId?: string; record?: HeartbeatTaskRunRecord; failed: false }

--- a/src/core/heartbeat/targeted-host/README.md
+++ b/src/core/heartbeat/targeted-host/README.md
@@ -29,8 +29,11 @@ the replaceable invocation-target port preserves that migration seam.
 `isAdmissionEnabled` is only a best-effort precheck that avoids unnecessary
 polling or invocation. It is not the durable authority because it can race with
 the final claim. Likewise, `host.pause()` is a process-local drain/cancellation
-operation. Closing durable namespace or group admission affects future claims
-only and does not cancel already claimed work.
+operation. Closing durable namespace or group admission blocks fresh logical
+work but does not cancel or strand already admitted work. An exact durable
+single-use recovery replacement may bypass both scopes; caller-selected stale
+IDs cannot. Use host pause, drain, or cancellation when no execution may
+proceed.
 
 `taskIdPrefix` is an optional defense-in-depth filter, not an authorization
 boundary. Prefer giving each host a store already scoped to its tenant or task

--- a/src/core/heartbeat/targeted-host/README.md
+++ b/src/core/heartbeat/targeted-host/README.md
@@ -18,11 +18,19 @@ and expired-owner recovery around `HeartbeatSchedulerService.runTask()`.
 ## Boundaries
 
 The task store remains the durable authority. A product remains responsible for
-creating/reconciling tasks, its durable global admission gate, domain input and
-idempotency, and deciding which task namespace this host may see. The host does
+creating/reconciling tasks, controlling the separate durable
+`HeartbeatTaskAdmissionControl` port, domain input and idempotency, and deciding
+which task namespace this host may see. The store's final claim must serialize
+namespace and optional group admission with task eligibility. The host does
 not provide a distributed queue, leader election, or cross-process concurrency
 limit. Use a queue-backed dispatcher when scale or availability requires it;
 the replaceable invocation-target port preserves that migration seam.
+
+`isAdmissionEnabled` is only a best-effort precheck that avoids unnecessary
+polling or invocation. It is not the durable authority because it can race with
+the final claim. Likewise, `host.pause()` is a process-local drain/cancellation
+operation. Closing durable namespace or group admission affects future claims
+only and does not cancel already claimed work.
 
 `taskIdPrefix` is an optional defense-in-depth filter, not an authorization
 boundary. Prefer giving each host a store already scoped to its tenant or task
@@ -43,7 +51,7 @@ const host = new HeartbeatTargetedTaskHost({
   recoveryIntervalMs: 30_000,
   invocationTimeoutMs: 15 * 60_000,
   maxConcurrentInvocations: 1,
-  isAdmissionEnabled: readDurableOperatorGate,
+  isAdmissionEnabled: readBestEffortDispatchPrecheck,
 })
 
 host.start({ handler, admissionEnabled: true })

--- a/src/core/heartbeat/targeted-host/dispatcher.ts
+++ b/src/core/heartbeat/targeted-host/dispatcher.ts
@@ -517,6 +517,7 @@ export function resolveHeartbeatTargetedTaskDispatchDecision(
     status === 'retry'
     || status === 'failed'
     || status === 'not-due'
+    || status === 'admission-closed'
     || status === 'cancelled'
   ) {
     return { kind: 'wait-for-durable-schedule' };

--- a/src/core/heartbeat/targeted-host/types.ts
+++ b/src/core/heartbeat/targeted-host/types.ts
@@ -74,7 +74,11 @@ export type HeartbeatTargetedTaskDispatcherOptions = {
   invocationTimeoutMs: number;
   /** Retry delay only for transient ownership contention. */
   contentionRetryMs?: number;
-  /** Durable product/operator gate. Errors fail closed. */
+  /**
+   * Best-effort dispatch precheck used to avoid unnecessary polling/invocation.
+   * Errors fail closed locally, but the store's atomic task claim remains the
+   * durable admission authority.
+   */
   isAdmissionEnabled?: () => boolean | Promise<boolean>;
   now?: () => Date;
   createInvocationId?: (

--- a/src/core/heartbeat/tasks/administration.ts
+++ b/src/core/heartbeat/tasks/administration.ts
@@ -5,6 +5,7 @@ export type CreateHeartbeatTaskInput = {
   workspaceId?: string;
   id?: string;
   name?: string;
+  admissionGroupId?: string;
   task: string;
   enabled?: boolean;
   continuationMode?: HeartbeatTask['continuationMode'];
@@ -20,6 +21,8 @@ export type CreateHeartbeatTaskInput = {
 
 export type UpdateHeartbeatTaskInput = {
   name?: string;
+  /** Set `null` to return this task to namespace-only admission. */
+  admissionGroupId?: string | null;
   task?: string;
   enabled?: boolean;
   continuationMode?: HeartbeatTask['continuationMode'];

--- a/src/core/heartbeat/tasks/control-policy.ts
+++ b/src/core/heartbeat/tasks/control-policy.ts
@@ -43,6 +43,7 @@ export class HeartbeatTaskControlPolicy {
       id,
       workspaceId: args.input.workspaceId,
       name: args.input.name,
+      admissionGroupId: HeartbeatTaskControlPolicy.resolveAdmissionGroupId(args.input.admissionGroupId),
       task: args.input.task.trim(),
       enabled: args.input.enabled ?? true,
       continuationMode: args.input.continuationMode ?? 'operator',
@@ -81,6 +82,9 @@ export class HeartbeatTaskControlPolicy {
     return {
       ...args.task,
       name: args.input.name ?? args.task.name,
+      admissionGroupId:
+        args.input.admissionGroupId === undefined ? args.task.admissionGroupId
+        : HeartbeatTaskControlPolicy.resolveAdmissionGroupId(args.input.admissionGroupId),
       task: args.input.task?.trim() ?? args.task.task,
       enabled,
       continuationMode: args.input.continuationMode ?? args.task.continuationMode ?? 'operator',
@@ -314,6 +318,16 @@ export class HeartbeatTaskControlPolicy {
     }
 
     throw new Error(`Unable to create a unique heartbeat task id for ${base}`);
+  }
+
+  private static resolveAdmissionGroupId(value: string | null | undefined): string | undefined {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    if (!value.trim()) {
+      throw new Error('Heartbeat admission group id cannot be blank.');
+    }
+    return value;
   }
 
   private static requireValidDate(value: Date, label: string) {

--- a/src/core/heartbeat/tasks/control-policy.ts
+++ b/src/core/heartbeat/tasks/control-policy.ts
@@ -327,6 +327,9 @@ export class HeartbeatTaskControlPolicy {
     if (!value.trim()) {
       throw new Error('Heartbeat admission group id cannot be blank.');
     }
+    if (value !== value.trim()) {
+      throw new Error('Heartbeat admission group id cannot contain leading or trailing whitespace.');
+    }
     return value;
   }
 

--- a/src/core/heartbeat/tasks/heartbeat-task-store-conformance.ts
+++ b/src/core/heartbeat/tasks/heartbeat-task-store-conformance.ts
@@ -447,6 +447,56 @@ export class HeartbeatTaskStoreConformance {
       await admission.readAdmissionDecision(groupA) === 'closed',
       'an absent assigned group must fail closed',
     );
+    const prototypeNamedGroups = ['constructor', 'toString', '__proto__'] as const;
+    for (const [index, groupId] of prototypeNamedGroups.entries()) {
+      const target = { kind: 'group', groupId } as const;
+      assert(
+        await admission.readAdmissionDecision(target) === 'closed',
+        `an absent group named ${groupId} must not resolve through inherited object properties`,
+      );
+      const task = createGroupedTask(`admission-prototype-name-${groupId}`, target);
+      await first.saveTask(task);
+      const claim = await first.claimTaskExecution({
+        taskId: task.id,
+        execution: createExecution(`prototype-name-execution-${index}`, 'owner-a', harness),
+        loadedCheckpoint: false,
+        claimedAt: at(harness, 500),
+        claimMode: 'due',
+      });
+      assertAdmissionClosed(claim, target, `an absent group named ${groupId} must fail closed at claim time`);
+    }
+    const protoTarget = { kind: 'group', groupId: '__proto__' } as const;
+    await admission.setAdmissionDecision(protoTarget, 'ready');
+    assert(
+      await admission.readAdmissionDecision(protoTarget) === 'ready',
+      'an explicit __proto__ group decision must survive durable serialization as an own property',
+    );
+    assert(
+      await admission.readAdmissionDecision({ kind: 'group', groupId: 'constructor' }) === 'closed',
+      'writing __proto__ must not expose another inherited property as an admission decision',
+    );
+    const protoExecution = createExecution('prototype-name-ready-execution', 'owner-a', harness);
+    const protoClaim = await first.claimTaskExecution({
+      taskId: 'admission-prototype-name-__proto__',
+      execution: protoExecution,
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 750),
+      claimMode: 'due',
+    });
+    assert(protoClaim.status === 'claimed', 'an explicitly ready __proto__ group must claim normally');
+    const protoSettlement = await first.recordTaskExecutionOutcome({
+      taskId: 'admission-prototype-name-__proto__',
+      execution: protoExecution,
+      kind: 'skipped',
+      summary: 'Prototype-named group storage remained safe.',
+      finishedAt: at(harness, 800),
+    });
+    assert(protoSettlement.status === 'saved', 'an explicitly ready __proto__ group must settle normally');
+    await admission.setAdmissionDecision(protoTarget, 'closed');
+    assert(
+      await admission.readAdmissionDecision(protoTarget) === 'closed',
+      'an explicit __proto__ group close must survive durable serialization',
+    );
 
     const legacy = createTask('admission-legacy');
     const groupedWhileMissing = createGroupedTask('admission-missing', groupA);

--- a/src/core/heartbeat/tasks/heartbeat-task-store-conformance.ts
+++ b/src/core/heartbeat/tasks/heartbeat-task-store-conformance.ts
@@ -28,8 +28,12 @@ export type HeartbeatTaskStoreConformanceCapabilities = {
 export type HeartbeatTaskStoreConformanceHarness = {
   /** Return a fresh store instance using exactly this opaque backend namespace. */
   createStore(namespace: string): MaybePromise<HeartbeatTargetedTaskStore>;
-  /** Return the binary admission control port for the same backend namespace. */
-  createAdmissionControl(namespace: string): MaybePromise<HeartbeatTaskAdmissionControl>;
+  /**
+   * Return the binary admission control port for the same backend namespace.
+   * Omit only when certifying a legacy namespace-only adapter; scoped-admission
+   * conformance runs whenever this port is supplied.
+   */
+  createAdmissionControl?(namespace: string): MaybePromise<HeartbeatTaskAdmissionControl>;
   /** Remove every resource created for an opaque backend namespace. */
   cleanupNamespace(namespace: string): MaybePromise<void>;
   /** Return a deterministic base time; the suite derives fixed offsets from it. */
@@ -76,7 +80,7 @@ const scenarioName = {
   requests: 'run requests coalesce atomically and settlement preserves newer host state',
   settlement: 'success, skip, cancellation, and failure settle atomically',
   recovery: 'competing claims are busy, live work is retained, and stale settlement is fenced after recovery',
-  admission: 'namespace and group admission changes linearize with claims while unrelated groups keep progressing',
+  admission: 'namespace and group admission changes linearize with claims, exact recovery continues, and unrelated groups keep progressing',
   subscription: 'optional run-request subscriptions receive cross-instance signals and unsubscribe',
   history: 'optional run history supports save, list, filter, limit, and load',
 } as const;
@@ -95,8 +99,14 @@ export class HeartbeatTaskStoreConformance {
       HeartbeatTaskStoreConformance.createScenario(scenarioName.requests, harness, HeartbeatTaskStoreConformance.verifyRunRequests),
       HeartbeatTaskStoreConformance.createScenario(scenarioName.settlement, harness, HeartbeatTaskStoreConformance.verifySettlements),
       HeartbeatTaskStoreConformance.createScenario(scenarioName.recovery, harness, HeartbeatTaskStoreConformance.verifyRecoveryAndFencing),
-      HeartbeatTaskStoreConformance.createScenario(scenarioName.admission, harness, HeartbeatTaskStoreConformance.verifyAdmission),
     ];
+    if (harness.createAdmissionControl) {
+      scenarios.push(HeartbeatTaskStoreConformance.createScenario(
+        scenarioName.admission,
+        harness,
+        HeartbeatTaskStoreConformance.verifyAdmission,
+      ));
+    }
     if (harness.capabilities?.runRequestSubscription) {
       scenarios.push(HeartbeatTaskStoreConformance.createScenario(
         scenarioName.subscription,
@@ -355,7 +365,40 @@ export class HeartbeatTaskStoreConformance {
     const repeatedRecovery = await first.recoverInterruptedTasks({ ownerId: 'replacement-owner', recoveredAt: at(harness, 5_000), reason: 'host-restart' });
     assert(repeatedRecovery.length === 0, 'recovery must be idempotent');
     const replacement = createExecution('replacement-execution', 'replacement-owner', harness);
-    await assertClaimed(second, task.id, replacement, harness, 6_000);
+    await assertRejected(
+      async () => await second.claimTaskExecution({
+        taskId: task.id,
+        execution: replacement,
+        loadedCheckpoint: false,
+        claimedAt: at(harness, 6_000),
+        claimMode: 'recovery',
+      }),
+      'a recovery claim without an interrupted execution id must be rejected',
+    );
+    await assertRejected(
+      async () => await second.claimTaskExecution({
+        taskId: task.id,
+        execution: replacement,
+        loadedCheckpoint: false,
+        claimedAt: at(harness, 6_000),
+        claimMode: 'any',
+        recoveryOfExecutionId: expired.executionId,
+      }),
+      'a recovery id on a fresh claim must be rejected',
+    );
+    const replacementClaim = await second.claimTaskExecution({
+      taskId: task.id,
+      execution: replacement,
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 6_000),
+      claimMode: 'recovery',
+      recoveryOfExecutionId: expired.executionId,
+    });
+    assert(replacementClaim.status === 'claimed', 'the exact pending recovery must claim once');
+    assert(
+      replacementClaim.task.state?.recovery?.replacementExecutionId === replacement.executionId,
+      'the replacement claim must consume the pending recovery marker',
+    );
     const staleResult = createResult('late-success');
     const staleWrites = await Promise.all([
       first.completeTaskExecution({
@@ -389,7 +432,9 @@ export class HeartbeatTaskStoreConformance {
   private static async verifyAdmission(namespace: string, harness: HeartbeatTaskStoreConformanceHarness): Promise<void> {
     const first = await harness.createStore(namespace);
     const second = await harness.createStore(namespace);
-    const admission = await harness.createAdmissionControl(namespace);
+    const createAdmissionControl = harness.createAdmissionControl;
+    assert(createAdmissionControl, 'scoped-admission conformance requires createAdmissionControl');
+    const admission = await createAdmissionControl(namespace);
     const namespaceTarget = { kind: 'namespace' } as const;
     const groupA = { kind: 'group', groupId: 'publisher-a' } as const;
     const groupB = { kind: 'group', groupId: 'publisher-b' } as const;
@@ -427,6 +472,32 @@ export class HeartbeatTaskStoreConformance {
     assert(
       (await second.loadCheckpoint(preserved))?.runId === checkpoint.runId,
       'closing admission must preserve the checkpoint',
+    );
+
+    const legacyRecovery = {
+      ...createGroupedTask('admission-legacy-recovery', groupA),
+      state: {
+        status: 'waiting' as const,
+        recovery: {
+          interruptedExecutionId: 'legacy-interrupted-execution',
+          interruptedOwnerId: 'legacy-owner',
+          recoveredAt: at(harness, 1_000).toISOString(),
+          reason: 'host-restart' as const,
+        },
+      },
+    } satisfies HeartbeatTask;
+    await first.saveTask(legacyRecovery);
+    const legacyRecoveryClaim = await first.claimTaskExecution({
+      taskId: legacyRecovery.id,
+      execution: createExecution('legacy-replacement-attempt', 'owner-a', harness),
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 1_500),
+      claimMode: 'recovery',
+      recoveryOfExecutionId: 'legacy-interrupted-execution',
+    });
+    assert(
+      legacyRecoveryClaim.status === 'not-due',
+      'a legacy diagnostic recovery record must not authorize an admission bypass',
     );
 
     const legacyExecution = createExecution('legacy-execution', 'owner-a', harness);
@@ -504,18 +575,186 @@ export class HeartbeatTaskStoreConformance {
       assertDeepEqual(raceClaim.target, groupA, 'the racing claim must identify the blocking group');
     }
 
+    await admission.setAdmissionDecision(groupA, 'ready');
+    const recoveryTask = createGroupedTask('admission-recovery', groupA);
+    await first.saveTask(recoveryTask);
+    await first.requestTaskRun(recoveryTask.id, {
+      requestedAt: at(harness, 8_500),
+      reason: 'work-interrupted-after-claim',
+    });
+    const activeRecoveryExecution = createExecution('recovery-active-execution', 'owner-a', harness);
+    const activeRecoveryClaim = await first.claimTaskExecution({
+      taskId: recoveryTask.id,
+      execution: activeRecoveryExecution,
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 9_000),
+      claimMode: 'due',
+    });
+    assert(activeRecoveryClaim.status === 'claimed', 'the original requested work must claim before interruption');
+    assert(
+      activeRecoveryClaim.task.state?.execution?.runRequestGeneration === 1,
+      'the interrupted execution must own the first run-request generation',
+    );
+    await second.requestTaskRun(recoveryTask.id, {
+      requestedAt: at(harness, 10_000),
+      reason: 'fresh-work-after-recovery',
+    });
+    await admission.setAdmissionDecision(groupA, 'closed');
+    await admission.setAdmissionDecision(namespaceTarget, 'closed');
+
+    const crashedExecution = {
+      ...createExecution('recovery-crashed-execution', 'crashed-owner', harness),
+      runRequestGeneration: 1,
+    };
+    await harness.makeExecutionRecoverable({
+      namespace,
+      store: first,
+      task: await requireTask(first, recoveryTask.id),
+      execution: crashedExecution,
+      recoverAt: at(harness, 11_000),
+    });
+    const recoveries = await second.recoverInterruptedTasks({
+      ownerId: 'replacement-owner',
+      recoveredAt: at(harness, 11_000),
+      reason: 'host-restart',
+    });
+    assert(
+      recoveries.some(({ recovery }) => recovery.interruptedExecutionId === crashedExecution.executionId),
+      'expired ownership must create an exact durable recovery marker',
+    );
+
+    const staleRecovery = await first.claimTaskExecution({
+      taskId: recoveryTask.id,
+      execution: createExecution('stale-recovery-attempt', 'replacement-owner', harness),
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 12_000),
+      claimMode: 'recovery',
+      recoveryOfExecutionId: 'not-the-interrupted-execution',
+    });
+    assert(staleRecovery.status === 'not-due', 'a stale caller-supplied recovery id must not bypass closed admission');
+
+    const freshWhileClosed = await second.claimTaskExecution({
+      taskId: recoveryTask.id,
+      execution: createExecution('fresh-while-closed', 'owner-b', harness),
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 13_000),
+      claimMode: 'due',
+    });
+    assertAdmissionClosed(freshWhileClosed, namespaceTarget, 'fresh due work must remain blocked by namespace admission');
+
+    const replacementExecution = createExecution('recovery-replacement-execution', 'replacement-owner', harness);
+    const replacementClaim = await second.claimTaskExecution({
+      taskId: recoveryTask.id,
+      execution: replacementExecution,
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 14_000),
+      claimMode: 'recovery',
+      recoveryOfExecutionId: crashedExecution.executionId,
+    });
+    assert(replacementClaim.status === 'claimed', 'the exact unconsumed recovery must bypass closed namespace and group admission');
+    assert(
+      replacementClaim.task.state?.recovery?.replacementExecutionId === replacementExecution.executionId,
+      'the replacement claim must atomically consume the recovery marker',
+    );
+    assert(
+      replacementClaim.task.state?.runRequest?.generation === 2
+      && replacementClaim.task.state.runRequest.claimedGeneration === 1,
+      'recovery must not consume a newer pending run request',
+    );
+    assert(
+      replacementClaim.task.state?.execution?.runRequestGeneration === 1,
+      'recovery must retain the interrupted execution run-request generation',
+    );
+
+    const staleOriginalSettlement = await first.recordTaskExecutionOutcome({
+      taskId: recoveryTask.id,
+      execution: activeRecoveryExecution,
+      kind: 'skipped',
+      summary: 'The pre-crash execution cannot settle after replacement.',
+      finishedAt: at(harness, 15_000),
+    });
+    assert(staleOriginalSettlement.status === 'claim-lost', 'replacement recovery must fence the pre-crash execution');
+    const staleInterruptedSettlement = await first.recordTaskExecutionOutcome({
+      taskId: recoveryTask.id,
+      execution: crashedExecution,
+      kind: 'skipped',
+      summary: 'The interrupted execution cannot settle after replacement.',
+      finishedAt: at(harness, 15_000),
+    });
+    assert(staleInterruptedSettlement.status === 'claim-lost', 'replacement recovery must fence the interrupted execution');
+
+    const replacementSettlement = await second.recordTaskExecutionOutcome({
+      taskId: recoveryTask.id,
+      execution: replacementExecution,
+      kind: 'skipped',
+      summary: 'Recovered logical work settled.',
+      finishedAt: at(harness, 16_000),
+    });
+    assert(replacementSettlement.status === 'saved', 'the exact replacement must settle normally');
+
+    const repeatedRecovery = await first.claimTaskExecution({
+      taskId: recoveryTask.id,
+      execution: createExecution('repeated-recovery-attempt', 'replacement-owner', harness),
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 17_000),
+      claimMode: 'recovery',
+      recoveryOfExecutionId: crashedExecution.executionId,
+    });
+    assert(repeatedRecovery.status === 'not-due', 'a consumed recovery marker must not authorize another replacement');
+    const explicitWhileClosed = await first.claimTaskExecution({
+      taskId: recoveryTask.id,
+      execution: createExecution('explicit-while-closed', 'owner-a', harness),
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 18_000),
+      claimMode: 'any',
+    });
+    assertAdmissionClosed(explicitWhileClosed, namespaceTarget, 'explicit run-now work must not bypass namespace admission');
+
+    await admission.setAdmissionDecision(namespaceTarget, 'ready');
+    const groupClosedFresh = await first.claimTaskExecution({
+      taskId: recoveryTask.id,
+      execution: createExecution('group-closed-fresh', 'owner-a', harness),
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 19_000),
+      claimMode: 'due',
+    });
+    assertAdmissionClosed(groupClosedFresh, groupA, 'fresh requested work must remain blocked by group admission');
+
     const groupBTask = createGroupedTask('admission-unrelated', groupB);
     await first.saveTask(groupBTask);
     const groupBExecution = createExecution('group-b-execution', 'owner-b', harness);
-    await assertClaimed(second, groupBTask.id, groupBExecution, harness, 9_000);
+    await assertClaimed(second, groupBTask.id, groupBExecution, harness, 20_000);
     const groupBSettlement = await second.recordTaskExecutionOutcome({
       taskId: groupBTask.id,
       execution: groupBExecution,
       kind: 'skipped',
       summary: 'The unrelated group remained ready.',
-      finishedAt: at(harness, 10_000),
+      finishedAt: at(harness, 21_000),
     });
     assert(groupBSettlement.status === 'saved', 'closing one group must not block unrelated-group progress');
+
+    await admission.setAdmissionDecision(groupA, 'ready');
+    const freshExecution = createExecution('fresh-after-resume', 'owner-a', harness);
+    const freshClaim = await first.claimTaskExecution({
+      taskId: recoveryTask.id,
+      execution: freshExecution,
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 22_000),
+      claimMode: 'due',
+    });
+    assert(freshClaim.status === 'claimed', 'fresh pending work may claim only after admission resumes');
+    assert(
+      freshClaim.task.state?.execution?.runRequestGeneration === 2,
+      'the post-recovery claim must consume the newer pending run request',
+    );
+    const freshSettlement = await first.recordTaskExecutionOutcome({
+      taskId: recoveryTask.id,
+      execution: freshExecution,
+      kind: 'skipped',
+      summary: 'Fresh work settled after admission resumed.',
+      finishedAt: at(harness, 23_000),
+    });
+    assert(freshSettlement.status === 'saved', 'fresh work must settle after admission resumes');
   }
 
   private static async verifyRunRequestSubscription(namespace: string, harness: HeartbeatTaskStoreConformanceHarness): Promise<void> {
@@ -596,6 +835,15 @@ function assert(condition: unknown, detail: string): asserts condition {
 
 function assertDeepEqual(actual: unknown, expected: unknown, detail: string): void {
   if (JSON.stringify(actual) !== JSON.stringify(expected)) throw new Error(detail);
+}
+
+async function assertRejected(operation: () => Promise<unknown>, detail: string): Promise<void> {
+  try {
+    await operation();
+  } catch {
+    return;
+  }
+  throw new Error(detail);
 }
 
 function assertAdmissionClosed(

--- a/src/core/heartbeat/tasks/heartbeat-task-store-conformance.ts
+++ b/src/core/heartbeat/tasks/heartbeat-task-store-conformance.ts
@@ -9,7 +9,9 @@ import { randomUUID } from 'node:crypto';
 import type { AgentLoopCheckpoint, AgentLoopState } from '@/core/runtime/loop/index.js';
 import type { AgentHeartbeatResult } from '../agent/index.js';
 import type {
+  HeartbeatAdmissionTarget,
   HeartbeatTask,
+  HeartbeatTaskAdmissionControl,
   HeartbeatTaskExecution,
   HeartbeatTargetedTaskStore,
 } from './types.js';
@@ -26,6 +28,8 @@ export type HeartbeatTaskStoreConformanceCapabilities = {
 export type HeartbeatTaskStoreConformanceHarness = {
   /** Return a fresh store instance using exactly this opaque backend namespace. */
   createStore(namespace: string): MaybePromise<HeartbeatTargetedTaskStore>;
+  /** Return the binary admission control port for the same backend namespace. */
+  createAdmissionControl(namespace: string): MaybePromise<HeartbeatTaskAdmissionControl>;
   /** Remove every resource created for an opaque backend namespace. */
   cleanupNamespace(namespace: string): MaybePromise<void>;
   /** Return a deterministic base time; the suite derives fixed offsets from it. */
@@ -72,6 +76,7 @@ const scenarioName = {
   requests: 'run requests coalesce atomically and settlement preserves newer host state',
   settlement: 'success, skip, cancellation, and failure settle atomically',
   recovery: 'competing claims are busy, live work is retained, and stale settlement is fenced after recovery',
+  admission: 'namespace and group admission changes linearize with claims while unrelated groups keep progressing',
   subscription: 'optional run-request subscriptions receive cross-instance signals and unsubscribe',
   history: 'optional run history supports save, list, filter, limit, and load',
 } as const;
@@ -90,6 +95,7 @@ export class HeartbeatTaskStoreConformance {
       HeartbeatTaskStoreConformance.createScenario(scenarioName.requests, harness, HeartbeatTaskStoreConformance.verifyRunRequests),
       HeartbeatTaskStoreConformance.createScenario(scenarioName.settlement, harness, HeartbeatTaskStoreConformance.verifySettlements),
       HeartbeatTaskStoreConformance.createScenario(scenarioName.recovery, harness, HeartbeatTaskStoreConformance.verifyRecoveryAndFencing),
+      HeartbeatTaskStoreConformance.createScenario(scenarioName.admission, harness, HeartbeatTaskStoreConformance.verifyAdmission),
     ];
     if (harness.capabilities?.runRequestSubscription) {
       scenarios.push(HeartbeatTaskStoreConformance.createScenario(
@@ -380,6 +386,138 @@ export class HeartbeatTaskStoreConformance {
     assert(current.state?.execution?.executionId === replacement.executionId, 'a stale write must not replace the newer claim');
   }
 
+  private static async verifyAdmission(namespace: string, harness: HeartbeatTaskStoreConformanceHarness): Promise<void> {
+    const first = await harness.createStore(namespace);
+    const second = await harness.createStore(namespace);
+    const admission = await harness.createAdmissionControl(namespace);
+    const namespaceTarget = { kind: 'namespace' } as const;
+    const groupA = { kind: 'group', groupId: 'publisher-a' } as const;
+    const groupB = { kind: 'group', groupId: 'publisher-b' } as const;
+
+    assert(
+      await admission.readAdmissionDecision(namespaceTarget) === 'ready',
+      'an absent namespace decision must preserve legacy readiness',
+    );
+    assert(
+      await admission.readAdmissionDecision(groupA) === 'closed',
+      'an absent assigned group must fail closed',
+    );
+
+    const legacy = createTask('admission-legacy');
+    const groupedWhileMissing = createGroupedTask('admission-missing', groupA);
+    const checkpoint = createResult('admission-checkpoint').checkpoint;
+    await first.saveTask(legacy);
+    await first.saveTask(groupedWhileMissing);
+    await first.saveCheckpoint(groupedWhileMissing, checkpoint);
+
+    const missingGroupClaim = await first.claimTaskExecution({
+      taskId: groupedWhileMissing.id,
+      execution: createExecution('missing-group-execution', 'owner-a', harness),
+      loadedCheckpoint: true,
+      claimedAt: at(harness, 1_000),
+      claimMode: 'due',
+    });
+    assertAdmissionClosed(missingGroupClaim, groupA, 'a task cannot claim before its assigned group is initialized');
+    const preserved = await requireTask(second, groupedWhileMissing.id);
+    assert(preserved.enabled, 'closing admission must not disable the task');
+    assert(
+      preserved.schedule.nextRunAt === groupedWhileMissing.schedule.nextRunAt,
+      'closing admission must preserve the due schedule',
+    );
+    assert(
+      (await second.loadCheckpoint(preserved))?.runId === checkpoint.runId,
+      'closing admission must preserve the checkpoint',
+    );
+
+    const legacyExecution = createExecution('legacy-execution', 'owner-a', harness);
+    await assertClaimed(first, legacy.id, legacyExecution, harness, 2_000);
+    const legacySettlement = await first.recordTaskExecutionOutcome({
+      taskId: legacy.id,
+      execution: legacyExecution,
+      kind: 'skipped',
+      summary: 'Legacy namespace-only work settled.',
+      finishedAt: at(harness, 3_000),
+    });
+    assert(legacySettlement.status === 'saved', 'an ungrouped legacy task must retain namespace-only behavior');
+
+    await admission.setAdmissionDecision(groupA, 'ready');
+    await admission.setAdmissionDecision(groupB, 'ready');
+    const namespaceBlocked = createGroupedTask('namespace-blocked', groupB);
+    await first.saveTask(namespaceBlocked);
+    await admission.setAdmissionDecision(namespaceTarget, 'closed');
+    const namespaceClaim = await second.claimTaskExecution({
+      taskId: namespaceBlocked.id,
+      execution: createExecution('namespace-closed-execution', 'owner-b', harness),
+      loadedCheckpoint: false,
+      claimedAt: at(harness, 4_000),
+      claimMode: 'due',
+    });
+    assertAdmissionClosed(namespaceClaim, namespaceTarget, 'namespace admission must override a ready group');
+    await admission.setAdmissionDecision(namespaceTarget, 'ready');
+
+    const alreadyClaimed = createGroupedTask('admission-active', groupA);
+    await first.saveTask(alreadyClaimed);
+    const activeExecution = createExecution('admission-active-execution', 'owner-a', harness);
+    await assertClaimed(first, alreadyClaimed.id, activeExecution, harness, 5_000);
+    await admission.setAdmissionDecision(groupA, 'closed');
+    const activeSettlement = await first.recordTaskExecutionOutcome({
+      taskId: alreadyClaimed.id,
+      execution: activeExecution,
+      kind: 'skipped',
+      summary: 'Already claimed work remained owned after admission closed.',
+      finishedAt: at(harness, 6_000),
+    });
+    assert(activeSettlement.status === 'saved', 'closing admission must not cancel an already claimed execution');
+
+    await admission.setAdmissionDecision(groupA, 'ready');
+    const racing = createGroupedTask('admission-race', groupA);
+    await first.saveTask(racing);
+    const raceExecution = createExecution('admission-race-execution', 'owner-a', harness);
+    const [, raceClaim] = await Promise.all([
+      admission.setAdmissionDecision(groupA, 'closed'),
+      second.claimTaskExecution({
+        taskId: racing.id,
+        execution: raceExecution,
+        loadedCheckpoint: false,
+        claimedAt: at(harness, 7_000),
+        claimMode: 'due',
+      }),
+    ]);
+    assert(
+      raceClaim.status === 'claimed' || raceClaim.status === 'admission-closed',
+      'a close-vs-claim race must linearize as either a claim or a closed decision',
+    );
+    assert(
+      await admission.readAdmissionDecision(groupA) === 'closed',
+      'the completed close must remain durable after the race',
+    );
+    if (raceClaim.status === 'claimed') {
+      const settlement = await first.recordTaskExecutionOutcome({
+        taskId: racing.id,
+        execution: raceExecution,
+        kind: 'skipped',
+        summary: 'The claim linearized before admission closed.',
+        finishedAt: at(harness, 8_000),
+      });
+      assert(settlement.status === 'saved', 'closing admission must not cancel an already claimed execution');
+    } else {
+      assertDeepEqual(raceClaim.target, groupA, 'the racing claim must identify the blocking group');
+    }
+
+    const groupBTask = createGroupedTask('admission-unrelated', groupB);
+    await first.saveTask(groupBTask);
+    const groupBExecution = createExecution('group-b-execution', 'owner-b', harness);
+    await assertClaimed(second, groupBTask.id, groupBExecution, harness, 9_000);
+    const groupBSettlement = await second.recordTaskExecutionOutcome({
+      taskId: groupBTask.id,
+      execution: groupBExecution,
+      kind: 'skipped',
+      summary: 'The unrelated group remained ready.',
+      finishedAt: at(harness, 10_000),
+    });
+    assert(groupBSettlement.status === 'saved', 'closing one group must not block unrelated-group progress');
+  }
+
   private static async verifyRunRequestSubscription(namespace: string, harness: HeartbeatTaskStoreConformanceHarness): Promise<void> {
     const first = await harness.createStore(namespace);
     const second = await harness.createStore(namespace);
@@ -413,6 +551,10 @@ export class HeartbeatTaskStoreConformance {
 
 function createTask(id: string): HeartbeatTask {
   return { id, task: `Process ${id}.`, enabled: true, schedule: { intervalMs: 60_000, nextRunAt: '2000-01-01T00:00:00.000Z' } };
+}
+
+function createGroupedTask(id: string, target: Extract<HeartbeatAdmissionTarget, { kind: 'group' }>): HeartbeatTask {
+  return { ...createTask(id), admissionGroupId: target.groupId };
 }
 
 function createExecution(executionId: string, ownerId: string, harness: HeartbeatTaskStoreConformanceHarness): HeartbeatTaskExecution {
@@ -454,4 +596,13 @@ function assert(condition: unknown, detail: string): asserts condition {
 
 function assertDeepEqual(actual: unknown, expected: unknown, detail: string): void {
   if (JSON.stringify(actual) !== JSON.stringify(expected)) throw new Error(detail);
+}
+
+function assertAdmissionClosed(
+  claim: Awaited<ReturnType<HeartbeatTargetedTaskStore['claimTaskExecution']>>,
+  target: HeartbeatAdmissionTarget,
+  detail: string,
+): void {
+  assert(claim.status === 'admission-closed', detail);
+  assertDeepEqual(claim.target, target, `${detail}; the result must identify the blocking target`);
 }

--- a/src/core/heartbeat/tasks/index.ts
+++ b/src/core/heartbeat/tasks/index.ts
@@ -15,7 +15,10 @@ export type {
 } from './administration.js';
 export type { FileHeartbeatTaskServiceOptions } from './service.js';
 export type {
+  HeartbeatAdmissionDecision,
+  HeartbeatAdmissionTarget,
   HeartbeatTask,
+  HeartbeatTaskAdmissionControl,
   HeartbeatTaskAgentRunRecord,
   HeartbeatTaskClaimResult,
   HeartbeatTaskClaimMode,

--- a/src/core/heartbeat/tasks/repository.ts
+++ b/src/core/heartbeat/tasks/repository.ts
@@ -10,24 +10,58 @@ import { randomUUID } from 'node:crypto';
 import { basename, dirname, join } from 'node:path';
 import dayjs from 'dayjs';
 import type { AgentLoopCheckpoint } from '@/core/runtime/loop/index.js';
-import { AgentLoopCheckpointSchema, HeartbeatTaskRunRecordSchema, HeartbeatTaskSchema } from './schemas.js';
+import {
+  AgentLoopCheckpointSchema,
+  HeartbeatAdmissionStateSchema,
+  HeartbeatTaskRunRecordSchema,
+  HeartbeatTaskSchema,
+} from './schemas.js';
 import { HeartbeatTaskStateProjector } from './task-state.js';
 import type {
   FileHeartbeatTaskRepositoryOptions,
+  HeartbeatAdmissionDecision,
   HeartbeatTask,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
 } from './types.js';
 
+export type FileHeartbeatAdmissionState = {
+  version: 1;
+  namespace?: HeartbeatAdmissionDecision;
+  groups: Record<string, HeartbeatAdmissionDecision>;
+};
+
 export class FileHeartbeatTaskRepository {
+  private readonly admissionPath: string;
   private readonly tasksDir: string;
   private readonly checkpointsDir: string;
   private readonly runsDir: string;
 
   constructor(options: FileHeartbeatTaskRepositoryOptions) {
+    this.admissionPath = join(options.dir, 'admission.json');
     this.tasksDir = join(options.dir, 'tasks');
     this.checkpointsDir = join(options.dir, 'checkpoints');
     this.runsDir = join(options.dir, 'runs');
+  }
+
+  /**
+   * Loads the adapter-owned binary admission projection.
+   *
+   * A missing document preserves legacy namespace readiness. Malformed state
+   * throws so claim callers fail closed instead of silently restoring defaults.
+   */
+  async loadAdmissionState(): Promise<FileHeartbeatAdmissionState> {
+    if (!existsSync(this.admissionPath)) {
+      return { version: 1, groups: {} };
+    }
+
+    return HeartbeatAdmissionStateSchema.parse(
+      JSON.parse(readFileSync(this.admissionPath, 'utf8')) as unknown,
+    ) as FileHeartbeatAdmissionState;
+  }
+
+  async saveAdmissionState(state: FileHeartbeatAdmissionState): Promise<void> {
+    this.writeJsonAtomically(this.admissionPath, HeartbeatAdmissionStateSchema.parse(state));
   }
 
   async listTasks(): Promise<HeartbeatTask[]> {

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -17,18 +17,24 @@ export const HeartbeatDecisionSchema = z.enum(['continue', 'pause', 'complete', 
 export const HeartbeatTaskContinuationModeSchema = z.enum(['operator', 'agent']);
 export const HeartbeatTaskRecoveryReasonSchema = z.enum(['host-restart', 'operator']);
 export const HeartbeatAdmissionDecisionSchema = z.enum(['ready', 'closed']);
+export const HeartbeatAdmissionGroupIdSchema = z.string()
+  .refine((value) => value.trim().length > 0, 'Admission group id cannot be blank.')
+  .refine(
+    (value) => value === value.trim(),
+    'Admission group id cannot contain leading or trailing whitespace.',
+  );
 export const HeartbeatAdmissionTargetSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('namespace') }),
   z.object({
     kind: z.literal('group'),
-    groupId: z.string().refine((value) => value.trim().length > 0, 'Admission group id cannot be blank.'),
+    groupId: HeartbeatAdmissionGroupIdSchema,
   }),
 ]);
 
 export const HeartbeatAdmissionStateSchema = z.object({
   version: z.literal(1),
   namespace: HeartbeatAdmissionDecisionSchema.optional(),
-  groups: z.record(z.string(), HeartbeatAdmissionDecisionSchema),
+  groups: z.record(HeartbeatAdmissionGroupIdSchema, HeartbeatAdmissionDecisionSchema),
 });
 
 const HeartbeatTaskExecutionSchema = z.object({
@@ -48,8 +54,16 @@ const HeartbeatTaskRunRequestSchema = z.object({
 const HeartbeatTaskRecoverySchema = z.object({
   interruptedExecutionId: z.string().describe('Fencing token of the interrupted execution.'),
   interruptedOwnerId: z.string().describe('Scheduler owner whose execution was interrupted.'),
+  interruptedRunRequestGeneration: z.number().int().nonnegative().optional()
+    .describe('Run-request generation already owned by the interrupted execution.'),
   recoveredAt: z.string().describe('Timestamp when the task became retryable again.'),
   reason: HeartbeatTaskRecoveryReasonSchema.describe('Host-owned reason for recovering the execution.'),
+  replacementStatus: z.enum(['pending', 'claimed']).optional()
+    .describe('Whether this current-format recovery still authorizes one exact replacement.'),
+  replacementExecutionId: z.string().optional()
+    .describe('Single replacement execution that atomically consumed this recovery.'),
+  replacementClaimedAt: z.string().optional()
+    .describe('Timestamp when the replacement execution consumed this recovery.'),
 });
 
 export const HeartbeatTaskExecutionOutcomeSchema = z.object({
@@ -66,8 +80,7 @@ export const HeartbeatTaskExecutionOutcomeSchema = z.object({
 export const HeartbeatTaskSchema = z.object({
   id: z.string().describe('Stable heartbeat task identifier.'),
   workspaceId: z.string().optional().describe('Workspace identifier this task belongs to.'),
-  admissionGroupId: z.string()
-    .refine((value) => value.trim().length > 0, 'Admission group id cannot be blank.')
+  admissionGroupId: HeartbeatAdmissionGroupIdSchema
     .optional()
     .describe('Opaque admission group checked in addition to namespace admission.'),
   task: z.string().describe('Durable task instruction the heartbeat should pursue.'),

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -16,6 +16,20 @@ export const HeartbeatTaskStatusSchema = z.enum(['idle', 'running', 'waiting', '
 export const HeartbeatDecisionSchema = z.enum(['continue', 'pause', 'complete', 'escalate']);
 export const HeartbeatTaskContinuationModeSchema = z.enum(['operator', 'agent']);
 export const HeartbeatTaskRecoveryReasonSchema = z.enum(['host-restart', 'operator']);
+export const HeartbeatAdmissionDecisionSchema = z.enum(['ready', 'closed']);
+export const HeartbeatAdmissionTargetSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('namespace') }),
+  z.object({
+    kind: z.literal('group'),
+    groupId: z.string().refine((value) => value.trim().length > 0, 'Admission group id cannot be blank.'),
+  }),
+]);
+
+export const HeartbeatAdmissionStateSchema = z.object({
+  version: z.literal(1),
+  namespace: HeartbeatAdmissionDecisionSchema.optional(),
+  groups: z.record(z.string(), HeartbeatAdmissionDecisionSchema),
+});
 
 const HeartbeatTaskExecutionSchema = z.object({
   executionId: z.string().describe('Fencing token for the currently owned execution attempt.'),
@@ -52,6 +66,10 @@ export const HeartbeatTaskExecutionOutcomeSchema = z.object({
 export const HeartbeatTaskSchema = z.object({
   id: z.string().describe('Stable heartbeat task identifier.'),
   workspaceId: z.string().optional().describe('Workspace identifier this task belongs to.'),
+  admissionGroupId: z.string()
+    .refine((value) => value.trim().length > 0, 'Admission group id cannot be blank.')
+    .optional()
+    .describe('Opaque admission group checked in addition to namespace admission.'),
   task: z.string().describe('Durable task instruction the heartbeat should pursue.'),
   name: z.string().optional().describe('Human-facing task label.'),
   enabled: z.boolean().describe('Whether the scheduler may run this task.'),

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod';
 import { LlmUsageSchema } from '@/core/llm/usage/index.js';
 import {
+  type HeartbeatAdmissionDecision,
   MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH,
   MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH,
 } from './types.js';
@@ -23,6 +24,20 @@ export const HeartbeatAdmissionGroupIdSchema = z.string()
     (value) => value === value.trim(),
     'Admission group id cannot contain leading or trailing whitespace.',
   );
+
+function isAdmissionGroupRecord(value: unknown): value is Record<string, HeartbeatAdmissionDecision> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  if (prototype !== null && prototype !== Object.prototype) {
+    return false;
+  }
+  return Object.entries(value).every(([groupId, decision]) =>
+    HeartbeatAdmissionGroupIdSchema.safeParse(groupId).success
+    && HeartbeatAdmissionDecisionSchema.safeParse(decision).success);
+}
+
 export const HeartbeatAdmissionTargetSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('namespace') }),
   z.object({
@@ -30,11 +45,15 @@ export const HeartbeatAdmissionTargetSchema = z.discriminatedUnion('kind', [
     groupId: HeartbeatAdmissionGroupIdSchema,
   }),
 ]);
+const HeartbeatAdmissionGroupsSchema = z.custom<Record<string, HeartbeatAdmissionDecision>>(
+  isAdmissionGroupRecord,
+  { message: 'Admission groups must map valid opaque ids to ready or closed.' },
+).transform((groups) => Object.fromEntries(Object.entries(groups)));
 
 export const HeartbeatAdmissionStateSchema = z.object({
   version: z.literal(1),
   namespace: HeartbeatAdmissionDecisionSchema.optional(),
-  groups: z.record(HeartbeatAdmissionGroupIdSchema, HeartbeatAdmissionDecisionSchema),
+  groups: HeartbeatAdmissionGroupsSchema,
 });
 
 const HeartbeatTaskExecutionSchema = z.object({

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -193,6 +193,7 @@ export class FileHeartbeatTaskService implements
    * implementation uses database compare-and-swap or leases.
    */
   async claimTaskExecution(input: Parameters<HeartbeatTargetedTaskStore['claimTaskExecution']>[0]) {
+    FileHeartbeatTaskService.assertRecoveryClaimInput(input);
     return await this.mutationMutex.runExclusive(async () => {
       const task = await this.findTask(input.taskId);
       if (!task) {
@@ -204,7 +205,8 @@ export class FileHeartbeatTaskService implements
       if (task.state?.status === 'running') {
         return { status: 'busy' } as const;
       }
-      if (input.claimMode === 'due') {
+      const claimMode = input.claimMode ?? 'any';
+      if (claimMode !== 'any') {
         const eligibility = HeartbeatTaskExecutionEligibilityPolicy.evaluate(task, input.claimedAt);
         if (!eligibility.eligible) {
           if (eligibility.reason === 'not-due') {
@@ -214,10 +216,19 @@ export class FileHeartbeatTaskService implements
         }
       }
 
-      const admissionState = await this.repository.loadAdmissionState();
-      const closedTarget = FileHeartbeatTaskService.resolveClosedAdmissionTarget(task, admissionState);
-      if (closedTarget) {
-        return { status: 'admission-closed', target: closedTarget } as const;
+      const recoveryOfExecutionId = claimMode === 'recovery' ? input.recoveryOfExecutionId : undefined;
+      if (
+        recoveryOfExecutionId
+        && HeartbeatTaskStateProjector.pendingRecoveryExecutionId(task) !== recoveryOfExecutionId
+      ) {
+        return { status: 'not-due', task } as const;
+      }
+      if (!recoveryOfExecutionId) {
+        const admissionState = await this.repository.loadAdmissionState();
+        const closedTarget = FileHeartbeatTaskService.resolveClosedAdmissionTarget(task, admissionState);
+        if (closedTarget) {
+          return { status: 'admission-closed', target: closedTarget } as const;
+        }
       }
 
       const runningTask = HeartbeatTaskStateProjector.markRunning({
@@ -225,6 +236,7 @@ export class FileHeartbeatTaskService implements
         now: input.claimedAt,
         loadedCheckpoint: input.loadedCheckpoint,
         execution: input.execution,
+        recoveryOfExecutionId,
       });
       await this.repository.saveTask(runningTask);
       FileHeartbeatTaskService.activeExecutions.add(this.executionKey(input.execution));
@@ -679,6 +691,17 @@ export class FileHeartbeatTaskService implements
 
     const group = { kind: 'group', groupId: task.admissionGroupId } as const;
     return FileHeartbeatTaskService.resolveAdmissionDecision(state, group) === 'closed' ? group : undefined;
+  }
+
+  private static assertRecoveryClaimInput(
+    input: Parameters<HeartbeatTargetedTaskStore['claimTaskExecution']>[0],
+  ): void {
+    if (input.claimMode === 'recovery' && !input.recoveryOfExecutionId) {
+      throw new Error('Heartbeat recovery claims require recoveryOfExecutionId.');
+    }
+    if (input.claimMode !== 'recovery' && input.recoveryOfExecutionId !== undefined) {
+      throw new Error('recoveryOfExecutionId is valid only for a heartbeat recovery claim.');
+    }
   }
 
   private static resolveAdmissionDecision(

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -708,8 +708,13 @@ export class FileHeartbeatTaskService implements
     state: FileHeartbeatAdmissionState,
     target: HeartbeatAdmissionTarget,
   ): HeartbeatAdmissionDecision {
-    return target.kind === 'namespace' ? state.namespace ?? 'ready'
-      : state.groups[target.groupId] ?? 'closed';
+    if (target.kind === 'namespace') {
+      return state.namespace ?? 'ready';
+    }
+    if (!Object.hasOwn(state.groups, target.groupId)) {
+      return 'closed';
+    }
+    return state.groups[target.groupId] ?? 'closed';
   }
 
   private static withLegacyExecution(task: HeartbeatTask): HeartbeatTask {

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -12,7 +12,14 @@ import type {
   UpdateHeartbeatTaskInput,
 } from './administration.js';
 import { HeartbeatTaskControlPolicy } from './control-policy.js';
-import { FileHeartbeatTaskRepository } from './repository.js';
+import {
+  FileHeartbeatTaskRepository,
+  type FileHeartbeatAdmissionState,
+} from './repository.js';
+import {
+  HeartbeatAdmissionDecisionSchema,
+  HeartbeatAdmissionTargetSchema,
+} from './schemas.js';
 import { HeartbeatTaskExecutionEligibilityPolicy } from './execution-eligibility.js';
 import { HeartbeatTaskStateProjector } from './task-state.js';
 import {
@@ -21,7 +28,10 @@ import {
 } from './types.js';
 import type {
   FileHeartbeatTaskRepositoryOptions,
+  HeartbeatAdmissionDecision,
+  HeartbeatAdmissionTarget,
   HeartbeatTask,
+  HeartbeatTaskAdmissionControl,
   HeartbeatTaskExecution,
   HeartbeatTaskRunRecord,
   HeartbeatTaskRunRecordEntry,
@@ -51,7 +61,10 @@ export type {
  * run records, and operator-facing task/run projections. Hosts should call this
  * service, not the file repository.
  */
-export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore, HeartbeatTaskAdministrationService {
+export class FileHeartbeatTaskService implements
+  HeartbeatTargetedTaskStore,
+  HeartbeatTaskAdministrationService,
+  HeartbeatTaskAdmissionControl {
   private static readonly mutationMutexes = new Map<string, Mutex>();
   private static readonly activeExecutions = new Set<string>();
   private static readonly runRequestEventBuses = new Map<string, EventEmitter>();
@@ -81,6 +94,41 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore, Hea
 
   async saveTask(task: HeartbeatTask) {
     await this.mutationMutex.runExclusive(async () => await this.repository.saveTask(task));
+  }
+
+  async readAdmissionDecision(target: HeartbeatAdmissionTarget): Promise<HeartbeatAdmissionDecision> {
+    const parsedTarget = HeartbeatAdmissionTargetSchema.parse(target) as HeartbeatAdmissionTarget;
+    return await this.mutationMutex.runExclusive(async () => {
+      const state = await this.repository.loadAdmissionState();
+      return FileHeartbeatTaskService.resolveAdmissionDecision(state, parsedTarget);
+    });
+  }
+
+  /**
+   * Changes only future claim eligibility. Already claimed work keeps its
+   * fencing token and must be cancelled or drained through an explicit host
+   * operation.
+   */
+  async setAdmissionDecision(
+    target: HeartbeatAdmissionTarget,
+    decision: HeartbeatAdmissionDecision,
+  ): Promise<void> {
+    const parsedTarget = HeartbeatAdmissionTargetSchema.parse(target) as HeartbeatAdmissionTarget;
+    const parsedDecision = HeartbeatAdmissionDecisionSchema.parse(decision);
+    await this.mutationMutex.runExclusive(async () => {
+      const current = await this.repository.loadAdmissionState();
+      const next: FileHeartbeatAdmissionState = parsedTarget.kind === 'namespace' ? {
+        ...current,
+        namespace: parsedDecision,
+      } : {
+        ...current,
+        groups: Object.fromEntries([
+          ...Object.entries(current.groups),
+          [parsedTarget.groupId, parsedDecision],
+        ]),
+      };
+      await this.repository.saveAdmissionState(next);
+    });
   }
 
   async loadCheckpoint(task: HeartbeatTask) {
@@ -164,6 +212,12 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore, Hea
           }
           return { status: eligibility.reason } as const;
         }
+      }
+
+      const admissionState = await this.repository.loadAdmissionState();
+      const closedTarget = FileHeartbeatTaskService.resolveClosedAdmissionTarget(task, admissionState);
+      if (closedTarget) {
+        return { status: 'admission-closed', target: closedTarget } as const;
       }
 
       const runningTask = HeartbeatTaskStateProjector.markRunning({
@@ -609,6 +663,30 @@ export class FileHeartbeatTaskService implements HeartbeatTargetedTaskStore, Hea
     const eventBus = new EventEmitter();
     FileHeartbeatTaskService.runRequestEventBuses.set(heartbeatRoot, eventBus);
     return eventBus;
+  }
+
+  private static resolveClosedAdmissionTarget(
+    task: HeartbeatTask,
+    state: FileHeartbeatAdmissionState,
+  ): HeartbeatAdmissionTarget | undefined {
+    const namespace = { kind: 'namespace' } as const;
+    if (FileHeartbeatTaskService.resolveAdmissionDecision(state, namespace) === 'closed') {
+      return namespace;
+    }
+    if (!task.admissionGroupId) {
+      return undefined;
+    }
+
+    const group = { kind: 'group', groupId: task.admissionGroupId } as const;
+    return FileHeartbeatTaskService.resolveAdmissionDecision(state, group) === 'closed' ? group : undefined;
+  }
+
+  private static resolveAdmissionDecision(
+    state: FileHeartbeatAdmissionState,
+    target: HeartbeatAdmissionTarget,
+  ): HeartbeatAdmissionDecision {
+    return target.kind === 'namespace' ? state.namespace ?? 'ready'
+      : state.groups[target.groupId] ?? 'closed';
   }
 
   private static withLegacyExecution(task: HeartbeatTask): HeartbeatTask {

--- a/src/core/heartbeat/tasks/task-state.ts
+++ b/src/core/heartbeat/tasks/task-state.ts
@@ -40,10 +40,17 @@ export class HeartbeatTaskStateProjector {
     now: Date;
     loadedCheckpoint: boolean;
     execution: HeartbeatTaskExecution;
+    recoveryOfExecutionId?: string;
   }): HeartbeatTask {
+    const recovery = args.recoveryOfExecutionId ?
+      HeartbeatTaskStateProjector.requirePendingRecovery(args.task, args.recoveryOfExecutionId)
+    : undefined;
     const runRequest = args.task.state?.runRequest;
-    const claimsPendingRequest = HeartbeatTaskStateProjector.hasPendingRunRequest(args.task);
-    const execution = claimsPendingRequest && runRequest ? {
+    const claimsPendingRequest = !recovery && HeartbeatTaskStateProjector.hasPendingRunRequest(args.task);
+    const execution = recovery ? {
+      ...args.execution,
+      runRequestGeneration: recovery.interruptedRunRequestGeneration,
+    } : claimsPendingRequest && runRequest ? {
       ...args.execution,
       runRequestGeneration: runRequest.generation,
     } : args.execution;
@@ -54,7 +61,11 @@ export class HeartbeatTaskStateProjector {
         ...args.task.state,
         status: 'running',
         progress:
-          args.loadedCheckpoint ?
+          recovery && args.loadedCheckpoint ?
+            'Continuing recovered heartbeat work from the last checkpoint.'
+          : recovery ?
+            'Continuing recovered heartbeat work.'
+          : args.loadedCheckpoint ?
             'Resuming heartbeat runner from the last checkpoint.'
           : 'Starting a new heartbeat runner cycle.',
         loadedCheckpoint: args.loadedCheckpoint,
@@ -64,6 +75,12 @@ export class HeartbeatTaskStateProjector {
           ...runRequest,
           claimedGeneration: runRequest.generation,
         } : runRequest,
+        recovery: recovery ? {
+          ...recovery,
+          replacementStatus: 'claimed',
+          replacementExecutionId: execution.executionId,
+          replacementClaimedAt: dayjs(args.now).toISOString(),
+        } : args.task.state?.recovery,
         updatedAt: dayjs(args.now).toISOString(),
       },
     });
@@ -116,6 +133,14 @@ export class HeartbeatTaskStateProjector {
     return Boolean(request && request.generation > request.claimedGeneration);
   }
 
+  static pendingRecoveryExecutionId(task: Pick<HeartbeatTask, 'state'>): string | undefined {
+    const recovery = task.state?.recovery;
+    if (recovery?.replacementStatus !== 'pending' || recovery.replacementExecutionId) {
+      return undefined;
+    }
+    return recovery.interruptedExecutionId;
+  }
+
   static afterRecovery(args: {
     task: HeartbeatTask;
     now: Date;
@@ -130,8 +155,10 @@ export class HeartbeatTaskStateProjector {
     const recovery: HeartbeatTaskRecovery = {
       interruptedExecutionId: execution.executionId,
       interruptedOwnerId: execution.ownerId,
+      interruptedRunRequestGeneration: execution.runRequestGeneration,
       recoveredAt,
       reason: args.reason,
+      replacementStatus: 'pending',
     };
     const task = HeartbeatTaskStateProjector.normalize({
       ...args.task,
@@ -511,6 +538,24 @@ export class HeartbeatTaskStateProjector {
     return args.decision === 'continue' ?
       args.intervalMs
     : HeartbeatDecisionPolicy.suggestNextDelayMs(args.decision) ?? args.intervalMs;
+  }
+
+  private static requirePendingRecovery(
+    task: Pick<HeartbeatTask, 'id' | 'state'>,
+    interruptedExecutionId: string,
+  ): HeartbeatTaskRecovery {
+    const recovery = task.state?.recovery;
+    if (
+      !recovery
+      || recovery.replacementStatus !== 'pending'
+      || recovery.replacementExecutionId
+      || recovery.interruptedExecutionId !== interruptedExecutionId
+    ) {
+      throw new Error(
+        `Heartbeat task ${task.id} has no pending recovery for execution ${interruptedExecutionId}.`,
+      );
+    }
+    return recovery;
   }
 
   private static formatDelay(ms: number): string {

--- a/src/core/heartbeat/tasks/types.ts
+++ b/src/core/heartbeat/tasks/types.ts
@@ -30,7 +30,9 @@ export type HeartbeatAdmissionDecision = 'ready' | 'closed';
  * Implementations must serialize decision changes with `claimTaskExecution`.
  * An absent namespace decision is `ready` for legacy ungrouped tasks, while an
  * absent assigned-group decision is `closed` so partially reconciled grouped
- * tasks fail closed.
+ * tasks fail closed. Admission governs fresh logical work. An exact durable
+ * recovery continuation may bypass closed admission; use explicit host pause,
+ * drain, or cancellation when no execution may proceed.
  */
 export interface HeartbeatTaskAdmissionControl {
   readAdmissionDecision(target: HeartbeatAdmissionTarget): Promise<HeartbeatAdmissionDecision>;
@@ -108,8 +110,14 @@ export type HeartbeatTaskRecoveryReason = 'host-restart' | 'operator';
 export type HeartbeatTaskRecovery = {
   interruptedExecutionId: string;
   interruptedOwnerId: string;
+  interruptedRunRequestGeneration?: number;
   recoveredAt: string;
   reason: HeartbeatTaskRecoveryReason;
+  /** Missing on legacy diagnostic records, which never authorize a replacement. */
+  replacementStatus?: 'pending' | 'claimed';
+  /** Set atomically when one exact replacement execution consumes this recovery. */
+  replacementExecutionId?: string;
+  replacementClaimedAt?: string;
 };
 
 type HeartbeatTaskExecutionOutcomeBase = {
@@ -207,9 +215,16 @@ export type HeartbeatTaskClaimResult =
 /**
  * `due` makes the durable store re-check scheduler eligibility atomically with
  * the claim. `any` is reserved for explicit operator-triggered "run now"
- * paths that intentionally ignore the stored schedule.
+ * paths that intentionally ignore the stored schedule. Both modes are fresh
+ * logical work and require ready admission.
+ *
+ * `recovery` is only for the exact unconsumed recovery identified by
+ * `recoveryOfExecutionId`. It still requires an enabled, due, non-running task,
+ * but may bypass closed namespace/group admission because it continues work
+ * admitted by the interrupted execution. The claim must consume that recovery
+ * marker atomically and must not consume a newer run-request generation.
  */
-export type HeartbeatTaskClaimMode = 'any' | 'due';
+export type HeartbeatTaskClaimMode = 'any' | 'due' | 'recovery';
 
 export type HeartbeatTaskExecutionWriteResult =
   | { status: 'saved'; task: HeartbeatTask; record?: HeartbeatTaskRunRecord }
@@ -234,7 +249,8 @@ export type HeartbeatTaskStore = {
   /**
    * Final durable admission authority. The claim must atomically recheck task
    * enablement, claim-mode schedule eligibility, active ownership, namespace
-   * admission, and the task's optional assigned-group admission.
+   * admission, and the task's optional assigned-group admission, or atomically
+   * match and consume the exact pending recovery allowed to bypass both scopes.
    */
   claimTaskExecution: (input: {
     taskId: string;
@@ -242,6 +258,8 @@ export type HeartbeatTaskStore = {
     loadedCheckpoint: boolean;
     claimedAt: Date;
     claimMode?: HeartbeatTaskClaimMode;
+    /** Required only for `claimMode: 'recovery'`; rejected on every other mode. */
+    recoveryOfExecutionId?: string;
   }) => Promise<HeartbeatTaskClaimResult>;
   completeTaskExecution: (input: {
     execution: HeartbeatTaskExecution;

--- a/src/core/heartbeat/tasks/types.ts
+++ b/src/core/heartbeat/tasks/types.ts
@@ -16,6 +16,30 @@ export type HeartbeatTaskSchedule = {
 
 export type HeartbeatTaskContinuationMode = 'operator' | 'agent';
 
+/** Provider-neutral admission scope consulted by the final durable task claim. */
+export type HeartbeatAdmissionTarget =
+  | { kind: 'namespace' }
+  | { kind: 'group'; groupId: string };
+
+/** Binary claim-time projection of an adapter's durable admission lifecycle. */
+export type HeartbeatAdmissionDecision = 'ready' | 'closed';
+
+/**
+ * Operator-facing control port for durable heartbeat admission.
+ *
+ * Implementations must serialize decision changes with `claimTaskExecution`.
+ * An absent namespace decision is `ready` for legacy ungrouped tasks, while an
+ * absent assigned-group decision is `closed` so partially reconciled grouped
+ * tasks fail closed.
+ */
+export interface HeartbeatTaskAdmissionControl {
+  readAdmissionDecision(target: HeartbeatAdmissionTarget): Promise<HeartbeatAdmissionDecision>;
+  setAdmissionDecision(
+    target: HeartbeatAdmissionTarget,
+    decision: HeartbeatAdmissionDecision,
+  ): Promise<void>;
+}
+
 export const MAX_HEARTBEAT_RUN_REQUEST_REASON_LENGTH = 200;
 export const MAX_HEARTBEAT_CANCELLATION_REASON_LENGTH = 200;
 export const DEFAULT_HEARTBEAT_HANDLER_RETRY_MS = 5 * 60_000;
@@ -134,6 +158,8 @@ export type HeartbeatTaskState = {
 export type HeartbeatTask = {
   id: string;
   workspaceId?: string;
+  /** Optional opaque admission group checked in addition to the store namespace. */
+  admissionGroupId?: string;
   task: string;
   name?: string;
   enabled: boolean;
@@ -175,6 +201,7 @@ export type HeartbeatTaskRunRecordEntry = {
 export type HeartbeatTaskClaimResult =
   | { status: 'claimed'; task: HeartbeatTask }
   | { status: 'not-due'; task: HeartbeatTask }
+  | { status: 'admission-closed'; target: HeartbeatAdmissionTarget }
   | { status: 'busy' | 'disabled' | 'not-found' };
 
 /**
@@ -204,6 +231,11 @@ export type HeartbeatTaskStore = {
     options?: RequestHeartbeatTaskRunOptions,
   ) => Promise<HeartbeatTaskRunRequestResult>;
   subscribeToRunRequests?: (listener: (request: HeartbeatTaskRunRequestSignal) => void) => () => void;
+  /**
+   * Final durable admission authority. The claim must atomically recheck task
+   * enablement, claim-mode schedule eligibility, active ownership, namespace
+   * admission, and the task's optional assigned-group admission.
+   */
   claimTaskExecution: (input: {
     taskId: string;
     execution: HeartbeatTaskExecution;


### PR DESCRIPTION
## Summary

- add provider-neutral namespace and one optional opaque group to final heartbeat claim admission
- expose a separate binary HeartbeatTaskAdmissionControl port while keeping hosted transition lifecycle adapter-owned
- serialize file-backed admission changes with task claims and return the blocking target as admission-closed
- add exact, single-use interrupted-execution recovery that can continue already-admitted work through closed scopes
- extend adapter conformance for fail-closed groups, close-vs-claim linearization, recovery fencing, request-generation preservation, and unrelated-group progress

## Contract and compatibility

- tasks without admissionGroupId retain namespace-only behavior
- absent namespace state defaults ready; absent assigned-group state defaults closed
- opaque group identities reject leading/trailing whitespace instead of silently canonicalizing
- durable group lookup uses own-key semantics; prototype-named IDs fail closed when absent, and `__proto__` round-trips without prototype mutation
- fresh due and explicit run-now claims require ready namespace/group admission
- exact recovery matches and consumes the current durable pending recovery marker atomically, bypasses both closed scopes, preserves the interrupted request generation, and leaves newer requests pending
- stale IDs, consumed markers, and legacy diagnostic recovery records cannot authorize recovery bypass
- closing admission does not disable tasks, alter due/checkpoint state, cancel active work, or drain workers; use explicit host pause/drain/cancel for a zero-execution stop
- exhaustive result consumers must handle the new admission-closed discriminant, and custom stores must implement the new recovery claim mode
- createAdmissionControl remains optional on the conformance harness for source compatibility; supplying it is required for scoped-admission certification
- desired state, preparing/blocked phases, transition IDs, retries, restart reconciliation, and product resume preparation remain outside Heddle

Coordinates with https://github.com/roackb2/heddle-execution-host/issues/43.

## Verification

- yarn vitest run src/__tests__/integration/core/heartbeat-task-store-conformance.test.ts src/__tests__/integration/core/heartbeat-scheduler.test.ts src/__tests__/integration/core/heartbeat-targeted-execution.test.ts src/__tests__/integration/core/heartbeat-targeted-dispatcher.test.ts src/__tests__/unit/core/heartbeat-task-control-policy.test.ts
- yarn typecheck
- yarn lint
- yarn test (142 unit files / 925 tests; 49 integration files / 441 tests)
- yarn build

## Release requirement

This needs a new @heddleagent/runtime release before Execution Host can pin and merge its provider adapter. The planned lane is 7.0.0 because `admission-closed` and `recovery` add members to public discriminated unions that exhaustive TypeScript consumers may treat as source-breaking. This PR does not bump, tag, publish, or deploy it.
