### PR TITLE
Release @heddleagent/runtime 8.0.0

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -504,6 +504,7 @@ hosted state.
 
 ```ts
 import type {
+  HeartbeatTask,
   HeartbeatTaskAdministrationService,
 } from '@heddleagent/runtime/advanced';
 
@@ -518,11 +519,43 @@ const task = await heartbeatTasks.createTask({
 await heartbeatTasks.setTaskEnabled(task.taskId, false);
 ```
 
+The default reconciliation policy preserves existing members wholesale, which
+is appropriate when operators may edit their configuration. A code-owned
+catalog can make its mutable configuration authoritative in one atomic call:
+
+```ts
+const desiredTask: HeartbeatTask = {
+  id: 'managed-digest',
+  name: 'Managed digest',
+  task: 'Produce the configured digest.',
+  enabled: true,
+  schedule: { intervalMs: 60_000 },
+};
+
+await heartbeatTasks.reconcileTasks({
+  namespace: 'managed-',
+  desired: [desiredTask],
+  existingTaskPolicy: 'synchronize-configuration',
+});
+```
+
+This synchronizes `name`, `admissionGroupId`, task instructions, `enabled`,
+`continuationMode`, `intervalMs`, and the mutable model/runtime options. It
+preserves identity/storage fields, the existing `nextRunAt`, execution and
+run-request state, checkpoint association, and run history. An actual enabled
+state transition intentionally updates scheduling and pending-request state
+through the normal enablement policy; in particular, a blocked task still
+requires an explicit `resumeTask()` call. The result's `updated`
+collection contains only tasks whose configuration changed, so repeated startup
+reconciliation is idempotent.
+
 Remote implementations should reuse `HeartbeatTaskControlPolicy` for task
 projections and `HeartbeatTaskViewProjector` for public views. Apply the control
 policy to the latest locked row inside the same database transaction that
-persists the result. The pure policy deliberately owns no transaction, lease,
-tenant authorization, or notification mechanism; reading through
+persists every `created`, `updated`, and `deleted` result. Supply the transaction's
+current timestamp when configuration synchronization is requested. The pure
+policy deliberately owns no transaction, lease, tenant authorization, or
+notification mechanism; reading through
 `loadTask()` and later writing through `saveTask()` is not an atomic
 administration implementation.
 

--- a/docs/releases/runtime-v8.0.0.md
+++ b/docs/releases/runtime-v8.0.0.md
@@ -1,7 +1,8 @@
 # `@heddleagent/runtime` 8.0.0
 
-This major release adds explicit terminal completion for successful tools and
-successful host-owned heartbeat work without fabricating an agent result.
+This major release adds explicit terminal completion for successful tools,
+successful host-owned heartbeat work without fabricating an agent result, and
+atomic configuration reconciliation for code-owned heartbeat catalogs.
 
 ## What changed
 
@@ -17,6 +18,12 @@ successful host-owned heartbeat work without fabricating an agent result.
 - Extend task, run, event, control-plane, and executable store-conformance
   projections so adapters can preserve the successful non-agent outcome
   without inventing an agent run ID or result.
+- Add the opt-in `reconcileTasks()` policy
+  `existingTaskPolicy: 'synchronize-configuration'` for code-owned catalogs.
+  It atomically updates mutable configuration while preserving checkpoints,
+  history, execution fencing state, and—when enablement is unchanged—the current
+  scheduling position and pending intent. Unchanged startup reconciliation
+  performs no write.
 
 ## Upgrade note
 
@@ -26,6 +33,13 @@ This is a major release because `HeartbeatExecutionContext`,
 `HeartbeatTaskStore.recordTaskExecutionOutcome` gain the public `completed`
 case. Custom stores, event codecs, and exhaustive TypeScript consumers must
 handle that variant before upgrading.
+
+`ReconcileHeartbeatTasksResult` also gains `updated`. Custom administration
+adapters must persist every updated task in the same transaction as membership
+reconciliation, and pass a current timestamp to `HeartbeatTaskControlPolicy`
+when configuration synchronization is requested. The default reconciliation
+policy remains `preserve`, so operator-managed catalogs keep their existing
+configuration unless a host opts in.
 
 Custom handlers must still settle each execution exactly once. Use
 `complete()` only after successful host-owned work, keep its durable summary

--- a/docs/releases/runtime-v8.0.0.md
+++ b/docs/releases/runtime-v8.0.0.md
@@ -1,0 +1,45 @@
+# `@heddleagent/runtime` 8.0.0
+
+This major release adds explicit terminal completion for successful tools and
+successful host-owned heartbeat work without fabricating an agent result.
+
+## What changed
+
+- Add `ToolDefinition.returnDirect` so a successful terminal tool can complete
+  the current run from its result without requesting another model turn.
+  Failed tool results remain recoverable by the agent, and existing tools keep
+  the previous behavior unless they opt in.
+- Add `HeartbeatExecutionContext.complete({ summary })` for custom handlers
+  that successfully perform host-owned work without calling `runAgent()`.
+- Persist that heartbeat settlement as the distinct non-agent `completed`
+  outcome, emit `heartbeat.task.completed`, retain the task checkpoint, and
+  schedule the next interval for enabled recurring tasks.
+- Extend task, run, event, control-plane, and executable store-conformance
+  projections so adapters can preserve the successful non-agent outcome
+  without inventing an agent run ID or result.
+
+## Upgrade note
+
+This is a major release because `HeartbeatExecutionContext`,
+`HeartbeatHandlerOutcome`, `HeartbeatTaskExecutionOutcome`,
+`HeartbeatTaskNonAgentRunRecord`, `HeartbeatSchedulerEvent`, and
+`HeartbeatTaskStore.recordTaskExecutionOutcome` gain the public `completed`
+case. Custom stores, event codecs, and exhaustive TypeScript consumers must
+handle that variant before upgrading.
+
+Custom handlers must still settle each execution exactly once. Use
+`complete()` only after successful host-owned work, keep its durable summary
+concise and non-secret, and use `skip()`, `retry()`, or `blocked()` for their
+existing meanings. Product identity, policy, payload persistence, and effects
+remain host-owned.
+
+Use `returnDirect` only for tools whose successful output is a complete,
+user-facing run result. String outputs become the result summary directly;
+other outputs are JSON serialized.
+
+## Verification
+
+The release candidate is verified with the repository build and test baseline,
+Runtime package build, npm dry-run packaging, focused terminal-tool and
+heartbeat coverage, and release-range review from `runtime-v7.1.1` through the
+release-preparation commit.

--- a/examples/heartbeat/README.md
+++ b/examples/heartbeat/README.md
@@ -18,7 +18,10 @@ for the work and controls you actually operate.
 Every stage uses `reconcileTasks()` at startup. Re-running an example therefore
 creates a missing task without overwriting its durable state, pending request,
 checkpoint association, or operator changes. Use the explicit task update APIs
-when the host intentionally changes an existing task.
+when the host intentionally changes an existing operator-managed task. A
+code-owned catalog can instead use the `synchronize-configuration` existing-task
+policy to update mutable configuration atomically while preserving its durable
+lifecycle state.
 
 ## Choose by two independent axes
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/runtime",
-  "version": "7.1.1",
+  "version": "8.0.0",
   "description": "Embeddable TypeScript and Node.js agent runtime and SDK for Heddle-powered products",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/src/__tests__/integration/core/heartbeat-file-concurrency.test.ts
+++ b/src/__tests__/integration/core/heartbeat-file-concurrency.test.ts
@@ -150,6 +150,103 @@ describe('file-backed heartbeat task concurrency', () => {
     await expect(store.requireTask('representative-obsolete')).rejects.toThrow(/not found/i);
   });
 
+  it('atomically synchronizes code-owned configuration while retaining durable lifecycle data', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-file-config-reconcile-'));
+    const store = new FileHeartbeatTaskService({ dir });
+    const task = {
+      ...createTask('managed-periodic'),
+      name: 'Old managed task',
+      task: 'Old managed instructions.',
+      schedule: {
+        intervalMs: 60_000,
+        nextRunAt: '2099-01-01T00:00:00.000Z',
+      },
+      runtime: {
+        model: 'old-model',
+        workspaceRoot: '/durable/workspace',
+      },
+      state: {
+        status: 'waiting' as const,
+        resumable: true,
+        runRequest: {
+          generation: 3,
+          claimedGeneration: 2,
+          requestedAt: NOW.toISOString(),
+        },
+        lastExecution: {
+          kind: 'skipped' as const,
+          executionId: 'previous-execution',
+          summary: 'Previous durable result.',
+          finishedAt: NOW.toISOString(),
+        },
+      },
+    };
+    const checkpoint = AgentLoopCheckpointService.createCheckpoint({
+      status: 'running',
+      runId: 'durable-run',
+      goal: 'Retain this checkpoint.',
+      model: 'gpt-test',
+      provider: 'openai',
+      workspaceRoot: '/durable/workspace',
+      startedAt: NOW.toISOString(),
+      transcript: [],
+      trace: [],
+    }, { createdAt: NOW.toISOString() });
+    await store.saveTask(task);
+    await store.saveCheckpoint(task, checkpoint);
+    await store.saveRunRecord({
+      task,
+      outcome: task.state.lastExecution,
+    });
+    const runHistory = await store.listRunRecords({ taskId: task.id });
+    const desired = {
+      ...createTask(task.id),
+      name: 'Current managed task',
+      task: 'Current managed instructions.',
+      schedule: {
+        intervalMs: 120_000,
+        nextRunAt: '2000-01-01T00:00:00.000Z',
+      },
+      runtime: {
+        model: 'current-model',
+        workspaceRoot: '/ignored/workspace',
+      },
+    };
+
+    const result = await store.reconcileTasks({
+      namespace: 'managed-',
+      desired: [desired],
+      existingTaskPolicy: 'synchronize-configuration',
+    });
+
+    expect(result.created).toEqual([]);
+    expect(result.deleted).toEqual([]);
+    expect(result.updated).toEqual([expect.objectContaining({ id: task.id })]);
+    await expect(store.requireTask(task.id)).resolves.toMatchObject({
+      name: desired.name,
+      task: desired.task,
+      schedule: {
+        intervalMs: desired.schedule.intervalMs,
+        nextRunAt: task.schedule.nextRunAt,
+      },
+      runtime: {
+        model: desired.runtime.model,
+        workspaceRoot: task.runtime.workspaceRoot,
+      },
+      state: {
+        runRequest: task.state.runRequest,
+        lastExecution: task.state.lastExecution,
+      },
+    });
+    await expect(store.loadCheckpoint(task)).resolves.toEqual(checkpoint);
+    await expect(store.listRunRecords({ taskId: task.id })).resolves.toEqual(runHistory);
+    await expect(store.reconcileTasks({
+      namespace: 'managed-',
+      desired: [desired],
+      existingTaskPolicy: 'synchronize-configuration',
+    })).resolves.toMatchObject({ updated: [] });
+  });
+
   it('allows scheduler polling to overlap host mutations without malformed reads', async () => {
     const stateRoot = mkdtempSync(join(tmpdir(), 'heddle-heartbeat-file-scheduler-'));
     const store = new FileHeartbeatTaskService({ stateRoot });

--- a/src/__tests__/unit/core/heartbeat-task-control-policy.test.ts
+++ b/src/__tests__/unit/core/heartbeat-task-control-policy.test.ts
@@ -180,6 +180,7 @@ describe('HeartbeatTaskControlPolicy', () => {
       input: { namespace: 'representative-', desired: [replacement, added] },
     });
     expect(reconciliation.created).toEqual([added]);
+    expect(reconciliation.updated).toEqual([]);
     expect(reconciliation.deleted).toEqual([obsolete]);
     expect(reconciliation.preservedRunning).toEqual([live]);
     expect(() => HeartbeatTaskControlPolicy.assertTaskCanBeDeleted(live)).toThrow(/running/i);
@@ -187,6 +188,183 @@ describe('HeartbeatTaskControlPolicy', () => {
       currentTasks: [],
       input: { namespace: 'representative-', desired: [outside] },
     })).toThrow(/must start with namespace/i);
+    expect(() => HeartbeatTaskControlPolicy.reconcileTasks({
+      currentTasks: [],
+      input: {
+        namespace: 'representative-',
+        desired: [],
+        existingTaskPolicy: 'replace-state' as never,
+      },
+    })).toThrow(/unsupported existing heartbeat task policy/i);
+  });
+
+  it('synchronizes code-owned configuration without replacing durable execution state', () => {
+    const current = createTask({
+      id: 'managed-task',
+      workspaceId: 'durable-workspace',
+      checkpointPath: '/durable/checkpoint.json',
+      name: 'Old name',
+      admissionGroupId: 'old-group',
+      task: 'Old instructions.',
+      continuationMode: 'operator',
+      schedule: {
+        intervalMs: 60_000,
+        nextRunAt: '2026-08-08T05:00:00.000Z',
+      },
+      runtime: {
+        model: 'old-model',
+        maxSteps: 2,
+        workspaceRoot: '/durable/workspace',
+        stateDir: '/durable/state',
+        memoryDir: '/durable/memory',
+        searchIgnoreDirs: ['old-ignore'],
+        systemContext: 'Old context.',
+      },
+      state: {
+        status: 'running',
+        execution: {
+          executionId: 'execution-live',
+          ownerId: 'worker-live',
+          claimedAt: NOW.toISOString(),
+        },
+        runRequest: {
+          generation: 2,
+          claimedGeneration: 1,
+          requestedAt: NOW.toISOString(),
+        },
+        lastExecution: {
+          kind: 'skipped',
+          executionId: 'execution-previous',
+          summary: 'Previous durable outcome.',
+          finishedAt: NOW.toISOString(),
+        },
+      },
+    });
+    const desired = createTask({
+      id: current.id,
+      workspaceId: 'ignored-workspace',
+      checkpointPath: '/ignored/checkpoint.json',
+      name: 'Managed name',
+      admissionGroupId: 'managed-group',
+      task: '  Managed instructions.  ',
+      continuationMode: 'agent',
+      schedule: {
+        intervalMs: 120_000,
+        nextRunAt: '2099-01-01T00:00:00.000Z',
+      },
+      runtime: {
+        model: 'managed-model',
+        maxSteps: 4,
+        workspaceRoot: '/ignored/workspace',
+        stateDir: '/ignored/state',
+        memoryDir: '/ignored/memory',
+        searchIgnoreDirs: ['managed-ignore'],
+        systemContext: 'Managed context.',
+      },
+      state: { status: 'idle' },
+    });
+
+    const reconciliation = HeartbeatTaskControlPolicy.reconcileTasks({
+      currentTasks: [current],
+      input: {
+        namespace: 'managed-',
+        desired: [desired],
+        existingTaskPolicy: 'synchronize-configuration',
+      },
+      now: NOW,
+    });
+
+    expect(reconciliation.updated).toHaveLength(1);
+    expect(reconciliation.updated[0]).toMatchObject({
+      id: current.id,
+      workspaceId: current.workspaceId,
+      checkpointPath: current.checkpointPath,
+      name: desired.name,
+      admissionGroupId: desired.admissionGroupId,
+      task: 'Managed instructions.',
+      enabled: true,
+      continuationMode: 'agent',
+      schedule: {
+        intervalMs: desired.schedule.intervalMs,
+        nextRunAt: current.schedule.nextRunAt,
+      },
+      runtime: {
+        model: desired.runtime?.model,
+        maxSteps: desired.runtime?.maxSteps,
+        workspaceRoot: current.runtime?.workspaceRoot,
+        stateDir: current.runtime?.stateDir,
+        memoryDir: current.runtime?.memoryDir,
+        searchIgnoreDirs: desired.runtime?.searchIgnoreDirs,
+        systemContext: desired.runtime?.systemContext,
+      },
+      state: {
+        status: 'running',
+        execution: current.state?.execution,
+        runRequest: current.state?.runRequest,
+        lastExecution: current.state?.lastExecution,
+        updatedAt: NOW.toISOString(),
+      },
+    });
+    expect(reconciliation.preservedRunning).toEqual(reconciliation.updated);
+    expect(current.name).toBe('Old name');
+
+    expect(() => HeartbeatTaskControlPolicy.reconcileTasks({
+      currentTasks: [current],
+      input: {
+        namespace: 'managed-',
+        desired: [desired],
+        existingTaskPolicy: 'synchronize-configuration',
+      },
+    })).toThrow(/requires a current timestamp/i);
+
+    expect(HeartbeatTaskControlPolicy.reconcileTasks({
+      currentTasks: reconciliation.updated,
+      input: {
+        namespace: 'managed-',
+        desired: [desired],
+        existingTaskPolicy: 'synchronize-configuration',
+      },
+      now: new Date(NOW.getTime() + 60_000),
+    }).updated).toEqual([]);
+  });
+
+  it('uses normal enablement safety when synchronizing code-owned configuration', () => {
+    const disabled = createTask({
+      id: 'managed-disabled',
+      enabled: false,
+      schedule: { intervalMs: 60_000 },
+      state: { status: 'idle' },
+    });
+    const enabled = HeartbeatTaskControlPolicy.reconcileTasks({
+      currentTasks: [disabled],
+      input: {
+        namespace: 'managed-',
+        desired: [{ ...disabled, enabled: true }],
+        existingTaskPolicy: 'synchronize-configuration',
+      },
+      now: NOW,
+    }).updated[0];
+
+    expect(enabled).toMatchObject({
+      enabled: true,
+      schedule: { nextRunAt: '2026-08-07T23:59:59.000Z' },
+      state: { status: 'waiting' },
+    });
+
+    const blocked = {
+      ...disabled,
+      id: 'managed-blocked',
+      state: { status: 'blocked' as const, resumable: true },
+    };
+    expect(() => HeartbeatTaskControlPolicy.reconcileTasks({
+      currentTasks: [blocked],
+      input: {
+        namespace: 'managed-',
+        desired: [{ ...blocked, enabled: true }],
+        existingTaskPolicy: 'synchronize-configuration',
+      },
+      now: NOW,
+    })).toThrow(/blocked.*resume/i);
   });
 
   it('validates and projects a durable run request for adapters', () => {

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -443,6 +443,7 @@ export type {
   FileHeartbeatTaskServiceOptions,
   HeartbeatAdmissionDecision,
   HeartbeatAdmissionTarget,
+  HeartbeatExistingTaskPolicy,
   HeartbeatTaskAdministrationService,
   HeartbeatTaskAdmissionControl,
   HeartbeatTaskDetail,

--- a/src/core/heartbeat/README.md
+++ b/src/core/heartbeat/README.md
@@ -156,10 +156,15 @@ operator-facing heartbeat views.
   `createTask` calls for the same ID produce one creation and one explicit
   conflict; distinct IDs are independent. `reconcileTasks({ namespace, desired
   })` atomically creates missing members and removes obsolete non-running members
-  from one host-owned namespace, while retaining existing configuration/state and
-  never rewriting a live running claim. Use the explicit task update APIs for
-  existing-task configuration changes. Its process-local wake signal reduces event
-  latency; polling remains the restart fallback. This is reliable for one Node.js
+  from one host-owned namespace. Existing task configuration and state are retained
+  by default. Code-owned catalogs may set `existingTaskPolicy` to
+  `synchronize-configuration`; Heddle then updates only mutable configuration and
+  returns those tasks in `updated`, while preserving checkpoint identity, history,
+  and live execution state. The current next-run time and pending intent also remain
+  intact when enablement is unchanged. Normal enablement safety applies to an
+  actual transition, so reconciliation cannot silently resume a blocked task. Its
+  process-local wake signal reduces event latency; polling remains the restart
+  fallback. This is reliable for one Node.js
   process owning a state root; it is not a distributed lease. Multiple processes
   or replicas must provide a remote
   `HeartbeatTaskStore` plus `HeartbeatTaskAdmissionControl` implementations that

--- a/src/core/heartbeat/index.ts
+++ b/src/core/heartbeat/index.ts
@@ -50,6 +50,7 @@ export type {
   FileHeartbeatTaskServiceOptions,
   HeartbeatAdmissionDecision,
   HeartbeatAdmissionTarget,
+  HeartbeatExistingTaskPolicy,
   HeartbeatTaskAdministrationService,
   HeartbeatTaskAdmissionControl,
   HeartbeatTaskDetail,

--- a/src/core/heartbeat/tasks/administration.ts
+++ b/src/core/heartbeat/tasks/administration.ts
@@ -33,17 +33,28 @@ export type UpdateHeartbeatTaskInput = {
   systemContext?: string;
 };
 
+export type HeartbeatExistingTaskPolicy = 'preserve' | 'synchronize-configuration';
+
 export type ReconcileHeartbeatTasksInput = {
   /** Prefix that limits this reconciliation to tasks owned by one host concern. */
   namespace: string;
-  /** Desired members of the namespace. Existing members retain their stored configuration and state. */
+  /** Desired members of the namespace. */
   desired: readonly HeartbeatTask[];
+  /**
+   * Existing members are preserved by default. Code-owned catalogs may opt in
+   * to synchronizing mutable configuration without replacing durable runtime
+   * state, checkpoint identity, or run history. Scheduling state is preserved
+   * unless the desired `enabled` value requires a normal enablement transition.
+   */
+  existingTaskPolicy?: HeartbeatExistingTaskPolicy;
 };
 
 export type ReconcileHeartbeatTasksResult = {
   created: HeartbeatTask[];
+  /** Existing desired tasks whose mutable configuration changed. */
+  updated: HeartbeatTask[];
   deleted: HeartbeatTask[];
-  /** Running tasks retained without rewriting their execution claim or state. */
+  /** Running tasks retained with their execution claim and state intact. */
   preservedRunning: HeartbeatTask[];
 };
 

--- a/src/core/heartbeat/tasks/control-policy.ts
+++ b/src/core/heartbeat/tasks/control-policy.ts
@@ -6,7 +6,9 @@
  * mutation boundary.
  */
 import dayjs from 'dayjs';
+import isEqual from 'lodash/isEqual.js';
 import omit from 'lodash/omit.js';
+import pickBy from 'lodash/pickBy.js';
 import type {
   CreateHeartbeatTaskInput,
   ReconcileHeartbeatTasksInput,
@@ -23,6 +25,13 @@ import type {
 } from './types.js';
 
 export class HeartbeatTaskControlPolicy {
+  private static readonly synchronizedRuntimeConfigurationKeys = [
+    'model',
+    'maxSteps',
+    'searchIgnoreDirs',
+    'systemContext',
+  ] as const;
+
   static createTask(args: {
     input: CreateHeartbeatTaskInput;
     existingTasks: readonly HeartbeatTask[];
@@ -179,6 +188,7 @@ export class HeartbeatTaskControlPolicy {
   static reconcileTasks(args: {
     currentTasks: readonly HeartbeatTask[];
     input: ReconcileHeartbeatTasksInput;
+    now?: Date;
   }): ReconcileHeartbeatTasksResult {
     HeartbeatTaskControlPolicy.assertReconciliationInput(args.input);
 
@@ -187,11 +197,23 @@ export class HeartbeatTaskControlPolicy {
     const namespaceTasks = args.currentTasks.filter((task) => task.id.startsWith(args.input.namespace));
     const created = [...desiredById.values()].filter((task) => !currentById.has(task.id));
     const obsolete = namespaceTasks.filter((task) => !desiredById.has(task.id));
+    const updated =
+      args.input.existingTaskPolicy === 'synchronize-configuration' ?
+        HeartbeatTaskControlPolicy.synchronizeDesiredTaskConfigurations({
+          currentById,
+          desired: args.input.desired,
+          now: HeartbeatTaskControlPolicy.requireReconciliationNow(args.now),
+        })
+      : [];
+    const updatedById = new Map(updated.map((task) => [task.id, task]));
 
     return {
       created,
+      updated,
       deleted: obsolete.filter((task) => task.state?.status !== 'running'),
-      preservedRunning: namespaceTasks.filter((task) => task.state?.status === 'running'),
+      preservedRunning: namespaceTasks
+        .filter((task) => task.state?.status === 'running')
+        .map((task) => updatedById.get(task.id) ?? task),
     };
   }
 
@@ -257,6 +279,13 @@ export class HeartbeatTaskControlPolicy {
     if (!input.namespace) {
       throw new Error('Heartbeat reconciliation namespace cannot be empty.');
     }
+    if (
+      input.existingTaskPolicy !== undefined
+      && input.existingTaskPolicy !== 'preserve'
+      && input.existingTaskPolicy !== 'synchronize-configuration'
+    ) {
+      throw new Error(`Unsupported existing heartbeat task policy: ${String(input.existingTaskPolicy)}`);
+    }
 
     const desiredIds = input.desired.map((task) => task.id);
     if (new Set(desiredIds).size !== desiredIds.length) {
@@ -265,6 +294,107 @@ export class HeartbeatTaskControlPolicy {
     if (desiredIds.some((taskId) => !taskId.startsWith(input.namespace))) {
       throw new Error(`Heartbeat reconciliation desired task IDs must start with namespace ${input.namespace}.`);
     }
+  }
+
+  private static synchronizeDesiredTaskConfigurations(args: {
+    currentById: ReadonlyMap<string, HeartbeatTask>;
+    desired: readonly HeartbeatTask[];
+    now: Date;
+  }): HeartbeatTask[] {
+    return args.desired.flatMap((desiredTask) => {
+      const currentTask = args.currentById.get(desiredTask.id);
+      if (!currentTask) {
+        return [];
+      }
+
+      const synchronized = HeartbeatTaskControlPolicy.synchronizeTaskConfiguration({
+        currentTask,
+        desiredTask,
+        now: args.now,
+      });
+      return synchronized === currentTask ? [] : [synchronized];
+    });
+  }
+
+  private static synchronizeTaskConfiguration(args: {
+    currentTask: HeartbeatTask;
+    desiredTask: HeartbeatTask;
+    now: Date;
+  }): HeartbeatTask {
+    const desiredConfiguration = HeartbeatTaskControlPolicy.projectSynchronizedConfiguration({
+      ...args.desiredTask,
+      admissionGroupId: HeartbeatTaskControlPolicy.resolveAdmissionGroupId(
+        args.desiredTask.admissionGroupId,
+      ),
+      task: args.desiredTask.task.trim(),
+      continuationMode: args.desiredTask.continuationMode ?? 'operator',
+    });
+    if (isEqual(
+      HeartbeatTaskControlPolicy.projectSynchronizedConfiguration(args.currentTask),
+      desiredConfiguration,
+    )) {
+      return args.currentTask;
+    }
+
+    const taskWithDesiredEnablement =
+      args.currentTask.enabled === desiredConfiguration.enabled ? args.currentTask
+      : HeartbeatTaskControlPolicy.setTaskEnabled({
+          task: args.currentTask,
+          enabled: desiredConfiguration.enabled,
+          now: args.now,
+        });
+    const runtime = {
+      ...omit(
+        taskWithDesiredEnablement.runtime ?? {},
+        HeartbeatTaskControlPolicy.synchronizedRuntimeConfigurationKeys,
+      ),
+      ...pickBy(desiredConfiguration.runtime, (value) => value !== undefined),
+    };
+
+    return {
+      ...taskWithDesiredEnablement,
+      name: desiredConfiguration.name,
+      admissionGroupId: desiredConfiguration.admissionGroupId,
+      task: desiredConfiguration.task,
+      enabled: desiredConfiguration.enabled,
+      continuationMode: desiredConfiguration.continuationMode,
+      schedule: {
+        ...taskWithDesiredEnablement.schedule,
+        intervalMs: desiredConfiguration.intervalMs,
+      },
+      runtime: Object.keys(runtime).length > 0 ? runtime : undefined,
+      state: {
+        ...taskWithDesiredEnablement.state,
+        updatedAt: args.now.toISOString(),
+      },
+    };
+  }
+
+  private static projectSynchronizedConfiguration(task: HeartbeatTask) {
+    return {
+      name: task.name,
+      admissionGroupId: task.admissionGroupId,
+      task: task.task.trim(),
+      enabled: task.enabled,
+      continuationMode: task.continuationMode ?? 'operator',
+      intervalMs: task.schedule.intervalMs,
+      runtime: {
+        model: task.runtime?.model,
+        maxSteps: task.runtime?.maxSteps,
+        searchIgnoreDirs: task.runtime?.searchIgnoreDirs,
+        systemContext: task.runtime?.systemContext,
+      },
+    };
+  }
+
+  private static requireReconciliationNow(now: Date | undefined): Date {
+    if (!now) {
+      throw new Error('Heartbeat configuration reconciliation requires a current timestamp.');
+    }
+    return HeartbeatTaskControlPolicy.requireValidDate(
+      now,
+      'Heartbeat configuration reconciliation timestamp',
+    ).toDate();
   }
 
   private static consumePendingRunRequest(

--- a/src/core/heartbeat/tasks/index.ts
+++ b/src/core/heartbeat/tasks/index.ts
@@ -5,6 +5,7 @@ export { HeartbeatTaskStateProjector } from './task-state.js';
 export type { HeartbeatTaskExecutionEligibility } from './execution-eligibility.js';
 export type {
   CreateHeartbeatTaskInput,
+  HeartbeatExistingTaskPolicy,
   HeartbeatTaskAdministrationService,
   HeartbeatTaskDetail,
   ListHeartbeatRunViewsOptions,

--- a/src/core/heartbeat/tasks/service.ts
+++ b/src/core/heartbeat/tasks/service.ts
@@ -446,18 +446,25 @@ export class FileHeartbeatTaskService implements
    * Reconciles membership for one host-owned task namespace under the same
    * mutation boundary used by scheduler claims and task control operations.
    *
-   * It only creates missing desired tasks and deletes obsolete non-running
-   * tasks. Existing tasks are left intact so reconciliation cannot erase an
-   * operator change, run-request generation, checkpoint association, or live
-   * execution fencing token. Call the explicit task update APIs when a host
-   * needs to change an existing task's configuration.
+   * It creates missing desired tasks and deletes obsolete non-running tasks.
+   * Existing tasks remain intact by default. An explicitly code-owned catalog
+   * may synchronize mutable configuration while retaining checkpoints, history,
+   * and live execution fencing state. Scheduling position and pending requests
+   * remain intact unless desired enablement requires a lifecycle transition.
    */
   async reconcileTasks(input: ReconcileHeartbeatTasksInput): Promise<ReconcileHeartbeatTasksResult> {
     return await this.mutationMutex.runExclusive(async () => {
       const currentTasks = await this.repository.listTasks();
-      const reconciliation = HeartbeatTaskControlPolicy.reconcileTasks({ currentTasks, input });
+      const reconciliation = HeartbeatTaskControlPolicy.reconcileTasks({
+        currentTasks,
+        input,
+        now: dayjs().toDate(),
+      });
 
-      await Promise.all(reconciliation.created.map(async (task) => await this.repository.saveTask(task)));
+      await Promise.all(
+        [...reconciliation.created, ...reconciliation.updated]
+          .map(async (task) => await this.repository.saveTask(task)),
+      );
       await Promise.all(reconciliation.deleted.map(async (task) => await this.repository.deleteTask(task)));
 
       return reconciliation;


### PR DESCRIPTION
## Summary

- bump @heddleagent/runtime to 8.0.0
- add return-direct terminal tools and successful non-agent heartbeat completion
- add opt-in declarative configuration synchronization for code-owned heartbeat catalogs
- document custom-store, administration-adapter, and exhaustive-consumer upgrade boundaries

## Why a major release

HeartbeatExecutionContext, heartbeat outcome/event unions, and HeartbeatTaskStore.recordTaskExecutionOutcome gain the completed case. ReconcileHeartbeatTasksResult also gains updated, and administration adapters that support synchronize-configuration must persist updated tasks in the catalog transaction.

## Verification

- yarn runtime:build
- yarn build
- yarn lint
- 959 unit tests
- 439 repository-owned integration tests, excluding the known machine-local user-skill catalog case
- 25 focused reconciliation/enablement tests
- npm pack ./packages/runtime --dry-run
- local Playwright browser integration: 8/8 passed
- local static-daemon browser smoke passed
- GitHub: unit, integration, Postgres reference, typecheck, and eslint pass

GitHub browser integration is currently infrastructure-blocked before any build or test runs: all three attempts hit a Google Chrome apt repository Hash Sum mismatch while Playwright installs system dependencies. The same browser and static-daemon suites pass locally. A prior run on this PR also passed browser integration before the upstream apt index changed.

Local yarn test also reads /Users/roackb2/.agents/skills/orchestration/SKILL.md and encounters one machine-local catalog assertion because that user-owned skill exceeds the 1024-character description limit. The clean GitHub integration job passes in full.

## Release boundary

This PR prepares the release only. It does not create a tag or GitHub release and does not publish npm artifacts.