### PR TITLE
Await heartbeat result projection before success

### DIFF
--- a/src/__tests__/unit/core/heartbeat-run-service.test.ts
+++ b/src/__tests__/unit/core/heartbeat-run-service.test.ts
@@ -69,6 +69,139 @@ describe('HeartbeatRunService', () => {
     expect(events[1]).not.toHaveProperty('result.state.usage');
   });
 
+  it('awaits host result projection before resolving or publishing the result terminal', async () => {
+    const heartbeatResult = result();
+    const projectionStarted = deferred<void>();
+    const releaseProjection = deferred<void>();
+    const runner = vi.fn(async () => heartbeatResult);
+    const service = new HeartbeatRunService({
+      createRunId: () => 'heartbeat-run-projected',
+      now: () => '2026-08-18T12:00:30.000Z',
+      runner,
+    });
+    const run = service.start({
+      task: 'Review the workspace.',
+      projectResult: async (value, context) => {
+        expect(context.runId).toBe('heartbeat-run-projected');
+        expect(context.signal.aborted).toBe(false);
+        projectionStarted.resolve();
+        await releaseProjection.promise;
+        return { decision: value.decision, summary: value.summary };
+      },
+    });
+    const iterator = run.events()[Symbol.asyncIterator]();
+    const terminal = iterator.next();
+    const resultSettled = vi.fn();
+    const terminalSettled = vi.fn();
+    void run.result.then(resultSettled);
+    void terminal.then(terminalSettled);
+
+    await projectionStarted.promise;
+    await Promise.resolve();
+    expect(resultSettled).not.toHaveBeenCalled();
+    expect(terminalSettled).not.toHaveBeenCalled();
+    expect(runner.mock.calls[0]?.[0]).not.toHaveProperty('projectResult');
+
+    releaseProjection.resolve();
+
+    const projected = {
+      decision: heartbeatResult.decision,
+      summary: heartbeatResult.summary,
+    };
+    await expect(run.result).resolves.toEqual(projected);
+    await expect(terminal).resolves.toEqual({
+      done: false,
+      value: {
+        kind: 'result',
+        result: projected,
+        runId: 'heartbeat-run-projected',
+        sequence: 1,
+        timestamp: '2026-08-18T12:00:30.000Z',
+      },
+    });
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it('publishes only the safe error terminal when host result projection fails', async () => {
+    const runner = vi.fn(async () => result());
+    const service = new HeartbeatRunService({
+      createRunId: () => 'heartbeat-run-projection-failed',
+      now: () => '2026-08-18T12:00:45.000Z',
+      runner,
+    });
+    const run = service.start({
+      task: 'Review the workspace.',
+      projectResult: () => {
+        throw new Error('durable checkpoint commit failed');
+      },
+    });
+
+    await expect(run.result).rejects.toThrow('durable checkpoint commit failed');
+    await expect(collect(run.events())).resolves.toEqual([
+      {
+        kind: 'error',
+        error: {
+          code: 'heartbeat_run_failed',
+          message: 'The heartbeat run could not complete.',
+        },
+        runId: 'heartbeat-run-projection-failed',
+        sequence: 1,
+        timestamp: '2026-08-18T12:00:45.000Z',
+      },
+    ]);
+  });
+
+  it.each(['handle', 'external'] as const)(
+    'lets %s cancellation win while host result projection is pending',
+    async (cancellationSource) => {
+      const projectionStarted = deferred<void>();
+      const releaseProjection = deferred<void>();
+      const externalController = new AbortController();
+      let projectionSignal: AbortSignal | undefined;
+      const runner = vi.fn(async () => result());
+      const service = new HeartbeatRunService({
+        createRunId: () => `heartbeat-run-${cancellationSource}-projection-cancelled`,
+        now: () => '2026-08-18T12:00:50.000Z',
+        runner,
+      });
+      const run = service.start({
+        task: 'Review the workspace.',
+        abortSignal: externalController.signal,
+        projectResult: async (value, context) => {
+          projectionSignal = context.signal;
+          projectionStarted.resolve();
+          await releaseProjection.promise;
+          return value;
+        },
+      });
+
+      await projectionStarted.promise;
+      if (cancellationSource === 'handle') {
+        expect(run.cancel()).toBe(true);
+        releaseProjection.resolve();
+      } else {
+        externalController.abort(new Error('External heartbeat cancellation.'));
+        releaseProjection.reject(new Error('Late projection failure must not win.'));
+      }
+      expect(projectionSignal?.aborted).toBe(true);
+
+      await expect(run.result).rejects.toThrow(
+        cancellationSource === 'handle'
+          ? 'Heartbeat run was cancelled.'
+          : 'External heartbeat cancellation.',
+      );
+      await expect(collect(run.events())).resolves.toEqual([
+        {
+          kind: 'cancelled',
+          reason: 'Heartbeat run was cancelled.',
+          runId: `heartbeat-run-${cancellationSource}-projection-cancelled`,
+          sequence: 1,
+          timestamp: '2026-08-18T12:00:50.000Z',
+        },
+      ]);
+    },
+  );
+
   it('aborts an active runner and publishes cancellation as the terminal', async () => {
     let markStarted: (() => void) | undefined;
     const started = new Promise<void>((resolve) => {
@@ -177,4 +310,14 @@ async function collect<Event>(events: AsyncIterable<Event>): Promise<Event[]> {
     collected.push(event);
   }
   return collected;
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value | PromiseLike<Value>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -329,11 +329,15 @@ export type {
 } from './core/heartbeat/agent/index.js';
 export { HeartbeatRunService } from './core/heartbeat/runs/index.js';
 export type {
+  HeartbeatRunContext,
   HeartbeatRunHandle,
   HeartbeatRunPublicError,
+  HeartbeatRunResultProjector,
   HeartbeatRunServiceOptions,
   HeartbeatRunStreamItem,
   HeartbeatRunner,
+  StartHeartbeatRunInput,
+  StartProjectedHeartbeatRunInput,
 } from './core/heartbeat/runs/index.js';
 export {
   FileHeartbeatCheckpointRepository,

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -14,7 +14,10 @@ operator-facing heartbeat views.
   beside it.
 - `runs/`: `HeartbeatRunService` owns the process-local lifecycle for one
   explicitly requested heartbeat cycle: run identity, cancellation, ordered
-  activity, and exactly one terminal result, cancellation, or safe error.
+  activity, awaited host result projection, and exactly one terminal result,
+  cancellation, or safe error. Result projection completes before either the
+  handle promise or canonical result stream item settles; cancellation remains
+  authoritative if it races projection.
   Hosts provide resolved model/tool/MCP options and consume its handle instead
   of rebuilding callback-to-stream coordination.
 - `checkpoint/`: `StoredHeartbeatService` and

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -93,11 +93,15 @@ export type {
 } from './agent/index.js';
 export { HeartbeatRunService } from './runs/index.js';
 export type {
+  HeartbeatRunContext,
   HeartbeatRunHandle,
   HeartbeatRunPublicError,
+  HeartbeatRunResultProjector,
   HeartbeatRunServiceOptions,
   HeartbeatRunStreamItem,
   HeartbeatRunner,
+  StartHeartbeatRunInput,
+  StartProjectedHeartbeatRunInput,
 } from './runs/index.js';
 export { HeartbeatLucidPresenter, HeartbeatTaskViewProjector } from './views/index.js';
 export type {

--- a/src/core/heartbeat/runs/README.md
+++ b/src/core/heartbeat/runs/README.md
@@ -11,6 +11,25 @@ Hosts can stream that handle without implementing their own buffer, sequence
 counter, cancellation controller, serialization shim, or terminal state
 machine.
 
+An optional per-run `projectResult` function is the host's awaited boundary
+between the internal agent result and the canonical result exposed by the
+handle and stream. A host may use it to durably commit or reconcile generic
+execution-owned state, then return the public result. Heddle does not publish
+the result terminal or resolve the handle promise until projection completes.
+Projection failure produces the standard safe error terminal, while
+cancellation remains authoritative if it races projection.
+
+```ts
+const run = heartbeatRuns.start({
+  task: 'Review the current situation and take useful action.',
+  projectResult: async (result, { signal }) => {
+    signal.throwIfAborted();
+    await executionState.commit(result);
+    return result;
+  },
+});
+```
+
 The service does not schedule tasks, persist checkpoints or task state, select
 models and tools, prepare MCP access, or know about AgentCore and HTTP. Those
 responsibilities remain with the heartbeat scheduler, persistence adapter, and

--- a/src/core/heartbeat/runs/index.ts
+++ b/src/core/heartbeat/runs/index.ts
@@ -1,8 +1,12 @@
 export { HeartbeatRunService } from './service.js';
 export type {
   HeartbeatRunHandle,
+  HeartbeatRunContext,
   HeartbeatRunPublicError,
+  HeartbeatRunResultProjector,
   HeartbeatRunServiceOptions,
   HeartbeatRunStreamItem,
   HeartbeatRunner,
+  StartHeartbeatRunInput,
+  StartProjectedHeartbeatRunInput,
 } from './types.js';

--- a/src/core/heartbeat/runs/service.ts
+++ b/src/core/heartbeat/runs/service.ts
@@ -3,17 +3,21 @@ import dayjs from 'dayjs';
 import { RuntimeSubscriptionStream } from '@/core/runtime/subscriptions/index.js';
 import { HeartbeatRunnerAgent } from '../agent/index.js';
 import type {
+  HeartbeatRunContext,
   HeartbeatRunHandle,
+  HeartbeatRunResultProjector,
   HeartbeatRunServiceOptions,
   HeartbeatRunStreamItem,
   HeartbeatRunner,
+  StartHeartbeatRunInput,
+  StartProjectedHeartbeatRunInput,
 } from './types.js';
-import type { RunAgentHeartbeatOptions } from '../agent/index.js';
+import type { AgentHeartbeatResult } from '../agent/index.js';
 
 const HEARTBEAT_CANCELLED_MESSAGE = 'Heartbeat run was cancelled.';
 const HEARTBEAT_FAILED_MESSAGE = 'The heartbeat run could not complete.';
 
-type HeartbeatRunStreamPayload = HeartbeatRunStreamItem extends infer Item
+type HeartbeatRunStreamPayload<Result> = HeartbeatRunStreamItem<Result> extends infer Item
   ? Item extends unknown
     ? Omit<Item, 'runId' | 'sequence' | 'timestamp'>
     : never
@@ -22,6 +26,7 @@ type HeartbeatRunStreamPayload = HeartbeatRunStreamItem extends infer Item
 /**
  * Owns the process-local lifecycle for one explicitly requested heartbeat run.
  *
+ * An optional result projector is awaited before public success settlement.
  * Scheduling and durable task settlement remain in the heartbeat scheduler;
  * deployment-specific model, tool, and MCP composition remain with the host.
  */
@@ -36,17 +41,27 @@ export class HeartbeatRunService {
     this.runner = options.runner ?? HeartbeatRunnerAgent.run.bind(HeartbeatRunnerAgent);
   }
 
-  start(options: RunAgentHeartbeatOptions): HeartbeatRunHandle {
+  start<Result>(options: StartProjectedHeartbeatRunInput<Result>): HeartbeatRunHandle<Result>;
+  start(options: StartHeartbeatRunInput): HeartbeatRunHandle;
+  start<Result>(
+    options: StartHeartbeatRunInput | StartProjectedHeartbeatRunInput<Result>,
+  ): HeartbeatRunHandle<AgentHeartbeatResult | Result> {
     const runId = this.createRunId();
     const controller = new AbortController();
     const signal = options.abortSignal
       ? AbortSignal.any([options.abortSignal, controller.signal])
       : controller.signal;
-    const stream = new RuntimeSubscriptionStream<HeartbeatRunStreamItem>();
+    const stream = new RuntimeSubscriptionStream<HeartbeatRunStreamItem<AgentHeartbeatResult | Result>>();
+    const context: HeartbeatRunContext = { runId, signal };
+    const projectResult = 'projectResult' in options
+      ? options.projectResult
+      : undefined;
+    const { projectResult: _projectResult, ...runnerOptions } = options as
+      StartProjectedHeartbeatRunInput<Result>;
     let sequence = 0;
     let terminal = false;
 
-    const publish = (item: HeartbeatRunStreamPayload): void => {
+    const publish = (item: HeartbeatRunStreamPayload<AgentHeartbeatResult | Result>): void => {
       if (terminal) {
         return;
       }
@@ -60,7 +75,7 @@ export class HeartbeatRunService {
         runId,
         sequence,
         timestamp: this.now(),
-      } as HeartbeatRunStreamItem);
+      } as HeartbeatRunStreamItem<AgentHeartbeatResult | Result>);
       if (isTerminal) {
         stream.sink.close();
       }
@@ -70,27 +85,36 @@ export class HeartbeatRunService {
       .then(async () => {
         HeartbeatRunService.throwIfCancelled(signal);
         const heartbeatResult = await this.runner({
-          ...options,
+          ...runnerOptions,
           abortSignal: signal,
           onEvent: (event) => {
             publish({ kind: 'activity', activity: event });
-            options.onEvent?.(event);
+            runnerOptions.onEvent?.(event);
           },
         });
         HeartbeatRunService.throwIfCancelled(signal);
-        publish({ kind: 'result', result: heartbeatResult });
-        return heartbeatResult;
+        const projectedResult = await HeartbeatRunService.projectResult(
+          projectResult,
+          heartbeatResult,
+          context,
+        );
+        HeartbeatRunService.throwIfCancelled(signal);
+        publish({ kind: 'result', result: projectedResult });
+        return projectedResult;
       })
       .catch((error: unknown) => {
-        publish(signal.aborted
-          ? { kind: 'cancelled', reason: HEARTBEAT_CANCELLED_MESSAGE }
-          : {
-            kind: 'error',
-            error: {
-              code: 'heartbeat_run_failed',
-              message: HEARTBEAT_FAILED_MESSAGE,
-            },
-          });
+        if (signal.aborted) {
+          publish({ kind: 'cancelled', reason: HEARTBEAT_CANCELLED_MESSAGE });
+          HeartbeatRunService.throwIfCancelled(signal);
+        }
+
+        publish({
+          kind: 'error',
+          error: {
+            code: 'heartbeat_run_failed',
+            message: HEARTBEAT_FAILED_MESSAGE,
+          },
+        });
         throw error;
       });
     result.catch(() => undefined);
@@ -117,6 +141,18 @@ export class HeartbeatRunService {
     throw signal.reason instanceof Error
       ? signal.reason
       : new Error(HEARTBEAT_CANCELLED_MESSAGE);
+  }
+
+  private static async projectResult<Result>(
+    projectResult: HeartbeatRunResultProjector<Result> | undefined,
+    result: AgentHeartbeatResult,
+    run: HeartbeatRunContext,
+  ): Promise<AgentHeartbeatResult | Result> {
+    if (!projectResult) {
+      return result;
+    }
+
+    return await projectResult(result, run);
   }
 }
 

--- a/src/core/heartbeat/runs/types.ts
+++ b/src/core/heartbeat/runs/types.ts
@@ -15,14 +15,31 @@ type HeartbeatRunStreamEnvelope = {
   timestamp: string;
 };
 
-export type HeartbeatRunStreamItem =
+export type HeartbeatRunContext = {
+  runId: string;
+  signal: AbortSignal;
+};
+
+export type HeartbeatRunResultProjector<Result> = (
+  result: AgentHeartbeatResult,
+  run: HeartbeatRunContext,
+) => Result | Promise<Result>;
+
+export type StartHeartbeatRunInput = RunAgentHeartbeatOptions;
+
+export type StartProjectedHeartbeatRunInput<Result> = RunAgentHeartbeatOptions & {
+  /** Runs before the canonical result terminal is published. */
+  projectResult: HeartbeatRunResultProjector<Result>;
+};
+
+export type HeartbeatRunStreamItem<Result = AgentHeartbeatResult> =
   | (HeartbeatRunStreamEnvelope & {
     kind: 'activity';
     activity: AgentHeartbeatEvent;
   })
   | (HeartbeatRunStreamEnvelope & {
     kind: 'result';
-    result: AgentHeartbeatResult;
+    result: Result;
   })
   | (HeartbeatRunStreamEnvelope & {
     kind: 'cancelled';
@@ -33,10 +50,10 @@ export type HeartbeatRunStreamItem =
     error: HeartbeatRunPublicError;
   });
 
-export type HeartbeatRunHandle = {
+export type HeartbeatRunHandle<Result = AgentHeartbeatResult> = {
   runId: string;
-  result: Promise<AgentHeartbeatResult>;
-  events(): AsyncIterable<HeartbeatRunStreamItem>;
+  result: Promise<Result>;
+  events(): AsyncIterable<HeartbeatRunStreamItem<Result>>;
   cancel(): boolean;
 };
 


### PR DESCRIPTION
## Summary

- add an optional typed projectResult boundary to HeartbeatRunService
- await host durability/reconciliation work before resolving the handle or publishing the canonical result terminal
- make projector failure emit only the safe heartbeat error terminal
- preserve cancellation authority when handle or external cancellation races projection
- keep the legacy no-projector API and result types backward compatible

## Verification

- focused heartbeat run-service tests: 8/8
- full unit suite: 142 files / 929 tests
- full integration suite: 49 files / 441 tests
- lint, multi-package typecheck, canonical build, and diff check

## Boundary

This is a generic lifecycle ordering seam. It does not implement a working-set store, product settlement, scheduling, Execution Host wiring, release, or deployment.