### PR TITLE
Add successful non-agent heartbeat completion

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -17,10 +17,10 @@ A heartbeat runner cycle:
 - returns a decision: `continue`, `pause`, `complete`, or `escalate`
 
 Scheduler state records the latest outer execution outcome. Agent executions
-also retain their real agent result and checkpoint. A no-work skip or
-cancellation instead stores a lightweight outcome with the outer `executionId`,
-summary, kind, and timestamp; it does not fabricate an agent run ID, model,
-provider, transcript, or checkpoint.
+also retain their real agent result and checkpoint. A successful host-owned
+completion, no-work skip, or cancellation instead stores a lightweight outcome
+with the outer `executionId`, summary, kind, and timestamp; it does not fabricate
+an agent run ID, model, provider, transcript, or checkpoint.
 
 Task continuation is explicit. A task can be configured for operator-controlled
 continuation or agent-selected continuation, and a blocked or paused task must be
@@ -73,9 +73,9 @@ For repeated runner cycles, Heddle also exposes a local-first scheduler core:
 - `FileHeartbeatTaskService`
 
 `HeartbeatSchedulerService.runDueTasks` returns durable execution records.
-`heartbeat.task.finished`, `heartbeat.task.skipped`, and
-`heartbeat.task.cancelled` events include the corresponding record. If you need a
-compact display shape for a UI or service integration, use
+`heartbeat.task.finished`, `heartbeat.task.completed`,
+`heartbeat.task.skipped`, and `heartbeat.task.cancelled` events include the
+corresponding record. If you need a compact display shape for a UI or service integration, use
 `FileHeartbeatTaskService` task/run view methods instead of flattening task
 state yourself.
 
@@ -613,8 +613,9 @@ An idle enabled task becomes due immediately. If the task is already running,
 Heddle persists one pending follow-up. Additional requests advance the durable
 generation but coalesce into that same follow-up. The execution claim records
 which generation it consumed, so a request arriving after the claim remains
-pending for the next run. Success, failure, skip, and cancellation settle from
-the latest stored task state and cannot overwrite a newer request.
+pending for the next run. Agent success, host completion, failure, skip, and
+cancellation settle from the latest stored task state and cannot overwrite a
+newer request.
 
 `HeartbeatSchedulerService.start()` and `runLoop()` subscribe to configured-store
 run requests and rescan promptly. `heartbeat.task.run_requested`,
@@ -627,7 +628,7 @@ Task views expose `state.runRequest.pending`, the latest generation,
 completed, and blocked tasks reject requests; they must be enabled or resumed
 explicitly instead of retaining hidden work that might run later.
 
-### Custom host work with the standard agent runtime
+### Custom host work with or without the standard agent runtime
 
 A custom handler owns domain discovery and acknowledgement. Heddle owns the
 execution identity, credential resolution, agent defaults, abort signal,
@@ -677,11 +678,42 @@ The host does not receive credential records or token fields and must not retain
 the execution context. Set `preferApiKey: true` in `runtime` only when an
 environment API key should take precedence over stored OpenAI OAuth state.
 
+When the handler itself completes admitted host-owned work without invoking the
+Heddle agent loop, return `context.complete()` instead:
+
+```ts
+const handler: HeartbeatTaskHandler = async (context) => {
+  const work = await domainQueue.claimNext({ signal: context.signal });
+  if (!work) {
+    return context.skip({ summary: 'No eligible domain work was available.' });
+  }
+
+  await hostWorkflow.execute(work, { signal: context.signal });
+  return context.complete({ summary: 'Processed one admitted work item.' });
+};
+```
+
+`complete` means the current execution succeeded; it does not mark an enabled
+recurring task terminal. Heddle retains the previous checkpoint, schedules the
+next interval, writes a claim-fenced non-agent run record with kind `completed`,
+and emits `heartbeat.task.completed`. The host remains responsible for making
+its domain claim and effects idempotent across crash recovery.
+
 Call `context.runAgent()` at most once, or return the exact outcome from
-`context.skip()`. Context methods are invalid after the handler settles. The
+`context.complete()` or `context.skip()`. A non-agent outcome cannot be selected
+after `runAgent()` starts, and only one context-created outcome may be selected.
+All custom-handler outcome summaries are trimmed, non-empty, and limited to 500
+characters. They are durable operator text, so never include secrets, prompts,
+or domain payloads. Context methods are invalid after the handler settles. The
 older positional `runner(task, checkpoint, context)` callback remains as a
 deprecated compatibility adapter, but it uses this same internal execution and
 persistence pipeline.
+
+Custom `HeartbeatTaskStore` implementations must handle `completed` in
+`recordTaskExecutionOutcome()` with the same atomic claim fence and run-history
+guarantees as the other outcome kinds. Adapter packages must not advertise
+compatibility with a Runtime major that can emit `completed` until their store,
+view codecs, and execution-activity projections support it.
 
 ### Awaitable shutdown and cancellation
 

--- a/src/__tests__/integration/core/heartbeat-execution-context.test.ts
+++ b/src/__tests__/integration/core/heartbeat-execution-context.test.ts
@@ -95,6 +95,80 @@ describe('heartbeat execution context', () => {
     expect(() => retainedContext?.skip({ summary: 'too late' })).toThrow(/no longer active/);
   });
 
+  it('persists successful host work without provider calls, fabricated agent state, or checkpoint changes', async () => {
+    const dir = createStateRoot('completed');
+    const store = new FileHeartbeatTaskService({ dir });
+    const task: HeartbeatTask = {
+      ...createTask('host-work'),
+      runtime: { model: 'gpt-5.4' },
+    };
+    const priorCheckpoint = createHeartbeatResult('pause', 'prior-host-run').checkpoint;
+    await store.saveTask(task);
+    await store.saveCheckpoint(task, priorCheckpoint);
+    const runAgent = vi.spyOn(HeartbeatRunnerAgent, 'run');
+    const createAdapter = vi.spyOn(LlmAdapterService, 'create');
+    const events: HeartbeatSchedulerEvent[] = [];
+    let retainedContext: HeartbeatExecutionContext | undefined;
+
+    const result = await HeartbeatSchedulerService.runDueTasks({
+      store,
+      now: () => NOW,
+      handler: async (context) => {
+        retainedContext = context;
+        return context.complete({ summary: '  Imported one durable source event.  ' });
+      },
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    expect(result).toMatchObject({ checked: 1, ran: 1, failed: 0 });
+    expect(runAgent).not.toHaveBeenCalled();
+    expect(createAdapter).not.toHaveBeenCalled();
+    await expect(store.loadCheckpoint(task)).resolves.toEqual(priorCheckpoint);
+    await expect(store.requireTask(task.id)).resolves.toMatchObject({
+      schedule: { nextRunAt: '2026-08-01T05:01:00.000Z' },
+      state: {
+        status: 'waiting',
+        lastExecution: {
+          kind: 'completed',
+          summary: 'Imported one durable source event.',
+        },
+      },
+    });
+    const savedTask = await store.requireTask(task.id);
+    expect(savedTask.state?.runId).toBeUndefined();
+    expect(savedTask.state?.result).toBeUndefined();
+
+    const [entry] = await store.listRunRecords({ taskId: task.id });
+    expect(entry).toMatchObject({
+      executionId: expect.any(String),
+      runId: undefined,
+      record: {
+        outcome: {
+          kind: 'completed',
+          summary: 'Imported one durable source event.',
+        },
+      },
+    });
+    expect(entry?.record.result).toBeUndefined();
+    expect(entry?.record.loadedCheckpoint).toBeUndefined();
+    expect(JSON.stringify(entry?.record)).not.toMatch(/checkpoint|transcript|provider|runId/);
+    await expect(store.listTaskViews()).resolves.toMatchObject([{
+      taskId: task.id,
+      state: { result: { kind: 'completed', summary: 'Imported one durable source event.' } },
+    }]);
+    await expect(store.listRunViews({ taskId: task.id })).resolves.toMatchObject([{
+      runId: undefined,
+      result: { kind: 'completed', outcome: 'completed' },
+    }]);
+    expect(events.map((event) => event.type)).toEqual([
+      'heartbeat.task.due',
+      'heartbeat.task.started',
+      'heartbeat.task.completed',
+    ]);
+    expect(events[2]).toMatchObject({ executionId: entry?.executionId });
+    expect(() => retainedContext?.complete({ summary: 'too late' })).toThrow(/no longer active/);
+  });
+
   it('routes dynamic prompts, tools, policy, abort, and events through the standard agent builder', async () => {
     const dir = createStateRoot('dynamic');
     const store = new FileHeartbeatTaskService({ dir });
@@ -587,6 +661,41 @@ describe('heartbeat execution context', () => {
 
   it('rejects forged, premature, oversized, and invalid-delay handler outcomes as failures', async () => {
     const cases = [
+      {
+        id: 'forged-completion',
+        handler: async () => ({ kind: 'completed', summary: 'Forged.' } as never),
+        error: /must return the completed or skipped outcome/i,
+      },
+      {
+        id: 'discarded-completion',
+        handler: async (context: HeartbeatExecutionContext) => {
+          context.complete({ summary: 'This selected outcome must be returned.' });
+          return undefined as never;
+        },
+        error: /must return the completed or skipped outcome.*after selecting/i,
+      },
+      {
+        id: 'multiple-outcomes',
+        handler: async (context: HeartbeatExecutionContext) => {
+          const outcome = context.complete({ summary: 'The first outcome.' });
+          context.skip({ summary: 'A second outcome.' });
+          return outcome;
+        },
+        error: /select only one outcome/i,
+      },
+      {
+        id: 'completion-after-agent',
+        handler: async (context: HeartbeatExecutionContext) => {
+          await context.runAgent();
+          return context.complete({ summary: 'This is not a non-agent execution.' });
+        },
+        error: /cannot complete.*after runAgent/i,
+      },
+      {
+        id: 'oversized-completion-summary',
+        handler: async (context: HeartbeatExecutionContext) => context.complete({ summary: 'x'.repeat(501) }),
+        error: /at most 500 characters/i,
+      },
       {
         id: 'premature-retry',
         handler: async (context: HeartbeatExecutionContext) => context.retry({ summary: 'Too early.' }),

--- a/src/__tests__/integration/core/heartbeat-runner-credentials.test.ts
+++ b/src/__tests__/integration/core/heartbeat-runner-credentials.test.ts
@@ -44,6 +44,7 @@ describe('custom heartbeat runner credentials', () => {
       'runAt',
       'signal',
       'runAgent',
+      'complete',
       'skip',
       'retry',
       'block',

--- a/src/__tests__/integration/core/heartbeat-targeted-execution.test.ts
+++ b/src/__tests__/integration/core/heartbeat-targeted-execution.test.ts
@@ -231,15 +231,20 @@ describe('targeted heartbeat execution', () => {
     const claimLossStore = createStore('claim-loss');
     const claimLossTask = createTask('claim-loss-task');
     await claimLossStore.saveTask(claimLossTask);
-    vi.spyOn(claimLossStore, 'recordTaskExecutionOutcome').mockResolvedValueOnce({ status: 'claim-lost' });
+    const recordOutcome = vi.spyOn(claimLossStore, 'recordTaskExecutionOutcome')
+      .mockResolvedValueOnce({ status: 'claim-lost' });
 
     await expect(HeartbeatSchedulerService.runTask({
       store: claimLossStore,
       taskId: claimLossTask.id,
       executionOwnerId: 'claim-loss-invocation',
       now: () => NOW,
-      handler: async (context) => context.skip({ summary: 'Settlement lost its claim.' }),
+      handler: async (context) => context.complete({ summary: 'Host work lost its execution claim.' }),
     })).resolves.toMatchObject({ status: 'claim-lost', taskId: claimLossTask.id, executionId: expect.any(String), failed: false });
+    expect(recordOutcome).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: claimLossTask.id,
+      kind: 'completed',
+    }));
   });
 
   it('returns an explicit custom-handler retry as a dispatcher-visible outcome', async () => {

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -37,8 +37,8 @@ operator-facing heartbeat views.
   `ready | closed` projection for the namespace and one optional opaque task
   group. The final claim checks that projection under the same mutation
   boundary. `HeartbeatTaskStateProjector`
-  owns task state transitions after agent success, no-work skip, cancellation,
-  failure, request, claim, or recovery.
+  owns task state transitions after agent success, host completion, no-work
+  skip, cancellation, failure, request, claim, or recovery.
 - `scheduler/`: `HeartbeatSchedulerService` owns due-task selection and the
   periodic scheduler loop. It selects due work in stable oldest-due-first order
   and uses `p-limit` to enforce the configured task concurrency ceiling. It delegates execution to
@@ -55,8 +55,9 @@ operator-facing heartbeat views.
   propagation, checkpoint persistence, task state transitions, and execution
   history persistence. Default and custom handlers share its framework-owned
   `context.runAgent()` path, so hosts can add domain prompts and tools without
-  receiving or translating provider credentials. `context.skip()` records
-  explicit no-work without fabricating agent state.
+  receiving or translating provider credentials. `context.complete()` records
+  successful host-owned work and `context.skip()` records explicit no-work;
+  neither fabricates agent state.
   An optional provider-neutral `HeartbeatAgentExecutionTransport` replaces only
   the nested agent call. Task lookup, claim fencing, checkpoint load,
   cancellation, settlement, history, and recovery remain in this service; when
@@ -85,8 +86,8 @@ operator-facing heartbeat views.
   task authority. It must not claim tasks, persist checkpoints, or settle task
   history.
 - `executionId` is the fencing token for one task attempt. A store must reject
-  completion, failure, skip, or cancellation persistence when that execution
-  no longer owns the task.
+  agent completion, host completion, failure, skip, or cancellation persistence
+  when that execution no longer owns the task.
 - Run requests are durable, level-triggered intent. `generation` advances for
   accepted requests, `claimedGeneration` identifies work already admitted, and
   an execution records the request generation it claimed. Multiple requests
@@ -204,20 +205,25 @@ operator-facing heartbeat views.
   `HeartbeatTask` objects, write heartbeat JSON, or run its own scheduler loop.
 - A custom scheduler handler may claim domain work before model execution. It
   must either delegate model work to execution-scoped `context.runAgent()` or
-  return `context.skip()` when no work exists. The context owns model credential
-  resolution, OAuth refresh, unattended approval defaults, checkpoint
-  continuation, abort propagation, and heartbeat event forwarding. It is valid
-  only during the current execution and must never be serialized or retained by
-  the host. The positional runner API is deprecated and adapted through this
-  same pipeline.
+  return `context.complete()` after successful host-owned work, or
+  `context.skip()` when no work exists. A completed non-agent execution retains
+  the previous checkpoint, schedules the next interval when enabled, persists a
+  claim-fenced `completed` run record, and emits `heartbeat.task.completed`.
+  It does not mean the recurring task is terminal. The context owns model
+  credential resolution, OAuth refresh, unattended approval defaults,
+  checkpoint continuation, abort propagation, and heartbeat event forwarding.
+  It is valid only during the current execution and must never be serialized or
+  retained by the host. The positional runner API is deprecated and adapted
+  through this same pipeline.
 - A custom handler can reject a completed nested agent result without throwing
   by returning `context.retry()` or `context.block()` after `await
   context.runAgent()`. Retry retains the previous checkpoint, records a
   claim-fenced non-agent outcome, and schedules one bounded retry delay.
   Block retains the previous checkpoint, records the nested agent run id for
   correlation, disables the task, and requires `resumeTask()` before another
-  run. Handler-outcome summaries are durable operator text: keep them concise,
-  non-secret, and free of prompts or domain payloads.
+  run. All context-created handler outcomes are mutually exclusive. Their
+  summaries are trimmed, non-empty, limited to 500 characters, and persisted as
+  operator text: keep them non-secret and free of prompts or domain payloads.
 
 ```ts
 handler: async (context) => {

--- a/src/core/heartbeat/scheduler/runner.ts
+++ b/src/core/heartbeat/scheduler/runner.ts
@@ -142,11 +142,11 @@ export class HeartbeatTaskRunnerService {
       }
 
       const settledAt = options.now?.() ?? dayjs().toDate();
-      if (HeartbeatTaskRunnerService.isSkippedOutcome(result)) {
+      if (HeartbeatTaskRunnerService.isStandaloneHandlerOutcome(result)) {
         const completion = await options.store.recordTaskExecutionOutcome({
           execution,
           taskId: task.id,
-          kind: 'skipped',
+          kind: result.kind,
           summary: result.summary,
           finishedAt: settledAt,
           signal: options.signal,
@@ -158,13 +158,30 @@ export class HeartbeatTaskRunnerService {
             execution,
           });
         }
-        if (completion.status !== 'saved' || !HeartbeatTaskRunnerService.isNonAgentRecord(completion.record, 'skipped')) {
+        if (completion.status !== 'saved') {
           if (completion.status === 'claim-lost') {
             return HeartbeatTaskRunnerService.claimLostResult(task.id, execution.executionId);
           }
-          throw new Error(`Heartbeat store saved an invalid skipped record for task ${task.id}.`);
+          throw new Error(`Heartbeat store failed to save the ${result.kind} record for task ${task.id}.`);
         }
 
+        if (result.kind === 'completed') {
+          if (!HeartbeatTaskRunnerService.isNonAgentRecord(completion.record, 'completed')) {
+            throw new Error(`Heartbeat store saved an invalid completed record for task ${task.id}.`);
+          }
+          options.onEvent?.({
+            type: 'heartbeat.task.completed',
+            taskId: task.id,
+            executionId: execution.executionId,
+            record: completion.record,
+            timestamp: completion.record.outcome.finishedAt,
+          });
+          return HeartbeatTaskRunnerService.settledResult(task.id, execution.executionId, completion.record);
+        }
+
+        if (!HeartbeatTaskRunnerService.isNonAgentRecord(completion.record, 'skipped')) {
+          throw new Error(`Heartbeat store saved an invalid skipped record for task ${task.id}.`);
+        }
         options.onEvent?.({
           type: 'heartbeat.task.skipped',
           taskId: task.id,
@@ -334,8 +351,7 @@ export class HeartbeatTaskRunnerService {
     let active = true;
     let agentInvocation: Promise<AgentHeartbeatResult> | undefined;
     let agentResult: AgentHeartbeatResult | undefined;
-    let skipSelected = false;
-    let explicitOutcome: HeartbeatHandlerOutcome | undefined;
+    let selectedOutcome: HeartbeatHandlerOutcome | undefined;
 
     const context: HeartbeatExecutionContext = Object.freeze({
       task: structuredClone(args.task),
@@ -345,7 +361,7 @@ export class HeartbeatTaskRunnerService {
       signal: args.signal,
       runAgent: async (options?: HeartbeatTaskRunnerAgentOptions) => {
         HeartbeatTaskRunnerService.assertContextActive(active, args.execution.executionId);
-        if (skipSelected || explicitOutcome) {
+        if (selectedOutcome) {
           throw new Error('Cannot run an agent after selecting a heartbeat execution outcome.');
         }
         if (agentInvocation) {
@@ -366,26 +382,42 @@ export class HeartbeatTaskRunnerService {
         agentResult = await agentInvocation;
         return agentResult;
       },
+      complete: (input: { summary: string }) => {
+        HeartbeatTaskRunnerService.assertContextActive(active, args.execution.executionId);
+        if (agentInvocation) {
+          throw new Error('Cannot complete a non-agent heartbeat execution after runAgent() has started.');
+        }
+        if (selectedOutcome) {
+          throw new Error('Heartbeat execution context may select only one outcome.');
+        }
+
+        const outcome = Object.freeze({
+          kind: 'completed' as const,
+          summary: HeartbeatTaskRunnerService.normalizeHandlerOutcomeSummary(input.summary),
+        });
+        selectedOutcome = outcome;
+        return outcome;
+      },
       skip: (input: { summary: string }) => {
         HeartbeatTaskRunnerService.assertContextActive(active, args.execution.executionId);
         if (agentInvocation) {
           throw new Error('Cannot skip a heartbeat execution after runAgent() has started.');
         }
-        if (skipSelected) {
-          throw new Error('Heartbeat execution context skip() may be called only once.');
+        if (selectedOutcome) {
+          throw new Error('Heartbeat execution context may select only one outcome.');
         }
 
-        const summary = input.summary.trim();
-        if (!summary) {
-          throw new Error('A skipped heartbeat execution requires a non-empty summary.');
-        }
-        skipSelected = true;
-        return Object.freeze({ kind: 'skipped' as const, summary });
+        const outcome = Object.freeze({
+          kind: 'skipped' as const,
+          summary: HeartbeatTaskRunnerService.normalizeHandlerOutcomeSummary(input.summary),
+        });
+        selectedOutcome = outcome;
+        return outcome;
       },
       retry: (input: { summary: string; delayMs?: number }) => {
         HeartbeatTaskRunnerService.assertContextActive(active, args.execution.executionId);
         const result = HeartbeatTaskRunnerService.requireCompletedAgentResult(agentResult);
-        if (skipSelected || explicitOutcome) {
+        if (selectedOutcome) {
           throw new Error('Heartbeat execution context may select only one outcome.');
         }
 
@@ -395,13 +427,13 @@ export class HeartbeatTaskRunnerService {
           delayMs: HeartbeatTaskRunnerService.normalizeHandlerRetryDelay(input.delayMs),
           agentRunId: result.state.runId,
         });
-        explicitOutcome = outcome;
+        selectedOutcome = outcome;
         return outcome;
       },
       block: (input: { summary: string }) => {
         HeartbeatTaskRunnerService.assertContextActive(active, args.execution.executionId);
         const result = HeartbeatTaskRunnerService.requireCompletedAgentResult(agentResult);
-        if (skipSelected || explicitOutcome) {
+        if (selectedOutcome) {
           throw new Error('Heartbeat execution context may select only one outcome.');
         }
 
@@ -410,7 +442,7 @@ export class HeartbeatTaskRunnerService {
           summary: HeartbeatTaskRunnerService.normalizeHandlerOutcomeSummary(input.summary),
           agentRunId: result.state.runId,
         });
-        explicitOutcome = outcome;
+        selectedOutcome = outcome;
         return outcome;
       },
     });
@@ -428,20 +460,23 @@ export class HeartbeatTaskRunnerService {
 
     try {
       const result = await handler(context);
-      if (HeartbeatTaskRunnerService.isSkippedOutcome(result)) {
-        if (!skipSelected || agentInvocation) {
-          throw new Error('Custom heartbeat handlers must return the outcome created by context.skip().');
+      if (HeartbeatTaskRunnerService.isStandaloneHandlerOutcome(result)) {
+        if (agentInvocation || result !== selectedOutcome) {
+          throw new Error('Custom heartbeat handlers must return the completed or skipped outcome created by their execution context before runAgent().');
         }
         return result;
       }
       if (HeartbeatTaskRunnerService.isExplicitHandlerOutcome(result)) {
-        if (!agentInvocation || !agentResult || result !== explicitOutcome) {
+        if (!agentInvocation || !agentResult || result !== selectedOutcome) {
           throw new Error('Custom heartbeat handlers must return the retry or blocked outcome created by their execution context after runAgent() settles.');
         }
         return result;
       }
-      if (explicitOutcome) {
+      if (HeartbeatTaskRunnerService.isExplicitHandlerOutcome(selectedOutcome)) {
         throw new Error('Custom heartbeat handlers must return the retry or blocked outcome created by their execution context after selecting it.');
+      }
+      if (selectedOutcome) {
+        throw new Error('Custom heartbeat handlers must return the completed or skipped outcome created by their execution context after selecting it.');
       }
       if (!HeartbeatTaskRunnerService.isAgentResult(result)) {
         throw new Error('Custom heartbeat handler returned an unsupported execution outcome.');
@@ -671,8 +706,15 @@ export class HeartbeatTaskRunnerService {
     }
   }
 
-  private static isSkippedOutcome(value: unknown): value is HeartbeatHandlerOutcome {
-    return Boolean(value && typeof value === 'object' && 'kind' in value && value.kind === 'skipped');
+  private static isStandaloneHandlerOutcome(
+    value: unknown,
+  ): value is Extract<HeartbeatHandlerOutcome, { kind: 'completed' | 'skipped' }> {
+    return Boolean(
+      value
+      && typeof value === 'object'
+      && 'kind' in value
+      && (value.kind === 'completed' || value.kind === 'skipped'),
+    );
   }
 
   private static isExplicitHandlerOutcome(value: unknown): value is Extract<HeartbeatHandlerOutcome, { kind: 'retry' | 'blocked' }> {
@@ -694,7 +736,7 @@ export class HeartbeatTaskRunnerService {
     return Boolean(record?.result);
   }
 
-  private static isNonAgentRecord<K extends 'skipped' | 'cancelled' | 'retry' | 'blocked'>(
+  private static isNonAgentRecord<K extends 'completed' | 'skipped' | 'cancelled' | 'retry' | 'blocked'>(
     record: HeartbeatTaskRunRecord | undefined,
     kind: K,
   ): record is HeartbeatTaskNonAgentRunRecord & { outcome: { kind: K } } {
@@ -711,10 +753,10 @@ export class HeartbeatTaskRunnerService {
   private static normalizeHandlerOutcomeSummary(summary: string): string {
     const normalized = summary.trim();
     if (!normalized) {
-      throw new Error('A heartbeat retry or blocked outcome requires a non-empty, non-secret summary.');
+      throw new Error('A heartbeat handler outcome requires a non-empty, non-secret summary.');
     }
     if (normalized.length > MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH) {
-      throw new Error(`Heartbeat retry and blocked summaries must be at most ${MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH} characters.`);
+      throw new Error(`Heartbeat handler outcome summaries must be at most ${MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH} characters.`);
     }
     return normalized;
   }

--- a/src/core/heartbeat/scheduler/types.ts
+++ b/src/core/heartbeat/scheduler/types.ts
@@ -98,6 +98,13 @@ export type HeartbeatSchedulerEvent =
       timestamp: string;
     }
   | {
+      type: 'heartbeat.task.completed';
+      taskId: string;
+      executionId: string;
+      record: HeartbeatTaskNonAgentRunRecord & { outcome: { kind: 'completed' } };
+      timestamp: string;
+    }
+  | {
       type: 'heartbeat.task.skipped';
       taskId: string;
       executionId: string;
@@ -178,6 +185,18 @@ export type HeartbeatExecutionContext = {
   runAt: Date;
   signal: AbortSignal;
   runAgent: (options?: HeartbeatTaskRunnerAgentOptions) => Promise<AgentHeartbeatResult>;
+  /**
+   * Records successful host-owned work without fabricating an agent result.
+   * This completes only the current execution; an enabled recurring task is
+   * scheduled normally. The summary is durable operator text and must be
+   * concise and free of credentials, tokens, prompts, or domain payloads.
+   */
+  complete: (input: { summary: string }) => HeartbeatHandlerOutcome;
+  /**
+   * Records that no eligible host-owned work was available for this execution.
+   * The summary follows the same durable, bounded, non-secret contract as
+   * other custom-handler outcomes.
+   */
   skip: (input: { summary: string }) => HeartbeatHandlerOutcome;
   /**
    * Rejects the completed nested agent result and schedules a bounded retry.
@@ -194,6 +213,7 @@ export type HeartbeatExecutionContext = {
 };
 
 export type HeartbeatHandlerOutcome =
+  | { kind: 'completed'; summary: string }
   | { kind: 'skipped'; summary: string }
   | { kind: 'retry'; summary: string; delayMs: number; agentRunId: string }
   | { kind: 'blocked'; summary: string; agentRunId: string };
@@ -298,9 +318,9 @@ export type RunDueHeartbeatTasksResult = {
 /**
  * Machine-readable result of one claim-fenced heartbeat execution attempt.
  *
- * `settled` covers agent, skipped, and blocked outcomes. An explicit custom
- * handler retry is surfaced separately so a dispatcher can distinguish it
- * from successful settlement without inspecting record internals.
+ * `settled` covers agent, completed, skipped, and blocked outcomes. An explicit
+ * custom handler retry is surfaced separately so a dispatcher can distinguish
+ * it from successful settlement without inspecting record internals.
  */
 export type HeartbeatTaskExecutionResult = {
   taskId: string;

--- a/src/core/heartbeat/tasks/heartbeat-task-store-conformance.ts
+++ b/src/core/heartbeat/tasks/heartbeat-task-store-conformance.ts
@@ -299,8 +299,10 @@ export class HeartbeatTaskStoreConformance {
 
   private static async verifySettlements(namespace: string, harness: HeartbeatTaskStoreConformanceHarness): Promise<void> {
     const store = await harness.createStore(namespace);
-    const tasks = ['success', 'skip', 'cancel', 'failure'].map(createTask);
+    const tasks = ['success', 'completed', 'skip', 'cancel', 'failure'].map(createTask);
     await Promise.all(tasks.map(async (task) => await store.saveTask(task)));
+    const retainedCheckpoint = createResult('completed-prior').checkpoint;
+    await store.saveCheckpoint(createTask('completed'), retainedCheckpoint);
 
     const successExecution = createExecution('success-execution', 'owner-a', harness);
     await assertClaimed(store, 'success', successExecution, harness, 1_000);
@@ -324,19 +326,46 @@ export class HeartbeatTaskStoreConformance {
     });
     assert(repeatedSuccess.status === 'claim-lost', 'repeating a settled execution must not duplicate or overwrite it');
 
+    const completedExecution = createExecution('completed-execution', 'owner-a', harness);
+    await assertClaimed(store, 'completed', completedExecution, harness, 3_000);
+    const completed = await store.recordTaskExecutionOutcome({
+      taskId: 'completed',
+      execution: completedExecution,
+      kind: 'completed',
+      summary: 'Host-owned work completed.',
+      finishedAt: at(harness, 4_000),
+    });
+    assert(completed.status === 'saved' && completed.record?.outcome?.kind === 'completed', 'host completion must atomically return its durable run record');
+    const persistedCompletion = await requireTask(store, 'completed');
+    assert(persistedCompletion.state?.lastExecution?.kind === 'completed', 'host completion must durably settle the task state');
+    assert((await store.loadCheckpoint(persistedCompletion))?.runId === retainedCheckpoint.runId, 'host completion must retain the previous checkpoint');
+    if (harness.capabilities?.runHistory) {
+      assert(store.listRunRecords, 'runHistory requires listRunRecords');
+      const records = await store.listRunRecords({ taskId: 'completed' });
+      assert(records.some((entry) => entry.executionId === completedExecution.executionId), 'host completion must durably persist its run record');
+    }
+    const repeatedCompletion = await store.recordTaskExecutionOutcome({
+      taskId: 'completed',
+      execution: completedExecution,
+      kind: 'completed',
+      summary: 'Duplicate host completion.',
+      finishedAt: at(harness, 4_000),
+    });
+    assert(repeatedCompletion.status === 'claim-lost', 'repeating a completed execution must not duplicate or overwrite it');
+
     const skipExecution = createExecution('skip-execution', 'owner-a', harness);
-    await assertClaimed(store, 'skip', skipExecution, harness, 3_000);
-    const skipped = await store.recordTaskExecutionOutcome({ taskId: 'skip', execution: skipExecution, kind: 'skipped', summary: 'No work.', finishedAt: at(harness, 4_000) });
+    await assertClaimed(store, 'skip', skipExecution, harness, 5_000);
+    const skipped = await store.recordTaskExecutionOutcome({ taskId: 'skip', execution: skipExecution, kind: 'skipped', summary: 'No work.', finishedAt: at(harness, 6_000) });
     assert(skipped.status === 'saved' && skipped.record?.outcome?.kind === 'skipped', 'skip must atomically return its durable run record');
 
     const cancelledExecution = createExecution('cancel-execution', 'owner-a', harness);
-    await assertClaimed(store, 'cancel', cancelledExecution, harness, 5_000);
-    const cancelled = await store.recordTaskExecutionOutcome({ taskId: 'cancel', execution: cancelledExecution, kind: 'cancelled', summary: 'Stopped.', reason: 'operator-request', finishedAt: at(harness, 6_000) });
+    await assertClaimed(store, 'cancel', cancelledExecution, harness, 7_000);
+    const cancelled = await store.recordTaskExecutionOutcome({ taskId: 'cancel', execution: cancelledExecution, kind: 'cancelled', summary: 'Stopped.', reason: 'operator-request', finishedAt: at(harness, 8_000) });
     assert(cancelled.status === 'saved' && cancelled.record?.outcome?.kind === 'cancelled', 'cancellation must atomically return its durable run record');
 
     const failureExecution = createExecution('failure-execution', 'owner-a', harness);
-    await assertClaimed(store, 'failure', failureExecution, harness, 7_000);
-    const failed = await store.failTaskExecution({ taskId: 'failure', execution: failureExecution, error: new Error('temporary failure'), failedAt: at(harness, 8_000), retryMs: 60_000 });
+    await assertClaimed(store, 'failure', failureExecution, harness, 9_000);
+    const failed = await store.failTaskExecution({ taskId: 'failure', execution: failureExecution, error: new Error('temporary failure'), failedAt: at(harness, 10_000), retryMs: 60_000 });
     assert(failed.status === 'saved' && failed.task.state?.lastExecution?.kind === 'failed', 'failure must settle only the current claim');
   }
 

--- a/src/core/heartbeat/tasks/schemas.ts
+++ b/src/core/heartbeat/tasks/schemas.ts
@@ -86,7 +86,7 @@ const HeartbeatTaskRecoverySchema = z.object({
 });
 
 export const HeartbeatTaskExecutionOutcomeSchema = z.object({
-  kind: z.enum(['agent', 'skipped', 'cancelled', 'retry', 'blocked', 'failed']).describe('How this outer heartbeat execution settled.'),
+  kind: z.enum(['agent', 'completed', 'skipped', 'cancelled', 'retry', 'blocked', 'failed']).describe('How this outer heartbeat execution settled.'),
   executionId: z.string().describe('Outer heartbeat execution fencing identity.'),
   summary: z.string().describe('Operator-facing execution outcome summary.'),
   agentRunId: z.string().optional().describe('Nested agent run rejected by an explicit custom-handler outcome.'),
@@ -173,7 +173,7 @@ const HeartbeatTaskAgentRunRecordSchema = z.object({
 const HeartbeatTaskNonAgentRunRecordSchema = z.object({
   task: HeartbeatTaskSchema.describe('Task state captured after this execution.'),
   outcome: HeartbeatTaskExecutionOutcomeSchema.extend({
-    kind: z.enum(['skipped', 'cancelled', 'retry', 'blocked']),
+    kind: z.enum(['completed', 'skipped', 'cancelled', 'retry', 'blocked']),
   }).describe('Lightweight execution outcome with no fabricated agent state.'),
 }).strict();
 

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -331,10 +331,16 @@ export class FileHeartbeatTaskService implements
       }
 
       const execution = currentTask.state?.execution ?? input.execution;
-      const summary = input.kind === 'retry' || input.kind === 'blocked' ?
-        FileHeartbeatTaskService.normalizeHandlerOutcomeSummary(input.summary)
-      : input.summary;
+      const summary = input.kind === 'cancelled' ?
+        input.summary
+      : FileHeartbeatTaskService.normalizeHandlerOutcomeSummary(input.summary);
       const projectors = {
+        completed: () => HeartbeatTaskStateProjector.afterHandlerCompletion({
+          task: currentTask,
+          execution,
+          summary,
+          now: input.finishedAt,
+        }),
         skipped: () => HeartbeatTaskStateProjector.afterSkip({
           task: currentTask,
           execution,
@@ -595,7 +601,7 @@ export class FileHeartbeatTaskService implements
   private static normalizeHandlerOutcomeSummary(summary: string): string {
     const normalized = summary.trim();
     if (!normalized || normalized.length > MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH) {
-      throw new Error(`Heartbeat retry and blocked summaries must be non-empty and at most ${MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH} characters.`);
+      throw new Error(`Heartbeat handler outcome summaries must be non-empty and at most ${MAX_HEARTBEAT_HANDLER_OUTCOME_SUMMARY_LENGTH} characters.`);
     }
     return normalized;
   }

--- a/src/core/heartbeat/tasks/task-state.ts
+++ b/src/core/heartbeat/tasks/task-state.ts
@@ -260,39 +260,32 @@ export class HeartbeatTaskStateProjector {
     }));
   }
 
+  static afterHandlerCompletion(args: {
+    task: HeartbeatTask;
+    execution: HeartbeatTaskExecution;
+    summary: string;
+    now: Date;
+  }): HeartbeatTask {
+    return HeartbeatTaskStateProjector.afterRecurringNonAgentOutcome({
+      ...args,
+      kind: 'completed',
+      enabledProgress: `Custom heartbeat handler completed successfully. Waiting until the next scheduled run in ${HeartbeatTaskStateProjector.formatDelay(args.task.schedule.intervalMs)}.`,
+      disabledProgress: 'Custom heartbeat handler completed successfully. Task remains disabled.',
+    });
+  }
+
   static afterSkip(args: {
     task: HeartbeatTask;
     execution: HeartbeatTaskExecution;
     summary: string;
     now: Date;
   }): HeartbeatTask {
-    const finishedAt = dayjs(args.now).toISOString();
-    return HeartbeatTaskStateProjector.afterExecutionSettlement(HeartbeatTaskStateProjector.normalize({
-      ...args.task,
-      schedule: {
-        ...args.task.schedule,
-        nextRunAt: args.task.enabled ? dayjs(args.now).add(args.task.schedule.intervalMs, 'millisecond').toISOString() : undefined,
-      },
-      state: {
-        status: args.task.enabled ? 'waiting' : 'idle',
-        progress: args.task.enabled ?
-          `No work was available. Waiting until the next scheduled run in ${HeartbeatTaskStateProjector.formatDelay(args.task.schedule.intervalMs)}.`
-        : 'No work was available. Task remains disabled.',
-        runAt: finishedAt,
-        resumable: true,
-        error: undefined,
-        execution: undefined,
-        runRequest: args.task.state?.runRequest,
-        lastExecution: HeartbeatTaskStateProjector.executionOutcome({
-          kind: 'skipped',
-          execution: args.execution,
-          summary: args.summary,
-          finishedAt,
-        }),
-        recovery: args.task.state?.recovery,
-        updatedAt: finishedAt,
-      },
-    }));
+    return HeartbeatTaskStateProjector.afterRecurringNonAgentOutcome({
+      ...args,
+      kind: 'skipped',
+      enabledProgress: `No work was available. Waiting until the next scheduled run in ${HeartbeatTaskStateProjector.formatDelay(args.task.schedule.intervalMs)}.`,
+      disabledProgress: 'No work was available. Task remains disabled.',
+    });
   }
 
   static afterHandlerRetry(args: {
@@ -414,6 +407,42 @@ export class HeartbeatTaskStateProjector {
       status: state?.status ?? 'idle',
       resumable: state?.resumable ?? true,
     };
+  }
+
+  private static afterRecurringNonAgentOutcome(args: {
+    task: HeartbeatTask;
+    execution: HeartbeatTaskExecution;
+    summary: string;
+    now: Date;
+    kind: 'completed' | 'skipped';
+    enabledProgress: string;
+    disabledProgress: string;
+  }): HeartbeatTask {
+    const finishedAt = dayjs(args.now).toISOString();
+    return HeartbeatTaskStateProjector.afterExecutionSettlement(HeartbeatTaskStateProjector.normalize({
+      ...args.task,
+      schedule: {
+        ...args.task.schedule,
+        nextRunAt: args.task.enabled ? dayjs(args.now).add(args.task.schedule.intervalMs, 'millisecond').toISOString() : undefined,
+      },
+      state: {
+        status: args.task.enabled ? 'waiting' : 'idle',
+        progress: args.task.enabled ? args.enabledProgress : args.disabledProgress,
+        runAt: finishedAt,
+        resumable: true,
+        error: undefined,
+        execution: undefined,
+        runRequest: args.task.state?.runRequest,
+        lastExecution: HeartbeatTaskStateProjector.executionOutcome({
+          kind: args.kind,
+          execution: args.execution,
+          summary: args.summary,
+          finishedAt,
+        }),
+        recovery: args.task.state?.recovery,
+        updatedAt: finishedAt,
+      },
+    }));
   }
 
   private static afterExecutionSettlement(task: HeartbeatTask): HeartbeatTask {
@@ -592,6 +621,8 @@ export class HeartbeatTaskStateProjector {
     switch (args.kind) {
       case 'agent':
         return { ...base, kind: 'agent' };
+      case 'completed':
+        return { ...base, kind: 'completed' };
       case 'skipped':
         return { ...base, kind: 'skipped' };
       case 'failed':

--- a/src/core/heartbeat/tasks/types.ts
+++ b/src/core/heartbeat/tasks/types.ts
@@ -93,9 +93,9 @@ export type HeartbeatTaskRuntime = Pick<
 /**
  * Identifies one owned attempt to execute a heartbeat task.
  *
- * Hosted stores must treat `executionId` as a fencing token: completion,
- * failure, skip, and cancellation writes are valid only while this exact
- * execution still owns the task. `ownerId` identifies the scheduler process/
+ * Hosted stores must treat `executionId` as a fencing token: agent completion,
+ * host completion, failure, skip, and cancellation writes are valid only while
+ * this exact execution still owns the task. `ownerId` identifies the scheduler process/
  * worker generation for operator diagnostics and explicit recovery.
  */
 export type HeartbeatTaskExecution = {
@@ -129,6 +129,7 @@ type HeartbeatTaskExecutionOutcomeBase = {
 
 export type HeartbeatTaskExecutionOutcome =
   | (HeartbeatTaskExecutionOutcomeBase & { kind: 'agent' })
+  | (HeartbeatTaskExecutionOutcomeBase & { kind: 'completed' })
   | (HeartbeatTaskExecutionOutcomeBase & { kind: 'skipped' })
   | (HeartbeatTaskExecutionOutcomeBase & {
       kind: 'retry';
@@ -188,7 +189,7 @@ export type HeartbeatTaskAgentRunRecord = {
 
 export type HeartbeatTaskNonAgentRunRecord = {
   task: HeartbeatTask;
-  outcome: HeartbeatTaskExecutionOutcome & { kind: 'skipped' | 'cancelled' | 'retry' | 'blocked' };
+  outcome: HeartbeatTaskExecutionOutcome & { kind: 'completed' | 'skipped' | 'cancelled' | 'retry' | 'blocked' };
   result?: never;
   loadedCheckpoint?: never;
 };
@@ -281,7 +282,7 @@ export type HeartbeatTaskStore = {
   recordTaskExecutionOutcome: (input: {
     execution: HeartbeatTaskExecution;
     taskId: string;
-    kind: 'skipped' | 'cancelled' | 'retry' | 'blocked';
+    kind: 'completed' | 'skipped' | 'cancelled' | 'retry' | 'blocked';
     summary: string;
     /** Nested agent run rejected by an explicit custom-handler outcome. */
     agentRunId?: string;

--- a/src/core/heartbeat/views/lucid-presenter.ts
+++ b/src/core/heartbeat/views/lucid-presenter.ts
@@ -111,6 +111,7 @@ export class HeartbeatLucidPresenter {
           HeartbeatLucidPresenter.responseMessage(agentId, result.summary, event.timestamp),
         ];
       }
+      case 'heartbeat.task.completed':
       case 'heartbeat.task.skipped':
       case 'heartbeat.task.cancelled':
       case 'heartbeat.task.retry':

--- a/src/core/heartbeat/views/types.ts
+++ b/src/core/heartbeat/views/types.ts
@@ -8,7 +8,7 @@ import type {
 } from '../tasks/index.js';
 
 export type HeartbeatTaskResultView = {
-  kind: 'agent' | 'skipped' | 'cancelled' | 'retry' | 'blocked' | 'failed';
+  kind: 'agent' | 'completed' | 'skipped' | 'cancelled' | 'retry' | 'blocked' | 'failed';
   decision?: HeartbeatDecision;
   summary: string;
   outcome: string;

--- a/src/server/control-plane-types.ts
+++ b/src/server/control-plane-types.ts
@@ -366,7 +366,7 @@ export type ControlPlaneHeartbeatEvent =
     timestamp: string;
   }
   | {
-    type: 'heartbeat.task.skipped' | 'heartbeat.task.cancelled' | 'heartbeat.task.retry' | 'heartbeat.task.blocked';
+    type: 'heartbeat.task.completed' | 'heartbeat.task.skipped' | 'heartbeat.task.cancelled' | 'heartbeat.task.retry' | 'heartbeat.task.blocked';
     taskId: string;
     executionId: string;
     record: HeartbeatRunView;

--- a/src/server/controllers/trpc/control-plane/heartbeat-events.ts
+++ b/src/server/controllers/trpc/control-plane/heartbeat-events.ts
@@ -66,6 +66,7 @@ export class ControlPlaneHeartbeatEventsController {
   private static projectEvent(event: HeartbeatSchedulerEvent): ControlPlaneHeartbeatEvent {
     if (
       event.type === 'heartbeat.task.finished'
+      || event.type === 'heartbeat.task.completed'
       || event.type === 'heartbeat.task.skipped'
       || event.type === 'heartbeat.task.cancelled'
       || event.type === 'heartbeat.task.retry'

--- a/src/server/lifecycle.ts
+++ b/src/server/lifecycle.ts
@@ -265,6 +265,7 @@ function logHeartbeatSchedulerEvent(
     'heartbeat.task.agent_event': 'Heartbeat task agent event',
     'heartbeat.task.agent_activity': 'Heartbeat task remote agent activity',
     'heartbeat.task.finished': 'Heartbeat task finished',
+    'heartbeat.task.completed': 'Heartbeat custom handler completed successfully',
     'heartbeat.task.skipped': 'Heartbeat task skipped because no work was available',
     'heartbeat.task.cancelled': 'Heartbeat task execution cancelled',
     'heartbeat.task.retry': 'Heartbeat task retry requested by custom handler',

--- a/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
+++ b/src/web-v2/hooks/tasks/useControlPlaneHeartbeatEvents.ts
@@ -47,6 +47,7 @@ export function useControlPlaneHeartbeatEvents({
 
     if (
       event.type === 'heartbeat.task.finished'
+      || event.type === 'heartbeat.task.completed'
       || event.type === 'heartbeat.task.skipped'
       || event.type === 'heartbeat.task.cancelled'
       || event.type === 'heartbeat.task.retry'
@@ -176,6 +177,7 @@ function projectHeartbeatTaskEvent(
         progress: event.record.task.state.progress ?? 'Heartbeat runner finished.',
         runId: event.record.runId,
       };
+    case 'heartbeat.task.completed':
     case 'heartbeat.task.skipped':
     case 'heartbeat.task.cancelled':
     case 'heartbeat.task.retry':


### PR DESCRIPTION
## Summary

- add HeartbeatExecutionContext.complete({ summary }) for successful host-owned work that does not invoke the Heddle agent loop
- persist a claim-fenced non-agent completed outcome while retaining checkpoints and recurring cadence
- project completed through task/run views, scheduler and control-plane events, and host-facing presenters
- enforce one context-created outcome plus the shared bounded non-secret summary contract
- extend the public store conformance suite and heartbeat guide

## Contract

completed means the current heartbeat execution succeeded. It does not mark an enabled recurring task terminal. The handler must return the exact outcome created by context.complete, cannot combine it with runAgent, skip, retry, or block, and remains responsible for idempotent domain effects across recovery.

## Compatibility and release order

This widens required public implementor contracts on HeartbeatExecutionContext and HeartbeatTaskStore.recordTaskExecutionOutcome. Current @heddleagent/runtime 7.1.1 and the released Postgres adapter do not contain this contract. It must ship in a Runtime 8 major, followed by a compatible Execution Host/Postgres release before adopters use context.complete. This PR does not version, merge, release, or publish artifacts.

## Verification

- yarn typecheck
- yarn build
- 5 focused test files, 44 tests passed: execution context, targeted execution, task-store conformance, task/run views, and event presenter