### PR TITLE
Fix return-direct terminal tool completion

### DIFF
--- a/docs/guides/programmatic/host-extensions.md
+++ b/docs/guides/programmatic/host-extensions.md
@@ -42,3 +42,36 @@ const engine = createConversationEngine({
 When multiple extensions are provided, Heddle composes them in declaration
 order. Tool names and toolkit ids must be unique. Heddle rejects duplicates
 before the first turn runs.
+
+## Return-direct terminal tools
+
+Use `returnDirect: true` when a successful host tool invocation is already the
+canonical end of the run—for example, committing a workflow result through a
+host-owned durable service:
+
+```ts
+const commitWorkflowResult: ToolDefinition = {
+  name: 'commit_workflow_result',
+  description: 'Commit the final workflow result after all required work is complete.',
+  returnDirect: true,
+  parameters: {
+    type: 'object',
+    properties: {
+      summary: { type: 'string' },
+    },
+    required: ['summary'],
+  },
+  execute: async (input) => {
+    const { summary } = input as { summary: string }
+    await workflowResults.commit({ summary })
+    return { ok: true, output: summary }
+  },
+}
+```
+
+After a successful return-direct result, Heddle records the tool result and
+finishes the run without requesting ceremonial final text from the model. A
+failed result remains in the transcript as an ordinary tool failure and the
+model may recover within the remaining step budget. Heddle owns this portable
+loop transition; the host continues to own authorization, durable effects,
+idempotency, domain schemas, and the result text returned by the tool.

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -432,7 +432,6 @@ describe('conversation turn lifecycle', () => {
       prompt: 'Finish the durable workflow.',
       apiKey: 'explicit-key',
       tools: [commitWorkflowResult],
-      toolProfile: { preset: 'custom', memoryMode: 'none' },
       maxSteps: 3,
       memoryMaintenanceMode: 'none',
       artifactRoot: storage.artifactRoot,

--- a/src/__tests__/integration/control-plane/session-runtime.test.ts
+++ b/src/__tests__/integration/control-plane/session-runtime.test.ts
@@ -402,6 +402,82 @@ describe('conversation turn lifecycle', () => {
     expect(requestToolApproval).toHaveBeenCalledWith({ call, tool });
   });
 
+  it('persists one completed conversation turn from a return-direct tool result', async () => {
+    const storage = await createConversationTurnStorage();
+    let modelCalls = 0;
+    let toolExecutions = 0;
+    vi.spyOn(LlmAdapterService, 'create').mockReturnValue(testAdapter(async () => {
+      modelCalls += 1;
+      return {
+        toolCalls: [{ id: 'call-terminal', tool: 'commit_workflow_result', input: {} }],
+      };
+    }));
+    const commitWorkflowResult: ToolDefinition = {
+      name: 'commit_workflow_result',
+      description: 'Commit the canonical workflow result.',
+      returnDirect: true,
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        toolExecutions += 1;
+        return { ok: true, output: 'Workflow result committed exactly once.' };
+      },
+    };
+
+    const turnResult = await EngineConversationTurnService.run({
+      workspaceRoot: storage.workspaceRoot,
+      stateRoot: storage.stateRoot,
+      traceDir: join(storage.stateRoot, 'traces'),
+      sessionStoragePath: storage.sessionStoragePath,
+      sessionId: storage.sessionId,
+      prompt: 'Finish the durable workflow.',
+      apiKey: 'explicit-key',
+      tools: [commitWorkflowResult],
+      toolProfile: { preset: 'custom', memoryMode: 'none' },
+      maxSteps: 3,
+      memoryMaintenanceMode: 'none',
+      artifactRoot: storage.artifactRoot,
+      artifactsEnabled: true,
+    });
+
+    expect(turnResult).toMatchObject({
+      outcome: 'done',
+      summary: 'Workflow result committed exactly once.',
+      toolResults: [{
+        call: { id: 'call-terminal', tool: 'commit_workflow_result', input: {} },
+        result: { ok: true, output: 'Workflow result committed exactly once.' },
+      }],
+    });
+    expect(modelCalls).toBe(1);
+    expect(toolExecutions).toBe(1);
+
+    const reopened = await readStoredChatSession(
+      new FileChatSessionRepository({ sessionStoragePath: storage.sessionStoragePath }),
+      storage.sessionId,
+    );
+    expect(reopened?.turns).toHaveLength(1);
+    expect(reopened?.turns[0]).toMatchObject({
+      prompt: 'Finish the durable workflow.',
+      outcome: 'done',
+      summary: 'Workflow result committed exactly once.',
+    });
+    expect(reopened?.history).toEqual([
+      { role: 'user', content: 'Finish the durable workflow.' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [{ id: 'call-terminal', tool: 'commit_workflow_result', input: {} }],
+      },
+      {
+        role: 'tool',
+        content: JSON.stringify({
+          ok: true,
+          output: 'Workflow result committed exactly once.',
+        }),
+        toolCallId: 'call-terminal',
+      },
+    ]);
+  });
+
   it('persists two completed child records and reopens them with the parent turn', async () => {
     const storage = await createConversationTurnStorage();
     const childMessages: ChatMessage[][] = [];

--- a/src/__tests__/integration/core/agent-loop.test.ts
+++ b/src/__tests__/integration/core/agent-loop.test.ts
@@ -163,6 +163,75 @@ describe('AgentLoopRuntimeService.run', () => {
     expect(runSettled).toBe(true);
   });
 
+  it('awaits ordered return-direct tool completion before loop.finished', async () => {
+    let releaseToolCompletion!: () => void;
+    const toolCompletionPersisted = new Promise<void>((resolveCompletion) => {
+      releaseToolCompletion = resolveCompletion;
+    });
+    const entered: string[] = [];
+    const completed: string[] = [];
+    let runSettled = false;
+    let modelCalls = 0;
+    const fakeLlm: LlmAdapter = {
+      info: {
+        provider: 'openai',
+        model: 'gpt-test',
+        capabilities: {
+          toolCalls: true,
+          systemMessages: true,
+          reasoningSummaries: false,
+          parallelToolCalls: true,
+        },
+      },
+      async chat(): Promise<LlmResponse> {
+        modelCalls += 1;
+        return {
+          toolCalls: [{ id: 'call-terminal', tool: 'commit_workflow_result', input: {} }],
+        };
+      },
+    };
+    const commitWorkflowResult: ToolDefinition = {
+      name: 'commit_workflow_result',
+      description: 'Commit the canonical workflow result.',
+      returnDirect: true,
+      parameters: { type: 'object', properties: {} },
+      execute: async () => ({ ok: true, output: 'Workflow result committed.' }),
+    };
+
+    const run = AgentLoopRuntimeService.run({
+      goal: 'Finish one workflow.',
+      llm: fakeLlm,
+      tools: [commitWorkflowResult],
+      includeDefaultTools: false,
+      maxSteps: 3,
+      logger: silentLogger,
+      onEvent: async (event) => {
+        entered.push(event.type);
+        if (event.type === 'tool.completed') {
+          await toolCompletionPersisted;
+        }
+        completed.push(event.type);
+      },
+    });
+    void run.then(() => {
+      runSettled = true;
+    });
+
+    await vi.waitFor(() => expect(entered).toContain('tool.completed'));
+    expect(entered).not.toContain('loop.finished');
+    expect(runSettled).toBe(false);
+
+    releaseToolCompletion();
+    const result = await run;
+
+    expect(result.outcome).toBe('done');
+    expect(modelCalls).toBe(1);
+    expect(completed.filter(
+      (type) => type === 'tool.completed' || type === 'loop.finished',
+    )).toEqual(['tool.completed', 'loop.finished']);
+    expect(runSettled).toBe(true);
+  });
+
   it('rejects the run when an async event listener fails', async () => {
     const projectionFailure = new Error('durable activity write failed');
     const fakeLlm: LlmAdapter = {

--- a/src/__tests__/integration/core/run-agent.test.ts
+++ b/src/__tests__/integration/core/run-agent.test.ts
@@ -111,6 +111,105 @@ describe('AgentRunService.run', () => {
     });
   });
 
+  it('finishes from a successful return-direct tool without another model request', async () => {
+    let modelCalls = 0;
+    let toolExecutions = 0;
+    const fakeLlm: LlmAdapter = {
+      async chat(): Promise<LlmResponse> {
+        modelCalls += 1;
+        return {
+          toolCalls: [{ id: 'call-terminal', tool: 'commit_workflow_result', input: {} }],
+        };
+      },
+    };
+    const commitWorkflowResult: ToolDefinition = {
+      name: 'commit_workflow_result',
+      description: 'Commit the canonical workflow result.',
+      returnDirect: true,
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        toolExecutions += 1;
+        return { ok: true, output: 'Workflow result committed.' };
+      },
+    };
+
+    const result = await AgentRunService.run({
+      goal: 'Finish the workflow.',
+      llm: fakeLlm,
+      tools: [commitWorkflowResult],
+      maxSteps: 3,
+      logger: silentLogger,
+    });
+
+    expect(result.outcome).toBe('done');
+    expect(result.summary).toBe('Workflow result committed.');
+    expect(modelCalls).toBe(1);
+    expect(toolExecutions).toBe(1);
+    expect(result.transcript).toEqual([
+      { role: 'user', content: 'Finish the workflow.' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [{ id: 'call-terminal', tool: 'commit_workflow_result', input: {} }],
+      },
+      {
+        role: 'tool',
+        content: JSON.stringify({ ok: true, output: 'Workflow result committed.' }),
+        toolCallId: 'call-terminal',
+      },
+    ]);
+    expect(result.trace.map((event) => event.type)).toEqual([
+      'run.started',
+      'assistant.turn',
+      'tool.calling',
+      'tool.completed',
+      'run.finished',
+    ]);
+  });
+
+  it('keeps a failed return-direct tool recoverable within the same run', async () => {
+    let modelCalls = 0;
+    let toolExecutions = 0;
+    const fakeLlm: LlmAdapter = {
+      async chat(): Promise<LlmResponse> {
+        modelCalls += 1;
+        return modelCalls === 1
+          ? {
+              toolCalls: [{ id: 'call-terminal', tool: 'commit_workflow_result', input: {} }],
+            }
+          : { content: 'Recovered after the host rejected the commit.' };
+      },
+    };
+    const commitWorkflowResult: ToolDefinition = {
+      name: 'commit_workflow_result',
+      description: 'Commit the canonical workflow result.',
+      returnDirect: true,
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        toolExecutions += 1;
+        return { ok: false, error: 'Canonical result was not committed.' };
+      },
+    };
+
+    const result = await AgentRunService.run({
+      goal: 'Finish the workflow.',
+      llm: fakeLlm,
+      tools: [commitWorkflowResult],
+      maxSteps: 3,
+      logger: silentLogger,
+    });
+
+    expect(result.outcome).toBe('done');
+    expect(result.summary).toBe('Recovered after the host rejected the commit.');
+    expect(modelCalls).toBe(2);
+    expect(toolExecutions).toBe(1);
+    expect(result.transcript).toContainEqual({
+      role: 'tool',
+      content: JSON.stringify({ ok: false, error: 'Canonical result was not committed.' }),
+      toolCallId: 'call-terminal',
+    });
+  });
+
   it('records an error outcome when the LLM chat throws a non-retryable error', async () => {
     let calls = 0;
     const providerSecret = 'sk-provider-error-sentinel';

--- a/src/core/agent/README.md
+++ b/src/core/agent/README.md
@@ -9,6 +9,8 @@ execution engine used by runtime, chat turns, memory maintenance, and examples.
 - Calling the LLM adapter step by step.
 - Streaming assistant content to host callbacks.
 - Executing model-requested tools through a registry.
+- Completing a run directly from a successful host-declared return-direct tool
+  result, without a ceremonial follow-up model response.
 - Scheduling explicitly parallel-safe tool calls within a bounded concurrency
   limit while preserving deterministic transcript order.
 - Recording low-level `TraceEvent` evidence.
@@ -53,6 +55,11 @@ execution engine used by runtime, chat turns, memory maintenance, and examples.
 - Mark a tool `concurrency: 'parallel-safe'` only when independent invocations
   can overlap without shared-state, capability, or ordering conflicts. Adapter
   support and the host concurrency limit must also opt in before calls overlap.
+- Mark a host tool `returnDirect: true` when its successful execution is itself
+  the canonical completion of the run. Heddle records every tool result already
+  present in that assistant turn, then emits one terminal run result using the
+  return-direct output as its summary. A failed return-direct tool remains a
+  normal tool failure so the model can recover within the remaining step budget.
 - Add trace detail by emitting typed `TraceEvent` values and updating the
   observability summarizer/projection path. If the same moment is also
   user-facing, use the live recorder helper to emit trace and activity together

--- a/src/core/agent/finish/run-finisher.ts
+++ b/src/core/agent/finish/run-finisher.ts
@@ -1,7 +1,7 @@
 import { INTERRUPTED_SUMMARY } from '../constants.js';
 import { HeddleEventType } from '@/core/event-types.js';
 import type { LlmResponse } from '@/core/llm/types.js';
-import type { RunResult, StopReason } from '@/core/types.js';
+import type { RunResult, StopReason, ToolResult } from '@/core/types.js';
 import type { AgentRunContext } from '../types.js';
 import type { FinishAgentRunOptions } from './types.js';
 
@@ -57,6 +57,24 @@ export class AgentRunFinisher {
     });
   }
 
+  static finishToolResult(
+    context: AgentRunContext,
+    toolName: string,
+    result: ToolResult,
+  ): RunResult {
+    return AgentRunFinisher.finish(
+      context,
+      'done',
+      AgentRunFinisher.summarizeToolResult(toolName, result),
+      {
+        logging: {
+          logLevel: 'info',
+          logMessage: 'Agent run finished from return-direct tool',
+        },
+      },
+    );
+  }
+
   static maxSteps(context: AgentRunContext): RunResult {
     return AgentRunFinisher.finish(context, 'max_steps', `Reached maximum step limit (${context.maxSteps})`, {
       logging: {
@@ -103,5 +121,20 @@ export class AgentRunFinisher {
 
   static isRunResult(value: LlmResponse | RunResult): value is RunResult {
     return 'outcome' in value;
+  }
+
+  private static summarizeToolResult(toolName: string, result: ToolResult): string {
+    if (typeof result.output === 'string' && result.output.trim()) {
+      return result.output;
+    }
+
+    if (result.output !== undefined) {
+      const serialized = JSON.stringify(result.output);
+      if (serialized) {
+        return serialized;
+      }
+    }
+
+    return `${toolName} completed successfully.`;
   }
 }

--- a/src/core/agent/tools/tool-turn-service.ts
+++ b/src/core/agent/tools/tool-turn-service.ts
@@ -10,7 +10,7 @@ import type {
   HandleAgentToolResultArgs,
   HandleAgentToolTurnArgs,
 } from './types.js';
-import type { RunResult, ToolCall, ToolDefinition, ToolResult } from '@/core/types.js';
+import type { ToolCall, ToolDefinition, ToolResult } from '@/core/types.js';
 
 type ToolCallScheduleEntry = {
   index: number;
@@ -23,6 +23,11 @@ type ProjectedToolCall = {
   effectiveCall: ToolCall;
   result: ToolResult;
   executed: boolean;
+};
+
+type ReturnDirectToolCompletion = {
+  toolName: string;
+  result: ToolResult;
 };
 
 /**
@@ -135,6 +140,7 @@ export class AgentToolTurnService {
       return interruptedDuringExecution;
     }
 
+    let returnDirectCompletion: ReturnDirectToolCompletion | undefined;
     for (const [index, call] of toolCalls.entries()) {
       const projected = projectedByIndex.get(index);
       if (!projected) {
@@ -151,25 +157,31 @@ export class AgentToolTurnService {
       }
 
       context.state.executedToolCalls++;
-      const toolCallResult = AgentToolTurnService.handleExecutedResult({
+      const completion = AgentToolTurnService.handleExecutedResult({
         context,
         effectiveCall: projected.effectiveCall,
         toolCallId: call.id,
         result: projected.result,
       });
-      if (toolCallResult) {
-        return toolCallResult;
+      if (!returnDirectCompletion && completion) {
+        returnDirectCompletion = completion;
       }
     }
 
-    return 'continue';
+    return returnDirectCompletion
+      ? AgentRunFinisher.finishToolResult(
+          context,
+          returnDirectCompletion.toolName,
+          returnDirectCompletion.result,
+        )
+      : 'continue';
   }
 
   private static handleDeniedResult(
     context: HandleAgentToolTurnArgs['context'],
     toolCallId: string,
     result: ToolResult,
-  ): RunResult | undefined {
+  ): void {
     context.state.consecutiveErrors++;
 
     context.messages.push({
@@ -177,16 +189,14 @@ export class AgentToolTurnService {
       content: JSON.stringify(result),
       toolCallId,
     });
-    return undefined;
   }
 
-  private static handleExecutedResult(args: HandleAgentToolResultArgs): RunResult | undefined {
+  private static handleExecutedResult(
+    args: HandleAgentToolResultArgs,
+  ): ReturnDirectToolCompletion | undefined {
     const { context, effectiveCall, toolCallId, result } = args;
     if (!result.ok) {
-      const maybeFailure = AgentToolTurnService.handleFailedExecution(context, result);
-      if (maybeFailure) {
-        return maybeFailure;
-      }
+      AgentToolTurnService.handleFailedExecution(context);
     } else {
       context.state.consecutiveErrors = 0;
       AgentMutationTracker.trackToolResult({ state: context.mutation, effectiveCall, result });
@@ -209,12 +219,13 @@ export class AgentToolTurnService {
       toolCallId,
     });
     AgentToolTurnService.pushHostRequirementReminders(context);
-    return undefined;
+    return result.ok && context.registry.get(effectiveCall.tool)?.returnDirect
+      ? { toolName: effectiveCall.tool, result }
+      : undefined;
   }
 
-  private static handleFailedExecution(context: HandleAgentToolTurnArgs['context'], _result: ToolResult): RunResult | undefined {
+  private static handleFailedExecution(context: HandleAgentToolTurnArgs['context']): void {
     context.state.consecutiveErrors++;
-    return undefined;
   }
 
   private static pushHostRequirementReminders(context: HandleAgentToolTurnArgs['context']): void {

--- a/src/core/agent/tools/tool-turn-service.ts
+++ b/src/core/agent/tools/tool-turn-service.ts
@@ -195,6 +195,8 @@ export class AgentToolTurnService {
     args: HandleAgentToolResultArgs,
   ): ReturnDirectToolCompletion | undefined {
     const { context, effectiveCall, toolCallId, result } = args;
+    const returnDirect = result.ok
+      && context.registry.get(effectiveCall.tool)?.returnDirect === true;
     if (!result.ok) {
       AgentToolTurnService.handleFailedExecution(context);
     } else {
@@ -218,8 +220,10 @@ export class AgentToolTurnService {
       content: JSON.stringify(result),
       toolCallId,
     });
-    AgentToolTurnService.pushHostRequirementReminders(context);
-    return result.ok && context.registry.get(effectiveCall.tool)?.returnDirect
+    if (!returnDirect) {
+      AgentToolTurnService.pushHostRequirementReminders(context);
+    }
+    return returnDirect
       ? { toolName: effectiveCall.tool, result }
       : undefined;
   }

--- a/src/core/tools/README.md
+++ b/src/core/tools/README.md
@@ -11,6 +11,8 @@ workspace.
   tool names.
 - Tool registry creation and duplicate-name protection at execution time.
 - Tool execution wrapper, timeout behavior, and cooperative cancellation.
+- The host-authored `returnDirect` declaration on tool definitions. The agent
+  loop, not the tools domain, owns applying it to run completion.
 - Shared tool policy-envelope schema injection and input stripping.
 - Coding file tools under `toolkits/coding-files/`.
 - Knowledge and memory-surface tools under `toolkits/knowledge/`.
@@ -92,6 +94,11 @@ workspace.
 - Use `ToolDefinition.timeoutMs: null` only when the tool owns a bounded or
   host-cancellable lifecycle that must not race the generic wrapper timeout.
   This field is host-only and is never projected into model-visible schemas.
+- Use `ToolDefinition.returnDirect: true` only when a successful tool result is
+  already the host's canonical final outcome. The host still owns the durable
+  effect, idempotency, authorization, and result payload. Heddle owns ending the
+  run without another model request. Failed results never trigger direct
+  completion.
 - Extend the shared `ToolPolicyEnvelope` only when all tool families can use
   the field consistently. Tool-specific arguments stay in each tool schema.
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -53,6 +53,13 @@ export type ToolDefinition<Input = unknown, Output = unknown> = {
    * shared mutable state.
    */
   concurrency?: ToolConcurrencyMode;
+  /**
+   * Complete the current run from this tool's successful result without
+   * requesting another model turn. Failed results remain ordinary recoverable
+   * tool failures. A string output becomes the run summary directly; other
+   * outputs are JSON serialized.
+   */
+  returnDirect?: boolean;
   parameters: Record<string, unknown>; // JSON Schema object
   /** Canonical host-side validation schema for the model-provided input. */
   inputSchema?: ToolValidationSchema<Input>;


### PR DESCRIPTION
## Summary

- add the host-authored ToolDefinition returnDirect contract
- finish successful terminal tools without a redundant model request
- keep failed terminal tools recoverable within the same run budget
- preserve complete transcripts plus ordered, awaited terminal event delivery
- document the generic Heddle versus host ownership boundary

## Verification

- yarn build
- yarn vitest run src/__tests__/integration/core/run-agent.test.ts src/__tests__/integration/core/agent-loop.test.ts src/__tests__/integration/control-plane/session-runtime.test.ts (96 passed)