### PR TITLE
Runtime: settle async loop events in emission order

### DIFF
--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -105,6 +105,129 @@ describe('AgentLoopRuntimeService.run', () => {
     expect(modelVisibleTools).toEqual(['host_context_read']);
   });
 
+  it('serializes async event listeners and settles them before the run resolves', async () => {
+    let releaseFirst!: () => void;
+    const firstWrite = new Promise<void>((resolveFirst) => {
+      releaseFirst = resolveFirst;
+    });
+    const entered: string[] = [];
+    const completed: string[] = [];
+    let first = true;
+    let runSettled = false;
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: false,
+          parallelToolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        return { content: 'Done.' };
+      },
+    };
+
+    const run = AgentLoopRuntimeService.run({
+      goal: 'Complete one turn.',
+      llm: fakeLlm,
+      tools: [],
+      includeDefaultTools: false,
+      maxSteps: 1,
+      logger: silentLogger,
+      onEvent: async (event) => {
+        entered.push(event.type);
+        if (first) {
+          first = false;
+          await firstWrite;
+        }
+        completed.push(event.type);
+      },
+    });
+    void run.then(() => {
+      runSettled = true;
+    });
+
+    await new Promise<void>((resolveTurn) => setImmediate(resolveTurn));
+    expect(entered).toEqual(['loop.started']);
+    expect(completed).toEqual([]);
+    expect(runSettled).toBe(false);
+
+    releaseFirst();
+    await run;
+
+    expect(entered).toEqual(completed);
+    expect(completed.at(-1)).toBe('loop.finished');
+    expect(runSettled).toBe(true);
+  });
+
+  it('rejects the run when an async event listener fails', async () => {
+    const projectionFailure = new Error('durable activity write failed');
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: false,
+          parallelToolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        return { content: 'Done.' };
+      },
+    };
+
+    await expect(AgentLoopRuntimeService.run({
+      goal: 'Complete one turn.',
+      llm: fakeLlm,
+      tools: [],
+      includeDefaultTools: false,
+      maxSteps: 1,
+      logger: silentLogger,
+      onEvent: (event) => event.type === 'loop.started'
+        ? Promise.reject(projectionFailure)
+        : Promise.resolve(),
+    })).rejects.toBe(projectionFailure);
+  });
+
+  it('delivers synchronous start events before model execution', async () => {
+    let observedStart = false;
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: false,
+          parallelToolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        expect(observedStart).toBe(true);
+        return { content: 'Done.' };
+      },
+    };
+
+    await AgentLoopRuntimeService.run({
+      goal: 'Complete one turn.',
+      llm: fakeLlm,
+      tools: [],
+      includeDefaultTools: false,
+      maxSteps: 1,
+      logger: silentLogger,
+      onEvent: (event) => {
+        if (event.type === 'loop.started') {
+          observedStart = true;
+        }
+      },
+    });
+  });
+
   it('runs through the public execution loop and emits loop events around trace events', async () => {
     const workspaceRoot = resolve('/tmp/heddle-loop-test');
     const seenMessages: ChatMessage[][] = [];

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -356,7 +356,7 @@ export type {
   RunAgentOptions,
 } from './core/agent/index.js';
 export { AgentLoopCheckpointService, AgentLoopRuntimeService } from './core/runtime/loop/index.js';
-export type { AgentLoopCheckpoint, AgentLoopEvent, AgentLoopResult, AgentLoopState, AgentLoopStatus, RunAgentLoopOptions } from './core/runtime/loop/index.js';
+export type { AgentLoopCheckpoint, AgentLoopEvent, AgentLoopEventListener, AgentLoopResult, AgentLoopState, AgentLoopStatus, RunAgentLoopOptions } from './core/runtime/loop/index.js';
 
 // --- Specialized runtimes: read-only delegation ---------------------------
 export {

--- a/src/core/runtime/loop/README.md
+++ b/src/core/runtime/loop/README.md
@@ -25,6 +25,18 @@ Static `tools` remain supported. Toolkit and tool names are duplicate-checked
 through the same runtime tool assembly path whether default tools are enabled
 or disabled.
 
+## Event delivery
+
+`onEvent` may be synchronous or asynchronous. Synchronous listeners retain
+immediate streaming delivery. After a listener returns a Promise, Heddle queues
+later callbacks behind it in exact emission order and waits for the complete
+chain—including `loop.finished` on successful runs—before the run Promise
+settles. A callback rejection rejects the run; hosts therefore never receive a
+settled run while required durable activity writes are still pending or failed.
+
+Product schemas, persistence transactions, retry policy, and UI projection stay
+outside this lifecycle boundary.
+
 ## Tool Concurrency
 
 `maxToolConcurrency` bounds parallel-safe tool execution for one run. The

--- a/src/core/runtime/loop/event-delivery.ts
+++ b/src/core/runtime/loop/event-delivery.ts
@@ -1,0 +1,44 @@
+import type { AgentLoopEvent, AgentLoopEventListener } from './types.js';
+
+/**
+ * Preserves immediate synchronous listeners while serializing async delivery.
+ */
+export class AgentLoopEventDelivery {
+  private pending?: Promise<void>;
+
+  constructor(private readonly listener?: AgentLoopEventListener) {}
+
+  emit(event: AgentLoopEvent): void {
+    if (!this.listener) {
+      return;
+    }
+    if (!this.pending) {
+      const result = this.listener(event);
+      if (AgentLoopEventDelivery.isPromiseLike(result)) {
+        this.track(Promise.resolve(result));
+      }
+      return;
+    }
+
+    this.track(this.pending.then(() => this.listener?.(event)));
+  }
+
+  async settle(): Promise<void> {
+    await this.pending;
+  }
+
+  private track(pending: Promise<void>): void {
+    this.pending = pending;
+    // The owning run awaits the original Promise before settling. Attach an
+    // immediate observer so an early rejection is not reported as unhandled
+    // while model/tool work is still in flight.
+    void pending.catch(() => undefined);
+  }
+
+  private static isPromiseLike(value: unknown): value is PromiseLike<void> {
+    return (typeof value === 'object' || typeof value === 'function')
+      && value !== null
+      && 'then' in value
+      && typeof value.then === 'function';
+  }
+}

--- a/src/core/runtime/loop/index.ts
+++ b/src/core/runtime/loop/index.ts
@@ -3,6 +3,7 @@ export { AgentLoopRuntimeService } from './service.js';
 export type {
   AgentLoopCheckpoint,
   AgentLoopEvent,
+  AgentLoopEventListener,
   AgentLoopResult,
   AgentLoopState,
   AgentLoopStatus,

--- a/src/core/runtime/loop/service.ts
+++ b/src/core/runtime/loop/service.ts
@@ -18,6 +18,7 @@ import { RuntimeCredentialService } from '../credentials/index.js';
 import { LlmProviderRuntimeService } from '../provider-runtime/index.js';
 import { RuntimeToolService } from '../tools/index.js';
 import { AgentLoopCheckpointService } from './checkpoint.js';
+import { AgentLoopEventDelivery } from './event-delivery.js';
 import type { AgentLoopEvent, AgentLoopResult, RunAgentLoopOptions } from './types.js';
 
 /**
@@ -72,89 +73,100 @@ export class AgentLoopRuntimeService {
     });
     const now = () => new Date().toISOString();
     const startedAt = now();
+    const eventDelivery = new AgentLoopEventDelivery(options.onEvent);
 
-    logger.info({
-      model,
-      provider: providerRuntime.provider,
-      credentialSource: providerRuntime.credentialSource.type,
-      credentialProvider: 'provider' in providerRuntime.credentialSource ? providerRuntime.credentialSource.provider : undefined,
-    }, 'Agent runtime configured');
+    try {
+      logger.info({
+        model,
+        provider: providerRuntime.provider,
+        credentialSource: providerRuntime.credentialSource.type,
+        credentialProvider: 'provider' in providerRuntime.credentialSource ? providerRuntime.credentialSource.provider : undefined,
+      }, 'Agent runtime configured');
 
-    const resumeMetadata = AgentLoopCheckpointService.resolveResumeMetadata(options.resumeFrom);
+      const resumeMetadata = AgentLoopCheckpointService.resolveResumeMetadata(options.resumeFrom);
 
-    options.onEvent?.({
-      source: 'agent-loop',
-      type: HeddleEventType.loopStarted,
-      runId,
-      goal: options.goal,
-      model,
-      provider: providerRuntime.provider,
-      workspaceRoot,
-      resumedFromCheckpoint: resumeMetadata?.checkpointRunId,
-      timestamp: startedAt,
-    });
-
-    if (resumeMetadata) {
-      options.onEvent?.({
-        type: HeddleEventType.loopResumed,
+      eventDelivery.emit({
+        source: 'agent-loop',
+        type: HeddleEventType.loopStarted,
         runId,
-        fromCheckpoint: resumeMetadata.checkpointRunId,
-        priorTraceEvents: resumeMetadata.priorTraceEvents,
-        timestamp: now(),
+        goal: options.goal,
+        model,
+        provider: providerRuntime.provider,
+        workspaceRoot,
+        resumedFromCheckpoint: resumeMetadata?.checkpointRunId,
+        timestamp: startedAt,
       });
+
+      if (resumeMetadata) {
+        eventDelivery.emit({
+          type: HeddleEventType.loopResumed,
+          runId,
+          fromCheckpoint: resumeMetadata.checkpointRunId,
+          priorTraceEvents: resumeMetadata.priorTraceEvents,
+          timestamp: now(),
+        });
+      }
+
+      const result = await AgentRunService.run({
+        goal: options.goal,
+        llm,
+        tools,
+        workspaceRoot,
+        maxSteps: options.maxSteps,
+        maxToolConcurrency: options.maxToolConcurrency,
+        logger,
+        history: AgentLoopCheckpointService.resolveHistory(options),
+        systemContext,
+        onEvent: (event) => {
+          AgentLoopRuntimeService.emitAgentRunEvent({
+            event,
+            runId,
+            now,
+            eventDelivery,
+            onTraceEvent: options.onTraceEvent,
+          });
+        },
+        approvalPolicies: options.approvalPolicies,
+        approveToolCall: options.approveToolCall,
+        shouldStop: options.shouldStop,
+        abortSignal: options.abortSignal,
+        recoverModelContext: options.recoverModelContext,
+      });
+
+      const finishedAt = now();
+      const state = AgentLoopCheckpointService.createFinishedState({
+        runId,
+        goal: options.goal,
+        model,
+        provider: providerRuntime.provider,
+        workspaceRoot,
+        startedAt,
+        finishedAt,
+        result,
+      });
+
+      eventDelivery.emit({
+        source: 'agent-loop',
+        type: HeddleEventType.loopFinished,
+        runId,
+        outcome: result.outcome,
+        summary: result.summary,
+        ...(result.failure ? { failure: result.failure } : {}),
+        usage: result.usage,
+        state,
+        timestamp: finishedAt,
+      });
+
+      return {
+        ...result,
+        model,
+        provider: providerRuntime.provider,
+        workspaceRoot,
+        state,
+      };
+    } finally {
+      await eventDelivery.settle();
     }
-
-    const result = await AgentRunService.run({
-      goal: options.goal,
-      llm,
-      tools,
-      workspaceRoot,
-      maxSteps: options.maxSteps,
-      maxToolConcurrency: options.maxToolConcurrency,
-      logger,
-      history: AgentLoopCheckpointService.resolveHistory(options),
-      systemContext,
-      onEvent: (event) => {
-        AgentLoopRuntimeService.emitAgentRunEvent({ event, runId, now, options });
-      },
-      approvalPolicies: options.approvalPolicies,
-      approveToolCall: options.approveToolCall,
-      shouldStop: options.shouldStop,
-      abortSignal: options.abortSignal,
-      recoverModelContext: options.recoverModelContext,
-    });
-
-    const finishedAt = now();
-    const state = AgentLoopCheckpointService.createFinishedState({
-      runId,
-      goal: options.goal,
-      model,
-      provider: providerRuntime.provider,
-      workspaceRoot,
-      startedAt,
-      finishedAt,
-      result,
-    });
-
-    options.onEvent?.({
-      source: 'agent-loop',
-      type: HeddleEventType.loopFinished,
-      runId,
-      outcome: result.outcome,
-      summary: result.summary,
-      ...(result.failure ? { failure: result.failure } : {}),
-      usage: result.usage,
-      state,
-      timestamp: finishedAt,
-    });
-
-    return {
-      ...result,
-      model,
-      provider: providerRuntime.provider,
-      workspaceRoot,
-      state,
-    };
   }
 
   static isConversationActivity(
@@ -169,16 +181,17 @@ export class AgentLoopRuntimeService {
     event: AgentRunEvent;
     runId: string;
     now: () => string;
-    options: RunAgentLoopOptions;
+    eventDelivery: AgentLoopEventDelivery;
+    onTraceEvent?: RunAgentLoopOptions['onTraceEvent'];
   }): void {
-    const { event, runId, now, options } = args;
+    const { event, runId, now, eventDelivery, onTraceEvent } = args;
     if (event.type === HeddleEventType.trace) {
-      options.onEvent?.({ type: HeddleEventType.trace, runId, event: event.event, timestamp: now() });
-      options.onTraceEvent?.(event.event);
+      eventDelivery.emit({ type: HeddleEventType.trace, runId, event: event.event, timestamp: now() });
+      onTraceEvent?.(event.event);
       return;
     }
 
-    options.onEvent?.({ source: 'agent-loop', ...event, runId, timestamp: now() });
+    eventDelivery.emit({ source: 'agent-loop', ...event, runId, timestamp: now() });
   }
 
   private static resolveCredentialStorePath(args: {

--- a/src/core/runtime/loop/types.ts
+++ b/src/core/runtime/loop/types.ts
@@ -82,6 +82,10 @@ export type AgentLoopEvent =
       state: AgentLoopState;
     };
 
+export type AgentLoopEventListener = (
+  event: AgentLoopEvent,
+) => void | Promise<void>;
+
 export type RunAgentLoopOptions = {
   /**
    * Optional host-preallocated identity for this run. Omit it to preserve the
@@ -114,7 +118,8 @@ export type RunAgentLoopOptions = {
   includeDefaultTools?: boolean;
   includePlanTool?: boolean;
   logger?: Logger;
-  onEvent?: (event: AgentLoopEvent) => void;
+  /** Async listeners are serialized and settled before the run settles. */
+  onEvent?: AgentLoopEventListener;
   onTraceEvent?: (event: TraceEvent) => void;
   approvalPolicies?: ToolApprovalPolicy[];
   approveToolCall?: (


### PR DESCRIPTION
## Summary

- widen `AgentLoopRuntimeService.onEvent` to accept synchronous or asynchronous listeners
- preserve immediate delivery for synchronous listeners while serializing Promise-returning callbacks in emission order
- settle the complete delivery chain, including `loop.finished` on success, before the run Promise settles
- reject the run when an asynchronous listener fails, so hosts cannot report success ahead of failed durable projections

## Ownership boundary

Heddle owns event ordering and run-settlement semantics. Product schemas, persistence transactions, retry policy, and UI projection remain host-owned.

## Verification

- rebased onto merged PR #386 / `main` at `ac3aa6d5`
- focused combined runtime/tool contracts (4 files, 135 tests)
- `yarn test:unit` (145 files, 957 tests)
- `yarn vitest run src/__tests__/integration --exclude src/__tests__/integration/control-plane/session-lifecycle.test.ts` (48 files, 428 tests)
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- all six GitHub PR checks

The excluded lifecycle file reads globally installed workspace skills; this machine currently has an unrelated skill description that exceeds its fixture's 1,024-character limit.

Closes #385
