### PR TITLE
Treat MCP isError responses as tool failures

### DIFF
--- a/docs/guides/programmatic/mcp-host-extensions.md
+++ b/docs/guides/programmatic/mcp-host-extensions.md
@@ -64,10 +64,14 @@ const prepared = await prepareMcpHostExtension({
 `returnDirect` is host-owned. Use it only when a successful MCP response is the
 canonical end of the run. Heddle records that tool result and finishes without
 another model turn. Failed calls remain recoverable, and tools without the
-override retain the normal loop. Never infer terminal behavior from remote MCP
-annotations, descriptions, names, or result content. The remote operation must
-remain authorized and idempotent because every tool call in the current model
-turn is executed before Heddle applies the terminal transition.
+override retain the normal loop. This includes resolved MCP responses marked
+`isError: true`, which become failed Heddle tool results so the model can
+self-correct. Ordinary calls retain bounded text details; request-scoped calls
+use a generic error so reflected authorization material cannot enter the model
+transcript. Never infer terminal behavior from remote MCP annotations,
+descriptions, names, or result content. The remote operation must remain
+authorized and idempotent because every tool call in the current model turn is
+executed before Heddle applies the terminal transition.
 
 `resultArtifacts: true` is the recommended starting point for MCP servers that
 return generated source, HTML, JSON, or other large text outputs. Heddle scans

--- a/docs/releases/runtime-v8.1.0.md
+++ b/docs/releases/runtime-v8.1.0.md
@@ -8,6 +8,10 @@ successful terminal-result behavior.
 - Add `McpHostToolOverride.returnDirect` to the public MCP host-extension API.
 - Project the host-owned override into the generated `ToolDefinition`, including
   request-scoped MCP extensions with short-lived authorization headers.
+- Treat resolved MCP SDK responses marked `isError: true` as failed Heddle tool
+  results instead of allowing a return-direct tool to finish successfully.
+  Ordinary calls retain bounded text details for model recovery, while
+  request-scoped calls keep the existing response-body redaction boundary.
 - Keep existing behavior unchanged by default: tools without the override
   continue through the normal model loop, and failed overridden calls remain
   recoverable within the current run.
@@ -26,5 +30,6 @@ for authorization, idempotency, domain persistence, and the returned result.
 
 The release candidate is verified with focused request-scoped MCP tests for
 successful terminal completion, unchanged non-overridden behavior, and failed
-call recovery, plus the repository build/test baseline and Runtime package
-build.
+call recovery; raw SDK-response boundary regressions for `isError`, including
+request-scoped response-body redaction; successful compatibility `toolResult`
+coverage; plus the repository build/test baseline and Runtime package build.

--- a/src/__tests__/unit/core/mcp-client-lifecycle.test.ts
+++ b/src/__tests__/unit/core/mcp-client-lifecycle.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentRunService } from '@/core/agent/index.js';
+import { prepareMcpHostExtension } from '@/core/chat/engine/index.js';
+import type { LlmAdapter, LlmResponse } from '@/core/llm/types.js';
 import type { McpServerConfig } from '@/core/mcp/index.js';
+import type { ToolToolkitContext } from '@/core/tools/index.js';
+import { createLogger } from '@/core/utils/logger.js';
 
 const mocks = vi.hoisted(() => ({
   clientCallTool: vi.fn(),
@@ -52,6 +57,8 @@ vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
 }));
 
 import { McpClientService } from '@/core/mcp/client-service.js';
+
+const silentLogger = createLogger({ level: 'silent', console: false });
 
 const servers: McpServerConfig[] = [
   {
@@ -122,6 +129,149 @@ describe('MCP client lifecycle', () => {
 
     expect(mocks.clientClose).toHaveBeenCalledTimes(1);
     expect(mocks.transportClose).toHaveBeenCalledWith('http');
+  });
+
+  it('maps a resolved SDK isError response to a bounded failed tool result', async () => {
+    const omittedStructuredValue = 'structured-value-must-not-enter-the-error';
+    mocks.clientCallTool.mockResolvedValueOnce({
+      isError: true,
+      content: [{ type: 'text', text: `Validation failed: ${'x'.repeat(5_000)}` }],
+      structuredContent: { internal: omittedStructuredValue },
+    });
+
+    const result = await new McpClientService().callTool(servers[2]!, 'commit_workflow_result', {});
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected the MCP SDK error result to remain failed.');
+    }
+    expect(result.error).toMatch(/^Validation failed:/);
+    expect(result.error).toHaveLength(4_000);
+    expect(result.error.endsWith('…')).toBe(true);
+    expect(result.error).not.toContain(omittedStructuredValue);
+    expect(mocks.clientClose).toHaveBeenCalledOnce();
+    expect(mocks.transportClose).toHaveBeenCalledWith('http');
+  });
+
+  it('redacts resolved SDK isError content for request-scoped tool calls', async () => {
+    const reflectedCapability = 'reflected-capability-secret';
+    mocks.clientCallTool.mockResolvedValueOnce({
+      isError: true,
+      content: [{ type: 'text', text: `backend echoed ${reflectedCapability}` }],
+    });
+
+    const result = await new McpClientService().callTool(
+      servers[2]!,
+      'read_scope',
+      {},
+      undefined,
+      async () => ({ Authorization: `Bearer ${reflectedCapability}` }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Request-scoped MCP operation failed: http/call_tool',
+    });
+    expect(JSON.stringify(result)).not.toContain(reflectedCapability);
+  });
+
+  it('preserves successful compatibility toolResult responses', async () => {
+    mocks.clientCallTool.mockResolvedValueOnce({
+      toolResult: { status: 'committed', revision: 3 },
+    });
+
+    await expect(new McpClientService().callTool(servers[2]!, 'commit_workflow_result', {}))
+      .resolves.toEqual({
+        ok: true,
+        output: { status: 'committed', revision: 3 },
+      });
+  });
+
+  it('keeps a raw SDK isError response recoverable for a return-direct MCP tool', async () => {
+    mocks.clientListTools.mockResolvedValueOnce({
+      tools: [{
+        name: 'commit_workflow_result',
+        description: 'Commit the canonical workflow result.',
+        inputSchema: { type: 'object', properties: {} },
+      }],
+    });
+    mocks.clientCallTool.mockResolvedValueOnce({
+      isError: true,
+      content: [{ type: 'text', text: 'Workflow result was not committed: secret-capability.' }],
+    });
+    const prepared = await prepareMcpHostExtension({
+      mode: 'request-scoped',
+      id: 'workflow-capabilities',
+      serverId: 'workflow_backend',
+      server: {
+        transport: 'http',
+        url: 'https://workflow.example/mcp',
+        tools: { allow: ['commit_workflow_result'], approval: 'never' },
+      },
+      includeTools: ['commit_workflow_result'],
+      toolOverrides: {
+        commit_workflow_result: { returnDirect: true },
+      },
+      resolveRequestHeaders: async () => ({ Authorization: 'Bearer test-capability' }),
+    });
+    if (!prepared.ok) {
+      throw new Error(prepared.error);
+    }
+
+    const context: ToolToolkitContext = {
+      workspaceRoot: '/workspace',
+      stateRoot: '/state',
+      artifactRoot: '/state/artifacts',
+      sessionId: 'session-mcp-error',
+      model: 'gpt-5.5',
+      memoryDir: '/state/memory',
+      memoryMode: 'none',
+    };
+    const [tool] = prepared.extension.toolkits
+      ?.flatMap((toolkit) => toolkit.createTools(context)) ?? [];
+    if (!tool) {
+      throw new Error('Expected the prepared MCP extension to expose its selected tool.');
+    }
+
+    let modelCalls = 0;
+    const llm: LlmAdapter = {
+      async chat(): Promise<LlmResponse> {
+        modelCalls += 1;
+        return modelCalls === 1
+          ? {
+              toolCalls: [{
+                id: 'call-terminal',
+                tool: 'commit_workflow_result',
+                input: {},
+              }],
+            }
+          : { content: 'The workflow recovered after the failed commit.' };
+      },
+    };
+
+    const result = await AgentRunService.run({
+      goal: 'Complete the workflow.',
+      llm,
+      tools: [tool],
+      maxSteps: 3,
+      logger: silentLogger,
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'done',
+      summary: 'The workflow recovered after the failed commit.',
+    });
+    expect(result.transcript).toContainEqual({
+      role: 'tool',
+      content: JSON.stringify({
+        ok: false,
+        error: 'Request-scoped MCP operation failed: workflow_backend/call_tool',
+      }),
+      toolCallId: 'call-terminal',
+    });
+    expect(JSON.stringify(result.transcript)).not.toContain('secret-capability');
+    expect(modelCalls).toBe(2);
+    expect(mocks.clientCallTool).toHaveBeenCalledOnce();
   });
 
   it.each(servers.slice(1))('resolves request-scoped headers for $transport discovery', async (server) => {

--- a/src/core/mcp/README.md
+++ b/src/core/mcp/README.md
@@ -96,6 +96,9 @@ work inside a synchronous toolkit.
   - owns the official `@modelcontextprotocol/sdk` client usage;
   - creates stdio, Streamable HTTP, or legacy SSE transports;
   - lists tools and calls tools;
+  - maps resolved MCP results with `isError: true` to failed Heddle tool
+    results, retaining only bounded text details for ordinary calls and using a
+    generic failure for request-scoped calls;
   - forwards the owning run's abort signal to connection and request calls;
   - closes client and transport resources after each operation, on both success
     and failure.
@@ -200,6 +203,11 @@ Keep these invariants:
 - MCP server id, tool name, transport, configured environment, and tenant
   provenance are host-owned. A model policy envelope cannot override them.
 - MCP server/tool descriptions and outputs are untrusted external content.
+- A resolved MCP `isError` result is a tool failure, not a successful output;
+  non-text error content and metadata must not be copied into the model-facing
+  error string.
+- Request-scoped MCP failures must not expose server response content because
+  it can reflect short-lived authorization material.
 - Local stdio servers run commands with the user's OS permissions.
 - Secret values should be resolved at connection time and redacted from
   diagnostics/logs where possible.

--- a/src/core/mcp/client-service.ts
+++ b/src/core/mcp/client-service.ts
@@ -6,6 +6,7 @@ import type {
   FetchLike,
   Transport,
 } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { truncate } from '@/core/utils/text.js';
 import type {
   McpCallToolResult,
   McpClientSessionInfo,
@@ -17,6 +18,7 @@ import type {
 } from './types.js';
 
 const DEFAULT_MCP_TIMEOUT_MS = 30_000;
+const MAX_MCP_TOOL_ERROR_LENGTH = 4_000;
 
 export class McpClientService {
   async listTools(
@@ -64,10 +66,14 @@ export class McpClientService {
           timeout: DEFAULT_MCP_TIMEOUT_MS,
         });
 
-        return {
-          ok: true,
-          output: normalizeToolResult(result),
-        };
+        return isMcpToolErrorResult(result)
+          ? {
+              ok: false,
+              error: requestHeaders
+                ? requestScopedOperationError(server.id, 'call_tool').message
+                : normalizeMcpToolError(result),
+            }
+          : { ok: true, output: normalizeToolResult(result) };
       }, { operation: 'call_tool', serverId: server.id, toolName, signal }, signal, requestHeaders);
     } catch (error) {
       return {
@@ -234,4 +240,27 @@ function normalizeToolResult(result: unknown): unknown {
     structuredContent: value.structuredContent,
     content: value.content,
   };
+}
+
+function isMcpToolErrorResult(result: unknown): result is { content?: unknown[]; isError: true } {
+  return result !== null
+    && typeof result === 'object'
+    && (result as { isError?: unknown }).isError === true;
+}
+
+function normalizeMcpToolError(result: { content?: unknown[] }): string {
+  const text = (result.content ?? [])
+    .filter(isMcpTextContent)
+    .map((entry) => entry.text.trim())
+    .filter(Boolean)
+    .join('\n');
+
+  return truncate(text || 'MCP tool reported an error without text details.', MAX_MCP_TOOL_ERROR_LENGTH);
+}
+
+function isMcpTextContent(value: unknown): value is { type: 'text'; text: string } {
+  return value !== null
+    && typeof value === 'object'
+    && (value as { type?: unknown }).type === 'text'
+    && typeof (value as { text?: unknown }).text === 'string';
 }


### PR DESCRIPTION
## Summary

- map resolved MCP SDK responses marked isError to failed Heddle tool results
- bound ordinary error text and exclude structured or non-text payloads
- preserve generic response-body redaction for request-scoped capability calls
- keep return-direct tools recoverable when the remote tool reports failure

Fixes #393

## Verification

- yarn vitest run src/__tests__/unit/core/mcp-client-lifecycle.test.ts src/__tests__/unit/core/mcp-host-extension-return-direct.test.ts
- yarn test:unit
- yarn typecheck
- yarn lint
- yarn build
- yarn vitest run src/__tests__/integration --exclude src/__tests__/integration/control-plane/session-lifecycle.test.ts
- yarn runtime:build
- npm pack ./packages/runtime --dry-run --json
- yarn release:context runtime-v8.0.0 HEAD

Runtime remains at the unpublished 8.1.0 package version. This PR does not tag, release, or publish it.