### PR TITLE
Resume the most recent session on startup

### DIFF
--- a/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
+++ b/src/__tests__/browser-integration/web-v2/control-plane-v2.spec.ts
@@ -11,6 +11,18 @@ const trpc = createTRPCProxyClient<AppRouter>({
   ],
 });
 
+test('resumes the most recent session without letting pinned display order override it', async ({ page }) => {
+  const pinned = await trpc.controlPlane.sessionCreate.mutate({ name: `Pinned startup smoke ${Date.now()}` });
+  await trpc.controlPlane.sessionPinnedUpdate.mutate({ id: pinned.id, pinned: true });
+  const recent = await trpc.controlPlane.sessionCreate.mutate({ name: `Recent startup smoke ${Date.now()}` });
+
+  await page.goto('/sessions');
+
+  await expect(page).toHaveURL(new RegExp(`/sessions/${recent.id}$`));
+  await expect(page.getByTestId('web-v2-workbench-title')).toHaveText(recent.name);
+  await expect(page.getByRole('button', { name: new RegExp(pinned.name) })).toBeVisible();
+});
+
 test('loads the web v2 shell sections', async ({ page }) => {
   const eventStreams = new Set<string>();
   page.on('request', (request) => {

--- a/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
+++ b/src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
@@ -52,6 +52,43 @@ describe('ControlPlaneSessionStore', () => {
     store.dispose();
   });
 
+  it('starts on the most recently updated session instead of the first pinned session', async () => {
+    const fixture = createClientFixture();
+    fixture.calls.sessionsQuery.mockResolvedValueOnce({
+      workspaceId: 'workspace-1',
+      sessions: [
+        {
+          id: 'pinned-old',
+          name: 'Pinned old',
+          pinned: true,
+          updatedAt: '2026-08-28T09:00:00.000Z',
+          messageCount: 1,
+          turnCount: 1,
+          queuedPromptCount: 0,
+        },
+        {
+          id: 'recent-work',
+          name: 'Recent work',
+          pinned: false,
+          updatedAt: '2026-08-29T09:00:00.000Z',
+          messageCount: 1,
+          turnCount: 1,
+          queuedPromptCount: 0,
+        },
+      ],
+    });
+    const store = new ControlPlaneSessionStore({ client: fixture.client });
+
+    await store.start();
+
+    expect(fixture.calls.sessionQuery).toHaveBeenCalledWith({
+      id: 'recent-work',
+      workspaceId: 'workspace-1',
+    });
+    expect(store.getSnapshot().activeSessionId).toBe('recent-work');
+    store.dispose();
+  });
+
   it('refreshes the canonical workspace change list after a live workspace-changing activity', async () => {
     const fixture = createClientFixture();
     const store = new ControlPlaneSessionStore({ client: fixture.client });

--- a/src/__tests__/unit/client-shared/session-selection-service.test.ts
+++ b/src/__tests__/unit/client-shared/session-selection-service.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { ControlPlaneSessionView } from '../../../client-shared/api/types.js';
+import { ClientSharedSessionSelectionService } from '../../../client-shared/services/session-selection/index.js';
+
+describe('ClientSharedSessionSelectionService', () => {
+  it('resumes the most recently updated session instead of the first pinned session', () => {
+    const pinned = session({
+      id: 'pinned-old',
+      pinned: true,
+      updatedAt: '2026-08-28T09:00:00.000Z',
+    });
+    const recent = session({
+      id: 'recent-work',
+      updatedAt: '2026-08-29T09:00:00.000Z',
+    });
+
+    expect(ClientSharedSessionSelectionService.resolveStartupSession([pinned, recent])).toBe(recent);
+    expect(ClientSharedSessionSelectionService.resolveStartupSession([recent, pinned])).toBe(recent);
+  });
+
+  it('falls back to creation time and resolves ties independently of pinned display order', () => {
+    const pinned = session({
+      id: 'z-pinned',
+      pinned: true,
+      updatedAt: 'invalid',
+      createdAt: '2026-08-29T09:00:00.000Z',
+    });
+    const recent = session({
+      id: 'a-recent',
+      createdAt: '2026-08-29T09:00:00.000Z',
+    });
+
+    expect(ClientSharedSessionSelectionService.resolveStartupSession([pinned, recent])).toBe(recent);
+    expect(ClientSharedSessionSelectionService.resolveStartupSession([recent, pinned])).toBe(recent);
+  });
+
+  it('returns undefined when no session is available', () => {
+    expect(ClientSharedSessionSelectionService.resolveStartupSession([])).toBeUndefined();
+  });
+});
+
+function session(overrides: Partial<ControlPlaneSessionView>): ControlPlaneSessionView {
+  return {
+    id: 'session-1',
+    name: 'Session 1',
+    pinned: false,
+    messageCount: 0,
+    turnCount: 0,
+    queuedPromptCount: 0,
+    ...overrides,
+  };
+}

--- a/src/__tests__/unit/web-v2/control-plane-sidebar-data.test.tsx
+++ b/src/__tests__/unit/web-v2/control-plane-sidebar-data.test.tsx
@@ -1,0 +1,110 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const api = vi.hoisted(() => ({
+  heartbeatTasksUseQuery: vi.fn(),
+  sessionsUseQuery: vi.fn(),
+  stateUseQuery: vi.fn(),
+}));
+
+vi.mock('@web/api/client', () => ({
+  trpcReact: {
+    controlPlane: {
+      heartbeatTasks: { useQuery: api.heartbeatTasksUseQuery },
+      sessions: { useQuery: api.sessionsUseQuery },
+      state: { useQuery: api.stateUseQuery },
+    },
+  },
+}));
+
+import { useControlPlaneSidebarData } from '../../../web-v2/hooks/shell/useControlPlaneSidebarData.js';
+
+describe('useControlPlaneSidebarData', () => {
+  beforeEach(() => {
+    api.stateUseQuery.mockReturnValue({
+      data: {
+        activeWorkspaceId: 'workspace-1',
+        workspaces: [{ id: 'workspace-1' }],
+      },
+    });
+    api.sessionsUseQuery.mockReturnValue({
+      data: {
+        workspaceId: 'workspace-1',
+        sessions: [
+          {
+            id: 'pinned-old',
+            name: 'Pinned old',
+            pinned: true,
+            updatedAt: '2026-08-28T09:00:00.000Z',
+            messageCount: 1,
+            turnCount: 1,
+            queuedPromptCount: 0,
+          },
+          {
+            id: 'recent-work',
+            name: 'Recent work',
+            pinned: false,
+            updatedAt: '2026-08-29T09:00:00.000Z',
+            messageCount: 1,
+            turnCount: 1,
+            queuedPromptCount: 0,
+          },
+        ],
+      },
+    });
+    api.heartbeatTasksUseQuery.mockReturnValue({
+      data: { workspaceId: 'workspace-1', tasks: [] },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('navigates to the recent session when the sessions route has no explicit selection', async () => {
+    const selectSession = vi.fn();
+    renderHook(() => useControlPlaneSidebarData({
+      navigation: {
+        activeSurfaceId: 'sessions',
+        selectedSessionId: undefined,
+        selectedTaskId: undefined,
+        selectedWorkspaceId: 'workspace-1',
+        settingsOpen: false,
+        selectSession,
+        selectTask: vi.fn(),
+      } as never,
+      taskEvents: { liveTasks: {} } as never,
+    }));
+
+    await waitFor(() => {
+      expect(selectSession).toHaveBeenCalledWith('recent-work', {
+        workspaceId: 'workspace-1',
+        replace: true,
+      });
+    });
+  });
+
+  it('preserves an explicitly selected route session', async () => {
+    const selectSession = vi.fn();
+    renderHook(() => useControlPlaneSidebarData({
+      navigation: {
+        activeSurfaceId: 'sessions',
+        selectedSessionId: 'pinned-old',
+        selectedTaskId: undefined,
+        selectedWorkspaceId: 'workspace-1',
+        settingsOpen: false,
+        selectSession,
+        selectTask: vi.fn(),
+      } as never,
+      taskEvents: { liveTasks: {} } as never,
+    }));
+
+    await waitFor(() => {
+      expect(api.sessionsUseQuery).toHaveBeenCalled();
+    });
+    expect(selectSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli-v2/state/control-plane-session-store.ts
+++ b/src/cli-v2/state/control-plane-session-store.ts
@@ -24,6 +24,7 @@ import type {
   ControlPlaneSlashCommandHint,
   ControlPlaneWorkspaceFileSuggestion,
 } from '@/client-shared/api/types.js';
+import { ClientSharedSessionSelectionService } from '@/client-shared/services/session-selection/index.js';
 import { ControlPlaneSessionLoader } from './control-plane-session-loader.js';
 import { ControlPlaneDirectShellController } from './control-plane-direct-shell-controller.js';
 import { ControlPlaneSlashCommandController } from './control-plane-slash-command-controller.js';
@@ -201,7 +202,9 @@ export class ControlPlaneSessionStore {
       ]);
       this.subscriptions.subscribeToSessionList(workspaceId);
       const sessions = await this.refreshSessions();
-      const sessionId = input.sessionId ?? sessions[0]?.id ?? (await this.createSession()).id;
+      const sessionId = input.sessionId
+        ?? ClientSharedSessionSelectionService.resolveStartupSession(sessions)?.id
+        ?? (await this.createSession()).id;
       await this.selectSession(sessionId);
     } catch (error) {
       this.state.patch({ error: formatError(error), loading: false });

--- a/src/client-shared/README.md
+++ b/src/client-shared/README.md
@@ -33,8 +33,8 @@ the `ControlPlane*` types exported from `api/types.ts`.
 - `ClientSharedProxyApiService` for non-React proxy clients used by CLI/TUI/ask
   callers;
 - shared API-consumer services such as transient conversation message
-  shaping, session activity effect dispatch, and approval payload display
-  shaping;
+  shaping, implicit startup-session selection, session activity effect
+  dispatch, and approval payload display shaping;
 - shared live and settled subagent rows derived from correlated lifecycle
   events and durable turn records, excluding raw child transcripts and traces;
 - shared conversation-run cursor, duplicate suppression, terminal detection,

--- a/src/client-shared/services/session-selection/README.md
+++ b/src/client-shared/services/session-selection/README.md
@@ -1,0 +1,13 @@
+# Session Selection Service
+
+`ClientSharedSessionSelectionService` owns the implicit startup selection used
+by Heddle clients. When no route or CLI argument names a session, it resumes the
+session with the newest `updatedAt` timestamp, falling back to `createdAt` for
+compatible older views.
+
+Pinning is deliberately excluded from this decision. It is presentation
+metadata used to group frequently accessed sessions in navigation; it must not
+replace the user's most recently active session as the startup destination.
+
+Concrete clients still own explicit navigation. A session named in a browser
+route or CLI option takes precedence before this service is called.

--- a/src/client-shared/services/session-selection/index.ts
+++ b/src/client-shared/services/session-selection/index.ts
@@ -1,0 +1,1 @@
+export { ClientSharedSessionSelectionService } from './session-selection-service.js';

--- a/src/client-shared/services/session-selection/session-selection-service.ts
+++ b/src/client-shared/services/session-selection/session-selection-service.ts
@@ -1,0 +1,40 @@
+import dayjs from 'dayjs';
+import type { ControlPlaneSessionView } from '../../api/types.js';
+
+/**
+ * Owns frontend-neutral implicit session selection.
+ *
+ * Pinning controls list presentation only. When a client starts without an
+ * explicit session, it should resume the session with the newest durable
+ * activity timestamp regardless of where that session appears in the list.
+ */
+export class ClientSharedSessionSelectionService {
+  static resolveStartupSession(
+    sessions: readonly ControlPlaneSessionView[],
+  ): ControlPlaneSessionView | undefined {
+    return sessions.reduce<ControlPlaneSessionView | undefined>((latest, candidate) => {
+      if (!latest) {
+        return candidate;
+      }
+
+      const candidateTimestamp = ClientSharedSessionSelectionService.activityTimestamp(candidate);
+      const latestTimestamp = ClientSharedSessionSelectionService.activityTimestamp(latest);
+      if (candidateTimestamp !== latestTimestamp) {
+        return candidateTimestamp > latestTimestamp ? candidate : latest;
+      }
+
+      return candidate.id < latest.id ? candidate : latest;
+    }, undefined);
+  }
+
+  private static activityTimestamp(session: ControlPlaneSessionView): number {
+    for (const timestamp of [session.updatedAt, session.createdAt]) {
+      const parsed = timestamp ? dayjs(timestamp) : undefined;
+      if (parsed?.isValid()) {
+        return parsed.valueOf();
+      }
+    }
+
+    return Number.NEGATIVE_INFINITY;
+  }
+}

--- a/src/web-v2/hooks/shell/useControlPlaneSidebarData.ts
+++ b/src/web-v2/hooks/shell/useControlPlaneSidebarData.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { trpcReact } from '@web/api/client';
 import type { ControlPlaneState } from '@web/api/client';
+import { ClientSharedSessionSelectionService } from '@/client-shared/services/session-selection/index.js';
 import type { useWorkbenchNavigation } from '../useWorkbenchNavigation';
 import { applyLiveTaskState } from '../tasks/useControlPlaneTaskLiveState';
 import type { useControlPlaneHeartbeatEvents } from '../tasks/useControlPlaneHeartbeatEvents';
@@ -68,11 +69,14 @@ export function useControlPlaneSidebarData({
   );
 
   useEffect(() => {
-    if (navigation.selectedSessionId || navigation.settingsOpen || navigation.activeSurfaceId !== 'sessions' || sessions.length === 0) {
+    if (navigation.selectedSessionId || navigation.settingsOpen || navigation.activeSurfaceId !== 'sessions') {
       return;
     }
 
-    navigation.selectSession(sessions[0]!.id, { workspaceId, replace: true });
+    const startupSession = ClientSharedSessionSelectionService.resolveStartupSession(sessions);
+    if (startupSession) {
+      navigation.selectSession(startupSession.id, { workspaceId, replace: true });
+    }
   }, [navigation, sessions, workspaceId]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- separate implicit startup selection from pinned-first sidebar ordering
- use the same most-recent-session rule in web and CLI
- preserve explicit route and CLI session choices

## Verification
- yarn vitest run src/__tests__/unit/client-shared/session-selection-service.test.ts src/__tests__/unit/web-v2/control-plane-sidebar-data.test.tsx src/__tests__/unit/cli-v2/control-plane-session-store.test.ts
- yarn test:unit (147 files, 970 tests)
- yarn typecheck
- yarn lint
- yarn cli:build
- yarn test:browser-integration (9 tests)