### PR TITLE
Add return-direct overrides for MCP host tools

### DIFF
--- a/docs/guides/programmatic/mcp-host-extensions.md
+++ b/docs/guides/programmatic/mcp-host-extensions.md
@@ -49,7 +49,25 @@ model sees the curated host tool names instead of both paths.
 
 Use `toolNamePrefix` only when multiple MCP servers expose overlapping tool
 names in the same engine. Use `toolOverrides` when a host needs a sharper
-description, capability, approval setting, or public tool name.
+description, capability, approval setting, public tool name, or terminal
+result behavior:
+
+```ts
+const prepared = await prepareMcpHostExtension({
+  // ...server and scope configuration...
+  toolOverrides: {
+    commit_workflow_result: { returnDirect: true },
+  },
+})
+```
+
+`returnDirect` is host-owned. Use it only when a successful MCP response is the
+canonical end of the run. Heddle records that tool result and finishes without
+another model turn. Failed calls remain recoverable, and tools without the
+override retain the normal loop. Never infer terminal behavior from remote MCP
+annotations, descriptions, names, or result content. The remote operation must
+remain authorized and idempotent because every tool call in the current model
+turn is executed before Heddle applies the terminal transition.
 
 `resultArtifacts: true` is the recommended starting point for MCP servers that
 return generated source, HTML, JSON, or other large text outputs. Heddle scans

--- a/docs/releases/runtime-v8.1.0.md
+++ b/docs/releases/runtime-v8.1.0.md
@@ -1,0 +1,30 @@
+# `@heddleagent/runtime` 8.1.0
+
+This additive release lets curated MCP host tools retain Heddle's existing
+successful terminal-result behavior.
+
+## What changed
+
+- Add `McpHostToolOverride.returnDirect` to the public MCP host-extension API.
+- Project the host-owned override into the generated `ToolDefinition`, including
+  request-scoped MCP extensions with short-lived authorization headers.
+- Keep existing behavior unchanged by default: tools without the override
+  continue through the normal model loop, and failed overridden calls remain
+  recoverable within the current run.
+
+## Usage
+
+Set `returnDirect: true` only for a curated MCP operation whose successful
+result is already the canonical run result. Heddle records the tool result and
+finishes the run without requesting another model turn.
+
+Terminal behavior remains host-owned and must not be inferred from untrusted
+remote MCP metadata or content. The host and remote service remain responsible
+for authorization, idempotency, domain persistence, and the returned result.
+
+## Verification
+
+The release candidate is verified with focused request-scoped MCP tests for
+successful terminal completion, unchanged non-overridden behavior, and failed
+call recovery, plus the repository build/test baseline and Runtime package
+build.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleagent/runtime",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Embeddable TypeScript and Node.js agent runtime and SDK for Heddle-powered products",
   "author": "Jay / Fienna Liang <roackb2@gmail.com>",
   "license": "MIT",

--- a/src/__tests__/unit/core/mcp-host-extension-return-direct.test.ts
+++ b/src/__tests__/unit/core/mcp-host-extension-return-direct.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentRunService } from '@/core/agent/index.js';
+import { prepareMcpHostExtension } from '@/core/chat/engine/index.js';
+import type { LlmAdapter, LlmResponse } from '@/core/llm/types.js';
+import { McpClientService } from '@/core/mcp/index.js';
+import type { McpCallToolResult } from '@/core/mcp/index.js';
+import type { ToolDefinition } from '@/core/types.js';
+import type { ToolToolkitContext } from '@/core/tools/index.js';
+import { createLogger } from '@/core/utils/logger.js';
+
+const silentLogger = createLogger({ level: 'silent', console: false });
+
+type PreparedMcpTool = {
+  tool: ToolDefinition;
+  callTool: ReturnType<typeof vi.spyOn>;
+};
+
+async function prepareMcpTool(options: {
+  result: McpCallToolResult;
+  returnDirect?: boolean;
+}): Promise<PreparedMcpTool> {
+  vi.spyOn(McpClientService.prototype, 'listTools').mockResolvedValue({
+    tools: [{
+      name: 'commit_workflow_result',
+      description: 'Commit the canonical workflow result.',
+      inputSchema: { type: 'object', properties: {} },
+    }],
+  });
+  const callTool = vi.spyOn(McpClientService.prototype, 'callTool')
+    .mockResolvedValue(options.result);
+  const prepared = await prepareMcpHostExtension({
+    mode: 'request-scoped',
+    id: 'workflow-capabilities',
+    serverId: 'workflow_backend',
+    server: {
+      transport: 'http',
+      url: 'https://workflow.example/mcp',
+      tools: { allow: ['commit_workflow_result'], approval: 'never' },
+    },
+    includeTools: ['commit_workflow_result'],
+    resolveRequestHeaders: async () => ({ Authorization: 'Bearer test-capability' }),
+    ...(options.returnDirect === undefined
+      ? {}
+      : {
+          toolOverrides: {
+            commit_workflow_result: { returnDirect: options.returnDirect },
+          },
+        }),
+  });
+
+  if (!prepared.ok) {
+    throw new Error(prepared.error);
+  }
+
+  const context: ToolToolkitContext = {
+    workspaceRoot: '/workspace',
+    stateRoot: '/state',
+    artifactRoot: '/state/artifacts',
+    sessionId: 'session-return-direct',
+    model: 'gpt-5.5',
+    memoryDir: '/state/memory',
+    memoryMode: 'none',
+  };
+  const [tool] = prepared.extension.toolkits
+    ?.flatMap((toolkit) => toolkit.createTools(context)) ?? [];
+  if (!tool) {
+    throw new Error('Expected the prepared MCP extension to expose its selected tool.');
+  }
+
+  return { tool, callTool };
+}
+
+async function runPreparedTool(tool: ToolDefinition): Promise<{
+  modelCalls: number;
+  result: Awaited<ReturnType<typeof AgentRunService.run>>;
+}> {
+  let modelCalls = 0;
+  const llm: LlmAdapter = {
+    async chat(): Promise<LlmResponse> {
+      modelCalls += 1;
+      return modelCalls === 1
+        ? {
+            toolCalls: [{
+              id: 'call-terminal',
+              tool: 'commit_workflow_result',
+              input: {},
+            }],
+          }
+        : { content: 'The workflow continued after the tool result.' };
+    },
+  };
+  const result = await AgentRunService.run({
+    goal: 'Complete the workflow.',
+    llm,
+    tools: [tool],
+    maxSteps: 3,
+    logger: silentLogger,
+  });
+
+  return { modelCalls, result };
+}
+
+describe('request-scoped MCP return-direct tools', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('finishes from a successful overridden MCP tool without another model turn', async () => {
+    const { tool, callTool } = await prepareMcpTool({
+      returnDirect: true,
+      result: { ok: true, output: 'Workflow result committed.' },
+    });
+
+    expect(tool.returnDirect).toBe(true);
+    const { modelCalls, result } = await runPreparedTool(tool);
+
+    expect(result).toMatchObject({ outcome: 'done', summary: 'Workflow result committed.' });
+    expect(modelCalls).toBe(1);
+    expect(callTool).toHaveBeenCalledOnce();
+  });
+
+  it('keeps successful non-overridden MCP tools in the ordinary model loop', async () => {
+    const { tool, callTool } = await prepareMcpTool({
+      result: { ok: true, output: 'Intermediate workflow result.' },
+    });
+
+    expect(tool.returnDirect).toBeUndefined();
+    const { modelCalls, result } = await runPreparedTool(tool);
+
+    expect(result).toMatchObject({
+      outcome: 'done',
+      summary: 'The workflow continued after the tool result.',
+    });
+    expect(modelCalls).toBe(2);
+    expect(callTool).toHaveBeenCalledOnce();
+  });
+
+  it('keeps failed overridden MCP tools recoverable in the ordinary model loop', async () => {
+    const { tool, callTool } = await prepareMcpTool({
+      returnDirect: true,
+      result: { ok: false, error: 'Workflow result was not committed.' },
+    });
+
+    expect(tool.returnDirect).toBe(true);
+    const { modelCalls, result } = await runPreparedTool(tool);
+
+    expect(result).toMatchObject({
+      outcome: 'done',
+      summary: 'The workflow continued after the tool result.',
+    });
+    expect(result.transcript).toContainEqual({
+      role: 'tool',
+      content: JSON.stringify({ ok: false, error: 'Workflow result was not committed.' }),
+      toolCallId: 'call-terminal',
+    });
+    expect(modelCalls).toBe(2);
+    expect(callTool).toHaveBeenCalledOnce();
+  });
+});

--- a/src/core/chat/engine/mcp-host-extension/README.md
+++ b/src/core/chat/engine/mcp-host-extension/README.md
@@ -75,6 +75,12 @@ classification. The model still describes intent and expected effects in its
 policy envelope, but approval evaluation retains both sources and applies the
 host-owned facts when they disagree.
 
+The host may also mark one curated tool override as `returnDirect` when a
+successful MCP result is already the canonical run result. Keep this as
+host-owned tool-definition metadata: never infer terminal behavior from remote
+MCP annotations, names, descriptions, or outputs. Failed calls retain the
+ordinary recoverable loop behavior.
+
 Only classify `operations` when the embedding host knows the tool contract.
 Remote MCP annotations are untrusted hints, not Heddle authorization. An
 unclassified remote tool remains manual in autopilot rather than inheriting a

--- a/src/core/chat/engine/mcp-host-extension/tool-definition-service.ts
+++ b/src/core/chat/engine/mcp-host-extension/tool-definition-service.ts
@@ -96,6 +96,7 @@ export class McpHostToolDefinitionService {
       requiresApproval: override?.requiresApproval ?? shouldMcpToolRequireApproval(args.server),
       description: override?.description ?? McpHostToolDefinitionService.describeTool(args.options, args.tool),
       capabilities: override?.capabilities ?? args.options.defaultCapabilities ?? ['mcp.unknown'],
+      returnDirect: override?.returnDirect,
       parameters: args.tool.inputSchema,
       hostPolicy: McpPolicyContextService.create({
         server: args.server,

--- a/src/core/chat/engine/mcp-host-extension/types.ts
+++ b/src/core/chat/engine/mcp-host-extension/types.ts
@@ -18,6 +18,8 @@ export type McpHostToolOverride = {
   description?: string;
   capabilities?: string[];
   requiresApproval?: boolean;
+  /** Finish the current run from this tool's successful MCP result. */
+  returnDirect?: boolean;
   /**
    * Host-owned effect classification. Omit when the host cannot verify the
    * remote tool's effects; model claims remain proposals.


### PR DESCRIPTION
## Summary

- add the optional public `McpHostToolOverride.returnDirect` contract
- preserve it when Runtime projects curated MCP tools into `ToolDefinition`
- cover successful terminal completion, unchanged default behavior, and recoverable failures
- prepare the additive `@heddleagent/runtime` 8.1.0 release note and version

## Verification

- `yarn vitest run src/__tests__/unit/core/mcp-host-extension-return-direct.test.ts` (3/3)
- `yarn test:unit` (962/962)
- focused existing agent/conversation integration tests (96/96)
- repository integration tests excluding the known machine-local Agent Skills fixture (439/439)
- `yarn typecheck`
- `yarn lint`
- `yarn runtime:build`
- `yarn build`
- `npm pack ./packages/runtime --dry-run --loglevel=notice` (`@heddleagent/runtime@8.1.0`)

The unfiltered local integration command remains 462/463 because it discovers `/Users/roackb2/.agents/skills/orchestration/SKILL.md`, whose external description exceeds the fixture limit. The failure is unchanged from the Runtime 8.0.0 release baseline and is unrelated to this patch; clean CI remains the authoritative result.

No merge, tag, GitHub release, or npm publication is included.